### PR TITLE
Fix auto create of group's encounters and warning message

### DIFF
--- a/interface/therapy_groups/therapy_groups_controllers/participants_controller.php
+++ b/interface/therapy_groups/therapy_groups_controllers/participants_controller.php
@@ -70,6 +70,8 @@ class ParticipantsController extends BaseController
         $data['events'] = $this->groupEventsModel->getGroupEvents($groupId);
         $data['readonly'] = 'disabled';
         $data['participants'] = $this->groupParticipantsModel->getParticipants($groupId);
+        $statuses = array();
+        $names = array();
         foreach ($data['participants'] as $key => $row) {
             $statuses[$key]  = $row['group_patient_status'];
             $names[$key] = $row['lname'] . ' ' . $row['fname'];

--- a/library/encounter_events.inc.php
+++ b/library/encounter_events.inc.php
@@ -37,7 +37,9 @@ define('REPEAT_EVERY_WEEK', 1);
 define('REPEAT_EVERY_MONTH', 2);
 define('REPEAT_EVERY_YEAR', 3);
 define('REPEAT_EVERY_WORK_DAY', 4);
-    define('REPEAT_DAYS_EVERY_WEEK', 6);
+define('REPEAT_DAYS_EVERY_WEEK', 6);
+//===============================================================================
+$today=date('Y-m-d');
 //===============================================================================
 //Create event in calender as arrived
 function calendar_arrived($form_pid)


### PR DESCRIPTION
Hi.

We found bug in the auto create of group's encounter's, the encounter is created in every edit of event. the problem was that '$today' is always null.
+ fix of warning in the groups screen.

Thanks
Amiel