### PR TITLE
fix rules css

### DIFF
--- a/interface/super/rules/www/css/rules.css
+++ b/interface/super/rules/www/css/rules.css
@@ -86,7 +86,7 @@ root {
 .mid_col {
     float: left;
     display:block;
-    width: 200px;
+    width: 33%;
 }
 
 .end_col {


### PR DESCRIPTION
![selection_006](https://cloud.githubusercontent.com/assets/24208045/23609440/a6d802f4-0276-11e7-9728-b1b2691eb1d2.png)

on clinic rules, longs string tend to get on each other.
these css changes should fix this.