### PR TITLE
White list of files types that allowed to upload to server 

### DIFF
--- a/controllers/C_Document.class.php
+++ b/controllers/C_Document.class.php
@@ -113,14 +113,6 @@ class C_Document extends Controller {
         $sentUploadStatus = array();
         if( count($_FILES['file']['name']) > 0){
             $upl_inc = 0;
-            if($GLOBALS['secure_upload']){
-
-                $white_list = array();
-                $lres = sqlStatement("SELECT option_id FROM list_options WHERE list_id = 'files_white_list' AND activity = 1");
-                while ($lrow = sqlFetchArray($lres)) {
-                    $white_list[] = $lrow['option_id'];
-                }
-            }
 
             foreach($_FILES['file']['name'] as $key => $value){
                 $fname = $value;
@@ -134,7 +126,7 @@ class C_Document extends Controller {
                     if ($_FILES['file']['size'][$key] == 0) {
                         $error .= "The system does not permit uploading files of with size 0.\n";
                     }
-                }elseif($GLOBALS['secure_upload'] && !$this->isWhiteFile($_FILES['file']['tmp_name'][$key], $white_list)){
+                }elseif($GLOBALS['secure_upload'] && !isWhiteFile($_FILES['file']['tmp_name'][$key], $white_list)){
                        $error = "The system does not permit uploading files with MIME content type - " . mime_content_type($_FILES['file']['tmp_name'][$key]) . ".\n";
                 }else{
                     $tmpfile = fopen($_FILES['file']['tmp_name'][$key], "r");
@@ -1353,23 +1345,6 @@ function _check_relocation($url, $new_pid = null, $new_name = null) {
 }
 
 
-/**
- * This function detects a MIME type for a file and check if it in the white list of the allowed mime types.
- * @param string $file - file location.
- * @param array $whiteList - array of mime types that allowed to upload.
- */
-function isWhiteFile($file, $whiteList){
-
-    $mimetype  = mime_content_type($file);
-	if(in_array($mimetype, $whiteList)){
-		return true;
-	} else {
-		$splitMimeType = explode('/', $mimetype);
-		$categoryType = $splitMimeType[0];
-		if(in_array($categoryType. '/*',  $whiteList))return true;
-	}
-	return false;
-}
 
 }
 ?>

--- a/controllers/C_Document.class.php
+++ b/controllers/C_Document.class.php
@@ -122,12 +122,12 @@ class C_Document extends Controller {
                     if (empty($fname)) {
                         $fname = htmlentities("<empty>");
                     }
-                    $error = "Error number: " . $_FILES['file']['error'][$key] . " occured while uploading file named: " . $fname . "\n";
+                    $error = xl("Error number") .": " . $_FILES['file']['error'][$key] . " " . xl("occured while uploading file named") . ": " . $fname . "\n";
                     if ($_FILES['file']['size'][$key] == 0) {
-                        $error .= "The system does not permit uploading files of with size 0.\n";
+                        $error .= xl("The system does not permit uploading files of with size 0") . ".\n";
                     }
-                }elseif($GLOBALS['secure_upload'] && !isWhiteFile($_FILES['file']['tmp_name'][$key], $white_list)){
-                       $error = "The system does not permit uploading files with MIME content type - " . mime_content_type($_FILES['file']['tmp_name'][$key]) . ".\n";
+                }elseif($GLOBALS['secure_upload'] && !isWhiteFile($_FILES['file']['tmp_name'][$key])){
+                       $error = xl("The system does not permit uploading files with MIME content type") . " - " . mime_content_type($_FILES['file']['tmp_name'][$key]) . ".\n";
                 }else{
                     $tmpfile = fopen($_FILES['file']['tmp_name'][$key], "r");
                     $filetext = fread($tmpfile, $_FILES['file']['size'][$key]);

--- a/interface/super/manage_site_files.php
+++ b/interface/super/manage_site_files.php
@@ -138,18 +138,30 @@ if($GLOBALS['secure_upload']){
 
     curl_setopt_array($curl, array(
         CURLOPT_RETURNTRANSFER => 1,
-        CURLOPT_URL => 'https://cdn.rawgit.com/jshttp/mime-db/master/db.json'
+        CURLOPT_URL => 'https://cdn.rawgit.com/jshttp/mime-db/master/db.json',
+        CURLOPT_CONNECTTIMEOUT => 5,
+        CURLOPT_TIMEOUT => 5
     ));
    // Send the request & save response to $resp
     $resp = curl_exec($curl);
-    if($resp){
+    $httpinfo = curl_getinfo($curl);
+    if($resp && $httpinfo['http_code'] == 200 && $httpinfo['content_type'] == 'application/json;charset=utf-8'){
         $all_mime_types = json_decode($resp, true);
         foreach ($all_mime_types as $name => $value){
             $mime_types[] = $name;
         }
-
     } else {
         error_log('Get list of mime-type error: "' . curl_error($curl) . '" - Code: ' . curl_errno($curl));
+        $mime_types_list = array(
+            'application/pdf',
+            'image/jpeg',
+            'image/png',
+            'image/gif',
+            'application/msword',
+            'application/vnd.oasis.opendocument.spreadsheet',
+            'text/plain'
+        );
+        $mime_types = array_merge($mime_types, $mime_types_list);
     }
     curl_close($curl);
 

--- a/interface/super/manage_site_files.php
+++ b/interface/super/manage_site_files.php
@@ -337,7 +337,7 @@ function msfFileChanged() {
     <form id="whitelist_form" method="post">
         <div class="subject-black-list">
             <div class="top-list">
-               <h2><?php echo xlt('black-list'); ?></h2>
+               <h2><?php echo xlt('Black list'); ?></h2>
                <b><?php echo xlt('Filter');?>:</b> <input type="text" id="filter-black-list" >
             </div>
             <select multiple="multiple" id='black-list' class="form-control">
@@ -360,7 +360,7 @@ function msfFileChanged() {
 
         <div class="subject-white-list">
             <div class="top-list">
-                <h2><?php echo xlt('white-list'); ?></h2>
+                <h2><?php echo xlt('White list'); ?></h2>
                 <b><?php echo xlt('Add manually');?>:</b> <input type="text" id="add-manually-input"> <input type="button" id="add-manually" value="+">
             </div>
             <select name="white_list[]" multiple="multiple" id='white-list' class="form-control">

--- a/interface/themes/rtl.css
+++ b/interface/themes/rtl.css
@@ -600,3 +600,15 @@ form#pattrk #inanewwindow>span{
     /* IE8 and below */
     filter: progid:DXImageTransform.Microsoft.Matrix(M11=-1, M12=0, M21=0, M22=-1, DX=0, DY=0, SizingMethod='auto expand');
 }
+
+#file_type_whitelist .subject-black-list,
+#file_type_whitelist .subject-white-list,
+#file_type_whitelist .subject-info-save,
+#file_type_whitelist .subject-info-arrows
+{
+    float: right;
+}
+
+#white-list, #black-list{
+    direction: ltr;
+}

--- a/interface/themes/style_babyblu.css
+++ b/interface/themes/style_babyblu.css
@@ -1270,3 +1270,61 @@ table.dataTable#therapy_groups_list tbody td{
 #group_attendance_form_table tbody td{
   text-align: center;
 }
+
+#file_type_whitelist .subject-black-list,
+#file_type_whitelist .subject-white-list {
+
+    display: inline-block;
+    width: 420px;
+    float: left;
+}
+
+#file_type_whitelist{
+    height: 400px;
+    padding: 10px;
+}
+#white-list, #black-list{
+    margin: 10px;
+    padding: 10px;
+
+    width: 400px;
+}
+#file_type_whitelist select {
+    height: 250px;
+    padding: 0;
+}
+#file_type_whitelist option {
+    padding: 4px 10px 4px 10px;
+}
+
+#file_type_whitelist option:hover {
+    background: #EEEEEE;
+}
+
+#file_type_whitelist .subject-info-arrows {
+
+    display: inline-block;
+    width: 58px;
+    margin: 130px 30px 30px 30px;
+    float: left;
+}
+#file_type_whitelist .subject-info-save{
+    width: 60px;
+    margin: 170px 30px 30px 30px;
+    float: left;
+}
+
+#file_type_whitelist input[type=button]{
+    float: none !important;
+    width: 63px;
+}
+#file_type_whitelist #add-manually{
+    display: inline-block
+}
+#file_type_whitelist #add-manually-input{
+    width: 190px;
+}
+#file_type_whitelist .top-list{
+    margin: 20px 20px 2px 20px;
+
+}

