### PR TITLE
added global for 'all' option

### DIFF
--- a/interface/main/calendar/add_edit_event.php
+++ b/interface/main/calendar/add_edit_event.php
@@ -1716,7 +1716,9 @@ if ($repeatexdate != "") {
 <div id="recurr_popup" style="visibility: hidden; position: absolute; top: 50px; left: 50px; width: 400px; border: 3px outset yellow; background-color: yellow; padding: 5px;">
 <?php echo xlt('Apply the changes to the Current event only, to this and all Future occurrences, or to All occurrences?') ?>
 <br>
-<input type="button" name="all_events" id="all_events" value="  <?php echo xla('All'); ?>  ">
+<?php if($GLOBALS['submit_changes_for_all_appts_at_once']) {?>
+    <input type="button" name="all_events" id="all_events" value="  <?php echo xla('All'); ?>  ">
+<?php } ?>
 <input type="button" name="future_events" id="future_events" value="<?php echo xla('Future'); ?>">
 <input type="button" name="current_event" id="current_event" value="<?php echo xla('Current'); ?>">
 <input type="button" name="recurr_cancel" id="recurr_cancel" value="<?php echo xla('Cancel'); ?>">

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -868,6 +868,14 @@ $GLOBALS_METADATA = array(
       xl('Observation Results in Immunization')
     ),
 
+    'submit_changes_for_all_appts_at_once' => array(
+      xl('Submit Changes For All Appts At Once'),
+      'bool',                           // data type
+      '1',                              // default
+      xl('Enables to submit changes for all appointments of a recurrence at once.')
+    ),
+
+
    ),
     // Report Tab
     //

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -868,14 +868,6 @@ $GLOBALS_METADATA = array(
       xl('Observation Results in Immunization')
     ),
 
-    'submit_changes_for_all_appts_at_once' => array(
-      xl('Submit Changes For All Appts At Once'),
-      'bool',                           // data type
-      '1',                              // default
-      xl('Enables to submit changes for all appointments of a recurrence at once.')
-    ),
-
-
    ),
     // Report Tab
     //
@@ -1535,6 +1527,14 @@ $GLOBALS_METADATA = array(
       '0',                       // default
       xl('Maximum number of times a Patient can be tested in a year. Zero is no limit.')
     ),
+
+    'submit_changes_for_all_appts_at_once' => array(
+      xl('Submit Changes For All Appts At Once'),
+      'bool',                           // data type
+      '1',                              // default
+      xl('Enables to submit changes for all appointments of a recurrence at once.')
+    ),
+
 
   ),
 


### PR DESCRIPTION
Hi,
Here we're adding am option to turn off the option for submitting changes to all appointments in a recurrence, so users can't alter past information (only current or future).
Thanks!