### PR TITLE
Form-specific access control for standard encounter forms.

### DIFF
--- a/interface/forms_admin/forms_admin.php
+++ b/interface/forms_admin/forms_admin.php
@@ -4,9 +4,15 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
+$sanitize_all_escapes = true;
+$fake_register_globals = false;
+
 //INCLUDES, DO ANY ACTIONS, THEN GET OUR DATA
-include_once("../globals.php");
-include_once("$srcdir/registry.inc");
+require_once("../globals.php");
+require_once("$srcdir/acl.inc");
+require_once("$phpgacl_location/gacl_api.class.php");
+require_once("$srcdir/registry.inc");
+
 if ($_GET['method'] == "enable"){
 	updateRegistered ( $_GET['id'], "state=1" );
 }
@@ -25,7 +31,6 @@ elseif ($_GET['method'] == "register"){
 }
 $bigdata = getRegistered("%") or $bigdata = false;
 
-
 //START OUT OUR PAGE....
 ?>
 <html>
@@ -37,34 +42,32 @@ $bigdata = getRegistered("%") or $bigdata = false;
 <span class="title"><?php xl('Forms Administration','e');?></span>
 <br><br>
 <?php
-	foreach($_POST as $key=>$val) {
-	       if (preg_match('/nickname_(\d+)/', $key, $matches)) {
-               		$nickname_id = $matches[1];
-			sqlQuery("update registry set nickname='".$val."' where id=".$nickname_id);
-		}
-	       if (preg_match('/category_(\d+)/', $key, $matches)) {
-               		$category_id = $matches[1];
-			sqlQuery("update registry set category='".$val."' where id=".$category_id);
-		}
-	       if (preg_match('/priority_(\d+)/', $key, $matches)) {
-               		$priority_id = $matches[1];
-			sqlQuery("update registry set priority='".$val."' where id=".$priority_id);
-		}
-        }
+  foreach($_POST as $key => $val) {
+    if (preg_match('/nickname_(\d+)/', $key, $matches)) {
+      sqlQuery("update registry set nickname = ? where id = ?", array($val, $matches[1]));
+    }
+    else if (preg_match('/category_(\d+)/', $key, $matches)) {
+      sqlQuery("update registry set category = ? where id = ?", array($val, $matches[1]));
+    }
+    else if (preg_match('/priority_(\d+)/', $key, $matches)) {
+      sqlQuery("update registry set priority = ? where id = ?", array($val, $matches[1]));
+    }
+    else if (preg_match('/aco_spec_(\d+)/', $key, $matches)) {
+      sqlQuery("update registry set aco_spec = ? where id = ?", array($val, $matches[1]));
+    }
+  }
 ?>
-
 
 <?php //ERROR REPORTING
 if ($err)
 	echo "<span class=bold>$err</span><br><br>\n";
 ?>
 
-
 <?php //REGISTERED SECTION ?>
 <span class=bold><?php xl('Registered','e');?></span><br>
 <form method=POST action ='./forms_admin.php'>
-<i><?php xl('click here to update priority, category and nickname settings','e'); ?></i>
-<input type=submit name=update value='<?php xl('update','e'); ?>'><br>
+<i><?php echo xlt('click here to update priority, category, nickname and access control settings'); ?></i>
+<input type='submit' name='update' value='<?php echo xla('update'); ?>'><br>
 <table border=0 cellpadding=1 cellspacing=2 width="500">
 	<tr>
 		<td> </td>
@@ -72,68 +75,74 @@ if ($err)
 		<td> </td>
 		<td> </td>
 		<td> </td>