--- a/interface/themes/style_blue.css
+++ b/interface/themes/style_blue.css
@@ -485,3 +485,61 @@ table.dataTable#therapy_groups_list tbody td{
 #group_attendance_form_table tbody td{
   text-align: center;
 }
+
+#file_type_whitelist .subject-black-list,
+#file_type_whitelist .subject-white-list {
+
+	display: inline-block;
+	width: 420px;
+	float: left;
+}
+
+#file_type_whitelist{
+	height: 400px;
+	padding: 10px;
+}
+#white-list, #black-list{
+	margin: 10px;
+	padding: 10px;
+
+	width: 400px;
+}
+#file_type_whitelist select {
+	height: 250px;
+	padding: 0;
+}
+#file_type_whitelist option {
+	padding: 4px 10px 4px 10px;
+}
+
+#file_type_whitelist option:hover {
+	background: #EEEEEE;
+}
+
+#file_type_whitelist .subject-info-arrows {
+
+	display: inline-block;
+	width: 58px;
+	margin: 130px 30px 30px 30px;
+	float: left;
+}
+#file_type_whitelist .subject-info-save{
+	width: 60px;
+	margin: 170px 30px 30px 30px;
+	float: left;
+}
+
+#file_type_whitelist input[type=button]{
+	float: none !important;
+	width: 63px;
+}
+#file_type_whitelist #add-manually{
+	display: inline-block
+}
+#file_type_whitelist #add-manually-input{
+	width: 190px;
+}
+#file_type_whitelist .top-list{
+	margin: 20px 20px 2px 20px;
+
+}

