### PR TITLE
Some important fixes of the new feature of column options in the LBF

### DIFF
--- a/interface/new/new_comprehensive.php
+++ b/interface/new/new_comprehensive.php
@@ -40,7 +40,7 @@ function getLayoutRes()
     global $SHORT_FORM;
     return sqlStatement("SELECT * FROM layout_options " .
     "WHERE form_id = 'DEM' AND uor > 0 AND field_id != '' " .
-    ($SHORT_FORM ? "AND ( uor > 1 OR edit_options LIKE '%N%' ) " : "") .
+    ($SHORT_FORM ? "AND ( uor > 1 OR edit_options LIKE BINARY '%N%' ) " : "") .
     "ORDER BY group_id, seq");
 }
 

--- a/interface/super/edit_layout.php
+++ b/interface/super/edit_layout.php
@@ -1640,9 +1640,9 @@ foreach ($datatypes as $key => $value) {
         {id: 'DO',text:'" . xla('Outline Data Col') . "'},
         {id: 'SP',text:'" . xla('Span Entire Row') . "'}
     ]},
-    {id: '0',text:'" . xla('Read Only') . "'},
 	{id: '1',text:'" . xla('Write Once') . "'},
-	{id: '2',text:'" . xla('Billing Code Descriptions') . "'}];\n";
+	{id: '2',text:'" . xla('Billing Code Descriptions') . "'},
+	{id: '3',text:'" . xla('Read Only') . "'}];\n";
 
 // Language direction for select2
 echo 'var langDirection = "' . $_SESSION['language_direction'] . '";';

--- a/library/options.inc.php
+++ b/library/options.inc.php
@@ -32,9 +32,9 @@
 // T = Use description as default Text
 // U = Capitalize all letters (text fields)
 // V = Vendor types only (address book)
-// 0 = Read Only - the input element's "disabled" property is set
 // 1 = Write Once (not editable when not empty) (text fields)
 // 2 = Show descriptions instead of codes for billing code input
+// 3 = Read Only - the input element's "disabled" property is set
 
 require_once("user.inc");
 require_once("patient.inc");
@@ -356,7 +356,7 @@ function generate_form_field($frow, $currvalue)
         $empty_title = "Unassigned";
     }
 
-    $disabled = isOption($frow['edit_options'], '0') === false ? '' : 'disabled';
+    $disabled = isOption($frow['edit_options'], '3') === false ? '' : 'disabled';
 
     $lbfchange = (
         strpos($frow['form_id'], 'LBF') === 0 ||
@@ -3986,8 +3986,8 @@ function isOption($options, $test)
         }
     }
     $options = json_decode($options);
-    
-    return in_array($test, $options, true) ? true : false; // finally!
+
+    return !is_null($options) && in_array($test, $options, true) ? true : false; // finally!
 }
 
 ?>

--- a/sql/5_0_0-to-5_0_1_upgrade.sql
+++ b/sql/5_0_0-to-5_0_1_upgrade.sql
@@ -661,3 +661,7 @@ DELETE FROM list_options WHERE list_id = 'lists' AND option_id = 'lbfnames';
 DELETE FROM list_options WHERE list_id = 'transactions';
 DELETE FROM list_options WHERE list_id = 'lists' AND option_id = 'transactions';
 #EndIf
+
+#IfRow2D layout_options source F edit_options %0%
+UPDATE layout_options SET edit_options = REPLACE(edit_options, '0', '3') WHERE edit_options LIKE '%0%';
+#EndIf


### PR DESCRIPTION
Hi Brady.
We merged a latest master code into our project and we found some troubles with the new feature of multiselect in the LBF [(PR 1125](https://github.com/openemr/openemr/pull/1125))

1.It's not working with 'Read only' options. option '0' failed with the new code.
Solution - migration  'Read only'   to '3' instead '0' (zero always make problem).
2.In the new patient screen 'Short form' totally failed. (searching of 'N' option returns an all the columns with 'null' value)
Solution - Change sql query to case sensitive.
3.There are a lot of warnings in the demographics screen.
![image](https://user-images.githubusercontent.com/17809866/32001456-8a228ea2-b9a2-11e7-92c6-e5c6364b9ac1.png)

This fixes are important for us and we will be happy to merge them  as soon as possible..

Thanks.
Amiel
       