### PR TITLE
add php tag to cqm reports

### DIFF
--- a/library/classes/rulesets/Cqm/reports/NFQ_0101.php
+++ b/library/classes/rulesets/Cqm/reports/NFQ_0101.php
@@ -5,13 +5,13 @@
  * @package OpenEMR
  * @author Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (C) 2016 Brady Miller <brady.g.miller@gmail.com>
- * @link https://github.com/openemr/openemr/tree/master 
- * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3 
+ * @link https://github.com/openemr/openemr/tree/master
+ * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 class NFQ_0101 extends AbstractCqmReport
-{   
+{
     public function createPopulationCriteria()
     {
-         return new NFQ_0101_PopulationCriteria();    
+         return new NFQ_0101_PopulationCriteria();
     }
 }

--- a/library/classes/rulesets/Cqm/reports/NFQ_0101.php
+++ b/library/classes/rulesets/Cqm/reports/NFQ_0101.php
@@ -1,23 +1,12 @@
+<?php
 /**
- *
  * CQM NQF 0101
  *
- * Copyright (C) 2016 Brady Miller <brady.g.miller@gmail.com>
- *
- * LICENSE: This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://opensource.org/licenses/gpl-license.php>;.
- *
  * @package OpenEMR
- * @author  Brady Miller <brady.g.miller@gmail.com>
- * @link    http://www.open-emr.org
+ * @author Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (C) 2016 Brady Miller <brady.g.miller@gmail.com>
+ * @link https://github.com/openemr/openemr/tree/master 
+ * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3 
  */
 class NFQ_0101 extends AbstractCqmReport
 {   

--- a/library/classes/rulesets/Cqm/reports/NFQ_0384.php
+++ b/library/classes/rulesets/Cqm/reports/NFQ_0384.php
@@ -1,24 +1,13 @@
+<?php
 /**
- *
  * CQM NFQ 0384
  *
- * Copyright (C) 2016 Brady Miller <brady.g.miller@gmail.com>
- *
- * LICENSE: This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://opensource.org/licenses/gpl-license.php>;.
- *
  * @package OpenEMR
- * @author  Brady Miller <brady.g.miller@gmail.com>
- * @link    http://www.open-emr.org
- */
+ * @author Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (C) 2016 Brady Miller <brady.g.miller@gmail.com>
+ * @link https://github.com/openemr/openemr/tree/master
+ * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3 
+*/
 class NFQ_0384 extends AbstractCqmReport
 {
     public function createPopulationCriteria()

--- a/library/classes/rulesets/Cqm/reports/NFQ_0384.php
+++ b/library/classes/rulesets/Cqm/reports/NFQ_0384.php
@@ -6,7 +6,7 @@
  * @author Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (C) 2016 Brady Miller <brady.g.miller@gmail.com>
  * @link https://github.com/openemr/openemr/tree/master
- * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3 
+ * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
 */
 class NFQ_0384 extends AbstractCqmReport
 {


### PR DESCRIPTION
found this after running Reports->Clinic->Quality Measures(CQM)