### PR TITLE
fix for attendance form

### DIFF
--- a/interface/forms/group_attendance/new.php
+++ b/interface/forms/group_attendance/new.php
@@ -44,7 +44,10 @@ else {//In case didn't click 'edit' but an attendance form already exists (can't
 
 
 if($form_id){//If editing a form or the form already exists (inwhich case will automatically go into edit mode for existing form)
-    $participants_sql = "SELECT tgp.*, tgpa.*, p.fname, p.lname FROM therapy_groups_participant_attendance as tgpa JOIN patient_data as p ON tgpa.pid = p.id JOIN therapy_groups_participants tgp ON tgp.pid = tgpa.pid WHERE tgpa.form_id = ? AND tgp.group_patient_status = 10;";
+    $participants_sql =  "SELECT tgpa.*, p.fname, p.lname " .
+                         "FROM therapy_groups_participant_attendance as tgpa " .
+                         "JOIN patient_data as p ON tgpa.pid = p.id " .
+                         "WHERE tgpa.form_id = ?;";
     $result = sqlStatement($participants_sql, array($form_id));
     while($p = sqlFetchArray($result)){
         $participants[] = $p;


### PR DESCRIPTION
Brady hi,
The query would bring in the same participants multiple times (as many times as the groups they participate in) because of the extra JOIN.
This fixes it.
(And even though only active participants are supposed to be brought in, because this query is only for retrieving data from an already existing form, it makes no difference at this stage so we dont need to check this).
Also made the query more readable.
Thanks,
shachar