-		<td><?php xl('Priority ','e'); ?></td>
-		<td><?php xl('Category ','e'); ?></td>
-		<td><?php xl('Nickname','e'); ?></td>
+		<td><?php echo xlt('Priority'); ?> </td>
+		<td><?php echo xlt('Category'); ?> </td>
+		<td><?php echo xlt('Nickname'); ?> </td>
+		<td><?php echo xlt('Access Control'); ?></td>
 	</tr>
 <?php
 $color="#CCCCCC";
 if ($bigdata != false)
 foreach($bigdata as $registry)
 {
-	$priority_category = sqlQuery("select priority, category, nickname from registry where id=".$registry['id']);
-	?>
-	<tr>
-		<td bgcolor="<?php echo $color?>" width="2%">
-			<span class=text><?php echo $registry['id'];?></span>
-		</td>
-		<td bgcolor="<?php echo $color?>" width="30%">
-			<span class=bold><?php echo xl_form_title($registry['name']); ?></span>
-		</td>
-		<?php
-			if ($registry['sql_run'] == 0)
-				echo "<td bgcolor='$color' width='10%'><span class='text'>".xl('registered')."</span>";
-			elseif ($registry['state'] == "0")
-				echo "<td bgcolor='#FFCCCC' width='10%'><a class=link_submit href='./forms_admin.php?id={$registry['id']}&method=enable'>".xl('disabled')."</a>";
-			else
-				echo "<td bgcolor='#CCFFCC' width='10%'><a class=link_submit href='./forms_admin.php?id={$registry['id']}&method=disable'>".xl('enabled')."</a>";
-		?></td>
-		<td bgcolor="<?php $color?>" width="10%">
-			<span class=text><?php
-
-			if ($registry['unpackaged'])
-				echo xl('PHP extracted','e');
-			else
-				echo xl('PHP compressed','e');
-
-			?></span>
-		</td>
-		<td bgcolor="<?php echo $color?>" width="10%">
-			<?php
-			if ($registry['sql_run'])
-				echo "<span class=text>".xl('DB installed')."</span>";
-			else
-				echo "<a class=link_submit href='./forms_admin.php?id={$registry['id']}&method=install_db'>".xl('install DB')."</a>";
-			?>
-		</td>
-		<?php
-			echo "<td><input type=text size=4 name=priority_".$registry['id']." value='".$priority_category['priority']."'></td>";
-			echo "<td><input type=text size=8 name=category_".$registry['id']." value='".$priority_category['category']."'></td>";
-			echo "<td><input type=text size=8 name=nickname_".$registry['id']." value='".$priority_category['nickname']."'></td>";
-		?>
-	</tr>
-	<?php
-	if ($color=="#CCCCCC")
-		$color="#999999";
-	else
-		$color="#CCCCCC";
+  $priority_category = sqlQuery("select priority, category, nickname, aco_spec from registry where id = ?",
+    array($registry['id']));
+?>
+  <tr>
+    <td bgcolor="<?php echo $color; ?>" width="2%">
+      <span class='text'><?php echo $registry['id']; ?></span>
+    </td>
+    <td bgcolor="<?php echo $color; ?>" width="30%">
+      <span class='bold'><?php echo xl_form_title($registry['name']); ?></span>
+    </td>
+    <?php
+      if ($registry['sql_run'] == 0)
+        echo "<td bgcolor='$color' width='10%'><span class='text'>".xl('registered')."</span>";
+      elseif ($registry['state'] == "0")
+        echo "<td bgcolor='#FFCCCC' width='10%'><a class='link_submit' href='./forms_admin.php?id={$registry['id']}&method=enable'>".xl('disabled')."</a>";
+      else
+        echo "<td bgcolor='#CCFFCC' width='10%'><a class='link_submit' href='./forms_admin.php?id={$registry['id']}&method=disable'>".xl('enabled')."</a>";
+    ?></td>
+    <td bgcolor="<?php echo $color; ?>" width="10%">
+      <span class='text'><?php
+      if ($registry['unpackaged'])
+        echo xlt('PHP extracted');
+      else
+        echo xlt('PHP compressed');
+      ?></span>
+    </td>
+    <td bgcolor="<?php echo $color; ?>" width="10%">
+      <?php
+      if ($registry['sql_run'])
+        echo "<span class='text'>" . xlt('DB installed') . "</span>";
+      else
+        echo "<a class='link_submit' href='./forms_admin.php?id={$registry['id']}&method=install_db'>".xl('install DB')."</a>";
+      ?>
+    </td>
+    <?php
+      echo "<td><input type='text' size='4'  name='priority_" . $registry['id'] . "' value='" . $priority_category['priority'] . "'></td>";
+      echo "<td><input type='text' size='10' name='category_" . $registry['id'] . "' value='" . $priority_category['category'] . "'></td>";
+      echo "<td><input type='text' size='10' name='nickname_" . $registry['id'] . "' value='" . $priority_category['nickname'] . "'></td>";
+      echo "<td>";
+      echo "<select name='aco_spec_" . $registry['id'] . "'>";
+      echo "<option value=''></option>";
+      echo gen_aco_html_options($priority_category['aco_spec']);
+      echo "</select>";
+      echo "</td>";
+    ?>
+  </tr>
+  <?php
+  if ($color=="#CCCCCC")
+    $color="#999999";
+  else
+    $color="#CCCCCC";
 } //end of foreach
 	?>
 </table>
 <hr>
 
 <?php  //UNREGISTERED SECTION ?>
