### PR TITLE
Fix Patient selection for iOS

### DIFF
--- a/interface/main/finder/dynamic_finder.php
+++ b/interface/main/finder/dynamic_finder.php
@@ -104,7 +104,7 @@ $(document).ready(function() {
  });
 
  // OnClick handler for the rows
- $('#pt_table tbody tr').live('click', function () {
+ $('#pt_table tbody').delegate('tr', 'click', function () {
   var newpid = this.id.substring(4);
   if (document.myform.form_new_window.checked) {
    openNewTopWindow(newpid);


### PR DESCRIPTION
Currently, the Patients table does not respond to touch on an iOS device. The fix is to use the newer jQuery `delegate` instead of `live`.