### PR TITLE
start of project to remove pure php code from smarty templates

### DIFF
--- a/interface/forms/soap/templates/general_new.html
+++ b/interface/forms/soap/templates/general_new.html
@@ -3,7 +3,7 @@
 
 <title>{xl t='SOAP'|escape:'html'}</title>
 
-{php}require "{$GLOBALS['srcdir']}/templates/standard_header_template.php";{/php}
+{headerTemplate}
 
 </head>
 <body class="body_top">

--- a/library/smarty/plugins/function.headerTemplate.php
+++ b/library/smarty/plugins/function.headerTemplate.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Smarty plugin
+ * @package Smarty
+ * @subpackage plugins
+ * headerTemplate() version for smarty templates
+ *
+ * Copyright (C) 2017 Brady Miller <brady.g.miller@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+
+/**
+ * Smarty {headerTemplate} function plugin
+ *
+ * Type:     function<br>
+ * Name:     headerTemplate<br>
+ * Purpose:  headerTemplate in OpenEMR - Smarty templates<br>
+ *
+ * @param array
+ * @param Smarty
+ */
+
+
+function smarty_function_headerTemplate($params, &$smarty)
+{
+    if (!empty($params['assets'])) {
+        $include_standard_style_js = explode('|',$params['assets']);
+    }
+    require "{$GLOBALS['srcdir']}/templates/standard_header_template.php";
+}

--- a/library/templates/standard_header_template.php
+++ b/library/templates/standard_header_template.php
@@ -3,9 +3,15 @@
  *
  * This is to standardize the header to ease ui standardization for developers.
  *
- * Example code in script:
+ * Example code in pure php script:
  *    $include_standard_style_js = array("datetimepicker"); (php command and optional)
  *    require "{$GLOBALS['srcdir']}/templates/standard_header_template.php"; (php command)
+ *
+ * Examples of code in smarty script (uses plugin wrapper at library/smarty/plugins/function.headerTemplate.php):
+ *    {headerTemplate}  (this will bring in all the standard stuff)
+ *    {headerTemplate assets='datetimepicker'}  (standard stuff plus 1 optional assets)
+ *    {headerTemplate assets='datetimepicker|report_helper.js'}  (standard stuff plus multiple optional assets. ie. via | delimiter)
+ *
  *
  * The $include_standard_style_js supports:
  *                                         jquery-ui (brings in just the js script)


### PR DESCRIPTION
For future proofing (to allow going smarty2 to smarty3 or to change to another templating structure), need to remove the pure php code from the smarty templates. This is the first code towards that where make the SOAP template without any pure php and also bring in a mechanism to bring in the standard header.