-<span class=bold><?php xl('Unregistered','e');?></span><br>
+<span class='bold'><?php echo xlt('Unregistered'); ?></span><br>
 <table border=0 cellpadding=1 cellspacing=2 width="500">
 <?php
 $dpath = "$srcdir/../interface/forms/";

--- a/interface/forms_admin/forms_admin.php
+++ b/interface/forms_admin/forms_admin.php
@@ -60,7 +60,7 @@ $bigdata = getRegistered("%") or $bigdata = false;
 
 <?php //ERROR REPORTING
 if ($err)
-	echo "<span class=bold>$err</span><br><br>\n";
+	echo "<span class=bold>" . text($err) . "</span><br><br>\n";
 ?>
 
 <?php //REGISTERED SECTION ?>
@@ -90,20 +90,20 @@ foreach($bigdata as $registry)
 ?>
   <tr>
     <td bgcolor="<?php echo $color; ?>" width="2%">
-      <span class='text'><?php echo $registry['id']; ?></span>
+      <span class='text'><?php echo text($registry['id']); ?></span>
     </td>
-    <td bgcolor="<?php echo $color; ?>" width="30%">
+    <td bgcolor="<?php echo attr($color); ?>" width="30%">
       <span class='bold'><?php echo xl_form_title($registry['name']); ?></span>
     </td>
     <?php
       if ($registry['sql_run'] == 0)
-        echo "<td bgcolor='$color' width='10%'><span class='text'>".xl('registered')."</span>";
+        echo "<td bgcolor='" . attr($color) . "' width='10%'><span class='text'>" . xlt('registered') . "</span>";
       elseif ($registry['state'] == "0")
-        echo "<td bgcolor='#FFCCCC' width='10%'><a class='link_submit' href='./forms_admin.php?id={$registry['id']}&method=enable'>".xl('disabled')."</a>";
+        echo "<td bgcolor='#FFCCCC' width='10%'><a class='link_submit' href='./forms_admin.php?id={$registry['id']}&method=enable'>" . xlt('disabled') . "</a>";
       else
-        echo "<td bgcolor='#CCFFCC' width='10%'><a class='link_submit' href='./forms_admin.php?id={$registry['id']}&method=disable'>".xl('enabled')."</a>";
+        echo "<td bgcolor='#CCFFCC' width='10%'><a class='link_submit' href='./forms_admin.php?id={$registry['id']}&method=disable'>" . xlt('enabled') . "</a>";
     ?></td>
-    <td bgcolor="<?php echo $color; ?>" width="10%">
+    <td bgcolor="<?php echo attr($color); ?>" width="10%">
       <span class='text'><?php
       if ($registry['unpackaged'])
         echo xlt('PHP extracted');
@@ -111,20 +111,20 @@ foreach($bigdata as $registry)
         echo xlt('PHP compressed');
       ?></span>
     </td>
-    <td bgcolor="<?php echo $color; ?>" width="10%">
+    <td bgcolor="<?php echo attr($color); ?>" width="10%">
       <?php
       if ($registry['sql_run'])
         echo "<span class='text'>" . xlt('DB installed') . "</span>";
       else
-        echo "<a class='link_submit' href='./forms_admin.php?id={$registry['id']}&method=install_db'>".xl('install DB')."</a>";
+        echo "<a class='link_submit' href='./forms_admin.php?id=" . attr($registry['id']) . "&method=install_db'>" . xlt('install DB') . "</a>";
       ?>
     </td>
     <?php
