### PR TITLE
fix for saving encounters and forms

### DIFF
--- a/interface/forms/newGroupEncounter/save.php
+++ b/interface/forms/newGroupEncounter/save.php
@@ -158,20 +158,20 @@ $result4 = sqlStatement("SELECT fe.encounter,fe.date,openemr_postcalendar_catego
     //todo - checking necessary
     if(parent.left_nav) {
         parent.left_nav.setEncounter(<?php echo "'" . attr(oeFormatShortDate($date)) . "', '" . attr($encounter) . "', window.name"; ?>);
-        console.log('new - parent.left_nav is defined');
+        //console.log('new - parent.left_nav is defined');
     }
     else {
         parent.parent.frames["left_nav"].setEncounter(<?php echo "'" . attr(oeFormatShortDate($date)) . "', '" . attr($encounter) . "', window.name"; ?>);
-        console.log('new - parent.left_nav is undefined');
+        //console.log('new - parent.left_nav is undefined');
     }
 <?php } // end if new encounter ?>
     if(parent.left_nav) {
         parent.left_nav.loadFrame('enc2', window.name, '<?php echo $nexturl; ?>');
-        console.log('modify - parent.left_nav is defined');
+        //console.log('modify - parent.left_nav is defined');
     }
     else {
         parent.parent.frames["left_nav"].loadFrame('enc2', parent.name, '<?php echo $nexturl; ?>');
-        console.log('modify - parent.left_nav is undefined');
+        //console.log('modify - parent.left_nav is undefined');
     }
 </script>
 

--- a/interface/forms/newGroupEncounter/save.php
+++ b/interface/forms/newGroupEncounter/save.php
@@ -156,9 +156,23 @@ $result4 = sqlStatement("SELECT fe.encounter,fe.date,openemr_postcalendar_catego
  top.restoreSession();
 <?php if ($mode == 'new') { ?>
     //todo - checking necessary
- parent.left_nav.setEncounter(<?php echo "'" . attr(oeFormatShortDate($date)) . "', '" . attr($encounter) . "', window.name"; ?>);
+    if(parent.left_nav) {
+        parent.left_nav.setEncounter(<?php echo "'" . attr(oeFormatShortDate($date)) . "', '" . attr($encounter) . "', window.name"; ?>);
+        console.log('new - parent.left_nav is defined');
+    }
+    else {
+        parent.parent.frames["left_nav"].setEncounter(<?php echo "'" . attr(oeFormatShortDate($date)) . "', '" . attr($encounter) . "', window.name"; ?>);
+        console.log('new - parent.left_nav is undefined');
+    }
 <?php } // end if new encounter ?>
- parent.left_nav.loadFrame('enc2', window.name, '<?php echo $nexturl; ?>');
+    if(parent.left_nav) {
+        parent.left_nav.loadFrame('enc2', window.name, '<?php echo $nexturl; ?>');
+        console.log('modify - parent.left_nav is defined');
+    }
+    else {
+        parent.parent.frames["left_nav"].loadFrame('enc2', parent.name, '<?php echo $nexturl; ?>');
+        console.log('modify - parent.left_nav is undefined');
+    }
 </script>
 
 </body>

--- a/interface/forms/newpatient/save.php
+++ b/interface/forms/newpatient/save.php
@@ -176,20 +176,20 @@ $result4 = sqlStatement("SELECT fe.encounter,fe.date,openemr_postcalendar_catego
 <?php if ($mode == 'new') { ?>
     if(parent.left_nav) {
         parent.left_nav.setEncounter(<?php echo "'" . attr(oeFormatShortDate($date)) . "', '" . attr($encounter) . "', window.name"; ?>);
-        console.log('new - parent.left_nav is defined');
+        //console.log('new - parent.left_nav is defined');
     }
     else {
         parent.parent.frames["left_nav"].setEncounter(<?php echo "'" . attr(oeFormatShortDate($date)) . "', '" . attr($encounter) . "', window.name"; ?>);
-        console.log('new - parent.left_nav is undefined');
+        //console.log('new - parent.left_nav is undefined');
     }
 <?php } // end if new encounter ?>
     if(parent.left_nav){
         parent.left_nav.loadFrame('enc2', window.name, '<?php echo $nexturl; ?>');
-        console.log('modify - parent.left_nav is defined');
+        //console.log('modify - parent.left_nav is defined');
     }
     else {
         parent.parent.frames["left_nav"].loadFrame('enc2', parent.name, '<?php echo $nexturl; ?>');
-        console.log('modify - parent.left_nav is undefined');
+        //console.log('modify - parent.left_nav is undefined');
     }
 </script>
 

--- a/interface/forms/newpatient/save.php
+++ b/interface/forms/newpatient/save.php
@@ -174,9 +174,23 @@ $result4 = sqlStatement("SELECT fe.encounter,fe.date,openemr_postcalendar_catego
      top.window.parent.left_nav.setPatientEncounter(EncounterIdArray,EncounterDateArray,CalendarCategoryArray);
  top.restoreSession();
 <?php if ($mode == 'new') { ?>
- parent.left_nav.setEncounter(<?php echo "'" . attr(oeFormatShortDate($date)) . "', '" . attr($encounter) . "', window.name"; ?>);
+    if(parent.left_nav) {
+        parent.left_nav.setEncounter(<?php echo "'" . attr(oeFormatShortDate($date)) . "', '" . attr($encounter) . "', window.name"; ?>);
+        console.log('new - parent.left_nav is defined');
+    }
+    else {
+        parent.parent.frames["left_nav"].setEncounter(<?php echo "'" . attr(oeFormatShortDate($date)) . "', '" . attr($encounter) . "', window.name"; ?>);
+        console.log('new - parent.left_nav is undefined');
+    }
 <?php } // end if new encounter ?>
- parent.left_nav.loadFrame('enc2', window.name, '<?php echo $nexturl; ?>');
+    if(parent.left_nav){
+        parent.left_nav.loadFrame('enc2', window.name, '<?php echo $nexturl; ?>');
+        console.log('modify - parent.left_nav is defined');
+    }
+    else {
+        parent.parent.frames["left_nav"].loadFrame('enc2', parent.name, '<?php echo $nexturl; ?>');
+        console.log('modify - parent.left_nav is undefined');
+    }
 </script>
 
 </body>


### PR DESCRIPTION
Currently there are critical js errors when saving and editing forms and encounters.
After some testing I did, I saw that the problem was that in many scenarios the frames hierarchies were different from one another, so checking what the current hierarchy is in the code (by checking for undefined) was the only way I was able to fix this issue.