### PR TITLE
option not to show sql query in lists edit

### DIFF
--- a/library/sql.inc
+++ b/library/sql.inc
@@ -514,19 +514,31 @@ function sqlNumRows($r)
 */
 function HelpfulDie ($statement, $sqlerr='')
 {
-  echo "<p><p><font color='red'>ERROR:</font> ".text($statement)."<p>";
+
+  if($GLOBALS['sql_string_no_show_screen']){
+    echo "<h2>" . xlt('Save Unsuccessful.') . "</h2>";
+  }
+
+  if(!$GLOBALS['sql_string_no_show_screen']) {
+    echo "<p><p><font color='red'>ERROR:</font> " . text($statement) . "<p>";
+  }
   $logMsg="SQL Error with statement:".$statement;
   if ($sqlerr) {
-    echo "Error: <font color='red'>".text($sqlerr)."</font><p>";
+    if(!$GLOBALS['sql_string_no_show_screen']) {
+       echo "Error: <font color='red'>" . text($sqlerr) . "</font><p>";
+    }
     $logMsg.="--".$sqlerr;
   }//if error
-  $backtrace=debug_backtrace();
-  for($level=1;$level<count($backtrace);$level++)
-  {
-      $info=$backtrace[$level];
-      echo "<br>".text($info["file"]." at ".$info["line"].":".$info["function"]);
-      if($level>1){
-          echo "(".text(implode(",",$info["args"])).")";
+
+  if(!$GLOBALS['sql_string_no_show_screen']) {
+      $backtrace = debug_backtrace();
+      for ($level = 1; $level < count($backtrace); $level++)
+      {
+          $info = $backtrace[$level];
+          echo "<br>" . text($info["file"] . " at " . $info["line"] . ":" . $info["function"]);
+          if ($level > 1) {
+              echo "(" . text(implode(",", $info["args"])) . ")";
+          }
       }
   }
   $logMsg.="==>".$backtrace[1]["file"]." at ".$backtrace[1]["line"].":".$backtrace[1]["function"];

--- a/library/sql.inc
+++ b/library/sql.inc
@@ -518,11 +518,12 @@ function HelpfulDie ($statement, $sqlerr='')
   if($GLOBALS['sql_string_no_show_screen']){
     echo "<h2>" . xlt('Save Unsuccessful.') . "</h2>";
   }
-
-  if(!$GLOBALS['sql_string_no_show_screen']) {
+  else {
     echo "<p><p><font color='red'>ERROR:</font> " . text($statement) . "<p>";
   }
+
   $logMsg="SQL Error with statement:".$statement;
+
   if ($sqlerr) {
     if(!$GLOBALS['sql_string_no_show_screen']) {
        echo "Error: <font color='red'>" . text($sqlerr) . "</font><p>";
@@ -530,8 +531,9 @@ function HelpfulDie ($statement, $sqlerr='')
     $logMsg.="--".$sqlerr;
   }//if error
 
+  $backtrace = debug_backtrace();
+
   if(!$GLOBALS['sql_string_no_show_screen']) {
-      $backtrace = debug_backtrace();
       for ($level = 1; $level < count($backtrace); $level++)
       {
           $info = $backtrace[$level];
@@ -541,7 +543,9 @@ function HelpfulDie ($statement, $sqlerr='')
           }
       }
   }
+
   $logMsg.="==>".$backtrace[1]["file"]." at ".$backtrace[1]["line"].":".$backtrace[1]["function"];
+
   error_log($logMsg);
 
   exit;


### PR DESCRIPTION
Hi Brady,
Issue:
Whenever sqlInsert is called and returns an error, this HelpfulDie method shows the query on the screen.
So I used the `sql_string_no_show_screen` global so we have the option not to show the sql query.
Is it okay that I used this global or do I need to create a new global?

thanks