-      echo "<td><input type='text' size='4'  name='priority_" . $registry['id'] . "' value='" . $priority_category['priority'] . "'></td>";
-      echo "<td><input type='text' size='10' name='category_" . $registry['id'] . "' value='" . $priority_category['category'] . "'></td>";
-      echo "<td><input type='text' size='10' name='nickname_" . $registry['id'] . "' value='" . $priority_category['nickname'] . "'></td>";
+      echo "<td><input type='text' size='4'  name='priority_" . attr($registry['id']) . "' value='" . attr($priority_category['priority']) . "'></td>";
+      echo "<td><input type='text' size='10' name='category_" . attr($registry['id']) . "' value='" . attr($priority_category['category']) . "'></td>";
+      echo "<td><input type='text' size='10' name='nickname_" . attr($registry['id']) . "' value='" . attr($priority_category['nickname']) . "'></td>";
       echo "<td>";
-      echo "<select name='aco_spec_" . $registry['id'] . "'>";
+      echo "<select name='aco_spec_" . attr($registry['id']) . "'>";
       echo "<option value=''></option>";
       echo gen_aco_html_options($priority_category['aco_spec']);
       echo "</select>";

--- a/interface/main/left_nav.php
+++ b/interface/main/left_nav.php
@@ -795,7 +795,9 @@ function clearactive() {
  //It is called when a new patient is create/selected from the search menu.
   var str = '<Select class="text" id="EncounterHistory" onchange="{top.restoreSession();toencounter(this.options[this.selectedIndex].value)}">';
   str+='<option value=""><?php echo htmlspecialchars( xl('Encounter History'), ENT_QUOTES) ?></option>';
+<?php if (acl_check_form('newpatient', '', array('write', 'addonly'))) { ?>
   str+='<option value="New Encounter"><?php echo htmlspecialchars( xl('New Encounter'), ENT_QUOTES) ?></option>';
+<?php } ?>
   str+='<option value="Past Encounter List"><?php echo htmlspecialchars( xl('Past Encounter List'), ENT_QUOTES) ?></option>';
   for(CountEncounter=0;CountEncounter<EncounterDateArray.length;CountEncounter++)
    {
@@ -1117,10 +1119,10 @@ if ($GLOBALS['gbl_portal_cms_enable'] && acl_check('patientportal','portal')) {
       <?php if (acl_check('patients','demo'))
         genTreeLink('RTop','dem',xl('Summary')); ?>
 
-      <?php if (acl_check('patients','appt')) { ?>
+      <?php if (acl_check('patients','appt') || acl_check_form('newpatient', '', array('write', 'addonly'))) { ?>
       <li class="open"><a class="expanded_lv2"><span><?php xl('Visits','e') ?></span></a>
         <ul>
-          <?php if (acl_check('patients','appt', '', 'write') || acl_check('patients','appt', '', 'addonly'))
+          <?php if (acl_check_form('newpatient', '', array('write', 'addonly')))
             genTreeLink('RBot','nen',xl('Create Visit')); ?>
           <?php if (acl_check('patients','appt'))
             genTreeLink('RBot','enc',xl('Current')); ?>
@@ -1144,7 +1146,6 @@ if ($GLOBALS['gbl_portal_cms_enable'] && acl_check('patientportal','portal')) {
 <?php
 // Generate the items for visit forms, both traditional and LBF.
 //
-
 $lres = sqlStatement("SELECT * FROM list_options " .
   "WHERE list_id = 'lbfnames' AND activity = 1 ORDER BY seq, title");
 while ($lrow = sqlFetchArray($lres)) {
@@ -1154,11 +1155,12 @@ while ($lrow = sqlFetchArray($lres)) {
   $jobj = json_decode($lrow['notes'], true);
   if (!empty($jobj['aco'])) {
     $tmp = explode('|', $jobj['aco']);
-    if (!acl_check($tmp[0], $tmp[1])) continue;
+    if (!acl_check($tmp[0], $tmp[1], '', 'write')) continue;
   }
   genMiscLink('RBot','cod','2',xl_form_title($title),
     "patient_file/encounter/load_form.php?formname=$option_id");
 }
+//
 include_once("$srcdir/registry.inc");
 $reg = getRegistered();
 if (!empty($reg)) {
@@ -1167,6 +1169,12 @@ if (!empty($reg)) {
 	  $title = trim($entry['nickname']);
     if ($option_id == 'fee_sheet' ) continue;
     if ($option_id == 'newpatient') continue;
+    // Check permission to create forms of this type.
+    $tmp = explode('|', $entry['aco_spec']);
+    if (!empty($tmp[1])) {
+      if (!acl_check($tmp[0], $tmp[1], '', 'write') && !acl_check($tmp[0], $tmp[1], '', 'addonly'))
+        continue;
+    }
 	  if (empty($title)) $title = $entry['name'];
     genMiscLink('RBot','cod','2',xl_form_title($title),
       "patient_file/encounter/load_form.php?formname=" .

--- a/interface/main/tabs/menu/menu_data.php
+++ b/interface/main/tabs/menu/menu_data.php
@@ -34,7 +34,7 @@ $menu_json='[
     {"label":"Summary","menu_id":"dem1","target":"pat","url":"/interface/patient_file/summary/demographics.php","children":[],"requirement":1,"acl_req":["patients","demo"]},
     {"label":"Visits","icon":"fa-caret-right","children":[
       {"label":"Calendar","menu_id":"cal0","target":"cal","url":"/interface/main/main_info.php","children":[],"requirement":0,"acl_req":["patients","appt"],"global_req_strict":["ippf_specific","!disable_calendar"]},
-      {"label":"Create Visit","menu_id":"nen1","target":"enc","url":"/interface/forms/newpatient/new.php?autoloaded=1&calenc=","children":[],"requirement":1,"acl_req":["patients","appt","write","addonly"]},
+      {"label":"Create Visit","menu_id":"nen1","target":"enc","url":"/interface/forms/newpatient/new.php?autoloaded=1&calenc=","children":[],"requirement":1},
       {"label":"Current","menu_id":"enc2","target":"enc","url":"/interface/patient_file/encounter/encounter_top.php","children":[],"requirement":3,"acl_req":["patients","appt"]},
       {"label":"Visit History","menu_id":"ens1","target":"enc","url":"/interface/patient_file/history/encounters.php","children":[],"requirement":1,"acl_req":["patients","appt"]}
       ],"requirement":0},

--- a/interface/main/tabs/menu/menu_updates.php
+++ b/interface/main/tabs/menu/menu_updates.php
@@ -27,6 +27,7 @@ include_once("$srcdir/registry.inc");
 $menu_update_map=array();
 $menu_update_map["Visit Forms"]="update_visit_forms";
 $menu_update_map["Modules"]="update_modules_menu";
+$menu_update_map["Create Visit"] = "update_create_visit";
 
 function update_modules_menu(&$menu_list)
 {
@@ -78,7 +79,10 @@ function update_visit_forms(&$menu_list) {
     // Plug in ACO attribute, if any, of this LBF.
     $jobj = json_decode($lrow['notes'], true);
     if (!empty($jobj['aco'])) {
-      $formEntry->acl_req = explode('|', $jobj['aco']);
+      $tmp = explode('|', $jobj['aco']);
+      if (!empty($tmp[1])) {
+        $formEntry->acl_req = array($tmp[0], $tmp[1], 'write', 'addonly');
+      }
     }
     array_push($menu_list->children, $formEntry);
   }
@@ -97,8 +101,21 @@ function update_visit_forms(&$menu_list) {
       $formEntry->url = $formURL;
       $formEntry->requirement = 2;
       $formEntry->target = 'enc';
+      // Plug in ACO attribute, if any, of this form.
+      $tmp = explode('|', $entry['aco_spec']);
+      if (!empty($tmp[1])) {
+        $formEntry->acl_req = array($tmp[0], $tmp[1], 'write', 'addonly');
+      }
       array_push($menu_list->children, $formEntry);
     }
+  }
+}
+
+function update_create_visit(&$menu_list) {
+  $tmp = getRegistryEntryByDirectory('newpatient', 'aco_spec');
+  if (!empty($tmp['aco_spec'])) {
+    $tmp = explode('|', $tmp['aco_spec']);
+    $menu_list->acl_req = array($tmp[0], $tmp[1], 'write', 'addonly');
   }
 }
 

--- a/interface/super/edit_layout_props.php
+++ b/interface/super/edit_layout_props.php
@@ -136,26 +136,7 @@ function submitProps() {
   <td>
    <select name='form_aco'>
     <option value=''></option>
-<?php
-  $gacl = new gacl_api();
-  // collect and sort all aco objects
-  $list_aco_objects = $gacl->get_objects(NULL, 0, 'ACO');
-  ksort($list_aco_objects);
-  foreach ($list_aco_objects as $seckey => $dummy) {
-    if (empty($dummy)) continue;
-    asort($list_aco_objects[$seckey]);
-    $aco_section_data = $gacl->get_section_data($seckey, 'ACO');
-    $aco_section_title = $aco_section_data[3];
-    echo " <optgroup label='" . xla($aco_section_title) . "'>\n";
-    foreach($list_aco_objects[$seckey] as $acokey) {
-      $aco_id = $gacl->get_object_id($seckey, $acokey,'ACO');
-      $aco_data = $gacl->get_object_data($aco_id, 'ACO');
-      $aco_title = $aco_data[0][3];
-      echo "  <option value='" . attr("$seckey|$acokey") . "'>" . xlt($aco_title) . "</option>\n";
-    }
-    echo " </optgroup>\n";
-  }
-?>
+    <?php echo gen_aco_html_options(); ?>
    </select>
   </td>
  </tr>

--- a/library/acl.inc
+++ b/library/acl.inc
@@ -835,4 +835,48 @@
         else
             return false;
     }
+
+  // This generates an HTML options list for all ACOs.
+  // The caller inserts this between <select> and </select> tags.
+  //
+  function gen_aco_html_options($default='') {
+    $s = '';
+    $gacl = new gacl_api();
+    // collect and sort all aco objects
+    $list_aco_objects = $gacl->get_objects(NULL, 0, 'ACO');
+    ksort($list_aco_objects);
+    foreach ($list_aco_objects as $seckey => $dummy) {
+      if (empty($dummy)) continue;
+      asort($list_aco_objects[$seckey]);
+      $aco_section_data = $gacl->get_section_data($seckey, 'ACO');
+      $aco_section_title = $aco_section_data[3];
+      $s .= "<optgroup label='" . xla($aco_section_title) . "'>\n";
+      foreach($list_aco_objects[$seckey] as $acokey) {
+        $aco_id = $gacl->get_object_id($seckey, $acokey,'ACO');
+        $aco_data = $gacl->get_object_data($aco_id, 'ACO');
+        $aco_title = $aco_data[0][3];
+        $optkey = "$seckey|$acokey";
+        $s .= "<option value='" . attr($optkey) . "'";
+        if ($optkey == $default) $s .= ' selected';
+        $s .= ">" . xlt($aco_title) . "</option>";
+      }
+      $s .= "</optgroup>";
+    }
+    return $s;
+  }
+
+  // Permissions check for a specified encounter form type.
+  // Note $return_value may be an array of return values.
+  //
+  function acl_check_form($formdir, $user='', $return_value='') {
+    require_once(dirname(__FILE__) . '/registry.inc');
+    $tmp = getRegistryEntryByDirectory($formdir, 'aco_spec');
+    if (empty($tmp['aco_spec'])) return true;
+    $tmp = explode('|', $tmp['aco_spec']);
+    if (!is_array($return_value)) $return_value = array($return_value);
+    foreach ($return_value as $rv) {
+      if (acl_check($tmp[0], $tmp[1], $user, $rv)) return true;
+    }
+    return false;
+  }
 ?>

--- a/library/registry.inc
+++ b/library/registry.inc
@@ -57,6 +57,11 @@ function getRegistryEntry ( $id, $cols = "*" )
 	return sqlQuery($sql);
 }
 
+function getRegistryEntryByDirectory($directory, $cols = "*") {
+	$sql = "select $cols from registry where directory = '$directory'";
+	return sqlQuery($sql);
+}
+
 function installSQL ( $dir )
 {
 	$sqltext = $dir."/table.sql";

--- a/library/registry.inc
+++ b/library/registry.inc
@@ -58,8 +58,8 @@ function getRegistryEntry ( $id, $cols = "*" )
 }
 
 function getRegistryEntryByDirectory($directory, $cols = "*") {
-	$sql = "select $cols from registry where directory = '$directory'";
-	return sqlQuery($sql);
+	$sql = "select $cols from registry where directory = ?";
+	return sqlQuery($sql, $directory);
 }
 
 function installSQL ( $dir )

--- a/sql/5_0_0-to-5_0_1_upgrade.sql
+++ b/sql/5_0_0-to-5_0_1_upgrade.sql
@@ -405,3 +405,12 @@ UPDATE categories_seq SET id = (select MAX(id) from categories);
 #IfNotRow2D list_options list_id apptstat option_id ^
 INSERT INTO list_options ( `list_id`, `option_id`, `title`, `seq`, `is_default`, `notes` ) VALUES ('apptstat','^','^ Pending',70,0,'FEFDCF|0');
 #EndIf
+
+#IfMissingColumn registry aco_spec
+ALTER TABLE `registry` ADD `aco_spec` varchar(63) NOT NULL default 'encounters|notes';
+UPDATE `registry` SET `aco_spec` = 'patients|appt'     WHERE directory = 'newpatient';
+UPDATE `registry` SET `aco_spec` = 'patients|appt'     WHERE directory = 'newGroupEncounter';
+UPDATE `registry` SET `aco_spec` = 'encounters|coding' WHERE directory = 'fee_sheet';
+UPDATE `registry` SET `aco_spec` = 'encounters|coding' WHERE directory = 'misc_billing_options';
+UPDATE `registry` SET `aco_spec` = 'patients|lab'      WHERE directory = 'procedure_order';
+#EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -5801,6 +5801,7 @@ CREATE TABLE `registry` (
   `nickname` varchar(255) default NULL,
   `patient_encounter` TINYINT NOT NULL DEFAULT '1',
   `therapy_group_encounter` TINYINT NOT NULL DEFAULT '0',
+  `aco_spec` varchar(63) NOT NULL default 'encounters|notes',
   PRIMARY KEY  (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=22 ;
 
@@ -5808,22 +5809,22 @@ CREATE TABLE `registry` (
 -- Dumping data for table `registry`
 --
 
-INSERT INTO `registry` VALUES ('New Encounter Form', 1, 'newpatient', 1, 1, 1, '2003-09-14 15:16:45', 0, 'Administrative', '',1,0);
-INSERT INTO `registry` VALUES ('Review of Systems Checks', 1, 'reviewofs', 9, 1, 1, '2003-09-14 15:16:45', 0, 'Clinical', '',1,0);
-INSERT INTO `registry` VALUES ('Speech Dictation', 1, 'dictation', 10, 1, 1, '2003-09-14 15:16:45', 0, 'Clinical', '',1,0);
-INSERT INTO `registry` VALUES ('SOAP', 1, 'soap', 11, 1, 1, '2005-03-03 00:16:35', 0, 'Clinical', '',1,0);
-INSERT INTO `registry` VALUES ('Vitals', 1, 'vitals', 12, 1, 1, '2005-03-03 00:16:34', 0, 'Clinical', '',1,0);
-INSERT INTO `registry` VALUES ('Review Of Systems', 1, 'ros', 13, 1, 1, '2005-03-03 00:16:30', 0, 'Clinical', '',1,0);
-INSERT INTO `registry` VALUES ('Fee Sheet', 1, 'fee_sheet', 14, 1, 1, '2007-07-28 00:00:00', 0, 'Administrative', '',1,0);
-INSERT INTO `registry` VALUES ('Misc Billing Options HCFA', 1, 'misc_billing_options', 15, 1, 1, '2007-07-28 00:00:00', 0, 'Administrative', '',1,0);
-INSERT INTO `registry` VALUES ('Procedure Order', 1, 'procedure_order', 16, 1, 1, '2010-02-25 00:00:00', 0, 'Administrative', '',1,0);
-INSERT INTO `registry` VALUES ('Observation', 1, 'observation', 17, 1, 1, '2015-09-09 00:00:00', 0, 'Clinical', '',1,0);
-INSERT INTO `registry` VALUES ('Care Plan', 1, 'care_plan', 18, 1, 1, '2015-09-09 00:00:00', 0, 'Clinical', '',1,0);
-INSERT INTO `registry` VALUES ('Functional and Cognitive Status', 1, 'functional_cognitive_status', 19, 1, 1, '2015-09-09 00:00:00', 0, 'Clinical', '',1,0);
-INSERT INTO `registry` VALUES ('Clinical Instructions', 1, 'clinical_instructions', 20, 1, 1, '2015-09-09 00:00:00', 0, 'Clinical', '',1,0);
-INSERT INTO `registry` VALUES ('Eye Exam', 1, 'eye_mag', 21, 1, 1, '2015-10-15 00:00:00', 0, 'Clinical', '',1,0);
-INSERT INTO `registry` VALUES ('Group Attendance Form', 1, 'group_attendance', 22, 1, 1, '2015-10-15 00:00:00', 0, 'Clinical', '',0,1);
-INSERT INTO `registry` VALUES ('New Group Encounter Form', 1, 'newGroupEncounter', 23, 1, 1, '2015-10-15 00:00:00', 0, 'Clinical', '',0,1);
+INSERT INTO `registry` VALUES ('New Encounter Form', 1, 'newpatient', 1, 1, 1, '2003-09-14 15:16:45', 0, 'Administrative', '',1,0,'patients|appt');
+INSERT INTO `registry` VALUES ('Review of Systems Checks', 1, 'reviewofs', 9, 1, 1, '2003-09-14 15:16:45', 0, 'Clinical', '',1,0,'encounters|notes');
+INSERT INTO `registry` VALUES ('Speech Dictation', 1, 'dictation', 10, 1, 1, '2003-09-14 15:16:45', 0, 'Clinical', '',1,0,'encounters|notes');
+INSERT INTO `registry` VALUES ('SOAP', 1, 'soap', 11, 1, 1, '2005-03-03 00:16:35', 0, 'Clinical', '',1,0,'encounters|notes');
+INSERT INTO `registry` VALUES ('Vitals', 1, 'vitals', 12, 1, 1, '2005-03-03 00:16:34', 0, 'Clinical', '',1,0,'encounters|notes');
+INSERT INTO `registry` VALUES ('Review Of Systems', 1, 'ros', 13, 1, 1, '2005-03-03 00:16:30', 0, 'Clinical', '',1,0,'encounters|notes');
+INSERT INTO `registry` VALUES ('Fee Sheet', 1, 'fee_sheet', 14, 1, 1, '2007-07-28 00:00:00', 0, 'Administrative', '',1,0,'encounters|coding');
+INSERT INTO `registry` VALUES ('Misc Billing Options HCFA', 1, 'misc_billing_options', 15, 1, 1, '2007-07-28 00:00:00', 0, 'Administrative', '',1,0,'encounters|coding');
+INSERT INTO `registry` VALUES ('Procedure Order', 1, 'procedure_order', 16, 1, 1, '2010-02-25 00:00:00', 0, 'Administrative', '',1,0,'patients|lab');
+INSERT INTO `registry` VALUES ('Observation', 1, 'observation', 17, 1, 1, '2015-09-09 00:00:00', 0, 'Clinical', '',1,0,'encounters|notes');
+INSERT INTO `registry` VALUES ('Care Plan', 1, 'care_plan', 18, 1, 1, '2015-09-09 00:00:00', 0, 'Clinical', '',1,0,'encounters|notes');
+INSERT INTO `registry` VALUES ('Functional and Cognitive Status', 1, 'functional_cognitive_status', 19, 1, 1, '2015-09-09 00:00:00', 0, 'Clinical', '',1,0,'encounters|notes');
+INSERT INTO `registry` VALUES ('Clinical Instructions', 1, 'clinical_instructions', 20, 1, 1, '2015-09-09 00:00:00', 0, 'Clinical', '',1,0,'encounters|notes');
+INSERT INTO `registry` VALUES ('Eye Exam', 1, 'eye_mag', 21, 1, 1, '2015-10-15 00:00:00', 0, 'Clinical', '',1,0,'encounters|notes');
+INSERT INTO `registry` VALUES ('Group Attendance Form', 1, 'group_attendance', 22, 1, 1, '2015-10-15 00:00:00', 0, 'Clinical', '',0,1,'encounters|notes');
+INSERT INTO `registry` VALUES ('New Group Encounter Form', 1, 'newGroupEncounter', 23, 1, 1, '2015-10-15 00:00:00', 0, 'Clinical', '',0,1,'patients|appt');
 
 -- --------------------------------------------------------
 

--- a/version.php
+++ b/version.php
@@ -17,7 +17,7 @@ $v_realpatch = '0';
 // is a database change in the course of development.  It is used
 // internally to determine when a database upgrade is needed.
 //
-$v_database = 213;
+$v_database = 214;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
This is similar to and builds on my PR #473 on 2017-02-08, but deals with standard encounter forms rather than layout-based. In the forms admin page you can specify an ACO for each form, and appropriate checking is done where menus and buttons are presented.

Reviews/comments appreciated.