### PR TITLE
New ACO for manage modules

### DIFF
--- a/acl_setup.php
+++ b/acl_setup.php
@@ -112,6 +112,9 @@ $gacl->add_object('admin', 'Multipledb', 'multipledb', 10, 0, 'ACO');
 // xl('Multipledb')
 $gacl->add_object('admin', 'Menu', 'menu', 10, 0, 'ACO');
 // xl('Menu')
+$gacl->add_object('admin', 'Manage modules', 'manage_modules', 10, 0, 'ACO');
+// xl('Manage modules')
+
 
 // Create ACOs for encounters.
 //

--- a/acl_upgrade.php
+++ b/acl_upgrade.php
@@ -625,9 +625,44 @@ if ($acl_version < $upgrade_acl) {
     $acl_version = $upgrade_acl;
 }
 
-/* This is a template for a new revision, when needed
+
 // Upgrade for acl_version 7
 $upgrade_acl = 7;
+if ($acl_version < $upgrade_acl) {
+    echo "<B>UPGRADING ACCESS CONTROLS TO VERSION ".$upgrade_acl.":</B></BR>";
+
+    //Collect the ACL ID numbers.
+    echo "<B>Checking to ensure all the proper ACL(access control list) are present:</B></BR>";
+    $admin_write = getAclIdNumber('Administrators', 'write');
+    $emergency_write = getAclIdNumber('Emergency Login', 'write');
+
+    //Add new object Sections
+    echo "<BR/><B>Adding new object sections</B><BR/>";
+    addObjectAcl('admin', 'Administration', 'manage_modules', 'Manage modules');
+
+    //Add new Objects
+    echo "<BR/><B>Adding new objects</B><BR/>";
+
+    //Update already existing Objects
+    echo "<BR/><B>Upgrading objects</B><BR/>";
+
+    //Add new ACLs here (will return the ACL ID of newly created or already existant ACL)
+    // (will also place in the appropriate group and CREATE a new group if needed)
+    echo "<BR/><B>Adding ACLs(Access Control Lists) and groups</B><BR/>";
+    updateAcl($admin_write, 'Administrators', 'admin', 'Administration', 'manage_modules', 'Manage modules', 'write');
+    updateAcl($emergency_write, 'Emergency Login', 'admin', 'Administration', 'manage_modules', 'Manage modules', 'write');
+
+    //Update the ACLs
+    echo "<BR/><B>Updating the ACLs(Access Control Lists)</B><BR/>";
+
+    //DONE with upgrading to this version
+    $acl_version = $upgrade_acl;
+}
+
+
+/* This is a template for a new revision, when needed
+// Upgrade for acl_version 8
+$upgrade_acl = 8;
 if ($acl_version < $upgrade_acl) {
     echo "<B>UPGRADING ACCESS CONTROLS TO VERSION ".$upgrade_acl.":</B></BR>";
 
@@ -656,8 +691,8 @@ if ($acl_version < $upgrade_acl) {
 */
 
 /* This is a template for a new revision, when needed
-// Upgrade for acl_version 8
-$upgrade_acl = 8;
+// Upgrade for acl_version 9
+$upgrade_acl = 9;
 if ($acl_version < $upgrade_acl) {
     echo "<B>UPGRADING ACCESS CONTROLS TO VERSION ".$upgrade_acl.":</B></BR>";
 

--- a/interface/main/left_nav.php
+++ b/interface/main/left_nav.php
@@ -1305,7 +1305,10 @@ if ($reglastcat) {
     <?php  if (acl_check('menus', 'modle')) {?>
    <li><a class="collapsed" id="modimg" ><span><?php echo xlt('Modules') ?></span></a>
     <ul>
-    <?php genMiscLink('RTop', 'adm', '0', xl('Manage Modules'), 'modules/zend_modules/public/Installer'); ?>
+    <?php if (acl_check('admin', 'manage_modules')) {
+        genMiscLink('RTop', 'adm', '0', xl('Manage Modules'), 'modules/zend_modules/public/Installer');
+    }  ?>
+
         <?php //genTreeLink('RTop','ort',xl('Settings')); ?>
         <?php
         $module_query = sqlStatement("select mod_id, mod_directory,mod_name,mod_nick_name,mod_relative_link,type from modules where mod_active = 1 AND sql_run= 1 order by mod_ui_order asc");

--- a/interface/main/tabs/menu/menus/standard.json
+++ b/interface/main/tabs/menu/menus/standard.json
@@ -501,12 +501,16 @@
         "children": [],
         "requirement": 0,
         "acl_req": [
-          "menus",
-          "modle"
+          "admin",
+          "manage_modules"
         ]
       }
     ],
-    "requirement": 0
+    "requirement": 0,
+    "acl_req": [
+    "menus",
+    "modle"
+  ]
   },
   {
     "label": "Inventory",

--- a/version.php
+++ b/version.php
@@ -33,7 +33,7 @@ $v_database = 244;
 // controls is (subsequently the acl_upgrade.php script then is used to
 // upgrade and track this value)
 //
-$v_acl = 6;
+$v_acl = 7;
 
 //Offsite Portal SOAP functions version, which are at myportal directory.
 $v_offsite_portal='1.47';


### PR DESCRIPTION
Hi.

This PR contains creation of new ACO for manage modules.
Without the new ACO every user with one of ACO of admin section (Calendar Settings, Pharmacy Dispensary etc.) in the old menu or every user with ACO Modules->menus in the new tabs menu can edit/remove all the modules of the clinic.

Thanks.
Amiel
   