### PR TITLE
Restyled printable reports heading and new global addition. 

### DIFF
--- a/interface/globals.php
+++ b/interface/globals.php
@@ -141,6 +141,9 @@ if (empty($_SESSION['site_id']) || !empty($_GET['site'])) {
 // Set the site-specific directory path.
 $GLOBALS['OE_SITE_DIR'] = $GLOBALS['OE_SITES_BASE'] . "/" . $_SESSION['site_id'];
 
+// Set a site-specific uri root path.
+$GLOBALS['OE_SITE_WEBROOT'] = $web_root . "/sites/" . $_SESSION['site_id'];
+
 require_once($GLOBALS['OE_SITE_DIR'] . "/config.php");
 
 // Collecting the utf8 disable flag from the sqlconf.php file in order

--- a/interface/patient_file/report/custom_report.php
+++ b/interface/patient_file/report/custom_report.php
@@ -210,9 +210,12 @@ if ($printable) {
 
   // Use logo if it exists as 'practice_logo.gif' in the site dir
   // old code used the global custom dir which is no longer a valid
-   $practice_logo = "$OE_SITE_DIR/images/practice_logo.gif";
+  $practice_logo = "$OE_SITE_DIR/images/practice_logo.gif";
+  echo "<div><table><tr><td>";
    if (file_exists($practice_logo)) {
-        echo "<img src='$practice_logo' align='left'><br />\n";
+       $logo_path = $GLOBALS['OE_SITE_WEBROOT'] . "/images/practice_logo.gif"; // property img src needs a uri path
+       echo "<img src='$logo_path' align='left'><br />";
+       echo "</td><td>";
      }
 ?>
 <h2><?php echo $facility['name'] ?></h2>
@@ -222,7 +225,7 @@ if ($printable) {
 
 <a href="javascript:window.close();"><span class='title'><?php echo $titleres['fname'] . " " . $titleres['lname']; ?></span></a><br>
 <span class='text'><?php xl('Generated on','e'); ?>: <?php echo oeFormatShortDate(); ?></span>
-<br><br>
+<?php echo "</td></tr></table></div>";?>
 
 <?php
 }


### PR DESCRIPTION
Restyled printable patient reports heading for consistency and fixed practice logo path error in img scr.
ref issue: #670
With more and more use of sites document directory the building in-place of uri's for properties that require a uri instead of a file path becomes tedious. Made available $GLOBALS['OE_SITE_WEBROOT'] to address.