### PR TITLE
Sub categories in the 'modules' section

### DIFF
--- a/interface/main/tabs/menu/menu_updates.php
+++ b/interface/main/tabs/menu/menu_updates.php
@@ -31,30 +31,66 @@ $menu_update_map["Create Visit"] = "update_create_visit";
 
 function update_modules_menu(&$menu_list)
 {
-    $module_query = sqlStatement("select mod_directory,mod_name,mod_nick_name,mod_relative_link,type from modules where mod_active = 1 AND sql_run= 1 order by mod_ui_order asc");
+    $module_query = sqlStatement("select mod_id,mod_directory,mod_name,mod_nick_name,mod_relative_link,type from modules where mod_active = 1 AND sql_run= 1 order by mod_ui_order asc");
     if (sqlNumRows($module_query)) {
-      while ($modulerow = sqlFetchArray($module_query)) {
-                    $acl_section = strtolower($modulerow['mod_directory']);
-                    if (!zh_acl_check($_SESSION['authUserID'],$acl_section)) continue;
-                    $modulePath = "";
-                    $added 		= "";
-                    if($modulerow['type'] == 0) {
-                            $modulePath = $GLOBALS['customModDir'];
-                            $added		= "";
-                    }
-                    else{
-                            $added		= "index";
-                            $modulePath = $GLOBALS['zendModDir'];
-                    }
+        while ($modulerow = sqlFetchArray($module_query)) {
 
-                    $relative_link ="/interface/modules/".$modulePath."/".$modulerow['mod_relative_link'].$added;
-                    $mod_nick_name = $modulerow['mod_nick_name'] ? $modulerow['mod_nick_name'] : $modulerow['mod_name'];
-          $newEntry=new stdClass();
-          $newEntry->label=xlt($mod_nick_name);
-          $newEntry->url=$relative_link;
-          $newEntry->requirement=0;
-          $newEntry->target='mod';
-          array_push($menu_list->children,$newEntry);
+            $module_hooks =  sqlStatement("SELECT msh.*,ms.obj_name,ms.menu_name,ms.path,m.mod_ui_name,m.type FROM modules_hooks_settings AS msh LEFT OUTER JOIN modules_settings AS ms ON
+                                    obj_name=enabled_hooks AND ms.mod_id=msh.mod_id LEFT OUTER JOIN modules AS m ON m.mod_id=ms.mod_id
+                                    WHERE m.mod_id = ? AND fld_type=3 AND mod_active=1 AND sql_run=1 AND attached_to='modules' ORDER BY m.mod_id",array($modulerow['mod_id']));
+
+            $modulePath = "";
+            $added 		= "";
+            if($modulerow['type'] == 0) {
+                $modulePath = $GLOBALS['customModDir'];
+                $added		= "";
+            }
+            else{
+                $added		= "index";
+                $modulePath = $GLOBALS['zendModDir'];
+            }
+            $relative_link ="/interface/modules/".$modulePath."/".$modulerow['mod_relative_link'].$added;
+            $mod_nick_name = $modulerow['mod_nick_name'] ? $modulerow['mod_nick_name'] : $modulerow['mod_name'];
+
+            if (sqlNumRows($module_hooks) == 0) {
+                // module without hooks in module section
+                $acl_section = strtolower($modulerow['mod_directory']);
+                if (acl_check('admin','super') || zh_acl_check($_SESSION['authUserID'],$acl_section) ?  "" : "1")continue;
+                $newEntry=new stdClass();
+                $newEntry->label=xlt($mod_nick_name);
+                $newEntry->url=$relative_link;
+                $newEntry->requirement=0;
+                $newEntry->target='mod';
+                array_push($menu_list->children,$newEntry);
+            } else {
+                // module with hooks in module section
+                $newEntry=new stdClass();
+                $newEntry->requirement=0;
+                $newEntry->icon="fa-caret-right";
+                $newEntry->label=xlt($mod_nick_name);
+                $newEntry->children=array();
+                $jid = 0;
+                $modid = '';
+                while ($hookrow = sqlFetchArray($module_hooks)) {
+                    if (acl_check('admin','super') || zh_acl_check($_SESSION['authUserID'],$hookrow['obj_name']) ?  "" : "1")continue;
+
+                    $relative_link ="/interface/modules/".$modulePath."/".$hookrow['mod_relative_link'].$hookrow['path'];
+                    $mod_nick_name = $hookrow['menu_name'] ? $hookrow['menu_name'] : 'NoName';
+
+                    if($jid==0 || ($modid!=$hookrow['mod_id'])){
+
+                        $subEntry=new stdClass();
+                        $subEntry->requirement=0;
+                        $subEntry->target='mod';
+                        $subEntry->menu_id='mod0';
+                        $subEntry->label=xlt($mod_nick_name);
+                        $subEntry->url=$relative_link;
+                        $newEntry->children[] = $subEntry;
+                    }
+                    $jid++;
+                }
+                array_push($menu_list->children,$newEntry);
+            }
        }
     }
 }

--- a/interface/modules/zend_modules/module/Installer/src/Installer/Model/InstModuleTable.php
+++ b/interface/modules/zend_modules/module/Installer/src/Installer/Model/InstModuleTable.php
@@ -673,6 +673,7 @@ class InstModuleTable
       'reports'       => "Reports",
       'encounter'     => "Encounter",
       'demographics'  => "Demographics",
+      'modules'  => "Modules",
     );
   }
   


### PR DESCRIPTION
Hi brady.

Here I've added functionality for the hooks of openemr modules.
Without this PR after installation of new module added new link for the module under  'Modules' section, but it's doesn't support sub categories and it's possible to add only one screen for every modules.
I've saved on the last  functionality but I add option for locate hooks in the modules section -
![image](https://cloud.githubusercontent.com/assets/17809866/26358155/4ba99d9c-3fda-11e7-8796-d1310690e6aa.png)
Now if you choose to put the hooks in the modules it will locate in sub categories under the name of the module and it's possible to put few screens under one label.
![image](https://cloud.githubusercontent.com/assets/17809866/26358442/487b5bf0-3fdb-11e7-8efe-83215924aa43.png)

It's work correctly in the frames menu and also with tabs layout.

Thanks.
Amiel
