### PR TITLE
Access control for individual issue types and document categories.

### DIFF
--- a/controllers/C_Document.class.php
+++ b/controllers/C_Document.class.php
@@ -1105,10 +1105,13 @@ class C_Document extends Controller {
 			$icon = "file3.png";
 			if (is_array($categories[$id])) {
 				foreach ($categories[$id] as $doc) {
+          $link = $this->_link("view") . "doc_id=" . $doc['document_id'] . "&";
+          // If user has no access then there will be no link.
+          if (!acl_check_aco_spec($doc['aco_spec'])) $link = '';
           if($this->tree->get_node_name($id) == "CCR"){
             $current_node->addItem(new HTML_TreeNode(array(
               'text' => $doc['docdate'] . ' ' . basename_international($doc['url']),
-              'link' => $this->_link("view") . "doc_id=" . $doc['document_id'] . "&",
+              'link' => $link,
               'icon' => $icon,
               'expandedIcon' => $expandedIcon,
               'events' => array('Onclick' => "javascript:newwindow=window.open('ccr/display.php?type=CCR&doc_id=" . $doc['document_id'] . "','CCR');")
@@ -1116,7 +1119,7 @@ class C_Document extends Controller {
           }elseif($this->tree->get_node_name($id) == "CCD"){
             $current_node->addItem(new HTML_TreeNode(array(
               'text' => $doc['docdate'] . ' ' . basename_international($doc['url']),
-              'link' => $this->_link("view") . "doc_id=" . $doc['document_id'] . "&",
+              'link' => $link,
               'icon' => $icon,
               'expandedIcon' => $expandedIcon,
               'events' => array('Onclick' => "javascript:newwindow=window.open('ccr/display.php?type=CCD&doc_id=" . $doc['document_id'] . "','CCD');")
@@ -1124,7 +1127,7 @@ class C_Document extends Controller {
           }else{
             $current_node->addItem(new HTML_TreeNode(array(
               'text' => $doc['docdate'] . ' ' . basename_international($doc['url']),
-              'link' => $this->_link("view") . "doc_id=" . $doc['document_id'] . "&",
+              'link' => $link,
               'icon' => $icon,
               'expandedIcon' => $expandedIcon
             )));

--- a/controllers/C_DocumentCategory.class.php
+++ b/controllers/C_DocumentCategory.class.php
@@ -46,24 +46,49 @@ class C_DocumentCategory extends Controller {
 	function add_node_action($parent_is) {
 		//echo $parent_is ."<br>";
 		//echo $this->tree->get_node_name($parent_is);
+    $info = $this->tree->get_node_info($parent_is);
 		$this->assign("parent_name",$this->tree->get_node_name($parent_is));
 		$this->assign("parent_is",$parent_is);
 		$this->assign("add_node",true);
+    $this->assign("edit_node", false);
+    $this->assign("VALUE", '');
+    // Access control defaults to that of the parent.
+    $this->assign("ACO_OPTIONS", "<option value=''></option>" . gen_aco_html_options($info['aco_spec']));
 		return $this->list_action();
 	}
 
 	function add_node_action_process() {
-		if ($_POST['process'] != "true")
-			return;
+    if ($_POST['process'] != "true") return;
 		$name = $_POST['name'];
 		$parent_is = $_POST['parent_is'];
 		$parent_name = $this->tree->get_node_name($parent_is);
-		$this->tree->add_node($parent_is,$name);
+		$this->tree->add_node($parent_is, $name, $_POST['value'], $_POST['aco_spec']);
 	        $trans_message = xl('Sub-category','','',' ') . "'" . xl_document_category($name) . "'" . xl('successfully added to category,','',' ',' ') . "'" . $parent_name . "'";
 		$this->assign("message",$trans_message);
 		$this->_state = false;
 		return $this->list_action();
 	}
+
+  function edit_node_action($parent_is) {
+    $info = $this->tree->get_node_info($parent_is);
+    $this->assign("parent_is",$parent_is);
+    $this->assign("NAME" , $this->tree->get_node_name($parent_is));
+    $this->assign("VALUE", $info['value']);
+    $this->assign("ACO_OPTIONS", "<option value=''></option>" . gen_aco_html_options($info['aco_spec']));
+    $this->assign("add_node",false);
+    $this->assign("edit_node",true);
+    return $this->list_action();
+  }
+
+  function edit_node_action_process() {
+    if ($_POST['process'] != "true") return;
+    $parent_is = $_POST['parent_is'];
+    $this->tree->edit_node($parent_is, $_POST['name'], $_POST['value'], $_POST['aco_spec']);
+    $trans_message = xl('Category changed.');
+    $this->assign("message", $trans_message);
+    $this->_state = false;
+    return $this->list_action();
+  }
 
 	function delete_node_action_process($id) {
 		if ($_POST['process'] != "true")
@@ -91,24 +116,6 @@ class C_DocumentCategory extends Controller {
 		$this->_state = false;
 
 		return $this->list_action();
-	}
-
-	function edit_action_process() {
-		if ($_POST['process'] != "true")
-			return;
-		//print_r($_POST);
-		if (is_numeric($_POST['id'])) {
-			$this->document_categories[0] = new Pharmacy($_POST['id']);
-		}
-		else {
-			$this->document_categories[0] = new Pharmacy();
-		}
-  		parent::populate_object($this->document_categories[0]);
-		//print_r($this->document_categories[0]);
-		//echo $this->document_categories[0]->toString(true);
-		$this->document_categories[0]->persist();
-		//echo "action processeed";
-		$_POST['process'] = "";
 	}
 
 	function &_array_recurse($array) {

--- a/interface/forms/newpatient/common.php
+++ b/interface/forms/newpatient/common.php
@@ -19,6 +19,9 @@
  */
 
 require_once("$srcdir/options.inc.php");
+require_once("$srcdir/acl.inc");
+require_once("$srcdir/lists.inc");
+
 if($GLOBALS['enable_group_therapy']){
     require_once("$srcdir/group.inc");
 }
@@ -356,6 +359,18 @@ if ($fres) {
 
 
   <td class='bold' width='33%' nowrap>
+
+<?php
+  // To see issues stuff user needs write access to all issue types.
+  $issuesauth = true;
+  foreach ($ISSUE_TYPES as $type => $dummy) {
+    if (!acl_check_issue($type, '', 'write')) {
+      $issuesauth = false;
+      break;
+    }
+  }
+  if ($issuesauth) {
+?>
     <div style='float:left'>
    <?php echo xlt('Issues (Injuries/Medical/Allergy)'); ?>
     </div>
@@ -365,6 +380,8 @@ if ($fres) {
         onclick="top.restoreSession()"><span><?php echo xlt('Add'); ?></span></a>
       <?php } ?>
     </div>
+<?php } ?>
+
   </td>
  </tr>
 
@@ -374,6 +391,8 @@ if ($fres) {
     ><?php echo $viewmode ? text($result['reason']) : text($GLOBALS['default_chief_complaint']); ?></textarea>
   </td>
   <td class='text' valign='top'>
+
+<?php if ($issuesauth) { ?>
    <select multiple name='issues[]' size='8' style='width:100%'
     title='<?php echo xla('Hold down [Ctrl] for multiple selections or to unselect'); ?>'>
 <?php
@@ -396,10 +415,10 @@ while ($irow = sqlFetchArray($ires)) {
 }
 ?>
    </select>
-
    <p><i><?php echo xlt('To link this encounter/consult to an existing issue, click the '
    . 'desired issue above to highlight it and then click [Save]. '
    . 'Hold down [Ctrl] button to select multiple issues.'); ?></i></p>
+<?php } ?>
 
   </td>
  </tr>
@@ -471,7 +490,5 @@ if (!$viewmode) { ?>
   <?php } ?>
 <?php } ?>
 </script>
-
-
 
 </html>

--- a/interface/forms/newpatient/new.php
+++ b/interface/forms/newpatient/new.php
@@ -28,14 +28,10 @@ include_once("$srcdir/lists.inc");
 // Check permission to create encounters.
 $tmp = getPatientData($pid, "squad");
 if (($tmp['squad'] && ! acl_check('squads', $tmp['squad'])) ||
-     ! (acl_check('encounters', 'notes_a' ) ||
-        acl_check('encounters', 'notes'   ) ||
-        acl_check('encounters', 'coding_a') ||
-        acl_check('encounters', 'coding'  ) ||
-        acl_check('encounters', 'relaxed' )))
+  !acl_check_form('newpatient', '', array('write', 'addonly')))
 {
   echo "<body>\n<html>\n";
-  echo "<p>(" . xlt('New encounters not authorized'). ")</p>\n";
+  echo "<p>(" . xlt('New encounters not authorized') . ")</p>\n";
   echo "</body>\n</html>\n";
   exit();
 }

--- a/interface/forms/newpatient/save.php
+++ b/interface/forms/newpatient/save.php
@@ -101,9 +101,9 @@ else {
 setencounter($encounter);
 
 // Update the list of issues associated with this encounter.
-sqlStatement("DELETE FROM issue_encounter WHERE " .
-  "pid = ? AND encounter = ?", array($pid,$encounter) );
 if (is_array($_POST['issues'])) {
+  sqlStatement("DELETE FROM issue_encounter WHERE " .
+    "pid = ? AND encounter = ?", array($pid, $encounter));
   foreach ($_POST['issues'] as $issue) {
     $query = "INSERT INTO issue_encounter ( pid, list_id, encounter ) VALUES (?,?,?)";
     sqlStatement($query, array($pid,$issue,$encounter));

--- a/interface/patient_file/report/patient_report.php
+++ b/interface/patient_file/report/patient_report.php
@@ -457,20 +457,22 @@ while($row = sqlFetchArray($res)) {
 <?php
 // show available documents
 $db = $GLOBALS['adodb']['db'];
-$sql = "SELECT d.id, d.url, c.name FROM documents AS d " .
+$sql = "SELECT d.id, d.url, c.name, c.aco_spec FROM documents AS d " .
         "LEFT JOIN categories_to_documents AS ctd ON d.id=ctd.document_id " .
         "LEFT JOIN categories AS c ON c.id = ctd.category_id WHERE " .
         "d.foreign_id = " . $db->qstr($pid);
 $result = $db->Execute($sql);
 if ($db->ErrorMsg()) echo $db->ErrorMsg();
 while ($result && !$result->EOF) {
+  if (empty($result->fields['aco_spec']) || acl_check_aco_spec($result->fields['aco_spec'])) {
     echo "<li class='bold'>";
     echo '<input type="checkbox" name="documents[]" value="' .
         $result->fields['id'] . '">';
     echo '&nbsp;&nbsp;<i>' .  xl_document_category($result->fields['name']) . "</i>";
     echo '&nbsp;&nbsp;' . xl('Name') . ': <i>' . basename($result->fields['url']) . "</i>";
     echo '</li>';
-    $result->MoveNext();
+  }
+  $result->MoveNext();
 }
 ?>
 </ul>

--- a/interface/patient_file/summary/stats.php
+++ b/interface/patient_file/summary/stats.php
@@ -16,20 +16,6 @@ include_once("$srcdir/options.inc.php");
 
 <div id="patient_stats_summary">
 
-<?php
-$thisauth = acl_check('patients', 'med');
-if ($thisauth) {
-    $tmp = getPatientData($pid, "squad");
-    if ($tmp['squad'] && ! acl_check('squads', $tmp['squad']))
-        $thisauth = 0;
-}
-if (!$thisauth) {
-    echo "<p>(".htmlspecialchars(xl('Issues not authorized'),ENT_NOQUOTES).")</p>\n";
-    echo "</body>\n</html>\n";
-    exit();
-}
-?>
-
 <script type='text/javascript'>
     function load_location( location ) {
         top.restoreSession();
@@ -46,115 +32,116 @@ if (!$thisauth) {
 <?php
 $numcols = '1';
 $erx_upload_complete = 0;
-$old_key="";$display_current_medications_below=1;
-foreach ($ISSUE_TYPES as $key => $arr) {
-    // $result = getListByType($pid, $key, "id,title,begdate,enddate,returndate,extrainfo", "all", "all", 0);
+$old_key="";
+$display_current_medications_below=1;
 
-    $query = "SELECT * FROM lists WHERE pid = ? AND type = ? AND ";
-    $query .= "(enddate is null or enddate = '' or enddate = '0000-00-00') ";
-    if($GLOBALS['erx_enable'] && $GLOBALS['erx_medication_display'] && $key=='medication')
-		$query .= "and erx_uploaded != '1' ";
-	if($GLOBALS['erx_enable'] && $GLOBALS['erx_allergy_display'] && $key=='allergy')
-		$query .= "and erx_uploaded != '1' ";
-    $query .= "ORDER BY begdate";
-    $pres = sqlStatement($query, array($pid, $key) );
-    if($old_key=="medication" && $GLOBALS['erx_enable'] && $erx_upload_complete == 1)
-    {
-	$display_current_medications_below=0;
-	?>
+foreach ($ISSUE_TYPES as $key => $arr) {
+  // Skip if user has no access to this issue type.
+  if (!acl_check_issue($key)) continue;
+
+  // $result = getListByType($pid, $key, "id,title,begdate,enddate,returndate,extrainfo", "all", "all", 0);
+  $query = "SELECT * FROM lists WHERE pid = ? AND type = ? AND ";
+  $query .= "(enddate is null or enddate = '' or enddate = '0000-00-00') ";
+  if($GLOBALS['erx_enable'] && $GLOBALS['erx_medication_display'] && $key=='medication')
+    $query .= "and erx_uploaded != '1' ";
+  if($GLOBALS['erx_enable'] && $GLOBALS['erx_allergy_display'] && $key=='allergy')
+    $query .= "and erx_uploaded != '1' ";
+  $query .= "ORDER BY begdate";
+  $pres = sqlStatement($query, array($pid, $key) );
+  if($old_key=="medication" && $GLOBALS['erx_enable'] && $erx_upload_complete == 1) {
+    $display_current_medications_below=0;
+?>
 	<div>
 	    <table id="patient_stats_prescriptions">
-	    <?php if($GLOBALS['erx_enable']){ ?>
+<?php
+    if($GLOBALS['erx_enable']) {
+?>
 	    <tr><td>
-	    <?php if ($_POST['embeddedScreen']) {
-		$widgetTitle = '';
-		$widgetTitle = xl('Current Medications');
-		$widgetLabel = "current_prescriptions";
-		$widgetButtonLabel = '';
-		$widgetButtonLink = '';
-		$widgetAuth = false;
-		$widgetButtonClass = '';
-		$bodyClass = "summary_item small";
-		$fixedWidth = false;
-		expand_collapse_widget($widgetTitle, $widgetLabel, $widgetButtonLabel , $widgetButtonLink, $widgetButtonClass, $linkMethod, $bodyClass, $widgetAuth, $fixedWidth);
-	    }
-	    ?>
-
-	    <?php
-	    $res=sqlStatement("select * from prescriptions where patient_id=? and active='1'",array($pid));
-	    ?>
+<?php
+      if ($_POST['embeddedScreen']) {
+        $widgetTitle = xl('Current Medications');
+        $widgetLabel = "current_prescriptions";
+        $widgetButtonLabel = '';
+        $widgetButtonLink = '';
+        $widgetAuth = false;
+        $widgetButtonClass = '';
+        $bodyClass = "summary_item small";
+        $fixedWidth = false;
+        expand_collapse_widget($widgetTitle, $widgetLabel, $widgetButtonLabel , $widgetButtonLink,
+            $widgetButtonClass, $linkMethod, $bodyClass, $widgetAuth, $fixedWidth);
+      }
+      $res=sqlStatement("select * from prescriptions where patient_id=? and active='1'",array($pid));
+?>
 	    <table>
-	    <?php
-	    if(sqlNumRows($res)==0)
-	    {
-		?>
+<?php
+      if (sqlNumRows($res) == 0) {
+?>
 		<tr class=text>
 			<td><?php echo htmlspecialchars(xl('None'), ENT_NOQUOTES);?></td>
 		</tr>
-		<?php
-	    }
-	    while($row_currentMed=sqlFetchArray($res))
-	    {
-		$runit=generate_display_field(array('data_type'=>'1','list_id'=>'drug_units'),htmlspecialchars($row_currentMed['unit'],ENT_NOQUOTES));
-		$rin=generate_display_field(array('data_type'=>'1','list_id'=>'drug_form'),htmlspecialchars($row_currentMed['form'],ENT_NOQUOTES));
-		$rroute=generate_display_field(array('data_type'=>'1','list_id'=>'drug_route'),htmlspecialchars($row_currentMed['route'],ENT_NOQUOTES));
-		$rint=generate_display_field(array('data_type'=>'1','list_id'=>'drug_interval'),htmlspecialchars($row_currentMed['interval'],ENT_NOQUOTES));
-		?>
+<?php
+      }
+      while($row_currentMed=sqlFetchArray($res)) {
+        $runit=generate_display_field(array('data_type'=>'1','list_id'=>'drug_units'),htmlspecialchars($row_currentMed['unit'],ENT_NOQUOTES));
+        $rin=generate_display_field(array('data_type'=>'1','list_id'=>'drug_form'),htmlspecialchars($row_currentMed['form'],ENT_NOQUOTES));
+        $rroute=generate_display_field(array('data_type'=>'1','list_id'=>'drug_route'),htmlspecialchars($row_currentMed['route'],ENT_NOQUOTES));
+        $rint=generate_display_field(array('data_type'=>'1','list_id'=>'drug_interval'),htmlspecialchars($row_currentMed['interval'],ENT_NOQUOTES));
+?>
 		<tr class=text >
 			<td><?php echo htmlspecialchars($row_currentMed['drug'],ENT_NOQUOTES);?></td>
 			<td><?php
-			    $unit='';
-			    if($row_currentMed['size']>0)
-				$unit=$row_currentMed['size']." ".$runit." ";
-			    echo htmlspecialchars($unit." ".$row_currentMed['dosage']." ".$rin." ".$rroute." ".$rint,ENT_NOQUOTES);
-			?></td>
+        $unit='';
+        if($row_currentMed['size'] > 0)
+          $unit=$row_currentMed['size']." ".$runit." ";
+        echo htmlspecialchars($unit." ".$row_currentMed['dosage']." ".$rin." ".$rroute." ".$rint,ENT_NOQUOTES);
+?></td>
 		</tr>
-	    <?php
-	    }
-	    ?>
+<?php
+      } // end while
+?>
 	    </table>
 	    </td></tr>
-	    <?php }
-	    $old_key='';
-    }
-    if (sqlNumRows($pres) > 0 || $arr[4] == 1) {
-	$old_key=$key;
-	if ($_POST['embeddedScreen']) {
+<?php
+    } // end erx_enable
+    $old_key='';
+  }
 
-	    if($GLOBALS['erx_enable'] && $key == "medication"){
-		$query_uploaded = "SELECT * FROM lists WHERE pid = ? AND type = 'medication' AND ";
-		$query_uploaded .= "(enddate is null or enddate = '' or enddate = '0000-00-00') ";
-		$query_uploaded .= "and erx_uploaded != '1' ";
-		$query_uploaded .= "ORDER BY begdate";
-		$res_uploaded = sqlStatement($query_uploaded, array($pid) );
-		if(sqlNumRows($res_uploaded) == 0){
-		    $erx_upload_complete = 1;
-		    continue;
-		}
-	    }
+  if (sqlNumRows($pres) > 0 || $arr[4] == 1) {
+    $old_key=$key;
+    if ($_POST['embeddedScreen']) {
+      if($GLOBALS['erx_enable'] && $key == "medication") {
+        $query_uploaded = "SELECT * FROM lists WHERE pid = ? AND type = 'medication' AND ";
+        $query_uploaded .= "(enddate is null or enddate = '' or enddate = '0000-00-00') ";
+        $query_uploaded .= "and erx_uploaded != '1' ";
+        $query_uploaded .= "ORDER BY begdate";
+        $res_uploaded = sqlStatement($query_uploaded, array($pid) );
+        if(sqlNumRows($res_uploaded) == 0) {
+          $erx_upload_complete = 1;
+          continue;
+        }
+      }
 
-	    echo "<tr><td>";
-            // Issues expand collapse widget
-            $widgetTitle = $arr[0];
-            $widgetLabel = $key;
-	    if(($key == "allergy" || $key == "medication") && $GLOBALS['erx_enable'])
-	    {
-		$widgetButtonLabel = xl("Add");
-		$widgetButtonLink = "load_location(\"${GLOBALS['webroot']}/interface/eRx.php?page=medentry\")";
-	    }
-	    else
-	    {
-		$widgetButtonLabel = xl("Edit");
-		$widgetButtonLink = "load_location(\"${GLOBALS['webroot']}/interface/patient_file/summary/stats_full.php?active=all&category=" . $key . "\")";
-	    }
-	    $widgetButtonClass = "";
-            $linkMethod = "javascript";
-            $bodyClass = "summary_item small";
-            $widgetAuth = true;
-            $fixedWidth = false;
-            expand_collapse_widget($widgetTitle, $widgetLabel, $widgetButtonLabel , $widgetButtonLink, $widgetButtonClass, $linkMethod, $bodyClass, $widgetAuth, $fixedWidth);
-	}
-	else { ?>
+      echo "<tr><td>";
+      // Issues expand collapse widget
+      $widgetTitle = $arr[0];
+      $widgetLabel = $key;
+      if(($key == "allergy" || $key == "medication") && $GLOBALS['erx_enable']) {
+        $widgetButtonLabel = xl("Add");
+        $widgetButtonLink = "load_location(\"${GLOBALS['webroot']}/interface/eRx.php?page=medentry\")";
+      }
+      else {
+        $widgetButtonLabel = xl("Edit");
+        $widgetButtonLink = "load_location(\"${GLOBALS['webroot']}/interface/patient_file/summary/stats_full.php?active=all&category=" . $key . "\")";
+      }
+      $widgetButtonClass = "";
+      $linkMethod = "javascript";
+      $bodyClass = "summary_item small";
+      $widgetAuth = acl_check_issue($key, '', array('write', 'addonly'));
+      $fixedWidth = false;
+      expand_collapse_widget($widgetTitle, $widgetLabel, $widgetButtonLabel , $widgetButtonLink, $widgetButtonClass, $linkMethod, $bodyClass, $widgetAuth, $fixedWidth);
+    } // end embeddedScreen
+    else {
+?>
             <tr class='issuetitle'>
             <td colspan='$numcols'>
             <span class="text"><b><?php echo htmlspecialchars($arr[0],ENT_NOQUOTES); ?></b></span>
@@ -163,50 +150,49 @@ foreach ($ISSUE_TYPES as $key => $arr) {
             </a>
             </td>
             </tr>
-        <?php }
-        echo "<table>";
-	if (sqlNumRows($pres) == 0) {
-          if ( getListTouch($pid,$key) ) {
-            // Data entry has happened to this type, so can display an explicit None.
-            echo "  <tr><td colspan='$numcols' class='text'>&nbsp;&nbsp;" . htmlspecialchars( xl('None'), ENT_NOQUOTES) . "</td></tr>\n";
-          }
-          else {
-            // Data entry has not happened to this type, so show 'Nothing Recorded"
-            echo "  <tr><td colspan='$numcols' class='text'>&nbsp;&nbsp;" . htmlspecialchars( xl('Nothing Recorded'), ENT_NOQUOTES) . "</td></tr>\n";
-          }
-	}
-
-        while ($row = sqlFetchArray($pres)) {
-            // output each issue for the $ISSUE_TYPE
-            if (!$row['enddate'] && !$row['returndate'])
-                $rowclass="noend_noreturn";
-            else if (!$row['enddate'] && $row['returndate'])
-                $rowclass="noend";
-            else if ($row['enddate'] && !$row['returndate'])
-                $rowclass = "noreturn";
-
-            echo " <tr class='text $rowclass;'>\n";
-
-	    //turn allergies red and bold and show the reaction (if exist)
-	    if ($key == "allergy") {
-                $reaction = "";
-                if (!empty($row['reaction'])) {
-                    $reaction = " (" . $row['reaction'] . ")";
-                }
-                echo "  <td colspan='$numcols' style='color:red;font-weight:bold;'>&nbsp;&nbsp;" . htmlspecialchars( $row['title'] . $reaction, ENT_NOQUOTES) . "</td>\n";
-	    }
-	    else {
-	        echo "  <td colspan='$numcols'>&nbsp;&nbsp;" . htmlspecialchars($row['title'],ENT_NOQUOTES) . "</td>\n";
-	    }
-
-            echo " </tr>\n";
-        }
-	echo "</table>";
-	if ($_POST['embeddedScreen']) {
-	    echo "</div></td></tr>";
-        }
-
+<?php
     }
+    echo "<table>";
+    if (sqlNumRows($pres) == 0) {
+      if ( getListTouch($pid,$key) ) {
+        // Data entry has happened to this type, so can display an explicit None.
+        echo "  <tr><td colspan='$numcols' class='text'>&nbsp;&nbsp;" . htmlspecialchars( xl('None'), ENT_NOQUOTES) . "</td></tr>\n";
+      }
+      else {
+        // Data entry has not happened to this type, so show 'Nothing Recorded"
+        echo "  <tr><td colspan='$numcols' class='text'>&nbsp;&nbsp;" . htmlspecialchars( xl('Nothing Recorded'), ENT_NOQUOTES) . "</td></tr>\n";
+      }
+    }
+
+    while ($row = sqlFetchArray($pres)) {
+      // output each issue for the $ISSUE_TYPE
+      if (!$row['enddate'] && !$row['returndate'])
+        $rowclass="noend_noreturn";
+      else if (!$row['enddate'] && $row['returndate'])
+        $rowclass="noend";
+      else if ($row['enddate'] && !$row['returndate'])
+        $rowclass = "noreturn";
+      echo " <tr class='text $rowclass;'>\n";
+
+      //turn allergies red and bold and show the reaction (if exist)
+      if ($key == "allergy") {
+        $reaction = "";
+        if (!empty($row['reaction'])) {
+          $reaction = " (" . $row['reaction'] . ")";
+        }
+        echo "  <td colspan='$numcols' style='color:red;font-weight:bold;'>&nbsp;&nbsp;" . htmlspecialchars( $row['title'] . $reaction, ENT_NOQUOTES) . "</td>\n";
+      }
+      else {
+        echo "  <td colspan='$numcols'>&nbsp;&nbsp;" . htmlspecialchars($row['title'],ENT_NOQUOTES) . "</td>\n";
+      }
+
+      echo " </tr>\n";
+    }
+    echo "</table>";
+    if ($_POST['embeddedScreen']) {
+      echo "</div></td></tr>";
+    }
+  }
 }
 ?>
 </table> <!-- end patient_stats_issues -->
@@ -327,7 +313,7 @@ else { ?>
 </div>
 <?php } ?>
 
-<?php if (!$GLOBALS['disable_prescriptions']) { ?>
+<?php if (!$GLOBALS['disable_prescriptions'] && acl_check('patients', 'rx')) { ?>
 <div>
 <table id="patient_stats_prescriptions">
 <?php if($GLOBALS['erx_enable'] && $display_current_medications_below==1){ ?>

--- a/library/acl.inc
+++ b/library/acl.inc
@@ -23,6 +23,9 @@
  * @link    http://www.open-emr.org
  */
 
+require_once(dirname(__FILE__) . '/lists.inc');
+require_once(dirname(__FILE__) . '/registry.inc');
+
 // php-GACL access controls are included in OpenEMR. The below
 // function will automatically create the path where gacl.class.php
 // can be found. Note that this path can be manually set below
@@ -884,7 +887,6 @@
   // Note $return_value may be an array of return values.
   //
   function acl_check_form($formdir, $user='', $return_value='') {
-    require_once(dirname(__FILE__) . '/registry.inc');
     $tmp = getRegistryEntryByDirectory($formdir, 'aco_spec');
     return acl_check_aco_spec($tmp['aco_spec'], $user, $return_value);
   }
@@ -893,7 +895,6 @@
   // Note $return_value may be an array of return values.
   //
   function acl_check_issue($type, $user='', $return_value='') {
-    require_once(dirname(__FILE__) . '/lists.inc');
     global $ISSUE_TYPES;
     if (empty($ISSUE_TYPES[$type][5])) return true;
     return acl_check_aco_spec($ISSUE_TYPES[$type][5], $user, $return_value);

--- a/library/acl.inc
+++ b/library/acl.inc
@@ -840,6 +840,8 @@
   // The caller inserts this between <select> and </select> tags.
   //
   function gen_aco_html_options($default='') {
+    global $phpgacl_location;
+    require_once("$phpgacl_location/gacl_api.class.php");
     $s = '';
     $gacl = new gacl_api();
     // collect and sort all aco objects
@@ -865,18 +867,45 @@
     return $s;
   }
 
+  // Permissions check for an ACO in "section|aco" format.
+  // Note $return_value may be an array of return values.
+  //
+  function acl_check_aco_spec($aco_spec, $user='', $return_value='') {
+    if (empty($aco_spec)) return true;
+    $tmp = explode('|', $aco_spec);
+    if (!is_array($return_value)) $return_value = array($return_value);
+    foreach ($return_value as $rv) {
+      if (acl_check($tmp[0], $tmp[1], $user, $rv)) return true;
+    }
+    return false;
+  }
+
   // Permissions check for a specified encounter form type.
   // Note $return_value may be an array of return values.
   //
   function acl_check_form($formdir, $user='', $return_value='') {
     require_once(dirname(__FILE__) . '/registry.inc');
     $tmp = getRegistryEntryByDirectory($formdir, 'aco_spec');
+    return acl_check_aco_spec($tmp['aco_spec'], $user, $return_value);
+  }
+
+  // Permissions check for a specified issue type.
+  // Note $return_value may be an array of return values.
+  //
+  function acl_check_issue($type, $user='', $return_value='') {
+    require_once(dirname(__FILE__) . '/lists.inc');
+    global $ISSUE_TYPES;
+    if (empty($ISSUE_TYPES[$type][5])) return true;
+    return acl_check_aco_spec($ISSUE_TYPES[$type][5], $user, $return_value);
+  }
+
+  // Permissions check for a specified document category name.
+  // Note $return_value may be an array of return values.
+  //
+  function acl_check_cat_name($catname, $user='', $return_value='') {
+    $tmp = sqlQuery("SELECT aco_spec FROM categories WHERE name = ? ORDER BY id LIMIT 1",
+      array($catname));
     if (empty($tmp['aco_spec'])) return true;
-    $tmp = explode('|', $tmp['aco_spec']);
-    if (!is_array($return_value)) $return_value = array($return_value);
-    foreach ($return_value as $rv) {
-      if (acl_check($tmp[0], $tmp[1], $user, $rv)) return true;
-    }
-    return false;
+    return acl_check_aco_spec($tmp['aco_spec'], $user, $return_value);
   }
 ?>

--- a/library/classes/CategoryTree.class.php
+++ b/library/classes/CategoryTree.class.php
@@ -8,7 +8,6 @@
 
 class CategoryTree extends Tree {
 
-
 	/*
 	*	This just sits on top of the parent constructor, only a shell so that the _table var gets set
 	*/
@@ -17,9 +16,9 @@ class CategoryTree extends Tree {
 		parent::__construct($root,$root_type);
 	}
 
-	function _get_categories_array($patient_id) {
+	function _get_categories_array($patient_id, $user='') {
 		$categories = array();
-		$sql = "SELECT c.id, c.name, d.id AS document_id, d.type, d.url, d.docdate"
+		$sql = "SELECT c.id, c.name, c.aco_spec, d.id AS document_id, d.type, d.url, d.docdate"
 			. " FROM categories AS c, documents AS d, categories_to_documents AS c2d"
 			. " WHERE c.id = c2d.category_id"
 			. " AND c2d.document_id = d.id";
@@ -40,12 +39,14 @@ class CategoryTree extends Tree {
 		$result = $this->_db->Execute($sql);
 
 	  while ($result && !$result->EOF) {
-	  	$categories[$result->fields['id']][$result->fields['document_id']] = $result->fields;
+      // Omit documents for which the user does not have category permission.
+      if (acl_check_aco_spec($result->fields['aco_spec'], $user)) {
+        $categories[$result->fields['id']][$result->fields['document_id']] = $result->fields;
+      }
 	  	$result->MoveNext();
 	  }
 
 	  return $categories;
-
 	}
 }
 ?>

--- a/library/classes/CategoryTree.class.php
+++ b/library/classes/CategoryTree.class.php
@@ -39,10 +39,7 @@ class CategoryTree extends Tree {
 		$result = $this->_db->Execute($sql);
 
 	  while ($result && !$result->EOF) {
-      // Omit documents for which the user does not have category permission.
-      if (acl_check_aco_spec($result->fields['aco_spec'], $user)) {
-        $categories[$result->fields['id']][$result->fields['document_id']] = $result->fields;
-      }
+      $categories[$result->fields['id']][$result->fields['document_id']] = $result->fields;
 	  	$result->MoveNext();
 	  }
 

--- a/library/js/CategoryTreeMenu.js
+++ b/library/js/CategoryTreeMenu.js
@@ -222,9 +222,14 @@ function arrayCopy(input)
 			var imgTag    = this.stringFormat('<img src="{0}/{1}{2}.gif" width="20" height="20" align="top" border="0" name="img_{3}" {4}>', this.iconpath, gifname, modifier, layerID, onMDown);
 			var linkTarget= nodes[i].linkTarget ? nodes[i].linkTarget : this.linkTarget;
 			var linkStart = nodes[i].link ? this.stringFormat('<a href="{0}" target="{1}">', nodes[i].link, linkTarget) : '';
-			
 			var delLink	  = nodes[i].link.replace('add_node','delete_node');
-			var linkEnd   = nodes[i].link ? '</a>&nbsp;&nbsp;&nbsp;<a href="' + delLink  + 'process=1" style="text-decoration:none;"><span style="color:red; font-size:70%; font-family: sans-serif;">(' + deleteLabel + ')</span></a>' : '';
+      var editLink = nodes[i].link.replace('add_node','edit_node');
+      var linkEnd = nodes[i].link ? '</a>' +
+        '&nbsp;&nbsp;<a href="' + editLink + '" style="text-decoration:none;">' +
+        '<span style="font-size:70%; font-family: sans-serif;">(' + editLabel + ')</span></a>' +
+        '&nbsp;&nbsp;<a href="' + delLink  + 'process=1" style="text-decoration:none;">' +
+        '<span style="color:red; font-size:70%; font-family: sans-serif;">(' + deleteLabel + ')</span></a>'
+        : '';
 
 			this.output += this.stringFormat('{0}<nobr>{1}{2}{3}{4}<span {5}>{6}</span>{7}</nobr><br></div>',
 			                  layerTag,

--- a/library/lists.inc
+++ b/library/lists.inc
@@ -12,7 +12,7 @@
  *  2   - The abbreviated title (one letter abbreviation). 
  *  3   - Style ('0 - Normal; 1 - Simplified: only title, start date, comments and an Active checkbox;no diagnosis, occurrence, end date, referred-by or sports fields.; 2 - Football Injury; 3 and 4 are IPPF specific)
  *  4   - Force show this issue category in the patient summary screen even if empty (setting to 1 will force it to show and setting it to 0 will turn this off).
- *
+ *  5   - ACO for this type, for example "patients|med".
  *
  * Note there is a mechanism to show whether a category is explicitly set to
  * 'Nothing' via the getListTouch() and setListTouch() functions that store
@@ -73,9 +73,16 @@ function collect_issue_type_category() {
 }
 
 // Build the $ISSUE_TYPES array (see script header for description)
-$res = sqlStatement("SELECT * FROM `issue_types` WHERE active=1 AND `category`=? ORDER BY `ordering` ASC", array( collect_issue_type_category() ));
+$res = sqlStatement("SELECT * FROM `issue_types` WHERE active = 1 AND `category`=? ORDER BY `ordering`",
+  array(collect_issue_type_category()));
 while($row = sqlFetchArray($res)){
-  $ISSUE_TYPES[$row['type']] = array(xl($row['plural']),xl($row['singular']),xl($row['abbreviation']),$row['style'],$row['force_show']);
+  $ISSUE_TYPES[$row['type']] = array(
+    xl($row['plural']),
+    xl($row['singular']),
+    xl($row['abbreviation']),
+    $row['style'],
+    $row['force_show'],
+    $row['aco_spec']);
 }
 
 $ISSUE_CLASSIFICATIONS = array(
@@ -98,12 +105,10 @@ function getListByType ($pid, $type, $cols = "*", $active = "all", $limit = "all
 	if ($limit != "all")
 		$sql .= " limit $offset,$limit";
 	
-
 	$res = sqlStatement($sql);
 	for($iter =0;$row = sqlFetchArray($res);$iter++)
 		$all[$iter] = $row;
 	return $all;
-
 }
 
 function addList ($pid, $type, $title, $comments, $activity = "1")

--- a/sql/5_0_0-to-5_0_1_upgrade.sql
+++ b/sql/5_0_0-to-5_0_1_upgrade.sql
@@ -418,3 +418,11 @@ UPDATE `registry` SET `aco_spec` = 'patients|lab'      WHERE directory = 'proced
 #IfNotColumnType lbf_data field_value longtext
 ALTER TABLE `lbf_data` CHANGE `field_value` `field_value` longtext NOT NULL;
 #EndIf
+
+#IfMissingColumn issue_types aco_spec
+ALTER TABLE `issue_types` ADD `aco_spec` varchar(63) NOT NULL default 'patients|med';
+#EndIf
+
+#IfMissingColumn categories aco_spec
+ALTER TABLE `categories` ADD `aco_spec` varchar(63) NOT NULL default 'patients|docs';
+#EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -223,6 +223,7 @@ CREATE TABLE `categories` (
   `parent` int(11) NOT NULL default '0',
   `lft` int(11) NOT NULL default '0',
   `rght` int(11) NOT NULL default '0',
+  `aco_spec` varchar(63) NOT NULL DEFAULT 'patients|docs',
   PRIMARY KEY  (`id`),
   KEY `parent` (`parent`),
   KEY `lft` (`lft`,`rght`)
@@ -231,35 +232,35 @@ CREATE TABLE `categories` (
 --
 -- Dumping data for table `categories`
 --
-INSERT INTO `categories` VALUES (1, 'Categories', '', 0, 0, 57);
-INSERT INTO `categories` VALUES (2, 'Lab Report', '', 1, 1, 2);
-INSERT INTO `categories` VALUES (3, 'Medical Record', '', 1, 3, 4);
-INSERT INTO `categories` VALUES (4, 'Patient Information', '', 1, 5, 10);
-INSERT INTO `categories` VALUES (5, 'Patient ID card', '', 4, 6, 7);
-INSERT INTO `categories` VALUES (6, 'Advance Directive', '', 1, 11, 18);
-INSERT INTO `categories` VALUES (7, 'Do Not Resuscitate Order', '', 6, 12, 13);
-INSERT INTO `categories` VALUES (8, 'Durable Power of Attorney', '', 6, 14, 15);
-INSERT INTO `categories` VALUES (9, 'Living Will', '', 6, 16, 17);
-INSERT INTO `categories` VALUES (10, 'Patient Photograph', '', 4, 8, 9);
-INSERT INTO `categories` VALUES (11, 'CCR', '', 1, 19, 20);
-INSERT INTO `categories` VALUES (12, 'CCD', '', 1, 21, 22);
-INSERT INTO `categories` VALUES (13, 'CCDA', '', 1, 23, 24);
-INSERT INTO `categories` VALUES (14, 'Eye Module', '', 1, 25, 50);
-INSERT INTO `categories` VALUES (15, 'Communication - Eye', '', 14, 26, 27);
-INSERT INTO `categories` VALUES (16, 'Encounters - Eye', '', 14, 28, 29);
-INSERT INTO `categories` VALUES (17, 'Imaging - Eye', '', 14, 30, 49);
-INSERT INTO `categories` VALUES (18, 'OCT - Eye', 'POSTSEG', 17, 31, 32);
-INSERT INTO `categories` VALUES (19, 'FA/ICG - Eye', 'POSTSEG', 17, 33, 34);
-INSERT INTO `categories` VALUES (20, 'External Photos - Eye', 'EXT', 17, 35, 36);
-INSERT INTO `categories` VALUES (21, 'AntSeg Photos - Eye', 'ANTSEG', 17, 37, 38);
-INSERT INTO `categories` VALUES (22, 'Optic Disc - Eye', 'POSTSEG', 17, 39, 40);
-INSERT INTO `categories` VALUES (23, 'Fundus - Eye', 'POSTSEG', 17, 41, 42);
-INSERT INTO `categories` VALUES (24, 'Radiology - Eye', 'NEURO', 17, 43, 44);
-INSERT INTO `categories` VALUES (25, 'VF - Eye', 'NEURO', 17, 45, 46);
-INSERT INTO `categories` VALUES (26, 'Drawings - Eye', '', 17, 47, 48);
-INSERT INTO `categories` VALUES (27, 'Onsite Portal', '', 1, 51, 56);
-INSERT INTO `categories` VALUES (28, 'Patient', '', 27, 52, 53);
-INSERT INTO `categories` VALUES (29, 'Reviewed', '', 27, 54, 55);
+INSERT INTO `categories` VALUES (1, 'Categories', '', 0, 0, 57, 'patients|docs');
+INSERT INTO `categories` VALUES (2, 'Lab Report', '', 1, 1, 2, 'patients|docs');
+INSERT INTO `categories` VALUES (3, 'Medical Record', '', 1, 3, 4, 'patients|docs');
+INSERT INTO `categories` VALUES (4, 'Patient Information', '', 1, 5, 10, 'patients|docs');
+INSERT INTO `categories` VALUES (5, 'Patient ID card', '', 4, 6, 7, 'patients|docs');
+INSERT INTO `categories` VALUES (6, 'Advance Directive', '', 1, 11, 18, 'patients|docs');
+INSERT INTO `categories` VALUES (7, 'Do Not Resuscitate Order', '', 6, 12, 13, 'patients|docs');
+INSERT INTO `categories` VALUES (8, 'Durable Power of Attorney', '', 6, 14, 15, 'patients|docs');
+INSERT INTO `categories` VALUES (9, 'Living Will', '', 6, 16, 17, 'patients|docs');
+INSERT INTO `categories` VALUES (10, 'Patient Photograph', '', 4, 8, 9, 'patients|docs');
+INSERT INTO `categories` VALUES (11, 'CCR', '', 1, 19, 20, 'patients|docs');
+INSERT INTO `categories` VALUES (12, 'CCD', '', 1, 21, 22, 'patients|docs');
+INSERT INTO `categories` VALUES (13, 'CCDA', '', 1, 23, 24, 'patients|docs');
+INSERT INTO `categories` VALUES (14, 'Eye Module', '', 1, 25, 50, 'patients|docs');
+INSERT INTO `categories` VALUES (15, 'Communication - Eye', '', 14, 26, 27, 'patients|docs');
+INSERT INTO `categories` VALUES (16, 'Encounters - Eye', '', 14, 28, 29, 'patients|docs');
+INSERT INTO `categories` VALUES (17, 'Imaging - Eye', '', 14, 30, 49, 'patients|docs');
+INSERT INTO `categories` VALUES (18, 'OCT - Eye', 'POSTSEG', 17, 31, 32, 'patients|docs');
+INSERT INTO `categories` VALUES (19, 'FA/ICG - Eye', 'POSTSEG', 17, 33, 34, 'patients|docs');
+INSERT INTO `categories` VALUES (20, 'External Photos - Eye', 'EXT', 17, 35, 36, 'patients|docs');
+INSERT INTO `categories` VALUES (21, 'AntSeg Photos - Eye', 'ANTSEG', 17, 37, 38, 'patients|docs');
+INSERT INTO `categories` VALUES (22, 'Optic Disc - Eye', 'POSTSEG', 17, 39, 40, 'patients|docs');
+INSERT INTO `categories` VALUES (23, 'Fundus - Eye', 'POSTSEG', 17, 41, 42, 'patients|docs');
+INSERT INTO `categories` VALUES (24, 'Radiology - Eye', 'NEURO', 17, 43, 44, 'patients|docs');
+INSERT INTO `categories` VALUES (25, 'VF - Eye', 'NEURO', 17, 45, 46, 'patients|docs');
+INSERT INTO `categories` VALUES (26, 'Drawings - Eye', '', 17, 47, 48, 'patients|docs');
+INSERT INTO `categories` VALUES (27, 'Onsite Portal', '', 1, 51, 56, 'patients|docs');
+INSERT INTO `categories` VALUES (28, 'Patient', '', 27, 52, 53, 'patients|docs');
+INSERT INTO `categories` VALUES (29, 'Reviewed', '', 27, 54, 55, 'patients|docs');
 -- --------------------------------------------------------
 
 --
@@ -2607,6 +2608,7 @@ CREATE TABLE `issue_types` (
     `style` smallint(6) NOT NULL DEFAULT '0',
     `force_show` smallint(6) NOT NULL DEFAULT '0',
     `ordering` int(11) NOT NULL DEFAULT '0',
+    `aco_spec` varchar(63) NOT NULL default 'patients|med',
     PRIMARY KEY (`category`,`type`)
 ) ENGINE=InnoDB;
 

--- a/templates/document_categories/general_list.html
+++ b/templates/document_categories/general_list.html
@@ -15,25 +15,43 @@
 {/literal}
 <script type="text/javascript">
 var deleteLabel="{xl t="Delete"}";
+var editLabel="{xl t="Edit"}";
 </script>
-<script type="text/javascript" src="{$WEBROOT}/library/js/CategoryTreeMenu.js"></script>
+<script type="text/javascript" src="{$WEBROOT}/library/js/CategoryTreeMenu.js?v=3"></script>
 <table>
 	<tr>
 		<td height="20" valign="top">{xl t="Document Categories"}</td>
-
 	</tr>
 	<tr>
 		<td valign="top">{$tree_html}</td>
 		{if $message}
 		<td valign="top">{$message}</td>
 		{/if}
-		{if $add_node eq true}
+		{if $add_node eq true or $edit_node eq true}
 		<td width="25"></td>
 		<td valign="top">
-		{xl t="The new category will be a sub-category of "} {$parent_name}<br>
+    {if $add_node eq true}
+		{xl t="This new category will be a sub-category of "} {$parent_name}<br>
+		{/if}
 		<form method="post" action="{$FORM_ACTION}" onsubmit="return top.restoreSession()">
-		{xl t="Category Name"}:&nbsp;<input type="text" name="name" onKeyDown="PreventIt(event)" >&nbsp;&nbsp;
-		<input type="submit" name="Add Category" value="{xl t='Add Category'}">
+
+    <table>
+      <tr>
+        <td>{xl t="Category Name"}&nbsp;</td>
+        <td><input type="text" name="name" value="{$NAME}" onKeyDown="PreventIt(event)" /></td>
+      </tr>
+      <tr>
+        <td>{xl t="Value"}&nbsp;</td>
+		    <td><input type="text" name="value" value="{$VALUE}" onKeyDown="PreventIt(event)" ></td>
+      </tr>
+      <tr>
+        <td>{xl t="Access Control"}&nbsp;</td>
+		    <td><select name="aco_spec">{$ACO_OPTIONS}</select></td>
+      </tr>
+    </table>
+    &nbsp;<br />
+
+		<input type="submit" name="Add Category" value="{xl t='Save Category'}">
 		<input type="hidden" name="parent_is" value="{$parent_is}">
 		<input type="hidden" name="process" value="{$PROCESS}" />
 		</form>

--- a/templates/document_categories/general_list.html
+++ b/templates/document_categories/general_list.html
@@ -17,7 +17,7 @@
 var deleteLabel="{xl t="Delete"}";
 var editLabel="{xl t="Edit"}";
 </script>
-<script type="text/javascript" src="{$WEBROOT}/library/js/CategoryTreeMenu.js?v=3"></script>
+<script type="text/javascript" src="{$WEBROOT}/library/js/CategoryTreeMenu.js?v={php}echo $GLOBALS['v_js_includes'];{/php}"></script>
 <table>
 	<tr>
 		<td height="20" valign="top">{xl t="Document Categories"}</td>

--- a/templates/practice_settings/general_list.html
+++ b/templates/practice_settings/general_list.html
@@ -28,7 +28,7 @@
         <b>{$ACTION_NAME}</b>
     </div>
     <div class="tabContainer">
-        <div class="tab current">
+        <div class="tab current" style="width:100%">
             {$display}
         </div>
     </div>

--- a/version.php
+++ b/version.php
@@ -35,7 +35,7 @@ $v_offsite_portal='1.47';
 // end with "?v=$v_js_includes".  Search the code for examples of doing this.
 // All this is to keep browsers from using an older cached version.
 // Need to assign it as a global below to work in template scripts.
-$v_js_includes = 20;
+$v_js_includes = 21;
 
 // Do note modify below
 $GLOBALS['v_js_includes'] = $v_js_includes;

--- a/version.php
+++ b/version.php
@@ -17,7 +17,7 @@ $v_realpatch = '0';
 // is a database change in the course of development.  It is used
 // internally to determine when a database upgrade is needed.
 //
-$v_database = 215;
+$v_database = 217;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used
@@ -36,7 +36,6 @@ $v_offsite_portal='1.47';
 // All this is to keep browsers from using an older cached version.
 // Need to assign it as a global below to work in template scripts.
 $v_js_includes = 20;
-
 
 // Do note modify below
 $GLOBALS['v_js_includes'] = $v_js_includes;


### PR DESCRIPTION
Here are more access control improvements.

This adds features for assigning ACOs to specific issue types and specific document categories, and adds some associated logic for checking those permissions.

For issue type ACOs see Administration -> Lists -> Issue Types.

For document category ACOs see  Administration -> Practice -> Documents -> Edit Categories. Note the new "(Edit)" link, and the new fields when adding a category. The "Value" attribute was already in the database and seems to be used by the eye exam forms, so I included that as an editable field.