### PR TITLE
php warning fix by Sherwin in vitals form

### DIFF
--- a/interface/forms/vitals/C_FormVitals.class.php
+++ b/interface/forms/vitals/C_FormVitals.class.php
@@ -7,7 +7,8 @@ require_once("FormVitals.class.php");
 
 class C_FormVitals extends Controller {
 
-	var $template_dir;
+    var $template_dir;
+    var $form_id;
 
     function __construct($template_mod = "general") {
     	parent::__construct();

--- a/interface/forms/vitals/C_FormVitals.class.php
+++ b/interface/forms/vitals/C_FormVitals.class.php
@@ -32,7 +32,13 @@ class C_FormVitals extends Controller {
     	return $this->fetch($this->template_dir . $this->template_mod . "_new.html");
 	}
 
-    function default_action($form_id) {
+    function setFormId($form_id){
+        $this->form_id = $form_id;
+    }
+
+    function default_action() {
+
+        $form_id = $this->form_id;
 
         if (is_numeric($form_id)) {
     		$vitals = new FormVitals($form_id);

--- a/interface/forms/vitals/new.php
+++ b/interface/forms/vitals/new.php
@@ -5,6 +5,6 @@ include_once("$srcdir/api.inc");
 require ("C_FormVitals.class.php");
 
 $c = new C_FormVitals();
-#echo $c->view_action(0);
-echo $c->default_action(0);
+$c->setFormId(0);
+echo $c->default_action();
 ?>

--- a/interface/forms/vitals/view.php
+++ b/interface/forms/vitals/view.php
@@ -5,5 +5,6 @@ include_once("$srcdir/api.inc");
 require ("C_FormVitals.class.php");
 
 $c = new C_FormVitals();
-echo $c->default_action($_GET['id']);
+$c->setFormId($_GET['id']);
+echo $c->default_action();
 ?>


### PR DESCRIPTION
This is a second revision from the original PR here:
https://github.com/openemr/openemr/pull/240

This fixes the following php warning in php7:
PHP Warning:  Declaration of C_FormVitals::default_action($form_id) should be compatible with Controller::default_action() in /var/www/openemr/interface/forms/vitals/C_FormVitals.class.php on line 8