### PR TITLE
Add language direction javascript global to top frames. issue #1456

### DIFF
--- a/interface/main/main_screen.php
+++ b/interface/main/main_screen.php
@@ -158,6 +158,7 @@ if ($GLOBALS['new_tabs_layout']) {
 var tab_mode=false;
 
 var webroot_url = '<?php echo $GLOBALS['web_root']; ?>';
+var jsLanguageDirection = "<?php echo $_SESSION["language_direction"]; ?>";
 
 <?php require($GLOBALS['srcdir'] . "/restoreSession.php"); ?>
 

--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -105,6 +105,7 @@ function isEncounterLocked( encounterId ) {
     <?php } ?>
 }
 var webroot_url="<?php echo $web_root; ?>";
+var jsLanguageDirection = "<?php echo $_SESSION["language_direction"]; ?>";
 </script>
 
 <?php Header::setupHeader(["knockout","tabs-theme",'jquery-ui']); ?>

--- a/library/dialog.js
+++ b/library/dialog.js
@@ -208,11 +208,9 @@ function dlgopen(url, winname, width, height, forceNewWindow, title, opts) {
     jQuery(function () {
         // Check for dependencies we will need.
         // webroot_url is a global defined in main_screen.php or main.php.
-        let bscss = "";
-        if (top.jsLanguageDirection !== 'rtl')
-            bscss = top.webroot_url + '/public/assets/bootstrap-3-3-4/dist/css/bootstrap.min.css';
-        else
-            bscss = top.webroot_url + '/public/assets/bootstrap-rtl-3-3-4/dist/css/bootstrap-rtl.min.css';
+
+        let bscss = top.webroot_url + '/public/assets/bootstrap-3-3-4/dist/css/bootstrap.min.css';
+        let bscssRtl = top.webroot_url + '/public/assets/bootstrap-rtl-3-3-4/dist/css/bootstrap-rtl.min.css';
         let bsurl = top.webroot_url + '/public/assets/bootstrap-3-3-4/dist/js/bootstrap.min.js';
         let jqui = top.webroot_url + '/public/assets/jquery-ui-1-12-1/jquery-ui.min.js';
 
@@ -224,6 +222,9 @@ function dlgopen(url, winname, width, height, forceNewWindow, title, opts) {
         }
         if (!inDom('bootstrap.min.css', 'link', false)) {
             includeScript(bscss, false, 'link');
+            if (top.jsLanguageDirection === 'rtl') {
+                includeScript(bscssRtl, false, 'link');
+            }
         }
         if (typeof jQuery.fn.modal === 'undefined') {
             if (!inDom('bootstrap.min.js', 'script', false))

--- a/library/dialog.js
+++ b/library/dialog.js
@@ -208,8 +208,11 @@ function dlgopen(url, winname, width, height, forceNewWindow, title, opts) {
     jQuery(function () {
         // Check for dependencies we will need.
         // webroot_url is a global defined in main_screen.php or main.php.
-
-        let bscss = top.webroot_url + '/public/assets/bootstrap-3-3-4/dist/css/bootstrap.min.css';
+        let bscss = "";
+        if (top.jsLanguageDirection !== 'rtl')
+            bscss = top.webroot_url + '/public/assets/bootstrap-3-3-4/dist/css/bootstrap.min.css';
+        else
+            bscss = top.webroot_url + '/public/assets/bootstrap-rtl-3-3-4/dist/css/bootstrap-rtl.min.css';
         let bsurl = top.webroot_url + '/public/assets/bootstrap-3-3-4/dist/js/bootstrap.min.js';
         let jqui = top.webroot_url + '/public/assets/jquery-ui-1-12-1/jquery-ui.min.js';
 


### PR DESCRIPTION
This is meant to allow the correct css to be loaded by dialog.js for rtl if dependency is missing from calling script. A more correct solution is to add the correct dependency where it is needed but I guess it can't hurt to have the global in top.