### PR TITLE
fixed save js error in provider tab

### DIFF
--- a/interface/main/calendar/add_edit_event.php
+++ b/interface/main/calendar/add_edit_event.php
@@ -1986,7 +1986,12 @@ function validateform(event,valu){
     if($GLOBALS['select_multi_providers']){
     ?>
     //If multiple providers is enabled, create provider validation (Note: if no provider is chosen it causes bugs when deleting recurrent events).
-    collectvalidation.form_provider = {presence: true};
+    if(typeof (collectvalidation) == 'undefined'){
+        collectvalidation = {form_provider:{presence: true}};
+    }
+    else{
+        collectvalidation.form_provider = {presence: true};
+    }
     <?php
     }
     ?>


### PR DESCRIPTION
hi, 
bug fixed:
When multi provider is turned on, there's a js error when saving an event in provider tab.
