### PR TITLE
ckeditor interface

### DIFF
--- a/library/asset_ckeditor.inc.php
+++ b/library/asset_ckeditor.inc.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Drop-in ckeditor control
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This script should be included after </body> tag.
+ * Main form(s) should specify fields with class : oemr_editable
+ **/
+
+// Performance considerations -
+// TBD
+//
+// Server setup
+
+// -- Bring in components if needed --
+//if (class_exists('OpenEMR\Core\Header')) {
+// ckeditor won't work unless added to the Header::setupHeader list
+//} else {
+// This will fail if base script has not brought in jQ
+$oemr_cke_dir = $GLOBALS['assets_static_relative']."/ckeditor-4-7-0";
+printf('
+<script type="text/javascript" src="%s/ckeditor.js"></script>
+<script type="text/javascript" src="%s/adapters/jquery.js"></script>',
+    $oemr_cke_dir, $oemr_cke_dir);
+//}
+?>
+
+<script type="text/javascript">
+$( 'textarea.md-edit' ).ckeditor();
+
+$(".md-edit.md-edit-inline").each(function() {
+    $(this).attr("contenteditable", "true");
+    CKEDITOR.disableAutoInline = true;
+    CKEDITOR.inline( $(this).attr('id') );
+});
+
+</script>

--- a/library/asset_ckeditor.inc.php
+++ b/library/asset_ckeditor.inc.php
@@ -22,10 +22,10 @@
 //} else {
 // This will fail if base script has not brought in jQ
 $oemr_cke_dir = $GLOBALS['assets_static_relative']."/ckeditor-4-7-0";
-printf('
-<script type="text/javascript" src="%s/ckeditor.js"></script>
-<script type="text/javascript" src="%s/adapters/jquery.js"></script>',
-    $oemr_cke_dir, $oemr_cke_dir);
+print <<<_CKE_SCRIPTS
+<script type="text/javascript" src="$oemr_cke_dir/ckeditor.js"></script>
+<script type="text/javascript" src="$oemr_cke_dir/adapters/jquery.js"></script>
+_CKE_SCRIPTS;
 //}
 ?>
 


### PR DESCRIPTION
This library simplifies use of ckeditor add-on in openemr.
In current version, two options are implemented -

1. Enable ckeditor for existing textarea fields in 2 steps

    a. Add this library at the end of script
    b. Add class 'md-edit' to current textarea tags


2. Enable ckeditor inline editing in 3 steps

   a. Add this library at the end of script
   b. Add classes 'md-edit md-edit-inline' to current display tags like div, a or p.
   c. Add logic to act of user changes