### PR TITLE
Logout fix.

### DIFF
--- a/interface/main/main_screen.php
+++ b/interface/main/main_screen.php
@@ -139,6 +139,11 @@ var tab_mode=false;
 
 <?php require($GLOBALS['srcdir'] . "/restoreSession.php"); ?>
 
+// Since this should be the parent window, this is to prevent calls to the
+// window that opened this window. For example when a new window is opened
+// from the Patient Flow Board or the Patient Finder.
+window.opener = null;
+
 // This flag indicates if another window or frame is trying to reload the login
 // page to this top-level window.  It is set by javascript returned by auth.inc
 // and is checked by handlers of beforeunload events.

--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -38,6 +38,11 @@ $esignApi = new Api();
 <script type="text/javascript">
 <?php require($GLOBALS['srcdir'] . "/restoreSession.php"); ?>
 
+// Since this should be the parent window, this is to prevent calls to the
+// window that opened this window. For example when a new window is opened
+// from the Patient Flow Board or the Patient Finder.
+window.opener = null;
+
 // This flag indicates if another window or frame is trying to reload the login
 // page to this top-level window.  It is set by javascript returned by auth.inc
 // and is checked by handlers of beforeunload events.


### PR DESCRIPTION
This is to prevent following logout bug:
1. Login to OpenEMR.
2. Go to Patient Flow Board and toggle on Open Patient in New Window.
3. A new window(OpenEMR instance) now opens up.
4. Click to logout of the new OpenEMR instance.

Because of code in library/auth.inc, the following bugs happen:
1. The window of the OpenEMR instance that you clicked to logout
   will go away.
2. The Original window (from step 2 above) will then logout.

This is because the 'opener' javascript variable is linked to the
original instance. The fix is to always set the 'opener' variable
to null in the main script for frames (interface/main/main_screen.php)
and tabs (interface/main/tabs/main.php).