### PR TITLE
Sz/saving hidden field dem

### DIFF
--- a/library/validation/validation_script.js.php
+++ b/library/validation/validation_script.js.php
@@ -82,8 +82,8 @@ function submitme(new_validate,e,form_id, constraints) {
                     element = $('[name="'+ key + '"]');
                     if(!$(element).is('select[multiple]')) {
 
-                        if($(element).parent().prop('style') != undefined && $(element).parent().prop('style').visibility == 'hidden'){
-                            $(element).val("");
+                        if($(element).parent().prop('style') != undefined && ($(element).parent().prop('style').visibility == 'hidden'|| element.parent().parent().css('display')== 'none')){
+                            $(element).val("");                        }
                         }
                     }
                 }

--- a/library/validation/validation_script.js.php
+++ b/library/validation/validation_script.js.php
@@ -87,7 +87,6 @@ function submitme(new_validate,e,form_id, constraints) {
                             }
 
                     }
-                    }
                 }
 
             //get the input value after romoving hide fields

--- a/library/validation/validation_script.js.php
+++ b/library/validation/validation_script.js.php
@@ -82,9 +82,11 @@ function submitme(new_validate,e,form_id, constraints) {
                     element = $('[name="'+ key + '"]');
                     if(!$(element).is('select[multiple]')) {
 
-                        if($(element).parent().prop('style') != undefined && ($(element).parent().prop('style').visibility == 'hidden'|| element.parent().parent().css('display')== 'none')){
-                            $(element).val("");                        }
-                        }
+                            if($(element).parent().prop('style') != undefined && ($(element).parent().prop('style').visibility == 'hidden'|| element.parent().parent().css('display')== 'none')){
+                                $(element).val("");
+                            }
+
+                    }
                     }
                 }
 


### PR DESCRIPTION
Hi ,
The bug:
In the demograpics editing let's say that field B is hidden when A =1 but shows when A=2. We choose A=2 and fill in B. We save. We then edit again and choose A=1 thus hiding B. Save. We then edit again and choose A=1. B now appears but instead of being empty like in default, it still has the value that was once inserted.
This fix makes sure that when hiding a field and then saving, the value in the hidden field is cleared. 