### PR TITLE
Bug fix for login.php

### DIFF
--- a/interface/login/login.php
+++ b/interface/login/login.php
@@ -240,11 +240,11 @@ if (count($result3) != 1) { ?>
         echo "<option selected='selected' value='" . attr($defaultLangID) . "'>" . xlt('Default') . " - " . xlt($defaultLangName) . "</option>\n";
         foreach ($result3 as $iter) {
 	        if ($GLOBALS['language_menu_showall']) {
-                    if ( !$GLOBALS['allow_debug_language'] && $iter[lang_description] == 'dummy') continue; // skip the dummy language
+                    if ( !$GLOBALS['allow_debug_language'] && $iter['lang_description'] == 'dummy') continue; // skip the dummy language
                     echo "<option value='".attr($iter['lang_id'])."'>".text($iter['trans_lang_description'])."</option>\n";
 		}
 	        else {
-		    if (in_array($iter[lang_description], $GLOBALS['language_menu_show'])) {
+		    if (in_array($iter['lang_description'], $GLOBALS['language_menu_show'])) {
                         if ( !$GLOBALS['allow_debug_language'] && $iter['lang_description'] == 'dummy') continue; // skip the dummy language
 		        echo "<option value='".attr($iter['lang_id'])."'>" . text($iter['trans_lang_description']) . "</option>\n";
 		    }


### PR DESCRIPTION
In PHP 7.0.4 installation the error log is showing
[23-Oct-2016 12:06:09 UTC] PHP Stack trace:

[23-Oct-2016 12:06:09 UTC] PHP   1. {main}() C:\emr_wamp\www\openemr\interface\login\login.php:0

[23-Oct-2016 12:06:09 UTC] PHP Notice:  Use of undefined constant lang_description - assumed 'lang_description' in C:\emr_wamp\www\openemr\interface\login\login.php on line 195

