### PR TITLE
Payments recurring appt related fixes

### DIFF
--- a/library/encounter_events.inc.php
+++ b/library/encounter_events.inc.php
@@ -45,13 +45,13 @@ function calendar_arrived($form_pid) {
   if($appts) {
     $enc = todaysEncounterCheck($form_pid);
     foreach($appts as $row) {
-    if($row['pc_recurrtype'] == 0) {
-    sqlStatement("UPDATE openemr_postcalendar_events SET pc_apptstatus = '@' WHERE pc_eid = ?", array($row['pc_eid']));
-    } else {
-      update_event($row['pc_eid']);
+      if($row['pc_recurrtype'] == 0) {
+        sqlStatement("UPDATE openemr_postcalendar_events SET pc_apptstatus = '@' WHERE pc_eid = ?", array($row['pc_eid']));
+      } else {
+        update_event($row['pc_eid']);
+      }
     }
-  }
-  return $enc;
+    return $enc;
   } else {
     echo "<br><br><br>".htmlspecialchars( xl('Sorry No Appointment is Fixed'), ENT_QUOTES ).". ".htmlspecialchars( xl('No Encounter could be created'), ENT_QUOTES ).".";
     die;


### PR DESCRIPTION
Rewrite of the calendar_arrived function to synchronize recurring rt2 appts to the calendar.

Fixes this bug also...

For recurring appts set on the same day as payment ($today) status of rt1 or rt2 event is changed to '@'
instead of the date ($today) being converted to an rt0 event with status '@'.

Notes...

the code calculating rt2 appts in the original calendar_arrived function disagrees with the calendar however since __increment is used to calculate rt1 appts it already responds to the weekend setting in admin for appts set with the "workday" option.

The calendar_arrived function is called when a payment is made for the current day ( Fees > Payments ) and no encounter exists for that day.

Code in front_payment.php ( line 170 ) calls calendar_arrived and this is the only call to calendar_arrived.

$zero_enc occurs three times in the codebase, once in front_payment.php and twice in calendar_arrived
and does not seem to do anything.

For more than one appt the updated appts (status) are likely written to the database in different order with
the new code.