--- a/interface/themes/style_light.css
+++ b/interface/themes/style_light.css
@@ -1433,3 +1433,60 @@ table.dataTable#therapy_groups_list tbody td{
   text-align: center;
 }
 
+#file_type_whitelist .subject-black-list,
+#file_type_whitelist .subject-white-list {
+
+  display: inline-block;
+  width: 420px;
+  float: left;
+}
+
+#file_type_whitelist{
+  height: 400px;
+  padding: 10px;
+}
+#white-list, #black-list{
+  margin: 10px;
+  padding: 10px;
+
+  width: 400px;
+}
+#file_type_whitelist select {
+  height: 250px;
+  padding: 0;
+}
+#file_type_whitelist option {
+  padding: 4px 10px 4px 10px;
+}
+
+#file_type_whitelist option:hover {
+  background: #EEEEEE;
+}
+
+#file_type_whitelist .subject-info-arrows {
+
+  display: inline-block;
+  width: 58px;
+  margin: 130px 30px 30px 30px;
+  float: left;
+}
+#file_type_whitelist .subject-info-save{
+  width: 60px;
+  margin: 170px 30px 30px 30px;
+  float: left;
+}
+
+#file_type_whitelist input[type=button]{
+  float: none !important;
+  width: 63px;
+}
+#file_type_whitelist #add-manually{
+  display: inline-block
+}
+#file_type_whitelist #add-manually-input{
+  width: 190px;
+}
+#file_type_whitelist .top-list{
+  margin: 20px 20px 2px 20px;
+
+}

--- a/interface/themes/style_metal.css
+++ b/interface/themes/style_metal.css
@@ -1276,3 +1276,61 @@ table.dataTable#therapy_groups_list tbody td{
 #group_attendance_form_table tbody td{
   text-align: center;
 }
+
+#file_type_whitelist .subject-black-list,
+#file_type_whitelist .subject-white-list {
+
+    display: inline-block;
+    width: 420px;
+    float: left;
+}
+
+#file_type_whitelist{
+    height: 400px;
+    padding: 10px;
+}
+#white-list, #black-list{
+    margin: 10px;
+    padding: 10px;
+
+    width: 400px;
+}
+#file_type_whitelist select {
+    height: 250px;
+    padding: 0;
+}
+#file_type_whitelist option {
+    padding: 4px 10px 4px 10px;
+}
+
+#file_type_whitelist option:hover {
+    background: #EEEEEE;
+}
+
+#file_type_whitelist .subject-info-arrows {
+
+    display: inline-block;
+    width: 58px;
+    margin: 130px 30px 30px 30px;
+    float: left;
+}
+#file_type_whitelist .subject-info-save{
+    width: 60px;
+    margin: 170px 30px 30px 30px;
+    float: left;
+}
+
+#file_type_whitelist input[type=button]{
+    float: none !important;
+    width: 63px;
+}
+#file_type_whitelist #add-manually{
+    display: inline-block
+}
+#file_type_whitelist #add-manually-input{
+    width: 190px;
+}
+#file_type_whitelist .top-list{
+    margin: 20px 20px 2px 20px;
+
+}

