### PR TITLE
fix translation in the group's participants screen

### DIFF
--- a/interface/therapy_groups/therapy_groups_views/groupDetailsParticipants.php
+++ b/interface/therapy_groups/therapy_groups_views/groupDetailsParticipants.php
@@ -200,7 +200,7 @@
             <?php // Bring in the translations ?>
             <?php $translationsDatatablesOverride = array('lengthMenu'=>(xla('Display').' _MENU_  '.xla('records per page')),
                                                           'zeroRecords'=>(xla('Nothing found - sorry')),
-                                                          'info'=>(xla('Showing') .' _START_ '. xla('to') . ' _END_ ' . xla('of') . ' _TOTAL_ ' . xla('participants')),
+                                                          'info'=>(xla('Showing') .' _START_ '. xla('to{{range}}') . ' _END_ ' . xla('of') . ' _TOTAL_ ' . xla('participants')),
                                                           'infoEmpty'=>(xla('No records available')),
                                                           'infoFiltered'=>('('.xla('filtered from').' _MAX_ '.xla('total records').')'),
                                                           'infoPostFix'=>(''),


### PR DESCRIPTION
Hi.

I fixed the translation of the info statement of datatable in the participants screen as it work well in the openemr/library/js/xl/datatables-net.js.php (patients list).

Thanks.
Amiel