### PR TITLE
php warning fix in edit_globals.php

### DIFF
--- a/interface/super/edit_globals.php
+++ b/interface/super/edit_globals.php
@@ -118,7 +118,7 @@ function handleAltServices($this_serviceid, $gln = '', $sinterval = 1)
     if (!$bs_active && $this_serviceid == 'ccdaservice') {
         require_once(dirname(__FILE__)."/../../ccdaservice/ssmanager.php");
 
-        service_shutdown(0);
+        @service_shutdown(0);
     }
 }
 ?>


### PR DESCRIPTION
For:
``````
PHP Warning:  socket_connect(): unable to connect [111]: Connection refused in /var/www/openemr/ccdaservice/ssmanager.php on line 105, referer: http://localhost/openemr/interface/super/edit_globals.php
``````

Note there is no way to actually avoid this warning. So the next best thing is to just have php not report it :)