### PR TITLE
New dialog not working in IE browser

### DIFF
--- a/library/dialog.js
+++ b/library/dialog.js
@@ -279,7 +279,7 @@ function dlgopen(url, winname, width, height, forceNewWindow, title, opts) {
 
     // Convert dialog size to percentages and/or css class.
     var sizeChoices = ['modal-sm', 'modal-md', 'modal-mlg', 'modal-lg', 'modal-xl'];
-    if (Number.isInteger(width)) {
+    if (Math.abs(width) > 0) {
         width = Math.abs(width);
         mWidth = (width / where.innerWidth * 100).toFixed(4) + '%';
         msSize = '<style>.modal-custom' + winname + ' {width:' + mWidth + ';}</style>';


### PR DESCRIPTION
Hi.

The last changes in the popups contains a new JS function - 'isInteger', [IE not supports that function](https://developer.mozilla.org/he/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger#Browser_compatibility) and all the screens are failed.  
So I changed it to another function.

Thanks.
Amiel