### PR TITLE
Prevent default form action on select all button.

### DIFF
--- a/interface/billing/billing_report.php
+++ b/interface/billing/billing_report.php
@@ -548,7 +548,7 @@ if (! isset($_REQUEST['mode'])) { // default case
             </tr>
             <tr>
                 <td>&nbsp;</td>
-                <td><button onclick="select_all()" class="btn btn-default btn-sm"><?php  echo xlt('Select All') ?></button></td>
+                <td><button onclick="select_all(); return false;" class="btn btn-default btn-sm"><?php  echo xlt('Select All') ?></button></td>
             </tr>
         </table>
     </td>


### PR DESCRIPTION
Billing manager select all reset fix found by @stephenwaite .