### PR TITLE
Fix link to edit encounter's forms screen

### DIFF
--- a/interface/patient_file/encounter/forms.php
+++ b/interface/patient_file/encounter/forms.php
@@ -963,8 +963,7 @@ if (($pass_sens_squad) && ($result = getFormByEncounter($attendant_id, $encounte
         } else {
             if ((!$aco_spec || acl_check($aco_spec[0], $aco_spec[1], '', 'write') and $is_group == 0 and $authPostCalendarCategoryWrite)
             or (((!$aco_spec || acl_check($aco_spec[0], $aco_spec[1], '', 'write')) and $is_group and acl_check("groups", "glog", false, 'write')) and $authPostCalendarCategoryWrite)) {
-                echo "<a class='css_button_small form-edit-button' id='form-edit-button-".attr($formdir)."-".attr($iter['id'])."' target='".
-                    "_parent" .
+                echo "<a class='css_button_small form-edit-button' id='form-edit-button-".attr($formdir)."-".attr($iter['id']).
                     "' href='$rootdir/patient_file/encounter/view_form.php?" .
                     "formname=" . attr($formdir) . "&id=" . attr($iter['form_id']) .
                     "' onclick='top.restoreSession()'>";


### PR DESCRIPTION
Hi.
This is addition fix connect to PR [959](https://github.com/openemr/openemr/pull/959) in the forms frames.
I've found that screen of edit from is opened in the parent frame and not in the forms frame so it cause bug when clicking on save/cancel buttons (it's opened in the parent frame - full screen).
I removed traget="_parent" from a tag.

Thanks.
Amiel  