### PR TITLE
Encounter Forms Display Order

### DIFF
--- a/library/forms.inc
+++ b/library/forms.inc
@@ -34,14 +34,22 @@ function getFormsByPid ($pid, $cols = "*")
 function getFormByEncounter($pid,$encounter, $cols="form_id, form_name", $name="")
 {
  	$arraySqlBind = array();
-	$sql = "select $cols from forms where encounter = ? and pid=? ";
+
+  // mdsupport - incorporate ACO and order from formACL list
+  $sql = "SELECT lo.title AS ACO, $cols from forms LEFT JOIN list_options lo " .
+         "ON (lo.list_id='formACL') and (forms.formdir = lo.option_id) ".
+         "WHERE encounter = ? and pid = ? ";
+
 	array_push($arraySqlBind,$encounter,$pid);
 	if(!empty($name)){
 		$sql .= "and form_name=? ";
 		array_push($arraySqlBind,$name);
 	}
-  // This puts vitals first in the list, and newpatient last:
-  $sql .= "ORDER BY FIND_IN_SET(formdir,'vitals') DESC, date DESC";
+  
+  // Order encounter forms by formACL seq (if present), then 
+  // Original order - vitals first in the list, and newpatient last:
+  $sql .= "ORDER BY IF((lo.option_id IS NULL),0,1) DESC, lo.seq ASC, " .
+          "FIND_IN_SET(formdir,'vitals') DESC, date DESC";
 
 	$res = sqlStatement($sql,$arraySqlBind);
 

--- a/sql/patch.sql
+++ b/sql/patch.sql
@@ -47,3 +47,15 @@
 
 --  #EndIf
 --    all blocks are terminated with and #EndIf statement.
+
+#IfNotRow2D list_options list_id lists option_id formACL
+	INSERT INTO list_options (list_id, option_id, title) VALUES ('lists','formACL','Encounter Forms Display Order');
+--  INSERT INTO list_options (list_id, option_id, title, seq) VALUES ('formACL','newpatient','-',10);
+--  INSERT INTO list_options (list_id, option_id, title, seq) VALUES ('formACL','ros','-',10);
+--  INSERT INTO list_options (list_id, option_id, title, seq) VALUES ('formACL','vitals','-',10);
+--  INSERT INTO list_options (list_id, option_id, title, seq) VALUES ('formACL','reviewofs','-',10);
+--  INSERT INTO list_options (list_id, option_id, title, seq) VALUES ('formACL','physical_exam','-',10);
+--  INSERT INTO list_options (list_id, option_id, title, seq) VALUES ('formACL','soap','-',10);
+--  INSERT INTO list_options (list_id, option_id, title, seq) VALUES ('formACL','scanned_notes','-',10);
+--  INSERT INTO list_options (list_id, option_id, title, seq) VALUES ('formACL','procedure_order','-',10);
+#EndIf


### PR DESCRIPTION
Provides an optional way to control the order in display of forms in encounter summary or reports.  Current display order is vitals + order of entry which creates ever changing / random display.
