### PR TITLE
Fix - LBF content width limited to 30 characters in Encounter Summary

### DIFF
--- a/interface/forms/LBF/report.php
+++ b/interface/forms/LBF/report.php
@@ -13,7 +13,7 @@ include_once($GLOBALS["srcdir"] . "/api.inc");
 // when viewing a "comprehensive patient report".  Also from
 // interface/patient_file/encounter/forms.php.
 
-function lbf_report($pid, $encounter, $cols, $id, $formname) {
+function lbf_report($pid, $encounter, $cols, $id, $formname, $no_wrap = false) {
   require_once($GLOBALS["srcdir"] . "/options.inc.php");
   $arr = array();
   $shrow = getHistoryData($pid);
@@ -33,7 +33,10 @@ function lbf_report($pid, $encounter, $cols, $id, $formname) {
     if ($currvalue === '') continue;
     // $arr[$field_id] = $currvalue;
     // A previous change did this instead of the above, not sure if desirable? -- Rod
-    $arr[$field_id] = wordwrap($currvalue, 30, "\n", true);
+    // $arr[$field_id] = wordwrap($currvalue, 30, "\n", true);
+    // Hi Rod content width issue in Encounter Summary - epsdky
+    if($no_wrap) $arr[$field_id] = $currvalue; // Making wordwrap selectable - epsdky 2017
+    else $arr[$field_id] = wordwrap($currvalue, 30, "\n", true);
   }
   echo "<table>\n";
   display_layout_rows($formname, $arr);

--- a/interface/patient_file/encounter/forms.php
+++ b/interface/patient_file/encounter/forms.php
@@ -637,7 +637,7 @@ if ( $esign->isButtonViewable() ) {
         //
         if (substr($formdir,0,3) == 'LBF') {
           include_once($GLOBALS['incdir'] . "/forms/LBF/report.php");
-          call_user_func("lbf_report", $pid, $encounter, 2, $iter['form_id'], $formdir);
+          call_user_func("lbf_report", $pid, $encounter, 2, $iter['form_id'], $formdir, true);
         }
         else  {
           include_once($GLOBALS['incdir'] . "/forms/$formdir/report.php");


### PR DESCRIPTION
The width of the LBF content in the Encounter Summary is being restricted (by a recent code change) to 30 characters.
