### PR TITLE
Resolve bug was caused after escaping a urls of calendar.

### DIFF
--- a/interface/main/calendar/includes/pnMod.php
+++ b/interface/main/calendar/includes/pnMod.php
@@ -649,7 +649,7 @@ function pnModFunc($modname, $type = 'user', $func = 'main', $args = array())
  * @returns string
  * @return absolute URL for call
  */
-function pnModURL($modname, $type = 'user', $func = 'main', $args = array(), $path = '')
+function pnModURL($modname, $type = 'user', $func = 'main', $args = array(), $path = '', $escapeUrl = true)
 {
     if (empty($modname)) {
         return false;
@@ -698,8 +698,13 @@ function pnModURL($modname, $type = 'user', $func = 'main', $args = array(), $pa
 
     //remove characters not belonging in a path, prevent possible injection
     //this may break windows path accesses?
-    $path = preg_replace("/[^\.\/a-zA-Z0-9]/", "", $path)
-    ;
+    $path = preg_replace("/[^\.\/a-zA-Z0-9]/", "", $path);
+
+    //Escapes several special chars
+    if ($escapeUrl) {
+        $url=attr($url);
+    }
+
 
     // The URL
     $final_url = pnGetBaseURL() . $path . $url;

--- a/interface/main/calendar/modules/PostCalendar/pnadmin.php
+++ b/interface/main/calendar/modules/PostCalendar/pnadmin.php
@@ -1245,7 +1245,7 @@ EOF;
         $dels = implode(',', $del);
         $delText = _PC_DELETE_CATS . $dels .'.';
     }
-    $output->FormStart(pnModURL(__POSTCALENDAR__, 'admin', 'categoriesUpdate'));
+    $output->FormStart(pnModURL(__POSTCALENDAR__, 'admin', 'categoriesUpdate', array(), '',false));
     $output->Text(_PC_ARE_YOU_SURE);
     $output->Linebreak(2);
     // deletions

--- a/interface/main/calendar/modules/PostCalendar/pnadminapi.php
+++ b/interface/main/calendar/modules/PostCalendar/pnadminapi.php
@@ -113,7 +113,7 @@ function postcalendar_adminapi_buildAdminList($args)
     global $bgcolor1, $bgcolor2, $bgcolor3, $bgcolor4, $bgcolor5;
     global $textcolor1, $textcolor2;
     
-    $formUrl = pnModUrl(__POSTCALENDAR__, 'admin', 'adminevents');
+    $formUrl = pnModUrl(__POSTCALENDAR__, 'admin', 'adminevents', array(), '', false);
     $output->FormStart($formUrl);
     $output->Text('<table border="0" cellpadding="1" cellspacing="0" width="100%" bgcolor="'.$bgcolor2.'"><tr><td>');
     $output->Text('<table border="0" cellpadding="5" cellspacing="0" width="100%" bgcolor="'.$bgcolor1.'"><tr><td>');

--- a/interface/main/calendar/modules/PostCalendar/pnuser.php
+++ b/interface/main/calendar/modules/PostCalendar/pnuser.php
@@ -317,7 +317,7 @@ function postcalendar_user_submit2($args)
         // get the theme globals :: is there a better way to do this?
         pnThemeLoad(pnUserGetTheme());
         $all_categories = pnModAPIFunc(__POSTCALENDAR__, 'admin', 'getCategories');
-        $output->Text('<form name="cats" method="post" action="'.pnModURL(__POSTCALENDAR__, 'user', 'submit2', $args).'">');
+        $output->Text('<form name="cats" method="post" action="'.pnModURL(__POSTCALENDAR__, 'user', 'submit2', $args, '', false).'">');
         $output->FormHidden('no_nav', $_GET['no_nav']);
         $output->FormHidden('event_startampm', $_GET['event_startampm']);
         $output->FormHidden('event_starttimeh', $_GET['event_starttimeh']);

--- a/interface/main/calendar/modules/PostCalendar/pnuser.php
+++ b/interface/main/calendar/modules/PostCalendar/pnuser.php
@@ -201,7 +201,7 @@ function postcalendar_user_delete()
     //}
     unset($event);
 
-    $output->FormStart(pnModUrl(__POSTCALENDAR__, 'user', 'deleteevents'));
+    $output->FormStart(pnModUrl(__POSTCALENDAR__, 'user', 'deleteevents', array(), '',false));
     $output->FormHidden('pc_eid', $pc_event_id);
     $output->Text(_PC_DELETE_ARE_YOU_SURE.' ');
     $output->FormSubmit(_PC_ADMIN_YES);


### PR DESCRIPTION
Hi @bradymiller
I saw a problems that my fix caused in PR #1091 just today..
I push here a solution of the problem with create new category (prevent double escaping) and make a calendar safe from XSS attacks.
See this example  
![image](https://user-images.githubusercontent.com/17809866/32826017-8810ac40-c9ef-11e7-85cb-b8ed60bb7f3a.png)
It's simple to inject malicious code instead.
I think it's important to prevent it.

Thanks
Amiel


       