### PR TITLE
simple fix to segment delimiter

### DIFF
--- a/interface/reports/edi_271.php
+++ b/interface/reports/edi_271.php
@@ -74,7 +74,7 @@ if (isset($_FILES) && !empty($_FILES)) {
                     }
                 } else {
                     foreach ($DataSegment271[$i] as $datastrings) {
-                        $Segments271[$j] = explode("*", $datastrings);
+                        $Segments271[$j] = explode("~", $datastrings);
 
                         $segment         = $Segments271[$j][0];
 


### PR DESCRIPTION
references this [community post](https://community.open-emr.org/t/4-1-2-dev-270-271/5359/5?u=stephenwaite) by @juggernautsei 

with this simple fix was able to view elig info from this [sample](https://community.open-emr.org/t/eligibility-response-not-parsing-into-table/8956/3?u=stephenwaite)

also found this old doc 
[mmf-batch_eligibilityverification.pdf](https://github.com/openemr/openemr/files/1275539/mmf-batch_eligibilityverification.pdf)

you view the 271 response info on the tab next to patient insurance from their main page

kudos to mmf whose code still holds up and brady's work bringing it in 7 years ago