### PR TITLE
calendar date format fix

### DIFF
--- a/interface/main/calendar/modules/PostCalendar/pntemplates/default/views/week/ajax_template.html
+++ b/interface/main/calendar/modules/PostCalendar/pntemplates/default/views/week/ajax_template.html
@@ -422,7 +422,7 @@ foreach ($providers as $provider) {
         if ($Date == $dateFmt) { $currclass= "week_currday"; }
         echo "<td align='center' class='week_dateheader $currclass' style='width:".$colWidth."%;' >";
         echo "<a href='$gotoURL'>";
-        echo xl(date("D", strtotime($date))) . " " . oeFormatShortDate($date);
+        echo xl(date("D", strtotime($date))) . " " . oeFormatShortDate($date, false);
         echo "</a></td>";
     }
     echo " </tr>\n";

--- a/interface/main/calendar/modules/PostCalendar/pntemplates/default/views/week/ajax_template.html
+++ b/interface/main/calendar/modules/PostCalendar/pntemplates/default/views/week/ajax_template.html
@@ -14,6 +14,7 @@
 
 [-*Values used in setting timeslot and event heights*-]
 [-php-]
+require_once($GLOBALS['srcdir'] . "/formatting.inc.php");
 /* if you change these be sure to change their matching values in
  * the CSS for the calendar, found in interface/themes/ajax_calendar.css
  */
@@ -421,7 +422,7 @@ foreach ($providers as $provider) {
         if ($Date == $dateFmt) { $currclass= "week_currday"; }
         echo "<td align='center' class='week_dateheader $currclass' style='width:".$colWidth."%;' >";
         echo "<a href='$gotoURL'>";
-        echo xl(date("D", strtotime($date))) . " " . date("m/d", strtotime($date));
+        echo xl(date("D", strtotime($date))) . " " . oeFormatShortDate($date);
         echo "</a></td>";
     }
     echo " </tr>\n";

--- a/library/formatting.inc.php
+++ b/library/formatting.inc.php
@@ -17,16 +17,26 @@ function oeFormatMoney($amount, $symbol=false) {
   return $s;
 }
 
-function oeFormatShortDate($date='today') {
+function oeFormatShortDate($date='today', $showYear = true) {
   if ($date === 'today') $date = date('Y-m-d');
   if (strlen($date) == 10) {
     // assume input is yyyy-mm-dd
     if ($GLOBALS['date_display_format'] == 1)      // mm/dd/yyyy
-      $date = substr($date, 5, 2) . '/' . substr($date, 8, 2) . '/' . substr($date, 0, 4);
+      $newDate = substr($date, 5, 2) . '/' . substr($date, 8, 2);
     else if ($GLOBALS['date_display_format'] == 2) // dd/mm/yyyy
-      $date = substr($date, 8, 2) . '/' . substr($date, 5, 2) . '/' . substr($date, 0, 4);
+      $newDate = substr($date, 8, 2) . '/' . substr($date, 5, 2);
+
+    //if should show year as well
+    if($GLOBALS['date_display_format'] == 1 || $GLOBALS['date_display_format'] == 2){
+        if($showYear){
+            $newDate .= '/' . substr($date, 0, 4);
+        }
+    }
+    elseif(!$showYear) //if format is yyyy-mm-dd and don''t want to show year
+      $newDate = substr($date, 5, 2) . '/' . substr($date, 8, 2);
+
   }
-  return $date;
+  return $newDate;
 }
 
 // 0 - Time format 24 hr


### PR DESCRIPTION
Hi,
In the calendar week view, the date shows up in mm/dd format (it's hardcoded). This is not optimal for places where the standard is dd/mm. 
I used the oeShortDate function that takes date format from the globals and shows the date according to this.
This shows the year too in the date, so if we want to show only month and day I'm not sure how to go about it. Do you have any suggestions for this issue? Or maybe it's not such an issue.
Thanks,
shachar