### PR TITLE
move dicom viewer to iframe

### DIFF
--- a/controllers/C_Document.class.php
+++ b/controllers/C_Document.class.php
@@ -151,12 +151,19 @@ class C_Document extends Controller
                     if ($_POST['destination'] != '') {
                         $fname = $_POST['destination'];
                     }
+                    $mimetype = $_FILES['file']['type'][$key];
+                    if ($mimetype == 'application/octet-stream') { // windows most likely...
+                        $parts = pathinfo($fname);
+                        if (strtolower($parts['extension']) == 'dcm') { // cheat for dicom on windows because MS must be different!!!
+                            $mimetype = 'application/dicom';
+                        }
+                    }
                     $d = new Document();
                     $rc = $d->createDocument(
                         $patient_id,
                         $category_id,
                         $fname,
-                        $_FILES['file']['type'][$key],
+                        $mimetype,
                         $filetext,
                         empty($_GET['higher_level_path']) ? '' : $_GET['higher_level_path'],
                         empty($_POST['path_depth']) ? 1 : $_POST['path_depth'],

--- a/library/classes/Document.class.php
+++ b/library/classes/Document.class.php
@@ -199,18 +199,24 @@ class Document extends ORDataObject
             if (file_exists($filename)) {
                 $d = new Document($result->fields['id']);
             } else {
-                $sql = "DELETE FROM  " . $d->_table . " WHERE id= '" . $result->fields['id'] ."'";
+                $sql = "DELETE FROM  " . $d->_table . " WHERE id= '" . $result->fields['id'] . "'";
                 $result = $d->_db->Execute($sql);
                 echo("There is a database for the file but it no longer exists on the file system. Its document entry has been deleted. '$filename'\n");
             }
         } else {
-            $file_command = $GLOBALS['oer_config']['document']['file_command_path'] ;
-            $cmd_args = "-i ".escapeshellarg($new_path.$fname);
+            $file_command = $GLOBALS['oer_config']['document']['file_command_path'];
+            $cmd_args = "-i " . escapeshellarg($new_path . $fname);
 
-            $command = $file_command." ".$cmd_args;
+            $command = $file_command . " " . $cmd_args;
             $mimetype = exec($command);
             $mime_array = explode(":", $mimetype);
             $mimetype = $mime_array[1];
+            if ($mimetype == 'application/octet-stream') { // windows most likely...
+                $parts = pathinfo($fname);
+                if (strtolower($parts['extension']) == 'dcm') { // cheat for dicom on windows because MS must be different!!!
+                    $mimetype = 'application/dicom';
+                }
+            }
             $d->set_mimetype($mimetype);
             $d->url = $url;
             $d->size = filesize($filename);

--- a/library/dicom_frame.php
+++ b/library/dicom_frame.php
@@ -1,0 +1,72 @@
+<?php
+
+require_once('../interface/globals.php');
+
+$web_path = $_REQUEST['web_path'];
+$patid = $_REQUEST['patient_id'];
+$docid = $_REQUEST['document_id'];
+$web_path .= '&retrieve&patient_id=' . $patid . '&document_id=' . $docid . '&as_file=false'
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/jquery-min-3-1-1/index.js"></script>
+    <script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/modernizr-3-5-0/dist/modernizr-build.js"></script>
+    <script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/i18next-9-0-1/i18next.min.js"></script>
+    <script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/i18next-xhr-backend-1-4-3/i18nextXHRBackend.min.js"></script>
+    <script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/i18next-browser-languagedetector-2-0-0/i18nextBrowserLanguageDetector.min.js"></script>
+    <script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/konva-1-6-8/konva.min.js"></script>
+    <script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/magic-wand-js/js/magic-wand-min.js"></script>
+    <script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/jszip-3-1-5/dist/jszip.min.js"></script>
+    <!-- Third party (viewer) -->
+    <script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/flot-0-8-3/jquery.flot.js"></script>
+    <!-- decoders -->
+    <script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/dwv-0-21-0/decoders/pdfjs/jpx.js"></script>
+    <script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/dwv-0-21-0/decoders/pdfjs/util.js"></script>
+    <script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/dwv-0-21-0/decoders/pdfjs/arithmetic_decoder.js"></script>
+    <script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/dwv-0-21-0/decoders/pdfjs/jpg.js"></script>
+    <script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/dwv-0-21-0/decoders/rii-mango/lossless-min.js"></script>
+    <!-- Local (dwv) -->
+    <script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/dwv-0-21-0/dist/dwv.min.js"></script>
+    <!-- i18n dwv wrapper -->
+    <script type="text/javascript" src="<?php echo $GLOBALS['web_root']?>/library/js/dwv/dwv_i18n.js"></script>
+</head>
+<style type="text/css">
+    .warn_diagnostic {
+        margin: 10 auto 10 auto;
+        color: rgb(255, 0, 0);
+        font-size: 1.5em;
+    }
+    .ui-autocomplete {
+        position: absolute;
+        top: 0;
+        left: 0;
+        min-width:200px;
+        cursor: default;
+    }
+    .ui-menu-item{
+        min-width:200px;
+    }
+    .fixed-height{
+        min-width:200px;
+        padding: 1px;
+        max-height: 35%;
+        overflow: auto;
+    }
+</style>
+<body>
+<!-- DWV -->
+<div id="dwv" src='<?php echo $web_path ?>'>
+    <!-- Toolbar -->
+    <div class="toolbar"></div>
+    <div class="warn_diagnostic"><?php echo xlt('Not For Diagnostic Use') ?></div>
+    <!-- Layer Container -->
+    <div class="layerContainer">
+        <canvas class="imageLayer"><?php echo xlt('Only for HTML5 compatible browsers.') ?></canvas>
+    </div><!-- /layerContainer -->
+ </div><!-- /dwv -->
+ <!-- Main -->
+ <script type="text/javascript" src="<?php echo $GLOBALS['web_root']?>/library/js/dwv/dicom_gui.js"></script>
+ <script type="text/javascript" src="<?php echo $GLOBALS['web_root']?>/library/js/dwv/dicom_launcher.js"></script>
+</body>
+</html>

--- a/library/dicom_frame.php
+++ b/library/dicom_frame.php
@@ -1,15 +1,31 @@
 <?php
+/**
+ * Dicom viewer wrapper script for documents
+ *
+ * @package OpenEMR
+ * @link    http://www.open-emr.org
+ * @author  Jerry Padgett <sjpadgett@gmail.com> 'Viewer wrapper'
+ * @author  Victor Kofia <https://kofiav.com> 'Viewer'
+ * @copyright Copyright (c) 2018 Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright Copyright (c) 2017-2018 Victor Kofia <https://kofiav.com>
+ * @license https://www.gnu.org/licenses/agpl-3.0.en.html GNU Affero General Public License 3
+ */
+
+/* Warning: This script wraps the Dicom viewer which is HTML5 compatible only and bootstrap styling
+*  should not be used inside this script due to style conflicts with viewer, namely, hidden class.
+*/
 
 require_once('../interface/globals.php');
 
 $web_path = $_REQUEST['web_path'];
 $patid = $_REQUEST['patient_id'];
-$docid = $_REQUEST['document_id'];
-$web_path .= '&retrieve&patient_id=' . $patid . '&document_id=' . $docid . '&as_file=false'
+$docid = isset($_REQUEST['document_id']) ? $_REQUEST['document_id'] : $_REQUEST['doc_id'];
+$web_path .= '&retrieve&patient_id=' . attr($patid) . '&document_id=' . attr($docid) . '&as_file=false'
 ?>
 <!DOCTYPE html>
 <html>
 <head>
+    <link rel="stylesheet" href="<?php echo $css_header;?>" type="text/css">
     <script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/jquery-min-3-1-1/index.js"></script>
     <script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/modernizr-3-5-0/dist/modernizr-build.js"></script>
     <script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/i18next-9-0-1/i18next.min.js"></script>
@@ -33,7 +49,7 @@ $web_path .= '&retrieve&patient_id=' . $patid . '&document_id=' . $docid . '&as_
 </head>
 <style type="text/css">
     .warn_diagnostic {
-        margin: 10 auto 10 auto;
+        margin: 10px auto 10px auto;
         color: rgb(255, 0, 0);
         font-size: 1.5em;
     }

--- a/library/js/dwv/dwv_i18n.js
+++ b/library/js/dwv/dwv_i18n.js
@@ -25,7 +25,7 @@ dwv.i18nLocalesPath = null;
 dwv.i18nInitialise = function (language, localesPath)
 {
     var lng = (typeof language === "undefined") ? "auto" : language;
-    var lpath = (typeof localesPath === "undefined") ? "public/assets/dwv-0-21-0" : localesPath;
+    var lpath = (typeof localesPath === "undefined") ? "./../public/assets/dwv-0-21-0" : localesPath;
     // store as global
     dwv.i18nLocalesPath = lpath;
     // i18n options: default 'en' language and

--- a/templates/documents/general_list.html
+++ b/templates/documents/general_list.html
@@ -151,9 +151,8 @@ $(function () {
         let sizeHeight = 'full';
         if (dflg) {
             size = 'modal-md';
-            sizeHeight = 'auto';
         }
-        dlgopen(popsrc, 'popdoc', size, 700, '', '', {
+        dlgopen(popsrc, 'popdoc', size, 600, '', '', {
             buttons: [
                 {text: btnText, close: true, style: 'primary btn-xs', click: poContentModal},
                 {text: btnClose, close: true, style: 'default btn-xs'}

--- a/templates/documents/general_list.html
+++ b/templates/documents/general_list.html
@@ -122,7 +122,7 @@ $("#list_collapse").detach().appendTo("#objTreeMenu_1_node_1 nobr");
 
 // functions to view and pop out documents as needed.
 //
-$(function() {
+$(function () {
     $("img[id^='icon_objTreeMenu_']").tooltip({
         items: $("img[src*='file3.png']"),
         content: '{/literal}{xl t="Double Click on this icon to pop up document in a new viewer."|escape:"html"}{literal}'
@@ -130,7 +130,14 @@ $(function() {
 
     $("img[id^='icon_objTreeMenu_']").on('dblclick', function (e) {
         let popsrc = $(this).next("a").attr('href') || '';
-        if (!popsrc.includes('&view&')) return false;
+        let diview = $(this).next("a").text();
+        let dflg = false;
+        if (!popsrc.includes('&view&')) {
+            return false;
+        } else if (diview.toLowerCase().includes('.dcm')) {
+            popsrc = "{/literal}{$GLOBALS.webroot}{literal}/library/dicom_frame.php?web_path=" + popsrc;
+            dflg = true;
+        }
         popsrc = popsrc.replace('&view&', '&retrieve&') + 'as_file=false';
         let poContentModal = function () {
             let wname = '_' + Math.random().toString(36).substr(2, 6);
@@ -140,14 +147,19 @@ $(function() {
 
         let btnText = '{/literal}{xl t="Full Screen"|escape:"html"}{literal}';
         let btnClose = '{/literal}{xl t="Close"|escape:"html"}{literal}';
-
-        dlgopen(popsrc, 'popdoc', 'modal-xl', 700, '', '', {
+        let size = 'modal-xl';
+        let sizeHeight = 'full';
+        if (dflg) {
+            size = 'modal-md';
+            sizeHeight = 'auto';
+        }
+        dlgopen(popsrc, 'popdoc', size, 700, '', '', {
             buttons: [
                 {text: btnText, close: true, style: 'primary btn-xs', click: poContentModal},
                 {text: btnClose, close: true, style: 'default btn-xs'}
             ],
-            sizeHeight: 'full',
-            allowResize: false,
+            sizeHeight: sizeHeight,
+            allowResize: true,
             allowDrag: true,
             dialogId: '',
             type: 'iframe'

--- a/templates/documents/general_view.html
+++ b/templates/documents/general_view.html
@@ -338,39 +338,7 @@ function ImgProcedure() {literal}{{/literal}
 			 $file->get_mimetype() eq "application/pdf" }
 			<iframe frameborder="0" type="{$file->get_mimetype()}" src="{$web_path}as_file=false"></iframe>
             {elseif $file->get_mimetype() eq "application/dicom"}
-            <!-- DWV -->
-            <div id="dwv" src="{$web_path}as_file=false">
-                <!-- Toolbar -->
-                <div class="toolbar"></div>
-                <div class="warn_diagnostic">{xl t='Not For Diagnostic Use'|escape:'html'}</div>
-                <!-- Layer Container -->
-                <div class="layerContainer">
-                    <canvas class="imageLayer">Only for HTML5 compatible browsers...</canvas>
-                </div><!-- /layerContainer -->
-            </div><!-- /dwv -->
-            <!-- Third party (dwv) -->
-            <script type="text/javascript" src="{$assets_static_relative}/modernizr-3-5-0/dist/modernizr-build.js"></script>
-            <script type="text/javascript" src="{$assets_static_relative}/i18next-9-0-1/i18next.min.js"></script>
-            <script type="text/javascript" src="{$assets_static_relative}/i18next-xhr-backend-1-4-3/i18nextXHRBackend.min.js"></script>
-            <script type="text/javascript" src="{$assets_static_relative}/i18next-browser-languagedetector-2-0-0/i18nextBrowserLanguageDetector.min.js"></script>
-            <script type="text/javascript" src="{$assets_static_relative}/konva-1-6-8/konva.min.js"></script>
-            <script type="text/javascript" src="{$assets_static_relative}/magic-wand-js/js/magic-wand-min.js"></script>
-            <script type="text/javascript" src="{$assets_static_relative}/jszip-3-1-5/dist/jszip.min.js"></script>
-            <!-- Third party (viewer) -->
-            <script type="text/javascript" src="{$assets_static_relative}/flot-0-8-3/jquery.flot.js"></script>
-            <!-- decoders -->
-            <script type="text/javascript" src="{$assets_static_relative}/dwv-0-21-0/decoders/pdfjs/jpx.js"></script>
-            <script type="text/javascript" src="{$assets_static_relative}/dwv-0-21-0/decoders/pdfjs/util.js"></script>
-            <script type="text/javascript" src="{$assets_static_relative}/dwv-0-21-0/decoders/pdfjs/arithmetic_decoder.js"></script>
-            <script type="text/javascript" src="{$assets_static_relative}/dwv-0-21-0/decoders/pdfjs/jpg.js"></script>
-            <script type="text/javascript" src="{$assets_static_relative}/dwv-0-21-0/decoders/rii-mango/lossless-min.js"></script>
-            <!-- Local (dwv) -->
-            <script type="text/javascript" src="{$assets_static_relative}/dwv-0-21-0/dist/dwv.min.js"></script>
-            <!-- i18n dwv wrapper -->
-            <script type="text/javascript" src="{$webroot}/library/js/dwv/dwv_i18n.js"></script>
-            <!-- Main -->
-            <script type="text/javascript" src="{$webroot}/library/js/dwv/dicom_gui.js"></script>
-            <script type="text/javascript" src="{$webroot}/library/js/dwv/dicom_launcher.js"></script>
+            <iframe frameborder="0" type="{$file->get_mimetype()}" src="{$GLOBALS.webroot}/library/dicom_frame.php?web_path={$web_path}as_file=false"></iframe>
             {elseif $file->get_ccr_type($file->get_id()) ne "CCR" and $file->get_ccr_type($file->get_id()) ne "CCD"}
             <iframe frameborder="0" type="{$file->get_mimetype()}" src="{$web_path}as_file=true"></iframe>
 			{/if}

--- a/templates/documents/general_view.html
+++ b/templates/documents/general_view.html
@@ -327,20 +327,20 @@ function ImgProcedure() {literal}{{/literal}
             <h4>{xl t='Contents'|escape:'html'}</h4>
 		</td>
 	</tr>
-	<tr id="DocContents">
+	<tr id="DocContents" style="height:100%">
 		<td>
             {if $file->get_mimetype() eq "image/tiff"}
-			<embed frameborder="0" type="{$file->get_mimetype()}" src="{$web_path}as_file=false"></embed>
+			<embed frameborder="0" style="height:84vh" type="{$file->get_mimetype()|escape:'html'}" src="{$web_path|escape:'html'}as_file=false"></embed>
 			{elseif $file->get_mimetype() eq "image/png" or
 			 $file->get_mimetype() eq "image/jpg" or
 			 $file->get_mimetype() eq "image/jpeg" or
 			 $file->get_mimetype() eq "image/gif" or
 			 $file->get_mimetype() eq "application/pdf" }
-			<iframe frameborder="0" type="{$file->get_mimetype()}" src="{$web_path}as_file=false"></iframe>
+			<iframe frameborder="0" style="height:84vh" type="{$file->get_mimetype()|escape:'html'}" src="{$web_path|escape:'html'}as_file=false"></iframe>
             {elseif $file->get_mimetype() eq "application/dicom"}
-            <iframe frameborder="0" type="{$file->get_mimetype()|escape:'html'}" src="{$GLOBALS.webroot}/library/dicom_frame.php?web_path={$web_path|escape:'html'}as_file=false"></iframe>
+            <iframe frameborder="0" style="height:84vh" type="{$file->get_mimetype()|escape:'html'}" src="{$GLOBALS.webroot}/library/dicom_frame.php?web_path={$web_path|escape:'html'}as_file=false"></iframe>
             {elseif $file->get_ccr_type($file->get_id()) ne "CCR" and $file->get_ccr_type($file->get_id()) ne "CCD"}
-            <iframe frameborder="0" type="{$file->get_mimetype()}" src="{$web_path}as_file=true"></iframe>
+            <iframe frameborder="0" style="height:84vh" type="{$file->get_mimetype()|escape:'html'}" src="{$web_path|escape:'html'}as_file=true"></iframe>
 			{/if}
 		</td>
 	</tr>

--- a/templates/documents/general_view.html
+++ b/templates/documents/general_view.html
@@ -338,7 +338,7 @@ function ImgProcedure() {literal}{{/literal}
 			 $file->get_mimetype() eq "application/pdf" }
 			<iframe frameborder="0" type="{$file->get_mimetype()}" src="{$web_path}as_file=false"></iframe>
             {elseif $file->get_mimetype() eq "application/dicom"}
-            <iframe frameborder="0" type="{$file->get_mimetype()}" src="{$GLOBALS.webroot}/library/dicom_frame.php?web_path={$web_path}as_file=false"></iframe>
+            <iframe frameborder="0" type="{$file->get_mimetype()|escape:'html'}" src="{$GLOBALS.webroot}/library/dicom_frame.php?web_path={$web_path|escape:'html'}as_file=false"></iframe>
             {elseif $file->get_ccr_type($file->get_id()) ne "CCR" and $file->get_ccr_type($file->get_id()) ne "CCD"}
             <iframe frameborder="0" type="{$file->get_mimetype()}" src="{$web_path}as_file=true"></iframe>
 			{/if}


### PR DESCRIPTION
viewer needed to be in a container because of viewer style/html stepping on tab/frame html.
Cheap fix for windows dicom mime type.
Pop out of viewer allowed.