### PR TITLE
Not really a bug fix but more of an interop compromise! MSIE seems to…

### DIFF
--- a/interface/themes/tabs_style_compact.css
+++ b/interface/themes/tabs_style_compact.css
@@ -88,6 +88,7 @@ body
 {
     flex: 1 0 auto;
     border: 0px solid black;
+    width: 100%;
 }
 
 .tabControls

--- a/interface/themes/tabs_style_full.css
+++ b/interface/themes/tabs_style_full.css
@@ -91,6 +91,7 @@ body
 {
     flex: 1 0 auto;
     border: 0px solid black;
+    width: 100%
 }
 
 .tabControls


### PR DESCRIPTION
… want a width (or height) for flex column (or row) so added a width to tab styles for iframes. If looking to slip in to v5.0 keep in mind these sheets come from master branch and an id patientData was recently renamed to attendentData on one style.

Tested on Edge, Firefox 49+ and Chrome.