### PR TITLE
fix php warn double value oeformatmoney

### DIFF
--- a/library/formatting.inc.php
+++ b/library/formatting.inc.php
@@ -9,7 +9,7 @@
 function oeFormatMoney($amount, $symbol = false)
 {
     $s = number_format(
-        $amount,
+        doubleval($amount),
         $GLOBALS['currency_decimals'],
         $GLOBALS['currency_dec_point'],
         $GLOBALS['currency_thousands_sep']

--- a/library/formatting.inc.php
+++ b/library/formatting.inc.php
@@ -9,7 +9,7 @@
 function oeFormatMoney($amount, $symbol = false)
 {
     $s = number_format(
-        doubleval($amount),
+        floatval($amount),
         $GLOBALS['currency_decimals'],
         $GLOBALS['currency_dec_point'],
         $GLOBALS['currency_thousands_sep']


### PR DESCRIPTION
hope to fix this:

PHP Warning:  number_format() expects parameter 1 to be double, string given in /var/www/html/openemr/library/formatting.inc.php on line 13, referer: https:// /openemr/interface/billing/sl_eob_process.php?eraname=20170725_441355165_&debug=0&paydate=&original=original