### PR TITLE
2 minor fixes in document system

### DIFF
--- a/library/classes/thumbnail/Thumbnail.class.php
+++ b/library/classes/thumbnail/Thumbnail.class.php
@@ -35,7 +35,8 @@ class Thumbnail
         //validate that GD extension was enabled
         if (!extension_loaded('gd'))
         {
-            die('Abort '.basename(__FILE__).' : Missing DG extensions');
+            error_log('Thumbnail generator error: Missing DG extensions');
+            die('Abort. Thumbnail generator error : Missing DG extensions');
         }
 
         if(!is_null($max_size)) {

--- a/library/classes/thumbnail/Thumbnail.class.php
+++ b/library/classes/thumbnail/Thumbnail.class.php
@@ -32,6 +32,12 @@ class Thumbnail
      */
     public function __construct($max_size = null)
     {
+        //validate that GD extension was enabled
+        if (!extension_loaded('gd'))
+        {
+            die('Abort '.basename(__FILE__).' : Missing zlib extensions');
+        }
+
         if(!is_null($max_size)) {
             $this->max_size = $max_size;
         } else {

--- a/library/classes/thumbnail/Thumbnail.class.php
+++ b/library/classes/thumbnail/Thumbnail.class.php
@@ -35,7 +35,7 @@ class Thumbnail
         //validate that GD extension was enabled
         if (!extension_loaded('gd'))
         {
-            die('Abort '.basename(__FILE__).' : Missing zlib extensions');
+            die('Abort '.basename(__FILE__).' : Missing DG extensions');
         }
 
         if(!is_null($max_size)) {

--- a/sites/default/documents/temp/README
+++ b/sites/default/documents/temp/README
@@ -1,0 +1,2 @@
+This folder holds temporary files that created when downloading file from couchDB.
+Here the system stores the file with the content from couchDB and removes it after downloading is finished.


### PR DESCRIPTION
Hi.
1. I added error message in the construct of thumbnail generator in case that missing GD extension (PHP extension).

2. adding  empty folder in the sites/documents. without this folder php throws warning error when retrieving file from couchDB and doesn't present the file .
Error screenshot -   
![image](https://cloud.githubusercontent.com/assets/17809866/20179743/3bbd487e-a760-11e6-8135-70590488758a.png)

Thanks.
Amiel
   