### PR TITLE
Fix 2 bugs in the group's participants screen

### DIFF
--- a/interface/therapy_groups/therapy_groups_controllers/participants_controller.php
+++ b/interface/therapy_groups/therapy_groups_controllers/participants_controller.php
@@ -54,7 +54,7 @@ class ParticipantsController extends BaseController
                     'group_patient_status' => FILTER_VALIDATE_INT,
                     'group_patient_start' => FILTER_DEFAULT,
                     'group_patient_end' => FILTER_SANITIZE_SPECIAL_CHARS,
-                    'group_patient_comment' => FILTER_SANITIZE_SPECIAL_CHARS,
+                    'group_patient_comment' => FILTER_DEFAULT,
                 );
                 //filter and sanitize all post data.
                 $participant = filter_var_array($patient, $filters);
@@ -110,7 +110,7 @@ class ParticipantsController extends BaseController
                 'group_id' => FILTER_VALIDATE_INT,
                 'pid' => FILTER_VALIDATE_INT,
                 'group_patient_start' => FILTER_DEFAULT,
-                'group_patient_comment' => FILTER_SANITIZE_SPECIAL_CHARS,
+                'group_patient_comment' => FILTER_DEFAULT,
             );
 
             $participant_data = filter_var_array($_POST, $filters);

--- a/interface/therapy_groups/therapy_groups_views/groupDetailsParticipants.php
+++ b/interface/therapy_groups/therapy_groups_views/groupDetailsParticipants.php
@@ -227,7 +227,7 @@
                    return  e.preventDefault();
                 }
                 if(typeof $('#end-date'+i).val() == 'string'){
-                    if(moment($('#end-date'+i).val()).isBefore($('#start-date'+i).val())){
+                    if(moment(DateToYYYYMMDD_js($('#end-date'+i).val())).isBefore(DateToYYYYMMDD_js($('#start-date'+i).val()))){
                         $('#end-date'+i).addClass('error-border').after('<p class="error-message" id="error-end-date' + i + '" ><?php echo xlt('End date must be equal or bigger than start date');?></p>');
                         $('#end-date'+i).on('focus', function(){
                             $(this).removeClass('error-border');

--- a/interface/therapy_groups/therapy_groups_views/header.php
+++ b/interface/therapy_groups/therapy_groups_views/header.php
@@ -46,6 +46,9 @@
     <script src="<?php echo $GLOBALS['assets_static_relative'];?>/jquery-datetimepicker-2-5-4/build/jquery.datetimepicker.full.min.js"></script>
     <script src="<?php echo $GLOBALS['web_root'];?>/library/topdialog.js"></script>
     <script src="<?php echo $GLOBALS['web_root'];?>/library/dialog.js"></script>
+    <script>
+    <?php require $GLOBALS['srcdir'] . "/formatting_DateToYYYYMMDD_js.js.php" ?>
+    </script>
 </head>
 
 <body class="body_top therapy_group">


### PR DESCRIPTION
Hi.

1. Remove unnecessary escaping from comment field.
2. Adding date format to JS validation of 'end date' field.

Thanks.
Amiel