### PR TITLE
Import snomed rf2

### DIFF
--- a/contrib/snomed_rf2/README
+++ b/contrib/snomed_rf2/README
@@ -1,0 +1,2 @@
+Directory to place SNOMED RF 2 Database files.
+In OpenEMR, go to Administration -> Other -> 'External Data Loads' for instructions.

--- a/interface/code_systems/dataloads_ajax.php
+++ b/interface/code_systems/dataloads_ajax.php
@@ -61,7 +61,7 @@ $activeAccordionSection = isset($_GET['aas']) ? $_GET['aas'] : '0';
 
 // placemaker for when support DSMIV
 // var db_list = [ "DSMIV", "ICD9", "ICD10", "RXNORM", "SNOMED"];
-var db_list = [ "ICD9", "ICD10", "RXNORM", "SNOMED"];
+var db_list = [ "ICD9", "ICD10", "RXNORM", "SNOMED", "SNOMED_RF2"];
 var accOpts = {
     header: "h3", 
     autoHeight: false,
@@ -130,7 +130,7 @@ var accOpts = {
 			var stg_load_id = '#' + $(ui.newContent).attr('id') + "_stg_loading";
   			$(stg_load_id).show();
 			var thisInterval; 
-      		        var parm = 'db=' + $(ui.newContent).attr('id') + '&newInstall=' + (($(this).val() === 'INSTALL') ? 1 : 0) + '&file_checksum=' + $(this).attr('file_checksum') + '&file_revision_date=' + $(this).attr('file_revision_date') + '&version=' + $(this).attr('version');
+      		var parm = 'db=' + $(ui.newContent).attr('id') + '&newInstall=' + (($(this).val() === 'INSTALL') ? 1 : 0) + '&file_checksum=' + $(this).attr('file_checksum') + '&file_revision_date=' + $(this).attr('file_revision_date') + '&version=' + $(this).attr('version') + '&snomed_extension=' + $(this).attr('snomed_extension');
 			var stg_dets_id = '#' + $(ui.newContent).attr('id') + "_stage_details";
 			$activeAccordionSection = $("#accordion").accordion('option', 'active');
 
@@ -270,7 +270,7 @@ div.tooltip p {
 //
 // placemaker for when support DSMIV
 //$db_list = array("DSMIV", "ICD9", "ICD10", "RXNORM", "SNOMED");
-$db_list = array("ICD9", "ICD10", "RXNORM", "SNOMED");
+$db_list = array("ICD9", "ICD10", "RXNORM", "SNOMED", "SNOMED_RF2");
 foreach ($db_list as $db) {
     ?>
     <h3><a href="#"><?php echo attr($db); ?></a></h3>

--- a/interface/code_systems/list_staged.php
+++ b/interface/code_systems/list_staged.php
@@ -129,7 +129,7 @@ if (is_dir($mainPATH)) {
             }
             else if ($db == 'SNOMED_RF2') {
             	if (preg_match("/SnomedCT_RF2Release_([A-Z]+)_([0-9]{8}).zip/", $file, $matches)) {	//import RF2-format
-            		$version = $matches[1];				//'INT' signals the (English) core, NL the Dutch Extension
+            		$version = $matches[1];				//'INT' signals the International core
             		$snomed_extension = "_".$matches[1]."_".$matches[2];
             		$date_release = substr($matches[2],0,4)."-".substr($matches[2],4,-2)."-".substr($matches[2],6);
             		$temp_date = array('date'=>$date_release, 'version'=>$version, 'path'=>$mainPATH."/".$matches[0]);

--- a/interface/code_systems/list_staged.php
+++ b/interface/code_systems/list_staged.php
@@ -91,6 +91,7 @@ if (!empty($sqlReturn)) {
 $file_revision_path = ''; //Holds the database file
 $file_revision_date = ''; //Holds the database file revision date
 $version = '';
+$snomed_extension = '';
 $revisions = array();
 $files_array = array();
 if (is_dir($mainPATH)) {
@@ -125,6 +126,16 @@ if (is_dir($mainPATH)) {
                     array_push($revisions,$temp_date);
 	    	    $supported_file = 1;
                 }
+            }
+            else if ($db == 'SNOMED_RF2') {
+            	if (preg_match("/SnomedCT_RF2Release_([A-Z]+)_([0-9]{8}).zip/", $file, $matches)) {	//import RF2-format
+            		$version = $matches[1];				//'INT' signals the (English) core, NL the Dutch Extension
+            		$snomed_extension = "_".$matches[1]."_".$matches[2];
+            		$date_release = substr($matches[2],0,4)."-".substr($matches[2],4,-2)."-".substr($matches[2],6);
+            		$temp_date = array('date'=>$date_release, 'version'=>$version, 'path'=>$mainPATH."/".$matches[0]);
+            		array_push($revisions,$temp_date);
+            		$supported_file = 1;
+            	}
             }
             else if ($db == 'SNOMED') {
                 if (preg_match("/SnomedCT_INT_([0-9]{8}).zip/",$file,$matches)) {
@@ -383,7 +394,7 @@ if ($supported_file === 1) {
     }
     if (strlen($action) > 0) {
     ?>
-	  <input id="<?php echo attr($db); ?>_install_button" version="<?php echo attr($file_revision); ?>" file_revision_date="<?php echo attr($file_revision_date); ?>" file_checksum="<?php echo attr($file_checksum); ?>" type="button" value="<?php echo attr($action); ?>"/>
+	  <input id="<?php echo attr($db); ?>_install_button" version="<?php echo attr($file_revision); ?>" snomed_extension="<?php echo attr($snomed_extension); ?>" file_revision_date="<?php echo attr($file_revision_date); ?>" file_checksum="<?php echo attr($file_checksum); ?>" type="button" value="<?php echo attr($action); ?>"/>
 	  </div> 
     <?php
     }

--- a/interface/code_systems/standard_tables_manage.php
+++ b/interface/code_systems/standard_tables_manage.php
@@ -49,6 +49,7 @@ if (!acl_check('admin', 'super')) {
 
 $db = isset($_GET['db']) ? $_GET['db'] : '0';
 $version = isset($_GET['version']) ? $_GET['version'] : '0';
+$snomed_extension = isset($_GET['snomed_extension']) ? $_GET['snomed_extension'] : '0';
 $file_revision_date = isset($_GET['file_revision_date']) ? $_GET['file_revision_date'] : '0';
 $file_checksum = isset($_GET['file_checksum']) ? $_GET['file_checksum'] : '0';
 $newInstall = 	isset($_GET['newInstall']) ? $_GET['newInstall'] : '0';
@@ -75,6 +76,12 @@ if ($db == 'RXNORM') {
         temp_dir_cleanup($db);
         exit;
     }
+} else if ($db == 'SNOMED_RF2') {		//attempt RF2 import
+	if (!snomed_rf2_import($version, $snomed_extension)) {
+		echo htmlspecialchars( xl('ERROR: Unable to load the file into the database.'), ENT_NOQUOTES)."<br>";
+		temp_dir_cleanup($db);
+		exit;
+	}
 } else if ( $db == 'SNOMED') {
     if ($version == "US Extension") {
         if (!snomed_import(TRUE)) {

--- a/library/standard_tables_capture.inc
+++ b/library/standard_tables_capture.inc
@@ -27,13 +27,13 @@
 // Function to copy a package to temp
 // $type (RXNORM, SNOMED etc.)
 function temp_copy($filename,$type) {
-
     if(!file_exists($filename)) {
         return false;
     }
 
     if(!file_exists($GLOBALS['temporary_files_dir']."/".$type)) {
         if(!mkdir($GLOBALS['temporary_files_dir']."/".$type, 0777, true)) {
+        		error_log("Could not make dir ".$GLOBALS['temporary_files_dir']."/".$type);
                 return false;
         }
     }
@@ -42,6 +42,7 @@ function temp_copy($filename,$type) {
         return true;
     }
     else {
+    	error_log("Could not copy file to".$GLOBALS['temporary_files_dir']."/".$type."/".basename($filename));
         return false;
     }
 }
@@ -55,7 +56,7 @@ function temp_unarchive($filename,$type) {
     }
     else {
 
-	// let's uzip the file
+	// let's unzip the file
 	// use checksums to determine the "version" 
 	//
         $zip = new ZipArchive;
@@ -235,6 +236,138 @@ function snomed_import($us_extension=FALSE) {
     return true;
 }
 
+/** Function to import SNOMED CT through the RF2 format. To start with, only
+ * import the core. TODO: accommodate RF2 extensions.
+ */
+function snomed_rf2_import($version, $file_extension) {
+	// set up array
+	$table_array_for_snomed=array(
+			"sct_concepts_drop"=>"DROP TABLE IF EXISTS `sct_rf2_concepts`",
+			"sct_concepts_structure"=>"CREATE TABLE IF NOT EXISTS `sct_rf2_concepts` (
+            `conceptId` bigint(18) NOT NULL,
+            `effectiveTime` int(8) NOT NULL,
+			`active` tinyint(1) NOT NULL,
+            `moduleId` bigint(18) NOT NULL,
+            `definitionStatusId` bigint(18) NOT NULL,
+            PRIMARY KEY (`conceptId`)
+            ) ENGINE=MyISAM",
+			"sct_descriptions_drop"=>"DROP TABLE IF EXISTS `sct_rf2_descriptions`",
+			"sct_descriptions_structure"=>"CREATE TABLE IF NOT EXISTS `sct_rf2_descriptions` (
+            `descriptionId` bigint(18) NOT NULL,
+			`effectiveTime` int(8) NOT NULL,
+			`active` tinyint(1) NOT NULL,
+            `moduleId` bigint(18) NOT NULL,
+            `conceptId` bigint(18) NOT NULL,
+			`languageCode` varchar(8) NOT NULL,
+			`typeId` bigint(18) NOT NULL,
+            `term` varchar(255) NOT NULL,
+            `caseSignificanceId` bigint(18) NOT NULL,
+            PRIMARY KEY (`descriptionId`)
+            ) ENGINE=MyISAM",
+			"sct_relationships_drop"=>"DROP TABLE IF EXISTS `sct_rf2_relationships`",
+			"sct_relationships_structure"=>"CREATE TABLE IF NOT EXISTS `sct_rf2_relationships` (
+            `relationshipId` bigint(18) NOT NULL,
+			`effectiveTime` int(8) NOT NULL,
+			`active` tinyint(1) NOT NULL,
+            `moduleId` bigint(18) NOT NULL,
+            `sourceId` bigint(18) NOT NULL,
+            `destinationId` bigint(18) NOT NULL,
+            `relationshipGroup` tinyint(1) NOT NULL,
+			`typeId` bigint(18) NOT NULL,
+            `characteristicTypeId`  bigint(18) NOT NULL,
+            `modifierId`  bigint(18) NOT NULL,
+            PRIMARY KEY (`relationshipId`)
+            ) ENGINE=MyISAM",
+			"sct_simplerefsets_drop"=>"DROP TABLE IF EXISTS `sct_rf2_simplerefsets`",
+			"sct_simplerefsets_structure"=>"CREATE TABLE IF NOT EXISTS `sct_rf2_simplerefsets` (
+            `id` bigint(36) NOT NULL,
+			`effectiveTime` int(8) NOT NULL,
+			`active` tinyint(1) NOT NULL,
+            `moduleId` bigint(18) NOT NULL,
+            `refsetId` bigint(18) NOT NULL,
+            `referencedComponentId` bigint(18) NOT NULL,
+            PRIMARY KEY (`id`)
+            ) ENGINE=MyISAM",
+			"sct_languagerefsets_drop"=>"DROP TABLE IF EXISTS `sct_rf2_languagerefsets`",
+			"sct_languagefsets_structure"=>"CREATE TABLE IF NOT EXISTS `sct_rf2_languagerefsets` (
+            `id` bigint(36) NOT NULL,
+			`effectiveTime` int(8) NOT NULL,
+			`active` tinyint(1) NOT NULL,
+            `moduleId` bigint(18) NOT NULL,
+            `refsetId` bigint(18) NOT NULL,
+            `referencedComponentId` bigint(18) NOT NULL,
+			`acceptabilityId` bigint(18) NOT NULL,
+            PRIMARY KEY (`id`)
+            ) ENGINE=MyISAM",
+			"sct_extendedmaprefsets_drop"=>"DROP TABLE IF EXISTS `sct_rf2_extendedmaprefsets`",
+			"sct_extendedmaprefsets_structure"=>"CREATE TABLE IF NOT EXISTS `sct_rf2_extendedmaprefsets` (
+            `id` bigint(36) NOT NULL,
+			`effectiveTime` int(8) NOT NULL,
+			`active` tinyint(1) NOT NULL,
+            `moduleId` bigint(18) NOT NULL,
+            `refsetId` bigint(18) NOT NULL,
+            `referencedComponentId` bigint(18) NOT NULL,
+			`mapGroup` int(8) NOT NULL,
+			`mapPriority` int(8) NOT NULL,
+			`mapRule` varchar(255) NOT NULL,
+			`mapAdvice` varchar(255) NOT NULL,
+			`mapTarget` varchar(36) NOT NULL,
+			`correlationId` bigint(18) NOT NULL,
+            PRIMARY KEY (`id`)
+            ) ENGINE=MyISAM"
+	);
+		
+	// executing the create statement for tables,
+	foreach ( $table_array_for_snomed as $val ) {
+		if (trim ( $val ) != '') {
+			sqlStatement ( $val );
+		}
+	}
+	
+	 // set up paths
+    $dir_snomed = $GLOBALS['temporary_files_dir']."/SNOMED_RF2/SnomedCT_RF2Release".$file_extension."/Snapshot/";
+    $dir_snomed=str_replace('\\','/',$dir_snomed);
+	
+	if(!(is_dir($dir_snomed) && $handle = opendir($dir_snomed))) {
+		echo "Cannot open $dir<br>";
+		return false;
+	}
+
+	$load_script = "Load data local infile '#FILENAME#' into table #TABLE# fields terminated by '\\t' ESCAPED BY '' lines terminated by '\\n' ignore 1 lines   ";
+	$array_replace = array (
+			"#FILENAME#",
+			"#TABLE#"
+	);
+	
+	$dir_terminology=$dir_snomed."Terminology/";
+	$conceptFile = $dir_terminology."sct2_Concept_Snapshot".$file_extension.".txt";
+	import_snomed_rf2_file($conceptFile, "sct_rf2_concepts", $load_script, $array_replace);
+	
+	$descriptionFile = $dir_terminology."sct2_Description_Snapshot-en".$file_extension.".txt";	//TODO in extensions language might be other than 'en'
+	import_snomed_rf2_file($descriptionFile, "sct_rf2_descriptions", $load_script, $array_replace);
+	
+	$relationFile = $dir_terminology."sct2_Relationship_Snapshot".$file_extension.".txt";	//TODO in extensions language might be other than 'en'
+	import_snomed_rf2_file($relationFile, "sct_rf2_relationships", $load_script, $array_replace);
+	
+	$dir_refset=$dir_snomed."Refset/";
+	$simpleRefsetFile = $dir_refset."Content/der2_Refset_SimpleSnapshot".$file_extension.".txt";
+	import_snomed_rf2_file($simpleRefsetFile, "sct_rf2_simplerefsets", $load_script, $array_replace);
+	
+	$languageRefsetFile = $dir_refset."Language/der2_cRefset_LanguageSnapshot-en".$file_extension.".txt";	//TODO language in extension
+	import_snomed_rf2_file($languageRefsetFile, "sct_rf2_languagerefsets", $load_script, $array_replace);
+	
+	$extendedmapRefsetFile = $dir_refset."Map/der2_iisssccRefset_ExtendedMapSnapshot".$file_extension.".txt";
+	import_snomed_rf2_file($extendedmapRefsetFile, "sct_rf2_extendedmaprefsets", $load_script, $array_replace);
+	
+	return true; 
+}
+
+function import_snomed_rf2_file($file, $table, $load_script, $array_replace)
+{
+	$conceptSql = str_replace($array_replace, array($file, $table), $load_script);
+	sqlStatement($conceptSql);
+}
+
 // Function to import ICD tables $type differentiates ICD 9, 10 and eventually 11 (circa 2018 :-) etc.
 //
 function icd_import($type) {
@@ -408,6 +541,10 @@ function update_tracker_table($type,$revision,$version,$file_checksum) {
     else if ($type == 'SNOMED') {
         sqlStatement("INSERT INTO `standardized_tables_track` (`imported_date`,`name`,`revision_date`, `revision_version`, `file_checksum`) VALUES (NOW(),'SNOMED',?,?,?)", array($revision, $version, $file_checksum) );
         return true;
+    }
+    else if ($type == 'SNOMED_RF2') {
+    	sqlStatement("INSERT INTO `standardized_tables_track` (`imported_date`,`name`,`revision_date`, `revision_version`, `file_checksum`) VALUES (NOW(),'SNOMED_RF2',?,?,?)", array($revision, $version, $file_checksum) );
+    	return true;
     }
     else if ($type == 'ICD9') {
         sqlStatement("INSERT INTO `standardized_tables_track` (`imported_date`,`name`,`revision_date`, `revision_version`, `file_checksum`) VALUES (NOW(),'ICD9',?,?,?)", array($revision, $version, $file_checksum) );

--- a/library/standard_tables_capture.inc
+++ b/library/standard_tables_capture.inc
@@ -241,7 +241,7 @@ function snomed_import($us_extension=FALSE) {
  */
 function snomed_rf2_import($version, $file_extension) {
 	// set up array
-	$table_array_for_snomed=array(
+	$table_array_for_snomed=array(			//concept table
 			"sct_concepts_drop"=>"DROP TABLE IF EXISTS `sct_rf2_concepts`",
 			"sct_concepts_structure"=>"CREATE TABLE IF NOT EXISTS `sct_rf2_concepts` (
             `conceptId` bigint(18) NOT NULL,
@@ -251,7 +251,7 @@ function snomed_rf2_import($version, $file_extension) {
             `definitionStatusId` bigint(18) NOT NULL,
             PRIMARY KEY (`conceptId`)
             ) ENGINE=MyISAM",
-			"sct_descriptions_drop"=>"DROP TABLE IF EXISTS `sct_rf2_descriptions`",
+			"sct_descriptions_drop"=>"DROP TABLE IF EXISTS `sct_rf2_descriptions`",		//description table
 			"sct_descriptions_structure"=>"CREATE TABLE IF NOT EXISTS `sct_rf2_descriptions` (
             `descriptionId` bigint(18) NOT NULL,
 			`effectiveTime` int(8) NOT NULL,
@@ -264,7 +264,7 @@ function snomed_rf2_import($version, $file_extension) {
             `caseSignificanceId` bigint(18) NOT NULL,
             PRIMARY KEY (`descriptionId`)
             ) ENGINE=MyISAM",
-			"sct_relationships_drop"=>"DROP TABLE IF EXISTS `sct_rf2_relationships`",
+			"sct_relationships_drop"=>"DROP TABLE IF EXISTS `sct_rf2_relationships`",	//relation table
 			"sct_relationships_structure"=>"CREATE TABLE IF NOT EXISTS `sct_rf2_relationships` (
             `relationshipId` bigint(18) NOT NULL,
 			`effectiveTime` int(8) NOT NULL,
@@ -278,7 +278,7 @@ function snomed_rf2_import($version, $file_extension) {
             `modifierId`  bigint(18) NOT NULL,
             PRIMARY KEY (`relationshipId`)
             ) ENGINE=MyISAM",
-			"sct_simplerefsets_drop"=>"DROP TABLE IF EXISTS `sct_rf2_simplerefsets`",
+			"sct_simplerefsets_drop"=>"DROP TABLE IF EXISTS `sct_rf2_simplerefsets`",	//simple refset (pick list) table
 			"sct_simplerefsets_structure"=>"CREATE TABLE IF NOT EXISTS `sct_rf2_simplerefsets` (
             `id` bigint(36) NOT NULL,
 			`effectiveTime` int(8) NOT NULL,
@@ -288,7 +288,7 @@ function snomed_rf2_import($version, $file_extension) {
             `referencedComponentId` bigint(18) NOT NULL,
             PRIMARY KEY (`id`)
             ) ENGINE=MyISAM",
-			"sct_languagerefsets_drop"=>"DROP TABLE IF EXISTS `sct_rf2_languagerefsets`",
+			"sct_languagerefsets_drop"=>"DROP TABLE IF EXISTS `sct_rf2_languagerefsets`",	//language refset (to identify preferred terms)
 			"sct_languagefsets_structure"=>"CREATE TABLE IF NOT EXISTS `sct_rf2_languagerefsets` (
             `id` bigint(36) NOT NULL,
 			`effectiveTime` int(8) NOT NULL,
@@ -299,8 +299,8 @@ function snomed_rf2_import($version, $file_extension) {
 			`acceptabilityId` bigint(18) NOT NULL,
             PRIMARY KEY (`id`)
             ) ENGINE=MyISAM",
-			"sct_extendedmaprefsets_drop"=>"DROP TABLE IF EXISTS `sct_rf2_extendedmaprefsets`",
-			"sct_extendedmaprefsets_structure"=>"CREATE TABLE IF NOT EXISTS `sct_rf2_extendedmaprefsets` (
+			"sct_extendedmaprefsets_drop"=>"DROP TABLE IF EXISTS `sct_rf2_extendedmaprefsets`",	//mapping table (only included mappings to ICD-10)
+			"sct_extendedmaprefsets_structure"=>"CREATE TABLE IF NOT EXISTS `sct_rf2_extendedmaprefsets` (	
             `id` bigint(36) NOT NULL,
 			`effectiveTime` int(8) NOT NULL,
 			`active` tinyint(1) NOT NULL,
@@ -325,7 +325,7 @@ function snomed_rf2_import($version, $file_extension) {
 	}
 	
 	 // set up paths
-    $dir_snomed = $GLOBALS['temporary_files_dir']."/SNOMED_RF2/SnomedCT_RF2Release".$file_extension."/Snapshot/";
+    $dir_snomed = $GLOBALS['temporary_files_dir']."/SNOMED_RF2/SnomedCT_RF2Release".$file_extension."/";
     $dir_snomed=str_replace('\\','/',$dir_snomed);
 	
 	if(!(is_dir($dir_snomed) && $handle = opendir($dir_snomed))) {
@@ -339,33 +339,55 @@ function snomed_rf2_import($version, $file_extension) {
 			"#TABLE#"
 	);
 	
-	$dir_terminology=$dir_snomed."Terminology/";
-	$conceptFile = $dir_terminology."sct2_Concept_Snapshot".$file_extension.".txt";
-	import_snomed_rf2_file($conceptFile, "sct_rf2_concepts", $load_script, $array_replace);
+	$dir_terminology=$dir_snomed."Snapshot/Terminology/";
+	$dir_refset=$dir_snomed."Snapshot/Refset/";
+	$language = "-en";		//TODO If you can figure out the language from the filename (not consistent among SNOMED distributions)
+							//then change this variable, e.g. to "-es"
+	//import the core tables. This should also work for US and Spanish Editions (Extensions are no longer distributed by these NRC's)
+	import_snomed_rf2_file($dir_terminology, "sct2_Concept_Snapshot", $file_extension, "sct_rf2_concepts", $load_script, $array_replace);
+	import_snomed_rf2_file($dir_terminology, "sct2_Description_Snapshot".$language, $file_extension, "sct_rf2_descriptions", $load_script, $array_replace);
+	import_snomed_rf2_file($dir_terminology, "sct2_Relationship_Snapshot", $file_extension, "sct_rf2_relationships", $load_script, $array_replace);
+	import_snomed_rf2_file($dir_refset, "Content/der2_Refset_SimpleSnapshot", $file_extension, "sct_rf2_simplerefsets", $load_script, $array_replace);
+	import_snomed_rf2_file($dir_refset, "Language/der2_cRefset_LanguageSnapshot".$language, $file_extension, "sct_rf2_languagerefsets", $load_script, $array_replace);
+	import_snomed_rf2_file($dir_refset, "Map/der2_iisssccRefset_ExtendedMapSnapshot", $file_extension, "sct_rf2_extendedmaprefsets", $load_script, $array_replace);
 	
-	$descriptionFile = $dir_terminology."sct2_Description_Snapshot-en".$file_extension.".txt";	//TODO in extensions language might be other than 'en'
-	import_snomed_rf2_file($descriptionFile, "sct_rf2_descriptions", $load_script, $array_replace);
-	
-	$relationFile = $dir_terminology."sct2_Relationship_Snapshot".$file_extension.".txt";	//TODO in extensions language might be other than 'en'
-	import_snomed_rf2_file($relationFile, "sct_rf2_relationships", $load_script, $array_replace);
-	
-	$dir_refset=$dir_snomed."Refset/";
-	$simpleRefsetFile = $dir_refset."Content/der2_Refset_SimpleSnapshot".$file_extension.".txt";
-	import_snomed_rf2_file($simpleRefsetFile, "sct_rf2_simplerefsets", $load_script, $array_replace);
-	
-	$languageRefsetFile = $dir_refset."Language/der2_cRefset_LanguageSnapshot-en".$file_extension.".txt";	//TODO language in extension
-	import_snomed_rf2_file($languageRefsetFile, "sct_rf2_languagerefsets", $load_script, $array_replace);
-	
-	$extendedmapRefsetFile = $dir_refset."Map/der2_iisssccRefset_ExtendedMapSnapshot".$file_extension.".txt";
-	import_snomed_rf2_file($extendedmapRefsetFile, "sct_rf2_extendedmaprefsets", $load_script, $array_replace);
-	
+	$dir_extension = $dir_snomed."NL_Extension/";	//if the Dutch Extension is included, import that as well
+	if (is_dir($dir_extension))			//Extension is distributed within Dutch Edition alongside the INT-version. Just add the extra lines to each table
+	{
+		$language_nl = "";				//Dutch extension contains English and Dutch descriptions, therefore does not include language in filename
+		$dir_terminology_extension = $dir_extension."Snapshot/Terminology/";
+		$dir_refset_extension = $dir_extension."Snapshot/Refset/";
+		$files_array = scandir($dir_terminology_extension);
+		$file_extension_nl = $file_extension;
+		
+		foreach ($files_array as $file)	//Dutch extension is generated 1-2 months later than core (of necessity), so find new file extension
+		{
+			if (preg_match("/sct2_Concept_Snapshot(_[A-Z]+_[0-9]{8}).txt/", $file, $matches))
+			{
+				$file_extension_nl = $matches[1];
+				break;
+			}
+		}
+		
+		import_snomed_rf2_file($dir_terminology_extension, "sct2_Concept_Snapshot", $file_extension_nl, "sct_rf2_concepts", $load_script, $array_replace);
+		import_snomed_rf2_file($dir_terminology_extension, "sct2_Description_Snapshot".$language_nl, $file_extension_nl, "sct_rf2_descriptions", $load_script, $array_replace);
+		import_snomed_rf2_file($dir_terminology_extension, "sct2_Relationship_Snapshot", $file_extension_nl, "sct_rf2_relationships", $load_script, $array_replace);
+		import_snomed_rf2_file($dir_refset_extension, "Content/der2_Refset_SimpleSnapshot", $file_extension_nl, "sct_rf2_simplerefsets", $load_script, $array_replace);
+		import_snomed_rf2_file($dir_refset_extension, "Language/der2_cRefset_LanguageSnapshot".$language_nl, $file_extension_nl, "sct_rf2_languagerefsets", $load_script, $array_replace);
+		import_snomed_rf2_file($dir_refset_extension, "Map/der2_iisssccRefset_ExtendedMapSnapshot", $file_extension_nl, "sct_rf2_extendedmaprefsets", $load_script, $array_replace);
+	}
+
 	return true; 
 }
 
-function import_snomed_rf2_file($file, $table, $load_script, $array_replace)
+function import_snomed_rf2_file($dir, $filename, $fileextension, $table, $load_script, $array_replace)
 {
-	$conceptSql = str_replace($array_replace, array($file, $table), $load_script);
-	sqlStatement($conceptSql);
+	$file = $dir.$filename.$fileextension.".txt";
+	if (file_exists($file))
+	{
+		$sql = str_replace($array_replace, array($file, $table), $load_script);
+		sqlStatement($sql);
+	}
 }
 
 // Function to import ICD tables $type differentiates ICD 9, 10 and eventually 11 (circa 2018 :-) etc.


### PR DESCRIPTION
Goal: supporting the import SNOMED CT with the new RF2 format (as part of Developer projects 2 & 3). The RF2 data is loaded into separate tables, all starting with sct_rf2_, and is not yet used in any part of OpenEMR. The import includes the core components (concepts, descriptions and relations) as well as a number of useful extensions (subsets for pick lists, identifying preferred descriptions, and mappings to ICD-10).
