### PR TITLE
Extend the JS validation to support dd/mm/YYYY format 

### DIFF
--- a/library/js/vendors/validate/validate_extend.js
+++ b/library/js/vendors/validate/validate_extend.js
@@ -65,7 +65,25 @@ validate.validators.pastDate = function(value, options) {
         }
     }
 
-    var date =  new Date(value);
+    var format=options.format;
+    var date = '';
+
+    if (options.format){
+        switch(format) {
+            // case date format is dd/mm/YYYY
+            // use example :{"pastDate":{"message":"must be past date","format":"2"}}
+            case "2":
+                var dateParts = value.split("/");
+                var date = new Date(dateParts[2], dateParts[1] - 1, dateParts[0]);
+                break;
+            default:
+                date =  new Date(value);
+        }
+    }
+    else {
+        date =  new Date(value);
+    }
+    
     var mls_date = date.getTime();
     if(isNaN(mls_date)) {
        return throwError('Must be valid date');

--- a/library/js/vendors/validate/validate_extend.js
+++ b/library/js/vendors/validate/validate_extend.js
@@ -65,13 +65,15 @@ validate.validators.pastDate = function(value, options) {
         }
     }
 
-    var format=options.format;
+    var format=0;
+    if (typeof(g_date_format) !== 'undefined') {
+        format=g_date_format;
+    }
+
     var date = '';
 
-    if (options.format){
         switch(format) {
             // case date format is dd/mm/YYYY
-            // use example :{"pastDate":{"message":"must be past date","format":"2"}}
             case "2":
                 var dateParts = value.split("/");
                 var date = new Date(dateParts[2], dateParts[1] - 1, dateParts[0]);
@@ -79,11 +81,8 @@ validate.validators.pastDate = function(value, options) {
             default:
                 date =  new Date(value);
         }
-    }
-    else {
-        date =  new Date(value);
-    }
-    
+
+
     var mls_date = date.getTime();
     if(isNaN(mls_date)) {
        return throwError('Must be valid date');

--- a/library/validation/validation_script.js.php
+++ b/library/validation/validation_script.js.php
@@ -42,7 +42,7 @@ if ($use_validate_js) {
     /*e: event*/
     /*form id: used to get the validation rules*/?>
 
-
+    var g_date_format='<?php echo $GLOBALS["date_display_format"];?>';
 
 function submitme(new_validate,e,form_id, constraints) {
 


### PR DESCRIPTION
This commit add the option to validate dates in format dd/mm/YYYY format  with the pastDate function 
by editing the  LBF_Validations and changing it to 
{"pastDate":{"message":"must be past date","format":"2"}}