### PR TITLE
Cleaner display of theme options

### DIFF
--- a/interface/super/edit_globals.php
+++ b/interface/super/edit_globals.php
@@ -511,9 +511,13 @@ foreach ($GLOBALS_METADATA as $grpname => $grparr) {
             $tfname == 'style_blue.css' || $tfname == 'style_pdf.css')
             continue;
           echo "<option value='$tfname'";
+          // Drop the "style_" part and any replace any underscores with spaces
+          $styleDisplayName = str_replace("_", " ", substr($tfname, 6));
+          // Strip the ".css" and uppercase the first character
+          $styleDisplayName = ucfirst(str_replace(".css", "", $styleDisplayName));
           if ($tfname == $fldvalue) echo " selected";
           echo ">";
-          echo $tfname;
+          echo $styleDisplayName;
           echo "</option>\n";
         }
         closedir($dh);


### PR DESCRIPTION
Just a simple change to update the way the edit_globals page displays the theme options. Instead of "style_light.css" it displays "Light" but leaves the value option still set to "style_light.css"