### PR TITLE
Convert table-based form to proper bootstrap form-groups

### DIFF
--- a/common/database/connector.php
+++ b/common/database/connector.php
@@ -118,6 +118,9 @@ final class Connector {
             $driverOptionsString = 'SET sql_mode = \'\'';
         }
 
+        $this->logger->trace("Setting time zone");
+        $driverOptionsString .= ", time_zone = '" . (new \DateTime())->format("P") . "'";
+
         // 1002 is the integer value of PDO::MYSQL_ATTR_INIT_COMMAND, which is
         // executed when connecting to the MySQL server. Note if utf8 or sql
         // mode commands fail, the connection will not be made.

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "support": {
         "website": "http://www.open-emr.org/",
         "issues": "https://github.com/openemr/openemr/issues",
-        "forum": "https://sourceforge.net/p/openemr/discussion/",
+        "forum": "https://community.open-emr.org/",
         "wiki": "http://www.open-emr.org/wiki/index.php/OpenEMR_Wiki_Home_Page",
         "source": "http://github.com/openemr/openemr"
     },

--- a/contrib/forms/xmlformgen/xslt/common_objects.xslt
+++ b/contrib/forms/xmlformgen/xslt/common_objects.xslt
@@ -226,7 +226,7 @@ while ($frow = sqlFetchArray($fres)) {
   if ($titlecols > 0) {
     end_cell();
     echo "<td colspan='$titlecols' valign='top'";
-    echo ($frow['uor'] == 2) ? " class='required'" : " class='label'";
+    echo ($frow['uor'] == 2) ? " class='required'" : " class='label_custom'";
     if ($cell_count == 2) echo " style='padding-left:10pt'";
     echo '>';
     $cell_count += $titlecols;

--- a/interface/billing/indigent_patients_report.php
+++ b/interface/billing/indigent_patients_report.php
@@ -111,14 +111,14 @@ $form_end_date   = fixDate($_POST['form_end_date'], date("Y-m-d"));
 
 	<table class='text'>
 		<tr>
-			<td class='label'>
+			<td class='label_custom'>
 			   <?php xl('Visits From','e'); ?>:
 			</td>
 			<td>
 			   <input type='text' class='datepicker' name='form_start_date' id="form_start_date" size='10' value='<?php echo $form_start_date ?>'
 				title='yyyy-mm-dd'>
 			</td>
-			<td class='label'>
+			<td class='label_custom'>
 			   <?php xl('To','e'); ?>:
 			</td>
 			<td>

--- a/interface/billing/sl_receipts_report.php
+++ b/interface/billing/sl_receipts_report.php
@@ -174,13 +174,13 @@ function sel_diagnosis() {
 
 	<table class='text'>
 		<tr>
-			<td class='label'>
+			<td class='label_custom'>
 				<?php echo xlt('Facility'); ?>:
 			</td>
 			<td>
 			<?php dropdown_facility($form_facility, 'form_facility'); ?>
 			</td>
-			<td class='label'>
+			<td class='label_custom'>
 			   <?php echo xlt('Provider'); ?>:
 			</td>
 			<td>
@@ -213,14 +213,14 @@ function sel_diagnosis() {
 			</td>
 		</tr>
 		<tr>
-			<td class='label'>
+			<td class='label_custom'>
 			   <?php echo xlt('From'); ?>:
 			</td>
 			<td>
 			   <input type='text' class='datepicker' name='form_from_date' id="form_from_date" size='10' value='<?php  echo attr($form_from_date); ?>'
 				title='<?php echo xla('Date of appointments mm/dd/yyyy'); ?>' >
 			</td>
-			<td class='label'>
+			<td class='label_custom'>
 			   <?php echo xlt('To'); ?>:
 			</td>
 			<td>

--- a/interface/forms/eye_mag/SpectacleRx.php
+++ b/interface/forms/eye_mag/SpectacleRx.php
@@ -29,18 +29,13 @@ $fake_register_globals=false;
 $sanitize_all_escapes=true;
 
 require_once("../../globals.php");
-require_once("$srcdir/html2pdf/vendor/autoload.php");
 require_once("$srcdir/api.inc");
 require_once("$srcdir/acl.inc");
 require_once("$srcdir/forms.inc");
 require_once("$srcdir/lists.inc");
 require_once("$srcdir/options.inc.php");
-
-require_once($srcdir . "/../controllers/C_Document.class.php");
-require_once($srcdir . "/documents.php");
 require_once("$srcdir/patient.inc");
 require_once("$srcdir/report.inc");
-require_once("$srcdir/html2pdf/html2pdf.class.php");
 
 
 $form_name = "Eye Form";
@@ -97,7 +92,7 @@ if ($_REQUEST['mode'] =="update") {  //store any changed fields in dispense tabl
 }
 
 
-formHeader("Rx Vision: ".$prov_data[facility]);
+formHeader("OpenEMR Eye: ".$prov_data[facility]);
 
 if ($_REQUEST['REFTYPE']) {
     $REFTYPE = $_REQUEST['REFTYPE'];
@@ -340,204 +335,198 @@ if ($_REQUEST['dispensed']) {
 
             </script>
         </head>
-        <body>
             <?php echo report_header($pid,"web"); ?>
-            <div style="margin:5;text-align:center;">
-                <table>
-                    <tr>
-                        <td colspan="2"><h4 class="underline"><?php echo xlt('Rx History'); ?></h4></td>
-                    </tr>
+            <div class="row">
+                <div class="col-sm-2"></div>
+                <div class="col-sm-8" style="margin:5;text-align:center;">
+                    <table>
+                        <tr>
+                            <td colspan="2"><h4 class="underline"><?php echo xlt('Rx History'); ?></h4></td>
+                        </tr>
+                        <?php
+                        if (sqlNumRows($dispensed) == 0) {
+                            echo "<tr><td colspan='2' style='font-size:1.2em;text-align:middle;padding:25px;'>".xlt('There are no Glasses or Contact Lens Presciptions on file for this patient')."</td></tr>";
+                        }
+                        ?>
+                    </table>
                     <?php
-                    if (sqlNumRows($dispensed) == 0) {
-                        echo "<tr><td colspan='2' style='font-size:1.2em;text-align:middle;padding:25px;'>".xlt('There are no Glasses or Contact Lens Presciptions on file for this patient')."</td></tr>";
-                    }
-                    ?>
-                </table>
-                <?php
-                while ($row = sqlFetchArray($dispensed)) {
-                    $i++;
-                    $Single ='';$Bifocal='';$Trifocal='';$Progressive='';
-                    if ($row['RXTYPE'] == "Single") $Single = "checked='checked'";
-                    if ($row['RXTYPE'] == "Bifocal") $Bifocal = "checked='checked'";
-                    if ($row['RXTYPE'] == "Trifocal") $Trifocal = "checked='checked'";
-                    if ($row['RXTYPE'] == "Progressive") $Progressive = "checked='checked'";
+                    while ($row = sqlFetchArray($dispensed)) {
+                        $i++;
+                        $Single ='';$Bifocal='';$Trifocal='';$Progressive='';
+                        if ($row['RXTYPE'] == "Single") $Single = "checked='checked'";
+                        if ($row['RXTYPE'] == "Bifocal") $Bifocal = "checked='checked'";
+                        if ($row['RXTYPE'] == "Trifocal") $Trifocal = "checked='checked'";
+                        if ($row['RXTYPE'] == "Progressive") $Progressive = "checked='checked'";
 
-                    $row['REFDATE'] = oeFormatShortDate($row['REFDATE']);
-                    $row['date'] = oeFormatShortDate($row['REFDATE']);
-                    ?>
-                    <div id="RXID_<?php echo attr($row['id']); ?>" style="position:relative;width:640px;text-align:center;margin: 10 auto;">
-                        <i class="pull-right fa fa-close" onclick="delete_me('<?php echo attr(addslashes($row['id'])); ?>');" title="<?php echo xla('Remove this Prescription from the list of RXs dispensed'); ?>"></i>
-                        <table style="min-width:615px;">
-                        <tr>
-                            <td class="right bold" style="width:250px;"><b><?php echo xlt('RX Date'); ?>: </b></td>
-                            <td>&nbsp;&nbsp;<?php echo text($row['date']); ?></td>
-                        </tr>
-                        <tr>
-                            <td class="right bold"><b><?php echo xlt('Visit Date'); ?>: </b></td>
-                            <td>&nbsp;&nbsp;<?php echo text($row['REFDATE']); ?></td>
-                        </tr>
+                        $row['REFDATE'] = oeFormatShortDate($row['REFDATE']);
+                        $row['date'] = oeFormatShortDate(date('Y-m-d',strtotime($row['date'])));
+                        ?>
+                        <div id="RXID_<?php echo attr($row['id']); ?>" style="position:relative;text-align:center;width:80%;margin: 10 auto;">
+                            <i class="pull-right fa fa-close"
+                                onclick="delete_me('<?php echo attr(addslashes($row['id'])); ?>');"
+                                title="<?php echo xla('Remove this Prescription from the list of RXs dispensed'); ?>"></i>
+                            <table style="margin:2px auto;">
+                                <tr>
+                                    <td class="right bold" style="width:250px;"><b><?php echo xlt('RX Date'); ?>: </b></td>
+                                    <td>&nbsp;&nbsp;<?php echo text($row['date']); ?></td>
+                                </tr>
+                                <tr>
+                                    <td class="right bold"><b><?php echo xlt('Visit Date'); ?>: </b></td>
+                                    <td>&nbsp;&nbsp;<?php echo text($row['REFDATE']); ?></td>
+                                </tr>
 
-                        <tr>
-                            <td class="right bold"><?php echo xlt('Refraction Method'); ?>: </td>
-                            <td>&nbsp;&nbsp;<?php
-                                if ($row['REFTYPE'] == "W") {
-                                    echo xlt('Duplicate Rx -- unchanged from current Rx{{The refraction did not change, New Rx=old Rx}}');
-                                } else if ($row['REFTYPE'] == "CR") {
-                                    echo xlt('Cycloplegic (Wet) Refraction');
-                                } else if ($row['REFTYPE'] == "MR") {
-                                    echo xlt('Manifest (Dry) Refraction');
-                                } else if ($row['REFTYPE'] == "AR") {
-                                    echo xlt('Auto Refraction');
-                                } else if ($row['REFTYPE'] == "CTL") {
-                                    echo xlt('Contact Lens');
-                                }  ?>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td colspan="2"> <?php
-                                if ($row['REFTYPE'] != "CTL") { ?>
-                                    <table id="SpectacleRx" name="SpectacleRx" class="refraction" style="top:0px;">
-                                        <tr style="font-style:bold;">
-                                            <td></td>
-                                            <td></td>
-                                            <td class="center"><?php echo xlt('Sph{{Sphere}}'); ?></td>
-                                            <td class="center"><?php echo xlt('Cyl{{Cylinder}}'); ?></td>
-                                            <td class="center"><?php echo xlt('Axis{{Axis of a glasses prescription}}'); ?></td>
-                                            <td rowspan="5" class="right bold underline" colspan="2" style="min-width:200px;font-weight:bold;">
-                                                <?php echo xlt('Rx Type'); ?><br /><br />
-                                                <?php echo xlt('Single'); ?>
-                                                    <input type="radio" disabled <?php echo text($Single); ?>><br />
-                                                <?php echo xlt('Bifocal'); ?>
-                                                    <input type="radio" disabled <?php echo text($Bifocal); ?>><br />
-                                                <?php echo xlt('Trifocal'); ?>
-                                                    <input type="radio" disabled <?php echo text($Trifocal); ?>><br />
-                                                <?php echo xlt('Prog.{{Progressive lenses}}'); ?>
-                                                    <input type="radio" disabled <?php echo text($Progressive); ?>><br />
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td rowspan="2" style="text-align:right;font-weight:bold;"><?php echo xlt('Distance'); ?></td>
-                                            <td><b><?php echo xlt('OD{{right eye}}'); ?></b></td>
-                                            <td><?php echo text($row['ODSPH']); ?></td>
-                                            <td><?php echo text($row['ODCYL']); ?></td>
-                                            <td><?php echo text($row['ODAXIS']); ?></td>
-                                            <td><?php echo text($row['ODPRISM']); ?></td>
-                                        </tr>
-                                        <tr>
-                                            <td><b><?php echo xlt('OS{{left eye}}'); ?></b></td>
-                                            <td><?php echo text($row['OSSPH']); ?></td>
-                                            <td><?php echo text($row['OSCYL']); ?></td>
-                                            <td><?php echo text($row['OSAXIS']); ?></td>
-                                            <td><?php echo text($row['OSPRISM']); ?></td>
-                                        </tr>
-                                        <tr class="NEAR">
-                                            <td rowspan=2 nowrap><span style="text-decoration:none;"><?php echo xlt('ADD'); ?>:<br /><?php echo xlt("Mid{{Middle segment in a trifocal glasses prescription}}"); ?>/<?php echo xlt("Near"); ?></span></td>
-                                            <td><b><?php echo xlt('OD{{right eye}}'); ?></b></td>
-                                            <td class="WMid"><?php echo text($row['ODMIDADD']); ?></td>
-                                            <td class="WAdd2"><?php echo text($row['ODADD2']); ?></td>
-                                        </tr>
-                                        <tr class="NEAR">
-                                            <td><b><?php echo xlt('OS{{left eye}}'); ?></b></td>
-                                            <td class="WMid"><?php echo text($row['OSMIDADD']); ?></td>
-                                            <td class="WAdd2"><?php echo text($row['OSADD2']); ?></td>
-                                        </tr>
-                                        <tr style="">
-                                            <td colspan="2" class="up" style="text-align:right;vertical-align:top;top:0px;font-weight:bold;"><?php echo xlt('Comments'); ?>:
-                                            </td>
-                                            <td colspan="4" class="up" style="text-align:left;vertical-align:middle;top:0px;">
-                                                <textarea style="width:100%;height:2.1em;" id="COMMENTS" disabled name="COMMENTS"><?php echo text($row['COMMENTS']); ?></textarea>
-                                            </td>
-                                        </tr>
-                                    </table>
-                                    <?php
-                                } else { ?>
-                                <center>
-                                    <table id="CTLRx" name="CTLRx" class="refraction">
-                                        <tr>
-                                            <td colspan="4" class="bold underline left"><?php echo xlt('Right Lens'); ?></u></td>
-                                        </tr>
-                                        <tr>
-                                            <td colspan="3" class="left"><?php echo text($row['CTLBRANDOD']); ?></td>
-                                        </tr>
-                                        <tr class="bold" style="text-decoration:underline;">
-                                            <td></td>
-                                            <td><?php echo xlt('Sph{{Sphere}}'); ?></td>
-                                            <td><?php echo xlt('Cyl{{Cylinder}}'); ?></td>
-                                            <td><?php echo xlt('Axis{{Axis of a glasses prescription}}'); ?></td>
-                                            <td><?php echo xlt('BC{{Base Curve}}'); ?></td>
-                                            <td><?php echo xlt('Diam{{Diameter}}'); ?></td>
-                                            <td><?php echo xlt('ADD'); ?></td>
-                                            <td><td>
-                                            <td><?php echo xlt('Supplier'); ?></td>
-                                        </tr>
-                                        <tr>
-                                            <td></td>
-                                            <td><?php echo text($row['ODSPH']); ?></td>
-                                            <td><?php echo text($row['ODCYL']); ?></td>
-                                            <td><?php echo text($row['ODAXIS']); ?></td>
-                                            <td><?php echo text($row['ODBC']); ?></td>
-                                            <td><?php echo text($row['ODDIAM']); ?></td>
-                                            <td><?php echo text($row['ODADD']); ?></td>
-                                            <td colspan="3" class="right"><?php echo text($row['CTLSUPPLIEROD']); ?></td>
-                                        </tr>
-                                        <tr>
-                                            <td colspan="4" class="bold underline left"><u><?php echo xlt('Left Lens'); ?></u>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td colspan="3" class="left"><?php echo text($row['CTLBRANDOS']); ?></td>
-                                        </tr>
-                                        <tr class="bold" style="text-decoration:underline;">
-                                            <td></td>
-                                            <td><?php echo xlt('Sph{{Sphere}}'); ?></td>
-                                            <td><?php echo xlt('Cyl{{Cylinder}}'); ?></td>
-                                            <td><?php echo xlt('Axis{{Axis of a glasses prescription}}'); ?></td>
-                                            <td><?php echo xlt('BC{{Base Curve}}'); ?></td>
-                                            <td><?php echo xlt('Diam{{Diameter}}'); ?></td>
-                                            <td><?php echo xlt('ADD'); ?></td>
-                                            <td><td>
-                                            <td><?php echo xlt('Supplier'); ?></td>
-                                        </tr>
-                                        <tr>
-                                            <td></td>
-                                            <td><?php echo text($row['OSSPH']); ?></td>
-                                            <td><?php echo text($row['OSCYL']); ?></td>
-                                            <td><?php echo text($row['OSAXIS']); ?></td>
-                                            <td><?php echo text($row['OSBC']); ?></td>
-                                            <td><?php echo text($row['OSDIAM']); ?></td>
-                                            <td><?php echo text($row['OSADD']); ?></td>
-                                            <td colspan="3" class="right"><?php echo text($row['CTLSUPPLIEROS']); ?></td>
+                                <tr>
+                                    <td class="right bold"><?php echo xlt('Refraction Method'); ?>: </td>
+                                    <td>&nbsp;&nbsp;<?php
+                                        if ($row['REFTYPE'] == "W") {
+                                            echo xlt('Duplicate Rx -- unchanged from current Rx{{The refraction did not change, New Rx=old Rx}}');
+                                        } else if ($row['REFTYPE'] == "CR") {
+                                            echo xlt('Cycloplegic (Wet) Refraction');
+                                        } else if ($row['REFTYPE'] == "MR") {
+                                            echo xlt('Manifest (Dry) Refraction');
+                                        } else if ($row['REFTYPE'] == "AR") {
+                                            echo xlt('Auto-Refraction');
+                                        } else if ($row['REFTYPE'] == "CTL") {
+                                            echo xlt('Contact Lens');
+                                        }  ?>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td colspan="2"> <?php
+                                        if ($row['REFTYPE'] != "CTL") { ?>
+                                            <table id="SpectacleRx" name="SpectacleRx" class="refraction" style="top:0px;">
+                                                <tr style="font-style:bold;">
+                                                    <td></td>
+                                                    <td></td>
+                                                    <td class="center"><?php echo xlt('Sph{{Sphere}}'); ?></td>
+                                                    <td class="center"><?php echo xlt('Cyl{{Cylinder}}'); ?></td>
+                                                    <td class="center"><?php echo xlt('Axis{{Axis in a glasses prescription}}'); ?></td>
+                                                    <td rowspan="5" class="right bold underline" colspan="2" style="min-width:200px;font-weight:bold;">
+                                                        <?php echo xlt('Rx Type'); ?><br /><br />
+                                                        <?php echo xlt('Single'); ?>
+                                                            <input type="radio" disabled <?php echo text($Single); ?>><br />
+                                                        <?php echo xlt('Bifocal'); ?>
+                                                            <input type="radio" disabled <?php echo text($Bifocal); ?>><br />
+                                                        <?php echo xlt('Trifocal'); ?>
+                                                            <input type="radio" disabled <?php echo text($Trifocal); ?>><br />
+                                                        <?php echo xlt('Prog.{{Progressive lenses}}'); ?>
+                                                            <input type="radio" disabled <?php echo text($Progressive); ?>><br />
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td rowspan="2" style="text-align:right;font-weight:bold;"><?php echo xlt('Distance'); ?></td>
+                                                    <td><b><?php echo xlt('OD{{right eye}}'); ?></b></td>
+                                                    <td><?php echo text($row['ODSPH']); ?></td>
+                                                    <td><?php echo text($row['ODCYL']); ?></td>
+                                                    <td><?php echo text($row['ODAXIS']); ?></td>
+                                                    <td><?php echo text($row['ODPRISM']); ?></td>
+                                                </tr>
+                                                <tr>
+                                                    <td><b><?php echo xlt('OS{{left eye}}'); ?></b></td>
+                                                    <td><?php echo text($row['OSSPH']); ?></td>
+                                                    <td><?php echo text($row['OSCYL']); ?></td>
+                                                    <td><?php echo text($row['OSAXIS']); ?></td>
+                                                    <td><?php echo text($row['OSPRISM']); ?></td>
+                                                </tr>
+                                                <tr class="NEAR">
+                                                    <td rowspan=2 nowrap><span style="text-decoration:none;"><?php echo xlt('ADD'); ?>:<br /><?php echo xlt("Mid{{Middle segment in a trifocal glasses prescription}}"); ?>/<?php echo xlt("Near"); ?></span></td>
+                                                    <td><b><?php echo xlt('OD{{right eye}}'); ?></b></td>
+                                                    <td class="WMid"><?php echo text($row['ODMIDADD']); ?></td>
+                                                    <td class="WAdd2"><?php echo text($row['ODADD2']); ?></td>
+                                                </tr>
+                                                <tr class="NEAR">
+                                                    <td><b><?php echo xlt('OS{{left eye}}'); ?></b></td>
+                                                    <td class="WMid"><?php echo text($row['OSMIDADD']); ?></td>
+                                                    <td class="WAdd2"><?php echo text($row['OSADD2']); ?></td>
+                                                </tr>
+                                                <tr style="">
+                                                    <td colspan="2" class="up" style="text-align:right;vertical-align:top;top:0px;font-weight:bold;"><?php echo xlt('Comments'); ?>:
+                                                    </td>
+                                                    <td colspan="4" class="up" style="text-align:left;vertical-align:middle;top:0px;">
+                                                        <textarea style="width:100%;height:2.1em;" id="COMMENTS" disabled name="COMMENTS"><?php echo text($row['COMMENTS']); ?></textarea>
+                                                    </td>
+                                                </tr>
+                                            </table>
+                                            <?php
+                                        } else { ?>
+                                            <center>
+                                                <table id="CTLRx" name="CTLRx" class="refraction">
+                                                    <tr>
+                                                        <td colspan="4" class="bold underline left"><?php echo xlt('Right Lens'); ?></u></td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td colspan="3" class="left"><?php echo text($row['CTLBRANDOD']); ?></td>
+                                                    </tr>
+                                                    <tr class="bold" style="text-decoration:underline;">
+                                                        <td></td>
+                                                        <td><?php echo xlt('Sph{{Sphere}}'); ?></td>
+                                                        <td><?php echo xlt('Cyl{{Cylinder}}'); ?></td>
+                                                        <td><?php echo xlt('Axis{{Axis in a glasses prescription}}'); ?></td>
+                                                        <td><?php echo xlt('BC{{Base Curve}}'); ?></td>
+                                                        <td><?php echo xlt('Diam{{Diameter}}'); ?></td>
+                                                        <td><?php echo xlt('ADD'); ?></td>
+                                                        <td><td>
+                                                        <td><?php echo xlt('Supplier'); ?></td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td></td>
+                                                        <td><?php echo text($row['ODSPH']); ?></td>
+                                                        <td><?php echo text($row['ODCYL']); ?></td>
+                                                        <td><?php echo text($row['ODAXIS']); ?></td>
+                                                        <td><?php echo text($row['ODBC']); ?></td>
+                                                        <td><?php echo text($row['ODDIAM']); ?></td>
+                                                        <td><?php echo text($row['ODADD']); ?></td>
+                                                        <td colspan="3" class="right"><?php echo text($row['CTLSUPPLIEROD']); ?></td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td colspan="4" class="bold underline left"><u><?php echo xlt('Left Lens'); ?></u>
+                                                        </td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td colspan="3" class="left"><?php echo text($row['CTLBRANDOS']); ?></td>
+                                                    </tr>
+                                                    <tr class="bold" style="text-decoration:underline;">
+                                                        <td></td>
+                                                        <td><?php echo xlt('Sph{{Sphere}}'); ?></td>
+                                                        <td><?php echo xlt('Cyl{{Cylinder}}'); ?></td>
+                                                        <td><?php echo xlt('Axis{{Axis in a glasses prescription}}'); ?></td>
+                                                        <td><?php echo xlt('BC{{Base Curve}}'); ?></td>
+                                                        <td><?php echo xlt('Diam{{Diameter}}'); ?></td>
+                                                        <td><?php echo xlt('ADD'); ?></td>
+                                                        <td><td>
+                                                        <td><?php echo xlt('Supplier'); ?></td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td></td>
+                                                        <td><?php echo text($row['OSSPH']); ?></td>
+                                                        <td><?php echo text($row['OSCYL']); ?></td>
+                                                        <td><?php echo text($row['OSAXIS']); ?></td>
+                                                        <td><?php echo text($row['OSBC']); ?></td>
+                                                        <td><?php echo text($row['OSDIAM']); ?></td>
+                                                        <td><?php echo text($row['OSADD']); ?></td>
+                                                        <td colspan="3" class="right"><?php echo text($row['CTLSUPPLIEROS']); ?></td>
 
-                                        </tr>
-                                    </table>
-                                </center>
-                                    <?php
-                                } ?>
-                            </td>
-                        </tr>
-                        </table>
-                    <hr>
+                                                    </tr>
+                                                </table>
+                                            </center>
+                                            <?php
+                                        } ?>
+                                    </td>
+                                </tr>
+                            </table>
+                        <hr>
 
-                    </div>
-                    <?php
-                }
-            ?>
+                        </div>
+                        <?php  } ?>
+                </div>
+                <div class="col-sm-2"></div>
             </div>
         </body>
     </html>
     <?php
     exit;
 }
-    $filename = $pid."_".$encounter."_RX_".$REFTYPE.".pdf";
-    $pdf = new HTML2PDF ($GLOBALS['pdf_layout'],
-                         $GLOBALS['pdf_size'],
-                         $GLOBALS['pdf_language'],
-                         true,    // default unicode setting is true
-                         'UTF-8', // default encoding setting is UTF-8
-                         array($GLOBALS['pdf_left_margin'],$GLOBALS['pdf_top_margin'],$GLOBALS['pdf_right_margin'],$GLOBALS['pdf_bottom_margin']),
-                         $_SESSION['language_direction'] == 'rtl' ? true : false
-                      );
-    ob_start();
+   ob_start();
     ?>
     <html>
         <head>
@@ -1145,8 +1134,7 @@ if ($_REQUEST['dispensed']) {
                                                 }
                                                 });
                 $("input,textarea,text,checkbox").change(function(){
-                                                           //$(this).css("background-color","#F0F8FF");
-                                                           //submit_form($(this));
+                                                           submit_form($(this));
                                                            });
                 $("#reverse").click(function() {
                     //alert('Start');
@@ -1167,40 +1155,7 @@ if ($_REQUEST['dispensed']) {
     </html>
 
     <?php
-exit;
-    global $web_root, $webserver_root;
     $content = ob_get_clean();
     echo $content;
-
-    //display Rx to user, now store it too...
-    // Fix a nasty html2pdf bug - it ignores document root!
-    $i = 0;
-    $wrlen = strlen($web_root);
-    $wsrlen = strlen($webserver_root);
-    while (true) {
-      $i = stripos($content, " src='/", $i + 1);
-      if ($i === false) break;
-      if (substr($content, $i+6, $wrlen) === $web_root &&
-          substr($content, $i+6, $wsrlen) !== $webserver_root)
-      {
-        $content = substr($content, 0, $i + 6) . $webserver_root . substr($content, $i + 6 + $wrlen);
-      }
-    }
-    $temp_filename = '/tmp/'.$filename;
-
-    $query = "select id from categories where name like 'Communication'";
-    $result = sqlStatement($query);
-    $ID = sqlFetchArray($result);
-    $category_id = $ID['id'];
-    $pdf->writeHTML($content, false);
-    $content_pdf = $pdf->Output($temp_filename, 'F');
-    $type = "application/pdf";
-
-    $size = filesize($temp_filename);
-
-    $return = addNewDocument($filename,$type,$temp_filename,0,$size,$_SESSION['authUserID'],$pid,$category_id);
-    $doc_id = $return['doc_id'];
-    $sql = "UPDATE documents set encounter_id=? where id=?"; //link it to this encounter
-    sqlQuery($sql,array($encounter,$doc_id));
 exit;
 ?>

--- a/interface/forms/eye_mag/a_issue.php
+++ b/interface/forms/eye_mag/a_issue.php
@@ -297,7 +297,7 @@ foreach (explode(',',$given) as $item) {
     function refreshIssue() {  parent.refresh_page(); }
     function submit_this_form() {
         var url = "../../forms/eye_mag/save.php?PMSFH_save=1&mode=update&form_save=1";
-        var formData = $("form#theform").serialize();
+        var formData = $("form#theform2").serialize();
         var f = document.forms[0];
         top.restoreSession();
         $.ajax({
@@ -598,7 +598,10 @@ foreach (explode(',',$given) as $item) {
          .navy {
           background-color: navy !important;
          }
-
+         form {
+          margin:7px auto;
+         }
+         
       </style>
 
       <link rel="shortcut icon" href="<?php echo $GLOBALS['images_static_relative']; ?>/favicon.ico" />
@@ -611,7 +614,7 @@ foreach (explode(',',$given) as $item) {
   </head>
   <body>
     <div id="page" style="text-align: justify; text-justify: newspaper;">
-      <form method='POST' name='theform' id='theform'
+      <form method='POST' name='theform2' id='theform2'
       action='a_issue.php?pid=<?php echo attr($pid); ?>&encounter=<?php echo attr($encounter); ?>'
        onsubmit='return validate();'
        >

--- a/interface/forms/eye_mag/css/style.css
+++ b/interface/forms/eye_mag/css/style.css
@@ -419,7 +419,6 @@ background-color: red;
     position:relative; 
     box-shadow: 5px 5px 9px #888888;
     margin: 1px 2px 1px 2px; 
-    position:relative; 
     border: 1.00pt solid #000000; 
     background: #ffffff;
     font-family:  "FontAwesome",Arial,Serif, Arial;
@@ -2041,6 +2040,6 @@ div[name=prior_selector] { position:absolute;top:0.083in;right:0.241in;}
     box-shadow: 5px 5px 9px #888888;
 }
 .status_on {
-    background-color: red;
+    background-color: #d3f2d3;
     box-shadow: 0 0 0px 0px #C0C0C0;
 }

--- a/interface/forms/eye_mag/help.php
+++ b/interface/forms/eye_mag/help.php
@@ -500,13 +500,13 @@ Choly 2010.Lap Band 2014.;All:sulfa - hives.PCN - SOB;</textarea>
 					<div id="external_output" style="text-align:left;margin:0;padding:20;">
 						<blockquote class="style2">
 							Input:<br /><br />
-							<b>D;bc:+2 inj;bk:med pter;rk:mod endo gut.a;bac:+1 fc, +1 pig cells/b><br />
+							<b>D;bc:+2 inj;bk:med pter;rk:mod endo gut.a;bac:+1 fc, +1 pig cells</b><br />
 							<br />
 							Output:
 							<br /><br />
-							<div class="output_EMR">
+							<div class="output_EMR well-sm">
 								<h4>Eye Exam</h4>
-								<img src="<?php echo $GLOBALS['webroot']; ?>/interface/forms/eye_mag/images/sh_antseg_EMR.png" width="95%" alt="Shorthand Example: openEMR">
+								<img src="<?php echo $GLOBALS['webroot']; ?>/interface/forms/eye_mag/images/sh_antseg_EMR.png" width="90%" alt="Shorthand Example: openEMR">
 							</div>
 							<div class="output_reports">
 								<h4>Reports</h4>

--- a/interface/forms/eye_mag/js/eye_base.php
+++ b/interface/forms/eye_mag/js/eye_base.php
@@ -57,6 +57,8 @@ var Code_new_est;
 var config_byday;
 var $root = $('html, body');
 var scroll;
+var visit_modifier=[];
+var visit_justify=[];
 
 /*
  * Functions to add a quick pick selection to the correct fields on the form.
@@ -138,7 +140,7 @@ function submit_form(action) {
                    // ACTIVE chart.
                    // Coding engine returns any positive Clinical findings.
                    //List these findings in the IMP_PLAN Builder
-                   populate_form(result);
+                   if (action=='1') {}else{populate_form(result);}
                    }
                    });
 };
@@ -1268,7 +1270,7 @@ function build_IMPPLAN(items,nodisplay) {
       $('#IMPPLAN_zone').html("");
     }
       $('#Coding_DX_Codes').html("");
-
+    
     if ((items == null) || ((typeof items == "undefined")|| (items.length =='0'))) {
         items = [];
         $('#IMPPLAN_text').removeClass('nodisplay'); //Display Builder instructions for starting out
@@ -1279,57 +1281,60 @@ function build_IMPPLAN(items,nodisplay) {
         $('#IMPPLAN_zone').removeClass('nodisplay');
         count_dx=0;
         $.each(items, function( index, value ) {
-               if (!value.codetext) value.codetext="";
-               if (!value.code) value.code="";
-               if ((value.code==="") || (value.code.match(/Code/) || (value.code==null))) {
-               value.code="<i class='fa fa-search-plus'></i>&nbsp;Code";
-               } else {
-               count_dx++;
-               if (value.code.match(/\,/g)) {
-               // If there is a comma in there, there is more than one code present for this item. Split them out.
-               // If code is manually changed or copied from a prior visit - item will not have a PMSFH_link
-               // PMSFH_link is only present when the Builder was used to make the entry.
-               if ((typeof value.PMSFH_link !== "undefined") || (value.PMSFH_link !== null)) {
-               //The Title should have the description.
-               var CodeArr =  value.code.split(",");
-               var TitleArr = value.codedesc.split("\r");
-               for (i=0;i < CodeArr.length;i++) {
-               if (CodeArr.length == (TitleArr.length-1)) { //there is a trailing \r
-               $('#Coding_DX_Codes').append(count_dx +'. '+CodeArr[i]+': '+TitleArr[i]+'<br />');
-               } else {
-               //just look it up via ajax or tell them to code it manually on the feesheet ;).
-               $('#Coding_DX_Codes').append(CodeArr[i]+': <?php echo xlt('Manually retrieve description on Fee Sheet'); ?> <br />');
-               }
-               }
-               } else  {
-               //this works for Clinical-derived terms with more than one Dx Code (found in more than one location/field)
-               if (value.PMSFH_link.match(/Clinical_(.*)/)) {
-               if (typeof obj.Clinical !== "undefined") {
-               var location = value.PMSFH_link.match(/Clinical_(.*)/)[1];
-               if (obj.Clinical[location]!=null ) {
-               for (i=0; i< obj.Clinical[location].length; i++) {
-               $('#Coding_DX_Codes').append(count_dx +'. '+obj.Clinical[location][i].code+': '+obj.Clinical[location][i].codedesc+'<br />');
-               }
-               } else {
-               //item has a PMSFH_link but it is not from a Clinical field
-               alert("Houston, we have a problem!");
-               }
-               }
-               }
-               }
-               } else { //all is good, one code only
-               $('#Coding_DX_Codes').append(count_dx +'. '+value.code+': '+value.codedesc+'<br />');
-               }
-               }
+            if (!value.codetext) value.codetext="";
+            if (!value.code) value.code="";
+            if ((value.code==="") || (value.code.match(/Code/) || (value.code==null))) {
+              value.code="<i class='fa fa-search-plus'></i>&nbsp;Code";
+            } else {
+              count_dx++;
+              if (value.code.match(/\,/g)) {
+                // If there is a comma in there, there is more than one code present for this item. Split them out.
+                // If code is manually changed or copied from a prior visit - item will not have a PMSFH_link
+                // PMSFH_link is only present when the Builder was used to make the entry.
+                if ((typeof value.PMSFH_link !== "undefined") || (value.PMSFH_link !== null)) {
+                   //The Title should have the description.
+                  var CodeArr =  value.code.split(",");
+                  var TitleArr = value.codedesc.split("\r");
+                    for (i=0;i < CodeArr.length;i++) {
+                      if (CodeArr.length == (TitleArr.length-1)) { //there is a trailing \r
+                        $('#Coding_DX_Codes').append(count_dx +'. '+CodeArr[i]+': '+TitleArr[i]+'<br />');
+                      } else {
+                        //just look it up via ajax or tell them to code it manually on the feesheet ;).
+                        $('#Coding_DX_Codes').append(CodeArr[i]+': <?php echo xlt('Manually retrieve description on Fee Sheet'); ?> <br />');
+                      }
+                    }
+                } else  {
+                 //this works for Clinical-derived terms with more than one Dx Code (found in more than one location/field)
+                  if (value.PMSFH_link.match(/Clinical_(.*)/)) {
+                    if (typeof obj.Clinical !== "undefined") {
+                      var location = value.PMSFH_link.match(/Clinical_(.*)/)[1];
+                      if (obj.Clinical[location]!=null ) {
+                        for (i=0; i< obj.Clinical[location].length; i++) {
+                          $('#Coding_DX_Codes').append(count_dx +'. '+obj.Clinical[location][i].code+': '+obj.Clinical[location][i].codedesc+'<br />');
+                        }
+                      } else {
+                        //item has a PMSFH_link but it is not from a Clinical field
+                        alert("Houston, we have a problem!");
+                      }
+                    }
+                  }
+                }
+              } else { //all is good, one code only
+                $('#Coding_DX_Codes').append(count_dx +'. '+value.code+': '+value.codedesc+'<br />');
+              }
+            }
+
+            if (typeof nodisplay !== "undefined") {
+              return;
+            }
                var title2 = value.title.replace(/(\')/g, '');
-               contents_here = ( index + 1 ) +
-               ". <span contenteditable title='<?php echo xla('Click to edit'); ?>' id='IMPRESSION_"+index+"'>" +
+               contents_here = "<span class='bold' contenteditable title='<?php echo xla('Click to edit'); ?>' id='IMPRESSION_"+index+"'>" +
                value.title +"</span>"+
                "<span contenteditable class='pull-right' onclick='sel_diagnosis("+index+",\""+title2+"\");' title='"+value.codetext+"' id='CODE_"+index+"'>"+
                value.code + "</span>&nbsp;"+
                "<br /><textarea id='PLAN_"+index+"' name='PLAN_"+index+
                "' style='width:100%;max-width:100%;height:auto;min-height:3em;overflow-y: hidden;padding-top: 1.1em; '>"+
-               value.plan +"</textarea><br />";
+               value.plan +"</textarea><br /></li>";
                $('#IMPPLAN_zone').append('<div id="IMPPLAN_zone_'+index+'" class="IMPPLAN_class">'+
                                          '<i class="pull-right fa fa-close" id="BUTTON_IMPPLAN_'+index+'"></i>'+
                                          contents_here+'</div>');
@@ -1340,8 +1345,7 @@ function build_IMPPLAN(items,nodisplay) {
                                                  store_IMPPLAN(obj.IMPPLAN_items,'1');
                                                  });
                $('#PLAN_'+index).css("background-color","#F0F8FF");
-
-               });
+          });
             //end each
 
             // The IMPRESSION DXs are "contenteditable" spans.
@@ -1362,8 +1366,8 @@ function build_IMPPLAN(items,nodisplay) {
                               //obj.IMPPLAN_items[item].codetext = '';
                               //obj.IMPPLAN_items[item].codedesc = '';
                               $(this).css('background-color','#F0F8FF');
-                              store_IMPPLAN(obj.IMPPLAN_items,'1');
-                              });
+                              store_IMPPLAN(obj.IMPPLAN_items);
+                            });
 
         $('[id^=PLAN_]').change(function() {
                                 var item = this.id.match(/PLAN_(.*)/)[1];
@@ -1453,15 +1457,15 @@ function CODING_to_feesheet(CODING_items) {
         var formData =  JSON.stringify(CODING_items);
         top.restoreSession();
         $.ajax({
-               type         : 'POST',
-               url          :  url,
-               data     : {
-               parameter     : formData,
-               action        : 'code_visit',
-               pid           : $('#pid').val(),
-               form_id       : $('#form_id').val(),
-               encounter     : $('#encounter').val(),
-               uniqueID      : $('#uniqueID').val()
+               'type'         : 'POST',
+               'url'          :  url,
+               'data'         : {
+               'parameter'    : formData,
+               'action'       : 'code_visit',
+               'pid'          : $('#pid').val(),
+               'form_id'      : $('#form_id').val(),
+               'encounter'    : $('#encounter').val(),
+               'uniqueID'     : $('#uniqueID').val()
                }
                }).done(function(result) {
                        if (result == "Code 400") {
@@ -1565,13 +1569,46 @@ function build_CODING_list() {
      2. Tests performed
      3. Diagnostic codes
      */
-        //1.  Visit Codes.
+         //3. Diagnostic Codes
+    $.each(obj.IMPPLAN_items, function( index, value ) {
+      if (value['codetype']) {
+        if (value['code'].match(/\,/g)) {
+          // physical finding found in more than one location, more than one code...
+          // if there is a comma in there, there is more than one code present. Split them out.
+          // And all those in one group have the same link out (PMSFH_link) value
+          var location = value.PMSFH_link.match(/Clinical_(.*)/)[1];
+          for (i=0; i< obj.Clinical[location].length; i++) {
+            CODING_items.push({
+                             code:     obj.Clinical[location][i]['code'],
+                             codedesc: obj.Clinical[location][i]['codedesc'],
+                             codetext: obj.Clinical[location][i]['codetext'],
+                             codetype: obj.Clinical[location][i]['codetype'],
+                             title:    obj.Clinical[location][i]['title']
+                             });
+          }
+        } else if (value['code'].match(/Code/)){
+          //ignore
+        } else {
+          CODING_items.push({
+                             code:     value['code'],
+                             codedesc: value['codedesc'],
+                             codetext: value['codetext'],
+                             codetype: value['codetype'],
+                             title:    value['title']
+                             });
+        
+        }
+      }
+    });
+        //1.  Visit Codes.  These can have a modifier (22,25,57 hard coded so far)
     CODING_items.push({
                       code:     visit_code,
                       codedesc: visit_desc,
                       codetext: '',
                       codetype: 'CPT4',
-                      title:    'Visit Code'
+                      title:    'Visit Code',
+                      modifier: visit_modifier,
+                      justify:  visit_justify
                       });
         //neurosensory
     if (CPT_92060 == 'here') {
@@ -1602,34 +1639,7 @@ function build_CODING_list() {
                                        });
                      }
                      });
-        //3. Diagnostic Codes
-    $.each(obj.IMPPLAN_items, function( index, value ) {
-           if (value['codetype']) {
-           if (value['code'].match(/\,/g)) {
-           //physical finding found in more than one location, more than one code...
-           //if there is a comma in there, there is more than one code present. Split them out.
-           // And all those in one group have the same link out (PMSFH_link) value
-           var location = value.PMSFH_link.match(/Clinical_(.*)/)[1];
-           for (i=0; i< obj.Clinical[location].length; i++) {
-           CODING_items.push({
-                             code:     obj.Clinical[location][i]['code'],
-                             codedesc: obj.Clinical[location][i]['codedesc'],
-                             codetext: obj.Clinical[location][i]['codetext'],
-                             codetype: obj.Clinical[location][i]['codetype'],
-                             title:    obj.Clinical[location][i]['title']
-                             });
-           }
-           } else {
-           CODING_items.push({
-                             code:     value['code'],
-                             codedesc: value['codedesc'],
-                             codetext: value['codetext'],
-                             codetype: value['codetype'],
-                             title:    value['title']
-                             });
-           }
-           }
-           });
+    
     CODING_to_feesheet(CODING_items);
 }
 
@@ -1749,7 +1759,9 @@ function dopopup(url) {
     window.open(url, 'clinical', 'width=fullscreen,height=fullscreen,resizable=1,scrollbars=1,directories=0,titlebar=0,toolbar=0,location=0,status=0,menubar=0');
 }
 function goto_url(url) {
-    window.open(url);
+    R =  url;
+    top.restoreSession();
+    location.href = R;
 }
 function openImage() {
     dlgopen(base+'/controller.php?document&retrieve&patient_id=3&document_id=10&as_file=false', '_blank', 600, 475);
@@ -3557,7 +3569,7 @@ $(document).ready(function() {
                                                   $('#IMP_start_acc').slideDown();
                                                   zone='IMPPLAN';
                                                 }
-                                                if ($("#PREFS_"+zone+"_RIGHT").val() =='QP') {
+                                                if (($("#PREFS_"+zone+"_RIGHT").val() =='QP')&&(zone !='IMPPLAN')) {
                                                   $('#BUTTON_TEXTD_'+zone).trigger("click");
                                                   return;
                                                 }
@@ -3726,12 +3738,19 @@ $(document).ready(function() {
 
                   $("input,textarea,text,checkbox").change(function(){
                                                            $(this).css("background-color","#F0F8FF");
-                                                           submit_form($(this));
-                                                           });
+                                                           if ($(this).id != 'IMP') {
+                                                              //alert('form is '+$(this).id);
+                                                              submit_form();
+                                                            } else {
+                                                             // alert('Form was IMP');
+                                                           }
+                                                         });
+                                                         
                   $('#IMP').blur(function() {
                                  //add this DX to the obj.IMPPLAN_items array
                                  //take the first line as the impression and the rest as the plan
                                  var total_imp = $('#IMP').val();
+                                 $('#IMP').val('');//clear the box
                                  var local_plan = '';
                                  var local_code= '';
                                  if (total_imp.length < '2') return; //reject text under two letters?
@@ -3769,10 +3788,10 @@ $(document).ready(function() {
                                                         codedesc:'',
                                                         PMSFH_link: ''
                                                         });
-                                 build_IMPPLAN(obj.IMPPLAN_items);
-                                 store_IMPPLAN(obj.IMPPLAN_items,'1');
-                                 $('#IMP').val('');//clear the box
-                                 submit_form('1');//tell the server where we stand
+                                 build_IMPPLAN(obj.IMPPLAN_items,'1');
+                                 store_IMPPLAN(obj.IMPPLAN_items);
+                                 
+                                 //submit_form('1');//tell the server where we stand
                                  });
                   $('#Add_Glasses').click(function() {
                                           for (i=2; i <6; i++) { //come on, 5 current rx glasses should be enough...

--- a/interface/forms/misc_billing_options/new.php
+++ b/interface/forms/misc_billing_options/new.php
@@ -121,7 +121,7 @@ function genProviderSelect($selname, $toptext, $default=0, $disabled=false) {
  </tr>
     <br><br>
 
-    <td class='label'><?php echo xlt('BOX 17. Provider') ?>:</td>
+    <td class='label_custom'><?php echo xlt('BOX 17. Provider') ?>:</td>
     <td><?php  # Build a drop-down list of providers. # Added (TLH)
                genProviderSelect('provider_id', '-- '.xl("Please Select").' --',$obj{"provider_id"});
 		?></td>&nbsp;&nbsp;

--- a/interface/forms/procedure_order/new.php
+++ b/interface/forms/procedure_order/new.php
@@ -499,7 +499,7 @@ $(document).ready(function() {
                     </textarea>
                 </div>
             </div>
-
+            <div class="procedure-order-container">
             <?php
 
             // This section merits some explanation. :)
@@ -595,11 +595,11 @@ $(document).ready(function() {
                     </select>
                 </div>
             </div>
-
+            </div>
             <div class="btn-group pull-right" role="group">
                 <button type="button" class="btn" onclick="addProcLine()"><i class="fa fa-plus"></i>&nbsp;<?php echo xla('Add Procedure'); ?></button>
-                <button type="submit" class="btn btn-success" name='bn_save' onclick='transmitting = false;'><i class="fa fa-check"></i>&nbsp;<?php echo xla('Save'); ?></button>
-                <button type="submit" class="btn btn-success" name='bn_xmit' onclick='transmitting = true;' ><i class="fa fa-arrow-right"></i>&nbsp;<?php echo xla('Save and Transmit'); ?></button>
+                <button type="submit" class="btn btn-success" name='bn_save' value="save" onclick='transmitting = false;'><i class="fa fa-check"></i>&nbsp;<?php echo xla('Save'); ?></button>
+                <button type="submit" class="btn btn-success" name='bn_xmit' value="transmit" onclick='transmitting = true;' ><i class="fa fa-arrow-right"></i>&nbsp;<?php echo xla('Save and Transmit'); ?></button>
                 <button type="button" class="btn btn-danger" onclick="top.restoreSession();location='<?php echo $GLOBALS['form_exit_url']; ?>'"><i class="fa fa-times"></i>&nbsp;<?php echo xla('Cancel'); ?></button>
             </div>
             <div class="clearfix"></div>

--- a/interface/forms/procedure_order/new.php
+++ b/interface/forms/procedure_order/new.php
@@ -214,34 +214,19 @@ $enrow = sqlQuery("SELECT p.fname, p.mname, p.lname, fe.date FROM " .
 <head>
 <?php html_header_show(); ?>
 
-<?php $include_standard_style_js = array("datetimepicker"); ?>
-<?php require($GLOBALS['srcdir'] . '/templates/standard_header_template.php'); ?>
+<link rel="stylesheet" href="<?php echo $css_header;?>" type="text/css" />
+<link rel="stylesheet" href="<?php echo $GLOBALS['assets_static_relative'] ?>/bootstrap-3-3-4/dist/css/bootstrap.min.css">
+<link rel="stylesheet" href="<?php echo $GLOBALS['assets_static_relative'] ?>/font-awesome-4-6-3/css/font-awesome.min.css">
+<?php if($_SESSION['language_direction'] == 'rtl'): ?>
+<link rel="stylesheet" href="<?php echo $GLOBALS['assets_static_relative'];?>/bootstrap-rtl-3-3-4/dist/css/bootstrap-rtl.min.css" type="text/css">
+<?php endif; ?>
+<link rel="stylesheet" href="<?php echo $GLOBALS['assets_static_relative']; ?>/jquery-datetimepicker-2-5-4/build/jquery.datetimepicker.min.css">
 
+<script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/jquery-min-3-1-1/index.js"></script>
 <script type="text/javascript" src="../../../library/dialog.js?v=<?php echo $v_js_includes; ?>"></script>
 <script type="text/javascript" src="<?php echo $GLOBALS['webroot'] ?>/library/textformat.js?v=<?php echo $v_js_includes; ?>"></script>
-
-<style>
-
-td {
- font-size:10pt;
-}
-
-.inputtext {
- padding-left:2px;
- padding-right:2px;
-}
-
-.form-inline
-{
-  width: 60%;
-  margin: 0 auto;
-}
-.table
-{
-  border: #ddd solid 1px ;
-}
-
-</style>
+<script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/jquery-datetimepicker-2-5-4/build/jquery.datetimepicker.full.min.js"></script>
+<script src="<?php echo $GLOBALS['assets_static_relative'] ?>/bootstrap-3-3-4/dist/js/bootstrap.min.js"></script>
 
 <script language='JavaScript'>
 
@@ -401,228 +386,225 @@ $(document).ready(function() {
 </head>
 
 <body class="body_top">
+<div class="container">
+    <div class="col-md-6 col-md-offset-3">
+        <form method="post" action="<?php echo $rootdir ?>/forms/procedure_order/new.php?id=<?php echo $formid ?>"
+              onsubmit="return validate(this)" class="form-horizontal">
 
-<div class="span9 centered">
-<form method="post" action="<?php echo $rootdir ?>/forms/procedure_order/new.php?id=<?php echo $formid ?>"
- onsubmit="return validate(this)" class="form-inline">
+            <p class='lead'>
+                <?php
+                $name = $enrow['fname'] . ' ';
+                $name .= (!empty($enrow['mname'])) ? $enrow['mname'] . ' ' . $enrow['lname'] : $enrow['lname'];
+                $date = xl('on') . ' ' . oeFormatShortDate(substr($enrow['date'], 0, 10));
+                $title = array(xl('Procedure Order for'), $name, $date);
+                echo join(" ", $title);
+                ?>
+            </p>
 
-<p class='title' style='margin-top:8px;margin-bottom:8px;text-align:center'>
-<?php
-  echo xl('Procedure Order for') . ' ';
-  echo $enrow['fname'] . ' ' . $enrow['mname'] . ' ' . $enrow['lname'];
-  echo ' ' . xl('on') . ' ' . oeFormatShortDate(substr($enrow['date'], 0, 10));
-?>
-</p>
+            <div class="form-group">
+                <label for="provider_id" class="control-label col-sm-4"><?php xl('Ordering Provider', 'e'); ?></label>
+                <div class="col-sm-8">
+                    <?php generate_form_field(array('data_type'=>10,'field_id'=>'provider_id'), $row['provider_id']); ?>
+                </div>
+            </div>
 
+            <div class="form-group">
+                <label for="lab_id" class="control-label col-sm-4"><?php xl('Sending To', 'e');?></label>
+                <div class="col-sm-8">
+                    <select name='form_lab_id' onchange='lab_id_changed()' class='form-control'>
+                        <?php
+                        $ppres = sqlStatement("SELECT ppid, name FROM procedure_providers " .
+                            "ORDER BY name, ppid");
+                        while ($pprow = sqlFetchArray($ppres)) {
+                            echo "<option value='" . attr($pprow['ppid']) . "'";
+                            if ($pprow['ppid'] == $row['lab_id']) echo " selected";
+                            echo ">" . text($pprow['name']) . "</option>";
+                        }
+                        ?>
+                    </select>
+                </div>
+            </div>
 
+            <div class="form-group">
+                <label for="form_data_ordered" class="control-label col-sm-4"><?php xl('Order Date', 'e'); ?></label>
+                <div class="col-sm-8">
+                    <input type='text'
+                           class='datepicker form-control'
+                           name='form_date_ordered'
+                           id='form_date_ordered'
+                           value="<?php echo $row['date_ordered'];?>"
+                           title="<?php xl('Date of this order', 'e');?>" />
+                </div>
+            </div>
 
-<p>
-<table  width='100%' id='proctable' class="table">
+            <div class="form-group">
+                <label for="form_data_ordered" class="control-label col-sm-4"><?php xl('Internal Time Collected','e'); ?></label>
+                <div class="col-sm-8">
+                    <input class='datetimepicker form-control'
+                           type='text'
+                           name='form_date_collected'
+                           id='form_date_collected'
+                           value="<?php echo substr($row['date_collected'], 0, 16);?>"
+                           title="<?php xl('Date and time that the sample was collected', 'e');?>" />
+                </div>
+            </div>
 
- <tr>
-  <td valign='top' align='right' nowrap><b><?php xl('Ordering Provider','e'); ?>:</b></td>
-  <td valign='top'>
-<?php
-generate_form_field(array('data_type'=>10,'field_id'=>'provider_id'),
-  $row['provider_id']);
-?>
-  </td>
- </tr>
+            <div class="form-group">
+                <label for="form_data_ordered" class="control-label col-sm-4"><?php xl('Priority','e'); ?></label>
+                <div class="col-sm-8">
+                    <?php
+                    generate_form_field(array('data_type'=>1,'field_id'=>'order_priority',
+                        'list_id'=>'ord_priority'), $row['order_priority']);
+                    ?>
+                </div>
+            </div>
 
- <tr>
-  <td width='1%' valign='top' align='right' nowrap><b><?php xl('Sending To','e'); ?>:</b></td>
-  <td valign='top'>
-   <select name='form_lab_id' onchange='lab_id_changed()' class='form-control'>
- <?php
-  $ppres = sqlStatement("SELECT ppid, name FROM procedure_providers " .
-    "ORDER BY name, ppid");
-  while ($pprow = sqlFetchArray($ppres)) {
-    echo "<option value='" . attr($pprow['ppid']) . "'";
-    if ($pprow['ppid'] == $row['lab_id']) echo " selected";
-    echo ">" . text($pprow['name']) . "</option>";
-  }
-?>
-   </select>
-  </td>
- </tr>
+            <div class="form-group">
+                <label for="form_data_ordered" class="control-label col-sm-4"><?php xl('Status','e'); ?></label>
+                <div class="col-sm-8">
+                    <?php
+                    generate_form_field(array('data_type'=>1,'field_id'=>'order_status',
+                        'list_id'=>'ord_status'), $row['order_status']);
+                    ?>
+                </div>
+            </div>
 
- <tr>
-  <td width='1%' valign='top' align='right' nowrap><b><?php xl('Order Date','e'); ?>:</b></td>
-  <td valign='top'>
-<?php
-    echo "<input type='text' size='10' class='datepicker form-control' name='form_date_ordered' id='form_date_ordered'" .
-      " value='" . $row['date_ordered'] . "'" .
-      " title='" . xl('Date of this order') . "'" .
-      " />";
-?>
-  </td>
- </tr>
+            <div class="form-group">
+                <label for="form_data_ordered" class="control-label col-sm-4"><?php xl('History Order','e'); ?></label>
+                <div class="col-sm-8">
+                    <?php
+                        $historyOrderOpts = array(
+                            'data_type' => 1,
+                            'field_id' => 'history_order',
+                            'list_id' => 'boolean'
+                        );
+                        generate_form_field($historyOrderOpts,  $row['history_order']); ?>
+                </div>
+            </div>
 
- <tr>
-  <td width='1%' valign='top' align='right' nowrap><b><?php xl('Internal Time Collected','e'); ?>:</b></td>
-  <td valign='top'>
-<?php
-    echo "<input class='datetimepicker form-control' type='text' size='16' name='form_date_collected' id='form_date_collected'" .
-      " value='" . substr($row['date_collected'], 0, 16) . "'" .
-      " title='" . xl('Date and time that the sample was collected') . "'" .
-      " />";
-?>
-  </td>
- </tr>
+            <div class="form-group">
+                <label for="form_data_ordered" class="control-label col-sm-4"><?php xl('Clinical History','e'); ?></label>
+                <div class="col-sm-8">
+                    <input type='text' maxlength='255' name='form_clinical_hx'
+                           class='form-control inputtext' value='<?php echo attr($row['clinical_hx']); ?>' />
+                </div>
+            </div>
 
- <tr>
-  <td width='1%' valign='top' align='right' nowrap><b><?php xl('Priority','e'); ?>:</b></td>
-  <td valign='top'>
-<?php
-generate_form_field(array('data_type'=>1,'field_id'=>'order_priority',
-  'list_id'=>'ord_priority'), $row['order_priority']);
-?>
-  </td>
- </tr>
+            <?php // Hide this for now with a hidden class as it does not yet do anything ?>
+            <div class="form-group hidden">
+                <label for="form_data_ordered" class="control-label col-sm-4"><?php xl('Patient Instructions','e'); ?></label>
+                <div class="col-sm-8">
+                    <textarea rows='3' cols='40' name='form_patient_instructions' wrap='virtual' class='form-control inputtext'>
+                        <?php echo $row['patient_instructions'] ?>
+                    </textarea>
+                </div>
+            </div>
 
- <tr>
-  <td width='1%' valign='top'  align='right' nowrap><b><?php xl('Status','e'); ?>:</b></td>
-  <td valign='top'>
-<?php
-generate_form_field(array('data_type'=>1,'field_id'=>'order_status',
-  'list_id'=>'ord_status'), $row['order_status']);
-?>
-  </td>
- </tr>
- <tr>
- <td width='1%' valign='top' align='right' nowrap><b><?php xl('History order','e'); ?>:</b>
- <td valign='top'>
- <?php generate_form_field(array('data_type'=>1,'field_id'=>'history_order','list_id'=>'boolean'),$row['history_order']); ?>
- </td>
- </tr>
- <tr>
-  <td width='1%' valign='top' align='right' nowrap><b><?php xl('Clinical History','e'); ?>:</b></td>
-  <td valign='top'>
-   <input type='text' maxlength='255' name='form_clinical_hx' style='width:100%'
-    class='form-control inputtext' value='<?php echo attr($row['clinical_hx']); ?>' />
-  </td>
- </tr>
+            <?php
 
- <!-- Will enable this later, nothing uses it yet. -->
- <tr style='display:none'>
-  <td width='1%' valign='top' align='right' nowrap><b><?php xl('Patient Instructions','e'); ?>:</b></td>
-  <td valign='top'>
-   <textarea rows='3' cols='40' name='form_patient_instructions' style='width:100%'
-    wrap='virtual' class='form-control inputtext' /><?php echo $row['patient_instructions'] ?></textarea>
-  </td>
- </tr>
+            // This section merits some explanation. :)
+            //
+            // If any procedures have already been saved for this form, then a top-level table row is
+            // created for each of them, and includes the relevant questions and any existing answers.
+            // Otherwise a single empty table row is created for entering the first or only procedure.
+            //
+            // If a new procedure is selected or changed, the questions for it are (re)generated from
+            // the dialog window from which the procedure is selected, via JavaScript.  The sel_proc_type
+            // function and the types.php script that it invokes collaborate to support this feature.
+            //
+            // The generate_qoe_html function in qoe.inc.php contains logic to generate the HTML for
+            // the questions, and can be invoked either from this script or from types.php.
+            //
+            // The $i counter that you see below is to resolve the need for unique names for form fields
+            // that may occur for each of the multiple procedure requests within the same order.
+            // procedure_order_seq serves a similar need for uniqueness at the database level.
 
-<?php
+            $oparr = array();
+            if ($formid) {
+                $opres = sqlStatement("SELECT " .
+                    "pc.procedure_order_seq, pc.procedure_code, pc.procedure_name, " .
+                    "pc.diagnoses, pc.procedure_order_title, " .
+                    // In case of duplicate procedure codes this gets just one.
+                    "(SELECT pt.procedure_type_id FROM procedure_type AS pt WHERE " .
+                    "pt.procedure_type LIKE 'ord%' AND pt.lab_id = ? AND " .
+                    "pt.procedure_code = pc.procedure_code ORDER BY " .
+                    "pt.activity DESC, pt.procedure_type_id LIMIT 1) AS procedure_type_id " .
+                    "FROM procedure_order_code AS pc " .
+                    "WHERE pc.procedure_order_id = ? " .
+                    "ORDER BY pc.procedure_order_seq",
+                    array($row['lab_id'], $formid));
+                while ($oprow = sqlFetchArray($opres)) {
+                    $oparr[] = $oprow;
+                }
+            }
+            if (empty($oparr)) $oparr[] = array('procedure_name' => '');
 
-  // This section merits some explanation. :)
-  //
-  // If any procedures have already been saved for this form, then a top-level table row is
-  // created for each of them, and includes the relevant questions and any existing answers.
-  // Otherwise a single empty table row is created for entering the first or only procedure.
-  //
-  // If a new procedure is selected or changed, the questions for it are (re)generated from
-  // the dialog window from which the procedure is selected, via JavaScript.  The sel_proc_type
-  // function and the types.php script that it invokes collaborate to support this feature.
-  //
-  // The generate_qoe_html function in qoe.inc.php contains logic to generate the HTML for
-  // the questions, and can be invoked either from this script or from types.php.
-  //
-  // The $i counter that you see below is to resolve the need for unique names for form fields
-  // that may occur for each of the multiple procedure requests within the same order.
-  // procedure_order_seq serves a similar need for uniqueness at the database level.
+            $i = 0;
+            foreach ($oparr as $oprow) {
+                $ptid = -1; // -1 means no procedure is selected yet
+                if (!empty($oprow['procedure_type_id'])) {
+                    $ptid = $oprow['procedure_type_id'];
+                }
+                ?>
+                <div class="form-group">
+                    <?php if (empty($formid) || empty($oprow['procedure_order_title'])):?>
+                        <label for="" class="control-label col-sm-4"><?php echo xlt('Procedure:');?></label>
+                        <input type="hidden" name="form_proc_order_title[<?php echo $i; ?>]" value="Procedure">
+                    <?php else: ?>
+                        <label for="" class="control-label col-sm-4"><?php echo text($oprow['procedure_order_title']) ?></label>
+                        <input type='hidden' name='form_proc_order_title[<?php echo $i; ?>]' value='<?php echo attr($oprow['procedure_order_title']) ?>'>
+                    <?php endif; ?>
+                    <div class="col-sm-8">
+                        <input type='text' size='50' name='form_proc_type_desc[<?php echo $i; ?>]'
+                               value='<?php echo attr($oprow['procedure_name']) ?>'
+                               onclick="sel_proc_type(<?php echo $i; ?>)"
+                               onfocus='this.blur()'
+                               title='<?php xla('Click to select the desired procedure','e'); ?>'
+                               style='cursor:pointer;cursor:hand' class='form-control' readonly />
+                        <input type='hidden' name='form_proc_type[<?php echo $i; ?>]' value='<?php echo $ptid ?>' />
+                        <br /><?php echo xlt('Diagnosis Codes'); ?>:
+                        <input class='form-control' type='text' size='50' name='form_proc_type_diag[<?php echo $i; ?>]'
+                               value='<?php echo attr($oprow['diagnoses']) ?>' onclick='sel_related(this.name)'
+                               title='<?php echo xla('Click to add a diagnosis'); ?>'
+                               onfocus='this.blur()'
+                               style='cursor:pointer;cursor:hand' readonly />
+                        <!-- MSIE innerHTML property for a TABLE element is read-only, so using a DIV here. -->
+                        <div style='width:95%;' id='qoetable[<?php echo $i; ?>]'>
+                            <?php
+                            $qoe_init_javascript = '';
+                            echo generate_qoe_html($ptid, $formid, $oprow['procedure_order_seq'], $i);
+                            if ($qoe_init_javascript)
+                                echo "<script language='JavaScript'>$qoe_init_javascript</script>";
+                            ?>
+                        </div>
+                    </div>
+                </div>
+                <?php
+                ++$i;
+            }
+            ?>
 
-  $oparr = array();
-  if ($formid) {
-    $opres = sqlStatement("SELECT " .
-      "pc.procedure_order_seq, pc.procedure_code, pc.procedure_name, " .
-      "pc.diagnoses, pc.procedure_order_title, " .
-      // In case of duplicate procedure codes this gets just one.
-      "(SELECT pt.procedure_type_id FROM procedure_type AS pt WHERE " .
-      "pt.procedure_type LIKE 'ord%' AND pt.lab_id = ? AND " .
-      "pt.procedure_code = pc.procedure_code ORDER BY " .
-      "pt.activity DESC, pt.procedure_type_id LIMIT 1) AS procedure_type_id " .
-      "FROM procedure_order_code AS pc " .
-      "WHERE pc.procedure_order_id = ? " .
-      "ORDER BY pc.procedure_order_seq",
-      array($row['lab_id'], $formid));
-    while ($oprow = sqlFetchArray($opres)) {
-      $oparr[] = $oprow;
-    }
-  }
-  if (empty($oparr)) $oparr[] = array('procedure_name' => '');
+            <div class="form-group">
+                <label for="form_data_ordered" class="control-label col-sm-4"><?php xl('Procedure','e'); ?></label>
+                <div class="col-sm-8">
+                    <?php $procedure_order_type = getListOptions('order_type' , array('option_id', 'title')); ?>
+                    <select name="procedure_type_names" id="procedure_type_names" class='form-control'>
+                        <?php foreach($procedure_order_type as $ordered_types){?>
+                            <option value="<?php echo attr($ordered_types['option_id']); ?>" ><?php echo text(xl_list_label($ordered_types['title'])) ; ?></option>
+                        <?php } ?>
+                    </select>
+                </div>
+            </div>
 
-  $i = 0;
-  foreach ($oparr as $oprow) {
-    $ptid = -1; // -1 means no procedure is selected yet
-    if (!empty($oprow['procedure_type_id'])) {
-      $ptid = $oprow['procedure_type_id'];
-    }
-?>
- <tr>
- <!--<td width='1%' valign='top'><b><?php echo xl('Procedure') . ' ' . ($i + 1); ?>:</b></td>-->
- <?php if(empty($formid) || empty($oprow['procedure_order_title'])) {?>
-        <td width='1%' valign='top' align="right"><input type='hidden' name='form_proc_order_title[<?php echo $i; ?>]' value='Procedure'><b><?php echo xlt('Procedure:');?></b></td>
-    <?php } else {?>
-     <td width='1%' valign='top'>
-        <input type='hidden' name='form_proc_order_title[<?php echo $i; ?>]' value='<?php echo attr($oprow['procedure_order_title']) ?>'><b><?php echo text($oprow['procedure_order_title']) ?></b>
-     </td>
-    <?php } ?>
-  <td valign='top'>
-   <input type='text' size='50' name='form_proc_type_desc[<?php echo $i; ?>]'
-    value='<?php echo attr($oprow['procedure_name']) ?>'
-    onclick="sel_proc_type(<?php echo $i; ?>)"
-    onfocus='this.blur()'
-    title='<?php xla('Click to select the desired procedure','e'); ?>'
-    style='width:100%;cursor:pointer;cursor:hand' class='form-control' readonly />
-   <input type='hidden' name='form_proc_type[<?php echo $i; ?>]' value='<?php echo $ptid ?>' />
-   <br /><?php echo xlt('Diagnosis Codes'); ?>:
-   <input class='form-control' type='text' size='50' name='form_proc_type_diag[<?php echo $i; ?>]'
-    value='<?php echo attr($oprow['diagnoses']) ?>' onclick='sel_related(this.name)'
-    title='<?php echo xla('Click to add a diagnosis'); ?>'
-    onfocus='this.blur()'
-    style='cursor:pointer;cursor:hand' readonly />
-   <!-- MSIE innerHTML property for a TABLE element is read-only, so using a DIV here. -->
-   <div style='width:95%;' id='qoetable[<?php echo $i; ?>]'>
-<?php
-$qoe_init_javascript = '';
-echo generate_qoe_html($ptid, $formid, $oprow['procedure_order_seq'], $i);
-if ($qoe_init_javascript)
-  echo "<script language='JavaScript'>$qoe_init_javascript</script>";
-?>
-   </div>
-  </td>
- </tr>
-<?php
-    ++$i;
-  }
-?>
-
-</table>
-<div style="text-align: left">
-<div style="display:inline-block">
-<?php $procedure_order_type = getListOptions('order_type' , array('option_id', 'title')); ?>
-<select name="procedure_type_names" id="procedure_type_names" class='form-control'>
-	<?php foreach($procedure_order_type as $ordered_types){?>
-	<option value="<?php echo attr($ordered_types['option_id']); ?>" ><?php echo text(xl_list_label($ordered_types['title'])) ; ?></option>
-	<?php } ?>
-</select>
-</div>
-<div style="display:inline-block">
-<input type='button' value='<?php echo xla('Add Procedure'); ?>' onclick="addProcLine()" />
-&nbsp;
-<input type='submit' name='bn_save' value='<?php echo xla('Save'); ?>' onclick='transmitting = false;' />
-&nbsp;
-<input type='submit' name='bn_xmit' value='<?php echo xla('Save and Transmit'); ?>' onclick='transmitting = true;' />
-&nbsp;
-<input type='button' value='<?php echo xla('Cancel'); ?>' onclick="top.restoreSession();location='<?php echo $GLOBALS['form_exit_url']; ?>'" />
-</div>
-</div>
-</p>
-
-
-
-
-</form>
-</div><!--end of div wrapper -->
+            <div class="btn-group pull-right" role="group">
+                <button type="button" class="btn" onclick="addProcLine()"><i class="fa fa-plus"></i>&nbsp;<?php echo xla('Add Procedure'); ?></button>
+                <button type="submit" class="btn btn-success" name='bn_save' onclick='transmitting = false;'><i class="fa fa-check"></i>&nbsp;<?php echo xla('Save'); ?></button>
+                <button type="submit" class="btn btn-success" name='bn_xmit' onclick='transmitting = true;' ><i class="fa fa-arrow-right"></i>&nbsp;<?php echo xla('Save and Transmit'); ?></button>
+                <button type="button" class="btn btn-danger" onclick="top.restoreSession();location='<?php echo $GLOBALS['form_exit_url']; ?>'"><i class="fa fa-times"></i>&nbsp;<?php echo xla('Cancel'); ?></button>
+            </div>
+            <div class="clearfix"></div>
+        </form>
+    </div> <!--end of .col-md-6 -->
+</div><!--end of .container -->
 </body>
 </html>

--- a/interface/forms/procedure_order/new.php
+++ b/interface/forms/procedure_order/new.php
@@ -214,14 +214,11 @@ $enrow = sqlQuery("SELECT p.fname, p.mname, p.lname, fe.date FROM " .
 <head>
 <?php html_header_show(); ?>
 
-<link rel="stylesheet" href="<?php echo $css_header;?>" type="text/css" />
-<link rel="stylesheet" href="<?php echo $GLOBALS['assets_static_relative'] ?>/bootstrap-3-3-4/dist/css/bootstrap.min.css">
-<?php if($_SESSION['language_direction'] == 'rtl'): ?>
-<link rel="stylesheet" href="<?php echo $GLOBALS['assets_static_relative'];?>/bootstrap-rtl-3-3-4/dist/css/bootstrap-rtl.min.css" type="text/css">
-<?php endif; ?>
-<link rel="stylesheet" href="<?php echo $GLOBALS['assets_static_relative']; ?>/jquery-datetimepicker-2-5-4/build/jquery.datetimepicker.min.css">
+<?php $include_standard_style_js = array("datetimepicker"); ?>
+<?php require($GLOBALS['srcdir'] . '/templates/standard_header_template.php'); ?>
 
-
+<script type="text/javascript" src="../../../library/dialog.js?v=<?php echo $v_js_includes; ?>"></script>
+<script type="text/javascript" src="<?php echo $GLOBALS['webroot'] ?>/library/textformat.js?v=<?php echo $v_js_includes; ?>"></script>
 
 <style>
 
@@ -245,12 +242,6 @@ td {
 }
 
 </style>
-
-<script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/jquery-min-3-1-1/index.js"></script>
-<script type="text/javascript" src="../../../library/dialog.js?v=<?php echo $v_js_includes; ?>"></script>
-<script type="text/javascript" src="<?php echo $GLOBALS['webroot'] ?>/library/textformat.js?v=<?php echo $v_js_includes; ?>"></script>
-<script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/jquery-datetimepicker-2-5-4/build/jquery.datetimepicker.full.min.js"></script>
-<script src="<?php echo $GLOBALS['assets_static_relative'] ?>/bootstrap-3-3-4/dist/js/bootstrap.min.js"></script>
 
 <script language='JavaScript'>
 

--- a/interface/forms/vitals/growthchart/chart.php
+++ b/interface/forms/vitals/growthchart/chart.php
@@ -52,7 +52,7 @@ if (isset($pid) && is_numeric($pid)) {
     $name = $patient_data['fname'] ." ".$patient_data['lname'];
 }
 
-// The first data point in the DATA set is significant. It tells date 
+// The first data point in the DATA set is significant. It tells date
 // of the currently viewed vitals by the user. We will use this
 // date to define which chart is displayed on the screen
 $charttype = "2-20"; // default the chart-type to ages 2-20
@@ -61,7 +61,7 @@ if (isset($datapoints) && $datapoints != "") {
     list($date, $height, $weight, $head_circ) = explode('-', $datapoints[0]);
     if ($date != "") { $charttype_date = $date; }
     $tmpAge = getPatientAgeInDays($patient_data['DOB'], $date);
-    // use the birth-24 chart if the age-on-date-of-vitals is 24months or younger 
+    // use the birth-24 chart if the age-on-date-of-vitals is 24months or younger
     if ($tmpAge < (365*2)) { $charttype = "birth"; }
 }
 
@@ -113,7 +113,7 @@ $heightOffset = 0;
 $weightOffset = 0;
 
 if ($charttype == 'birth') {
-    // Use birth to 24 months chart 
+    // Use birth to 24 months chart
 
     $dot_x = 190;         //months starts here (pixel)
     $delta_x = 26.13;     //pixels per month  - length
@@ -129,9 +129,9 @@ if ($charttype == 'birth') {
 
 	$WT_y = 1127; //start here to draw wt and height graph at bottom of Head circumference chart
 	$WT_delta_y = 12.96;
-	$HT_x = 1187; //start here to draw wt and height graph at bottom of Head circumference chart 
+	$HT_x = 1187; //start here to draw wt and height graph at bottom of Head circumference chart
 	$HT_delta_x = 24.32;
-	
+
     if (preg_match('/^male/i', $patient_data['sex'])) {
         $chart = "birth-24mos_boys_HC.png";
 
@@ -161,7 +161,7 @@ if ($charttype == 'birth') {
     $datatable_hc_offset = 300;
     $datatable_y = 1052;
     $datatable_y_increment = 17;
-    
+
     // pixel positions and offsets for head-circ data table
     $datatable2_x = 1360;
     $datatable2_age_offset = 75;
@@ -204,7 +204,7 @@ elseif ($charttype == "2-20") {
     $ageOffset = 2;
     $heightOffset = 30;
     $weightOffset = 14;
-   
+
     // pixel positions and offsets data table
     $datatable_x = 96;
     $datatable_age_offset = 84;
@@ -213,7 +213,7 @@ elseif ($charttype == "2-20") {
     $datatable_bmi_offset = 360;
     $datatable_y = 188;
     $datatable_y_increment = 18;
-    
+
     // pixel positions and offsets for BMI data table
     $datatable2_x = 1071;
     $datatable2_age_offset = 73;
@@ -270,14 +270,14 @@ function cssHeader() {
             height: <?php echo $cssHeight; ?>pt;
             page-break-after: always;
         }
-        div.label {
+        div.label_custom {
             font-size: 7pt;
         }
 	div.DoNotPrint {
 	    position: absolute;
 	    top: 2pt;
 	    left: 200pt;
-	}	
+	}
         img {
             margin: 0;
             padding: 0;
@@ -289,13 +289,13 @@ function cssHeader() {
         @media print {
 	    div.DoNotPrint {
 	        display: none;
-	    }	
-	}	
+	    }
+	}
     </style>
-    <SCRIPT LANGUAGE="JavaScript">  
+    <SCRIPT LANGUAGE="JavaScript">
         function FormSetup()	{
 	    changeStyle('page1')
-	}	
+	}
 	function changeStyle(css_title) {
 	    var i, link_tag ;
 	    for (i = 0, link_tag = document.getElementsByTagName("link") ; i < link_tag.length ; i++ ) {
@@ -303,10 +303,10 @@ function cssHeader() {
 		    link_tag[i].disabled = true ;
 	    	    if (link_tag[i].title == css_title) {
 	    	        link_tag[i].disabled = false ;
-	    	    }	
-	    	}	
-	    }	
-	}	
+	    	    }
+	    	}
+	    }
+	}
   function pagePrint(title) {
     changeStyle(title);
     var win = top.printLogPrint ? top : opener.top;
@@ -327,7 +327,7 @@ function cssHeader() {
                 </td>
             </tr>
         </table>
-    </div>    
+    </div>
     <?php
 }
 
@@ -349,7 +349,7 @@ function cssPage($image1,$image2) {
     <?php
 }
 
-// Convert a point from above settings for gd into a 
+// Convert a point from above settings for gd into a
 // a format (pt) to use for css html document
 //  return - Array(Xcoord,Ycoord,page)
 function convertpoint($coord) {
@@ -358,16 +358,16 @@ function convertpoint($coord) {
     //manual offsets to help line up output
     $Xoffset=-3;
     $Yoffset=-2;
-    
+
     //collect coordinates from input array
     $Xcoord=$coord[0];
     $Ycoord=$coord[1];
-    
+
     //adjust with offsets
     $Xcoord = $Xcoord + $Xoffset;
     $Ycoord = $Ycoord + $Yoffset;
-    
-    
+
+
     if ($Xcoord > 1000) {
         //on second page so subtract 1000 from x
 	$Xcoord = $Xcoord - 1000;
@@ -376,13 +376,13 @@ function convertpoint($coord) {
     else {
         $page = "page1";
     }
-    
+
     //calculate conversion to pt (decrease number of decimals)
     $Xcoord = ($cssWidth*$Xcoord)/1000;
     $Xcoord = number_format($Xcoord,1,'.','');
     $Ycoord = ($cssHeight*$Ycoord)/1294;
     $Ycoord = number_format($Ycoord,1,'.','');
-    
+
     //return point
     return(Array($Xcoord,$Ycoord,$page));
 }
@@ -392,7 +392,7 @@ if ($_GET['html'] == 1) {
     //build the html css page if selected
     cssHeader();
     cssPage($chartCss1,$chartCss2);
-    
+
     //output name
     $point = convertpoint(Array($name_x,$name_y));
     echo("<div id='" . $point[2]  . "' class='name' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . $name  . "</div>\n");
@@ -468,60 +468,60 @@ if ($_GET['html'] == 1) {
         //birth to 24 mos chart has 8 rows to fill.
         if ($count < 8 && $charttype == "birth") {
 	    $point = convertpoint(Array($datatable_x,$datatable_y));
-	    echo("<div id='" . $point[2]  . "' class='label' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . $datestr . "</div>\n");
+	    echo("<div id='" . $point[2]  . "' class='label_custom' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . $datestr . "</div>\n");
             $point = convertpoint(Array($datatable_x+$datatable_age_offset,$datatable_y));
-            echo("<div id='" . $point[2]  . "' class='label' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . $ageinYMD . "</div>\n");
+            echo("<div id='" . $point[2]  . "' class='label_custom' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . $ageinYMD . "</div>\n");
             $point = convertpoint(Array($datatable_x+$datatable_weight_offset,$datatable_y));
-	    echo("<div id='" . $point[2]  . "' class='label' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . unitsWt($weight) . "</div>\n");
+	    echo("<div id='" . $point[2]  . "' class='label_custom' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . unitsWt($weight) . "</div>\n");
             $point = convertpoint(Array($datatable_x+$datatable_height_offset,$datatable_y));
-	    echo("<div id='" . $point[2]  . "' class='label' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . unitsDist($height) . "</div>\n");
+	    echo("<div id='" . $point[2]  . "' class='label_custom' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . unitsDist($height) . "</div>\n");
             $point = convertpoint(Array($datatable_x+$datatable_hc_offset,$datatable_y));
-	    echo("<div id='" . $point[2]  . "' class='label' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . unitsDist($head_circ) . "</div>\n");
+	    echo("<div id='" . $point[2]  . "' class='label_custom' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . unitsDist($head_circ) . "</div>\n");
             $datatable_y = $datatable_y + $datatable_y_increment; // increment the datatable "row pointer"
         }
 
         // 2 to 20 year-old chart has 7 rows to fill.
         if ($count < 7  && $charttype == "2-20") {
 	    $point = convertpoint(Array($datatable_x,$datatable_y));
-	    echo("<div id='" . $point[2]  . "' class='label' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . $datestr . "</div>\n");
+	    echo("<div id='" . $point[2]  . "' class='label_custom' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . $datestr . "</div>\n");
 	    $point = convertpoint(Array($datatable_x+$datatable_age_offset,$datatable_y));
-	    echo("<div id='" . $point[2]  . "' class='label' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . $ageinYMD . "</div>\n");
+	    echo("<div id='" . $point[2]  . "' class='label_custom' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . $ageinYMD . "</div>\n");
 	    $point = convertpoint(Array($datatable_x+$datatable_weight_offset,$datatable_y));
-	    echo("<div id='" . $point[2]  . "' class='label' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . unitsWt($weight) . "</div>\n");
+	    echo("<div id='" . $point[2]  . "' class='label_custom' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . unitsWt($weight) . "</div>\n");
 	    $point = convertpoint(Array($datatable_x+$datatable_height_offset,$datatable_y));
-	    echo("<div id='" . $point[2]  . "' class='label' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . unitsDist($height) . "</div>\n");
+	    echo("<div id='" . $point[2]  . "' class='label_custom' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . unitsDist($height) . "</div>\n");
 	    $point = convertpoint(Array($datatable_x+$datatable_bmi_offset,$datatable_y));
-	    echo("<div id='" . $point[2]  . "' class='label' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . substr($bmi,0,5) . "</div>\n");
+	    echo("<div id='" . $point[2]  . "' class='label_custom' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . substr($bmi,0,5) . "</div>\n");
             $datatable_y = $datatable_y + $datatable_y_increment; // increment the datatable "row pointer"
         }
 
         // Head Circumference chart has 5 rows to fill in
         if ($count < 5 && $charttype == "birth") {
 	    $point = convertpoint(Array($datatable2_x,$datatable2_y));
-	    echo("<div id='" . $point[2]  . "' class='label' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . $datestr . "</div>\n");
+	    echo("<div id='" . $point[2]  . "' class='label_custom' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . $datestr . "</div>\n");
 	    $point = convertpoint(Array($datatable2_x+$datatable2_age_offset,$datatable2_y));
-	    echo("<div id='" . $point[2]  . "' class='label' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . $ageinYMD . "</div>\n");
+	    echo("<div id='" . $point[2]  . "' class='label_custom' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . $ageinYMD . "</div>\n");
             $point = convertpoint(Array($datatable2_x+$datatable2_weight_offset,$datatable2_y));
-	    echo("<div id='" . $point[2]  . "' class='label' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . unitsWt($weight) . "</div>\n");
+	    echo("<div id='" . $point[2]  . "' class='label_custom' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . unitsWt($weight) . "</div>\n");
             $point = convertpoint(Array($datatable2_x+$datatable2_height_offset,$datatable2_y));
-	    echo("<div id='" . $point[2]  . "' class='label' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . unitsDist($height) . "</div>\n");
+	    echo("<div id='" . $point[2]  . "' class='label_custom' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . unitsDist($height) . "</div>\n");
             $point = convertpoint(Array($datatable2_x+$datatable2_hc_offset,$datatable2_y));
-	    echo("<div id='" . $point[2]  . "' class='label' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . unitsDist($head_circ) . "</div>\n");
+	    echo("<div id='" . $point[2]  . "' class='label_custom' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . unitsDist($head_circ) . "</div>\n");
             $datatable2_y = $datatable2_y + $datatable2_y_increment; // increment the datatable2 "row pointer"
         }
 
         // BMI chart has 14 rows to fill in.
         if ($count < 14 && $charttype == "2-20") {
 	    $point = convertpoint(Array($datatable2_x,$datatable2_y));
-	    echo("<div id='" . $point[2]  . "' class='label' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . $datestr . "</div>\n");
+	    echo("<div id='" . $point[2]  . "' class='label_custom' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . $datestr . "</div>\n");
             $point = convertpoint(Array($datatable2_x+$datatable2_age_offset,$datatable2_y));
-	    echo("<div id='" . $point[2]  . "' class='label' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . $ageinYMD . "</div>\n");
+	    echo("<div id='" . $point[2]  . "' class='label_custom' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . $ageinYMD . "</div>\n");
 	    $point = convertpoint(Array($datatable2_x+$datatable2_weight_offset,$datatable2_y));
-	    echo("<div id='" . $point[2]  . "' class='label' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . unitsWt($weight) . "</div>\n");
+	    echo("<div id='" . $point[2]  . "' class='label_custom' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . unitsWt($weight) . "</div>\n");
 	    $point = convertpoint(Array($datatable2_x+$datatable2_height_offset,$datatable2_y));
-	    echo("<div id='" . $point[2]  . "' class='label' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . unitsDist($height) . "</div>\n");
+	    echo("<div id='" . $point[2]  . "' class='label_custom' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . unitsDist($height) . "</div>\n");
 	    $point = convertpoint(Array($datatable2_x+$datatable2_bmi_offset,$datatable2_y));
-	    echo("<div id='" . $point[2]  . "' class='label' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . substr($bmi,0,5) . "</div>\n");
+	    echo("<div id='" . $point[2]  . "' class='label_custom' style='position: absolute; top: " . $point[1]  . "pt; left: " . $point[0] . "pt;'>" . substr($bmi,0,5) . "</div>\n");
             $datatable2_y = $datatable2_y + $datatable2_y_increment; // increment the datatable2 "row pointer"
         }
 
@@ -535,19 +535,19 @@ if ($_GET['html'] == 1) {
 /******************************/
 
 
-// create the graph 
+// create the graph
 $im     = imagecreatefrompng($chartpath.$chart);
 $color1 = imagecolorallocate($im, 0, 0, 255); //blue - color scheme imagecolorallocate($im, Red, Green, Blue)
 $color  = imagecolorallocate($im, 255, 51, 51); //red
 
-// draw the patient's name 
+// draw the patient's name
 imagestring($im, 12, $name_x, $name_y, $name, $color);
 imagestring($im, 12, $name_x1, $name_y1, $name, $color);
 
 // counter to limit the number of data points plotted
 $count = 0;
-		
-// plot the data points 
+
+// plot the data points
 foreach ($datapoints as $data) {
     list($date, $height, $weight, $head_circ) = explode('-', $data);
     if ($date == "") { continue; }
@@ -556,18 +556,18 @@ foreach ($datapoints as $data) {
     // Rational is only well visit will need both, sick visit only needs weight
     // for some clinic.
     if ($weight == 0 || $height == 0 ) { continue; }
-    
+
     // get age of patient at this data-point
     // to get data from function getPatientAgeYMD including $age, $ageinYMD, $age_in_months
     extract(getPatientAgeYMD($dob, $date));
     if($charttype=='birth')
     {
-        // for birth style chart, we use the age in months        
+        // for birth style chart, we use the age in months
         $age=$age_in_months;
     }
-    
+
     // exclude data points that do not belong on this chart
-    // for example, a data point for a 18 month old can be excluded 
+    // for example, a data point for a 18 month old can be excluded
     // from that patient's 2-20 yr chart
     $daysold = getPatientAgeInDays($dob, $date);
     if ($daysold > (365*2) && $charttype == "birth") { continue; }
@@ -575,11 +575,11 @@ foreach ($datapoints as $data) {
 
     // calculate the x-axis (Age) value
     $x = $dot_x + $delta_x * ($age - $ageOffset);
-	
+
     // Draw Height dot
     $y1 = $dot_y1 - $delta_y1 * ($height - $heightOffset);
     imagefilledellipse($im, $x, $y1, 10, 10, $color);
-	  
+
     // Draw Weight bullseye
     $y2 = $dot_y2 - $delta_y2 * ($weight - $weightOffset);
     imageellipse($im, $x, $y2, 12, 12, $color); // outter ring
@@ -602,11 +602,11 @@ foreach ($datapoints as $data) {
         $bmi_y = $bmi_dot_y - $bmi_delta_y * ($bmi - 10);
         imagefilledellipse($im, $bmi_x, $bmi_y, 10, 10, $color1);
     }
-		
+
     // fill in data tables
 
     $datestr = substr($date,0,4)."/".substr($date,4,2)."/".substr($date,6,2);
-    
+
     //birth to 24 mos chart has 8 rows to fill.
     if ($count < 8 && $charttype == "birth") {
         imagestring($im, 2, $datatable_x, $datatable_y, $datestr, $color);
@@ -634,7 +634,7 @@ foreach ($datapoints as $data) {
         imagestring($im, 2, ($datatable2_x+$datatable2_weight_offset), $datatable2_y, unitsWt($weight), $color);
         imagestring($im, 2, ($datatable2_x+$datatable2_height_offset), $datatable2_y, unitsDist($height), $color);
         imagestring($im, 2, ($datatable2_x+$datatable2_hc_offset), $datatable2_y, unitsDist($head_circ), $color);
-        $datatable2_y = $datatable2_y + $datatable2_y_increment; // increment the datatable2 "row pointer"			
+        $datatable2_y = $datatable2_y + $datatable2_y_increment; // increment the datatable2 "row pointer"
     }
 
     // BMI chart has 14 rows to fill in.
@@ -670,7 +670,7 @@ if ($_GET['pdf'] == 1) {
     imagepng($page2,$tmpfilename);
     imagedestroy($page2);
     $pdf->ezImage($tmpfilename);
-    
+
     // temporary file is removed
     unlink($tmpfilename);
 

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -287,6 +287,16 @@ if (!empty($glrow)) {
       if ($gl_value == '2') $GLOBALS['sell_non_drug_products'] = 1;
       else if ($gl_value == '3') $GLOBALS['sell_non_drug_products'] = 2;
     }
+    else if ($gl_name == 'gbl_time_zone') {
+      // The default PHP time zone is set here if it was specified, and is used
+      // as source data for the MySQL time zone here and in some other places
+      // where MySQL connections are opened.
+      if ($gl_value) {
+        date_default_timezone_set($gl_value);
+      }
+      // Synchronize MySQL time zone with PHP time zone.
+      sqlStatement("SET time_zone = ?", array((new DateTime())->format("P")));
+    }
     else {
       $GLOBALS[$gl_name] = $gl_value;
     }

--- a/interface/main/calendar/includes/pnAPI.php
+++ b/interface/main/calendar/includes/pnAPI.php
@@ -521,6 +521,9 @@ function pnDBInit()
         $dbconn->Execute("alter session set NLS_DATE_FORMAT = 'YYYY-MM-DD HH24:MI:SS'");
     }
 
+    // Sync MySQL time zone with PHP time zone.
+    $dbconn->Execute("SET time_zone = '" . (new DateTime())->format("P") . "'");
+
     return true;
 }
 

--- a/interface/main/display_documents.php
+++ b/interface/main/display_documents.php
@@ -165,11 +165,11 @@ $display_collapse_msg = "display:inline;";
     <div id='docfilterdiv'<?php echo $display_div; ?>>
 	<table style="margin-left:10px; " width='40%'>
 		<tr>
-			<td scope="row" class='label'><?php echo xlt('From'); ?>:</td>
+			<td scope="row" class='label_custom'><?php echo xlt('From'); ?>:</td>
 			<td><input type='text' class='datepicker' name='form_from_doc_date' id="form_from_doc_date"
 				size='10' value='<?php echo attr($form_from_doc_date) ?>' title='<?php echo attr($title_tooltip) ?>'>
 			</td>
-			<td class='label'><?php echo xlt('To'); ?>:</td>
+			<td class='label_custom'><?php echo xlt('To'); ?>:</td>
 			<td><input type='text' class='datepicker' name='form_to_doc_date' id="form_to_doc_date"
 				size='10' value='<?php echo attr($form_to_doc_date) ?>' title='<?php echo attr($title_tooltip) ?>'>
 			</td>

--- a/interface/main/onotes/office_comments.php
+++ b/interface/main/onotes/office_comments.php
@@ -29,14 +29,8 @@ $oNoteService = new \services\ONoteService();
 <html>
 <head>
 
-<link rel="stylesheet" href="<?php echo $css_header;?>" type="text/css">
-<link rel="stylesheet" href="<?php echo $GLOBALS['assets_static_relative'] ?>/bootstrap-3-3-4/dist/css/bootstrap.min.css">
-<?php if ($_SESSION['language_direction'] == 'rtl') { ?>
-    <link rel="stylesheet" href="<?php echo $GLOBALS['assets_static_relative'] ?>/bootstrap-rtl-3-3-4/dist/css/bootstrap-rtl.min.css">
-<?php } ?>
+<?php require($GLOBALS['srcdir'] . '/templates/standard_header_template.php'); ?>
 
-<script src="<?php echo $GLOBALS['assets_static_relative'] ?>/jquery-min-1-11-1/index.js"></script>
-<script src="<?php echo $GLOBALS['assets_static_relative'] ?>/bootstrap-3-3-4/dist/js/bootstrap.min.js"></script>
 </head>
 <body class="body_top">
 
@@ -84,7 +78,7 @@ foreach ($notes as $note) {
     $card .= '        <h3 class="panel-title">'.text($date_string).' <strong>('.text($note->getUser()->getUsername()).')</strong></h3>';
     $card .= '    </div>';
     $card .= '    <div class="panel-body">';
-    $card .=          text($note->getBody());
+    $card .=          nl2br(text($note->getBody()));
     $card .= '    </div>';
     $card .= '</div>';
 

--- a/interface/main/onotes/office_comments_full.php
+++ b/interface/main/onotes/office_comments_full.php
@@ -52,7 +52,7 @@ if (isset($_POST['mode'])) {
 <html>
 <head>
 
-<link rel="stylesheet" href="<?php echo $css_header;?>" type="text/css">
+<?php require($GLOBALS['srcdir'] . '/templates/standard_header_template.php'); ?>
 
 </head>
 <body class="body_top">
@@ -77,34 +77,31 @@ else { $backurl="../main_info.php"; }
 <input type="hidden" name="offset" value="<?php echo attr($offset); ?>">
 <input type="hidden" name="active" value="<?php echo attr($active); ?>">
 
-<textarea name="note" rows="6" cols="40" wrap="virtual"></textarea>
-<br>
-<a href="javascript:top.restoreSession();document.new_note.submit();" class="link_submit">[<?php echo xlt('Add New Note'); ?>]</a>
+<textarea name="note" class="form-control" rows="3" placeholder="<?php echo xla("Enter new office note here"); ?>" ></textarea>
+<input type="submit" value="<?php echo xla('Add New Note'); ?>" />
 </form>
 
 <br/>
+<hr>
 
 <form method="post" name="update_activity" action="office_comments_full.php" onsubmit='return top.restoreSession()'>
 
 <?php //change the view on the current mode, whether all, active, or inactive
-$all_class="link"; $active_class="link"; $inactive_class="link";
-if ($active==="-1") { $all_class="link_selected"; }
-elseif ($active==="1") { $active_class="link_selected"; }
-elseif ($active==="0") { $inactive_class="link_selected"; }
+if ($active==="1") { $inactive_class="_small"; $all_class="_small"; }
+elseif ($active==="0") { $active_class="_small"; $all_class="_small";}
+else { $active_class="_small"; $inactive_class="_small";}
 ?>
 
-<span class="text"><?php echo xlt('View:'); ?> </span>
-<a href="office_comments_full.php?offset=0&active=-1" class="<?php echo attr($all_class);?>" onclick='top.restoreSession()'>[<?php echo xlt('All'); ?>]</a>
-<a href="office_comments_full.php?offset=0&active=1" class="<?php echo attr($active_class);?>" onclick='top.restoreSession()'>[<?php echo xlt('Only Active'); ?>]</a>
-<a href="office_comments_full.php?offset=0&active=0" class="<?php echo attr($inactive_class);?>" onclick='top.restoreSession()'>[<?php echo xlt('Only Inactive'); ?>]</a>
+<a href="office_comments_full.php?offset=0&active=-1" class="css_button<?php echo attr($all_class);?>" onclick='top.restoreSession()'><?php echo xlt('All'); ?></a>
+<a href="office_comments_full.php?offset=0&active=1" class="css_button<?php echo attr($active_class);?>" onclick='top.restoreSession()'><?php echo xlt('Only Active'); ?></a>
+<a href="office_comments_full.php?offset=0&active=0" class="css_button<?php echo attr($inactive_class);?>" onclick='top.restoreSession()'><?php echo xlt('Only Inactive'); ?></a>
 
 <input type="hidden" name="mode" value="update">
 <input type="hidden" name="offset" value="<?php echo attr($offset);?>">
 <input type="hidden" name="active" value="<?php echo attr($active);?>">
 <br/>
-<a href="javascript:top.restoreSession();document.update_activity.submit();" class="link_submit">[<?php echo xlt('Change Activity'); ?>]</a>
 
-<table border="0" class="existingnotes">
+<table border="0" class="existingnotes table table-striped">
 <?php
 //display all of the notes for the day, as well as others that are active from previous dates, up to a certain number, $N
 
@@ -113,6 +110,7 @@ $notes = $oNoteService->getNotes($active, $offset, $N);
 $result_count = 0;
 //retrieve all notes
 if ($notes) {
+    print "<thead><tr><th>" . xlt("Active") . "</th><th>" . xlt("Date") . " (" . xlt("Sender") . ")</th><th>" . xlt("Office Note") . "</th></tr></thead><tbody>";
 foreach ($notes as $note) {
     $result_count++;
 
@@ -133,7 +131,7 @@ foreach ($notes as $note) {
     print "<input name='box".attr($note->getId())."' id='box".attr($note->getId())."' onClick='javascript:document.update_activity.act".attr($note->getId()).".value=this.checked' type=checkbox $checked></td>";
     print "<td><label for='box".attr($note->getId())."' class='bold'>".text($date_string) . "</label>";
     print " <label for='box".attr($note->getId())."' class='bold'>(". text($note->getUser()->getUsername()).")</label></td>";
-    print "<td><label for='box".attr($note->getId())."' class='text'>" . text($note->getBody()) . "&nbsp;</label></td></tr>\n";
+    print "<td><label for='box".attr($note->getId())."' class='text'>" . nl2br(text($note->getBody())) . "&nbsp;</label></td></tr></tbody>\n";
 
 }
 }else{
@@ -144,26 +142,24 @@ print "<tr><td></td><td></td><td></td></tr>\n";
 ?>
 </table>
 
-<a href="javascript:top.restoreSession();document.update_activity.submit();" class="link_submit">[<?php echo xlt('Change Activity'); ?>]</a>
+<input type="submit" value="<?php echo xla('Save Activity'); ?>" />
 </form>
-
 <hr>
-<table width="400" border="0" cellpadding="0" cellspacing="0">
+<table width="400" border="0" cellpadding="0" cellspacing="0" class="table">
 <tr><td>
 <?php
 if ($offset>($N-1)) {
-echo "<a class='link' href=office_comments_full.php?active=".attr($active)."&offset=".attr($offset-$N)." onclick='top.restoreSession()'>[".xlt('Previous')."]</a>";
+echo "<a class='css_button' href=office_comments_full.php?active=".attr($active)."&offset=".attr($offset-$N)." onclick='top.restoreSession()'>".xlt('Previous')."</a>";
 }
 ?>
 </td><td align=right>
 <?php
 if ($result_count == $N) {
-echo "<a class='link' href=office_comments_full.php?active=".attr($active)."&offset=".attr($offset+$N)." onclick='top.restoreSession()'>[".xlt('Next')."]</a>";
+echo "<a class='css_button' href=office_comments_full.php?active=".attr($active)."&offset=".attr($offset+$N)." onclick='top.restoreSession()'>".xlt('Next')."</a>";
 }
 ?>
 </td></tr>
 </table>
 </div>
-
 </body>
 </html>

--- a/interface/modules/zend_modules/config/autoload/global.php
+++ b/interface/modules/zend_modules/config/autoload/global.php
@@ -15,7 +15,9 @@
  */
 
 // If to use utf-8 or not in my sql query
-$utf8 =  ($GLOBALS['disable_utf8_flag']) ? array(PDO::MYSQL_ATTR_INIT_COMMAND => 'SET sql_mode = \'\'') : array(PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES \'UTF8\', sql_mode = \'\'');
+$tmp = $GLOBALS['disable_utf8_flag'] ? "SET sql_mode = ''" : "SET NAMES 'UTF8', sql_mode = ''";
+$tmp .= ", time_zone = '" . (new DateTime())->format("P") . "'";
+$utf8 = array(PDO::MYSQL_ATTR_INIT_COMMAND => $tmp);
 
 // Sets default factory using the default database
 $factories = array(

--- a/interface/patient_file/reminder/patient_reminders.php
+++ b/interface/patient_file/reminder/patient_reminders.php
@@ -189,7 +189,7 @@ else {
         <div style='float:left'>
           <table class='text'>
             <tr>
-              <td class='label'>
+              <td class='label_custom'>
                 <?php echo " "; ?>
               </td>
             </tr>

--- a/interface/patient_tracker/patient_tracker.php
+++ b/interface/patient_tracker/patient_tracker.php
@@ -201,7 +201,7 @@ function openNewTopWindow(newpid,newencounterid) {
     <div id="flow_board_parameters">
         <table>
             <tr class="text">
-                <td class='label'><?php echo xlt('Provider'); ?>:</td>
+                <td class='label_custom'><?php echo xlt('Provider'); ?>:</td>
                 <td><?php
 
                     # Build a drop-down list of providers.
@@ -229,7 +229,7 @@ function openNewTopWindow(newpid,newencounterid) {
 
                     ?>
                 </td>
-                <td class='label'><?php echo xlt('Status'); # status code drop down creation ?>:</td>
+                <td class='label_custom'><?php echo xlt('Status'); # status code drop down creation ?>:</td>
                 <td><?php generate_form_field(array('data_type'=>1,'field_id'=>'apptstatus','list_id'=>'apptstat','empty_title'=>'All'),$_POST['form_apptstatus']);?></td>
                 <td><?php echo xlt('Category') #category drop down creation ?>:</td>
                 <td>

--- a/interface/reports/amc_tracking.php
+++ b/interface/reports/amc_tracking.php
@@ -204,7 +204,7 @@ $provider  = trim($_POST['form_provider']);
 	<table class='text'>
 
                  <tr>
-                      <td class='label'>
+                      <td class='label_custom'>
                         <?php echo htmlspecialchars( xl('Begin Date'), ENT_NOQUOTES); ?>:
                       </td>
                       <td>
@@ -215,7 +215,7 @@ $provider  = trim($_POST['form_provider']);
                  </tr>
 
                 <tr>
-                        <td class='label'>
+                        <td class='label_custom'>
                            <?php echo htmlspecialchars( xl('End Date'), ENT_NOQUOTES); ?>:
                         </td>
                         <td>
@@ -226,7 +226,7 @@ $provider  = trim($_POST['form_provider']);
                 </tr>
 
                 <tr>
-                        <td class='label'>
+                        <td class='label_custom'>
                             <?php echo htmlspecialchars( xl('Rule'), ENT_NOQUOTES); ?>:
                         </td>
                         <td>
@@ -242,7 +242,7 @@ $provider  = trim($_POST['form_provider']);
                 </tr>
 
                 <tr>
-			<td class='label'>
+			<td class='label_custom'>
 			   <?php echo htmlspecialchars( xl('Provider'), ENT_NOQUOTES); ?>:
 			</td>
 			<td>

--- a/interface/reports/appointments_report.php
+++ b/interface/reports/appointments_report.php
@@ -209,10 +209,10 @@ function fetch_reminders($pid, $appt_date) {
 
 		<table class='text'>
 			<tr>
-				<td class='label'><?php echo xlt('Facility'); ?>:</td>
+				<td class='label_custom'><?php echo xlt('Facility'); ?>:</td>
 				<td><?php dropdown_facility($facility , 'form_facility'); ?>
 				</td>
-				<td class='label'><?php echo xlt('Provider'); ?>:</td>
+				<td class='label_custom'><?php echo xlt('Provider'); ?>:</td>
 				<td><?php
 
 				// Build a drop-down list of providers.
@@ -238,13 +238,13 @@ function fetch_reminders($pid, $appt_date) {
 				</td>
 			</tr>
 			<tr>
-				<td class='label'><?php echo xlt('From'); ?>:</td>
+				<td class='label_custom'><?php echo xlt('From'); ?>:</td>
 				<td><input type='text' name='form_from_date' id="form_from_date"
 				    class='datepicker'
 					size='10' value='<?php echo attr($from_date) ?>'
 					title='yyyy-mm-dd'>
 				</td>
-				<td class='label'><?php echo xlt('To'); ?>:</td>
+				<td class='label_custom'><?php echo xlt('To'); ?>:</td>
 				<td><input type='text' name='form_to_date' id="form_to_date"
 				    class='datepicker'
 					size='10' value='<?php echo attr($to_date) ?>'
@@ -253,7 +253,7 @@ function fetch_reminders($pid, $appt_date) {
 			</tr>
 
 			<tr>
-				<td class='label'><?php echo xlt('Status'); # status code drop down creation ?>:</td>
+				<td class='label_custom'><?php echo xlt('Status'); # status code drop down creation ?>:</td>
 				<td><?php generate_form_field(array('data_type'=>1,'field_id'=>'apptstatus','list_id'=>'apptstat','empty_title'=>'All'),$_POST['form_apptstatus']);?></td>
 				<td><?php echo xlt('Category') #category drop down creation ?>:</td>
 				<td>

--- a/interface/reports/appt_encounter_report.php
+++ b/interface/reports/appt_encounter_report.php
@@ -234,7 +234,7 @@ $(document).ready(function() {
 
 	<table class='text'>
 		<tr>
-			<td class='label'>
+			<td class='label_custom'>
 				<?php xl('Facility','e'); ?>:
 			</td>
 			<td>
@@ -257,14 +257,14 @@ $(document).ready(function() {
 				 echo "   </select>\n";
 				?>
 			</td>
-			<td class='label'>
+			<td class='label_custom'>
 			   <?php xl('DOS','e'); ?>:
 			</td>
 			<td>
 			   <input type='text' class='datepicker' name='form_from_date' id="form_from_date" size='10' value='<?php  echo $form_from_date; ?>'
 				title='Date of appointments mm/dd/yyyy' >
 			</td>
-			<td class='label'>
+			<td class='label_custom'>
 			   <?php xl('To','e'); ?>:
 			</td>
 			<td>

--- a/interface/reports/cdr_log.php
+++ b/interface/reports/cdr_log.php
@@ -113,7 +113,7 @@ $(document).ready(function() {
 	<table class='text'>
 
                    <tr>
-                      <td class='label'>
+                      <td class='label_custom'>
                          <?php echo xlt('Begin Date'); ?>:
                       </td>
                       <td>
@@ -124,7 +124,7 @@ $(document).ready(function() {
                    </tr>
 
                 <tr>
-                        <td class='label'>
+                        <td class='label_custom'>
                               <?php echo xlt('End Date'); ?>:
                         </td>
                         <td>

--- a/interface/reports/chart_location_activity.php
+++ b/interface/reports/chart_location_activity.php
@@ -108,7 +108,7 @@ if (!empty($ptrow)) {
 
 	<table class='text'>
 		<tr>
-			<td class='label'>
+			<td class='label_custom'>
 			   <?php echo xlt('Patient ID'); ?>:
 			</td>
 			<td>

--- a/interface/reports/clinical_reports.php
+++ b/interface/reports/clinical_reports.php
@@ -261,47 +261,47 @@ Search options include diagnosis, procedure, prescription, medical history, and 
 			<td width='740px'><div style='float:left'>
 		 		<table class='text'>
 					<tr>
-						<td class='label' width="100"><?php echo htmlspecialchars(xl('Facility'),ENT_NOQUOTES); ?>: </td>
+						<td class='label_custom' width="100"><?php echo htmlspecialchars(xl('Facility'),ENT_NOQUOTES); ?>: </td>
 						<td width="250"> <?php dropdown_facility($facility,'facility',false); ?> </td>
-						<td class='label' width="100"><?php echo htmlspecialchars(xl('From'),ENT_NOQUOTES); ?>: </td>
+						<td class='label_custom' width="100"><?php echo htmlspecialchars(xl('From'),ENT_NOQUOTES); ?>: </td>
 						<td><input type='text' class='datetimepicker' name='date_from' id="date_from" size='18' value='<?php echo htmlspecialchars($sql_date_from,ENT_QUOTES); ?>' title='yyyy-mm-dd H:m:s'></td>
 					</tr>
 					<tr>
-						<td class='label'><?php echo htmlspecialchars(xl('Patient ID'),ENT_NOQUOTES); ?>:</td>
+						<td class='label_custom'><?php echo htmlspecialchars(xl('Patient ID'),ENT_NOQUOTES); ?>:</td>
 						<td><input name='patient_id' class="numeric_only" type='text' id="patient_id" title='<?php echo htmlspecialchars(xl('Optional numeric patient ID'),ENT_QUOTES); ?>' value='<?php echo htmlspecialchars($patient_id,ENT_QUOTES); ?>' size='10' maxlength='20' /></td>
-						<td class='label'><?php echo htmlspecialchars(xl('To'),ENT_NOQUOTES); ?>: </td>
+						<td class='label_custom'><?php echo htmlspecialchars(xl('To'),ENT_NOQUOTES); ?>: </td>
 						<td><input type='text' class='datetimepicker' name='date_to' id="date_to" size='18' value='<?php echo htmlspecialchars($sql_date_to,ENT_QUOTES); ?>' title='yyyy-mm-dd H:m:s'></td>
 					</tr>
 					<tr>
-						<td class='label'><?php echo htmlspecialchars(xl('Age Range'),ENT_NOQUOTES); ?>:</td>
+						<td class='label_custom'><?php echo htmlspecialchars(xl('Age Range'),ENT_NOQUOTES); ?>:</td>
 						<td><?php echo htmlspecialchars(xl('From'),ENT_NOQUOTES); ?>
 							<input name='age_from' class="numeric_only" type='text' id="age_from" value="<?php echo htmlspecialchars($age_from,ENT_QUOTES); ?>" size='3' maxlength='3' /> <?php echo htmlspecialchars(xl('To'),ENT_NOQUOTES); ?>
 							<input name='age_to' class="numeric_only" type='text' id="age_to" value="<?php echo htmlspecialchars($age_to,ENT_QUOTES); ?>" size='3' maxlength='3' /></td>
-						<td class='label'><?php echo htmlspecialchars(xl('Problem DX'),ENT_NOQUOTES); ?>:</td>
+						<td class='label_custom'><?php echo htmlspecialchars(xl('Problem DX'),ENT_NOQUOTES); ?>:</td>
 						<td><input type='text' name='form_diagnosis' size='10' maxlength='250' value='<?php echo htmlspecialchars($form_diagnosis,ENT_QUOTES); ?>' onclick='sel_diagnosis(this)' title='<?php echo htmlspecialchars(xl('Click to select or change diagnoses'),ENT_QUOTES); ?>' readonly /></td>
                                                	<td>&nbsp;</td>
 <!-- Visolve -->
 					</tr>
 					<tr>
-						<td class='label'><?php echo htmlspecialchars(xl('Gender'),ENT_NOQUOTES); ?>:</td>
+						<td class='label_custom'><?php echo htmlspecialchars(xl('Gender'),ENT_NOQUOTES); ?>:</td>
 						<td><?php echo generate_select_list('gender', 'sex', $sql_gender, 'Select Gender', 'Unassigned', '', ''); ?></td>
-						<td class='label'><?php echo htmlspecialchars(xl('Drug'),ENT_NOQUOTES); ?>:</td>
+						<td class='label_custom'><?php echo htmlspecialchars(xl('Drug'),ENT_NOQUOTES); ?>:</td>
 						<td><input type='text' name='form_drug_name' size='10' maxlength='250' value='<?php echo htmlspecialchars($form_drug_name,ENT_QUOTES); ?>' title='<?php echo htmlspecialchars(xl('Optional drug name, use % as a wildcard'),ENT_QUOTES); ?>' /></td>
 
 					</tr>
 					<tr>
-						<td class='label'><?php echo htmlspecialchars(xl('Race'),ENT_NOQUOTES); ?>:</td>
+						<td class='label_custom'><?php echo htmlspecialchars(xl('Race'),ENT_NOQUOTES); ?>:</td>
 						<td><?php echo generate_select_list('race', 'race', $sql_race, 'Select Race', 'Unassigned', '', ''); ?></td>
-             			<td class='label'><?php echo htmlspecialchars(xl('Ethnicity'),ENT_NOQUOTES); ?>:</td>
+             			<td class='label_custom'><?php echo htmlspecialchars(xl('Ethnicity'),ENT_NOQUOTES); ?>:</td>
                         <td><?php echo generate_select_list('ethnicity', 'ethnicity', $sql_ethnicity, 'Select Ethnicity', 'Unassigned', '', ''); ?></td>
-						<td class='label'><?php echo htmlspecialchars(xl('Immunization'),ENT_NOQUOTES); ?>:</td>
+						<td class='label_custom'><?php echo htmlspecialchars(xl('Immunization'),ENT_NOQUOTES); ?>:</td>
 						<td><input type='text' name='form_immunization' size='10' maxlength='250' value='<?php echo htmlspecialchars($form_immunization,ENT_QUOTES); ?>' title='<?php echo htmlspecialchars(xl('Optional immunization name or code, use % as a wildcard'),ENT_QUOTES); ?>' /></td>
 					</tr>
 					<tr>
-						<td class='label' width='100'><?php echo htmlspecialchars(xl('Lab Result'),ENT_NOQUOTES); ?>:</td>
+						<td class='label_custom' width='100'><?php echo htmlspecialchars(xl('Lab Result'),ENT_NOQUOTES); ?>:</td>
 						<td width='100'><input type='text' name='form_lab_results' size='13' maxlength='250' value='<?php echo htmlspecialchars($form_lab_results,ENT_QUOTES); ?>' title='<?php echo htmlspecialchars(xl('Result, use % as a wildcard'),ENT_QUOTES); ?>' /></td>
 
-						<td class='label' width='100'><?php echo htmlspecialchars(xl('Option'),ENT_NOQUOTES); ?>:</td>
+						<td class='label_custom' width='100'><?php echo htmlspecialchars(xl('Option'),ENT_NOQUOTES); ?>:</td>
 						<td><select name="type" id="type" onChange="checkType();">
 							<option> <?php echo htmlspecialchars(xl('Select'),ENT_NOQUOTES); ?></option>
 							<option value="Procedure" <?php if($type == 'Procedure') { echo "selected"; } ?>><?php echo htmlspecialchars(xl('Procedure'),ENT_NOQUOTES); ?></option>
@@ -309,7 +309,7 @@ Search options include diagnosis, procedure, prescription, medical history, and 
 							<option value="Service Codes" <?php if($type == 'Service Codes') { echo "selected"; } ?>><?php echo htmlspecialchars(xl('Service Codes'),ENT_NOQUOTES); ?></option>
 						   </select>
 						</td>
-						<td class='label'><?php echo htmlspecialchars(xl('Communication'),ENT_NOQUOTES); ?>:</td>
+						<td class='label_custom'><?php echo htmlspecialchars(xl('Communication'),ENT_NOQUOTES); ?>:</td>
                         <td>
 							<select name="communication" id="communication" title="<?php echo htmlspecialchars(xl('Select Communication Preferences'),ENT_NOQUOTES); ?>">
 								<option value=""> <?php echo htmlspecialchars(xl('Select'),ENT_NOQUOTES); ?></option>
@@ -325,14 +325,14 @@ Search options include diagnosis, procedure, prescription, medical history, and 
 					<td width='100'>&nbsp;</td>
 					<td width='100'>&nbsp;</td>
 					<td width='195'>&nbsp;</td>
-					<td class='label' width='76'><?php echo htmlspecialchars(xl('Code'),ENT_NOQUOTES); ?>:</td>
+					<td class='label_custom' width='76'><?php echo htmlspecialchars(xl('Code'),ENT_NOQUOTES); ?>:</td>
                                         <td> <input type='text' name='form_service_codes' size='10' maxlength='250' value='<?php echo htmlspecialchars($form_service_codes,ENT_QUOTES); ?>' onclick='sel_procedure(this)' title='<?php echo htmlspecialchars(xl('Click to select or change service codes'),ENT_QUOTES); ?>' readonly />&nbsp;</td>
                                         </tr>
 				</table>
 				<table class='text'>
 					<tr>
 						<!-- Sort by Start -->
-                                                 <td class='label' width='63'><?php echo htmlspecialchars(xl('Sort By'),ENT_NOQUOTES); ?>:</td>
+                                                 <td class='label_custom' width='63'><?php echo htmlspecialchars(xl('Sort By'),ENT_NOQUOTES); ?>:</td>
                                                  <td>
                                                    <input type='checkbox' name='form_pt_name'<?php if ($_POST['form_pt_name'] == true) echo ' checked'; ?>>
                                                    <?php echo htmlspecialchars(xl('Patient Name'),ENT_NOQUOTES); ?>&nbsp;

--- a/interface/reports/collections_report.php
+++ b/interface/reports/collections_report.php
@@ -349,7 +349,7 @@ function checkAll(checked) {
 
 	<table class='text'>
 		<tr>
-			<td class='label'>
+			<td class='label_custom'>
 				<table>
 					<tr>
 						<td><?php echo xlt('Displayed Columns') ?>:</td>
@@ -410,14 +410,14 @@ function checkAll(checked) {
 				<table>
 
 					<tr>
-						<td class='label'>
+						<td class='label_custom'>
 						   <?php echo xlt('Service Date'); ?>:
 						</td>
 						<td>
 						   <input type='text' class='datepicker' name='form_date' id="form_date" size='10' value='<?php echo attr($form_date) ?>'
 							title='yyyy-mm-dd'>
 						</td>
-						<td class='label'>
+						<td class='label_custom'>
 						   <?php echo xlt('To'); ?>:
 						</td>
 						<td>
@@ -440,14 +440,14 @@ function checkAll(checked) {
 
 
 					<tr>
-						<td class='label'>
+						<td class='label_custom'>
                         <?php echo xlt('Facility'); ?>:
                         </td>
                         <td>
                         <?php dropdown_facility($form_facility, 'form_facility', false); ?>
                         </td>
 
-                        <td class='label'>
+                        <td class='label_custom'>
                         <?php echo xlt('Payor'); ?>:
 						</td>
 						<td>
@@ -467,7 +467,7 @@ function checkAll(checked) {
 					</tr>
 
 					<tr>
-						<td class='label'>
+						<td class='label_custom'>
 						   <?php echo xlt('Age By') ?>:
 						</td>
 						<td>
@@ -482,7 +482,7 @@ function checkAll(checked) {
 						   </select>
 						</td>
 
-                        <td class='label'>
+                        <td class='label_custom'>
 						   <?php echo xlt('Provider') ?>:
 						</td>
 						<td>
@@ -510,13 +510,13 @@ function checkAll(checked) {
 						</td>
 					</tr>
 					</tr>
-						<td class='label'>
+						<td class='label_custom'>
 						   <?php echo xlt('Aging Columns') ?>:
 						</td>
 						<td>
 						   <input type='text' name='form_age_cols' size='2' value='<?php echo attr($form_age_cols); ?>' />
 						</td>
-						<td class='label'>
+						<td class='label_custom'>
 						   <?php echo xlt('Days/Col') ?>:
 						</td>
 						<td>

--- a/interface/reports/cqm.php
+++ b/interface/reports/cqm.php
@@ -372,7 +372,7 @@ else {
 
 		<?php if (($type_report == "amc") || ($type_report == "amc_2011") || ($type_report == "amc_2014_stage1") || ($type_report == "amc_2014_stage2")) { ?>
                    <tr>
-                      <td class='label'>
+                      <td class='label_custom'>
                          <?php echo htmlspecialchars( xl('Begin Date'), ENT_NOQUOTES); ?>:
                       </td>
                       <td>
@@ -386,7 +386,7 @@ else {
 		<?php } ?>
 
                 <tr>
-                        <td class='label'>
+                        <td class='label_custom'>
                            <?php if (($type_report == "amc") || ($type_report == "amc_2011") || ($type_report == "amc_2014_stage1") || ($type_report == "amc_2014_stage2")) { ?>
                               <?php echo htmlspecialchars( xl('End Date'), ENT_NOQUOTES); ?>:
                            <?php } else { ?>
@@ -404,7 +404,7 @@ else {
 
                 <?php if (($type_report == "cqm") || ($type_report == "cqm_2011") || ($type_report == "cqm_2014")) { ?>
                     <tr>
-                        <td class='label'>
+                        <td class='label_custom'>
                             <?php echo xlt('Rule Set'); ?>:
                         </td>
                         <td>
@@ -422,7 +422,7 @@ else {
 
                 <?php if (($type_report == "amc") || ($type_report == "amc_2011") || ($type_report == "amc_2014_stage1") || ($type_report == "amc_2014_stage2")) { ?>
                     <tr>
-                        <td class='label'>
+                        <td class='label_custom'>
                             <?php echo xlt('Rule Set'); ?>:
                         </td>
                         <td>
@@ -446,7 +446,7 @@ else {
 
                 <?php if ($type_report == "standard") { ?>
                     <tr>
-                        <td class='label'>
+                        <td class='label_custom'>
                             <?php echo xlt('Rule Set'); ?>:
                         </td>
                         <td>
@@ -466,7 +466,7 @@ else {
                     <input type='hidden' id='form_plan_filter' name='form_plan_filter' value=''>
                 <?php } else { ?>
                     <tr>
-                        <td class='label'>
+                        <td class='label_custom'>
                            <?php echo htmlspecialchars( xl('Plan Set'), ENT_NOQUOTES); ?>:
                         </td>
                         <td>
@@ -489,7 +489,7 @@ else {
                 <?php } ?>
 
                 <tr>
-			<td class='label'>
+			<td class='label_custom'>
 			   <?php echo htmlspecialchars( xl('Provider'), ENT_NOQUOTES); ?>:
 			</td>
 			<td>
@@ -528,7 +528,7 @@ else {
 		</tr>
 
                 <tr>
-                        <td class='label'>
+                        <td class='label_custom'>
                            <?php echo htmlspecialchars( xl('Provider Relationship'), ENT_NOQUOTES); ?>:
                         </td>
                         <td>

--- a/interface/reports/custom_report_range.php
+++ b/interface/reports/custom_report_range.php
@@ -202,14 +202,14 @@ if ($form_patient == '' ) $form_pid = '';
 
 	<table class='text'>
 		<tr>
-			<td class='label'>
+			<td class='label_custom'>
 			   <?php echo xlt('Start Date'); ?>:
 			</td>
 			<td>
 			   <input type='text' class='datepicker' name='start' id="form_from_date" size='10' value='<?php echo attr($startdate) ?>'
 				title='yyyy-mm-dd'>
 			</td>
-			<td class='label'>
+			<td class='label_custom'>
 			   <?php echo xlt('End Date'); ?>:
 			</td>
 			<td>

--- a/interface/reports/daily_summary_report.php
+++ b/interface/reports/daily_summary_report.php
@@ -106,16 +106,16 @@ $to_date = fixDate($selectedToDate, date('Y-m-d'));
                             <div style='float: left'>
                                 <table class='text'>
                                     <tr>
-                                        <td class='label'><?php echo xlt('Facility'); ?>:</td>
+                                        <td class='label_custom'><?php echo xlt('Facility'); ?>:</td>
                                         <td><?php dropdown_facility($selectedFacility, 'form_facility', false); ?></td>
-                                        <td class='label'><?php echo xlt('From'); ?>:</td>
+                                        <td class='label_custom'><?php echo xlt('From'); ?>:</td>
                                         <td>
                                             <input type='text' name='form_from_date' id="form_from_date"
                                                    class='datepicker'
                                                    size='10' value='<?php echo attr($from_date) ?>'
                                                    title='yyyy-mm-dd'>
                                         </td>
-                                        <td class='label'><?php echo xlt('To'); ?>:</td>
+                                        <td class='label_custom'><?php echo xlt('To'); ?>:</td>
                                         <td>
                                             <input type='text' name='form_to_date' id="form_to_date"
                                                    class='datepicker'
@@ -125,7 +125,7 @@ $to_date = fixDate($selectedToDate, date('Y-m-d'));
                                 </table>
                             </div>
                         </td>
-                        <td class='label'><?php echo xlt('Provider'); ?>:</td>
+                        <td class='label_custom'><?php echo xlt('Provider'); ?>:</td>
                         <td>
                             <?php
                             generate_form_field(array('data_type' => 10, 'field_id' => 'provider',

--- a/interface/reports/edi_270.php
+++ b/interface/reports/edi_270.php
@@ -311,13 +311,13 @@
 							<div style='float:left'>
 								<table class='text'>
 									<tr>
-										<td class='label'>
+										<td class='label_custom'>
 										   <?php xl('From','e'); ?>:
 										</td>
 										<td>
 										   <input type='text' class='datepicker' name='form_from_date' id="form_from_date" size='10' value='<?php echo htmlspecialchars( $from_date, ENT_QUOTES) ?>' title='yyyy-mm-dd'>
 										</td>
-										<td class='label'>
+										<td class='label_custom'>
 										   <?php echo htmlspecialchars( xl('To'), ENT_NOQUOTES); ?>:
 										</td>
 										<td>
@@ -328,13 +328,13 @@
 									</tr>
 
 									<tr>
-										<td class='label'>
+										<td class='label_custom'>
 											<?php echo htmlspecialchars( xl('Facility'), ENT_NOQUOTES); ?>:
 										</td>
 										<td>
 											<?php dropdown_facility($form_facility,'form_facility',false);	?>
 										</td>
-										<td class='label'>
+										<td class='label_custom'>
 										   <?php echo htmlspecialchars( xl('Provider'), ENT_NOQUOTES); ?>:
 										</td>
 										<td>
@@ -352,7 +352,7 @@
 									</tr>
 
 									<tr>
-										<td class='label'>
+										<td class='label_custom'>
 											<?php echo htmlspecialchars( xl('X12 Partner'), ENT_NOQUOTES); ?>:
 										</td>
 										<td colspan='5'>

--- a/interface/reports/edi_271.php
+++ b/interface/reports/edi_271.php
@@ -263,7 +263,7 @@
 				<div style='float:left'>
 					<table class='text'>
 						<tr>
-							<td style='width:125px;' class='label'> <?php echo htmlspecialchars( xl('Select EDI-271 file'), ENT_NOQUOTES); ?>:	</td>
+							<td style='width:125px;' class='label_custom'> <?php echo htmlspecialchars( xl('Select EDI-271 file'), ENT_NOQUOTES); ?>:	</td>
 							<td> <input name="uploaded" id="uploaded" type="file" size=37 /></td>
 						</tr>
 					</table>

--- a/interface/reports/encounters_report.php
+++ b/interface/reports/encounters_report.php
@@ -221,13 +221,13 @@ $res = sqlStatement($query);
 
 	<table class='text'>
 		<tr>
-			<td class='label'>
+			<td class='label_custom'>
 				<?php echo xlt('Facility'); ?>:
 			</td>
 			<td>
 			<?php dropdown_facility($form_facility, 'form_facility', true); ?>
 			</td>
-			<td class='label'>
+			<td class='label_custom'>
 			   <?php echo xlt('Provider'); ?>:
 			</td>
 			<td>
@@ -269,14 +269,14 @@ $res = sqlStatement($query);
 			</td>
 		</tr>
 		<tr>
-			<td class='label'>
+			<td class='label_custom'>
 			   <?php echo xlt('From'); ?>:
 			</td>
 			<td>
 			   <input type='text' class='datepicker' name='form_from_date' id="form_from_date" size='10' value='<?php echo attr($form_from_date) ?>'
 				title='yyyy-mm-dd'>
 			</td>
-			<td class='label'>
+			<td class='label_custom'>
 			   <?php echo xlt('To'); ?>:
 			</td>
 			<td>

--- a/interface/reports/front_receipts_report.php
+++ b/interface/reports/front_receipts_report.php
@@ -122,14 +122,14 @@ require_once("$srcdir/patient.inc");
 
 	<table class='text'>
 		<tr>
-			<td class='label'>
+			<td class='label_custom'>
 			   <?php xl('From','e'); ?>:
 			</td>
 			<td>
 			   <input type='text' class='datepicker' name='form_from_date' id="form_from_date" size='10' value='<?php echo attr($form_from_date) ?>'
 				title='yyyy-mm-dd'>
 			</td>
-			<td class='label'>
+			<td class='label_custom'>
 			   <?php xl('To','e'); ?>:
 			</td>
 			<td>

--- a/interface/reports/immunization_report.php
+++ b/interface/reports/immunization_report.php
@@ -326,7 +326,7 @@ onsubmit='return top.restoreSession()'>
     <div style='float:left'>
       <table class='text'>
         <tr>
-          <td class='label'>
+          <td class='label_custom'>
             <?php xl('Codes','e'); ?>:
           </td>
           <td>
@@ -348,7 +348,7 @@ onsubmit='return top.restoreSession()'>
  echo "   </select>\n";
 ?>
           </td>
-          <td class='label'>
+          <td class='label_custom'>
             <?php xl('From','e'); ?>:
           </td>
           <td>
@@ -357,7 +357,7 @@ onsubmit='return top.restoreSession()'>
             size='10' value='<?php echo $form_from_date ?>'
             title='yyyy-mm-dd'>
           </td>
-          <td class='label'>
+          <td class='label_custom'>
             <?php xl('To','e'); ?>:
           </td>
           <td>

--- a/interface/reports/insurance_allocation_report.php
+++ b/interface/reports/insurance_allocation_report.php
@@ -133,14 +133,14 @@ else {
 
 	<table class='text'>
 		<tr>
-			<td class='label'>
+			<td class='label_custom'>
 			   <?php xl('From','e'); ?>:
 			</td>
 			<td>
 			   <input type='text' class='datepicker' name='form_from_date' id="form_from_date" size='10' value='<?php echo $form_from_date ?>'
 				title='yyyy-mm-dd'>
 			</td>
-			<td class='label'>
+			<td class='label_custom'>
 			   <?php xl('To','e'); ?>:
 			</td>
 			<td>

--- a/interface/reports/inventory_activity.php
+++ b/interface/reports/inventory_activity.php
@@ -430,7 +430,7 @@ table.mymaintable td, table.mymaintable th {
   <td width='50%'>
    <table class='text'>
     <tr>
-     <td class='label'>
+     <td class='label_custom'>
       <?php echo htmlspecialchars(xl('By')); ?>:
      </td>
      <td nowrap>
@@ -439,7 +439,7 @@ table.mymaintable td, table.mymaintable th {
        <option value='w'<?php if (!$product_first) echo ' selected'; ?>><?php echo htmlspecialchars(xl('Warehouse')); ?></option>
       </select>
      </td>
-     <td class='label'>
+     <td class='label_custom'>
       <?php echo htmlspecialchars(xl('From')); ?>:
      </td>
      <td nowrap>
@@ -451,7 +451,7 @@ table.mymaintable td, table.mymaintable th {
        id='img_from_date' border='0' alt='[?]' style='cursor:pointer'
        title='<?php echo htmlspecialchars(xl('Click here to choose a date'), ENT_QUOTES); ?>'>
      </td>
-     <td class='label'>
+     <td class='label_custom'>
       <?php echo htmlspecialchars(xl('To')); ?>:
      </td>
      <td nowrap>
@@ -465,7 +465,7 @@ table.mymaintable td, table.mymaintable th {
      </td>
     </tr>
     <tr>
-     <td class='label'>
+     <td class='label_custom'>
       <?php echo htmlspecialchars(xl('For'), ENT_NOQUOTES); ?>:
      </td>
      <td nowrap>
@@ -485,7 +485,7 @@ while ($prow = sqlFetchArray($pres)) {
 echo "      </select>\n";
 ?>
      </td>
-     <td class='label'>
+     <td class='label_custom'>
       <?php echo htmlspecialchars(xl('Details')); ?>:
      </td>
      <td colspan='3' nowrap>

--- a/interface/reports/inventory_transactions.php
+++ b/interface/reports/inventory_transactions.php
@@ -236,7 +236,7 @@ else {
   <td width='50%'>
    <table class='text'>
     <tr>
-     <td class='label'>
+     <td class='label_custom'>
       <?php echo htmlspecialchars(xl('Type'), ENT_NOQUOTES); ?>:
      </td>
      <td nowrap>
@@ -258,7 +258,7 @@ foreach (array(
 ?>
       </select>
      </td>
-     <td class='label'>
+     <td class='label_custom'>
       <?php echo htmlspecialchars(xl('From'), ENT_NOQUOTES); ?>:
      </td>
      <td nowrap>
@@ -270,7 +270,7 @@ foreach (array(
        id='img_from_date' border='0' alt='[?]' style='cursor:pointer'
        title='<?php echo htmlspecialchars(xl('Click here to choose a date'), ENT_QUOTES); ?>'>
      </td>
-     <td class='label'>
+     <td class='label_custom'>
       <?php xl('To','e'); ?>:
      </td>
      <td nowrap>

--- a/interface/reports/non_reported.php
+++ b/interface/reports/non_reported.php
@@ -329,7 +329,7 @@ onsubmit='return top.restoreSession()'>
     <div style='float:left'>
       <table class='text'>
         <tr>
-          <td class='label'>
+          <td class='label_custom'>
             <?php xl('Diagnosis','e'); ?>:
           </td>
           <td>
@@ -355,7 +355,7 @@ onsubmit='return top.restoreSession()'>
  echo "   </select>\n";
 ?>
           </td>
-          <td class='label'>
+          <td class='label_custom'>
             <?php xl('From','e'); ?>:
           </td>
           <td>
@@ -364,7 +364,7 @@ onsubmit='return top.restoreSession()'>
             size='10' value='<?php echo $form_from_date ?>'
             title='yyyy-mm-dd'>
           </td>
-          <td class='label'>
+          <td class='label_custom'>
             <?php xl('To','e'); ?>:
           </td>
           <td>

--- a/interface/reports/pat_ledger.php
+++ b/interface/reports/pat_ledger.php
@@ -391,7 +391,7 @@ function sel_patient() {
 	<table class='text'>
 		<tr>
         <?php if($type_form == '0') { ?>
-			<td class='label'>
+			<td class='label_custom'>
 				<?php echo xlt('Facility'); ?>:
 			</td>
 			<td>
@@ -418,14 +418,14 @@ function sel_patient() {
         <?php echo xlt('From'); ?>:&nbsp;&nbsp;&nbsp;&nbsp;
         <input type='text' class='datepicker' name='form_from_date' id="form_from_date" size='10' value='<?php echo attr($form_from_date) ?>' title='yyyy-mm-dd'>
       </td>
-      <td class='label'>
+      <td class='label_custom'>
         <?php echo xlt('To'); ?>:
       </td>
       <td>
         <input type='text' class='datepicker' name='form_to_date' id="form_to_date" size='10' value='<?php echo attr($form_to_date) ?>' title='yyyy-mm-dd'>
       </td>
       <?php if($type_form == '0') { ?>
-      <td><span class='label'><?php echo xlt('Patient'); ?>:&nbsp;&nbsp;</span></td>
+      <td><span class='label_custom'><?php echo xlt('Patient'); ?>:&nbsp;&nbsp;</span></td>
       <td>
         <input type='text' size='20' name='form_patient' style='width:100%;cursor:pointer;cursor:hand' id='form_patient' value='<?php echo attr($form_patient) ? attr($form_patient) : xla('Click To Select'); ?>' onclick='sel_patient()' title='<?php echo xla('Click to select patient'); ?>' />
         <?php }else{ ?>

--- a/interface/reports/patient_flow_board_report.php
+++ b/interface/reports/patient_flow_board_report.php
@@ -180,10 +180,10 @@ if ($form_patient == '' ) $form_pid = '';
 
         <table class='text'>
             <tr>
-                <td class='label'><?php echo xlt('Facility'); ?>:</td>
+                <td class='label_custom'><?php echo xlt('Facility'); ?>:</td>
                 <td><?php dropdown_facility($facility, 'form_facility'); ?>
                 </td>
-                <td class='label'><?php echo xlt('Provider'); ?>:</td>
+                <td class='label_custom'><?php echo xlt('Provider'); ?>:</td>
                 <td><?php
 
                 # Build a drop-down list of providers.
@@ -211,13 +211,13 @@ if ($form_patient == '' ) $form_pid = '';
             </tr>
 
             <tr>
-                <td class='label'><?php echo xlt('From'); ?>:</td>
+                <td class='label_custom'><?php echo xlt('From'); ?>:</td>
                 <td><input type='text' name='form_from_date' id="form_from_date"
                     class='datepicker'
                     size='10' value='<?php echo attr($from_date) ?>'
                     title='yyyy-mm-dd'>
                 </td>
-                <td class='label'><?php echo xlt('To'); ?>:</td>
+                <td class='label_custom'><?php echo xlt('To'); ?>:</td>
                 <td><input type='text' name='form_to_date' id="form_to_date"
                     class='datepicker'
                     size='10' value='<?php echo attr($to_date) ?>'
@@ -226,7 +226,7 @@ if ($form_patient == '' ) $form_pid = '';
             </tr>
 
             <tr>
-                <td class='label'><?php echo xlt('Status'); # status code drop down creation ?>:</td>
+                <td class='label_custom'><?php echo xlt('Status'); # status code drop down creation ?>:</td>
                 <td><?php generate_form_field(array('data_type'=>1,'field_id'=>'apptstatus','list_id'=>'apptstat','empty_title'=>'All'),$_POST['form_apptstatus']);?></td>
                 <td><?php echo xlt('Category') #category drop down creation ?>:</td>
                 <td>

--- a/interface/reports/patient_list.php
+++ b/interface/reports/patient_list.php
@@ -56,12 +56,14 @@ else {
 <head>
 <?php html_header_show();?>
 <title><?php xl('Patient List','e'); ?></title>
+
+<?php $include_standard_style_js = array("datetimepicker"); ?>
+<?php require($GLOBALS['srcdir'] . '/templates/standard_header_template.php'); ?>
+
 <script type="text/javascript" src="../../library/overlib_mini.js"></script>
 <script type="text/javascript" src="../../library/textformat.js?v=<?php echo $v_js_includes; ?>"></script>
 <script type="text/javascript" src="../../library/dialog.js?v=<?php echo $v_js_includes; ?>"></script>
-<script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/jquery-min-3-1-1/index.js"></script>
 <script type="text/javascript" src="../../library/js/report_helper.js?v=<?php echo $v_js_includes; ?>"></script>
-<script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/jquery-datetimepicker-2-5-4/build/jquery.datetimepicker.full.min.js"></script>
 
 <script language="JavaScript">
  var mypcc = '<?php echo $GLOBALS['phone_country_code'] ?>';
@@ -81,9 +83,6 @@ $(document).ready(function() {
 });
 
 </script>
-
-<link rel='stylesheet' href='<?php echo $css_header ?>' type='text/css'>
-<link rel="stylesheet" href="<?php echo $GLOBALS['assets_static_relative']; ?>/jquery-datetimepicker-2-5-4/build/jquery.datetimepicker.min.css">
 
 <style type="text/css">
 
@@ -131,7 +130,7 @@ $(document).ready(function() {
 <?php } ?>
 </div>
 
-<form name='theform' id='theform' method='post' action='patient_list.php'>
+<form name='theform' id='theform' method='post' action='patient_list.php' onsubmit='return top.restoreSession()'>
 
 <div id="report_parameters">
 
@@ -145,7 +144,7 @@ $(document).ready(function() {
 
 	<table class='text'>
 		<tr>
-      <td class='label'>
+      <td class='control-label'>
         <?php xl('Provider','e'); ?>:
       </td>
       <td>
@@ -154,17 +153,17 @@ $(document).ready(function() {
            'empty_title' => '-- All --'), $_POST['form_provider']);
 	      ?>
       </td>
-			<td class='label'>
+			<td class='control-label'>
 			   <?php xl('Visits From','e'); ?>:
 			</td>
 			<td>
-			   <input class='datepicker' type='text' name='form_from_date' id="form_from_date" size='10' value='<?php echo oeFormatShortDate($from_date) ?>'>
+			   <input class='datepicker form-control' type='text' name='form_from_date' id="form_from_date" size='10' value='<?php echo oeFormatShortDate($from_date) ?>'>
 			</td>
-			<td class='label'>
+			<td class='control-label'>
 			   <?php xl('To','e'); ?>:
 			</td>
 			<td>
-			   <input class='datepicker' type='text' name='form_to_date' id="form_to_date" size='10' value='<?php echo oeFormatShortDate($to_date) ?>'>
+			   <input class='datepicker form-control' type='text' name='form_to_date' id="form_to_date" size='10' value='<?php echo oeFormatShortDate($to_date) ?>'>
 			</td>
 		</tr>
 	</table>

--- a/interface/reports/patient_list_creation.php
+++ b/interface/reports/patient_list_creation.php
@@ -238,14 +238,14 @@
                                             <div class="cancel-float" style='float:left'>
 						<table class='text'>
 							<tr>
-								<td class='label' ><?php echo xlt('From'); ?>: </td>
+								<td class='label_custom' ><?php echo xlt('From'); ?>: </td>
 								<td><input type='text' class='datetimepicker' name='date_from' id="date_from" size='18' value='<?php echo attr($sql_date_from); ?>' title='<?php echo attr($title_tooltip) ?>'>
 								</td>
-								<td class='label'><?php echo xlt('To{{range}}'); ?>: </td>
+								<td class='label_custom'><?php echo xlt('To{{range}}'); ?>: </td>
 								<td><input type='text' class='datetimepicker' name='date_to' id="date_to" size='18' value='<?php echo attr($sql_date_to); ?>' title='<?php echo  attr($title_tooltip) ?>'>
 								</td>
-								<td class='label'><?php echo xlt('Option'); ?>: </td>
-								<td class='label'>
+								<td class='label_custom'><?php echo xlt('Option'); ?>: </td>
+								<td class='label_custom'>
 									<select name="srch_option" id="srch_option" onchange="javascript:$('#sortby').val('');$('#sortorder').val('');if(this.value == 'Communication'){ $('#communication').val('');$('#com_pref').show();}else{ $('#communication').val('');$('#com_pref').hide();}">
 										<?php foreach($search_options as $skey => $svalue){ ?>
 										<option <?php if($_POST['srch_option'] == $skey) echo 'selected'; ?> value="<?php echo attr($skey); ?>"><?php echo text($svalue); ?></option>
@@ -268,13 +268,13 @@
 
 							</tr>
 							<tr>
-								<td class='label'><?php echo xlt('Patient ID'); ?>:</td>
+								<td class='label_custom'><?php echo xlt('Patient ID'); ?>:</td>
 								<td><input name='patient_id' class="numeric_only" type='text' id="patient_id" title='<?php echo xla('Optional numeric patient ID'); ?>' value='<?php echo attr($patient_id); ?>' size='10' maxlength='20' /></td>
-								<td class='label'><?php echo xlt('Age Range'); ?>:</td>
+								<td class='label_custom'><?php echo xlt('Age Range'); ?>:</td>
 								<td><?php echo xlt('From'); ?>
 								<input name='age_from' class="numeric_only" type='text' id="age_from" value="<?php echo attr($age_from); ?>" size='3' maxlength='3' /> <?php echo xlt('To{{range}}'); ?>
 								<input name='age_to' class="numeric_only" type='text' id="age_to" value="<?php echo attr($age_to); ?>" size='3' maxlength='3' /></td>
-								<td class='label'><?php echo xlt('Gender'); ?>:</td>
+								<td class='label_custom'><?php echo xlt('Gender'); ?>:</td>
 								<td colspan="2"><?php echo generate_select_list('gender', 'sex', $sql_gender, 'Select Gender', 'Unassigned', '', ''); ?></td>
 							</tr>
 

--- a/interface/reports/prescriptions_report.php
+++ b/interface/reports/prescriptions_report.php
@@ -130,20 +130,20 @@
 
 	<table class='text'>
 		<tr>
-			<td class='label'>
+			<td class='label_custom'>
 				<?php xl('Facility','e'); ?>:
 			</td>
 			<td>
 			<?php dropdown_facility(strip_escape_custom($form_facility), 'form_facility', true); ?>
 			</td>
-			<td class='label'>
+			<td class='label_custom'>
 			   <?php xl('From','e'); ?>:
 			</td>
 			<td>
 			   <input type='text' class='datepicker' name='form_from_date' id="form_from_date" size='10' value='<?php echo $form_from_date ?>'
 				 title='yyyy-mm-dd'>
 			</td>
-			<td class='label'>
+			<td class='label_custom'>
 			   <?php xl('To','e'); ?>:
 			</td>
 			<td>
@@ -152,21 +152,21 @@
 			</td>
 		</tr>
 		<tr>
-			<td class='label'>
+			<td class='label_custom'>
 			   <?php xl('Patient ID','e'); ?>:
 			</td>
 			<td>
 			   <input type='text' name='form_patient_id' size='10' maxlength='20' value='<?php echo $form_patient_id ?>'
 				title=<?php xl('Optional numeric patient ID','e','\'','\''); ?> />
 			</td>
-			<td class='label'>
+			<td class='label_custom'>
 			   <?php xl('Drug','e'); ?>:
 			</td>
 			<td>
 			   <input type='text' name='form_drug_name' size='10' maxlength='250' value='<?php echo $form_drug_name ?>'
 				title=<?php xl('Optional drug name, use % as a wildcard','e','\'','\''); ?> />
 			</td>
-			<td class='label'>
+			<td class='label_custom'>
 			   <?php xl('Lot','e'); ?>:
 			</td>
 			<td>

--- a/interface/reports/receipts_by_method_report.php
+++ b/interface/reports/receipts_by_method_report.php
@@ -292,7 +292,7 @@ function sel_procedure() {
 
 	<table class='text'>
 		<tr>
-			<td class='label'>
+			<td class='label_custom'>
 			   <?php xl('Report by','e'); ?>
 			</td>
 			<td>
@@ -333,7 +333,7 @@ function sel_procedure() {
 			   <input type='text' class='datepicker' name='form_from_date' id="form_from_date" size='10' value='<?php echo $form_from_date ?>'
 				title='yyyy-mm-dd'>
 			</td>
-			<td class='label'>
+			<td class='label_custom'>
 			   <?php xl('To','e'); ?>:
 			</td>
 			<td>

--- a/interface/reports/referrals_report.php
+++ b/interface/reports/referrals_report.php
@@ -131,13 +131,13 @@
 
 	<table class='text'>
 		<tr>
-			<td class='label'>
+			<td class='label_custom'>
 				<?php echo xlt('Facility'); ?>:
 			</td>
 			<td>
 			<?php dropdown_facility(($form_facility), 'form_facility', true); ?>
 			</td>
-			<td class='label'>
+			<td class='label_custom'>
 			   <?php echo xlt('From'); ?>:
 			</td>
 			<td>
@@ -145,7 +145,7 @@
          class='datepicker'
 				 title='<?php echo xla('yyyy-mm-dd') ?>'>
 			</td>
-			<td class='label'>
+			<td class='label_custom'>
 			   <?php echo xlt('To'); ?>:
 			</td>
 			<td>

--- a/interface/reports/report_results.php
+++ b/interface/reports/report_results.php
@@ -115,7 +115,7 @@ require_once "$srcdir/report_database.inc";
 	<table class='text'>
 
                    <tr>
-                      <td class='label'>
+                      <td class='label_custom'>
                          <?php echo htmlspecialchars( xl('Begin Date'), ENT_NOQUOTES); ?>:
                       </td>
                       <td>
@@ -126,7 +126,7 @@ require_once "$srcdir/report_database.inc";
                    </tr>
 
                 <tr>
-                        <td class='label'>
+                        <td class='label_custom'>
                               <?php echo htmlspecialchars( xl('End Date'), ENT_NOQUOTES); ?>:
                         </td>
                         <td>

--- a/interface/reports/sales_by_item.php
+++ b/interface/reports/sales_by_item.php
@@ -350,20 +350,20 @@ $(document).ready(function() {
     <div style='float:left'>
     <table class='text'>
         <tr>
-            <td class='label'>
+            <td class='label_custom'>
                 <?php echo xlt('Facility'); ?>:
             </td>
             <td>
             <?php dropdown_facility($form_facility, 'form_facility', true); ?>
             </td>
-            <td class='label'>
+            <td class='label_custom'>
                 <?php echo xlt('From'); ?>:
             </td>
             <td>
                 <input type='text' class='datepicker' name='form_from_date' id="form_from_date" size='10' value='<?php echo attr($form_from_date) ?>'
                 title='yyyy-mm-dd'>
             </td>
-            <td class='label'>
+            <td class='label_custom'>
                 <?php echo xlt('To'); ?>:
             </td>
             <td>
@@ -374,7 +374,7 @@ $(document).ready(function() {
     </table>
     <table class='text'>
         <tr>
-          <td class='label'>
+          <td class='label_custom'>
             <?php echo xlt('Provider'); ?>:
           </td>
           <td>

--- a/interface/reports/svc_code_financial_report.php
+++ b/interface/reports/svc_code_financial_report.php
@@ -134,7 +134,7 @@ $grand_total_amt_balance  = 0;
 	<div style='float:left'>
 	<table class='text'>
 		<tr>
-			<td class='label'>
+			<td class='label_custom'>
 				<?php echo xlt('Facility'); ?>:
 			</td>
 			<td>
@@ -164,7 +164,7 @@ $grand_total_amt_balance  = 0;
                            <input type='text' class='datepicker' name='form_from_date' id="form_from_date" size='10' value='<?php echo attr($form_from_date) ?>'
                                 title='yyyy-mm-dd'>
                         </td>
-                        <td class='label'>
+                        <td class='label_custom'>
                            <?php echo xlt('To'); ?>:
                         </td>
                         <td>

--- a/interface/reports/unique_seen_patients_report.php
+++ b/interface/reports/unique_seen_patients_report.php
@@ -145,14 +145,14 @@ require_once("$srcdir/patient.inc");
 
 	<table class='text'>
 		<tr>
-			<td class='label'>
+			<td class='label_custom'>
 			   <?php xl('Visits From','e'); ?>:
 			</td>
 			<td>
 			   <input type='text' class='datepicker' name='form_from_date' id="form_from_date" size='10' value='<?php echo $form_from_date ?>'
 				title='yyyy-mm-dd'>
 			</td>
-			<td class='label'>
+			<td class='label_custom'>
 			   <?php xl('To','e'); ?>:
 			</td>
 			<td>

--- a/interface/themes/rtl.css
+++ b/interface/themes/rtl.css
@@ -50,7 +50,7 @@ body {
  * Patient Demographics are a custom layout.
  *============================================================*/
 
-#DEM .label {
+#DEM .label_custom {
 
     text-align: left;
 }
@@ -204,32 +204,32 @@ float:right;
 
 ul.tabNav { margin: 0; padding: 0; }
 ul.tabNav { float: right; }
-ul.tabNav li { float: right; 
-               margin: 0 1px 0 0; 
+ul.tabNav li { float: right;
+               margin: 0 1px 0 0;
                padding: 6px 0 0;
     text-align: right;
 }
-ul.tabNav li.current { 
+ul.tabNav li.current {
     padding-top: 0;
     text-align: right;
 }
-ul.tabNav a { 
-   padding: 4px 4px 5px 4px; 
+ul.tabNav a {
+   padding: 4px 4px 5px 4px;
 }
 ul.tabNav li.current a {padding: 8px; }
 
-div.tabContainer { 
+div.tabContainer {
     float: right;
 }
 
 div.tab table td {
-	padding-right: 1px; 
+	padding-right: 1px;
 }
 /*
 * REPORTS
 */
 
-#report_parameters table table td.label {
+#report_parameters table table td.label_custom {
 	text-align: left;
 }
 
@@ -299,7 +299,7 @@ text-align:right;
 
 /* Calander */
 #bottomLeft{
-    
+
     float: right !important;
 }
 #bigCal{
@@ -309,22 +309,22 @@ text-align:right;
 
 /*miscellaneous*/
 .misc-internet-search{
-    float: right !important;  
+    float: right !important;
 }
 
 form#new_note div{
-    
+
     float: none !important;
 }
 /* record_disclosure.php */
 #record-disclosure, #record-disclosure>div {
-    
+
     float:none !important;
-    
+
 }
 /* newpatient/common.php  */
 form#new-encounter-form div{
-    
+
     float: none !important;
     display: inherit;
 }
@@ -349,7 +349,7 @@ table#main-title tr td:nth-child(2){
     text-align: center !important;
 }
 table#main-title tr td:nth-child(2) div, table#main-title tr td:nth-child(3) div{
-    float: none !important; 
+    float: none !important;
 }
 table#main-title tr td:nth-child(3){
     text-align: center !important;
@@ -368,7 +368,7 @@ table#main-title tr td:nth-child(4) table{
 .demographics-box>div{
     float: none !important;
     position: absolute;
-} 
+}
 .demographics-box>div:first-child{
     width: 55% !important;
 }
@@ -398,7 +398,7 @@ body>.nav{
 }
 
 
-/* ajax_template.html */ 
+/* ajax_template.html */
 
 #dateNAV img{
     display: none;
@@ -409,19 +409,19 @@ body>.nav{
     height: 15.5px;
 }
 #dateNav>a:nth-child(2){
-    
+
     background-image: url(../main/calendar/modules/PostCalendar/pntemplates/default/images/rightbtn.gif);
     margin-right: 10px;
-} 
+}
 #dateNav>a:nth-child(3){
-    
+
     background-image: url(../main/calendar/modules/PostCalendar/pntemplates/default/images/leftbtn.gif);
-  
-} 
+
+}
 
 /* /main/messages/messages.php */
 td.amount-msg{
-    
+
     text-align: left !important;
     direction: ltr;
 }
@@ -438,7 +438,7 @@ td.amount-msg{
     float: right !important;
 }
 .ui-dialog .ui-dialog-title{
-    
+
     float: none !important;
 }
 
@@ -446,7 +446,7 @@ td.amount-msg{
 /*  /library/js/datatables/media/css/demo_table.css */
 
 #pt_table_paginate #pt_table_next{
-    
+
     float: none !important;
      background: url('../../library/css/images/back_disabled.png') no-repeat top left !important;
      display: inline-block;
@@ -457,7 +457,7 @@ td.amount-msg{
 }
 
 #pt_table_paginate #pt_table_previous{
-    
+
     float: none !important;
      background: url('../../library/css/images/forward_disabled.png') no-repeat top right !important;
      display: inline-block;
@@ -473,7 +473,7 @@ td.amount-msg{
 
 /* /templates/documents/general_view.html */
 #documents_actions form[name^=document]>div>div, #documents_actions form[name=notes]>div>div{
-    
+
     float: none !important;
     display: inline-block;
 }
@@ -500,7 +500,7 @@ td.amount-msg{
 }
 
 .tabs-container ul.tabs li{
-    
+
     float: none !important;
 }
 .container_body .viewport .overview{
@@ -519,11 +519,11 @@ td.amount-msg{
     float: right !important;
 }
 .setup-carecoordination ul.virtualpage_system_based_forms{
-    
+
     float: right !important;
-} 
+}
 .setup-carecoordination .ca-ca-in-2{
-    
+
     float: right;
     padding-right: 2% !important;
     float: right !important;
@@ -544,7 +544,7 @@ div#portal-buttons-bottom{
     padding: 5px 15px;
 }
 
-#DEM .label, #report_parameters table table td.label {
+#DEM .label_custom, #report_parameters table table td.label_custom {
     text-align: left !important;
 }
 

--- a/interface/themes/style.css
+++ b/interface/themes/style.css
@@ -226,7 +226,7 @@ font-weight: bold;
     padding-right: 5px;
     vertical-align: bottom;
 }
-#DEM .label {
+#DEM .label_custom {
     font-weight: bold;
     font-size: 0.8em;
     vertical-align: bottom;

--- a/interface/themes/style_babyblu.css
+++ b/interface/themes/style_babyblu.css
@@ -1,7 +1,7 @@
 body {
     margin: 0px 0px 0px 2px;
     /* set the base font and size for all DOM children */
-    font-family: sans-serif; 
+    font-family: sans-serif;
     font-size: 1em;  /* set the base font size for all DOM children */
 }
 
@@ -173,7 +173,7 @@ a:hover {
 }
 
 /*=============================================================
- * Here we have taken variables from globals.php and turned them into CSS classes 
+ * Here we have taken variables from globals.php and turned them into CSS classes
  * these should be used in place of the GLOBAL variables -- JRM March 2008
  *=============================================================*/
 .body_top { background-color: #eae6ff; margin: 8px }    /* $top_bg_line */
@@ -258,7 +258,7 @@ font-weight: bold;
 #documents_list {
     width: 29%;
     height: 95%;
-    overflow: auto; 
+    overflow: auto;
     float: left;
     border-right: dashed 1px;
 }
@@ -271,8 +271,8 @@ font-weight: bold;
 }
 #documents_actions iframe {
     display: inline;
-    border:none; 
-    width:100%; 
+    border:none;
+    width:100%;
     height:600px;
     overflow: auto;
 }
@@ -296,7 +296,7 @@ font-weight: bold;
     padding-right: 5px;
     vertical-align: top;
 }
-#DEM .label {
+#DEM .label_custom {
     font-weight: bold;
     font-size: 0.8em;
     vertical-align: top;
@@ -319,7 +319,7 @@ font-weight: bold;
     vertical-align: top;
     height: 2em;
 }
-#HIS .label {
+#HIS .label_custom {
     font-weight: bold;
     font-size: 9pt;
     vertical-align: top;
@@ -337,7 +337,7 @@ font-weight: bold;
  * seen in the patient summary and notes screens
  *============================================================*/
 #pnotes .billing {
-    background-color: #dfd;  
+    background-color: #dfd;
 }
 
 #pnotes .highlight {
@@ -349,7 +349,7 @@ font-weight: bold;
 }
 
 #pnotes .noterow {
-    cursor: pointer; 
+    cursor: pointer;
 }
 
 #pnotes .noterow td {
@@ -445,7 +445,7 @@ font-weight: bold;
 #patient_pastenc {
     width:100%;
 }
-    
+
 #patient_pastenc .billing_note {
     width: 25%;
 }
@@ -522,7 +522,7 @@ font-weight: bold;
 #patient_reports ul {
     list-style: none;
 }
-    
+
 
 /*=============================================================
  * Report - Custom
@@ -638,6 +638,7 @@ font-weight: bold;
 .css_button_small:hover {
     background: #1050b6;
     box-shadow: 0px 1px 3px #DDD;
+    text-decoration: none;
 }
 
 .css_button, input[type="button"], input[type="submit"], button{
@@ -667,6 +668,7 @@ font-weight: bold;
 .css_button:hover, input[type="button"]:hover, input[type="submit"]:hover, button:hover {
     background: #1050b6;
     box-shadow: 3px 4px 6px #DDD ;
+    text-decoration: none;
 }
 
 input[type="button"][style="background-color:#ffff55"] {
@@ -724,7 +726,7 @@ div.tab table td {
 	padding-right: 1px; padding-bottom: 0px
 }
 
-div.tab table td.label {
+div.tab table td.label_custom {
 	min-width:80px;
 }
 
@@ -776,7 +778,7 @@ div.notab-right {
 	font-size: 0.8em;
 }
 
-#report_parameters table table td.label {
+#report_parameters table table td.label_custom {
 	text-align: right;
 }
 
@@ -861,15 +863,15 @@ font-size:9pt;
     padding: 10px 10px 10px 15px;
     color: black;
   }
-.alertmsg1 { 
+.alertmsg1 {
     border: 3px solid #fe7b7a;
     background-color: #ffd6d6 ;
   }
-.alertmsg2 { 
+.alertmsg2 {
     border: 3px solid #f56fff;
     background-color: #fabfff;
   }
-.alertmsg3 { 
+.alertmsg3 {
     border: 3px solid #9acc2e;
     background-color: #eef7dd;
   }

--- a/interface/themes/style_light.css
+++ b/interface/themes/style_light.css
@@ -156,7 +156,7 @@ a:hover {
 }
 
 /*=============================================================
- * Here we have taken variables from globals.php and turned them into CSS classes 
+ * Here we have taken variables from globals.php and turned them into CSS classes
  * these should be used in place of the GLOBAL variables -- JRM March 2008
  *=============================================================*/
 .body_top {
@@ -356,7 +356,7 @@ a:hover {
   padding-right: 5px;
   vertical-align: top;
 }
-#DEM .label {
+#DEM .label_custom {
   font-weight: bold;
   font-size: 0.8em;
   vertical-align: top;
@@ -379,7 +379,7 @@ a:hover {
   vertical-align: top;
   height: 2em;
 }
-#HIS .label {
+#HIS .label_custom {
   font-weight: bold;
   font-size: 9pt;
   vertical-align: top;
@@ -684,6 +684,7 @@ tr.odd, td.even {
 }
 .css_button_small:hover {
   background: #1050b6;
+  text-decoration: none;
 }
 
 .css_button, input[type="button"],input[type="submit"], button {
@@ -707,6 +708,7 @@ tr.odd, td.even {
 }
 .css_button:hover, input[type="button"]:hover, input[type="submit"]:hover, button:hover {
   background: #1050b6;
+  text-decoration: none;
 }
 .css_btn {
   background: #2672ec;
@@ -825,7 +827,7 @@ div.tab table td {
   padding-bottom: 0px;
 }
 
-div.tab table td.label {
+div.tab table td.label_custom {
   min-width: 80px;
 }
 
@@ -886,7 +888,7 @@ div.notab-right {
   font-size: 0.8em;
 }
 
-#report_parameters table table td.label {
+#report_parameters table table td.label_custom {
   text-align: right;
 }
 

--- a/interface/themes/style_light.css
+++ b/interface/themes/style_light.css
@@ -40,7 +40,7 @@ a:hover {
     z-index:100;
      }
 
-    .container{
+    .menuBar .container{
     margin-top:95px;
 }
 

--- a/interface/themes/style_metal.css
+++ b/interface/themes/style_metal.css
@@ -1,7 +1,7 @@
 body {
     margin: 0px 0px 0px 2px;
     /* set the base font and size for all DOM children */
-    font-family: sans-serif; 
+    font-family: sans-serif;
     font-size: 1em;  /* set the base font size for all DOM children */
 }
 
@@ -35,8 +35,8 @@ a:hover {
     background-color:#8CACBB;
     z-index:100;
      }
-    
-    .container{ 
+
+    .container{
     margin-top:95px;
 }
 
@@ -173,7 +173,7 @@ a:hover {
 }
 
 /*=============================================================
- * Here we have taken variables from globals.php and turned them into CSS classes 
+ * Here we have taken variables from globals.php and turned them into CSS classes
  * these should be used in place of the GLOBAL variables -- JRM March 2008
  *=============================================================*/
 .body_top { background-color: #8CACBB; margin: 8px }    /* $top_bg_line */
@@ -258,7 +258,7 @@ font-weight: bold;
 #documents_list {
     width: 29%;
     height: 95%;
-    overflow: auto; 
+    overflow: auto;
     float: left;
     border-right: dashed 1px;
 }
@@ -271,8 +271,8 @@ font-weight: bold;
 }
 #documents_actions iframe {
     display: inline;
-    border:none; 
-    width:100%; 
+    border:none;
+    width:100%;
     height:600px;
     overflow: auto;
 }
@@ -296,7 +296,7 @@ font-weight: bold;
     padding-right: 5px;
     vertical-align: top;
 }
-#DEM .label {
+#DEM .label_custom {
     font-weight: bold;
     font-size: 0.8em;
     vertical-align: top;
@@ -319,7 +319,7 @@ font-weight: bold;
     vertical-align: top;
     height: 2em;
 }
-#HIS .label {
+#HIS .label_custom {
     font-weight: bold;
     font-size: 9pt;
     vertical-align: top;
@@ -337,7 +337,7 @@ font-weight: bold;
  * seen in the patient summary and notes screens
  *============================================================*/
 #pnotes .billing {
-    background-color: #dfd;  
+    background-color: #dfd;
 }
 
 #pnotes .highlight {
@@ -349,7 +349,7 @@ font-weight: bold;
 }
 
 #pnotes .noterow {
-    cursor: pointer; 
+    cursor: pointer;
 }
 
 #pnotes .noterow td {
@@ -445,7 +445,7 @@ font-weight: bold;
 #patient_pastenc {
     width:100%;
 }
-    
+
 #patient_pastenc .billing_note {
     width: 25%;
 }
@@ -522,7 +522,7 @@ font-weight: bold;
 #patient_reports ul {
     list-style: none;
 }
-    
+
 
 /*=============================================================
  * Report - Custom
@@ -638,6 +638,7 @@ font-weight: bold;
 .css_button_small:hover {
     background: #1050b6;
     box-shadow: 0px 1px 3px #DDD;
+    text-decoration: none;
 }
 
 .css_button, input[type="button"], input[type="submit"], button{
@@ -667,6 +668,7 @@ font-weight: bold;
 .css_button:hover, input[type="button"]:hover, input[type="submit"]:hover, button:hover {
     background: #1050b6;
     box-shadow: 3px 4px 6px #DDD ;
+    text-decoration: none;
 }
 
 input[type="button"][style="background-color:#ffff55"] {
@@ -724,7 +726,7 @@ div.tab table td {
 	padding-right: 1px; padding-bottom: 0px
 }
 
-div.tab table td.label {
+div.tab table td.label_custom {
 	min-width:80px;
 }
 
@@ -776,7 +778,7 @@ div.notab-right {
 	font-size: 0.8em;
 }
 
-#report_parameters table table td.label {
+#report_parameters table table td.label_custom {
 	text-align: right;
 }
 
@@ -861,15 +863,15 @@ font-size:9pt;
     padding: 10px 10px 10px 15px;
     color: black;
   }
-.alertmsg1 { 
+.alertmsg1 {
     border: 3px solid #fe7b7a;
     background-color: #ffd6d6 ;
   }
-.alertmsg2 { 
+.alertmsg2 {
     border: 3px solid #f56fff;
     background-color: #fabfff;
   }
-.alertmsg3 { 
+.alertmsg3 {
     border: 3px solid #9acc2e;
     background-color: #eef7dd;
   }

--- a/interface/themes/style_oemr.css
+++ b/interface/themes/style_oemr.css
@@ -1,7 +1,7 @@
 body {
     margin: 0px 0px 0px 2px;
     /* set the base font and size for all DOM children */
-    font-family: sans-serif; 
+    font-family: sans-serif;
     font-size: 1em;  /* set the base font size for all DOM children */
 }
 
@@ -35,8 +35,8 @@ a:hover {
     background-color:#FEFDCF;
     z-index:100;
      }
-    
-    .container{ 
+
+    .container{
     margin-top:95px;
 }
 .menu_selected {
@@ -172,7 +172,7 @@ a:hover {
 }
 
 /*=============================================================
- * Here we have taken variables from globals.php and turned them into CSS classes 
+ * Here we have taken variables from globals.php and turned them into CSS classes
  * these should be used in place of the GLOBAL variables -- JRM March 2008
  *=============================================================*/
 .body_top { background-color: #fefdcf; margin: 8px }    /* $top_bg_line */
@@ -257,7 +257,7 @@ font-weight: bold;
 #documents_list {
     width: 29%;
     height: 95%;
-    overflow: auto; 
+    overflow: auto;
     float: left;
     border-right: dashed 1px;
 }
@@ -270,8 +270,8 @@ font-weight: bold;
 }
 #documents_actions iframe {
     display: inline;
-    border:none; 
-    width:100%; 
+    border:none;
+    width:100%;
     height:600px;
     overflow: auto;
 }
@@ -295,7 +295,7 @@ font-weight: bold;
     padding-right: 5px;
     vertical-align: top;
 }
-#DEM .label {
+#DEM .label_custom {
     font-weight: bold;
     font-size: 0.8em;
     vertical-align: top;
@@ -318,7 +318,7 @@ font-weight: bold;
     vertical-align: top;
     height: 2em;
 }
-#HIS .label {
+#HIS .label_custom {
     font-weight: bold;
     font-size: 9pt;
     vertical-align: top;
@@ -336,7 +336,7 @@ font-weight: bold;
  * seen in the patient summary and notes screens
  *============================================================*/
 #pnotes .billing {
-    background-color: #dfd;  
+    background-color: #dfd;
 }
 
 #pnotes .highlight {
@@ -348,7 +348,7 @@ font-weight: bold;
 }
 
 #pnotes .noterow {
-    cursor: pointer; 
+    cursor: pointer;
 }
 
 #pnotes .noterow td {
@@ -444,7 +444,7 @@ font-weight: bold;
 #patient_pastenc {
     width:100%;
 }
-    
+
 #patient_pastenc .billing_note {
     width: 25%;
 }
@@ -521,7 +521,7 @@ font-weight: bold;
 #patient_reports ul {
     list-style: none;
 }
-    
+
 
 /*=============================================================
  * Report - Custom
@@ -637,6 +637,7 @@ font-weight: bold;
 .css_button_small:hover {
     background: #1050b6;
     box-shadow: 0px 1px 3px #DDD;
+    text-decoration: none;
 }
 
 .css_button, input[type="button"], input[type="submit"], button{
@@ -666,6 +667,7 @@ font-weight: bold;
 .css_button:hover, input[type="button"]:hover, input[type="submit"]:hover, button:hover {
     background: #1050b6;
     box-shadow: 3px 4px 6px #DDD ;
+    text-decoration: none;
 }
 
 input[type="button"][style="background-color:#ffff55"] {
@@ -723,7 +725,7 @@ div.tab table td {
 	padding-right: 1px; padding-bottom: 0px
 }
 
-div.tab table td.label {
+div.tab table td.label_custom {
 	min-width:80px;
 }
 
@@ -775,7 +777,7 @@ div.notab-right {
 	font-size: 0.8em;
 }
 
-#report_parameters table table td.label {
+#report_parameters table table td.label_custom {
 	text-align: right;
 }
 
@@ -860,15 +862,15 @@ font-size:9pt;
     padding: 10px 10px 10px 15px;
     color: black;
   }
-.alertmsg1 { 
+.alertmsg1 {
     border: 3px solid #fe7b7a;
     background-color: #ffd6d6 ;
   }
-.alertmsg2 { 
+.alertmsg2 {
     border: 3px solid #f56fff;
     background-color: #fabfff;
   }
-.alertmsg3 { 
+.alertmsg3 {
     border: 3px solid #9acc2e;
     background-color: #eef7dd;
   }

--- a/interface/themes/style_pdf.css
+++ b/interface/themes/style_pdf.css
@@ -207,7 +207,7 @@ font-weight: bold;
 #documents_list {
     width: 29%;
     height: 95%;
-    overflow: auto; 
+    overflow: auto;
     float: left;
     border-right: dashed 1px;
 }
@@ -220,8 +220,8 @@ font-weight: bold;
 }
 #documents_actions iframe {
     display: inline;
-    border:none; 
-    width:100%; 
+    border:none;
+    width:100%;
     height:600px;
     overflow: auto;
 }
@@ -246,7 +246,7 @@ font-weight: bold;
     vertical-align: top;
     width: 12%;
 }
-#DEM .label {
+#DEM .label_custom {
     font-weight: bold;
     font-size: 9pt;
     vertical-align: top;
@@ -272,7 +272,7 @@ font-weight: bold;
     height: 2em;
     width: 12%;
 }
-#HIS .label {
+#HIS .label_custom {
     font-weight: bold;
     font-size: 9pt;
     vertical-align: top;
@@ -292,7 +292,7 @@ font-weight: bold;
  * seen in the patient summary and notes screens
  *============================================================*/
 #pnotes .billing {
-    background-color: #dfd;  
+    background-color: #dfd;
 }
 
 #pnotes .highlight {
@@ -304,7 +304,7 @@ font-weight: bold;
 }
 
 #pnotes .noterow {
-    cursor: pointer; 
+    cursor: pointer;
 }
 
 #pnotes .noterow td {
@@ -400,7 +400,7 @@ font-weight: bold;
 #patient_pastenc {
     width:100%;
 }
-    
+
 #patient_pastenc .billing_note {
     width: 25%;
 }
@@ -477,7 +477,7 @@ font-weight: bold;
 #patient_reports ul {
     list-style: none;
 }
-    
+
 
 /*=============================================================
  * Report - Custom
@@ -662,7 +662,7 @@ div.tab table td {
 	padding-right: 1px; padding-bottom: 0px
 }
 
-div.tab table td.label {
+div.tab table td.label_custom {
 	min-width:80px;
 }
 
@@ -714,7 +714,7 @@ div.notab-right {
 	font-size: 0.8em;
 }
 
-#report_parameters table table td.label {
+#report_parameters table table td.label_custom {
 	text-align: right;
 }
 
@@ -798,15 +798,15 @@ font-size:9pt;
     padding: 10px 10px 10px 15px;
     color: black;
   }
-.alertmsg1 { 
+.alertmsg1 {
     border: 3px solid #fe7b7a;
     background-color: #ffd6d6 ;
   }
-.alertmsg2 { 
+.alertmsg2 {
     border: 3px solid #f56fff;
     background-color: #fabfff;
   }
-.alertmsg3 { 
+.alertmsg3 {
     border: 3px solid #9acc2e;
     background-color: #eef7dd;
   }

--- a/interface/themes/style_purple.css
+++ b/interface/themes/style_purple.css
@@ -1,7 +1,7 @@
 body {
     margin: 0px 0px 0px 2px;
     /* set the base font and size for all DOM children */
-    font-family: sans-serif; 
+    font-family: sans-serif;
     font-size: 1em;  /* set the base font size for all DOM children */
 }
 
@@ -26,8 +26,8 @@ a:hover {
     background-color:#EAE6FF;
     z-index:100;
      }
-    
-    .container{ 
+
+    .container{
     margin-top:95px;
 }
 .menu {
@@ -172,7 +172,7 @@ a:hover {
 }
 
 /*=============================================================
- * Here we have taken variables from globals.php and turned them into CSS classes 
+ * Here we have taken variables from globals.php and turned them into CSS classes
  * these should be used in place of the GLOBAL variables -- JRM March 2008
  *=============================================================*/
 .body_top { background-color: #eae6ff; margin: 8px }    /* $top_bg_line */
@@ -257,7 +257,7 @@ font-weight: bold;
 #documents_list {
     width: 29%;
     height: 95%;
-    overflow: auto; 
+    overflow: auto;
     float: left;
     border-right: dashed 1px;
 }
@@ -270,8 +270,8 @@ font-weight: bold;
 }
 #documents_actions iframe {
     display: inline;
-    border:none; 
-    width:100%; 
+    border:none;
+    width:100%;
     height:600px;
     overflow: auto;
 }
@@ -295,7 +295,7 @@ font-weight: bold;
     padding-right: 5px;
     vertical-align: top;
 }
-#DEM .label {
+#DEM .label_custom {
     font-weight: bold;
     font-size: 0.8em;
     vertical-align: top;
@@ -318,7 +318,7 @@ font-weight: bold;
     vertical-align: top;
     height: 2em;
 }
-#HIS .label {
+#HIS .label_custom {
     font-weight: bold;
     font-size: 9pt;
     vertical-align: top;
@@ -336,7 +336,7 @@ font-weight: bold;
  * seen in the patient summary and notes screens
  *============================================================*/
 #pnotes .billing {
-    background-color: #dfd;  
+    background-color: #dfd;
 }
 
 #pnotes .highlight {
@@ -348,7 +348,7 @@ font-weight: bold;
 }
 
 #pnotes .noterow {
-    cursor: pointer; 
+    cursor: pointer;
 }
 
 #pnotes .noterow td {
@@ -444,7 +444,7 @@ font-weight: bold;
 #patient_pastenc {
     width:100%;
 }
-    
+
 #patient_pastenc .billing_note {
     width: 25%;
 }
@@ -521,7 +521,7 @@ font-weight: bold;
 #patient_reports ul {
     list-style: none;
 }
-    
+
 
 /*=============================================================
  * Report - Custom
@@ -637,6 +637,7 @@ font-weight: bold;
 .css_button_small:hover {
     background: #1050b6;
     box-shadow: 0px 1px 3px #DDD;
+    text-decoration: none;
 }
 
 .css_button, input[type="button"], input[type="submit"], button{
@@ -666,6 +667,7 @@ font-weight: bold;
 .css_button:hover, input[type="button"]:hover, input[type="submit"]:hover, button:hover {
     background: #1050b6;
     box-shadow: 3px 4px 6px #DDD ;
+    text-decoration: none;
 }
 
 input[type="button"][style="background-color:#ffff55"] {
@@ -723,7 +725,7 @@ div.tab table td {
 	padding-right: 1px; padding-bottom: 0px
 }
 
-div.tab table td.label {
+div.tab table td.label_custom {
 	min-width:80px;
 }
 
@@ -775,7 +777,7 @@ div.notab-right {
 	font-size: 0.8em;
 }
 
-#report_parameters table table td.label {
+#report_parameters table table td.label_custom {
 	text-align: right;
 }
 
@@ -860,15 +862,15 @@ font-size:9pt;
     padding: 10px 10px 10px 15px;
     color: black;
   }
-.alertmsg1 { 
+.alertmsg1 {
     border: 3px solid #fe7b7a;
     background-color: #ffd6d6 ;
   }
-.alertmsg2 { 
+.alertmsg2 {
     border: 3px solid #f56fff;
     background-color: #fabfff;
   }
-.alertmsg3 { 
+.alertmsg3 {
     border: 3px solid #9acc2e;
     background-color: #eef7dd;
   }

--- a/interface/themes/style_sky_blue.css
+++ b/interface/themes/style_sky_blue.css
@@ -295,7 +295,7 @@ font-weight: bold;
     padding-right: 5px;
     vertical-align: top;
 }
-#DEM .label {
+#DEM .label_custom {
     font-weight: bold;
     font-size: 0.8em;
     vertical-align: top;
@@ -318,7 +318,7 @@ font-weight: bold;
     vertical-align: top;
     height: 2em;
 }
-#HIS .label {
+#HIS .label_custom {
     font-weight: bold;
     font-size: 9pt;
     vertical-align: top;
@@ -637,6 +637,7 @@ font-weight: bold;
 .css_button_small:hover {
     background: #1050b6;
     box-shadow: 0px 1px 3px #DDD;
+    text-decoration: none;
 }
 
 .css_button, input[type="button"], input[type="submit"], button{
@@ -666,6 +667,7 @@ font-weight: bold;
 .css_button:hover, input[type="button"]:hover, input[type="submit"]:hover, button:hover {
     background: #1050b6;
     box-shadow: 3px 4px 6px #DDD ;
+    text-decoration: none;
 }
 
 input[type="button"][style="background-color:#ffff55"] {
@@ -723,7 +725,7 @@ div.tab table td {
 	padding-right: 1px; padding-bottom: 0px
 }
 
-div.tab table td.label {
+div.tab table td.label_custom {
 	min-width:80px;
 }
 
@@ -775,7 +777,7 @@ div.notab-right {
 	font-size: 0.8em;
 }
 
-#report_parameters table table td.label {
+#report_parameters table table td.label_custom {
 	text-align: right;
 }
 

--- a/interface/themes/style_tan.css
+++ b/interface/themes/style_tan.css
@@ -6,7 +6,7 @@
 body {
     margin: 0px 0px 0px 2px;
     /* set the base font and size for all DOM children */
-    font-family: 'FontAwesome' !important; 
+    font-family: 'FontAwesome' !important;
     content: "\f0c4";
     font-size: 1em;  /* set the base font size for all DOM children */
 }
@@ -141,7 +141,7 @@ a:hover {
 }
 
 /*=============================================================
- * Here we have taken variables from globals.php and turned them into CSS classes 
+ * Here we have taken variables from globals.php and turned them into CSS classes
  * these should be used in place of the GLOBAL variables -- JRM March 2008
  *=============================================================*/
 .body_top { background-color: #fffbeb; margin: 8px }    /* $top_bg_line */
@@ -240,8 +240,8 @@ font-weight: bold;
 }
 #documents_actions iframe {
     display: inline;
-    border:none; 
-    width:100%; 
+    border:none;
+    width:100%;
     height:600px;
     overflow: auto;
 }
@@ -267,7 +267,7 @@ font-weight: bold;
     padding-right: 5px;
     vertical-align: top;
 }
-#DEM .label {
+#DEM .label_custom {
     font-weight: bold;
     font-size: 0.8em;
     vertical-align: top;
@@ -290,7 +290,7 @@ font-weight: bold;
     vertical-align: top;
     height: 2em;
 }
-#HIS .label {
+#HIS .label_custom {
     font-weight: bold;
     font-size: 9pt;
     vertical-align: top;
@@ -308,7 +308,7 @@ font-weight: bold;
  * seen in the patient summary and notes screens
  *============================================================*/
 #pnotes .billing {
-    background-color: #dfd;  
+    background-color: #dfd;
 }
 #pnotes .highlight {
     background-color: #fff;
@@ -317,7 +317,7 @@ font-weight: bold;
     border-collapse:collapse;
 }
 #pnotes .noterow {
-    cursor: pointer; 
+    cursor: pointer;
 }
 #pnotes .noterow td {
     border-bottom:1px dashed black;
@@ -405,7 +405,7 @@ font-weight: bold;
 #patient_pastenc {
     width:100%;
 }
-    
+
 #patient_pastenc .billing_note {
     width: 25%;
 }
@@ -482,7 +482,7 @@ font-weight: bold;
 #patient_reports ul {
     list-style: none;
 }
-    
+
 
 /*=============================================================
  * Report - Custom
@@ -596,6 +596,7 @@ tr.odd {
 .css_button_small:hover {
   background: #1050b6;
   box-shadow: 0px 1px 3px #DDD;
+  text-decoration: none;
 }
 #dateNAV {
     font-size:1.1em !important;
@@ -624,6 +625,7 @@ tr.odd {
 .css_button:hover, input[type="button"]:hover, input[type="submit"]:hover, button:hover {
   background: #1050b6;
     box-shadow: 3px 4px 6px #DDD ;
+  text-decoration: none;
 }
 
 input[type="button"][style="background-color:#ffff55"] {
@@ -673,7 +675,7 @@ border-left: 1pt solid black;
 border-top: 1pt solid black;
 border-right: 1pt solid black;
 }
-ul.tabNav li.current { 
+ul.tabNav li.current {
     font-weight: bold;
     font-size: 0.8em;
     vertical-align: bottom;
@@ -683,7 +685,7 @@ z-index: 3;
 top: 0.0875em;
 border-left:1pt solid black;
 }
-ul.tabNav a { 
+ul.tabNav a {
     background: #F8E6CBE6;
 color: #333;
 display: block;
@@ -698,7 +700,7 @@ box-shadow: 2px -1px 1px #c0c0c0;
  }
 ul.tabNav li.current a { background:#FFFFFF; }
 
-div.tabContainer { 
+div.tabContainer {
     clear: both;
 float: left;
 width: 100%;
@@ -714,8 +716,8 @@ padding: 10px;
 }
 div.tabContainer div.tab { border: 1px solid #ffffff; color: #000; display: none; padding: 10px; }
 div.tabContainer div.current { display: block; box-shadow:0pt;}
-div.tab {   min-height: 180px; 
-    background: #ffffff none repeat scroll 0 0; 
+div.tab {   min-height: 180px;
+    background: #ffffff none repeat scroll 0 0;
     margin-bottom: 10px;
     width:800px;
 border: 1pt solid black;
@@ -730,7 +732,7 @@ table {
 div.tab table td {
     padding-right: 1px; padding-bottom: 0px;
 }
-div.tab table td.label {
+div.tab table td.label_custom {
     min-width:80px;
 }
 
@@ -815,7 +817,7 @@ div.summary_item div {
     font-size: 0.8em;
 }
 
-#report_parameters table table td.label {
+#report_parameters table table td.label_custom {
     text-align: right;
 }
 
@@ -900,15 +902,15 @@ font-size:9pt;
     padding: 10px 10px 10px 15px;
     color: black;
   }
-.alertmsg1 { 
+.alertmsg1 {
     border: 3px solid #fe7b7a;
     background-color: #ffd6d6 ;
   }
-.alertmsg2 { 
+.alertmsg2 {
     border: 3px solid #f56fff;
     background-color: #fabfff;
   }
-.alertmsg3 { 
+.alertmsg3 {
     border: 3px solid #9acc2e;
     background-color: #eef7dd;
   }
@@ -960,7 +962,7 @@ font-size:9pt;
 }
 
 #navigation-slide li a.collapsed{
-    
+
     color: #fff;
      background: none repeat scroll 0% 0% #16558C;
 }
@@ -995,7 +997,7 @@ body dl {
     list-style: none;
         float:left;
         background: #C9DBF2; /* for non-css3 browsers */
-        color:#000;    
+        color:#000;
 }
 
 #sddm li a

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -118,6 +118,17 @@ $USER_SPECIFIC_GLOBALS = array('default_top_pane',
                                'checkout_roll_off',
                                'erx_import_status_message');
 
+// Gets array of time zones supported by PHP.
+//
+function gblTimeZones() {
+  $zones = timezone_identifiers_list();
+  $arr = array('' => xl('Unassigned'));
+  foreach ($zones as $zone) {
+    $arr[$zone] = str_replace('_', ' ', $zone);
+  }
+  return $arr;
+}
+
 $GLOBALS_METADATA = array(
 
   // Appearance Tab
@@ -553,6 +564,13 @@ $GLOBALS_METADATA = array(
       ),
       '0',
       xl('Format used to display most times.')
+    ),
+
+    'gbl_time_zone' => array(
+      xl('Time Zone'),
+      gblTimeZones(),
+      '',
+      xl('If unassigned will default to php.ini setting for date.timezone.')
     ),
 
     'currency_decimals' => array(

--- a/library/options.inc.php
+++ b/library/options.inc.php
@@ -2418,9 +2418,9 @@ function display_layout_rows($formtype, $result1, $result2='') {
 	// Handle starting of a new label cell.
 	if ($titlecols > 0) {
 	  disp_end_cell();
-	  //echo "<td class='label' colspan='$titlecols' valign='top'";
+	  //echo "<td class='label_custom' colspan='$titlecols' valign='top'";
 	  $titlecols_esc = htmlspecialchars( $titlecols, ENT_QUOTES);
-	  echo "<td class='label' colspan='$titlecols_esc' ";
+	  echo "<td class='label_custom' colspan='$titlecols_esc' ";
 	  //if ($cell_count == 2) echo " style='padding-left:10pt'";
 	  echo ">";
 	  $cell_count += $titlecols;
@@ -2548,7 +2548,7 @@ function display_layout_tabs_data($formtype, $result1, $result2='') {
 					  disp_end_cell();
 					  $titlecols_esc = htmlspecialchars( $titlecols, ENT_QUOTES);
 					  $field_id_label = 'label_'.$group_fields['field_id'];
-					  echo "<td class='label' colspan='$titlecols_esc' id='" . attr($field_id_label) . "'";
+					  echo "<td class='label_custom' colspan='$titlecols_esc' id='" . attr($field_id_label) . "'";
 					  echo ">";
 					  $cell_count += $titlecols;
 					}
@@ -2686,7 +2686,7 @@ function display_layout_tabs_data_editable($formtype, $result1, $result2='') {
 					  disp_end_cell();
 					  $titlecols_esc = htmlspecialchars( $titlecols, ENT_QUOTES);
                       $field_id_label = 'label_'.$group_fields['field_id'];
-					  echo "<td class='label' colspan='$titlecols_esc' id='$field_id_label' ";
+					  echo "<td class='label_custom' colspan='$titlecols_esc' id='$field_id_label' ";
 					  echo ">";
 					  $cell_count += $titlecols;
 					}

--- a/library/templates/standard_header_template.php
+++ b/library/templates/standard_header_template.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ *
+ * This is to standardize the header to ease ui standardization for developers.
+ *
+ * Example code in script:
+ *    $include_standard_style_js = array("datetimepicker"); (php command and optional)
+ *    require($GLOBALS['srcdir'] . '/templates/standard_header_template.php'); (php command)
+ *
+ * The $include_standard_style_js supports:
+ *                                         datetimepicker
+ *
+ *
+ * Copyright (C) 2017 Brady Miller <brady.g.miller@gmail.com>
+ *
+ * LICENSE: This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://opensource.org/licenses/gpl-license.php>;.
+ *
+ * @package OpenEMR
+ * @author  Brady Miller <brady.g.miller@gmail.com>
+ * @link    http://www.open-emr.org
+ */
+?>
+<link rel="stylesheet" href="<?php echo $css_header;?>" type="text/css">
+<link rel="stylesheet" href="<?php echo $GLOBALS['assets_static_relative'] ?>/bootstrap-3-3-4/dist/css/bootstrap.min.css">
+<?php if ($_SESSION['language_direction'] == 'rtl') { ?>
+    <link rel="stylesheet" href="<?php echo $GLOBALS['assets_static_relative'] ?>/bootstrap-rtl-3-3-4/dist/css/bootstrap-rtl.min.css">
+<?php } ?>
+<link rel="stylesheet" href="<?php echo $GLOBALS['assets_static_relative'] ?>/font-awesome-4-6-3/css/font-awesome.min.css">
+<?php if (!empty($include_standard_style_js) && in_array("datetimepicker",$include_standard_style_js)) { ?>
+    <link rel="stylesheet" href="<?php echo $GLOBALS['assets_static_relative']; ?>/jquery-datetimepicker-2-5-4/build/jquery.datetimepicker.min.css">
+<?php } ?>
+
+<script src="<?php echo $GLOBALS['assets_static_relative'] ?>/jquery-min-3-1-1/index.js"></script>
+<script src="<?php echo $GLOBALS['assets_static_relative'] ?>/bootstrap-3-3-4/dist/js/bootstrap.min.js"></script>
+<?php if (!empty($include_standard_style_js) && in_array("datetimepicker",$include_standard_style_js)) { ?>
+    <script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/jquery-datetimepicker-2-5-4/build/jquery.datetimepicker.full.min.js"></script>
+<?php } ?>
+<?php $include_standard_style_js = array(); //clear this to prevent issues if this is called again in an embedded script ?>

--- a/portal/patient/_machine_config.php
+++ b/portal/patient/_machine_config.php
@@ -54,7 +54,8 @@ if (!$disable_utf8_flag) {
 }
 GlobalConfig::$CONNECTION_SETTING->Multibyte = true;
 // Turn off STRICT SQL
-GlobalConfig::$CONNECTION_SETTING->BootstrapSQL = "SET sql_mode = ''";
+GlobalConfig::$CONNECTION_SETTING->BootstrapSQL = "SET sql_mode = '', time_zone = '" .
+  (new DateTime())->format("P") . "'";
 
 /**
  * the root url of the application with trailing slash, for example http://localhost/patient/

--- a/portal/report/pat_ledger.php
+++ b/portal/report/pat_ledger.php
@@ -387,7 +387,7 @@ function sel_patient() {
 	<table class='text'>
 		<tr>
         <?php if($type_form == '0') { ?>
-			<td class='label'>
+			<td class='label_custom'>
 				<?php echo xlt('Facility'); ?>:
 			</td>
 			<td>
@@ -414,14 +414,14 @@ function sel_patient() {
         <?php echo xlt('From'); ?>:&nbsp;&nbsp;&nbsp;&nbsp;
         <input type='text' class='datepicker' name='form_from_date' id="form_from_date" size='10' value='<?php echo attr($form_from_date) ?>' title='yyyy-mm-dd'>
       </td>
-      <td class='label'>
+      <td class='label_custom'>
         <?php echo xlt('To'); ?>:
       </td>
       <td>
         <input type='text' class='datepicker' name='form_to_date' id="form_to_date" size='10' value='<?php echo attr($form_to_date) ?>' title='yyyy-mm-dd'>
       </td>
       <?php if($type_form == '0') { ?>
-      <td><span class='label'><?php echo xlt('Patient'); ?>:&nbsp;&nbsp;</span></td>
+      <td><span class='label_custom'><?php echo xlt('Patient'); ?>:&nbsp;&nbsp;</span></td>
       <td>
         <input type='text' size='20' name='form_patient' style='width:100%;cursor:pointer;cursor:hand' id='form_patient' value='<?php echo attr($form_patient) ? attr($form_patient) : xla('Click To Select'); ?>' onclick='sel_patient()' title='<?php echo xla('Click to select patient'); ?>' />
         <?php }else{ ?>

--- a/version.php
+++ b/version.php
@@ -35,7 +35,7 @@ $v_offsite_portal='1.47';
 // end with "?v=$v_js_includes".  Search the code for examples of doing this.
 // All this is to keep browsers from using an older cached version.
 // Need to assign it as a global below to work in template scripts.
-$v_js_includes = 21;
+$v_js_includes = 22;
 
 // Do note modify below
 $GLOBALS['v_js_includes'] = $v_js_includes;

--- a/version.php
+++ b/version.php
@@ -17,7 +17,7 @@ $v_realpatch = '0';
 // is a database change in the course of development.  It is used
 // internally to determine when a database upgrade is needed.
 //
-$v_database = 217;
+$v_database = 218;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
@juggernautsei This is how I would approach improving the UI -- I'd replace the table-based forms with the better `form-group` form.

Note the `container` wrapper and the use of the `col-md-<int>` classes to place the form in the center.

One random note, there was a bug in the style_light css file that was adding extraneous padding to the top of all `container` classes instead of just `menuBar > container`. Not sure why/how it was put there, but I pulled it.

![screen shot 2017-03-27 at 17 41 33](https://cloud.githubusercontent.com/assets/1381170/24379340/b03ac8d2-1314-11e7-967b-87f6c04c7682.png)
