### PR TITLE
Consider $ignoreAuth for generating proc report.

### DIFF
--- a/interface/orders/single_order_results.inc.php
+++ b/interface/orders/single_order_results.inc.php
@@ -250,10 +250,10 @@ function generate_result_row(&$ctx, &$row, &$rrow, $priors_omitted=false) {
 }
 
 function generate_order_report($orderid, $input_form=false, $genstyles=true, $finals_only=false) {
-  global $aNotes;
+  global $aNotes, $ignoreAuth;
 
   // Check authorization.
-  $thisauth = acl_check('patients', 'med');
+  $thisauth = acl_check('patients', 'med') || (isset($ignoreAuth) ? $ignoreAuth : false);;
   if (!$thisauth) return xl('Not authorized');
 
   $orow = sqlQuery("SELECT " .


### PR DESCRIPTION
We probably need to consider security implications of modifying acl_check to implement $ignoreAuth globally.  It does not make sense for application to allow this option and then force manual propagation in each script.
