### PR TITLE
Remove unnecessary 'parent' from cancel link in vitals form (related to #1110)

### DIFF
--- a/interface/forms/vitals/templates/vitals/general_new.html
+++ b/interface/forms/vitals/templates/vitals/general_new.html
@@ -393,7 +393,7 @@ $(document).ready(function(){
     $("#growthchart").click(function() { ShowGrowthchart(); });
     $("#pdfchart").click(function() { ShowGrowthchart(1); });
     $("#htmlchart").click(function() { ShowGrowthchart(2); });
-    $("#cancel").click(function() { parent.location.href=cancellink; });
+    $("#cancel").click(function() { location.href=cancellink; });
     addGCSelector();
 
     $('.datetimepicker').datetimepicker({


### PR DESCRIPTION
Hi.
Completion of PR  [#1110](https://github.com/openemr/openemr/pull/1110).
I removed 'parent' from cancel link in vitals form.

Thanks 
Amiel 