### PR TITLE
Support imaging with multiple images (CT or MRI)

### DIFF
--- a/controllers/C_Document.class.php
+++ b/controllers/C_Document.class.php
@@ -157,6 +157,20 @@ class C_Document extends Controller
                         if (strtolower($parts['extension']) == 'dcm') { // cheat for dicom on windows because MS must be different!!!
                             $mimetype = 'application/dicom';
                         }
+                    } else if ($mimetype == 'application/zip') {
+                        $za = new ZipArchive();
+                        $handler = $za->open($_FILES['file']['tmp_name'][$key]);
+                        if ($handler) {
+                            $mimetype = "application/dicom";
+                            for( $i = 0; $i < $za->numFiles; $i++ ){
+                                $stat = $za->statIndex( $i );
+                                $parts = pathinfo($stat['name']);
+                                if (strtolower($parts['extension']) != "dcm") {
+                                    $mimetype = "application/zip";
+                                    break;
+                                }
+                            }
+                        }
                     }
                     $d = new Document();
                     $rc = $d->createDocument(


### PR DESCRIPTION
Doing a PR to address this issue #1360

I believe the most straightforward way of getting dwv to load relevant zip files is to inspect each zip file during the upload process and if every file inside the zip file is a dicom, set the mimetype of the zip file to 'application/dicom'. 

All other ways of dealing with this seemed messy to me, but if there's a better way please let me know. 

Anyway, the feature itself doesn't work currently because I am getting this error message:

`Error: Not a valid DICOM file (no magic DICM word found).`

The zip files are being loaded like this `app.loadURLs(["myDicom.zip"]);` as suggested by @ivmartel

Any idea why it doesn't work?? 

below added by bradymiller:
Can demo this PR here: http://www.open-emr.org/wiki/index.php/Development_Demo#Delta_-_Up_For_Grabs_Demo