### PR TITLE
Fix Only Year validation

### DIFF
--- a/library/js/vendors/validate/validate_extend.js
+++ b/library/js/vendors/validate/validate_extend.js
@@ -63,6 +63,7 @@ validate.validators.pastDate = function(value, options) {
 
             return throwError('Must be year format');
         }
+        else return; // passed only year validation
     }
 
     var format=0;


### PR DESCRIPTION
If an only year validation is activated  and the value passes the check 
the function should terminate and not continue 