### PR TITLE
Optimized docker for development

### DIFF
--- a/contrib/util/docker/Dockerfile
+++ b/contrib/util/docker/Dockerfile
@@ -21,7 +21,6 @@
 
 # Quick one-liner:
 # cd contrib/util/docker; docker build . -t openemr; cd ../../..; docker run -it -p 8000:80 -p 3306:3306 -v `pwd`:/var/www/html/ openemr
-# For debugging things: docker run -it -p 8000:80 -p 3306:3306 openemr bash
 
 # NB: The current directory now matters much more when building the container. Move to the contrib/util/docker container to build
 #     so you aren't sending ~500mb to the docker server, then move to the root of the git repo (or hardcode the absolute path)

--- a/contrib/util/docker/Dockerfile
+++ b/contrib/util/docker/Dockerfile
@@ -20,8 +20,12 @@
 # @link    http://www.open-emr.org
 
 # Quick one-liner:
-# docker build -f contrib/util/docker/Dockerfile . -t openemr && docker run -it -p 9000:80 openemr
-# For debugging things: docker run -it -p 9000:80 openemr bash
+# cd contrib/util/docker; docker build . -t openemr; cd ../../..; docker run -it -p 8000:80 -p 3306:3306 -v `pwd`:/var/www/html/ openemr
+# For debugging things: docker run -it -p 8000:80 -p 3306:3306 openemr bash
+
+# NB: The current directory now matters much more when building the container. Move to the contrib/util/docker container to build
+#     so you aren't sending ~500mb to the docker server, then move to the root of the git repo (or hardcode the absolute path)
+#     so the -v flag lines up (the absolute path of the git repo must be on the left, path to mount inside container on right)
 
 # NB: 'localhost' does not resolve to this container - use 127.0.0.1 instead for things like sql server
 
@@ -35,19 +39,10 @@ RUN yes | apt-get update && \
     yes | apt-get install mysql-server libcurl4-gnutls-dev && \
     docker-php-ext-install mysqli curl pdo_mysql
 
-COPY . /var/www/html/
-WORKDIR /var/www/html
-RUN chmod a+w \
-        sites/default/sqlconf.php \
-        interface/modules/zend_modules/config/application.config.php \
-        gacl/admin/templates_c  \
-        sites/default/edi       \
-        sites/default/era       \
-        sites/default/documents \
-        custom/letter_templates \
-        interface/main/calendar/modules/PostCalendar/pntemplates/compiled \
-        interface/main/calendar/modules/PostCalendar/pntemplates/cache;   \
-    find . -exec chown -R www-data:www-data {} \;
+# Configure SQL
+RUN sed -i 's/bind-address.*127.0.0.1/bind-address = 0.0.0.0/g' /etc/mysql/my.cnf
+RUN /etc/init.d/mysql start; sleep 3; \
+    mysql -u root --password='' -e 'GRANT ALL PRIVILEGES ON *.* TO "root"@"%" IDENTIFIED BY "" WITH GRANT OPTION; FLUSH PRIVILEGES;'
 
 # Setup config per. req
 ENV INI /usr/local/etc/php/conf.d/fixes.ini
@@ -83,4 +78,4 @@ RUN echo '<Directory "/var/www/html">'                      >> $CONF; \
     echo '  </Directory>'                                   >> $CONF; \
     echo 'LoadModule rewrite_module /usr/lib/apache2/modules/mod_rewrite.so' >> $CONF
 
-CMD ["sh", "-c", "/etc/init.d/mysql start; apache2-foreground"]
+CMD ["sh", "-c", "[ -e /var/www/html/contrib/util/docker/container_init.sh ] && /var/www/html/contrib/util/docker/container_init.sh || echo 'You have not mounted the openemr directory inside the container.'"]

--- a/contrib/util/docker/container_init.sh
+++ b/contrib/util/docker/container_init.sh
@@ -44,9 +44,8 @@ service apache2 start
 sleep 2 # politeness
 
 # Run auto-setup things
