### PR TITLE
Auto-detected web-root path no longer omits first character.

### DIFF
--- a/interface/globals.php
+++ b/interface/globals.php
@@ -62,7 +62,7 @@ if (IS_WINDOWS) {
 }
 // Auto collect the relative html path, i.e. what you would type into the web
 // browser after the server address to get to OpenEMR.
-$web_root = substr($webserver_root, strlen($_SERVER['DOCUMENT_ROOT']));
+$web_root = substr($webserver_root, strlen($_SERVER['DOCUMENT_ROOT'])-1);
 // Ensure web_root starts with a path separator
 if (preg_match("/^[^\/]/",$web_root)) {
  $web_root = "/".$web_root;


### PR DESCRIPTION
The first character of the directory immediately following the server name was missing e.g., `http://example.com:8080/penemr` instead of `http://example.com:8080/openemr`
If I had a nickel for ever time I've been bitten by a zero-indexed string...