### PR TITLE
deceased date fix

### DIFF
--- a/library/patient.inc
+++ b/library/patient.inc
@@ -952,7 +952,7 @@ function fixDate($date, $default="0000-00-00") {
 
 function pdValueOrNull($key, $value) {
   if (($key == 'DOB' || $key == 'regdate' || $key == 'contrastart' ||
-    substr($key, 0, 8) == 'userdate') &&
+    substr($key, 0, 8) == 'userdate' || $key == 'deceased_date') &&
     (empty($value) || $value == '0000-00-00'))
   {
     return "NULL";


### PR DESCRIPTION
Bug:
When saving empty deceased date (patient demographics) the date would be inserted as 00-00-0000, not as null.

Fix:
Now if empty or 00-00-0000, will be saved as null in db and appear empty in demographics.

Thank you!
