### PR TITLE
Fix for moving Amazon target

### DIFF
--- a/cloud/assets/OpenEMR.json
+++ b/cloud/assets/OpenEMR.json
@@ -1,7 +1,7 @@
 {
   "AWSTemplateFormatVersion" : "2010-09-09",
 
-  "Description" : "Automated OpenEMR 5.0.0 Configuration",
+  "Description" : "Automated OpenEMR 5.0.0.4 Configuration",
 
   "Parameters" : {
     "EC2KeyPair" : {

--- a/cloud/assets/OpenEMR.json
+++ b/cloud/assets/OpenEMR.json
@@ -1361,7 +1361,7 @@
      "Properties" : {
        "ApplicationName" : { "Ref" : "EBApplication" },
         "Description" :  "OpenEMR v5.0.0 cloud deployment",
-        "SolutionStackName" : "64bit Amazon Linux 2017.03 v2.4.2 running PHP 7.0",
+        "SolutionStackName" : "64bit Amazon Linux 2017.03 v2.4.3 running PHP 7.0",
         "VersionLabel" : { "Ref" : "EBApplicationVersion" },
         "OptionSettings" : [
           {"Namespace" : "aws:autoscaling:launchconfiguration", "OptionName" : "SecurityGroups", "Value" : { "Ref" : "ApplicationSecurityGroup" }},

--- a/cloud/chapters/01-Getting-Started.md
+++ b/cloud/chapters/01-Getting-Started.md
@@ -25,10 +25,10 @@ This guide uses services that are _only_ available in certain AWS regions. As of
 ### Launch your Cloud
 
 1. Click the region link below that corresponds to the region you created your keypair in:
-   * [N. Virginia](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/new?stackName=OpenEMR&templateURL=https://s3.amazonaws.com/openemr-useast1/OpenEMR.014.json)
-   * [Oregon](https://console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/new?stackName=OpenEMR&templateURL=https://s3.amazonaws.com/openemr-uswest2/OpenEMR.014.json)
-   * [Ireland](https://console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks/new?stackName=OpenEMR&templateURL=https://s3.amazonaws.com/openemr-euwest1/OpenEMR.014.json)
-   * [Sydney](https://console.aws.amazon.com/cloudformation/home?region=ap-southeast-2#/stacks/new?stackName=OpenEMR&templateURL=https://s3.amazonaws.com/openemr-apsoutheast2/OpenEMR.014.json)
+   * [N. Virginia](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/new?stackName=OpenEMR&templateURL=https://s3.amazonaws.com/openemr-useast1/OpenEMR.015.json)
+   * [Oregon](https://console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/new?stackName=OpenEMR&templateURL=https://s3.amazonaws.com/openemr-uswest2/OpenEMR.015.json)
+   * [Ireland](https://console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks/new?stackName=OpenEMR&templateURL=https://s3.amazonaws.com/openemr-euwest1/OpenEMR.015.json)
+   * [Sydney](https://console.aws.amazon.com/cloudformation/home?region=ap-southeast-2#/stacks/new?stackName=OpenEMR&templateURL=https://s3.amazonaws.com/openemr-apsoutheast2/OpenEMR.015.json)
 2. Click **Next**, and configure your stack on this page.
    * For **DocumentStorage**, enter the size of your patient documents database in gigabytes.
    * For **EC2KeyPair**, select the key pair you created in the last section.


### PR DESCRIPTION
Amazon gates access to Elastic Beanstalk environments based on the age of the account -- the newest of the new accounts can't access older environments that lack new features or security enhancements. This updates the stack to use the new v2.4.3 environment, instead of the deprecated v2.4.2.