### PR TITLE
groups performance fix

### DIFF
--- a/interface/therapy_groups/therapy_groups_controllers/therapy_groups_controller.php
+++ b/interface/therapy_groups/therapy_groups_controllers/therapy_groups_controller.php
@@ -101,8 +101,10 @@ class TherapyGroupsController extends BaseController
         $userModel = $this->loadModel('Users');
 
         //Get group events
-        $events = $eventsModel->getGroupEvents($groupId);
-        $data['events'] = $events;
+        if($groupId){
+            $events = $eventsModel->getGroupEvents($groupId);
+            $data['events'] = $events;
+        }
 
         //Get users
         $users = $userModel->getAllUsers();

--- a/interface/therapy_groups/therapy_groups_controllers/therapy_groups_controller.php
+++ b/interface/therapy_groups/therapy_groups_controllers/therapy_groups_controller.php
@@ -101,7 +101,7 @@ class TherapyGroupsController extends BaseController
         $userModel = $this->loadModel('Users');
 
         //Get group events
-        if($groupId){
+        if ($groupId) {
             $events = $eventsModel->getGroupEvents($groupId);
             $data['events'] = $events;
         }


### PR DESCRIPTION
Issue:
When adding new group would take very long time to load. This is because when there is no group id in session all openemr post calendar events are loaded (not just a specific group's).

Fix:
Events are loaded only when there is a group id in session.