### PR TITLE
Zbig01 backup update 1

### DIFF
--- a/contrib/util/restore
+++ b/contrib/util/restore
@@ -142,6 +142,10 @@ fi
 
 dlg_msg "Now you will be asked for the backup file." "By default this is named emr_backup.tar, although you may have saved it as something else."
 
+#default values
+OEDIR=/var/www/openemr
+webroot_name=openemr
+
 LOOKING=1
 while [ $LOOKING -eq 1 ]; do
   dlg_fselect "Enter path/name of backup file"
@@ -154,6 +158,21 @@ while [ $LOOKING -eq 1 ]; do
     dlg_info "Extracting $TARFILE ..."
     cd $BAKDIR
     tar -xf $TARFILE
+    #RP_ADDED to get names of OEDIR ans webroot name if different from default by reading values from openemr_setup.txt
+    filename=$BAKDIR/openemr_setup.txt
+    while IFS= read -r line || [[ -n "$line" ]]
+    do
+        if [[ "${line}" == *WEBSERVER_ROOT* ]]
+        then
+            webserver_root=$(cut -d ':' -f2 <<< "$line")
+            echo $webserver_root
+        elif [[ "${line}" == *WEB_ROOT_NAME* ]]
+        then
+            webroot_name=$(cut -d ':' -f2 <<< "$line")
+            echo $webroot_name
+        fi
+    done < "$filename"
+    
     if [ $? -ne 0 ]; then
       dlg_msg "Error: tar could not extract '$TARFILE'."
     else
@@ -163,16 +182,16 @@ while [ $LOOKING -eq 1 ]; do
 done
 
 # Extract the OpenEMR web directory tree.
-dlg_info "Extracting $BAKDIR/openemr.tar.gz ..."
-mkdir openemr
-cd openemr
-tar zxf ../openemr.tar.gz
+dlg_info "Extracting $BAKDIR/$webroot_name.tar.gz ..."
+mkdir $webroot_name
+cd $webroot_name
+tar zxf ../$webroot_name.tar.gz
 if [ $? -ne 0 ]; then
-  dlg_msg "Error: tar could not extract '$BAKDIR/openemr.tar.gz'."
+  dlg_msg "Error: tar could not extract '$BAKDIR/$webroot_name.tar.gz'."
   exit 1
 fi
 
-OEDIR=/var/www/openemr
+
 
 # Get the Site ID, it should be the only site backed up.
 SITEID=`ls -1 sites | head -n 1`
@@ -422,7 +441,7 @@ mysqladmin --password="$MYROOTPASS" --force drop $OEDBNAME 2> /dev/null
 
 dlg_info "Restoring OpenEMR database ..."
 cd $BAKDIR
-gunzip openemr.sql.gz
+gunzip $OEDBNAME.sql.gz
 if [ $? -ne 0 ]; then
   dlg_msg "Error: Could not decompress '$BAKDIR/openemr.sql.gz'."
   exit 1
@@ -440,7 +459,7 @@ if [ $? -ne 0 ]; then
 fi
 
 mysql --password="$MYROOTPASS" --execute "GRANT ALL PRIVILEGES ON $OEDBNAME.* TO '$OEDBUSER'@'localhost' IDENTIFIED BY '$OEDBPASS'" $OEDBNAME
-mysql --user=$OEDBUSER --password="$OEDBPASS" $OEDBNAME < openemr.sql
+mysql --user=$OEDBUSER --password="$OEDBPASS" $OEDBNAME < $OEDBNAME.sql
 if [ $? -ne 0 ]; then
   dlg_msg "Error: Restore to database '$OEDBNAME' failed."
   exit 1

--- a/interface/main/backup.php
+++ b/interface/main/backup.php
@@ -85,7 +85,7 @@ $done = xlt('Done.  Will now send download.');
 $warning = xlt('WARNING: This will overwrite configuration information with data from the uploaded file');
 $use_feature = xlt('Use this feature only with newly installed sites, otherwise you will destroy references to/from existing data');
 $click_browse_and_select_one_configuration_file = xlt('Click Browse and select one configuration file usually named') . " openemr_config.sql";
