### PR TITLE
Default option in drop list element

### DIFF
--- a/library/options.inc.php
+++ b/library/options.inc.php
@@ -131,11 +131,11 @@ function generate_select_list($tag_name, $list_id, $currvalue, $title, $empty_na
 		$optionValue = attr($lrow ['option_id']);
 		$s .= "<option value='$optionValue'";
 
-		if ($multiple && (strlen ( $currvalue ) == 0 && $lrow ['is_default']) || (strlen ( $currvalue ) > 0 && in_array ( $lrow ['option_id'], $selectedValues ))) {
+		if ((strlen ( $currvalue ) == 0 && $lrow ['is_default']) || (strlen ( $currvalue ) > 0 && in_array ( $lrow ['option_id'], $selectedValues ))) {
 			$s .= " selected";
 			$got_selected = TRUE;
 		}
-		
+
 		$optionLabel = text(xl_list_label($lrow ['title']));
 		$s .= ">$optionLabel</option>\n";
 	}
@@ -184,7 +184,7 @@ function generate_select_list($tag_name, $list_id, $currvalue, $title, $empty_na
 			
 				$optionValue = attr($lrow ['option_id']);
 			
-				if ($multiple && (strlen ( $currvalue ) == 0 && $lrow_backup ['is_default']) || 
+				if ((strlen ( $currvalue ) == 0 && $lrow_backup ['is_default']) ||
 						(strlen ( $currvalue ) > 0 && in_array ( $lrow_backup ['option_id'], $selectedValues ))) {
 					$s .= "<option value='$optionValue'";
 					$s .= " selected";


### PR DESCRIPTION
This is small fix in the library/options.inc.php that adds attribute ‘selected’ to ‘is default’ option also in a regular drop list.
Now in the code this happen just in multi select element but I don’t know why.
The condition is  that if not has current value ($currvalue) the attribute select is added to the ‘is_default’ option. (is default is limit to one row in all list in the edit list screen)

If  I mistake please correct me..

I've opened about it - https://sourceforge.net/p/openemr/bugs/458/

Thanks
Amiel