### PR TITLE
Add management options to premission 

### DIFF
--- a/interface/super/edit_list.php
+++ b/interface/super/edit_list.php
@@ -1004,6 +1004,8 @@ if ($list_id) {
   else {
     /*
      *  Add edit options to show or hide in list management
+     *  If the edit_options setting of the main list entry is set to 0,
+     *  then none of the list items will show.
      */
     $res = sqlStatement("SELECT lo.* 
                          FROM list_options as lo 

--- a/interface/super/edit_list.php
+++ b/interface/super/edit_list.php
@@ -822,7 +822,7 @@ else {
     "LEFT JOIN lang_constants AS lc ON lc.constant_name = lo.title " .
     "LEFT JOIN lang_definitions AS ld ON ld.cons_id = lc.cons_id AND " .
     "ld.lang_id = '$lang_id' " .
-    "WHERE lo.list_id = 'lists' " .
+    "WHERE lo.list_id = 'lists' AND lo.edit_options = 1 " .
     "ORDER BY IF(LENGTH(ld.definition),ld.definition,lo.title), lo.seq");
 }
 
@@ -1002,8 +1002,14 @@ if ($list_id) {
     }
   }
   else {
-    $res = sqlStatement("SELECT * FROM list_options WHERE " .
-      "list_id = '$list_id' ORDER BY seq,title");
+    /*
+     *  Add edit options to show or hide in list management
+     */
+    $res = sqlStatement("SELECT lo.* 
+                         FROM list_options as lo 
+                         right join list_options as lo2 on lo2.option_id = lo.list_id AND lo2.edit_options = 1
+                         WHERE lo.list_id = '{$list_id}' AND lo.edit_options = 1
+                         ORDER BY seq,title");
     while ($row = sqlFetchArray($res)) {
       writeOptionLine($row['option_id'], $row['title'], $row['seq'],
         $row['is_default'], $row['option_value'], $row['mapping'],

--- a/interface/super/edit_list.php
+++ b/interface/super/edit_list.php
@@ -1004,8 +1004,10 @@ if ($list_id) {
   else {
     /*
      *  Add edit options to show or hide in list management
-     *  If the edit_options setting of the main list entry is set to 0,
-     *  then none of the list items will show.
+     *   If the edit_options setting of the main list entry is set to 0,
+     *    then none of the list items will show.
+     *   If the edit_options setting of the main list entry is set to 1,
+     *    then the list items with edit_options set to 1 will show.
      */
     $res = sqlStatement("SELECT lo.* 
                          FROM list_options as lo 

--- a/sql/5_0_0-to-5_0_1_upgrade.sql
+++ b/sql/5_0_0-to-5_0_1_upgrade.sql
@@ -88,7 +88,7 @@
 
 
 #IfMissingColumn list_options edit_options
-  ALTER TABLE `list_options` ADD `edit_options` TINYINT(1) NOT NULL DEFAULT '1' AFTER `subtype`;
+  ALTER TABLE `list_options` ADD `edit_options` TINYINT(1) NOT NULL DEFAULT '1';
 #Endif
 
 

--- a/sql/5_0_0-to-5_0_1_upgrade.sql
+++ b/sql/5_0_0-to-5_0_1_upgrade.sql
@@ -85,3 +85,10 @@
 --    arguments: none
 --    behavior: can take a long time.
 
+
+
+#IfMissingColumn list_options edit_options
+  ALTER TABLE `list_options` ADD `edit_options` TINYINT(1) NOT NULL DEFAULT '1' AFTER `subtype`;
+#Endif
+
+

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -2910,6 +2910,7 @@ CREATE TABLE `list_options` (
   `toggle_setting_2` tinyint(1) NOT NULL default '0',
   `activity` TINYINT DEFAULT 1 NOT NULL,
   `subtype` varchar(31) NOT NULL DEFAULT '',
+  `edit_options` tinyint(1) NOT NULL DEFAULT '1',
   PRIMARY KEY  (`list_id`,`option_id`)
 ) ENGINE=InnoDB;
 


### PR DESCRIPTION
Brady hello,
Here we want to add a feature that enables you to decide whether a list or option is editable in admin panel. We added a column to the list_options table called 'edit_options'. If the value is 0 it's not editable.

If a list/option is not editable it simply won't show up in the lists view in admin panel. 

If we insert 0 in the list's general row, the whole list won't show. If it's for a specific option, then only that option won't show.

Hope you like it! :)

thanks,
oshri