### PR TITLE
Adjust form tag placement

### DIFF
--- a/interface/super/edit_list.php
+++ b/interface/super/edit_list.php
@@ -1005,7 +1005,7 @@ function writeITLine($it_array)
                 </li>
             </ul>
                 <input type="hidden" name="formaction" id="formaction">
-                <div class="form-group">
+                <div class="form-group navbar-left">
                     <select name='list_id' class="form-control select-dropdown"
                             id="list_id">
                         <?php

--- a/interface/super/edit_list.php
+++ b/interface/super/edit_list.php
@@ -977,6 +977,7 @@ function writeITLine($it_array)
 </head>
 
 <body class="body_top">
+<form method='post' name='theform' id='theform' action='edit_list.php'>
 <nav class="navbar navbar-default navbar-fixed-top">
     <div class="container-fluid">
         <div class="navbar-header">
@@ -1003,8 +1004,6 @@ function writeITLine($it_array)
                     </a>
                 </li>
             </ul>
-            <form method='post' name='theform' id='theform'
-                  action='edit_list.php' class="navbar-form navbar-left">
                 <input type="hidden" name="formaction" id="formaction">
                 <div class="form-group">
                     <select name='list_id' class="form-control select-dropdown"


### PR DESCRIPTION
Bootstrap uses navbar-form for forms within navbar.  

This minor change makes theform correctly span navbar and remaining body.  Also fixes BS 4 issue.