--- a/interface/themes/style_oemr.css
+++ b/interface/themes/style_oemr.css
@@ -1286,3 +1286,61 @@ table.dataTable#therapy_groups_list tbody td{
 #group_attendance_form_table tbody td{
   text-align: center;
 }
+
+#file_type_whitelist .subject-black-list,
+#file_type_whitelist .subject-white-list {
+
+    display: inline-block;
+    width: 420px;
+    float: left;
+}
+
+#file_type_whitelist{
+    height: 400px;
+    padding: 10px;
+}
+#white-list, #black-list{
+    margin: 10px;
+    padding: 10px;
+
+    width: 400px;
+}
+#file_type_whitelist select {
+    height: 250px;
+    padding: 0;
+}
+#file_type_whitelist option {
+    padding: 4px 10px 4px 10px;
+}
+
+#file_type_whitelist option:hover {
+    background: #EEEEEE;
+}
+
+#file_type_whitelist .subject-info-arrows {
+
+    display: inline-block;
+    width: 58px;
+    margin: 130px 30px 30px 30px;
+    float: left;
+}
+#file_type_whitelist .subject-info-save{
+    width: 60px;
+    margin: 170px 30px 30px 30px;
+    float: left;
+}
+
+#file_type_whitelist input[type=button]{
+    float: none !important;
+    width: 63px;
+}
+#file_type_whitelist #add-manually{
+    display: inline-block
+}
+#file_type_whitelist #add-manually-input{
+    width: 190px;
+}
+#file_type_whitelist .top-list{
+    margin: 20px 20px 2px 20px;
+
+}

--- a/interface/themes/style_purple.css
+++ b/interface/themes/style_purple.css
@@ -1276,3 +1276,61 @@ table.dataTable#therapy_groups_list tbody td{
 #group_attendance_form_table tbody td{
   text-align: center;
 }
+
+#file_type_whitelist .subject-black-list,
+#file_type_whitelist .subject-white-list {
+
+    display: inline-block;
+    width: 420px;
+    float: left;
+}
+
+#file_type_whitelist{
+    height: 400px;
+    padding: 10px;
+}
+#white-list, #black-list{
+    margin: 10px;
+    padding: 10px;
+
+    width: 400px;
+}
+#file_type_whitelist select {
+    height: 250px;
+    padding: 0;
+}
+#file_type_whitelist option {
+    padding: 4px 10px 4px 10px;
+}
+
+#file_type_whitelist option:hover {
+    background: #EEEEEE;
+}
+
+#file_type_whitelist .subject-info-arrows {
+
+    display: inline-block;
+    width: 58px;
+    margin: 130px 30px 30px 30px;
+    float: left;
+}
+#file_type_whitelist .subject-info-save{
+    width: 60px;
+    margin: 170px 30px 30px 30px;
+    float: left;
+}
+
+#file_type_whitelist input[type=button]{
+    float: none !important;
+    width: 63px;
+}
+#file_type_whitelist #add-manually{
+    display: inline-block
+}
+#file_type_whitelist #add-manually-input{
+    width: 190px;
+}
+#file_type_whitelist .top-list{
+    margin: 20px 20px 2px 20px;
+
+}

--- a/interface/themes/style_radiant.css
+++ b/interface/themes/style_radiant.css
@@ -9904,3 +9904,61 @@ table.dataTable#therapy_groups_list tbody td{
 #group_attendance_form_table tbody td{
   text-align: center;
 }
+
+#file_type_whitelist .subject-black-list,
+#file_type_whitelist .subject-white-list {
+
+    display: inline-block;
+    width: 420px;
+    float: left;
+}
+
+#file_type_whitelist{
+    height: 400px;
+    padding: 10px;
+}
+#white-list, #black-list{
+    margin: 10px;
+    padding: 10px;
+
+    width: 400px;
+}
+#file_type_whitelist select {
+    height: 250px;
+    padding: 0;
+}
+#file_type_whitelist option {
+    padding: 4px 10px 4px 10px;
+}
+
+#file_type_whitelist option:hover {
+    background: #EEEEEE;
+}
+
+#file_type_whitelist .subject-info-arrows {
+
+    display: inline-block;
+    width: 58px;
+    margin: 130px 30px 30px 30px;
+    float: left;
+}
+#file_type_whitelist .subject-info-save{
+    width: 60px;
+    margin: 170px 30px 30px 30px;
+    float: left;
+}
+
+#file_type_whitelist input[type=button]{
+    float: none !important;
+    width: 63px;
+}
+#file_type_whitelist #add-manually{
+    display: inline-block
+}
+#file_type_whitelist #add-manually-input{
+    width: 190px;
+}
+#file_type_whitelist .top-list{
+    margin: 20px 20px 2px 20px;
+
+}

