### PR TITLE
Minor styling fix to full tab styling

### DIFF
--- a/interface/main/tabs/templates/tabs_template.php
+++ b/interface/main/tabs/templates/tabs_template.php
@@ -40,7 +40,7 @@
                 <!-- /ko -->
             </div>
         <!-- /ko -->
-        <div class="tabNotchosen" style="width:100%;"></div>
+        <div class="tabsNoHover" style="width:100%;"></div>
     </div>
 </script>
 <script type="text/html" id="tabs-frames">

--- a/interface/themes/tabs_style_full.css
+++ b/interface/themes/tabs_style_full.css
@@ -54,7 +54,7 @@ body
 #mainBox > div
 {
     flex: 0 1 auto;
-    margin: 0 0 0 0;
+    margin: 0;
 }
 
 #mainBox > div.mainFrames
@@ -62,9 +62,9 @@ body
     display: flex;
     flex: 1 0 auto;
     flex-direction: column;
-    padding: 0 0 0 0;
+    padding: 0;
     z-index: 3;
-    margin: 0 0 0 0;
+    margin: 0;
 }
 
 #framesDisplay
@@ -143,6 +143,15 @@ body
 }
 .tabNotchosen:hover {
     background: #e9e9e9;
+}
+
+.tabsNoHover {
+    background: transparent !important;
+    border-top: 3pt solid transparent;
+    border-left: none;
+    border-right: none;
+    border-bottom: 1pt solid #1976d2;
+    display:block;
 }
 
 #dialogDiv
@@ -315,7 +324,6 @@ div.closeDlgIframe:before {
 }
 
 .appMenu
-
 .appMenu > span:hover
 {
     color: #fff;


### PR DESCRIPTION
When hovering over the tab bar in an area without a tab, the entire area would
change to the :hover background-color of a tabNotChosen. This PR supresses that
hover