### PR TITLE
Patch in the datepicker popup for RTL languages

### DIFF
--- a/library/js/xl/jquery-datetimepicker-2-5-4.js.php
+++ b/library/js/xl/jquery-datetimepicker-2-5-4.js.php
@@ -59,6 +59,25 @@
             ]
         },
     },
+    <?php if ($_SESSION['language_direction'] == 'rtl') { ?>
+    /**
+     * In RTL languages a datepicker popup is opened in left and it's cutted by the edge of the window
+     * This patch resolves that and moves a datepicker popup to right side.
+     */
+    onGenerate:function(current_time,$input){
+        //position of input
+        var position = $($input).offset()
+        //width of date picke popup
+        var datepickerPopupWidth = $('.xdsoft_datetimepicker').width();
+
+        if(position.left < datepickerPopupWidth){
+            $('.xdsoft_datetimepicker').offset({left:position.left});
+        } else {
+            //put a popup in the regular position
+            $('.xdsoft_datetimepicker').offset({left:position.left - datepickerPopupWidth + $($input).innerWidth()});
+        }
+    },
+    <?php } ?>
     yearStart: '1900',
     scrollInput: false,
     scrollMonth: false,


### PR DESCRIPTION
Hi @sjpadgett @bradymiller .
I've found strange behavior of datepicker popup in the add/edit event screen after the last changes.
I'ts happen **only in RTL languages** .
1. The popup is opened at a distance of 50px from the input (It's happen in a few screens) -
![image](https://user-images.githubusercontent.com/17809866/33889041-96bc7134-df57-11e7-8a00-9458cf834b2e.png)
2. In the another place a popup is cutted  in the edge of screen.
![image](https://user-images.githubusercontent.com/17809866/33889110-d1cc3110-df57-11e7-8caf-8c78728f1e04.png)

I tried to research what the problem, I think it's bug in the datetimepicker library (https://xdsoft.net/jqplugins/datetimepicker/).

I suggest here option of patch to resolved this. (I haven't time to fix a library now).
If you knew another solution I will be happy, but we need any solution for this because a screen of edd/edit event is not working for RTL now.

Thank you!
Amiel