### PR TITLE
Some work toward speeing up OpenEMR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+sites/test/
+interface/main/calendar/modules/PostCalendar/pntemplates/

--- a/interface/patient_file/history/encounters.php
+++ b/interface/patient_file/history/encounters.php
@@ -24,6 +24,7 @@ require_once("$srcdir/invoice_summary.inc.php");
 require_once("$srcdir/formatting.inc.php");
 require_once("../../../custom/code_types.inc.php");
 require_once("$srcdir/formdata.inc.php");
+require_once("$srcdir/query_profile.php");
 
 // "issue" parameter exists if we are being invoked by clicking an issue title
 // in the left_nav menu.  Currently that is just for athletic teams.  In this
@@ -757,5 +758,6 @@ $(document).ready(function(){
 });
 
 </script>
-
+<?php queryProfileAsHtmlComment(); ?>
 </html>
+

--- a/library/log.inc
+++ b/library/log.inc
@@ -480,7 +480,6 @@ function send_atna_audit_msg($user, $group, $event, $patient_id, $outcome, $comm
  */
 function auditSQLEvent($statement, $outcome, $binds=NULL)
 {
-
     $user =  isset($_SESSION['authUser']) ? $_SESSION['authUser'] : "";
 	/* Don't log anything if the audit logging is not enabled. Exception for "emergency" users */
    if (!isset($GLOBALS['enable_auditlog']) || !($GLOBALS['enable_auditlog']))
@@ -749,4 +748,5 @@ function deleteDisclosure($deletelid)
         $sql="delete from extended_log where id='$deletelid'";
         $ret = sqlInsertClean_audit($sql);
 }
+
 ?>

--- a/library/query_profile.php
+++ b/library/query_profile.php
@@ -1,0 +1,71 @@
+<?php
+include_once(dirname(__FILE__) . "/sqlconf.php");
+
+// Sigh, globals.
+$__debug_query_log = [];
+
+function shouldLogQueries() {
+  // Count on this getting set in the site's sqlconf.php
+  // But really, you could set it anywhere.
+  return $GLOBALS["query_debug"];
+}
+
+function debugLogQuery($statement) {
+  if (!shouldLogQueries()) {
+    return;
+  }
+  $stack_trace = array_reverse(debug_backtrace());
+
+  // Trim this function call from the stack trace, it's not useful.
+  $stack_trace = array_slice($stack_trace, 0, count($stack_trace) - 1);
+  array_push($GLOBALS["__debug_query_log"],
+             array("query" => $statement,
+                   "stack_trace" => $stack_trace));
+}
+
+function formatQuery($logged_query) {
+  $traceback_message = "";
+  foreach ($logged_query["stack_trace"] as $stack_frame) {
+    $traceback_message .= "  " . $stack_frame["file"] . ":" .
+      $stack_frame['line'] . " " .
+      $stack_frame['function'] . "\n";
+    }
+  $message = "\n" . "  " . $logged_query["query"] . "\n" . $traceback_message;
+  return $message;
+}
+
+function formatProfile() {
+  $profile = "";
+  $query_log = $GLOBALS["__debug_query_log"];
+  foreach($query_log as $logged_query) {
+    $message = formatQuery($logged_query);
+    $profile .= $message;
+  }
+  $profile .= "\n" . count($query_log) . " total database queries.";
+  return $profile;
+}
+
+function loggingDisabledMessage() {
+  return "Query logging is disabled, set the global variable \$query_debug = true";
+}
+
+function printQueryProfileToConsole() {
+  if (!shouldLogQueries()) {
+    error_log(loggingDisabledMessage());
+    return;
+  }
+  error_log(formatProfile());
+}
+
+function queryProfileAsHtmlComment() {
+  $profile_comment = "<!-- SQL Query Profile: \n";
+  if (!shouldLogQueries()) {
+    $profile_comment .= loggingDisabledMessage();
+  } else {
+    $profile_comment .= formatProfile();
+  }
+  $profile_comment .= "\n-->\n";
+  print $profile_comment;
+}
+
+?>

--- a/library/sql.inc
+++ b/library/sql.inc
@@ -3,7 +3,7 @@
 include_once(dirname(__FILE__) . "/sqlconf.php");
 require_once(dirname(__FILE__) . "/adodb/adodb.inc.php");
 require_once(dirname(__FILE__) . "/adodb/drivers/adodb-mysql.inc.php");
-
+require_once(dirname(__FILE__) . "/query_profile.php");
 include_once(dirname(__FILE__) . "/log.inc");
 
 class ADODB_mysql_log extends ADODB_mysql
@@ -79,6 +79,7 @@ if (!$GLOBALS['dbh']) {
 //   and resource objects).
 function sqlStatement($statement, $binds=NULL )
 {
+  debugLogQuery($statement);
   if (is_array($binds)) {
     // Use adodb Execute with binding and return a recordset.
     //   Note that the auditSQLEvent function is embedded
@@ -107,6 +108,7 @@ function sqlStatement($statement, $binds=NULL )
 //   in very special situations.
 function sqlStatementNoLog($statement, $binds=NULL )
 {
+  debugLogQuery($statement);
   if (is_array($binds)) {
     // Use adodb ExecuteNoLog with binding and return a recordset.
     $recordset = $GLOBALS['adodb']['db']->ExecuteNoLog( $statement, $binds );
@@ -159,6 +161,7 @@ function sqlFetchArray($r)
 //   insert.
 function sqlInsert($statement, $binds=array())
 {
+  debugLogQuery($statement);
   //Run a adodb execute
   // Note the auditSQLEvent function is embedded in the
   //   adodb Execute function.
@@ -183,6 +186,7 @@ function sqlInsert($statement, $binds=array())
 //     does not work.
 function sqlQuery($statement, $status_or_binds=FALSE)
 {
+  debugLogQuery($statement);
   if ((is_array($status_or_binds)) || ($status_or_binds === FALSE)) {
     // run the adodb Execute function
     //   Note the auditSQLEvent function is embedded in the
@@ -222,7 +226,7 @@ function sqlQuery($statement, $status_or_binds=FALSE)
  */
 function sqlInsertClean_audit($statement)
 {
-
+  debugLogQuery($statement);
   $ret = $GLOBALS['adodb']['db']->ExecuteNoLog($statement);
   if ($ret === FALSE) {
     HelpfulDie("insert failed: $statement", $GLOBALS['adodb']['db']->ErrorMsg());
@@ -245,6 +249,7 @@ function getSqlLastID() {
 //   of columns that exist in a table.
 function sqlListFields($table) {
   $sql = "SHOW COLUMNS FROM ". mysql_real_escape_string($table);
+  debugLogQuery($sql);
   $resource = sqlQ($sql);
   $field_list = array();
   while($row = mysql_fetch_array($resource)) {

--- a/sites/default/sqlconf.php
+++ b/sites/default/sqlconf.php
@@ -11,6 +11,7 @@ $port	= '3306';
 $login	= 'openemr';
 $pass	= 'openemr';
 $dbase	= 'openemr';
+$query_debug = true;
 
 $sqlconf = array();
 global $sqlconf;


### PR DESCRIPTION
- Added the `query_profile.php` module, that will log both queries
  and the stack traces that produced them. Useful for tracking down
  handlers that do a lot of SQL work.
- Changed the translation module to pre-cache the language for the
  current user, as opposed to querying the DB every time it needed
  a translation. `encounters.php`, for example, did well over 200
  queries in translation alone. Precaching the language speeds that
  up significantly.