### PR TITLE
fixed bug: print window would open and close right away

### DIFF
--- a/interface/main/calendar/modules/PostCalendar/pntemplates/default/views/day_print/outlook_ajax_template.html
+++ b/interface/main/calendar/modules/PostCalendar/pntemplates/default/views/day_print/outlook_ajax_template.html
@@ -703,8 +703,8 @@ function PrintDatePicker($caldate, $DOWlist, $daynames) {
 <script type="text/javascript" src="[-php-] echo $GLOBALS['assets_static_relative'] [-/php-]/jquery-min-1-2-2/index.js"></script>
 <script>
 $(document).ready(function(){
-    var win = top.printLogPrint ? top : opener.top;
-    if (win.printLogPrint(window)) window.close();
+//    var win = top.printLogPrint ? top : opener.top;
+//    if (win.printLogPrint(window)) window.close();
 });
 </script>
 

--- a/interface/main/calendar/modules/PostCalendar/pntemplates/default/views/month_print/outlook_ajax_template.html
+++ b/interface/main/calendar/modules/PostCalendar/pntemplates/default/views/month_print/outlook_ajax_template.html
@@ -525,8 +525,8 @@ function PrintDatePicker($caldate, $DOWlist, $daynames) {
 
 <script language='JavaScript'>
 $(document).ready(function(){
-    var win = top.printLogPrint ? top : opener.top;
-    if (win.printLogPrint(window)) window.close();
+//    var win = top.printLogPrint ? top : opener.top;
+//    if (win.printLogPrint(window)) window.close();
 });
 </script>
 

--- a/interface/main/calendar/modules/PostCalendar/pntemplates/default/views/week_print/outlook_ajax_template.html
+++ b/interface/main/calendar/modules/PostCalendar/pntemplates/default/views/week_print/outlook_ajax_template.html
@@ -614,8 +614,8 @@ $(document).ready(function(){
     else if ($("#bigCal").height() > 1200) {
         $("#weekcal *").css("font-size", "80%");
     }
-    var win = top.printLogPrint ? top : opener.top;
-    if (win.printLogPrint(window)) window.close();
+//    var win = top.printLogPrint ? top : opener.top;
+//    if (win.printLogPrint(window)) window.close();
 });
 </script>
 


### PR DESCRIPTION
Hi,
There was a problem with the printing of calendar: the print window opened and closed right away.
We brought this up in the forums:
[https://sourceforge.net/p/openemr/bugs/459/](https://sourceforge.net/p/openemr/bugs/459/)
The solution they offered didn't work.
The only solution I found meanwhile is to erase the lines.
Thanks,
shachar
