### PR TITLE
Sort all the drop-lists by selected language

### DIFF
--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -357,6 +357,15 @@ $GLOBALS_METADATA = array(
       xl('Show Insurance Address Information in the Insurance Panel of Demographics.')
     
   ),
+      'gb_how_sort_list' => array(
+          xl('How to sort a drop-lists'),
+          array(
+              '0' => 'Sort by seq',
+              '1' => 'Sort alphabetically'
+          ),
+          '0',
+          xl('What kind of sorting will be in the drop lists.')
+      )
 
   ),
 

--- a/library/options.inc.php
+++ b/library/options.inc.php
@@ -126,21 +126,26 @@ function generate_select_list($tag_name, $list_id, $currvalue, $title, $empty_na
     // List order depends on language translation options.
     $lang_id = empty($_SESSION['language_choice']) ? '1' : $_SESSION['language_choice'];
 
-    if (($lang_id == '1' && !empty($GLOBALS['skip_english_translation'])) ||
-        !$GLOBALS['translate_lists']) {
-        $lres = sqlStatement("SELECT * FROM list_options WHERE list_id = ? AND activity=1 ORDER BY seq, title", array($list_id));
-    } else {
+    if ($GLOBALS['gb_how_sort_list'] == '0') {
+      //sort by seq
+      $lres = sqlStatement("SELECT * FROM list_options WHERE list_id = ? ORDER BY seq, title", array($list_id));
+    } elseif($GLOBALS['gb_how_sort_list'] == '1') {
+      // sort by title
+      if (($lang_id == '1' && !empty($GLOBALS['skip_english_translation'])) || !$GLOBALS['translate_lists']) {
+        $lres = sqlStatement("SELECT * FROM list_options WHERE list_id = ? ORDER BY title, seq", array($list_id));
+      } else {
         $lres = sqlStatement("SELECT lo.option_id, " .
             "IF(LENGTH(ld.definition),ld.definition,lo.title) AS title " .
             "FROM list_options AS lo " .
             "LEFT JOIN lang_constants AS lc ON lc.constant_name = lo.title " .
             "LEFT JOIN lang_definitions AS ld ON ld.cons_id = lc.cons_id AND " .
-            "ld.lang_id = '$lang_id' " .
+            "ld.lang_id = ? " .
             "WHERE lo.list_id = ? " .
-            "ORDER BY IF(LENGTH(ld.definition),ld.definition,lo.seq), lo.title", array($list_id));
+            "ORDER BY IF(LENGTH(ld.definition),ld.definition,lo.title), lo.seq", array($lang_id, $list_id));
+      }
     }
-	$got_selected = FALSE;
-	
+    $got_selected = FALSE;
+
 	while ( $lrow = sqlFetchArray ( $lres ) ) {
 		$selectedValues = explode ( "|", $currvalue );
 		
@@ -162,22 +167,25 @@ function generate_select_list($tag_name, $list_id, $currvalue, $title, $empty_na
 	  if (!$got_selected && strlen($currvalue) > 0)
 	  {
 
-          if (($lang_id == '1' && !empty($GLOBALS['skip_english_translation'])) ||
-              !$GLOBALS['translate_lists']) {
-              $lres_inactive = sqlStatement("SELECT * FROM list_options " .
-                  "WHERE list_id = ? AND activity = 0 AND option_id = ? ORDER BY seq, title", array($list_id, $currvalue));
+        if ($GLOBALS['gb_how_sort_list'] == '0') {
+          //sort by seq
+          $lres_inactive = sqlStatement("SELECT * FROM list_options WHERE list_id = ? ORDER BY seq, title", array($list_id));
+        } elseif($GLOBALS['gb_how_sort_list'] == '1') {
+          // sort by title
+          if (($lang_id == '1' && !empty($GLOBALS['skip_english_translation'])) || !$GLOBALS['translate_lists']) {
+            $lres_inactive = sqlStatement("SELECT * FROM list_options WHERE list_id = ? ORDER BY title, seq", array($list_id));
           } else {
-              $lres_inactive = sqlStatement("SELECT lo.option_id, " .
-                  "IF(LENGTH(ld.definition),ld.definition,lo.title) AS title " .
-                  "FROM list_options AS lo " .
-                  "LEFT JOIN lang_constants AS lc ON lc.constant_name = lo.title " .
-                  "LEFT JOIN lang_definitions AS ld ON ld.cons_id = lc.cons_id AND " .
-                  "ld.lang_id = '$lang_id' " .
-                  "WHERE lo.list_id = ? lo.activity = 0 AND lo.option_id = ? " .
-                  "ORDER BY IF(LENGTH(ld.definition),ld.definition,lo.seq),lo.title", array($list_id, $currvalue));
+            $lres_inactive = sqlStatement("SELECT lo.option_id, " .
+                "IF(LENGTH(ld.definition),ld.definition,lo.title) AS title " .
+                "FROM list_options AS lo " .
+                "LEFT JOIN lang_constants AS lc ON lc.constant_name = lo.title " .
+                "LEFT JOIN lang_definitions AS ld ON ld.cons_id = lc.cons_id AND " .
+                "ld.lang_id = ? " .
+                "WHERE lo.list_id = ? " .
+                "ORDER BY IF(LENGTH(ld.definition),ld.definition,lo.title), lo.seq", array($lang_id, $list_id));
           }
-
-	    $lrow_inactive = sqlFetchArray($lres_inactive);
+        }
+          $lrow_inactive = sqlFetchArray($lres_inactive);
 	    if($lrow_inactive['option_id']) {
 	      $optionValue = htmlspecialchars( $lrow_inactive['option_id'], ENT_QUOTES);
 	      $s .= "<option value='$optionValue' selected>" . htmlspecialchars( xl_list_label($lrow_inactive['title']), ENT_NOQUOTES) . "</option>\n";
@@ -204,18 +212,23 @@ function generate_select_list($tag_name, $list_id, $currvalue, $title, $empty_na
 	} else if (!$got_selected && strlen ( $currvalue ) > 0 && $multiple) {
 		//if not found in main list, display all selected values that exist in backup list
 		$list_id = $backup_list;
-        if (($lang_id == '1' && !empty($GLOBALS['skip_english_translation'])) ||
-            !$GLOBALS['translate_lists']) {
+        if ($GLOBALS['gb_how_sort_list'] == '0') {
+            //sort by seq
             $lres_backup = sqlStatement("SELECT * FROM list_options WHERE list_id = ? ORDER BY seq, title", array($list_id));
-        } else {
+        } elseif($GLOBALS['gb_how_sort_list'] == '1') {
+            // sort by title
+          if(($lang_id == '1' && !empty($GLOBALS['skip_english_translation'])) ||!$GLOBALS['translate_lists']){
+            $lres_backup = sqlStatement("SELECT * FROM list_options WHERE list_id = ? ORDER BY title, seq", array($list_id));
+          } else {
             $lres_backup = sqlStatement("SELECT lo.option_id, " .
                 "IF(LENGTH(ld.definition),ld.definition,lo.title) AS title " .
                 "FROM list_options AS lo " .
                 "LEFT JOIN lang_constants AS lc ON lc.constant_name = lo.title " .
                 "LEFT JOIN lang_definitions AS ld ON ld.cons_id = lc.cons_id AND " .
-                "ld.lang_id = '$lang_id' " .
+                "ld.lang_id = ? " .
                 "WHERE lo.list_id = ? " .
-                "ORDER BY IF(LENGTH(ld.definition),ld.definition,lo.seq), lo.title", array($list_id));
+                "ORDER BY IF(LENGTH(ld.definition),ld.definition,lo.title), lo.seq", array($lang_id,$list_id));
+          }
         }
 
 		$got_selected_backup = FALSE;

--- a/library/options.inc.php
+++ b/library/options.inc.php
@@ -128,11 +128,11 @@ function generate_select_list($tag_name, $list_id, $currvalue, $title, $empty_na
 
     if ($GLOBALS['gb_how_sort_list'] == '0') {
       //sort by seq
-      $lres = sqlStatement("SELECT * FROM list_options WHERE list_id = ? ORDER BY seq, title", array($list_id));
+      $lres = sqlStatement("SELECT * FROM list_options WHERE list_id = ?  AND activity=1 ORDER BY seq, title", array($list_id));
     } elseif($GLOBALS['gb_how_sort_list'] == '1') {
       // sort by title
       if (($lang_id == '1' && !empty($GLOBALS['skip_english_translation'])) || !$GLOBALS['translate_lists']) {
-        $lres = sqlStatement("SELECT * FROM list_options WHERE list_id = ? ORDER BY title, seq", array($list_id));
+        $lres = sqlStatement("SELECT * FROM list_options WHERE list_id = ?  AND activity=1 ORDER BY title, seq", array($list_id));
       } else {
         $lres = sqlStatement("SELECT lo.option_id, " .
             "IF(LENGTH(ld.definition),ld.definition,lo.title) AS title " .
@@ -140,7 +140,7 @@ function generate_select_list($tag_name, $list_id, $currvalue, $title, $empty_na
             "LEFT JOIN lang_constants AS lc ON lc.constant_name = lo.title " .
             "LEFT JOIN lang_definitions AS ld ON ld.cons_id = lc.cons_id AND " .
             "ld.lang_id = ? " .
-            "WHERE lo.list_id = ? " .
+            "WHERE lo.list_id = ?  AND lo.activity=1 " .
             "ORDER BY IF(LENGTH(ld.definition),ld.definition,lo.title), lo.seq", array($lang_id, $list_id));
       }
     }
@@ -169,11 +169,11 @@ function generate_select_list($tag_name, $list_id, $currvalue, $title, $empty_na
 
         if ($GLOBALS['gb_how_sort_list'] == '0') {
           //sort by seq
-          $lres_inactive = sqlStatement("SELECT * FROM list_options WHERE list_id = ? ORDER BY seq, title", array($list_id));
+          $lres_inactive = sqlStatement("SELECT * FROM list_options WHERE list_id = ? AND activity = 0 AND option_id = ? ORDER BY seq, title", array($list_id, $currvalue));
         } elseif($GLOBALS['gb_how_sort_list'] == '1') {
           // sort by title
           if (($lang_id == '1' && !empty($GLOBALS['skip_english_translation'])) || !$GLOBALS['translate_lists']) {
-            $lres_inactive = sqlStatement("SELECT * FROM list_options WHERE list_id = ? ORDER BY title, seq", array($list_id));
+            $lres_inactive = sqlStatement("SELECT * FROM list_options WHERE list_id = ? AND activity = 0 AND option_id = ? ORDER BY title, seq", array($list_id, $currvalue));
           } else {
             $lres_inactive = sqlStatement("SELECT lo.option_id, " .
                 "IF(LENGTH(ld.definition),ld.definition,lo.title) AS title " .
@@ -181,8 +181,8 @@ function generate_select_list($tag_name, $list_id, $currvalue, $title, $empty_na
                 "LEFT JOIN lang_constants AS lc ON lc.constant_name = lo.title " .
                 "LEFT JOIN lang_definitions AS ld ON ld.cons_id = lc.cons_id AND " .
                 "ld.lang_id = ? " .
-                "WHERE lo.list_id = ? " .
-                "ORDER BY IF(LENGTH(ld.definition),ld.definition,lo.title), lo.seq", array($lang_id, $list_id));
+                "WHERE lo.list_id = ? AND lo.activity = 0 AND lo.option_id = ? " .
+                "ORDER BY IF(LENGTH(ld.definition),ld.definition,lo.title), lo.seq", array($lang_id, $list_id, $currvalue));
           }
         }
           $lrow_inactive = sqlFetchArray($lres_inactive);


### PR DESCRIPTION
We've added to the 'generate select list' (in library/options.inc.php used in LBF forms) functionally to sort the drop-lists by the selected language.
The sorting is done in the sql query (like language list in the login page).
It only happen if the language is not English and skip_english_translation is empty.
