### PR TITLE
Allow for zero in string or singular in legacy modifiers.

### DIFF
--- a/interface/super/edit_layout.php
+++ b/interface/super/edit_layout.php
@@ -782,9 +782,9 @@ function writeFieldLine($linedata)
          htmlspecialchars($linedata['datacols'], ENT_QUOTES) . "' size='3' maxlength='10' class='optin' style='width:100%' />";
     echo "</td>\n";
     /* Below for compatabilty with existing string modifiers. */
-    if (strpos($linedata['edit_options'], ',') === false && ! empty($linedata['edit_options'])) {
-        json_decode($linedata['edit_options']);
-        if (is_string($linedata['edit_options']) && ! (json_last_error() === JSON_ERROR_NONE)) { // hopefully string of characters.
+    if (strpos($linedata['edit_options'], ',') === false && isset($linedata['edit_options'])) {
+        $t = json_decode($linedata['edit_options']);
+        if (json_last_error() !== JSON_ERROR_NONE || $t === 0) { // hopefully string of characters and 0 handled.
             $t = str_split(trim($linedata['edit_options']));
             $linedata['edit_options'] = json_encode($t); // convert to array select understands.
         }


### PR DESCRIPTION
I Missed handling 0 in legacy modifier string to json array conversion. Still have the on select data type error to deal with and found that the onchange call to NationNotesContext() from the select tag is fine but the document.getElementById("fld["+lineitem+"][contextName]").style.display=''; in function, returns null. Will add fix here when I find one.
Thought @matrix-amiel  could go ahead and see if this fixes his issue with Read Only option...
