### PR TITLE
Allow a default Visit Category type to be set

### DIFF
--- a/interface/forms/newpatient/common.php
+++ b/interface/forms/newpatient/common.php
@@ -206,11 +206,12 @@ function cancelClicked() {
                        FROM openemr_postcalendar_categories
                        WHERE pc_active = 1 ORDER BY pc_seq";
           $visitResult = sqlStatement($visitSQL);
+          $therapyGroupCategories = [];
 
           while ($row = sqlFetchArray($visitResult)) {
-              $id = $row['pc_catid'];
+              $catId = $row['pc_catid'];
               $name = $row['pc_catname'];
-              if (($id < 9 && $id != "5") || $id === "_blank") {
+              if (($catId < 9 && $catId != "5") || $catId === "_blank") {
                   continue;
               }
 
@@ -220,9 +221,9 @@ function cancelClicked() {
 
 
               $optionStr = '<option value="%pc_catid%" %selected%>%pc_catname%</option>';
-              $optionStr = str_replace("%pc_catid%", attr($id), $optionStr);
-              $optionStr = str_replace("%pc_catname%", xl($name), $optionStr);
-              $selected = ($GLOBALS['default_visit_category'] == $id) ? " selected" : "";
+              $optionStr = str_replace("%pc_catid%", attr($catId), $optionStr);
+              $optionStr = str_replace("%pc_catname%", text(xl_appt_category($name)), $optionStr);
+              $selected = ($GLOBALS['default_visit_category'] == $catId) ? " selected" : "";
               $optionStr = str_replace("%selected%", $selected, $optionStr);
               echo $optionStr;
           }

--- a/interface/forms/newpatient/common.php
+++ b/interface/forms/newpatient/common.php
@@ -200,22 +200,33 @@ function cancelClicked() {
      <td class='bold' nowrap><?php echo xlt('Visit Category:'); ?></td>
      <td class='text'>
       <select name='pc_catid' id='pc_catid'>
-	<option value='_blank'>-- <?php echo xlt('Select One'); ?> --</option>
-<?php
- $cres = sqlStatement("SELECT pc_catid, pc_catname, pc_cattype " .
-  "FROM openemr_postcalendar_categories where pc_active = 1 ORDER BY pc_seq ");
- $therapyGroupCategories = array();
- while ($crow = sqlFetchArray($cres)) {
-  $catid = $crow['pc_catid'];
-  if($crow['pc_cattype'] == 3)$therapyGroupCategories[] = $catid;
-  // Show Thrapy group category only if global enable_group_therapy is true
-  if($crow['pc_cattype'] == 3 && !$GLOBALS['enable_group_therapy']) continue;
-  if ($catid < 9 && $catid != 5) continue;
-  echo "       <option value='" . attr($catid) . "'";
-  if ($viewmode && $crow['pc_catid'] == $result['pc_catid']) echo " selected";
-  echo ">" . text(xl_appt_category($crow['pc_catname'])) . "</option>\n";
- }
-?>
+          <option value='_blank'>-- <?php echo xlt('Select One'); ?> --</option>
+          <?php
+          $visitSQL = "SELECT pc_catid, pc_catname, pc_cattype 
+                       FROM openemr_postcalendar_categories
+                       WHERE pc_active = 1 ORDER BY pc_seq";
+          $visitResult = sqlStatement($visitSQL);
+
+          while ($row = sqlFetchArray($visitResult)) {
+              $id = $row['pc_catid'];
+              $name = $row['pc_catname'];
+              if (($id < 9 && $id != "5") || $id === "_blank") {
+                  continue;
+              }
+
+              if ($row['pc_cattype'] == 3 && !$GLOBALS['enable_group_therapy']) {
+                  continue;
+              }
+
+
+              $optionStr = '<option value="%pc_catid%" %selected%>%pc_catname%</option>';
+              $optionStr = str_replace("%pc_catid%", $row['pc_catid'], $optionStr);
+              $optionStr = str_replace("%pc_catname%", $row['pc_catname'], $optionStr);
+              $selected = ($GLOBALS['default_visit_category'] == $id) ? " selected" : "";
+              $optionStr = str_replace("%selected%", $selected, $optionStr);
+              echo $optionStr;
+          }
+          ?>
       </select>
      </td>
     </tr>

--- a/interface/forms/newpatient/common.php
+++ b/interface/forms/newpatient/common.php
@@ -211,6 +211,10 @@ function cancelClicked() {
           while ($row = sqlFetchArray($visitResult)) {
               $catId = $row['pc_catid'];
               $name = $row['pc_catname'];
+
+              if ($row['pc_cattype'] == 3) {
+                  $therapyGroupCategories[] = $catId;
+              }
               if (($catId < 9 && $catId != "5") || $catId === "_blank") {
                   continue;
               }

--- a/interface/forms/newpatient/common.php
+++ b/interface/forms/newpatient/common.php
@@ -223,7 +223,11 @@ function cancelClicked() {
               $optionStr = '<option value="%pc_catid%" %selected%>%pc_catname%</option>';
               $optionStr = str_replace("%pc_catid%", attr($catId), $optionStr);
               $optionStr = str_replace("%pc_catname%", text(xl_appt_category($name)), $optionStr);
-              $selected = ($GLOBALS['default_visit_category'] == $catId) ? " selected" : "";
+              if ($viewmode) {
+                  $selected = ($result['pc_catid'] == $catId) ? " selected" : "";
+              } else {
+                  $selected = ($GLOBALS['default_visit_category'] == $catId) ? " selected" : "";
+              }
               $optionStr = str_replace("%selected%", $selected, $optionStr);
               echo $optionStr;
           }

--- a/interface/forms/newpatient/common.php
+++ b/interface/forms/newpatient/common.php
@@ -220,8 +220,8 @@ function cancelClicked() {
 
 
               $optionStr = '<option value="%pc_catid%" %selected%>%pc_catname%</option>';
-              $optionStr = str_replace("%pc_catid%", $row['pc_catid'], $optionStr);
-              $optionStr = str_replace("%pc_catname%", $row['pc_catname'], $optionStr);
+              $optionStr = str_replace("%pc_catid%", attr($id), $optionStr);
+              $optionStr = str_replace("%pc_catname%", xl($name), $optionStr);
               $selected = ($GLOBALS['default_visit_category'] == $id) ? " selected" : "";
               $optionStr = str_replace("%selected%", $selected, $optionStr);
               echo $optionStr;

--- a/interface/super/edit_globals.php
+++ b/interface/super/edit_globals.php
@@ -573,17 +573,17 @@ foreach ($GLOBALS_METADATA as $grpname => $grparr) {
         "<input type='button' value='" . xla('Default'). "' onclick=\"document.forms[0].form_$i.color.fromString('" . attr($flddef) . "')\">\n";
     }
 
-    else if ($fldtype == 'visit_category') {
+    else if ($fldtype == 'default_visit_category') {
         $sql = "SELECT pc_catid, pc_catname, pc_cattype 
                 FROM openemr_postcalendar_categories
                 WHERE pc_active = 1 ORDER BY pc_seq";
         $result = sqlStatement($sql);
         echo "<select name=\"form_{$i}\" id=\"form_{$i}\">\n";
-        echo "<option value='_blank'>" . xl('None') . "</option>";
+        echo "<option value='_blank'>" . xlt('None') . "</option>";
         while ($row = sqlFetchArray($result)) {
-            $id = $row['pc_catid'];
+            $catId = $row['pc_catid'];
             $name = $row['pc_catname'];
-            if ($id < 9 && $id != "5") {
+            if ($catId < 9 && $catId != "5") {
                 continue;
             }
 
@@ -592,9 +592,9 @@ foreach ($GLOBALS_METADATA as $grpname => $grparr) {
             }
 
             $optionStr = '<option value="%pc_catid%"%selected%>%pc_catname%</option>';
-            $optionStr = str_replace("%pc_catid%", attr($id), $optionStr);
-            $optionStr = str_replace("%pc_catname%", xl($name), $optionStr);
-            $selected = ($fldvalue == $id) ? " selected" : "";
+            $optionStr = str_replace("%pc_catid%", attr($catId), $optionStr);
+            $optionStr = str_replace("%pc_catname%", text(xl_appt_category($name)), $optionStr);
+            $selected = ($fldvalue == $catId) ? " selected" : "";
             $optionStr = str_replace("%selected%", $selected, $optionStr);
             echo $optionStr;
 

--- a/interface/super/edit_globals.php
+++ b/interface/super/edit_globals.php
@@ -573,6 +573,35 @@ foreach ($GLOBALS_METADATA as $grpname => $grparr) {
         "<input type='button' value='" . xla('Default'). "' onclick=\"document.forms[0].form_$i.color.fromString('" . attr($flddef) . "')\">\n";
     }
 
+    else if ($fldtype == 'visit_category') {
+        $sql = "SELECT pc_catid, pc_catname, pc_cattype 
+                FROM openemr_postcalendar_categories
+                WHERE pc_active = 1 ORDER BY pc_seq";
+        $result = sqlStatement($sql);
+        echo "<select name=\"form_{$i}\" id=\"form_{$i}\">\n";
+        echo "<option value='_blank'>" . xlt('None') . "</option>";
+        while ($row = sqlFetchArray($result)) {
+            $id = $row['pc_catid'];
+            $name = $row['pc_catname'];
+            if ($id < 9 && $id != "5") {
+                continue;
+            }
+
+            if ($row['pc_cattype'] == 3 && !$GLOBALS['enable_group_therapy']) {
+                continue;
+            }
+
+            $optionStr = '<option value="%pc_catid%"%selected%>%pc_catname%</option>';
+            $optionStr = str_replace("%pc_catid%", $row['pc_catid'], $optionStr);
+            $optionStr = str_replace("%pc_catname%", $row['pc_catname'], $optionStr);
+            $selected = ($fldvalue == $id) ? " selected" : "";
+            $optionStr = str_replace("%selected%", $selected, $optionStr);
+            echo $optionStr;
+
+        }
+        echo "</select>";
+    }
+
     else if ($fldtype == 'css') {
       if ($userMode) {
         $globalTitle = $globalValue;

--- a/interface/super/edit_globals.php
+++ b/interface/super/edit_globals.php
@@ -579,7 +579,7 @@ foreach ($GLOBALS_METADATA as $grpname => $grparr) {
                 WHERE pc_active = 1 ORDER BY pc_seq";
         $result = sqlStatement($sql);
         echo "<select name=\"form_{$i}\" id=\"form_{$i}\">\n";
-        echo "<option value='_blank'>" . xlt('None') . "</option>";
+        echo "<option value='_blank'>" . xl('None') . "</option>";
         while ($row = sqlFetchArray($result)) {
             $id = $row['pc_catid'];
             $name = $row['pc_catname'];
@@ -592,8 +592,8 @@ foreach ($GLOBALS_METADATA as $grpname => $grparr) {
             }
 
             $optionStr = '<option value="%pc_catid%"%selected%>%pc_catname%</option>';
-            $optionStr = str_replace("%pc_catid%", $row['pc_catid'], $optionStr);
-            $optionStr = str_replace("%pc_catname%", $row['pc_catname'], $optionStr);
+            $optionStr = str_replace("%pc_catid%", attr($id), $optionStr);
+            $optionStr = str_replace("%pc_catname%", xl($name), $optionStr);
             $selected = ($fldvalue == $id) ? " selected" : "";
             $optionStr = str_replace("%selected%", $selected, $optionStr);
             echo $optionStr;

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -697,7 +697,7 @@ $GLOBALS_METADATA = array(
 
         'default_visit_category' => [
             xl('Default Visit Category'),
-            'visit_category',
+            'default_visit_category',
             '_blank',
             xl('Define a default visit category'),
         ],

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -695,6 +695,13 @@ $GLOBALS_METADATA = array(
             xl('Option to support inventory and sales of products')
         ),
 
+        'default_visit_category' => [
+            xl('Default Visit Category'),
+            'visit_category',
+            '_blank',
+            xl('Define a default visit category'),
+        ],
+
         'disable_chart_tracker' => array(
             xl('Disable Chart Tracker'),
             'bool',                           // data type


### PR DESCRIPTION
Adds an option under Administration --> Globals --> Features which
allows the user to set a default category which will be automatically
set on the new encounter form