### PR TITLE
Fee sheet review hangs if the justify field in the database is empty

### DIFF
--- a/interface/forms/fee_sheet/review/fee_sheet_review_view_model.js
+++ b/interface/forms/fee_sheet/review/fee_sheet_review_view_model.js
@@ -48,7 +48,16 @@ function procedure(json_source)
     retval.units=ko.observable(json_source.units);
     retval.mod_size=ko.observable(json_source.mod_size);
     retval.justify=ko.observableArray();
+    //var justify_codes=json_source.justify.split(":"); //This does not take into account if the justification is empty
+	//If justify is empty the system will hang and not display the review
+	//This stops the review from hanging
+	if(json_source.justify !== null){
     var justify_codes=json_source.justify.split(":");
+    }else
+    {
+        var justify_codes="";  //Modified by Sherwin 6/28/2017
+    }
+	
     for(var idx=0;idx<justify_codes.length;idx++)
         {
             var justify_parse=justify_codes[idx].split("|");

--- a/interface/forms/fee_sheet/review/fee_sheet_review_view_model.js
+++ b/interface/forms/fee_sheet/review/fee_sheet_review_view_model.js
@@ -51,10 +51,9 @@ function procedure(json_source)
     //var justify_codes=json_source.justify.split(":"); //This does not take into account if the justification is empty
 	//If justify is empty the system will hang and not display the review
 	//This stops the review from hanging
-	if(json_source.justify !== null){
-    var justify_codes=json_source.justify.split(":");
-    }else
-    {
+	if(json_source.justify !== null) {
+        var justify_codes=json_source.justify.split(":");
+    } else {
         var justify_codes="";  //Modified by Sherwin 6/28/2017
     }
 	

--- a/interface/forms/fee_sheet/review/fee_sheet_review_view_model.js
+++ b/interface/forms/fee_sheet/review/fee_sheet_review_view_model.js
@@ -48,30 +48,22 @@ function procedure(json_source)
     retval.units=ko.observable(json_source.units);
     retval.mod_size=ko.observable(json_source.mod_size);
     retval.justify=ko.observableArray();
-    //var justify_codes=json_source.justify.split(":"); //This does not take into account if the justification is empty
-	//If justify is empty the system will hang and not display the review
-	//This stops the review from hanging
-	if(json_source.justify !== null) {
-        var justify_codes=json_source.justify.split(":");
-    } else {
-        var justify_codes="";  //Modified by Sherwin 6/28/2017
-    }
-	
-    for(var idx=0;idx<justify_codes.length;idx++)
-        {
-            var justify_parse=justify_codes[idx].split("|");
-            if(justify_parse.length==2)
-                {
-                    var new_code={};
-                    new_code.code_type=justify_parse[0];
-                    new_code.code=justify_parse[1];
-                    new_code.descriptions="";
-                    new_code.selected=true;
-                    var ko_code=new code_entry(new_code)
-                    ko_code.priority=idx+1;
-                    retval.justify.push(ko_code);                  
-                }
+    if (json_source.justify !== null) {
+        var justify_codes = json_source.justify.split(":");
+        for (var idx = 0; idx < justify_codes.length; idx++) {
+            var justify_parse = justify_codes[idx].split("|");
+            if (justify_parse.length == 2) {
+                var new_code = {};
+                new_code.code_type = justify_parse[0];
+                new_code.code = justify_parse[1];
+                new_code.descriptions = "";
+                new_code.selected = true;
+                var ko_code = new code_entry(new_code)
+                ko_code.priority = idx + 1;
+                retval.justify.push(ko_code);
+            }
         }
+    }
     retval.genJustify=function()
     {
         var justify_string="";


### PR DESCRIPTION
I have encountered this again. In our database, the justify field does not always contain data. So when the review button is clicked. The console error is shows that the justification justify_codes is null. I believe you can test this out on any system. Leave the justification null and it should hang or from the users view cause the Review button not to work. 