### PR TITLE
Left Nav fix for bootstrap override of doc html font-size.

### DIFF
--- a/interface/main/left_nav.php
+++ b/interface/main/left_nav.php
@@ -394,53 +394,52 @@ function genFindBlock()
 <link rel="stylesheet" href="<?php echo $css_header;?>" type="text/css">
 <link rel="stylesheet" href="<?php echo $GLOBALS['assets_static_relative'];?>/font-awesome-4-6-3/css/font-awesome.css" type="text/css">
 <style type="text/css">
- body {
-  font-size:1em;
-  line-height: 1em !important;
-  font-weight:normal;
-  padding: 5px 3px 5px 3px;
- }
- .smalltext {
-  font-family:sans-serif;
-  font-size:8pt;
-  font-weight:normal;
- }
- a.navitem, a.navitem:visited {
-  color:#0000ff;
-  font-family:sans-serif;
-  font-size:8pt;
-  font-weight:bold;
- }
-.inputtext {
-  font-size:9pt;
-  font-weight:normal;
-  border-style:solid;
-  border-width:1px;
-  padding-left:2px;
-  padding-right:2px;
-  border-color: #000000;
-  background-color:transparent;
-}
-#navigation-slide, #navigation-slide * {
-  font-size: 1.3rem !important;
-  cursor: pointer;
-}
-#navigation ul {
-  background-color:transparent;
-}
-#navigation-slide ul {
-  background-color:transparent;
-}
-#navigation-slide a{
-  width: 92%;
-}
-.nav-menu-img{
-  width:25px;
-  height:25px;
-  border:none;
-  margin-right:5px;
-  vertical-align:middle;
-}
+    html {
+        font-size: 1em;
+    }
+    body {
+        font-size:8pt;
+        font-weight:normal;
+        padding: 5px 3px 5px 3px;
+    }
+    .smalltext {
+        font-family:sans-serif;
+        font-size:8pt;
+        font-weight:normal;
+    }
+    a.navitem, a.navitem:visited {
+        color:#0000ff;
+        font-family:sans-serif;
+        font-size:8pt;
+        font-weight:bold;
+    }
+    .inputtext {
+        font-size:9pt;
+        font-weight:normal;
+        border-style:solid;
+        border-width:1px;
+        padding-left:2px;
+        padding-right:2px;
+        border-color: #000000;
+        background-color:transparent;
+    }
+
+    #navigation ul {
+        background-color:transparent;
+    }
+    #navigation-slide ul {
+        background-color:transparent;
+    }
+    #navigation-slide a{
+        width: 92%;
+    }
+    .nav-menu-img{
+        width:25px;
+        height:25px;
+        border:none;
+        margin-right:5px;
+        vertical-align:middle;
+    }
 </style>
 <link rel="stylesheet" href="../../library/js/jquery.treeview-1.4.1/jquery.treeview.css" />
 <script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/jquery-min-1-9-1/index.js"></script>


### PR DESCRIPTION
Tested across all browser's including IE11. Appears all left nav menus are now consistent. Bootstrap, for some reason, sets html base font to 10px causing newer themes to calculate font-size incorrectly. This was very apparent in light theme(tiny font-size). My previous attempt to fix broke other themes so here we are.