### PR TITLE
Add support for different date validation formats

### DIFF
--- a/interface/main/calendar/add_edit_event.php
+++ b/interface/main/calendar/add_edit_event.php
@@ -2028,6 +2028,8 @@ function are_days_checked(){
 * this enable to add new rules for this form in the pageValidation list.
 * */
 var collectvalidation = <?php echo($collectthis); ?>;
+var g_date_format='<?php echo $GLOBALS["date_display_format"];?>';
+
 function validateform(event,valu){
 
     $('#form_save').attr('disabled', true);

--- a/interface/main/calendar/add_edit_event.php
+++ b/interface/main/calendar/add_edit_event.php
@@ -2028,7 +2028,6 @@ function are_days_checked(){
 * this enable to add new rules for this form in the pageValidation list.
 * */
 var collectvalidation = <?php echo($collectthis); ?>;
-
 function validateform(event,valu){
 
     $('#form_save').attr('disabled', true);

--- a/interface/main/calendar/add_edit_event.php
+++ b/interface/main/calendar/add_edit_event.php
@@ -2028,7 +2028,6 @@ function are_days_checked(){
 * this enable to add new rules for this form in the pageValidation list.
 * */
 var collectvalidation = <?php echo($collectthis); ?>;
-var g_date_format='<?php echo $GLOBALS["date_display_format"];?>';
 
 function validateform(event,valu){
 

--- a/library/js/vendors/validate/validate_extend.js
+++ b/library/js/vendors/validate/validate_extend.js
@@ -14,6 +14,7 @@
  * @package OpenEMR
  * @author  Sharon Cohen <sharonco@matrix.co.il>
  * @author  Amiel Elboim <amielel@matrix.co.il>
+ * @author  Eyal Wolanowski <eyalvo@matrix.co.il>
  * @link    http://www.open-emr.org
  */
 
@@ -25,13 +26,60 @@ validate.extend(validate.validators.datetime, {
     // The value is guaranteed not to be null or undefined but otherwise it
     // could be anything.
     parse: function(value, options) {
-        var format = (typeof options.format !== 'undefined') ? options.format : 'YYYY-MM-DD';
+        var format = '';
+        if(typeof options.format !== 'undefined') {
+            format =options.format;
+        }
+        else {
+            if (typeof g_date_format !== 'undefined') {
+                switch(g_date_format) {
+                    case "0":
+                        format = 'YYYY-MM-DD';
+                        break;
+                    case "1":
+                        format = 'MM/DD/YYYY';
+                        break;
+                    case "2":
+                        format = 'DD/MM/YYYY';
+                        break;
+                    default:
+                        format = 'YYYY-MM-DD';
+                }
+            }
+            else{format = 'YYYY-MM-DD';} //default
+        }
         return (moment.utc(value, format));
     },
     // Input is a unix timestamp
     format: function(value, options) {
-        var format = options.dateOnly ? "YYYY-MM-DD" : "YYYY-MM-DD hh:mm:ss";
-        return moment.utc(value).format(format);
+        var format = '';
+        if (options.dateOnly){
+            if(typeof options.format !== 'undefined') {
+                format =options.format;
+            }
+            else {
+                if (typeof g_date_format !== 'undefined') {
+                    switch(g_date_format) {
+                        case "0":
+                            format = 'YYYY-MM-DD';
+                            break;
+                        case "1":
+                            format = 'MM/DD/YYYY';
+                            break;
+                        case "2":
+                            format = 'DD/MM/YYYY';
+                            break;
+                        default:
+                            format = 'YYYY-MM-DD';
+                    }
+                }
+                else{format = 'YYYY-MM-DD';} //default
+            }
+        }else{
+            format="YYYY-MM-DD hh:mm:ss";
+        }
+
+        return (moment.utc(value, format));
     }
 });
 


### PR DESCRIPTION
I changed the validation logic to support all date formats 

one can use the validation by setting 
options.format
OR
var g_date_format='<?php echo $GLOBALS["date_display_format"];?>';