### PR TITLE
fix for rtl in tabs

### DIFF
--- a/interface/themes/rtl_tabs_style_compact.css
+++ b/interface/themes/rtl_tabs_style_compact.css
@@ -60,9 +60,11 @@
     display: inline-block;
     float: left;
     position: relative;
-    top: 6px;
+    top: 12px;
     left: 5px;
+    right: 0;
     transform: scaleX(-1);
+    padding-right: 7px;
 }
 
 #userData
@@ -82,4 +84,8 @@
 
 .float-element {
     float: right;
+}
+
+.menuSection > .menuEntries .menuEntries {
+    right: 161px;
 }

--- a/interface/themes/rtl_tabs_style_full.css
+++ b/interface/themes/rtl_tabs_style_full.css
@@ -65,9 +65,11 @@
     display: inline-block;
     float: left;
     position: relative;
-    top: 6px;
+    top: 12px;
     left: 5px;
+    right: 0;
     transform: scaleX(-1);
+    padding-right: 7px;
 }
 
 #userData
@@ -87,4 +89,8 @@
 
 .float-element {
     float: right;
+}
+
+.menuSection > .menuEntries .menuEntries {
+    right: 161px;
 }


### PR DESCRIPTION
Fixes following issues:
- The 'fa-caret-right' arrow in submenus was outside of menu box.
- The child of submenu would open up on right side instead of left.