### PR TITLE
Fix - no recurring appointments are being displayed in the sixth row of calendar month view

### DIFF
--- a/interface/main/calendar/modules/PostCalendar/pnuserapi.php
+++ b/interface/main/calendar/modules/PostCalendar/pnuserapi.php
@@ -1331,8 +1331,8 @@ function calculateEvents($days,$events,$viewtype) {
   if      ($viewtype == 'day')   $tmpsecs +=  3 * 24 * 3600;
   else if ($viewtype == 'week')  $tmpsecs +=  9 * 24 * 3600;
   else if ($viewtype == 'month') {
-      if($day_number > 35) $tmpsecs = strtotime("+41 days", $tmpsecs); // Added for 6th row by epsdky 2017
-      else $tmpsecs = strtotime("+34 days", $tmpsecs);
+    if($day_number > 35) $tmpsecs = strtotime("+41 days", $tmpsecs); // Added for 6th row by epsdky 2017
+    else $tmpsecs = strtotime("+34 days", $tmpsecs);
   }
   else $tmpsecs += 367 * 24 * 3600;
   $last_date = date('Y-m-d', $tmpsecs);


### PR DESCRIPTION
Hello Brady,

No recurring appointments are being displayed in the sixth row of the calendar month view (when present).

And no recurring appointments are being displayed for the last day of the fifth row of the calendar month view when there is a day in the month view prior to the last day of the fifth row that contains more than 24 hours (daylight saving).

(Also some changes for efficiency).
