### PR TITLE
Trim search patient 

### DIFF
--- a/interface/main/finder/dynamic_finder_ajax.php
+++ b/interface/main/finder/dynamic_finder_ajax.php
@@ -50,7 +50,7 @@ if (isset($_GET['iSortCol_0'])) {
 //
 $where = '';
 if (isset($_GET['sSearch']) && $_GET['sSearch'] !== "") {
-    $sSearch = add_escape_custom($_GET['sSearch']);
+    $sSearch = add_escape_custom(trim($_GET['sSearch']));
     foreach ($aColumns as $colname) {
         $where .= $where ? "OR " : "WHERE ( ";
         if ($colname == 'name') {


### PR DESCRIPTION
Hi.

I added 'trim' function on the search input in the patients list screen. 
Without trim searches that beginning with space are not found. 

Thanks.
Amiel