### PR TITLE
Minor fixes in client side validation

### DIFF
--- a/interface/patient_file/summary/demographics_full.php
+++ b/interface/patient_file/summary/demographics_full.php
@@ -400,7 +400,7 @@ $constraints = LBF_Validation::generate_validate_constraints("DEM");
 			&nbsp;&nbsp;
 		</td>
         <td>
-            <input class="css_btn" type="submit" value="<?php xl('Save','e'); ?>">
+            <input id="submit_btn" class="css_btn" type="submit" disabled="disabled" value="<?php xl('Save','e'); ?>">
         </td>
 		<td>
 			<?php if ($GLOBALS['concurrent_layout']) { ?>
@@ -746,7 +746,6 @@ $group_seq=0; // this gives the DIV blocks unique IDs
 <br>
 
 <script language="JavaScript">
-
 // hard code validation for old validation, in the new validation possible to add match rules
 <?php if($GLOBALS['new_validate'] == 0) { ?>
  // fix inconsistently formatted phone numbers from the database

--- a/library/options.inc.php
+++ b/library/options.inc.php
@@ -2428,7 +2428,7 @@ function display_layout_tabs($formtype, $result1, $result2='') {
 	  if ($group_name === 'Employer' && $GLOBALS['omit_employers']) continue;
       ?>
 		<li <?php echo $first ? 'class="current"' : '' ?>>
-			<a href="/play/javascript-tabbed-navigation/" id="header_tab_<?php echo ".htmlspecialchars($group_name,ENT_QUOTES)."?>">
+            <a href="/play/javascript-tabbed-navigation/" id="header_tab_<?php echo str_replace(" ", "_",htmlspecialchars($group_name,ENT_QUOTES))?>">
                         <?php echo htmlspecialchars(xl_layout_label($group_name),ENT_NOQUOTES); ?></a>
 		</li>
 	  <?php

--- a/library/validation/validation_script.js.php
+++ b/library/validation/validation_script.js.php
@@ -217,5 +217,7 @@ function submitme(new_validate,e,form_id, constraints) {
         }
     }
     //enable submit button until load submitme function
-    document.getElementById('submit_btn').disabled = false;
+    if(document.getElementById('submit_btn') != null){
+        document.getElementById('submit_btn').disabled = false;
+    }
 </script>

--- a/library/validation/validation_script.js.php
+++ b/library/validation/validation_script.js.php
@@ -47,7 +47,7 @@ function submitme(new_validate,e,form_id, constraints) {
 
         //Use the old validation script if no parameter sent (backward compatibility)
         //if we want to use the "old" validate function (set in globals) the validate function that will be called is the one that
-        // was on code up to today (the validat library was not loaded ( look at the top of this file)
+        // was on code up to today (the validate library was not loaded ( look at the top of this file)
         if (new_validate !== 1) {
             var f = document.forms[0];
             if (validate(f)) {
@@ -71,23 +71,29 @@ function submitme(new_validate,e,form_id, constraints) {
             //TODO: implement a traslation mechanism of the errors that the library returns
             var error_msg ='<?php echo xl('is not valid');?>';
             var form = document.querySelector("form#"+form_id);
-
             //gets all the "elements" in the form and sends them to the validate library
             //for more information @see https://validatejs.org/
             var elements = validate.collectFormValues(form);
-            //before catch all values - clear filed that in display none, this will enable to fail on this fields.
-                $.each(elements, function(key, element){
+            var element, new_key;
 
-                   if( $('#'+key).css('display') == 'none' || ($('#'+key).parent().prop('style') != undefined && $('#'+key).parent().prop('style').visibility == 'hidden')){
-                       $('#'+key).val("");
-                   }
-                });
-               //get the input value after romoving hide fields
+            //before catch all values - clear filed that in display none, this will enable to fail on this fields.
+            for(var key in elements){
+                    //catch th element with the name because the id of select-multiple contain '[]'
+                   // and jquery throws error in those situation
+                    element = $('[name="'+ key + '"]');
+                    if(!$(element).is('select[multiple]')) {
+
+                        if($(element).parent().prop('style') != undefined && $(element).parent().prop('style').visibility == 'hidden'){
+                            console.log(element);
+                            $(element).val("");
+                        }
+                    }
+                }
+
+            //get the input value after romoving hide fields
             elements = validate.collectFormValues(form);
             //custom validate for multiple select(failed validate.js)
             //the validate js cannot handle the LBF multiple select fields
-            var element, new_key;
-
             for(var key in elements){
 
                 element = $('[name="'+ key + '"]');
@@ -207,8 +213,9 @@ function submitme(new_validate,e,form_id, constraints) {
                     $('a#header_tab_'+type_tab).css('color', 'black');
                 }
             }
-
             return valid;
         }
     }
+    //enable submit button until load submitme function
+    document.getElementById('submit_btn').disabled = false;
 </script>

--- a/library/validation/validation_script.js.php
+++ b/library/validation/validation_script.js.php
@@ -75,7 +75,15 @@ function submitme(new_validate,e,form_id, constraints) {
             //gets all the "elements" in the form and sends them to the validate library
             //for more information @see https://validatejs.org/
             var elements = validate.collectFormValues(form);
+            //before catch all values - clear filed that in display none, this will enable to fail on this fields.
+                $.each(elements, function(key, element){
 
+                   if( $('#'+key).css('display') == 'none' || ($('#'+key).parent().prop('style') != undefined && $('#'+key).parent().prop('style').visibility == 'hidden')){
+                       $('#'+key).val("");
+                   }
+                });
+               //get the input value after romoving hide fields
+            elements = validate.collectFormValues(form);
             //custom validate for multiple select(failed validate.js)
             //the validate js cannot handle the LBF multiple select fields
             var element, new_key;


### PR DESCRIPTION
1. We fix the line 2331 at library/options.inc.php to print right class in the tab of edit LBF screens. (before the fix the function doesn't run). This fix enable to mark the tab when have error.   

2. fix in library/validation/validation_script.js.php - before validation the script clean of all the disappear inputs else the validation will check them also and may fail. 