--- a/interface/themes/style_sky_blue.css
+++ b/interface/themes/style_sky_blue.css
@@ -1277,3 +1277,61 @@ table.dataTable#therapy_groups_list tbody td{
 #group_attendance_form_table tbody td{
   text-align: center;
 }
+
+#file_type_whitelist .subject-black-list,
+#file_type_whitelist .subject-white-list {
+
+    display: inline-block;
+    width: 420px;
+    float: left;
+}
+
+#file_type_whitelist{
+    height: 400px;
+    padding: 10px;
+}
+#white-list, #black-list{
+    margin: 10px;
+    padding: 10px;
+
+    width: 400px;
+}
+#file_type_whitelist select {
+    height: 250px;
+    padding: 0;
+}
+#file_type_whitelist option {
+    padding: 4px 10px 4px 10px;
+}
+
+#file_type_whitelist option:hover {
+    background: #EEEEEE;
+}
+
+#file_type_whitelist .subject-info-arrows {
+
+    display: inline-block;
+    width: 58px;
+    margin: 130px 30px 30px 30px;
+    float: left;
+}
+#file_type_whitelist .subject-info-save{
+    width: 60px;
+    margin: 170px 30px 30px 30px;
+    float: left;
+}
+
+#file_type_whitelist input[type=button]{
+    float: none !important;
+    width: 63px;
+}
+#file_type_whitelist #add-manually{
+    display: inline-block
+}
+#file_type_whitelist #add-manually-input{
+    width: 190px;
+}
+#file_type_whitelist .top-list{
+    margin: 20px 20px 2px 20px;
+
+}

--- a/interface/themes/style_tan.css
+++ b/interface/themes/style_tan.css
@@ -1354,3 +1354,62 @@ table.dataTable#therapy_groups_list tbody td{
 #group_attendance_form_table tbody td{
   text-align: center;
 }
+
+
+#file_type_whitelist .subject-black-list,
+#file_type_whitelist .subject-white-list {
+
+    display: inline-block;
+    width: 420px;
+    float: left;
+}
+
+#file_type_whitelist{
+    height: 400px;
+    padding: 10px;
+}
+#white-list, #black-list{
+    margin: 10px;
+    padding: 10px;
+
+    width: 400px;
+}
+#file_type_whitelist select {
+    height: 250px;
+    padding: 0;
+}
+#file_type_whitelist option {
+    padding: 4px 10px 4px 10px;
+}
+
+#file_type_whitelist option:hover {
+    background: #EEEEEE;
+}
+
+#file_type_whitelist .subject-info-arrows {
+
+    display: inline-block;
+    width: 58px;
+    margin: 130px 30px 30px 30px;
+    float: left;
+}
+#file_type_whitelist .subject-info-save{
+    width: 60px;
+    margin: 170px 30px 30px 30px;
+    float: left;
+}
+
+#file_type_whitelist input[type=button]{
+    float: none !important;
+    width: 63px;
+}
+#file_type_whitelist #add-manually{
+    display: inline-block
+}
+#file_type_whitelist #add-manually-input{
+    width: 190px;
+}
+#file_type_whitelist .top-list{
+    margin: 20px 20px 2px 20px;
+
+}

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -1580,21 +1580,18 @@ $GLOBALS_METADATA = array(
       '7200',                           // default
       xl('Maximum idle time in seconds before logout. Default is 7200 (2 hours).')
     ),
-
-    'secure_password' => array(
-      xl('Require Strong Passwords'),
-      'bool',                           // data type
-      '0',                              // default
-      xl('Strong password means at least 8 characters, and at least three of: a number, a lowercase letter, an uppercase letter, a special character.')
-    ),
-
     'secure_upload' => array(
       xl('Secure upload files'),
       'bool',                           // data type
       '0',                              // default
       xl('Block all files types that not found in the white-list. interface to edit white-list locate under the administrator->files.')
     ),