-$browse = xlt('Browse'); 
+$browse = xlt('Browse');
 $success = "&nbsp;<i class='fa fa-check-circle text-success' aria-hidden='true'></i>&nbsp;";
 $failure = "&nbsp;<i class='a fa fa-times-circle text-danger' aria-hidden='true'></i>&nbsp;";
 
@@ -106,7 +106,7 @@ if (!empty($_POST['form_import'])) {
 
 //ViSolve: Assign Unique Number for the Log Creation
 if (!empty($_POST['form_backup'])) {
-    $form_step = 301; 
+    $form_step = 301;
 }
 
 // When true the current form will submit itself after a brief pause.
@@ -155,13 +155,13 @@ if ($form_step == 0) {
     $legend_text = xl('Backing up the data');
 } elseif ($form_step == 2 &&(!empty($phpgacl_location) && $gacl_object->_db_name != $sqlconf["dbase"])) {
     $legend_text = xl('Backing the phpGACL database');
-} elseif ($form_step == 4 || $form_step == 103 || $form_step == 203 ) {
+} elseif ($form_step == 4 || $form_step == 103 || $form_step == 203) {
     $legend_text = xl('Success') . " !!";
-}elseif ($form_step == 3 || ($form_step > 1 && $form_step < 6) ) {
+} elseif ($form_step == 3 || ($form_step > 1 && $form_step < 6)) {
     $legend_text = xl('Backing the openEMR website');
 } elseif ($form_step == 4 && (!empty($phpgacl_location)) && ($phpgacl_location != $srcdir."/../gacl")) {
     $legend_text = xl('Backing the phpGACL web directory');
-}  elseif ($form_step == 101) {
+} elseif ($form_step == 101) {
     $legend_text = xl('Select the configuration items to export');
 } elseif ($form_step == 103) {
     $legend_text = xl('Exported items sent to download');
@@ -225,8 +225,7 @@ if ($form_step == 0) {
                 $file_to_compress = '';  // if named, this iteration's file will be gzipped after it is created
                 $eventlog=0;  // Eventlog Flag
                 if ($form_step == 0) {
-                  
-               $div = <<<EOF
+                    $div = <<<EOF
                 <div class='col-xs-12'> 
                     <div class='form-group col-xs-12'> 
                     <button type='submit' id='form_create' name='form_create' class='btn btn-default btn-save' value='$BTN_TEXT_CREATE' />$BTN_TEXT_CREATE</button>
@@ -234,10 +233,10 @@ if ($form_step == 0) {
                     </div>
                 </div>
 EOF;
-echo $div; 
+                    echo $div;
                 // The config import/export feature is optional.
-                if (!empty($GLOBALS['configuration_import_export'])) {
-                    $div = <<<EOF
+                    if (!empty($GLOBALS['configuration_import_export'])) {
+                        $div = <<<EOF
                 <div class='col-xs-12'>
                     <div class='form-group col-xs-12'>
                        <button type='submit' name='form_export' class='btn btn-default btn-transmit' value='$BTN_TEXT_EXPORT'>$BTN_TEXT_EXPORT</button>
@@ -251,9 +250,9 @@ echo $div;
                     </div>
                 </div>
 EOF;
-echo $div;                 
-                }
-                $div = <<<EOF
+                        echo $div;
+                    }
+                    $div = <<<EOF
                 <div class='col-xs-12'>
                     <div class='form-group col-xs-12'>
                         <button type='submit' id='form_backup' name='form_backup' class='btn btn-default btn-save' value='$BTN_TEXT_CREATE_EVENTLOG'>$BTN_TEXT_CREATE_EVENTLOG</button>
@@ -261,9 +260,9 @@ echo $div;
                     </div>
                 </div>
 EOF;
-echo $div;              
-               } 
-               if ($form_step == 1) {
+                    echo $div;
+                }
+                if ($form_step == 1) {
                     $form_status .= "&nbsp;&nbsp;". xl('Dumping OpenEMR database') . "...<br />";
                     echo nl2br($form_status);
                     if (file_exists($TAR_FILE_PATH)) {
@@ -301,7 +300,7 @@ echo $div;
                         escapeshellarg($sqlconf["dbase"]);
                     }
 
-                    $auto_continue = true;
+                     $auto_continue = true;
                 }
                 if ($form_step == 2) {
                     if (!empty($phpgacl_location) && $gacl_object->_db_name != $sqlconf["dbase"]) {
@@ -384,7 +383,7 @@ echo $div;
                     $file_list = array('.');
                     
                     // Creates a openemr_setup file containing setup details
-                    $myfile = fopen("openemr_setup.txt", "w") or die ($failure . xl("Unable to open file!"));
+                    $myfile = fopen("openemr_setup.txt", "w") or die($failure . xl("Unable to open file!"));
                     $txt = "ORIGINAL WEBSITE AND DATABASE DETAILS"."\n";
                     fwrite($myfile, $txt);
                     $txt = "WEBSERVER_ROOT:". $GLOBALS['webserver_root'] ."\n";
@@ -405,8 +404,9 @@ echo $div;
                     
                     //copy the restore shell script
                     
-                    $file = "$webserver_root/contrib/util/restore"; $newfile = "restore";
-                    copy($file,$newfile);
+                    $file = "$webserver_root/contrib/util/restore";
+                    $newfile = "restore";
+                    copy($file, $newfile);
                                       
                     if (!create_tar_archive($TAR_FILE_PATH, '', $file_list)) {
                         die($failure . xl("Error: Unable to create downloadable archive"));
@@ -421,7 +421,7 @@ echo $div;
                     $auto_continue = true;
                 }
                 if ($form_step == 101) {
-                $div = <<<EOF
+                    $div = <<<EOF
                 <div class='col-xs-12'>
                     <div class='col-xs-12'>
                         <button type='submit' value= '$continue' class='btn btn-default btn-transmit'>$continue</button>
@@ -453,35 +453,35 @@ echo $div;
                         <h4 class='head clearfix ' style='padding:5px 10px'>$lists  <i id='lists-tooltip' class='fa fa-info-circle text-primary h5 oe-small' title='' aria-hidden='true' data-original-title=''></i><input type='checkbox'  id='sel_lists_checkbox' class='pull-right'  style='margin-top:10px !Important' value='1'></h4>
                         <select multiple id='sel_lists' name='form_sel_lists[]'  style='width:100%;' size='15'>
 EOF;
-echo $div;
+                    echo $div;
                         $lres = sqlStatement("SELECT option_id, title FROM list_options WHERE " .
                                 "list_id = 'lists' AND activity = 1 ORDER BY title, seq");
-                                while ($lrow = sqlFetchArray($lres)) {
-                                    echo "<option value='" . attr($lrow['option_id']) . "'";
-                                    echo ">" . text(xl_list_label($lrow['title'])) . "</option>\n";
-                                } 
-                $div = <<<EOF
+                    while ($lrow = sqlFetchArray($lres)) {
+                        echo "<option value='" . attr($lrow['option_id']) . "'";
+                        echo ">" . text(xl_list_label($lrow['title'])) . "</option>\n";
+                    }
+                    $div = <<<EOF
                         </select>
                     </div>
                     <div class='col-xs-4'>
                         <h4 class='head clearfix ' style='padding:5px 10px'>$layouts  <i id='layouts-tooltip' class='fa fa-info-circle text-primary h5 oe-small' title='' aria-hidden='true' data-original-title=''></i><input type='checkbox'  id='sel_layouts_checkbox' class='pull-right'  style='margin-top:10px !Important' value='1'></h4>
                         <select multiple id='sel_layouts' name='form_sel_layouts[]' style='width:100%' size='15'>
 EOF;
-echo $div;
+                    echo $div;
                         $lres = sqlStatement("SELECT grp_form_id, grp_title FROM layout_group_properties WHERE " .
                               "grp_group_id = '' AND grp_activity = 1 ORDER BY grp_form_id");
-                            while ($lrow = sqlFetchArray($lres)) {
-                                $key = $lrow['grp_form_id'];
-                                echo "<option value='" . attr($key) . "'";
-                                echo ">" . text($key) . ": " . text(xl_layout_label($lrow['grp_title'])) . "</option>\n";
-                            }
+                    while ($lrow = sqlFetchArray($lres)) {
+                        $key = $lrow['grp_form_id'];
+                        echo "<option value='" . attr($key) . "'";
+                        echo ">" . text($key) . ": " . text(xl_layout_label($lrow['grp_title'])) . "</option>\n";
+                    }
                         
-                $div = <<<EOF
+                    $div = <<<EOF
                         </select>
                     </div>
                 </div>
 EOF;
-echo $div;
+                    echo $div;
                 }
                 if ($form_step == 102) {
                     $tables = '';
@@ -629,7 +629,7 @@ echo $div;
                 }
 
                 if ($form_step == 201) {
-                $div= <<<EOF
+                    $div= <<<EOF
                 <div class='col-xs-12'>
                     <div class='col-xs-11 col-xs-offset-1'> <p><i class='fa fa-exclamation-triangle' style='color:red' aria-hidden='true'></i> <strong>$warning</strong>
                         <p><i class="fa fa-exclamation-triangle" style="color:red" aria-hidden="true"></i> <strong>$use_feature</strong></p>
@@ -657,7 +657,7 @@ echo $div;
                     </div>
                 </div>
 EOF;
-echo $div; 
+                    echo $div;
                 }
 
                 if ($form_step == 202) {

--- a/interface/main/backup_help.php
+++ b/interface/main/backup_help.php
@@ -11,7 +11,7 @@
 
 use OpenEMR\Core\Header;
 
-require_once ("../globals.php");
+require_once("../globals.php");
 ?>
 <!DOCTYPE HTML>
 <html>

--- a/interface/main/backup_help.php
+++ b/interface/main/backup_help.php
@@ -1,0 +1,228 @@
+<?php
+/**
+ * Backup Help.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author Ranganath Pathak <pathak@scrs1.org>
+ * @copyright Copyright (c) 2017 Ranganath Pathak <pathak@scrs1.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+use OpenEMR\Core\Header;
+
+require_once ("../globals.php");
+?>
+<!DOCTYPE HTML>
+<html>
+    <head>
+    <?php Header::setupHeader();?>
+    <title><?php echo xlt("EOB Posting - Instructions");?></title>
+    <style>
+        .oe-help-heading{
+            color:#676666;
+            background-color: #E4E2E0;
+            border-color: #DADADA;
+            padding: 10px 5px;
+            border-radius: 5px;
+        }
+        .oe-help-redirect{
+            color:#676666;
+        }
+        a {
+            text-decoration: none !important;
+            color:#676666 !important;
+            font-weight:700;
+        }
+        h2 > a {
+            font-weight:500;
+        }
+        @media only screen and (max-width: 768px) {
+           [class*="col-"] {
+           width: 100%;
+           text-align:left!Important;
+            }
+        }
+        @media only screen and (max-width: 1004px) and (min-width: 641px)  {
+            .oe-large {
+                display: none;
+            }
+            .oe-small {
+                display: inline-block;
+            }
+        }
+    </style>
+    </head>
+    <body>
+        <div class="container">
+            <div>
+                <center><h2><a name = 'entire_doc'><?php echo xlt("Backup Help");?></a></h2></center>
+            </div>
+            <div class= "row">
+                <p><?php echo xlt("The flip side of instant access to all records is the possibility of instant loss of access to all records");?>.
+                
+                <p><?php echo xlt("A good backup strategy is essential to guard against the time when data WILL be lost");?>.
+                
+                <p><?php echo xlt("To be successful the backup should be periodic or continuous and be able to successfully restore data within an appopriate timeframe");?>.
+                
+                <p><?php echo xlt("In short a robust backup and disaster recovery policy and solution is essential to safeguard against catastrophic data loss and the attendant financial and legal ramifications of such loss");?>.
+                
+                <p><?php echo xlt("Backups can be of the following types");?>:
+               
+                <ul>
+                    <li><?php echo xlt("Full backup - a complete backup of an application or entire system");?></li>
+                    <li><?php echo xlt("Differential - backup all changes since the last FULL backup was performed");?></li>
+                    <li><?php echo xlt("Incremental - backup only the changes since that LAST backup was performed");?></li>
+                </ul>
+                
+                <p><?php echo xlt("These methods will backup data at predefined intervals");?>.
+                
+                <p><?php echo xlt("There are two other concepts that one must be familiar with");?>:
+                
+                <ul>
+                    <li><?php echo xlt("Continuous Data Protection (CDP)");?></li>
+                    <li><?php echo xlt("near-CDP");?></li>
+                </ul>
+                
+                <p><?php echo xlt("CDP - copies data from a source to a target every time a change is made and automatically saves a copy of every change made to that data, thus having the ability to restore data to any point in time upto the point of failure");?>.
+                 
+                <p><?php echo xlt("near-CDP - copies data from a source to a target at pre-set time intervals as snapshots");?>.
+
+                <p><?php echo xlt("Continuous data protection is different from traditional backup in that it is not necessary to specify the point in time to recover from until ready to restore");?>.
+
+                <p><?php echo xlt("Traditional backups only restore data up to the time the backup was made");?>.
+                
+                <p><?php echo xlt("CDP offers protection against physical loss or corruption as well as logical corruption, i.e. when the data exists but has become corrupted");?>.
+                
+                <p><?php echo xlt("Traditional backup strategies, i.e. full, incremental or differental backups, that simply replicate data at the block level in whatever condition it exists DO NOT protect against logical corruption");?>.
+                 
+                <p><?php echo xlt("This means that if the primary data becomes logically corrupted then that corruption is replicated in the backup rendering it useless for recovery");?>.
+
+                <p><i class="fa fa-exclamation-circle" style="color:orange" aria-hidden="true"></i> <strong><?php echo xlt("This backup module lets you create a full backup of the data and website of your OpenEMR installation");?>.</strong>
+                 
+                <p><?php echo xlt("Its main function is to be able to recover to a previous state if any upgrade fails and either the upgraded database or the website gets corrupted");?>.
+                
+                <p><i class="fa fa-exclamation-triangle" style="color:red" aria-hidden="true"></i> <strong><?php echo xlt("This should NOT be the only backup strategy in place");?>.</strong>
+
+                <p><?php echo xlt("There are four actions that can be performed");?>:
+                
+                <ul id='action_list'>
+                    <li><a href="#full_backup"><?php echo xlt("Create Full Backup"); ?></a></li>
+                    <li><a href="#export_configuration"><?php echo xlt("Export Configuration"); ?></a></li>
+                    <li><a href="#import_configuration"><?php echo xlt("Import Configuration"); ?></a></li>
+                    <li><a href="#eventlog_backup"><?php echo xlt("Backup the eventlog"); ?></a></li>
+                </ul>
+                
+                <p><?php echo xlt("With data generated an OpenEMR installation can be recovered");?>.
+            </div>
+            <div class= "row" id="full_backup">
+                <h4 class="oe-help-heading"><?php echo xlt("Create Full Backup"); ?><a href="#action_list"><i class="fa fa-arrow-circle-up float-right oe-help-redirect" aria-hidden="true"></i></a></h4>
+                <p><?php echo xlt("Click on the 'Create Full Backup' button to backup the entire openEMR database as well as the entire website");?>.
+
+                <p><?php echo xlt("A compressed archive 'emr_backup.tar' will be created and will be automatically downloaded into the Downloads folder of the computer that you are running the command from");?>.
+                
+                <p><i class="fa fa-exclamation-triangle" style="color:red" aria-hidden="true"></i> <strong><?php echo xlt("If you are executing this from any computer other than the one which holds the OpenEMR installation, over a network, the time to download depends on the size of the database and website and the network speed - (sometimes may take many hours) especially if your database and website holds a lot of data");?>.</strong>
+            </div>
+            <div class= "row" id="export_configuration">
+                <h4 class="oe-help-heading"><?php echo xlt("Export Configuration"); ?><a href="#action_list"><i class="fa fa-arrow-circle-up float-right oe-help-redirect" aria-hidden="true"></i></a></h4>
+                <p><?php echo xlt("Lets you export select tables and entries within some tables containing configuration data");?>.
+                
+                <p><?php echo xlt("To activate this feature check the checkbox Administration > Globals > Features > Configuration Export/Import and click 'Save'");?>.
+
+                <p><?php echo xlt("There are three sections");?>:
+                
+                <li><?php echo xlt("Tables  - contains data pertaining to Services, Products, Prices, Document Categories, Fee Sheet Options, Translations");?></li>
+                <li><?php echo xlt("Lists - All the items in table 'list_options' that are used through out the program ");?></li>
+                <li><?php echo xlt("Layouts - layout details of forms using the Layout Based Templates stored in table 'layout_options'");?></li>
+                <br>
+                <p><?php echo xlt("Select the needed and click 'Continue'");?>.
+                
+                <p><?php echo xlt("It will download a file called 'openemr_config.sql' that contains all the data from the selected tables as a sql file");?>.
+
+                <p><?php echo xlt("This file can then be imported into a new install to avoid having to input this data");?>.
+                
+            </div>
+            <div class= "row" id="import_configuration">
+                <h4 class="oe-help-heading"><?php echo xlt("Import Configuration"); ?><a href="#action_list"><i class="fa fa-arrow-circle-up float-right oe-help-redirect" aria-hidden="true"></i></a></h4>
+                <p><?php echo xlt("Lets you import configuration data into the OpenEMR database");?>.
+
+                <p><?php echo xlt("Useful when you setup a new install and want to import the configuration values of a pervious install");?>.
+                
+                <p><?php echo xlt("Click 'Browse' and select a sql file to import. You are usually importing a previously created openemr_cofig_sql file ans then click 'Continue'");?>.
+
+                <p><i class='fa fa-exclamation-triangle' style='color:red' aria-hidden='true'></i> <strong><?php echo xlt("WARNING: This will overwrite configuration information with data from the uploaded file") ?>.</strong>
+                
+                <p><i class="fa fa-exclamation-triangle" style="color:red" aria-hidden="true"></i> <strong><?php echo xlt("Use this feature only with newly installed sites, otherwise you will destroy references to/from existing data");?>.</strong></p>
+               
+                <p><?php echo xlt("Can use to recover the current install if you have modified any of the configuration data and want to revert to previous working version");?>.
+            </div>
+            <div class= "row" id="eventlog_backup">
+                <h4 class="oe-help-heading"><?php echo xlt("Backup the eventlog"); ?><a href="#action_list"><i class="fa fa-arrow-circle-up float-right oe-help-redirect" aria-hidden="true"></i></a></h4>
+                <p><?php echo xlt("All events/actions that are done to the databse in OpenEMR are logged");?>.
+
+                <p><?php echo xlt("The log data is stored in two tables 'log' and 'log_comment_encrypt'");?>.
+                
+                <p><?php echo xlt("These tables can get large over time");?>.
+
+                <p><?php echo xlt("Click on 'Eventlog backup' to backup this data as a eventlog_yyyymmdd_hhmmss.sql file in the tmp directory under a directory called 'emr_eventlog_backup'");?>.
+                
+                <p><?php echo xlt("It then creates two new and empty tables for fresh log data");?>.
+
+            </div>
+            <div class= "row" id="restore">
+                <h4 class="oe-help-heading"><?php echo xlt("Recovery"); ?><a href="#"><i class="fa fa-arrow-circle-up float-right oe-help-redirect" aria-hidden="true"></i></a></h4>
+                <p><?php echo xlt("For OpenEMR installations on a Linux server use the following method to restore the OpenEMR application");?>.
+                
+                <p><?php echo xlt("Brief explanation of what will happen"); ?>: 
+                
+                <ul>
+                    <li><?php echo xlt("A compressed archive is being used to recover an OpenEMR installation"); ?></li>
+                    <li><?php echo xlt("The compressed archive (default name -  `emr_backup.tar`) has 2 compressed archives - one containing the website data and the other the database data"); ?></li>
+                    <li><?php echo xlt("In addition there are 2 files - 'openemr-setup.txt' containing details regarding the website and database and a script called 'restore' that will be used for the actual restoration"); ?></li>
+                    <li><?php echo xlt("You will first delete the existing OpenEMR website and then recreate a new one with data from the compressed archive by running the 'restore' script"); ?></li>
+                </ul>
+                
+                <p><i class="fa fa-exclamation-circle" style="color:orange" aria-hidden="true"></i> <strong><?php echo xlt("You will need the  MySQL root user password to successfully complete this task");?>.</strong>
+
+                <p><?php echo xlt("Copy the 'emr_backup.tar' that was created into the home directory on the server that you want to install OpenEMR");?>.
+                
+                <p><?php echo xlt("If you have downloaded the backup directory 'emr_backup.tar' on another machine you should move it to the home directory of a user on the server that you want to install OpenEMR");?>.
+                
+                <p><?php echo xlt("Open Terminal on the server that hosts the OpenEMR installation or ssh into it from another computer by using PuTTY for Windows or the terminal for a Mac or Linux");?>.
+                
+                <p><?php echo xlt("Extract the 'openemr-setup.txt' file from the emr_backup.tar compressed folder by issuing the following command after the dollar sign: sudo ./tar -xvf emr_backup.tar openemr-setup.txt");?>.
+                
+                <p><?php echo xlt("It contains details of the OpenEMR installation. To read its contents issue following command sudo ./cat openemr-setup.txt");?>.
+                
+                <p><?php echo xlt("Select the data by highlighting with a mouse, press Ctrl + Insert to copy and Shift + Insert to paste into a text file");?>.
+                
+                <p><?php echo xlt("Extract the 'restore' script from the emr_backup.tar compressed folder by issuing the following command sudo ./tar -xvf emr_backup.tar restore");?>.
+                
+                <p><?php echo xlt("Make the  'restore' script executable  by issuing the following command sudo ./chmod 755 restore");?>.
+                
+                <p><i class='fa fa-exclamation-triangle' style='color:red' aria-hidden='true'></i> <strong><?php echo xlt("Delete the openemr web directory");?>.</strong>
+                
+                <p><?php echo xlt("If you are on terminal or have logged in via ssh you can issue this command after the dollar sign: sudo rm -rf <path to website> i.e. ($ sudo rm -rf  /var/www/html/openemr)");?>.
+                
+                <p><i class="fa fa-exclamation-circle" style="color:orange" aria-hidden="true"></i> <strong> <?php echo xlt("Be careful with this command , make sure that you have typed the correct path. It will delete the named directory and all its contents without any further warning");?>.</strong>
+                    
+                <p><?php echo xlt("Issue this command after the dollar sign: sudo ./restore ($ sudo ./restore), 1 space after $ with no space before restore");?>.
+                
+                <p><?php echo xlt("Enter the path to the backup file: /home/<your home directory username>/emr_backup.tar");?>.
+                
+                <p><?php echo xlt("Change values as needed by referring to the openemr-setup file that you had saved");?>.
+                
+                <p><?php echo xlt("Enter the MySQL root user password");?>.
+                
+                <p><?php echo xlt("Wait for the script to finish executing");?>.
+                
+                <p><?php echo xlt("If all goes well you should have a restored OpenEMR installation");?>.
+                
+                <p><?php echo xlt("Download the recovery instructions for those with OpenEMR installed on a Linux server as you will not be able to read this page when you are trying to restore the site"); ?>. &nbsp <a href="restore_instructions_linux.txt" class= "btn btn-default btn-download" download="Restore Instructions" target="_blank"> <?php echo xlt("Download"); ?></a>
+               
+                <p><?php echo xlt("For OpenEMR installations on a windows machine use the following method to restore the OpenEMR application by clicking on the following link");?>. <strong><a href="http://www.open-emr.org/wiki/index.php/Windows_Backup_And_Restore_Made_Easy" target="_blank"><?php echo xlt("Windows Backup and Recovery"); ?></a></strong> <strong><a href=""> </a>
+                    
+            </div>   
+        </div><!--end of container div-->
+    </body>
+</html>


### PR DESCRIPTION
User interface improvements to the Administration->Backup along with a help script. Taken from the following PR:
https://github.com/openemr/openemr/pull/1235

Also fixes to the commandline restore script:
"The first thing that I noted was that whatever your database and openemr installation was called the recovered one would be called openemr. Secondly the restore script assumed the Web root directory to be /var/www/
I order to fix these problems I created a text file that contains the installation data, openemr-setup.txt, and modified the restore script to accept these values as needed. This now results in the recovered installation to be identical in all respects to the original. In addition the restore script is now included in the emr_backup.tar which now contains 2 archives and two files - openemr-setup.txt and restore."

Demo is here:
http://www.open-emr.org/wiki/index.php/Development_Demo#Epsilon_-_Up_For_Grabs_Demo