### PR TITLE
Downed jquery version 1-11-3 to 1-10-2.

### DIFF
--- a/interface/forms/eye_mag/a_issue.php
+++ b/interface/forms/eye_mag/a_issue.php
@@ -609,7 +609,7 @@ foreach (explode(',', $given) as $item) {
       </style>
 
       <link rel="shortcut icon" href="<?php echo $GLOBALS['images_static_relative']; ?>/favicon.ico" />
-      <script src="<?php echo $GLOBALS['assets_static_relative'] ?>/jquery-min-1-11-3/index.js"></script>
+      <script src="<?php echo $GLOBALS['assets_static_relative'] ?>/jquery-min-1-10-2/index.js"></script>
       <script src="<?php echo $GLOBALS['assets_static_relative'] ?>/bootstrap-3-3-4/dist/js/bootstrap.min.js"></script>
       <script src="<?php echo $GLOBALS['assets_static_relative'] ?>/jquery-ui-1-11-4/jquery-ui.min.js"></script>
       <script src="<?php echo $GLOBALS['assets_static_relative'] ?>/qtip2-2-2-1/jquery.qtip.min.js"></script>

--- a/interface/forms/eye_mag/help.php
+++ b/interface/forms/eye_mag/help.php
@@ -58,7 +58,7 @@ if ($showit=='ext') {
     <meta name="author" content="openEMR: ophthalmology help">
     <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- jQuery library -->
-    <script src="<?php echo $GLOBALS['assets_static_relative'] ?>/jquery-min-1-11-3/index.js"></script>
+    <script src="<?php echo $GLOBALS['assets_static_relative'] ?>/jquery-min-1-10-2/index.js"></script>
     <script src="<?php echo $GLOBALS['assets_static_relative'] ?>/jquery-ui-1-11-4/jquery-ui.js"></script>
     <link rel="stylesheet" href="<?php echo $GLOBALS['assets_static_relative'] ?>/jquery-ui-1-11-4/themes/excite-bike/jquery-ui.css">
     <!-- Latest compiled JavaScript -->

--- a/interface/forms/eye_mag/php/eye_mag_functions.php
+++ b/interface/forms/eye_mag/php/eye_mag_functions.php
@@ -1570,7 +1570,7 @@ function build_PMSFH($pid)
     $PMSFH_labels = array("POH", "POS", "PMH", "Surgery", "Medication", "Allergy", "SOCH", "FH", "ROS");
 
     foreach ($PMSFH_labels as $panel_type) {
-        $PMSFH[$panel_type] ='';
+        $PMSFH[$panel_type][] ='';
         $subtype = " and (subtype is NULL or subtype ='' )";
         $order = "ORDER BY title";
         if ($panel_type == "FH" || $panel_type == "SOCH" || $panel_type == "ROS") {

--- a/interface/forms/eye_mag/view.php
+++ b/interface/forms/eye_mag/view.php
@@ -36,6 +36,7 @@ require_once("$srcdir/lists.inc");
 require_once("$srcdir/api.inc");
 require_once("$srcdir/forms.inc");
 require_once("$srcdir/patient.inc");
+require_once("$srcdir/FeeSheetHtml.class.php");
 
 $form_name = "eye_mag";
 $form_folder = "eye_mag";
@@ -99,7 +100,7 @@ $prov_data    =  sqlQuery($query, array($providerID));
 global $priors;
 global $earlier;
 $PMSFH = build_PMSFH($pid);
-
+$fs = new FeeSheetHtml();
 /*
   Two windows anywhere with the same chart open is not compatible with the autosave feature.
   Data integrity problems will arise.
@@ -3518,7 +3519,7 @@ if ($refresh and $refresh != 'fullscreen') {
                                         "WHERE superbill = ? AND active = 1 " .
                                         "ORDER BY code_text", array($prow['option_id']));
                                         while ($row = sqlFetchArray($res)) {
-                                            $ctkey = alphaCodeType($row['code_type']);
+                                            $ctkey = $fs->alphaCodeType($row['code_type']);
                                             if ($code_types[$ctkey]['nofs']) {
                                                 continue;
                                             }


### PR DESCRIPTION
The problem with 1-11-3 version is you may no longer invoke .each or .map on a string, null or undefined. Really should fix where these errors occur at some point.
Fixed module up for PHP7.1 capability and tested as much as the basics including code lookup's with new dialog.
The font size is causing content to overflow container and I would recommend making the tabs and panels responsive rather than simply changing font size.
See https://github.com/openemr/openemr/issues/1161