### PR TITLE
Enable larger option_id in the list_options table 

### DIFF
--- a/interface/super/edit_layout.php
+++ b/interface/super/edit_layout.php
@@ -593,7 +593,7 @@ function writeFieldLine($linedata)
         $linedata['data_type'] == 33 || $linedata['data_type'] == 36) {
         echo "<input type='text' name='fld[$fld_line_no][list_backup_id]' value='" .
             htmlspecialchars($linedata['list_backup_id'], ENT_QUOTES) .
-            "' size='3' maxlength='10' class='optin listid' style='cursor:pointer; width:100%' />";
+            "' size='3' maxlength='100' class='optin listid' style='cursor:pointer; width:100%' />";
     } else {
         echo "<input type='hidden' name='fld[$fld_line_no][list_backup_id]' value=''>";
     }
@@ -1248,7 +1248,7 @@ foreach ($datatypes as $key => $value) {
 <td><input type="textbox" name="gnewlengthWidth" id="gnewlengthWidth" value="" size="1" maxlength="3" title="<?php echo xla('Width'); ?>">
     <input type="textbox" name="gnewlengthHeight" id="gnewlengthHeight" value="" size="1" maxlength="3" title="<?php echo xla('Height'); ?>"></td>
 <td><input type="textbox" name="gnewmaxSize" id="gnewmaxSize" value="" size="1" maxlength="3" title="<?php echo xla('Maximum Size (entering 0 will allow any size)'); ?>"></td>
-<td><input type="textbox" name="gnewlistid" id="gnewlistid" value="" size="8" maxlength="31" class="listid">
+<td><input type="textbox" name="gnewlistid" id="gnewlistid" value="" size="8" maxlength="100" class="listid">
     <select name='gcontextName' id='gcontextName' style='display:none'>
         <?php
         $res = sqlStatement("SELECT * FROM customlists WHERE cl_list_type=2 AND cl_deleted=0");
@@ -1258,7 +1258,7 @@ foreach ($datatypes as $key => $value) {
         ?>
     </select>
 </td>
-<td><input type="textbox" name="gnewbackuplistid" id="gnewbackuplistid" value="" size="8" maxlength="31" class="listid"></td>
+<td><input type="textbox" name="gnewbackuplistid" id="gnewbackuplistid" value="" size="8" maxlength="100" class="listid"></td>
 <td><input type="textbox" name="gnewtitlecols" id="gnewtitlecols" value="" size="3" maxlength="3"> </td>
 <td><input type="textbox" name="gnewdatacols" id="gnewdatacols" value="" size="3" maxlength="3"> </td>
 <td><input type="textbox" name="gnewedit_options" id="gnewedit_options" value="" size="3" maxlength="36">

--- a/interface/super/edit_layout.php
+++ b/interface/super/edit_layout.php
@@ -565,7 +565,7 @@ function writeFieldLine($linedata)
 
         echo "<input type='text' name='fld[$fld_line_no][list_id]'  id='fld[$fld_line_no][list_id]' value='" .
         htmlspecialchars($linedata['list_id'], ENT_QUOTES) . "'".$type.
-        " size='6' maxlength='30' class='optin listid' style='width:100%;cursor:pointer'".
+        " size='6' maxlength='100' class='optin listid' style='width:100%;cursor:pointer'".
         "title='". xl('Choose list') . "' />";
     
         echo "<select name='fld[$fld_line_no][contextName]' id='fld[$fld_line_no][contextName]' ".$disp.">";

--- a/interface/super/edit_list.php
+++ b/interface/super/edit_list.php
@@ -1228,7 +1228,7 @@ if ($GLOBALS['ippf_specific']) { ?>
                     <label for="newlistname"
                            class="control-label"><?php xl('List Name', 'e'); ?></label>
                     <input type="text" size="20" class="form-control"
-                           maxlength="30" name="newlistname" id="newlistname">
+                           maxlength="100" name="newlistname" id="newlistname">
                     <input type="hidden" name="formaction" value="addlist">
 
                 </div>

--- a/sql/5_0_0-to-5_0_1_upgrade.sql
+++ b/sql/5_0_0-to-5_0_1_upgrade.sql
@@ -463,7 +463,19 @@ INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUE
 INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('apps','Calendar','main/calendar/index.php',20,0,0);
 #EndIf
 
+#IfNotColumnType list_options list_id varchar(100)
+ALTER TABLE `list_options` CHANGE `list_id` `list_id` VARCHAR(100) NOT NULL DEFAULT '';
+#EndIf
 
 #IfNotColumnType list_options option_id varchar(100)
 ALTER TABLE `list_options` CHANGE `option_id` `option_id` VARCHAR(100) NOT NULL DEFAULT '';
 #EndIf
+
+#IfNotColumnType layout_options list_id varchar(100)
+ALTER TABLE `layout_options` CHANGE `list_id` `list_id` VARCHAR(100) NOT NULL DEFAULT '';
+#EndIf
+
+#IfNotColumnType layout_options list_backup_id varchar(100)
+ALTER TABLE `layout_options` CHANGE `list_backup_id` `list_backup_id` VARCHAR(100) NOT NULL DEFAULT '';
+#EndIf
+

--- a/sql/5_0_0-to-5_0_1_upgrade.sql
+++ b/sql/5_0_0-to-5_0_1_upgrade.sql
@@ -462,3 +462,8 @@ INSERT INTO list_options (list_id,option_id,title) VALUES ('lists','apps','Apps'
 INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('apps','*OpenEMR','main/main_screen.php',10,1,0);
 INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('apps','Calendar','main/calendar/index.php',20,0,0);
 #EndIf
+
+
+#IfNotColumnType list_options option_id varchar(100)
+ALTER TABLE `list_options` CHANGE `option_id` `option_id` VARCHAR(100) NOT NULL DEFAULT '';
+#EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -2707,14 +2707,14 @@ CREATE TABLE `layout_options` (
   `uor` tinyint(1) NOT NULL default '1',
   `fld_length` int(11) NOT NULL default '15',
   `max_length` int(11) NOT NULL default '0',
-  `list_id` varchar(31) NOT NULL default '',
+  `list_id` varchar(100) NOT NULL default '',
   `titlecols` tinyint(3) NOT NULL default '1',
   `datacols` tinyint(3) NOT NULL default '1',
   `default_value` varchar(255) NOT NULL default '',
   `edit_options` varchar(36) NOT NULL default '',
   `description` text,
   `fld_rows` int(11) NOT NULL default '0',
-  `list_backup_id` varchar(31) NOT NULL default '',
+  `list_backup_id` varchar(100) NOT NULL default '',
   `source` char(1) NOT NULL default 'F' COMMENT 'F=Form, D=Demographics, H=History, E=Encounter',
   `conditions` text COMMENT 'serialized array of skip conditions',
   `validation` varchar(100) default NULL,
@@ -2903,8 +2903,8 @@ INSERT INTO `layout_options` (`form_id`,`field_id`,`group_name`,`title`,`seq`,`d
 
 DROP TABLE IF EXISTS `list_options`;
 CREATE TABLE `list_options` (
-  `list_id` varchar(31) NOT NULL default '',
-  `option_id` varchar(31) NOT NULL default '',
+  `list_id` varchar(100) NOT NULL default '',
+  `option_id` varchar(100) NOT NULL default '',
   `title` varchar(255) NOT NULL default '',
   `seq` int(11) NOT NULL default '0',
   `is_default` tinyint(1) NOT NULL default '0',

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@ $v_realpatch = '0';
 // is a database change in the course of development.  It is used
 // internally to determine when a database upgrade is needed.
 //
-$v_database = 231;
+$v_database = 232;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
Hi.
We've found problem with the white list of files mime-types that could be uploaded.
In the case type bigger than 31 (max length of option_id) only the first 31 chars is saved.
This causes duplicate entries between similar types in some of the files.

There is any problem with change of max length of option_id?
This is the simple and clean solution. 

Thanks
Amiel
