### PR TITLE
Turning off the new validation when validation list is inactive or not found

### DIFF
--- a/interface/main/calendar/add_edit_event.php
+++ b/interface/main/calendar/add_edit_event.php
@@ -1771,35 +1771,63 @@ function validateform(valu){
         return false;
     }
 
-    //add rule if choose repeating event
-    if ($('#form_repeat').is(':checked') || $('#days_every_week').is(':checked')){
-        collectvalidation.form_enddate = {
-            datetime: {
-                dateOnly: true,
-                earliest: $('#form_date').val(),
-                message: "An end date later than the start date is required for repeated events!"
-            },
-            presence: true
+    // old validation
+    if(typeof collectvalidation == 'undefined') {
+
+        var f = document.getElementById('theform');
+        if (f.form_repeat.checked &&
+            (! f.form_enddate.value || f.form_enddate.value < f.form_date.value))
+        {
+            alert('<?php echo addslashes(xl("An end date later than the start date is required for repeated events!")); ?>');
+            return false;
         }
+
+        <?php
+        if($_GET['prov']!=true){
+        ?>
+            if(f.form_pid.value == ''){
+                alert('<?php echo addslashes(xl('Patient Name Required'));?>');
+                return false;
+            }
+
+        <?php
+        }
+        ?>
+
+    // exist new validation in the pageValidation list
     } else {
-        if(collectvalidation.form_enddate != undefined){
-            delete collectvalidation.form_enddate;
+
+        //add rule if choose repeating event
+        if ($('#form_repeat').is(':checked') || $('#days_every_week').is(':checked')){
+            collectvalidation.form_enddate = {
+                datetime: {
+                    dateOnly: true,
+                    earliest: $('#form_date').val(),
+                    message: "An end date later than the start date is required for repeated events!"
+                },
+                presence: true
+            }
+        } else {
+            if(collectvalidation.form_enddate != undefined){
+                delete collectvalidation.form_enddate;
+            }
         }
-    }
 
-    <?php
-    if($_GET['prov']==true){
-    ?>
-    //remove rule if it's provider event
-    if(collectvalidation.form_patient != undefined){
-        delete collectvalidation.form_patient;
-    }
-    <?php
-    }
-    ?>
+        <?php
+        if($_GET['prov']==true){
+        ?>
+            //remove rule if it's provider event
+            if(collectvalidation.form_patient != undefined){
+                delete collectvalidation.form_patient;
+            }
 
-    var submit = submitme(1, undefined, 'theform', collectvalidation);
-    if(!submit)return;
+        <?php
+        }
+        ?>
+
+        var submit = submitme(1, undefined, 'theform', collectvalidation);
+        if (!submit)return;
+    }
 
     $('#form_action').val(valu);
 
@@ -1813,7 +1841,7 @@ function validateform(valu){
     }
     <?php endif; ?>
 
-    SubmitForm();
+    return SubmitForm();
 
 }
 

--- a/interface/usergroup/facilities_add.php
+++ b/interface/usergroup/facilities_add.php
@@ -55,9 +55,12 @@ parent.$.fn.fancybox.close();
 var collectvalidation = <?php echo($collectthis); ?>;
 
 function submitform() {
+    // new validation
+    if(typeof  collectvalidation != 'undefined') {
+        var valid = submitme(1, undefined, 'facility-add', collectvalidation);
+        if (!valid) return;
+    }
 
-    var valid = submitme(1, undefined, 'facility-add', collectvalidation);
-    if (!valid) return;
 
 	<?php if($GLOBALS['erx_enable']){ ?>
 	alertMsg='';
@@ -92,9 +95,28 @@ function submitform() {
 		return false;
 	}
 	<?php } ?>
+    //old validation
+    if(typeof  collectvalidation == 'undefined'){
 
-    document.forms[0].submit();
-    top.restoreSession();
+        if (document.forms[0].facility.value.length>0 && document.forms[0].ncolor.value != '') {
+            top.restoreSession();
+            document.forms[0].submit();
+        } else {
+            if(document.forms[0].facility.value.length<=0){
+                document.forms[0].facility.style.backgroundColor="red";
+                document.forms[0].facility.focus();
+            }
+        else if(document.forms[0].ncolor.value == ''){
+            document.forms[0].ncolor.style.backgroundColor="red";
+               document.forms[0].ncolor.focus();
+            }
+        }
+    }
+
+    if(typeof  collectvalidation != 'undefined') {
+        document.forms[0].submit();
+        top.restoreSession();
+    }
 }
 
 function toggle( target, div ) {

--- a/interface/usergroup/facility_admin.php
+++ b/interface/usergroup/facility_admin.php
@@ -63,8 +63,10 @@ var collectvalidation = <?php echo($collectthis); ?>;
 
 function submitform() {
 
-    var valid = submitme(1, undefined, 'facility-form', collectvalidation);
-    if (!valid) return;
+    if(typeof  collectvalidation != 'undefined') {
+        var valid = submitme(1, undefined, 'facility-form', collectvalidation);
+        if (!valid) return;
+    }
 
 <?php if($GLOBALS['erx_enable']){ ?>
 	alertMsg='';
@@ -99,9 +101,28 @@ function submitform() {
 		return false;
 	}
 	<?php } ?>
+    //old validation
+    if(typeof  collectvalidation == 'undefined'){
 
-    document.forms[0].submit();
-    top.restoreSession();
+        if (document.forms[0].facility.value.length>0 && document.forms[0].ncolor.value != '') {
+            top.restoreSession();
+            document.forms[0].submit();
+        } else {
+            if(document.forms[0].facility.value.length<=0){
+                document.forms[0].facility.style.backgroundColor="red";
+                document.forms[0].facility.focus();
+            }
+            else if(document.forms[0].ncolor.value == ''){
+                document.forms[0].ncolor.style.backgroundColor="red";
+                document.forms[0].ncolor.focus();
+            }
+        }
+    }
+
+    if(typeof  collectvalidation != 'undefined') {
+        document.forms[0].submit();
+        top.restoreSession();
+    }
 }
 
 $(document).ready(function(){

--- a/interface/usergroup/user_admin.php
+++ b/interface/usergroup/user_admin.php
@@ -200,13 +200,42 @@ var collectvalidation = <?php echo($collectthis); ?>;
   alert("<?php echo addslashes(xl('If you change e-RX Role for ePrescription, it may affect the ePrescription workflow. If you face any difficulty, contact your ePrescription vendor.'));?>");
 }
 function submitform() {
-
-    var valid = submitme(1, undefined, 'user_form', collectvalidation);
-    if (!valid) return;
+    //old validation
+    if(typeof  collectvalidation != 'undefined') {
+        var valid = submitme(1, undefined, 'user_form', collectvalidation);
+        if (!valid) return;
+    }
 
 	top.restoreSession();
 	var flag=0;
 
+    //old validation
+    if(typeof  collectvalidation == 'undefined'){
+        function trimAll(sString)
+        {
+            while (sString.substring(0,1) == ' ')
+                {
+                    sString = sString.substring(1, sString.length);
+            }
+            while (sString.substring(sString.length-1, sString.length) == ' ')
+                {
+                    sString = sString.substring(0,sString.length-1);
+            }
+            return sString;
+        }
+        if(trimAll(document.getElementById('fname').value) == ""){
+            alert("<?php xl('Required field missing: Please enter the First name','e');?>");
+            document.getElementById('fname').style.backgroundColor="red";
+            document.getElementById('fname').focus();
+            return false;
+        }
+        if(trimAll(document.getElementById('lname').value) == ""){
+            alert("<?php xl('Required field missing: Please enter the Last name','e');?>");
+            document.getElementById('lname').style.backgroundColor="red";
+            document.getElementById('lname').focus();
+            return false;
+        }
+    }
 	if(document.forms[0].clearPass.value!="")
 	{
 		//Checking for the strong password if the 'secure password' feature is enabled

--- a/interface/usergroup/usergroup_admin_add.php
+++ b/interface/usergroup/usergroup_admin_add.php
@@ -59,71 +59,107 @@ function trimAll(sString)
 
 function submitform() {
 
-    var valid = submitme(1, undefined, 'new_user', collectvalidation);
-    if (!valid) return;
-
+    var valid = false;
+    if(typeof  collectvalidation != 'undefined') {
+         valid = submitme(1, undefined, 'new_user', collectvalidation);
+        if (!valid) return;
+    } else {
+        //old validation
+        if (document.forms[0].rumple.value.length>0 && document.forms[0].stiltskin.value.length>0 && document.getElementById('fname').value.length >0 && document.getElementById('lname').value.length >0) {
+            valid = true;
+        }
+    }
    top.restoreSession();
+    if(valid) {
 
-   //Checking if secure password is enabled or disabled.
-   //If it is enabled and entered password is a weak password, alert the user to enter strong password.
-   if(document.new_user.secure_pwd.value == 1){
-      var password = trim(document.new_user.stiltskin.value);
-      if(password != "") {
-         var pwdresult = passwordvalidate(password);
-         if(pwdresult == 0){
-            alert("<?php echo xl('The password must be at least eight characters, and should'); echo '\n'; echo xl('contain at least three of the four following items:'); echo '\n'; echo xl('A number'); echo '\n'; echo xl('A lowercase letter'); echo '\n'; echo xl('An uppercase letter'); echo '\n'; echo xl('A special character');echo '('; echo xl('not a letter or number'); echo ').'; echo '\n'; echo xl('For example:'); echo ' healthCare@09'; ?>");
+        //Checking if secure password is enabled or disabled.
+        //If it is enabled and entered password is a weak password, alert the user to enter strong password.
+        if(document.new_user.secure_pwd.value == 1){
+            var password = trim(document.new_user.stiltskin.value);
+            if(password != "") {
+                var pwdresult = passwordvalidate(password);
+                if(pwdresult == 0){
+                    alert("<?php echo xl('The password must be at least eight characters, and should'); echo '\n'; echo xl('contain at least three of the four following items:'); echo '\n'; echo xl('A number'); echo '\n'; echo xl('A lowercase letter'); echo '\n'; echo xl('An uppercase letter'); echo '\n'; echo xl('A special character');echo '('; echo xl('not a letter or number'); echo ').'; echo '\n'; echo xl('For example:'); echo ' healthCare@09'; ?>");
+                    return false;
+                }
+            }
+        } //secure_pwd if ends here
+
+        <?php if($GLOBALS['erx_enable']){ ?>
+        alertMsg='';
+        f=document.forms[0];
+        for(i=0;i<f.length;i++){
+            if(f[i].type=='text' && f[i].value)
+            {
+                if(f[i].name == 'rumple')
+                {
+                    alertMsg += checkLength(f[i].name,f[i].value,35);
+                    alertMsg += checkUsername(f[i].name,f[i].value);
+                }
+                else if(f[i].name == 'fname' || f[i].name == 'mname' || f[i].name == 'lname')
+                {
+                    alertMsg += checkLength(f[i].name,f[i].value,35);
+                    alertMsg += checkUsername(f[i].name,f[i].value);
+                }
+                else if(f[i].name == 'federaltaxid')
+                {
+                    alertMsg += checkLength(f[i].name,f[i].value,10);
+                    alertMsg += checkFederalEin(f[i].name,f[i].value);
+                }
+                else if(f[i].name == 'state_license_number')
+                {
+                    alertMsg += checkLength(f[i].name,f[i].value,10);
+                    alertMsg += checkStateLicenseNumber(f[i].name,f[i].value);
+                }
+                else if(f[i].name == 'npi')
+                {
+                    alertMsg += checkLength(f[i].name,f[i].value,35);
+                    alertMsg += checkTaxNpiDea(f[i].name,f[i].value);
+                }
+                else if(f[i].name == 'federaldrugid')
+                {
+                    alertMsg += checkLength(f[i].name,f[i].value,30);
+                    alertMsg += checkAlphaNumeric(f[i].name,f[i].value);
+                }
+            }
+        }
+        if(alertMsg)
+        {
+            alert(alertMsg);
             return false;
-         }
-      }
-   } //secure_pwd if ends here
+        }
+        <?php } // End erx_enable only include block?>
 
-   <?php if($GLOBALS['erx_enable']){ ?>
-   alertMsg='';
-   f=document.forms[0];
-   for(i=0;i<f.length;i++){
-      if(f[i].type=='text' && f[i].value)
-      {
-         if(f[i].name == 'rumple')
-         {
-            alertMsg += checkLength(f[i].name,f[i].value,35);
-            alertMsg += checkUsername(f[i].name,f[i].value);
-         }
-         else if(f[i].name == 'fname' || f[i].name == 'mname' || f[i].name == 'lname')
-         {
-            alertMsg += checkLength(f[i].name,f[i].value,35);
-            alertMsg += checkUsername(f[i].name,f[i].value);
-         }
-         else if(f[i].name == 'federaltaxid')
-         {
-            alertMsg += checkLength(f[i].name,f[i].value,10);
-            alertMsg += checkFederalEin(f[i].name,f[i].value);
-         }
-         else if(f[i].name == 'state_license_number')
-         {
-            alertMsg += checkLength(f[i].name,f[i].value,10);
-            alertMsg += checkStateLicenseNumber(f[i].name,f[i].value);
-         }
-         else if(f[i].name == 'npi')
-         {
-            alertMsg += checkLength(f[i].name,f[i].value,35);
-            alertMsg += checkTaxNpiDea(f[i].name,f[i].value);
-         }
-         else if(f[i].name == 'federaldrugid')
-         {
-            alertMsg += checkLength(f[i].name,f[i].value,30);
-            alertMsg += checkAlphaNumeric(f[i].name,f[i].value);
-         }
-      }
-   }
-   if(alertMsg)
-   {
-      alert(alertMsg);
-      return false;
-   }
-   <?php } // End erx_enable only include block?>
+        document.forms[0].submit();
+        parent.$.fn.fancybox.close();
 
-    document.forms[0].submit();
-    parent.$.fn.fancybox.close();
+    } else {
+        if (document.forms[0].rumple.value.length<=0) {
+             document.forms[0].rumple.style.backgroundColor="red";
+         alert("<?php xl('Required field missing: Please enter the User Name','e');?>");
+          document.forms[0].rumple.focus();
+          return false;
+        }
+        if (document.forms[0].stiltskin.value.length<=0)
+           {
+              document.forms[0].stiltskin.style.backgroundColor="red";
+          alert("<?php echo xl('Please enter the password'); ?>");
+          document.forms[0].stiltskin.focus();
+          return false;
+        }
+        if(trimAll(document.getElementById('fname').value) == ""){
+              document.getElementById('fname').style.backgroundColor="red";
+              alert("<?php xl('Required field missing: Please enter the First name','e');?>");
+              document.getElementById('fname').focus();
+              return false;
+        }
+        if(trimAll(document.getElementById('lname').value) == ""){
+              document.getElementById('lname').style.backgroundColor="red";
+              alert("<?php xl('Required field missing: Please enter the Last name','e');?>");
+              document.getElementById('lname').focus();
+              return false;
+        }
+    }
 
 }
 function authorized_clicked() {


### PR DESCRIPTION
Hi.
This fix was missing in the pull request with the new validation in the forms - add/edit user, add/edit facility and ad/edit event (https://github.com/openemr/openemr/pull/224).
Here I turn off the new validation and I return the old validation when missing rules for one of the forms or the list is inactive. 

Thanks.
Amiel