### PR TITLE
reports order fix

### DIFF
--- a/interface/patient_file/report/patient_report.php
+++ b/interface/patient_file/report/patient_report.php
@@ -328,7 +328,7 @@ $res = sqlStatement("SELECT forms.encounter, forms.form_id, forms.form_name, " .
                     "forms.pid = '$pid' AND form_encounter.pid = '$pid' AND " .
                     "form_encounter.encounter = forms.encounter " .
                     " AND forms.deleted=0 ". // --JRM--
-                    "ORDER BY form_encounter.date DESC, fdate ASC");
+                    "ORDER BY form_encounter.encounter DESC, form_encounter.date DESC, fdate ASC");
 $res2 = sqlStatement("SELECT name FROM registry ORDER BY priority");
 $html_strings = array();
 $registry_form_name = array();


### PR DESCRIPTION
Fixes the following issue:
If there are multiple encounters created on the same day, in the patient's reports (accessed from patient demographics) the forms are grouped under the wrong encounter.
This happens because the algorithm for grouping the forms relies on the order in which the forms return from the query, and this is ordered by date.
This fix orders them first by encounter id so that forms are always grouped correctly.   