-if grep -q '$config = 0;' /var/www/html/sites/default/sqlconf.php; then
-	/var/www/html/contrib/util/docker/setup_automation.sh http://localhost
-fi
+sed -i 's/$config = 1;/$config = 0;/g' /var/www/html/sites/default/sqlconf.php
+/var/www/html/contrib/util/docker/setup_automation.sh http://localhost
 
 #sleep infinity
 bash

--- a/contrib/util/docker/container_init.sh
+++ b/contrib/util/docker/container_init.sh
@@ -44,8 +44,9 @@ service apache2 start
 sleep 2 # politeness
 
 # Run auto-setup things
-/var/www/html/contrib/util/docker/setup_automation.sh http://localhost
-
+if grep -q '$config = 0;' /var/www/html/sites/default/sqlconf.php; then
+	/var/www/html/contrib/util/docker/setup_automation.sh http://localhost
+fi
 
 #sleep infinity
 bash

--- a/contrib/util/docker/container_init.sh
+++ b/contrib/util/docker/container_init.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# contrib/util/docker/container_init.sh Docker container file to begin execution of openemr system
+#
+# A script which executes things when an openemr container starts.
+# Necessary because setup steps (changing file permissions) must happen
+# after we have access to files under /var/www/html/, and with
+# the newer setup this does not happen until after the container starts running.
+#
+# Copyright (C) 2017 Jeffrey McAteer <jeffrey.p.mcateer@gmail.com>
+#
+# LICENSE: This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://opensource.org/licenses/gpl-license.php>;.
+#
+# @package OpenEMR
+# @author  Jeffrey McAteer <jeffrey.p.mcateer@gmail.com>
+# @link    http://www.open-emr.org
+
+# Fix permissions
+cd /var/www/html/
+chmod a+w \
+    sites/default/sqlconf.php \
+    interface/modules/zend_modules/config/application.config.php \
+    gacl/admin/templates_c  \
+    sites/default/edi       \
+    sites/default/era       \
+    sites/default/documents \
+    custom/letter_templates \
+    interface/main/calendar/modules/PostCalendar/pntemplates/compiled \
+    interface/main/calendar/modules/PostCalendar/pntemplates/cache
+find . -exec chown -R www-data:www-data
+
+# Start mysql & apache
+service mysql start
+service apache2 start
+sleep 2 # politeness
+
+# Run auto-setup things
+/var/www/html/contrib/util/docker/setup_automation.sh http://localhost
+
+
+#sleep infinity
+bash
+# ^ better, you can poke things server-side with an interactive shell

--- a/contrib/util/docker/setup_automation.sh
+++ b/contrib/util/docker/setup_automation.sh
@@ -26,7 +26,7 @@ if ! hash curl >/dev/null 2>&1; then
 	exit 1
 fi
 
-# Password used for sql & openemr accounts created during setup
+# Password used for openemr accounts created during setup (sql root pass is empty)
 PASS=openemr
 IUFNAME=John
 IUNAME=Smith

--- a/contrib/util/docker/setup_automation.sh
+++ b/contrib/util/docker/setup_automation.sh
@@ -27,11 +27,14 @@ if ! hash curl >/dev/null 2>&1; then
 fi
 
 # Password used for sql & openemr accounts created during setup
-PASS='Passw0rd'
+PASS=openemr
 IUFNAME=John
 IUNAME=Smith
 
-BASE_URL=http://localhost:9000
+BASE_URL=$1
+if [[ "$BASE_URL" == "" ]]; then
+	BASE_URL=http://localhost:8000
+fi
 COOKIE_FILE=/tmp/curl_cookies
 # Change this to /dev/stdout debug the script
 CURL_REDIR=/dev/null


### PR DESCRIPTION
Docker now lets you mount outside files inside /var/ww/html, which means changes made in your favorite editor are now live in the container and changes the container makes go into existing files. I botched moving things around in git when I noticed running the docker container changed some files (e.g. sites/default/sqlconf.php) which hold information specific to one person's machine/setup, I was going to use .gitignore to keep them out of future commits. If anyone has a better idea I'd love to hear it. (like selectively picking files for commits - I have a script which just pushes everything in the working directory (shame on me)).