### PR TITLE
Flow tracker with persistent user settings

### DIFF
--- a/interface/main/left_nav.php
+++ b/interface/main/left_nav.php
@@ -1053,7 +1053,22 @@ $(document).ready(function(){
 <form method='post' name='find_patient' target='RTop'
  action='<?php echo $rootdir ?>/main/finder/patient_select.php'>
 
-<?php if ( ( $GLOBALS['concurrent_layout'] == 2) || ($GLOBALS['concurrent_layout'] == 3) ) { ?>
+<?php if ( ( $GLOBALS['concurrent_layout'] == 2) || ($GLOBALS['concurrent_layout'] == 3) ) {
+  // mdsupport - menu showhide arrows
+  if ($_SESSION['language_direction'] == 'ltr') {
+    $ahide = 'fa-angle-double-left';
+    $ashow = 'fa-angle-double-right';
+  } else {
+    $ahide = 'fa-angle-double-right';
+    $ashow = 'fa-angle-double-left';
+  }        
+?>
+<div>
+  <span style='margin-left:-3px;float:left;background:black;height:14px;width:8px;'>
+    <a id='showhide'><i id='fa-arrows' class="fa <?php echo $ahide ?>" aria-hidden="true" style='color:white;font-size: 16px;'></i></a>
+  </span>
+</div>
+
 <center>
 <select name='sel_frame' style='background-color:transparent;font-size:9pt;width:100;'>
  <option value='0'><?php xl('Default','e'); ?></option>
@@ -1534,6 +1549,35 @@ if (!empty($reg)) {
 
 <script language='JavaScript'>
 syncRadios();
+
+$('#showhide').click( function() {
+	var fa=$('#fa-arrows');
+	var exp = fa.hasClass('fa-angle-double-right');
+	var m = parent.document.getElementById("fsbody");
+	var r = parent.document.getElementById("fsright");
+	var nav = parent.document.getElementsByName("left_nav")[0];
+	var srv = <?php echo json_encode(array(
+	    'ahide' => $ahide,
+	    'whide' => ($_SESSION['language_direction'] == 'ltr' ? '8,*' : '*,8'),
+	    'ashow' => $ashow,
+	    'wshow' => ($_SESSION['language_direction'] == 'ltr' ? $GLOBALS['gbl_nav_area_width'].',*' : '*,'.$GLOBALS['gbl_nav_area_width']),
+	)); ?>;
+	if (m.cols == srv.whide) {
+ 	  m.frameborder = '1';
+ 	  r.frameborder = '1';
+		m.cols = srv.wshow;
+  	$('#fa-arrows').removeClass(srv.ashow);
+  	$('#fa-arrows').addClass(srv.ahide);
+  	nav.scrolling = 'yes';
+	} else {
+	  m.frameborder = '0';
+	  r.frameborder = '0';
+		m.cols = srv.whide;
+  	$('#fa-arrows').removeClass(srv.ahide);
+  	$('#fa-arrows').addClass(srv.ashow);
+  	nav.scrolling = 'no';
+	}
+});
 </script>
 
 </body>

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -113,7 +113,6 @@ $USER_SPECIFIC_GLOBALS = array('default_top_pane',
                                'pat_trkr_timer',
                                'ptkr_visit_reason',
                                'checkout_roll_off',
-                               'ptkr_pt_list_new_window',                               
                                'erx_import_status_message');
 
 $GLOBALS_METADATA = array(
@@ -1374,13 +1373,6 @@ $GLOBALS_METADATA = array(
       xl('Do not display the patient flow board.')
     ),
 
-    'ptkr_pt_list_new_window' => array(
-      xl('Open Demographics in New Window from Patient Flow Board'),
-      'bool',                           // data type
-      '0',                              // default = false
-      xl('When Checked, Demographics Will Open in New Window from Patient Flow Board.')
-    ),
-    
     'ptkr_visit_reason' => array(
       xl('Show Visit Reason in Patient Flow Board'),
       'bool',                           // data type

--- a/library/user.inc
+++ b/library/user.inc
@@ -19,16 +19,17 @@ function effectiveUser($user) {
  * 
  * @param string $label - Setting key
  * @param int $user - user id number from users table
+ * @param int $defaultUser - user id to check as alternative/default
  * @return Effective user setting for $label (NULL if does not exist)
  */
-function getUserSetting($label, $user=NULL) {
+function getUserSetting($label, $user=NULL, $defaultUser=0) {
 
   $user = effectiveUser($user);
 
   // Collect entry for specified user or 0 (global default user)
   $res = sqlQuery("SELECT setting_value FROM user_settings 
       WHERE (setting_user=? OR setting_user=?) AND setting_label=?
-      ORDER BY setting_user DESC", array($user, 0, $label));
+      ORDER BY setting_user DESC", array($user, $defaultUser, $label));
 
   // If no entries exist, then return NULL.
   return (isset($res['setting_value']) ? $res['setting_value'] : NULL);
@@ -64,7 +65,7 @@ function setUserSetting($label, $value, $user=NULL, $createDefault=TRUE) {
   
   $user = effectiveUser($user);
 
-  $cur_value = getUserSetting($label, $user);
+  $cur_value = getUserSetting($label, $user, $user);
 
   // Check for a custom settings
   if (is_null($cur_value)) {
@@ -93,11 +94,9 @@ function removeUserSetting($label,$user=NULL) {
       "WHERE setting_user=? AND setting_label=?", array($user, $label) );
 }
 
-// mdsupport - Seems superfluous - sqlQuery function will do the same thing.
 function getUserIDInfo($id)
 {
-    $res= sqlStatement("SELECT fname,lname,username FROM users where id=?",array($id));
-    return sqlFetchArray($res);
+    return sqlQuery("SELECT fname, lname, username FROM users where id=?", array($id));
 }
 
 /**

--- a/library/user.inc
+++ b/library/user.inc
@@ -9,139 +9,123 @@
 require_once(dirname(__FILE__) . "/sql.inc");
 require_once(dirname(__FILE__) . "/formdata.inc.php");
 
-//This will return the user setting(s) from the 'users' table.
-// $choice can be used to return only one specific user setting
-// $user is the user id number in the 'users' table
-// Returns the selected user setting (if does not exist, then returns 0)
-function getUserSetting($label,$user=NULL) {
-
-  // if no user id is sent, then use the currently logged in user
-  if (!isset($user)) {
-    $user = $_SESSION['authUserID'];
-  }
-    
-  // Collect entry if it exist.
-  //  If does not exist, then look for a default entry.
-  //    If default entry does not exist, then return a '0'.
-  // setting.
-  $result = sqlQuery("SELECT setting_value FROM user_settings " .
-    "WHERE setting_user=? AND setting_label=?", array($user, $label) );
-  if (empty($result)) {
-    $result = sqlQuery("SELECT setting_value FROM user_settings " .
-      "WHERE setting_user='0' AND setting_label=?", array($label) );
-    if (empty($result)) {
-      return '0';
-    }
-  }
-  
-  // Only one value, so collect it
-  $tempResult = $result;
-  foreach($tempResult as $key=>$value) {
-    $result = $value;
-  }
-  
-  return $result;
+// Set effective user - If no user id is provided, then use the currently logged in user
+function effectiveUser($user) {
+  return (is_null($user) ? $_SESSION['authUserID'] : $user);
 }
 
-//This will check a user setting
-// $name is the setting name in the 'users' table
-// $value is the setting value to be checked in the 'users' table
-// $user is the user id number in the 'users' table
-// Returns true if setting exist and false if does not exist
+/**
+ * Return user setting(s) from the 'users' table
+ * 
+ * @param string $label - Setting key
+ * @param int $user - user id number from users table
+ * @return Effective user setting for $label (NULL if does not exist)
+ */
+function getUserSetting($label, $user=NULL) {
+
+  $user = effectiveUser($user);
+
+  // Collect entry for specified user or 0 (global default user)
+  $res = sqlQuery("SELECT setting_value FROM user_settings 
+      WHERE (setting_user=? OR setting_user=?) AND setting_label=?
+      ORDER BY setting_user DESC", array($user, 0, $label));
+
+  // If no entries exist, then return NULL.
+  return (isset($res['setting_value']) ? $res['setting_value'] : NULL);
+}
+
+/**
+ * Check if effective user setting matches given value
+ * 
+ * @param string $label - Setting key
+ * @param string $value - Setting value
+ * @param int $user - user id number from users table
+ * @return boolean - true if setting exist and false if does not exist
+ */
 function checkUserSetting($label, $value, $user=NULL) {
 
-  // if no user id is sent, then use the currently logged in user
-  if (!isset($user)) {
-    $user = $_SESSION['authUserID'];
+  $curval = getUserSetting ($label, $user);
+  if (is_null($curval)) {
+    return false;
+  } else {
+    return ($curval === $value);
   }
-
-  // Check for the user settings
-  //  If does not exist, then check for a default entry.
-  //  (return false if setting does not exist)
-  $result = sqlQuery("SELECT setting_value FROM user_settings " .
-    "WHERE setting_user=? AND setting_label=? AND setting_value=?", array($user, $label, $value) );
-  if (empty($result)) {
-    $result = sqlQuery("SELECT setting_value FROM user_settings " .
-      "WHERE setting_user='0' AND setting_label=? AND setting_value=?", array($label, $value) );
-    if (empty($result)) {
-      return false;
-    }
-  }
-  
-  // Setting exist, so return true
-  return true;
 }
 
-//This will set a user setting
-// $name is the setting name in the 'users' table
-// $value is the setting value to be set in the 'users' table
-// $user is the user id number in the 'users' table
-// $createDefault is flag to create a default value if it does not yet exist
+/**
+ * Set a user setting 
+ * 
+ * @param string $label - Setting key
+ * @param string $value - Setting value
+ * @param int $user - user id number from users table
+ * @param boolean $createDefault - If no current global default value, create one. 
+ */
 function setUserSetting($label, $value, $user=NULL, $createDefault=TRUE) {
-  // if no user id is sent, then use the currently logged in user
-  if (!isset($user)) {
-    $user = $_SESSION['authUserID'];
-  }
+  
+  $user = effectiveUser($user);
 
-  $newCustom=false;
-  $newDefault=false;
+  $cur_value = getUserSetting($label, $user);
 
   // Check for a custom settings
-  $row = sqlQuery("SELECT setting_value FROM user_settings " .
-    "WHERE setting_user=? AND setting_label=?", array($user, $label) );
-  if (empty($row)) {
-    $newCustom=true;
-  }
-
-  // Set the custom setting
-  if ($newCustom) {
-    sqlStatement("INSERT INTO user_settings " .
-      "(setting_user, setting_label, setting_value) " .
+  if (is_null($cur_value)) {
+    sqlStatement("INSERT INTO user_settings(setting_user, setting_label, setting_value) " .
       "VALUES (?,?,?)", array($user, $label, $value) );
-  }
-  else {
+  } elseif ($cur_value !== $value) {
     sqlStatement("UPDATE user_settings SET setting_value=? " .
       "WHERE setting_user=? AND setting_label=?", array($value, $user, $label) );
   }
-
-  // Check for a default settings
-  $row = sqlQuery("SELECT setting_value FROM user_settings " .
-    "WHERE setting_user='0' AND setting_label=?", array($label) );
-  if (empty($row)) {
-    $newDefault=true;
-  }
-
-  // Place a default setting if it does not already exist (and createDefault flag is set)
-  if ($newDefault && $createDefault) {
-    sqlStatement("INSERT INTO user_settings " .
-      "(setting_user, setting_label, setting_value) " .
-      "VALUES ('0',?,?)", array($label, $value) );
+  
+  // Call self to create default value
+  if ($createDefault) {
+    setUserSetting($label, $value, 0, false);
   }
 }
 
 //This will remove the selected user setting from the 'user_settings' table.
 // $label is used to determine which setting to remove
-// $user is the user id number in the 'users' table
+// $user is the user id number from users table
 function removeUserSetting($label,$user=NULL) {
-  // if no user id is sent, then use the currently logged in user
-  if (!isset($user)) {
-    $user = $_SESSION['authUserID'];
-  }
+
+  $user = effectiveUser($user);
   
-  // Collect entry if it exist.
-  //  If it exists, then delete the entry.
-  $result = sqlQuery("SELECT setting_value FROM user_settings " .
-    "WHERE setting_user=? AND setting_label=?", array($user, $label) );
-  if (!empty($result)) {
-    sqlQuery("DELETE FROM user_settings " .
+  // mdsupport - DELETE has implicit select, no need to check and delete
+  sqlQuery("DELETE FROM user_settings " .
       "WHERE setting_user=? AND setting_label=?", array($user, $label) );
-  }
 }
 
-
+// mdsupport - Seems superfluous - sqlQuery function will do the same thing.
 function getUserIDInfo($id)
 {
     $res= sqlStatement("SELECT fname,lname,username FROM users where id=?",array($id));
     return sqlFetchArray($res);
+}
+
+/**
+ * Function to retain current user's choices from prior sessions  
+ * @param string $uspfx - Caller specified prefix to be used in settings key, typically script name
+ * @param string $postvar - $_POST variable name containing current value
+ * @param string $label - Caller specified constant added to $uspfx to create settings key
+ * @param string $initval - Initial value to be saved in case user setting does not exist
+ * @return Prior setting (if found) or initial value to be used in script
+ */
+function prevSetting($uspfx, $postvar, $label, $initval) {
+  
+  $setting_key = $uspfx.$label;
+  
+  if (isset($_POST[$postvar])) {
+    // If script provides current value, store it for future use.
+    $pset = $_POST[$postvar];
+    if ($pset != getUserSetting($setting_key)) {
+      setUserSetting($setting_key, $_POST[$postvar]);
+    }
+  } else {
+    // Script requires prior value
+    $pset = getUserSetting($setting_key);
+    if (is_null($pset)) {
+      setUserSetting($setting_key, $initval);
+      $pset = getUserSetting($setting_key);
+    }
+  }
+  return $pset;
 }
 ?>


### PR DESCRIPTION
1. Sharing new function (prevSetting) added to user.inc that enables persistent page settings per user.  This function reduces need for global settings and lets user control application behavior.  Existing user setting functions had no ability to return "not found" in cases where 0 can be a valid setting.  Revised function returns NULL if settings are not found.  Since php uses null and 0 interchangeably, it should not impact current code.  But further testing will be needed.

2. Use of prevSetting is illustrated in patient_tracker.php.  Due to background timer, persistence may not seem to work in few instances if the change does not go through one background cycle.  In most other form based manual submits scripts will not require these type of extra changes.

Please ignore whitespace conflicts as well as Eclipse friendly comments.