### PR TITLE
fix for new encounters form edit because of new hierarchy of frames

### DIFF
--- a/interface/forms/newGroupEncounter/save.php
+++ b/interface/forms/newGroupEncounter/save.php
@@ -154,9 +154,9 @@ $result4 = sqlStatement("SELECT fe.encounter,fe.date,openemr_postcalendar_catego
  top.restoreSession();
 <?php if ($mode == 'new') { ?>
     //todo - checking necessary
- parent.left_nav.setEncounter(<?php echo "'" . attr(oeFormatShortDate($date)) . "', '" . attr($encounter) . "', window.name"; ?>);
+ parent.parent.frames["left_nav"].setEncounter(<?php echo "'" . attr(oeFormatShortDate($date)) . "', '" . attr($encounter) . "', window.name"; ?>);
 <?php } // end if new encounter ?>
- parent.left_nav.loadFrame('enc2', window.name, '<?php echo $nexturl; ?>');
+ parent.parent.frames["left_nav"].loadFrame('enc2', parent.name, '<?php echo $nexturl; ?>');
 </script>
 
 </body>

--- a/interface/forms/newpatient/save.php
+++ b/interface/forms/newpatient/save.php
@@ -172,9 +172,9 @@ $result4 = sqlStatement("SELECT fe.encounter,fe.date,openemr_postcalendar_catego
      top.window.parent.left_nav.setPatientEncounter(EncounterIdArray,EncounterDateArray,CalendarCategoryArray);
  top.restoreSession();
 <?php if ($mode == 'new') { ?>
- parent.left_nav.setEncounter(<?php echo "'" . attr(oeFormatShortDate($date)) . "', '" . attr($encounter) . "', window.name"; ?>);
+ parent.parent.frames["left_nav"].setEncounter(<?php echo "'" . attr(oeFormatShortDate($date)) . "', '" . attr($encounter) . "', window.name"; ?>);
 <?php } // end if new encounter ?>
- parent.left_nav.loadFrame('enc2', window.name, '<?php echo $nexturl; ?>');
+ parent.parent.frames["left_nav"].loadFrame('enc2', parent.name, '<?php echo $nexturl; ?>');
 </script>
 
 </body>


### PR DESCRIPTION
Fixed the following issue:
Because the hierarchy of the frames changed, this caused a js error when trying to redirect the bottom part of window back to encounters list after editing a 'new encounter' form.
