### PR TITLE
Add global for SMTPSecure

### DIFF
--- a/library/classes/postmaster.php
+++ b/library/classes/postmaster.php
@@ -47,6 +47,7 @@ class MyMailer extends PHPMailer
                 $this->Username = $GLOBALS['SMTP_USER'];
                 $this->Password = $GLOBALS['SMTP_PASS'];
                 $this->Port = $GLOBALS['SMTP_PORT'];
+                $this->SMTPSecure = $GLOBALS['SMTP_SECURE'];
             }
             break;
             case "SENDMAIL" :

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -1155,6 +1155,17 @@ $GLOBALS_METADATA = array(
       xl('Must be empty if SMTP authentication is not used.')
     ),
 
+    'SMTP_SECURE' => array(
+      xlt('SMTP security protocol to connect with'),
+      array(
+        '' => 'None',
+        'ssl'  => 'SSL',
+        'tls'  => 'TLS'
+      ),
+      '',
+      xla('SMTP security protocol to connect with. Required by some servers such as gmail.')
+    ),
+
     'EMAIL_NOTIFICATION_HOUR' => array(
       xl('Email Notification Hours'),
       'num',                            // data type


### PR DESCRIPTION
Add a global that maps to the SMTPSecure variable.

Let's you use SSL/TLS on SMTP connections.

Specifically had several clients using gmail, who requires secure connections.