### PR TITLE
patient delete bug fix for tabs layout

### DIFF
--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -205,7 +205,11 @@ if ($result3['provider']) {   // Use provider in case there is an ins record w/ 
 
  // Called by the deleteme.php window on a successful delete.
  function imdeleted() {
-  parent.left_nav.clearPatient();
+  <?php if ($GLOBALS['new_tabs_layout']) { ?>
+   top.clearPatient();
+  <?php } else { ?>
+   parent.left_nav.clearPatient();
+  <?php } ?>
  }
 
  function newEvt() {


### PR DESCRIPTION
Noted this bug when I was testing the delete bug fix in the recent 5.0.0 patch. After deleting a patient in the tabs layout, nothing happened (ie. patient wasn't cleared from the display). This fixes that.