### PR TITLE
allow multiple codes of same code type on the layout billing code widget

### DIFF
--- a/interface/forms/LBF/new.php
+++ b/interface/forms/LBF/new.php
@@ -361,11 +361,6 @@ function set_related(codetype, code, selector, codedesc) {
  var s = frc.value;
  var sd = frcd ? frcd.value : s;
  if (code) {
-  if (codetype != 'PROD') {
-   if (s.indexOf(codetype + ':') == 0 || s.indexOf(';' + codetype + ':') > 0) {
-    return '<?php echo xl('A code of this type is already selected. Erase the field first if you need to replace it.') ?>';
-   }
-  }
   if (s.length > 0) {
    s  += ';';
    sd += ';';


### PR DESCRIPTION
Unclear why we are enforcing only 1 code per code type here.
Let me know if I am missing something and if there are there any good reasons to enforce this?