-
+    'secure_password' => array(
+      xl('Require Strong Passwords'),
+      'bool',                           // data type
+      '0',                              // default
+      xl('Strong password means at least 8 characters, and at least three of: a number, a lowercase letter, an uppercase letter, a special character.')
+    ),
     'password_history' => array(
       xl('Require Unique Passwords'),
       'bool',                           // data type

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -1588,6 +1588,13 @@ $GLOBALS_METADATA = array(
       xl('Strong password means at least 8 characters, and at least three of: a number, a lowercase letter, an uppercase letter, a special character.')
     ),
 
+    'secure_upload' => array(
+      xl('Secure upload files'),
+      'bool',                           // data type
+      '0',                              // default
+      xl('Block all files types that not found in the white-list. interface to edit white-list locate under the administrator->files.')
+    ),
+
     'password_history' => array(
       xl('Require Unique Passwords'),
       'bool',                           // data type

--- a/library/sanitize.inc.php
+++ b/library/sanitize.inc.php
@@ -54,8 +54,8 @@ function basename_international($path){
  * @param array|null $whiteList - array of mime types that allowed to upload.
  */
 $white_list = null;
-function isWhiteFile($file, &$white_list){
-
+function isWhiteFile($file){
+    global $white_list;
     if(is_null($white_list)){
         $white_list = array();
         $lres = sqlStatement("SELECT option_id FROM list_options WHERE list_id = 'files_white_list' AND activity = 1");

--- a/library/sanitize.inc.php
+++ b/library/sanitize.inc.php
@@ -47,4 +47,32 @@ function basename_international($path){
   return $decoded_file_name;
 }
 
+
+/**
+ * This function detects a MIME type for a file and check if it in the white list of the allowed mime types.
+ * @param string $file - file location.
+ * @param array|null $whiteList - array of mime types that allowed to upload.
+ */
+$white_list = null;
+function isWhiteFile($file, &$white_list){
+
+    if(is_null($white_list)){
+        $white_list = array();
+        $lres = sqlStatement("SELECT option_id FROM list_options WHERE list_id = 'files_white_list' AND activity = 1");
+        while ($lrow = sqlFetchArray($lres)) {
+            $white_list[] = $lrow['option_id'];
+        }
+    }
+
+    $mimetype  = mime_content_type($file);
+    if(in_array($mimetype, $white_list)){
+        return true;
+    } else {
+        $splitMimeType = explode('/', $mimetype);
+        $categoryType = $splitMimeType[0];
+        if(in_array($categoryType. '/*',  $white_list))return true;
+    }
+    return false;
+}
+
 ?>

--- a/sql/5_0_0-to-5_0_1_upgrade.sql
+++ b/sql/5_0_0-to-5_0_1_upgrade.sql
@@ -267,3 +267,8 @@ CREATE TABLE `form_therapy_groups_attendance` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB ;
 #EndIf
+
+
+#IfNotRow2D list_options list_id lists option_id files_white_list
+INSERT INTO list_options (`list_id`, `option_id`, `title`) VALUES ('lists', 'files_white_list', 'Files type white list');
+#EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -4643,6 +4643,10 @@ INSERT INTO list_options ( list_id, option_id, title, seq, is_default ) VALUES (
 INSERT INTO list_options ( list_id, option_id, title, seq, is_default ) VALUES ('provider_qualifier_code','dk','DK',10,0);
 INSERT INTO list_options ( list_id, option_id, title, seq, is_default ) VALUES ('provider_qualifier_code','dn','DN',20,0);
 
+-- Files type white list
+INSERT INTO list_options (`list_id`, `option_id`, `title`) VALUES ('lists', 'files_white_list', 'Files type white list');
+
+
 --
 -- Table structure for table `lists`
 --

--- a/templates/documents/general_upload.html
+++ b/templates/documents/general_upload.html
@@ -66,4 +66,4 @@
 		</div>
 	{/foreach}
 {/if}
-
+<h3>{$error}</h3>


### PR DESCRIPTION
Hi.
Here new feature to ensure secure uploading files in the system.
Right now all the files are allowed to upload even script file what that enabled easy incursion to server (and it was tried..)
This feature enables to create white list of MIME content types of  allowed files and blocks all the others.
It should turn on with 'secure_upload' global  and the edit interface is found at administator->files.

hopefully you agree with the importance of this issues..
Thanks

Amiel 