### PR TITLE
Removing unnecessary frameset and related bugs.

### DIFF
--- a/interface/patient_file/encounter/encounter_top.php
+++ b/interface/patient_file/encounter/encounter_top.php
@@ -22,4 +22,3 @@ if (isset($_GET["set_encounter"])) {
     setencounter($_GET["set_encounter"]);
 }
 include("forms.php");
-?>

--- a/interface/patient_file/encounter/encounter_top.php
+++ b/interface/patient_file/encounter/encounter_top.php
@@ -21,12 +21,5 @@ if (isset($_GET["set_encounter"])) {
 
     setencounter($_GET["set_encounter"]);
 }
+include("forms.php");
 ?>
-<html>
-<head>
-<?php html_header_show();?>
-</head>
-<frameset cols="*">
- <frame src="forms.php" name="Forms" scrolling="auto">
-</frameset>
-</html>

--- a/interface/patient_file/encounter/forms.php
+++ b/interface/patient_file/encounter/forms.php
@@ -1017,8 +1017,7 @@ if ($pass_sens_squad &&
         if (acl_check('admin', 'super')) {
             if ($formdir != 'newpatient' && $formdir != 'newGroupEncounter') {
                 // a link to delete the form from the encounter
-                echo "<a target='Forms'" .
-                    " href='$rootdir/patient_file/encounter/delete_form.php?" .
+                echo "<a href='$rootdir/patient_file/encounter/delete_form.php?" .
                     "formname=" . $formdir .
                     "&id=" . $iter['id'] .
                     "&encounter=". $encounter.

--- a/library/api.inc
+++ b/library/api.inc
@@ -77,8 +77,7 @@ function formJump($address = "0")
     if ($address == "0") {
         $address = "{$GLOBALS['rootdir']}/patient_file/encounter/$returnurl";
     }
-
-    echo "\n<script language='Javascript'>top.restoreSession();parent.window.location='$address';</script>\n";
+    echo "\n<script language='Javascript'>top.restoreSession();window.location='$address';</script>\n";
     exit;
 }
 


### PR DESCRIPTION
When an encounter is entered the code has been creating a frameset for it with
a single frame named "Forms". This seems to be a holdover from when the frameset
had a second frame in it.

Currently this frameset seems unnecessary since it is contained in another frame
or iframe, depending on the layout. In addition there is at least one bug where
canceling forms causes the frameset to be nested to arbitrary levels.

This commit removes the "Forms" frameset.