### PR TITLE
AD

### DIFF
--- a/interface/main/left_nav.php
+++ b/interface/main/left_nav.php
@@ -1419,7 +1419,7 @@ if (!empty($reg)) {
       <?php genMiscLink('RTop','adm','0',xl('BatchCom'),'batchcom/batchcom.php'); ?>
       <?php $myrow = sqlQuery("SELECT state FROM registry WHERE directory = 'track_anything'");
       if($myrow['state']=='1') { genTreeLink('RTop','tan',xl('Configure Tracks')); } ?>
-      <?php genTreeLink('RTop','pwd',xl('Password')); ?>
+      <?php if(!$GLOBALS['use_active_directory']) { genTreeLink('RTop','pwd',xl('Password')); } ?>
       <?php genMiscLink('RTop','prf','0',xl('Preferences'),'super/edit_globals.php?mode=user'); ?>
       <?php if(acl_check('patients','docs')) genMiscLink('RTop','adm','0',xl('New Documents'),'../controller.php?document&list&patient_id=00'); ?>
       <?php if (acl_check('patients','docs')) genMiscLink('RTop','adm','0',xl('Document Templates'),'super/manage_document_templates.php'); ?>

--- a/interface/usergroup/user_admin.php
+++ b/interface/usergroup/user_admin.php
@@ -205,7 +205,7 @@ function submitform() {
 
 	top.restoreSession();
 	var flag=0;
-
+    <?php if(!$GLOBALS['use_active_directory']){ ?>
 	if(document.forms[0].clearPass.value!="")
 	{
 		//Checking for the strong password if the 'secure password' feature is enabled
@@ -220,6 +220,7 @@ function submitform() {
 		}
 
 	}//If pwd null ends here
+    <?php } ?>
 	//Request to reset the user password if the user was deactived once the password expired.
 	if((document.forms[0].pwd_expires.value != 0) && (document.forms[0].clearPass.value == "")) {
 		if((document.forms[0].user_type.value != "Emergency Login") && (document.forms[0].pre_active.value == 0) && (document.forms[0].active.checked == 1) && (document.forms[0].grace_time.value != "") && (document.forms[0].current_date.value) > (document.forms[0].grace_time.value))
@@ -355,16 +356,19 @@ $bg_count=count($acl_name);
 <TR>
     <TD style="width:180px;"><span class=text><?php xl('Username','e'); ?>: </span></TD>
     <TD style="width:270px;"><input type=entry name=username style="width:150px;" value="<?php echo $iter["username"]; ?>" disabled></td>
-    <TD style="width:200px;"><span class=text><?php xl('Your Password','e'); ?>: </span></TD>
-    <TD class='text' style="width:280px;"><input type='password' name=adminPass style="width:150px;"  value="" autocomplete='off'><font class="mandatory">*</font></TD>
+    <?php if(!$GLOBALS['use_active_directory']){ ?>
+        <TD style="width:200px;"><span class=text><?php xl('Your Password','e'); ?>: </span></TD>
+        <TD class='text' style="width:280px;"><input type='password' name=adminPass style="width:150px;"  value="" autocomplete='off'><font class="mandatory">*</font></TD>
+    <?php } ?>
 </TR>
+    <?php if(!$GLOBALS['use_active_directory']){ ?>
 <TR>
     <TD style="width:180px;"><span class=text></span></TD>
     <TD style="width:270px;"></td>
     <TD style="width:200px;"><span class=text><?php xl('User\'s New Password','e'); ?>: </span></TD>
     <TD class='text' style="width:280px;">    <input type=text name=clearPass style="width:150px;"  value=""><font class="mandatory">*</font></td>
 </TR>
-
+    <?php } ?>
 
 <TR height="30" style="valign:middle;">
 <td><span class="text">&nbsp;</span></td><td>&nbsp;</td>

--- a/interface/usergroup/user_info.php
+++ b/interface/usergroup/user_info.php
@@ -1,6 +1,9 @@
 <?php
 include_once("../globals.php");
 include_once("$srcdir/auth.inc");
+if($GLOBALS['use_active_directory']) {
+    exit();
+}
 ?>
 <html>
 <head>

--- a/interface/usergroup/usergroup_admin_add.php
+++ b/interface/usergroup/usergroup_admin_add.php
@@ -162,7 +162,11 @@ function authorized_clicked() {
 <table border=0 cellpadding=0 cellspacing=0 style="width:600px;">
 <tr>
 <td style="width:150px;"><span class="text"><?php xl('Username','e'); ?>: </span></td><td  style="width:220px;"><input type=entry name="rumple" style="width:120px;"> <span class="mandatory">&nbsp;*</span></td>
-<td style="width:150px;"><span class="text"><?php xl('Password','e'); ?>: </span></td><td style="width:250px;"><input type=entry style="width:120px;" name="stiltskin"><span class="mandatory">&nbsp;*</span></td>
+    <?php if(!$GLOBALS['use_active_directory']) { ?>
+<td style="width:150px;"><span class="text"><?php xl('Password','e'); ?>: </span></td><td style="width:250px;"><input type="password" style="width:120px;" name="stiltskin"><span class="mandatory">&nbsp;*</span></td>
+    <?php }else{ ?>
+        <td> <input type="hidden" value="124" name="stiltskin" /></td>
+    <?php } ?>
 </tr>
 <tr>
     <td style="width:150px;"></td><td  style="width:220px;"></span></td>

--- a/library/ESign/Form/Controller.php
+++ b/library/ESign/Form/Controller.php
@@ -28,6 +28,7 @@ require_once $GLOBALS['srcdir'].'/ESign/Abstract/Controller.php';
 require_once $GLOBALS['srcdir'].'/ESign/Form/Configuration.php';
 require_once $GLOBALS['srcdir'].'/ESign/Form/Factory.php';
 require_once $GLOBALS['srcdir'].'/ESign/Form/Log.php';
+require_once $GLOBALS['srcdir'].'/authentication/login_operations.php';
 
 class Form_Controller extends Abstract_Controller
 {
@@ -86,7 +87,14 @@ class Form_Controller extends Abstract_Controller
             $lock = ( $this->getRequest()->getParam( 'lock', '' ) == 'on' ) ? true : false;
         }
         $amendment = $this->getRequest()->getParam( 'amendment', '' );
-        if ( confirm_user_password( $_SESSION['authUser'], $password ) ) {
+
+        if($GLOBALS['use_active_directory']) {
+            $valid = active_directory_validation($_SESSION['authUser'], $password);
+        }else {
+            $valid = confirm_user_password($_SESSION['authUser'], $password);
+        }
+
+        if ($valid) {
             $factory = new Form_Factory( $formId, $formDir, $encounterId );
             $signable = $factory->createSignable();
             if ( $signable->sign( $_SESSION['authUserID'], $lock, $amendment ) ) {

--- a/library/auth.inc
+++ b/library/auth.inc
@@ -120,6 +120,18 @@ if (!isset($_SESSION["last_update"])) {
 function authCheckSession ()
 {
     if (isset($_SESSION['authId'])) {
+         // If active directory was used, check a different session variable (as there is no password in database).
+        if($GLOBALS['use_active_directory'])
+        {
+            if($_SESSION['active_directory_auth'])
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
         $authDB = privQuery("select ".implode(",",array(TBL_USERS.".".COL_ID,
                                                         TBL_USERS.".".COL_UNM,
                                                         TBL_USERS_SECURE.".".COL_PWD,

--- a/library/authentication/login_operations.php
+++ b/library/authentication/login_operations.php
@@ -36,56 +36,66 @@ function validate_user_password($username,&$password,$provider)
     $ip=$_SERVER['REMOTE_ADDR'];
     
     $valid=false;
-    $getUserSecureSQL= " SELECT " . implode(",",array(COL_ID,COL_PWD,COL_SALT))
-                       ." FROM ".TBL_USERS_SECURE
-                       ." WHERE BINARY ".COL_UNM."=?";
-                       // Use binary keyword to require case sensitive username match
-    $userSecure=privQuery($getUserSecureSQL,array($username));
-    if(is_array($userSecure))
+
+    //Active Directory Authentication added by shachar zilbershlag <shaharzi@matrix.co.il>
+    if($GLOBALS['use_active_directory'])
     {
-        $phash=oemr_password_hash($password,$userSecure[COL_SALT]);
-        if($phash!=$userSecure[COL_PWD])
-        {
-            
-            return false;
-        }
-        $valid=true;
+        $valid = active_directory_validation($username, $password);
+        $_SESSION['active_directory_auth'] = $valid;
     }
     else
     {
-        if((!isset($GLOBALS['password_compatibility'])||$GLOBALS['password_compatibility']))           // use old password scheme if allowed.
+        $getUserSecureSQL= " SELECT " . implode(",",array(COL_ID,COL_PWD,COL_SALT))
+                        ." FROM ".TBL_USERS_SECURE
+                        ." WHERE BINARY ".COL_UNM."=?";
+                        // Use binary keyword to require case sensitive username match
+        $userSecure=privQuery($getUserSecureSQL,array($username));
+        if(is_array($userSecure))
         {
-            $getUserSQL="select username,id, password from users where BINARY username = ?";
-            $userInfo = privQuery($getUserSQL,array($username));
-            if($userInfo===false)
+            $phash=oemr_password_hash($password,$userSecure[COL_SALT]);
+            if($phash!=$userSecure[COL_PWD])
             {
-                return false;
-            }
                 
-            $username=$userInfo['username'];
-            $dbPasswordLen=strlen($userInfo['password']);
-            if($dbPasswordLen==32)
-            {
-                $phash=md5($password);
-                $valid=$phash==$userInfo['password'];
-            }
-            else if($dbPasswordLen==40)
-            {
-                $phash=sha1($password);
-                $valid=$phash==$userInfo['password'];
-            }
-            if($valid)
-            {
-                $phash=initializePassword($username,$userInfo['id'],$password);
-                purgeCompatabilityPassword($username,$userInfo['id']);
-                $_SESSION['relogin'] = 1;
-            }
-            else
-            {
                 return false;
             }
+            $valid=true;
         }
-        
+        else
+        {
+            if((!isset($GLOBALS['password_compatibility'])||$GLOBALS['password_compatibility']))           // use old password scheme if allowed.
+            {
+                $getUserSQL="select username,id, password from users where BINARY username = ?";
+                $userInfo = privQuery($getUserSQL,array($username));
+                if($userInfo===false)
+                {
+                    return false;
+                }
+                    
+                $username=$userInfo['username'];
+                $dbPasswordLen=strlen($userInfo['password']);
+                if($dbPasswordLen==32)
+                {
+                    $phash=md5($password);
+                    $valid=$phash==$userInfo['password'];
+                }
+                else if($dbPasswordLen==40)
+                {
+                    $phash=sha1($password);
+                    $valid=$phash==$userInfo['password'];
+                }
+                if($valid)
+                {
+                    $phash=initializePassword($username,$userInfo['id'],$password);
+                    purgeCompatabilityPassword($username,$userInfo['id']);
+                    $_SESSION['relogin'] = 1;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            
+        }
     }
     $getUserSQL="select id, authorized, see_auth".
                         ", cal_ui, active ".
@@ -136,5 +146,46 @@ function verify_user_gacl_group($user)
       }
     }
     return true;
+}
+
+/* Validation of user and password using active directory. */
+function active_directory_validation($user, $pass)
+{
+    $valid = false;
+
+    // Create class instance
+    $ad = new Adldap\Adldap();
+
+    // Create a configuration array.
+    $config = array(
+        // Your account suffix, for example: jdoe@corp.acme.org
+        'account_suffix'        => $GLOBALS['account_suffix'],
+
+        // You can use the host name or the IP address of your controllers.
+        'domain_controllers'    => [$GLOBALS['domain_controllers']],
+
+        // Your base DN.
+        'base_dn'               => $GLOBALS['base_dn'],
+
+        // The account to use for querying / modifying users. This
+        // does not need to be an actual admin account.
+        'admin_username'        => $user,
+        'admin_password'        => $pass,
+    );
+
+    // Add a connection provider to Adldap.
+    $ad->addProvider($config);
+
+    // If a successful connection is made, the provider will be returned.
+    try
+    {
+        $prov = $ad->connect();
+        $valid = $prov->auth()->attempt($user, $pass);
+    }
+    catch(Exception $e)
+    {
+        
+    }
+    return $valid;
 }
 ?>

--- a/library/authentication/password_change.php
+++ b/library/authentication/password_change.php
@@ -97,16 +97,28 @@ function update_password($activeUser,$targetUser,&$currentPwd,&$newPwd,&$errMsg,
     }
     else {
         // If this is an administrator changing someone else's password, then check that they have the password right
+        if($GLOBALS['use_active_directory']) {
+            $valid = active_directory_validation($_SESSION['authUser'], $currentPwd);
+            if(!$valid)
+            {
+                $errMsg=xl("Incorrect password!");
+                return false;
+            }else{
+                $newPwd = md5(uniqid());
+            }
+        }else {
 
-        $adminSQL=" SELECT ".implode(",",array(COL_PWD,COL_SALT))
-                  ." FROM ".TBL_USERS_SECURE
-                  ." WHERE ".COL_ID."=?";
-        $adminInfo=privQuery($adminSQL,array($activeUser));
-        $hash_admin = oemr_password_hash($currentPwd,$adminInfo[COL_SALT]);
-        if($hash_admin!=$adminInfo[COL_PWD])
-        {
-            $errMsg=xl("Incorrect password!");
-            return false;
+            $adminSQL=" SELECT ".implode(",",array(COL_PWD,COL_SALT))
+                      ." FROM ".TBL_USERS_SECURE
+                      ." WHERE ".COL_ID."=?";
+            $adminInfo=privQuery($adminSQL,array($activeUser));
+            $hash_admin = oemr_password_hash($currentPwd,$adminInfo[COL_SALT]);
+            if($hash_admin!=$adminInfo[COL_PWD])
+            {
+                $errMsg=xl("Incorrect password!");
+                return false;
+            }
+
         }
         if(!acl_check('admin', 'users'))
         {

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -1649,6 +1649,36 @@ $GLOBALS_METADATA = array(
       ),
   ),
 
+  // Active Directory Tab
+  //
+  'Active Directory' => array(
+    
+    'use_active_directory' => array(
+      xl('Use Active Directory'),
+      'bool',
+      '0',
+      xl('If enabled, uses the specified active directory for login and authentication.')
+     ),
+    'account_suffix' => array(
+      xl('Suffix Of Account'),
+      'text',
+      '',
+      xl('The suffix of the account.')
+     ),
+    'base_dn' => array(
+      xl('Domains Base'),
+      'text',
+      '',
+      xl('Users is the standard windows CN, replace the DC stuff with your domain.')
+     ),
+    'domain_controllers' => array(
+      xl('Domains Controllers'),
+      'text',
+      '',
+      xl('The IP address of your domain controller(s).')
+     ), 
+  ),
+
   // Notifications Tab
   //
   'Notifications' => array(


### PR DESCRIPTION
Hi Brady,

This is a cool addition to enable auth against active directory.

The general idea:
The authentication of the users will be against AD. Still though, the acl of users (and all user info) will be against the DB. This means that though 'user_security' table will not be used (as we are not storing passwords in the DB), every user MUST exist in the 'users' table. Therefore in the system initialization (setup), if the user wants for auth to be against AD, he will need to provide his username (not password) so system can create his user in the DB.  

There is still much work to be done - I've only developed the login procedure. 
We still need to:
- Authenticate the E-sign with active directory
- Disable 'change password' screen incase active directory auth is enabled
- When adding a user the password (of whoever is adding the user) is checked against the AD and no password is needed for the new user
- Update setup process so that if we want to use AD auth then user will be able to enter connection details and his user in the active directory (password will not be needed because when he logs in it is checked with AD

So this feature is still under heavy development, but wanted to hear your thoughts on what was done so far and suggestions for the future.

P.S. 
I have no idea why git made a whole scramble of the login_operations file - I tried reverting and commiting again but didn't help, tell me if you know how to beautify this.

Regards,
Shachar