### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,8 +3,7 @@ root = true
 [*]
 end_of_line = lf
 indent_style = tab
-indent_size = 4
 charset = utf-8
-trim_trailing_whitespace = false
-insert_final_newline = false
+trim_trailing_whitespace = true
+insert_final_newline = true
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+end_of_line = lf
+indent_style = tab
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false
+


### PR DESCRIPTION
.editorconfig is a file that integrates with many IDEs to help keep code standards in check.

This won't retroactively change spaces to tabs, will just create a tab when you hit the `tab` key from now on.