### PR TITLE
Fix - missing and incorrect dates for rt2 recurring appointments set on the 29th, 30th and 31st

### DIFF
--- a/interface/main/calendar/add_edit_event.php
+++ b/interface/main/calendar/add_edit_event.php
@@ -341,11 +341,11 @@ if ($_POST['form_action'] == "duplicate" || $_POST['form_action'] == "save")
                     );
 
     //
-    if($my_recurrtype == 2) {
+    if($my_recurrtype == 2) { // Added by epsdky 2016 (details in commit) 
       if($_POST['old_repeats'] == 2) {
         if($_POST['rt2_flag2']) $recurrspec['rt2_pf_flag'] = "1";
       } else $recurrspec['rt2_pf_flag'] = "1";
-    }
+    } // End of addition by epsdky
     //
     // no recurr specs, this is used for adding a new non-recurring event
     $noRecurrspec = array("event_repeat_freq" => "",
@@ -1216,8 +1216,10 @@ $classpati='';
 <!-- used for recurring events -->
 <input type="hidden" name="selected_date" id="selected_date" value="<?php echo attr($date); ?>">
 <input type="hidden" name="event_start_date" id="event_start_date" value="<?php echo attr($eventstartdate); ?>">
+<!-- Following added by epsdky 2016 (details in commit) -->
 <input type="hidden" name="old_repeats" id="old_repeats" value="<?php echo attr($repeats); ?>">
 <input type="hidden" name="rt2_flag2" id="rt2_flag2" value="<?php echo attr(isset($rspecs['rt2_pf_flag']) ? $rspecs['rt2_pf_flag'] : '0'); ?>">
+<!-- End of addition by epsdky -->
 <center>
 <table border='0' >
 <?php

--- a/interface/main/calendar/add_edit_event.php
+++ b/interface/main/calendar/add_edit_event.php
@@ -340,6 +340,13 @@ if ($_POST['form_action'] == "duplicate" || $_POST['form_action'] == "save")
                         "exdate" => $_POST['form_repeat_exdate']
                     );
 
+    //
+    if($my_recurrtype == 2) {
+      if($_POST['old_repeats'] == 2) {
+        if($_POST['rt2_flag2']) $recurrspec['rt2_pf_flag'] = "1";
+      } else $recurrspec['rt2_pf_flag'] = "1";
+    }
+    //
     // no recurr specs, this is used for adding a new non-recurring event
     $noRecurrspec = array("event_repeat_freq" => "",
                         "event_repeat_freq_type" => "",
@@ -1209,6 +1216,8 @@ $classpati='';
 <!-- used for recurring events -->
 <input type="hidden" name="selected_date" id="selected_date" value="<?php echo attr($date); ?>">
 <input type="hidden" name="event_start_date" id="event_start_date" value="<?php echo attr($eventstartdate); ?>">
+<input type="hidden" name="old_repeats" id="old_repeats" value="<?php echo attr($repeats); ?>">
+<input type="hidden" name="rt2_flag2" id="rt2_flag2" value="<?php echo attr(isset($rspecs['rt2_pf_flag']) ? $rspecs['rt2_pf_flag'] : '0'); ?>">
 <center>
 <table border='0' >
 <?php

--- a/interface/main/calendar/modules/PostCalendar/pnuserapi.php
+++ b/interface/main/calendar/modules/PostCalendar/pnuserapi.php
@@ -1445,6 +1445,13 @@ function calculateEvents($days,$events,$viewtype) {
         //  Populate - Enter data into the event array
         //==============================================================
         $nm = $esM; $ny = $esY; $nd = $esD;
+
+        if(isset($event_recurrspec['rt2_pf_flag']) && $event_recurrspec['rt2_pf_flag']) $nd = 1; // Added by epsdky 2016.
+        // $nd will sometimes be 29, 30 or 31 and if used in the mktime functions
+        // below a problem with overfow will occur so it is set to 1 to prevent this.
+        // (for rt2 appointments set prior to fix it remains unchanged). This can be done
+        // since $nd has no influence past the mktime functions - epsdky 2016.
+
         // make us current
         while($ny < $cy) {
           $occurance = date('Y-m-d',mktime(0,0,0,$nm+$rfreq,$nd,$ny));

--- a/library/appointments.inc.php
+++ b/library/appointments.inc.php
@@ -239,13 +239,16 @@ function fetchEvents( $from_date, $to_date, $where_param = null, $orderby_param 
 
         list($ny,$nm,$nd) = explode('-',$event['pc_eventDate']);
 
+        if(isset($event_recurrspec['rt2_pf_flag']) && $event_recurrspec['rt2_pf_flag']) $nd = 1;
+
         $occuranceYm = "$ny-$nm"; // YYYY-mm
         $from_dateYm = substr($from_date,0,7); // YYYY-mm
         $stopDateYm = substr($stopDate,0,7); // YYYY-mm
 
-        // $nd will sometimes be 29, 30 or 31, and if used in mktime below, a problem
-        // with overflow will occur ('01' should be plugged in to avoid this). We need
-        // to mirror the calendar code which has this problem, so $nd has been used.
+        // $nd will sometimes be 29, 30 or 31 and if used in the mktime functions below
+        // a problem with overflow will occur so it is set to 1 to avoid this (for rt2
+        // appointments set prior to fix $nd remains unchanged). This can be done since
+        // $nd has no influence past the mktime functions.
         while($occuranceYm < $from_dateYm) {
           $occuranceYmX = date('Y-m-d',mktime(0,0,0,$nm+$rfreq,$nd,$ny));
           list($ny,$nm,$nd) = explode('-',$occuranceYmX);


### PR DESCRIPTION
For rt2 recurring appointments set on the 29th, 30th and 31st where there is a month associated with a date in the corresponding recurring series that has a total number of days less than the day of month the appointment was set on (29 30 or 31) (first month if more than one) the date for this month will be missing when freq = 1. For freq > 1 all subsequent dates will be missing also and a series of wrong dates will be included each one month shifted from the missing correct dates.

Only new (post fix) appointment experience the fix, old appointments remain unchanged.