### PR TITLE
Fixed javascript error when saving a recurrent provider event using js validation

### DIFF
--- a/interface/main/calendar/add_edit_event.php
+++ b/interface/main/calendar/add_edit_event.php
@@ -119,7 +119,7 @@ if ($_GET['group'] == true) {
     $collectthis = collectValidationPageRules("/interface/main/calendar/add_edit_event.php?group=true");
 } elseif ($_GET['prov']) {
     //providers tab
-    $collectthis = collectValidationPageRules("/interface/main/calendar/add_edit_event.php?prov=true");;
+    $collectthis = collectValidationPageRules("/interface/main/calendar/add_edit_event.php?prov=true");
 } else { //patient tab
     $collectthis = collectValidationPageRules("/interface/main/calendar/add_edit_event.php");
 }

--- a/interface/main/calendar/add_edit_event.php
+++ b/interface/main/calendar/add_edit_event.php
@@ -119,7 +119,7 @@ if ($_GET['group'] == true) {
     $collectthis = collectValidationPageRules("/interface/main/calendar/add_edit_event.php?group=true");
 } elseif ($_GET['prov']) {
     //providers tab
-    $collectthis = '';
+    $collectthis = collectValidationPageRules("/interface/main/calendar/add_edit_event.php?prov=true");;
 } else { //patient tab
     $collectthis = collectValidationPageRules("/interface/main/calendar/add_edit_event.php");
 }

--- a/sql/5_0_0-to-5_0_1_upgrade.sql
+++ b/sql/5_0_0-to-5_0_1_upgrade.sql
@@ -511,3 +511,8 @@ INSERT INTO `supported_external_dataloads` (`load_type`, `load_source`, `load_re
 #IfColumn x12_partners x12_version
 ALTER TABLE `x12_partners` DROP COLUMN `x12_version`;
 #EndIf
+
+#IfNotRow2D list_options list_id page_validation option_id add_edit_event#theform_prov
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `option_value`, `mapping`, `notes`, `codes`, `toggle_setting_1`, `toggle_setting_2`, `activity`, `subtype`, `edit_options`) VALUES
+('page_validation', 'add_edit_event#theform_prov', '/interface/main/calendar/add_edit_event.php?prov=true', 170, 0, 0, '', '{}', '', 0, 0, 1, '', 1);
+#EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -8146,6 +8146,7 @@ INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `notes`, `ac
 INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `notes`, `activity`) VALUES ('page_validation', 'tg_add#add-participant-form', '/interface/therapy_groups/index.php?method=groupParticipants', 130, '{participant_name:{presence: true}, group_patient_start:{presence: true}}', 1);
 INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `notes`, `activity`) VALUES ('page_validation', 'common#new-encounter-form', '/interface/forms/newGroupEncounter/common.php', 160, '{pc_catid:{exclusion: ["_blank"]}}', 1);
 INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `notes`, `activity`) VALUES ('page_validation', 'add_edit_event#theform_groups','/interface/main/calendar/add_edit_event.php?group=true',150, '{form_group:{presence: true}}', 1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `notes`, `activity`) VALUES ('page_validation', 'add_edit_event#theform_prov', '/interface/main/calendar/add_edit_event.php?prov=true', 170, '{}',  1);
 
 
 


### PR DESCRIPTION
There was a js error that prevents the recurrent event for provider to be saved when the javascript validation mechanism is on