### PR TITLE
XSS remediation in prescription module  - re: issue #1018

### DIFF
--- a/templates/prescription/general_fragment.html
+++ b/templates/prescription/general_fragment.html
@@ -7,7 +7,7 @@
 	{foreach from=$prescriptions item=prescription}
   {if $prescription->get_active() > 0}
 	<tr class='text'>
-		<td>{$prescription->drug}</td>
+		<td>{$prescription->drug|escape:"html"}</td>
 		<td>{$prescription->get_dosage_display()}</td>
 	</tr>
   {/if}

--- a/templates/prescription/general_list.html
+++ b/templates/prescription/general_list.html
@@ -182,37 +182,37 @@ $(document).ready(function(){
       --> 
     </td>
 	<td class="editscript"  id="{$prescription->id}">
-	{if $prescription->active > 0}<b>{/if}{$prescription->drug}{if $prescription->active > 0}</b>{/if}&nbsp;
-  <br />{$prescription->note}
+	{if $prescription->active > 0}<b>{/if}{$prescription->drug|escape:"html"}{if $prescription->active > 0}</b>{/if}&nbsp;
+  <br />{$prescription->note|escape:"html"}
     </td>
 	{else}
   <td>&nbsp;</td>
     <td id="{$prescription->id}">
-	{if $prescription->active > 0}<b>{/if}{$prescription->drug}{if $prescription->active > 0}</b>{/if}&nbsp;
-  <br />{$prescription->note}
+	{if $prescription->active > 0}<b>{/if}{$prescription->drug|escape:"html"}{if $prescription->active > 0}</b>{/if}&nbsp;
+  <br />{$prescription->note|escape:"html"}
     </td>
 	{/if}
     <td id="{$prescription->id}">
-      {$prescription->rxnorm_drugcode}&nbsp;
+      {$prescription->rxnorm_drugcode|escape:"html"}&nbsp;
     </td>
     <td id="{$prescription->id}">
       {$prescription->date_added}<br />
       {$prescription->date_modified}&nbsp;
     </td>
     <td id="{$prescription->id}">
-      {$prescription->get_dosage_display()} &nbsp;
+      {$prescription->get_dosage_display()|escape:"html"} &nbsp;
     </td>
 	{if $prescription->erx_source==0}
     <td class="editscript" id="{$prescription->id}">
-      {$prescription->quantity} &nbsp;
+      {$prescription->quantity|escape:"html"} &nbsp;
     </td>
 	{else}
 	<td id="{$prescription->id}">
-      {$prescription->quantity} &nbsp;
+      {$prescription->quantity|escape:"html"} &nbsp;
     </td>
 	{/if}
     <td id="{$prescription->id}">
-       {$prescription->get_size()} {$prescription->get_unit_display()}&nbsp;
+       {$prescription->get_size()|escape:"html"} {$prescription->get_unit_display()}&nbsp;
     </td>
     <td id="{$prescription->id}">
       {$prescription->provider->get_name_display()}&nbsp;


### PR DESCRIPTION
Used the smarty php escape function to prevent the rendering of html
tags both in the prescription summary screen in the patient record and
in the prescription edit modal.

ASC