### PR TITLE
fix for notes titles

### DIFF
--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -1108,7 +1108,7 @@ if ($insurance_count > 0) {
             <td width='650px'>
 <?php
 // Notes expand collapse widget
-$widgetTitle = xl("Notes");
+$widgetTitle = xl("Messages");
 $widgetLabel = "pnotes";
 $widgetButtonLabel = xl("Edit");
 $widgetButtonLink = "pnotes_full.php?form_active=1";

--- a/interface/patient_file/summary/pnotes_full.php
+++ b/interface/patient_file/summary/pnotes_full.php
@@ -268,7 +268,7 @@ $urlparms = "docid=$docid&orderid=$orderid";
 ?>
 
     <div>
-        <span class="title"><?php echo xlt('Patient Notes') . $title_docname; ?></span>
+        <span class="title"><?php echo xlt('Patient Messages') . $title_docname; ?></span>
     </div>
     <div id='namecontainer_pnotes' class='namecontainer_pnotes' style='float:left;margin-right:10px'>
         <?php echo htmlspecialchars(xl('for'), ENT_NOQUOTES);?>&nbsp;<span class="title">


### PR DESCRIPTION
This is a small fix in the titles of the notes widget and notes full screen:
What these screens are actually showing are **messages**, not **notes**.
When we add a message in the bottom messages screen (accessed from the left nav), this is what later shows up in the 'notes widget'.
Therefore, in order to prevent confusion, we think it's important that the names match so users understand that this refers to messages.