### PR TITLE
Patient image fixups

### DIFF
--- a/interface/main/tabs/js/patient_data_view_model.js
+++ b/interface/main/tabs/js/patient_data_view_model.js
@@ -34,7 +34,7 @@ function patient_data_view_model(pname,pid,pubpid,str_dob)
     self.pubpid=ko.observable(pubpid);
     self.str_dob=ko.observable(str_dob);
     self.patient_picture=ko.computed(function(){
-      return '/openemr/controller.php' +
+      return webroot_url + '/controller.php' +
              '?document&retrieve' +
              '&patient_id=' + pubpid +
              '&document_id=-1' +

--- a/interface/main/tabs/templates/patient_data_template.php
+++ b/interface/main/tabs/templates/patient_data_template.php
@@ -23,7 +23,7 @@
               <!-- ko if: patient -->
                   <div data-bind="with: patient" class="patientPicture">
                       <img data-bind="attr: {src: patient_picture()}"
-                           alt="<?php echo xla("Patient Photograph") ?>"
+                           class="img-thumbnail"
                            onError="this.src = '<?php echo $GLOBALS['images_static_relative']; ?>/patient-picture-default.png'" />
                   </div>
               <!-- /ko -->

--- a/interface/themes/tabs_style_compact.css
+++ b/interface/themes/tabs_style_compact.css
@@ -284,11 +284,15 @@ div.closeDlgIframe {
     color:red;
 }
 
+.patientInfo .patientPicture
+{
+    margin-top: -1px;
+    margin-right: 7px;
+}
+
 .patientInfo .patientPicture img
 {
-    height: 55px;
-    margin-top: -5px;
-    padding-right: 5px;
+    height: 50px;
 }
 
 .top {

--- a/interface/themes/tabs_style_full.css
+++ b/interface/themes/tabs_style_full.css
@@ -224,11 +224,15 @@ div.closeDlgIframe:before {
     color: #333 !important;
 }
 
+.patientInfo .patientPicture
+{
+    margin-top: -1px;
+    margin-right: 7px;
+}
+
 .patientInfo .patientPicture img
 {
-    height: 55px;
-    margin-top: -5px;
-    padding-right: 5px;
+    height: 50px;
 }
 
 .patientCurrentEncounter {


### PR DESCRIPTION
@robertdown noticed the following issues with the new patient image picture feature:

1. `alt` text was showing while the image was being loaded in.
2. `/openemr` is not safe to hard code for public images.
3. His custom picture is not loading :(.

I have fixed the first 2 issues and incorporated his bootstrap css change recommendations in. However, the custom picture not loading needs to be tested out. Perhaps the category was not `Patient Photograph` and was the `Patient ID card` which shouldn't be shown as the patient picture.