### PR TITLE
ACL fix - hide forms data in the encounter with high sensitivity  

### DIFF
--- a/interface/patient_file/encounter/forms.php
+++ b/interface/patient_file/encounter/forms.php
@@ -379,12 +379,12 @@ if ($attendant_type == 'pid' && is_numeric($pid)) {
         $auth_notes_a = $auth_notes = $auth_relaxed = 0;
     }
     // Check for no access to the encounter's sensitivity level.
-    $high_sensitivity=false;
+    $no_match_sensitivity=false;
     $result = sqlQuery("SELECT sensitivity FROM form_encounter WHERE " .
                         "pid = '$pid' AND encounter = '$encounter' LIMIT 1");
     if ($result['sensitivity'] && !acl_check('sensitivities', $result['sensitivity'])) {
         $auth_notes_a = $auth_notes = $auth_relaxed = 0;
-        $high_sensitivity=true;
+        $no_match_sensitivity=true;
     }
     // for therapy group
 } else {
@@ -397,12 +397,12 @@ if ($attendant_type == 'pid' && is_numeric($pid)) {
         $auth_notes_a = $auth_notes = $auth_relaxed = 0;
     }
     // Check for no access to the encounter's sensitivity level.
-    $high_sensitivity=false;
+    $no_match_sensitivity=false;
     $result = sqlQuery("SELECT sensitivity FROM form_groups_encounter WHERE " .
         "group_id = ? AND encounter = ? LIMIT 1", array($groupId, $encounter));
     if ($result['sensitivity'] && !acl_check('sensitivities', $result['sensitivity'])) {
         $auth_notes_a = $auth_notes = $auth_relaxed = 0;
-        $high_sensitivity=true;
+        $no_match_sensitivity=true;
     }
 }
 ?>
@@ -580,7 +580,7 @@ if ( $esign->isButtonViewable() ) {
 
 <?php
 
-  if (!$high_sensitivity && $result = getFormByEncounter($attendant_id, $encounter, "id, date, form_id, form_name, formdir, user, deleted")) {
+  if (!$no_match_sensitivity && $result = getFormByEncounter($attendant_id, $encounter, "id, date, form_id, form_name, formdir, user, deleted")) {
     echo "<table width='100%' id='partable'>";
 	$divnos=1;
     foreach ($result as $iter) {

--- a/interface/patient_file/encounter/forms.php
+++ b/interface/patient_file/encounter/forms.php
@@ -379,12 +379,10 @@ if ($attendant_type == 'pid' && is_numeric($pid)) {
         $auth_notes_a = $auth_notes = $auth_relaxed = 0;
     }
     // Check for no access to the encounter's sensitivity level.
-    $no_match_sensitivity=false;
     $result = sqlQuery("SELECT sensitivity FROM form_encounter WHERE " .
                         "pid = '$pid' AND encounter = '$encounter' LIMIT 1");
     if ($result['sensitivity'] && !acl_check('sensitivities', $result['sensitivity'])) {
         $auth_notes_a = $auth_notes = $auth_relaxed = 0;
-        $no_match_sensitivity=true;
     }
     // for therapy group
 } else {
@@ -397,12 +395,10 @@ if ($attendant_type == 'pid' && is_numeric($pid)) {
         $auth_notes_a = $auth_notes = $auth_relaxed = 0;
     }
     // Check for no access to the encounter's sensitivity level.
-    $no_match_sensitivity=false;
     $result = sqlQuery("SELECT sensitivity FROM form_groups_encounter WHERE " .
         "group_id = ? AND encounter = ? LIMIT 1", array($groupId, $encounter));
     if ($result['sensitivity'] && !acl_check('sensitivities', $result['sensitivity'])) {
         $auth_notes_a = $auth_notes = $auth_relaxed = 0;
-        $no_match_sensitivity=true;
     }
 }
 ?>
@@ -580,7 +576,7 @@ if ( $esign->isButtonViewable() ) {
 
 <?php
 
-  if (!$no_match_sensitivity && $result = getFormByEncounter($attendant_id, $encounter, "id, date, form_id, form_name, formdir, user, deleted")) {
+  if ($auth_notes_a && $result = getFormByEncounter($attendant_id, $encounter, "id, date, form_id, form_name, formdir, user, deleted")) {
     echo "<table width='100%' id='partable'>";
 	$divnos=1;
     foreach ($result as $iter) {

--- a/interface/patient_file/encounter/forms.php
+++ b/interface/patient_file/encounter/forms.php
@@ -379,10 +379,12 @@ if ($attendant_type == 'pid' && is_numeric($pid)) {
         $auth_notes_a = $auth_notes = $auth_relaxed = 0;
     }
     // Check for no access to the encounter's sensitivity level.
+    $high_sensitivity=false;
     $result = sqlQuery("SELECT sensitivity FROM form_encounter WHERE " .
                         "pid = '$pid' AND encounter = '$encounter' LIMIT 1");
     if ($result['sensitivity'] && !acl_check('sensitivities', $result['sensitivity'])) {
         $auth_notes_a = $auth_notes = $auth_relaxed = 0;
+        $high_sensitivity=true;
     }
     // for therapy group
 } else {
@@ -395,10 +397,12 @@ if ($attendant_type == 'pid' && is_numeric($pid)) {
         $auth_notes_a = $auth_notes = $auth_relaxed = 0;
     }
     // Check for no access to the encounter's sensitivity level.
+    $high_sensitivity=false;
     $result = sqlQuery("SELECT sensitivity FROM form_groups_encounter WHERE " .
         "group_id = ? AND encounter = ? LIMIT 1", array($groupId, $encounter));
     if ($result['sensitivity'] && !acl_check('sensitivities', $result['sensitivity'])) {
         $auth_notes_a = $auth_notes = $auth_relaxed = 0;
+        $high_sensitivity=true;
     }
 }
 ?>
@@ -576,7 +580,7 @@ if ( $esign->isButtonViewable() ) {
 
 <?php
 
-  if ($result = getFormByEncounter($attendant_id, $encounter, "id, date, form_id, form_name, formdir, user, deleted")) {
+  if (!$high_sensitivity && $result = getFormByEncounter($attendant_id, $encounter, "id, date, form_id, form_name, formdir, user, deleted")) {
     echo "<table width='100%' id='partable'>";
 	$divnos=1;
     foreach ($result as $iter) {


### PR DESCRIPTION
Hi.

I've found that  in the encounter with high sensitivity the forms data is available to all user even if user is with normal sensitivity in the acl system. 
So I fixed it.. and hide all the encounter data.

Thanks
 Amiel