### PR TITLE
Fix past encounters list display

### DIFF
--- a/interface/main/tabs/templates/patient_data_template.php
+++ b/interface/main/tabs/templates/patient_data_template.php
@@ -81,16 +81,16 @@
                     (<span data-bind="text:encounterArray().length"></span>)
                     <span class="caret"></span>
                 </button>
-                <ul class="dropdown-menu" aria-labelledby="pastEncounters">
+                <ul class="container dropdown-menu" aria-labelledby="pastEncounters" style="max-width: 400px;">
                     <!-- ko foreach:encounterArray -->
-                    <li style="display: inline-flex;">
-                        <a href="#" data-bind="click:chooseEncounterEvent">
-                            <span data-bind="text:date"></span>
-                            <span data-bind="text:category"></span>
-                        </a>
-                        <a href="#" data-bind="click:reviewEncounterEvent">
+                    <li class="row">
+						<div class="col-sm-8"><a href="#" data-bind="click:chooseEncounterEvent">
+                            <div class="col-sm-4" data-bind="text:date"></div>
+                            <div class="col-sm-8" data-bind="text:category"></div>
+                        </a></div>
+                        <div class="col-sm-4 pull-right"><a href="#" data-bind="click:reviewEncounterEvent">
                             <i class="fa fa-rotate-left"></i>&nbsp;<?php echo xlt("Review");?>
-                        </a>
+                        </a></div>
                     </li>
                     <!-- /ko -->
                 </ul>

--- a/interface/main/tabs/templates/patient_data_template.php
+++ b/interface/main/tabs/templates/patient_data_template.php
@@ -13,6 +13,16 @@
  * @copyright Copyright (c) 2017 Robert Down <robertdown@live.com>
  */
 ?>
+<style>
+<!--
+.enc-sel {
+    margin-left: 20px !important;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis; 
+}
+-->
+</style>
 <script type="text/html" id="patient-data-template">
     <div>
         <span class="patientDataColumn">
@@ -83,14 +93,16 @@
                 </button>
                 <ul class="container dropdown-menu" aria-labelledby="pastEncounters" style="max-width: 400px;">
                     <!-- ko foreach:encounterArray -->
-                    <li class="row">
-						<div class="col-sm-8"><a href="#" data-bind="click:chooseEncounterEvent">
-                            <div class="col-sm-4" data-bind="text:date"></div>
-                            <div class="col-sm-8" data-bind="text:category"></div>
-                        </a></div>
-                        <div class="col-sm-4 pull-right"><a href="#" data-bind="click:reviewEncounterEvent">
-                            <i class="fa fa-rotate-left"></i>&nbsp;<?php echo xlt("Review");?>
-                        </a></div>
+                    <li class="row text-nowrap">
+                        <a href="#" class="col-sm-10 enc-sel" data-bind="click:chooseEncounterEvent">
+                            <span data-bind="text:date"></span>&nbsp;-&nbsp;
+                            <span data-bind="text:category"></span>
+                        </a>
+                        <span style="float: right;padding-right: 20px;">
+                            <a href="#" class="btn btn-xs btn-default" data-bind="click:reviewEncounterEvent" 
+                                title='<?php echo xlt("Review");?>'>
+                            <i class="fa fa-search"></i>
+                        </a></span>
                     </li>
                     <!-- /ko -->
                 </ul>


### PR DESCRIPTION
Recent change to past encounters list caused the display of `Review` link dependent on width of appointment type text.  This change fixes this partially.

For testing wide variety of appointment/encounter type description lengths are needed in the encounter list for the patient.