### PR TITLE
Fix - Past Appointments widget obscured when Recurrent Appointments widget is closed

### DIFF
--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -1528,8 +1528,8 @@ expand_collapse_widget($widgetTitle, $widgetLabel, $widgetButtonLabel,
                  }
                  echo "<span" . $red_text . ">" . xlt('End Date') . ': ' . text($row['pc_endDate']) . "</span>";
                  echo "</div>";
-                 echo "<br>";
              }
+             echo "</div>";
          }
      }
      /* End of recurrence widget */


### PR DESCRIPTION
Hello Brady,

The Past Appointments widget is obscured when Recurrent Appointments widget is closed. Also the font size for display of past appointments is effected by this bug.
