### PR TITLE
Preventing XSS attack through globals.

### DIFF
--- a/interface/super/edit_globals.php
+++ b/interface/super/edit_globals.php
@@ -244,7 +244,7 @@ if (array_key_exists('form_save', $_POST) && $_POST['form_save'] && !$userMode) 
                     sqlStatement("DELETE FROM globals WHERE gl_name = ?", array( $fldid ));
 
                     foreach ($_POST["form_$i"] as $fldvalue) {
-                        $fldvalue = trim($fldvalue);
+                        $fldvalue = strip_tags(trim($fldvalue));
                         sqlStatement('INSERT INTO `globals` ( gl_name, gl_index, gl_value ) VALUES ( ?,?,?)', array( $fldid, $fldindex, $fldvalue ));
                         ++$fldindex;
                     }
@@ -252,7 +252,7 @@ if (array_key_exists('form_save', $_POST) && $_POST['form_save'] && !$userMode) 
             } else {
                 /* check value of single field. Don't update if the database holds the same value */
                 if (isset($_POST["form_$i"])) {
-                    $fldvalue = trim($_POST["form_$i"]);
+                    $fldvalue = strip_tags(trim($_POST["form_$i"]));
                 } else {
                     $fldvalue = "";
                 }

--- a/library/user.inc
+++ b/library/user.inc
@@ -72,6 +72,8 @@ function setUserSetting($label, $value, $user = null, $createDefault = true, $ov
 
     $cur_value = getUserSetting($label, $user, $user);
 
+    $value = strip_tags($value);
+
   // Check for a custom settings
     if (is_null($cur_value)) {
         sqlStatement("INSERT INTO user_settings(setting_user, setting_label, setting_value) " .


### PR DESCRIPTION
We found a critical vulnerability when we saved into a global value (table globals) a script that injects javascript code into the page. This code is being executed.

There are 2 solutions:
1. AVOID inserting html into the globals values (strip_html).  ---> Done in this PR
*If there are html tags that are allowed for a field they should be added in a whitelist,

2. Add text() to every global that is being echoed in the system.-> This is a "large" changes as we need to scan all the code and find where are this variables being used. -> Separate PR

Please bring this change into the code base as its a critical security vulnerability.
please sent me a mail if you want an example of how to reproduce the vulnerability. 
I don't want to publish it here.


