### PR TITLE
Therapy group improvements

### DIFF
--- a/interface/forms/group_attendance/functions.php
+++ b/interface/forms/group_attendance/functions.php
@@ -141,7 +141,8 @@ function insert_patient_encounter($pid, $gid, $group_encounter_date, $participan
             "VALUES (?, ?, ?, ?, ?, ?, ?);";
         $enc_id = generate_id();
         $sqlBindArray = array();
-        array_push($sqlBindArray, $group_encounter_date, $participantData['comment'], $pid, $enc_id, get_groups_cat_id() ,$pc_aid, $gid);
+        $user = (is_null($pc_aid)) ? $_SESSION["authId"] : $pc_aid;
+        array_push($sqlBindArray, $group_encounter_date, $participantData['comment'], $pid, $enc_id, get_groups_cat_id() ,$user, $gid);
         $form_id = sqlInsert($insert_encounter_sql, $sqlBindArray);
 
         global $userauthorized;

--- a/interface/forms/group_attendance/new.php
+++ b/interface/forms/group_attendance/new.php
@@ -51,7 +51,7 @@ if($form_id){//If editing a form or the form already exists (inwhich case will a
     }
 }
 else{//new form
-    $participants = getParticipants($therapy_group);
+    $participants = getParticipants($therapy_group, true);
 }
 
 ?>

--- a/interface/patient_file/history/encounters.php
+++ b/interface/patient_file/history/encounters.php
@@ -363,11 +363,11 @@ $getStringForPage="&pagesize=".attr($pagesize)."&pagestart=".attr($pagestart);
   <th class='right'><?php echo htmlspecialchars( xl('Paid'), ENT_NOQUOTES); ?></th>
   <th class='right'><?php echo htmlspecialchars( xl('Adj'), ENT_NOQUOTES); ?></th>
   <th class='right'><?php echo htmlspecialchars( xl('Bal'), ENT_NOQUOTES); ?></th>
-<?php } else { ?>
+<?php } elseif($attendant_type == 'pid') { ?>
   <th colspan='5'><?php echo htmlspecialchars( (($GLOBALS['phone_country_code'] == '1') ? xl('Billing') : xl('Coding')), ENT_NOQUOTES); ?></th>
 <?php } ?>
 
-<?php if (!$GLOBALS['ippf_specific']) { ?>
+<?php if ($attendant_type == 'pid' && !$GLOBALS['ippf_specific']) { ?>
   <th>&nbsp;<?php echo htmlspecialchars( (($GLOBALS['weight_loss_clinic']) ? xl('Payment') : xl('Insurance')), ENT_NOQUOTES); ?></th>
 <?php } ?>
 
@@ -752,7 +752,7 @@ while ($result4 = sqlFetchArray($res4)) {
         }
 
         // show insurance
-        if (!$GLOBALS['ippf_specific']) {
+        if ($attendant_type == 'pid' && !$GLOBALS['ippf_specific']) {
             $insured = oeFormatShortDate($raw_encounter_date);
             if ($auth_demo) {
                 $responsible = -1;

--- a/interface/therapy_groups/therapy_groups_models/therapy_groups_participants_model.php
+++ b/interface/therapy_groups/therapy_groups_models/therapy_groups_participants_model.php
@@ -29,14 +29,19 @@ class Therapy_groups_participants{
     const TABLE = 'therapy_groups_participants';
     const PATIENT_TABLE = 'patient_data';
 
-    public function getParticipants($groupId){
+    public function getParticipants($groupId, $onlyActive=false){
 
         $sql = "SELECT gp.*, p.fname, p.lname FROM " . self::TABLE . " AS gp ";
         $sql .= "JOIN " . self::PATIENT_TABLE . " AS p ON gp.pid = p.pid ";
         $sql .= "WHERE gp.group_id = ?";
+        $binds = array($groupId);
 
+        if($onlyActive) {
+            $sql .= " AND gp.group_patient_status = ?";
+            $binds[] = 10;
+        }
         $groupParticipants = array();
-        $result = sqlStatement($sql, array($groupId));
+        $result = sqlStatement($sql,$binds);
         while($gp = sqlFetchArray($result)){
             $groupParticipants[] = $gp;
         }

--- a/interface/therapy_groups/therapy_groups_views/groupDetailsParticipants.php
+++ b/interface/therapy_groups/therapy_groups_views/groupDetailsParticipants.php
@@ -192,6 +192,7 @@
                 { "width": "35%", "targets": 5 }
             ],
             "pageLength":6,
+            "order": [[ 0, "asc" ],[ 2, "desc" ]],
             "searching": false,
             <?php // Bring in the translations ?>
             <?php $translationsDatatablesOverride = array('lengthMenu'=>(xla('Display').' _MENU_  '.xla('records per page')),

--- a/interface/therapy_groups/therapy_groups_views/groupDetailsParticipants.php
+++ b/interface/therapy_groups/therapy_groups_views/groupDetailsParticipants.php
@@ -80,7 +80,7 @@
                                                         <span class="bold"><?php echo xlt('Date of registration'); ?>:</span>
                                                     </div>
                                                     <div class="col-md-8">
-                                                        <input type="text" name="group_patient_start" class="full-width datepicker"  value="<?php echo !is_null($participant_data) ? attr($participant_data['group_patient_start']): date('Y-m-d');?>">
+                                                        <input type="text" id="group_patient_start" name="group_patient_start" class="full-width datepicker"  value="<?php echo !is_null($participant_data) ? attr($participant_data['group_patient_start']): date('Y-m-d');?>">
                                                     </div>
                                                 </div>
                                             </div>
@@ -90,7 +90,7 @@
                                                 <span class="bold"><?php echo xlt('Comment'); ?>:</span>
                                             </div>
                                             <div class="col-md-8">
-                                                <input type="text" name="group_patient_comment" value="<?php echo !is_null($participant_data) ? attr($participant_data['group_patient_comment']): ''?>" class="full-width">
+                                                <input type="text" id="group_patient_comment" name="group_patient_comment" value="<?php echo !is_null($participant_data) ? attr($participant_data['group_patient_comment']): ''?>" class="full-width">
                                             </div>
                                         </div>
                                         <div class="row">
@@ -252,6 +252,9 @@
         $('#cancelAddParticipant').on('click', function(e){
             e.preventDefault();
             $('#add-participant-form').removeClass('showAddForm');
+            $('#participant_name').val('');
+            $('#group_patient_comment').val('');
+            $('#group_patient_start').val('<?php echo date('Y-m-d');?>');
         });
 
         $('#participant_name').on('click', function(){

--- a/library/group.inc
+++ b/library/group.inc
@@ -68,9 +68,9 @@ function getCounselors($gid){
 }
 
 //Fetches participants of group
-function getParticipants($gid){
+function getParticipants($gid, $onlyActive=false){
     $model = new Therapy_groups_participants();
-    $result = $model->getParticipants($gid);
+    $result = $model->getParticipants($gid,$onlyActive);
     return $result;
 }
 


### PR DESCRIPTION
Hi.
Here some improvements and fixes in the therapy group system.
1. option to get only active patients in the form group attendance.
2. sort participants (according Alphabetical and active before inactive).
3. empty fields on click 'cancel' in add participants forms.
4. hide columns that not relevant to group (billing and insurance ) from encounters history of groups.

Thanks
Amiel