### PR TITLE
Pre_5.0.1

### DIFF
--- a/interface/forms/eye_mag/a_issue.php
+++ b/interface/forms/eye_mag/a_issue.php
@@ -1091,7 +1091,7 @@ foreach (explode(',', $given) as $item) {
                         <td class="text"><input type="radio" name="radio_hazardous_activities" id="radio_hazardous_activities[quit]" value="quithazardous_activities" <?php if ($PMSFH[0]['SOCH']['hazardous_activities']['restype'] =='quithazardous_activities') {
                             echo "checked";
 } ?>><?php echo xlt('Quit') ?>&nbsp;</td>
-                        <td class="text"><input type="text" size="6" class="datepicker" name="date_hazardous_activities" id="date_hazardous_activities" value="" title="<?php echo xla('Hazardous activities') ?>"> </td>
+                        <td class="text"><input type="text" size="6" class="datepicker" name="date_hazardous_activities" id="date_hazardous_activities" value="" title="<?php echo xla('Hazardous activities') ?>">&nbsp;</td>
                         <td class="text-center"><input type="radio" name="radio_hazardous_activities" id="radio_hazardous_activities[never]" value="neverhazardous_activities" <?php if ($PMSFH[0]['SOCH']['hazardous_activities']['restype'] =='neverhazardous_activities') {
                             echo "checked";
 } ?>></td>

--- a/interface/forms/eye_mag/css/report.css
+++ b/interface/forms/eye_mag/css/report.css
@@ -420,7 +420,6 @@ background: #C0C0C0;
     background: #ffffff;
     font-family:  Arial,Serif, Arial;
     padding:6px;
-    font-size:1.2em;
     text-align:left;
     vertical-align:top;
     width:720px;
@@ -441,11 +440,7 @@ background: #C0C0C0;
 .CTL {
     background-color: white;
 }
-.tab_content table {
-    font-size:0.8em;
-    min-height: 2.0in;
-    text-align:left;
-}
+
 th {
     font-size: 1.0em;
     text-align: center;
@@ -468,13 +463,7 @@ body
     */
     text-align:center;
 }
-.sections {
-    text-align:center;
-    vertical-align:top;
-    width:100%;
-    margin:0;
-    font-size:1.4em;
-}
+
 #form_container {
     border: 0px solid red;
     padding: 0px;
@@ -555,39 +544,7 @@ textarea.ANTSEGTEXT {
 .left {
     text-align:left;
 }
-.canvas {
-    
-   /* background:#29c7c4;*/
-  background-image: url('../../forms/eye_mag/images/beige013.jpg');
-    background-size: 10% 10%;
-    background-repeat: repeat;
-    Xheight:2.5in;
-}
-.AntSegSpan {
-    /* OU OD OS
-    If selected the background changes
 
-    */
-    position:relative;
-    padding-right:0.1in;
-    box-shadow: 1px 1px 1px #888888;
-    border-radius: 8px;
-    margin-right: 4px; 
-    position:relative; 
-    margin-right: 0.1in; 
-    padding: 0.1in; 
-    border: 1.00pt solid #000000; 
-    background: #C0C0C0;
-    font-color:#000000;
-    height:0.05in;
-    font-family:  Arial,Serif, Arial;
-    font-size: 8pt;
-
-}
-.ANTSEGTEXT {
-    width: 2in;
-    height: 16px;
-}
 .button {
     background-color: #E3E1B8; 
     padding: 2px 4px;

--- a/interface/forms/eye_mag/css/style.css
+++ b/interface/forms/eye_mag/css/style.css
@@ -53,6 +53,7 @@
 }
 .eye_mag {
     z-index:5;
+    width: 100%;
 }
 #sddm {
     z-index:31;
@@ -123,8 +124,8 @@ a:active {
     font-size:1.0em;
     text-align: center;
     border:1pt solid black;justify-content:center; align-items:center;
-    height:38px;
-    width:38px;
+    height:43px;
+    width:43px;
 }
 textarea.ACT {
     border: none;
@@ -227,7 +228,7 @@ input[type=text] {
 /* REFRACTION PANEL */
 
 #REFRACTION_sections {
-    position:relative;display:inline-block;margin:5px auto;max-width:90%;margin:0;
+    margin:0px auto;
 }
 
 .refraction_panel {
@@ -296,9 +297,8 @@ input[type=text] {
 }
 .refraction ul {
     list-style-type: none;
-    margin: 0;
-    padding: 0;
-    overflow: hidden;
+    margin: 0px 6px;
+    padding: 2px;
 }
 
 .refraction li {
@@ -557,7 +557,6 @@ body
     width: 550px;
     margin: 5px auto ;
     padding:10px;
-    height: 400px;
 }
 .exam_section_left b {
 
@@ -1847,7 +1846,7 @@ View.php
 #LayerTension { width: 1.9in; height: 1.05in;padding: 0.02in; border: 1.00pt solid #000000;float:left;}
 
 
-#DA_EXAM_sections { text-align: center;display:inline-table;max-width: 95%;}
+#DA_EXAM_sections { text-align: center;display:inline-table;max-width: 93%;}
 #DA_EXAM_sections input[type="text"] { margin:1px; }
 #LayerVision { width: 2.2in; min-height: 1.05in;padding: 0.02in; border: 1.00pt solid #000000;float:left;}
 #tabs { font-size:0.5em;}

--- a/interface/forms/eye_mag/php/eye_mag_functions.php
+++ b/interface/forms/eye_mag/php/eye_mag_functions.php
@@ -3443,7 +3443,32 @@ function build_IMPPLAN_items($pid, $form_id)
 
     return $IMPPLAN_items;
 }
-
+    
+            /**
+             *  This builds the CODING_items variable for a given pid and encounter.
+             *  @param string $pid patient_id
+             *  @param string $encounter field id in table form_encounters
+             *  @return object CODING_items
+             */
+function build_CODING_items($pid, $encounter)
+{
+    $query ="select * from billing where encounter=? and pid=? ORDER BY id";
+    $fres = sqlStatement($query, array($encounter,$pid));
+    $i=0;
+    
+    while ($frow = sqlFetchArray($fres)) {
+        $CODING_items[$i]['encounter'] = $frow['encounter'];
+        $CODING_items[$i]['pid'] = $frow['pid'];
+        $CODING_items[$i]['id'] = $frow['id'];
+        $CODING_items[$i]['codetype'] = $frow['code_type'];
+        $CODING_items[$i]['codedesc'] = $frow['code_desc'];
+        $CODING_items[$i]['codetext'] = $frow['code_text'];
+        $CODING_items[$i]['justify'] = $frow['justify'];
+        $i++;
+    }
+    
+    return $CODING_items;
+}
 /**
  *  This function builds an array of documents for this patient ($pid).
  *  We first list all the categories this practice has created by name and by category_id
@@ -3572,9 +3597,11 @@ function display($pid, $encounter, $category_value)
         }
         */
         //open via OpenEMR Documents with treemenu
-        if (count($documents['docs_in_cat_id'][$documents['zones'][$category_value][$j]['id']]) > '0') {
-            //$episode .= '<a onclick="openNewForm(\''.$GLOBALS['webroot'].'/controller.php?document&view&patient_id='.$pid.'&parent_id='.$documents['zones'][$category_value][$j]['id'].'&document_id='.$doc[id].'&as_file=false\',\'Documents\');"><img src="../../forms/'.$form_folder.'/images/jpg.png" class="little_image" /></a>';
-            $episode .= '<a onclick="openNewForm(\''.$GLOBALS['webroot'].'/controller.php?document&view&patient_id='.$pid.'&parent_id='.$documents['zones'][$category_value][$j]['id'].'\',\'Documents\');"><img src="../../forms/'.$form_folder.'/images/jpg.png" class="little_image" /></a>';
+        $count_here='0';
+        $count_here = count($documents['docs_in_cat_id'][$documents['zones'][$category_value][$j]['id']]);
+        if ($count_here > '0') {
+            $id_to_show = $documents['docs_in_cat_id'][$documents['zones'][$category_value][$j]['id']][$count_here-1]['document_id'];
+            $episode .= '<a onclick="openNewForm(\''.$GLOBALS['webroot'].'/controller.php?document&view&patient_id='.$pid.'&doc_id='.$id_to_show.'\',\'Documents\');"><img src="../../forms/'.$form_folder.'/images/jpg.png" class="little_image" /></a>';
         }
 
         $episode .= '</td></tr>';
@@ -3829,7 +3856,7 @@ function menu_overhaul_top($pid, $encounter, $title = "Eye Exam")
                                 <span id="tooltips_status" name="tooltips_status"></span>
                                 <span class="menu_icon"><i title="<?php echo xla('Turn the Tooltips on/off'); ?>" id="qtip_icon" class="fa fa-check fa-1"></i></span></a>
                             </li>
-                            <li role="presentation"><a role="menuitem" tabindex="-1" target="_blank" href="<?php echo $GLOBALS['webroot']; ?>/interface/forms/eye_mag/help.php">
+                            <li role="presentation"><a role="menuitem" tabindex="-1" target="_shorthand" href="<?php echo $GLOBALS['webroot']; ?>/interface/forms/eye_mag/help.php">
                                 <i class="fa fa-help"></i>  <?php echo xlt("Shorthand Help"); ?><span class="menu_icon"><i title="<?php echo xla('Click for Shorthand Help.'); ?>" class="fa fa-info-circle fa-1"></i></span></a>
                             </li>
                         </ul>

--- a/interface/forms/eye_mag/php/taskman_functions.php
+++ b/interface/forms/eye_mag/php/taskman_functions.php
@@ -83,7 +83,7 @@ function make_task($ajax_req)
         } else if ($task['DOC_TYPE'] == "Fax-resend") {
             //we need to resend this fax????
             //You can only resend from here once.
-            $send['comments'] = xlt('To resend, delete the file from Communications and try again.');
+            $send['comments'] = xlt('To resend, delete the file from Communications, reload this page and try again.');
             echo json_encode($send);
             update_taskman($task, 'refaxed', '2');
             exit;
@@ -302,6 +302,12 @@ function make_document($task)
         }
     } else {
         $category_name = "Encounters - Eye";
+        //$category_name = "Encounters";
+        // $category_name = "Encounters - Eye"; //<---- openEMR base requires this.  My Category names don't use the "- Eye" part...
+        // Should the end user change the Document Category Names, this as is will fail.
+        // Is this an issue also for foreign language users?
+        //  -- perhaps not as I suspect translations occur after DB work just before display to end user.
+        // Maybe we should search category_names for the first match to 'Encounters%' and use that id?
         $query = "select id from categories where name =?";
         $ID = sqlQuery($query, array($category_name));
         $category_id = $ID['id'];
@@ -316,17 +322,7 @@ function make_document($task)
         $sql = "DELETE from documents where documents.url like ?";
         sqlQuery($sql, array("%".$filename));
     }
-
-    /*$pdf = new HTML2PDF(
-        $GLOBALS['pdf_layout'],
-        $GLOBALS['pdf_size'],
-        $GLOBALS['pdf_language'],
-        true, // default unicode setting is true
-        'UTF-8', // default encoding setting is UTF-8
-        array($GLOBALS['pdf_left_margin'],$GLOBALS['pdf_top_margin'],$GLOBALS['pdf_right_margin'],$GLOBALS['pdf_bottom_margin']),
-        $_SESSION['language_direction'] == 'rtl' ? true : false
-    );*/
-
+    
     $pdf = new mPDF(
         $GLOBALS['pdf_language'],
         $GLOBALS['pdf_size'],

--- a/interface/forms/eye_mag/report.php
+++ b/interface/forms/eye_mag/report.php
@@ -270,13 +270,13 @@ function narrative($pid, $encounter, $cols, $form_id, $choice = 'full')
     if ($choice !== 'TEXT') { ?>
 
         <?php
-    } ?>
-    <table class="report_exam_group">
+    } ?><br /><br />
+    <table style="font-size:1.2em;">
       <tr>
         <td style="text-align:left;padding:1px;vertical-align:top;max-width:720px;">
           <table style="padding:5px;width:700px;">
             <tr>
-              <td colspan="1" style="text-align: justify;text-justify: inter-word;width:100%;">
+              <td style="text-align: justify;text-justify: inter-word;width:100%;">
                 <b><?php echo xlt('Chief Complaint'); ?>:</b> &nbsp;<?php echo text($CC1); ?>
                 <br /><br />
                 <b><?php echo xlt('HPI'); ?>:</b>
@@ -483,8 +483,7 @@ function narrative($pid, $encounter, $cols, $form_id, $choice = 'full')
     if ($choice !== 'TEXT') {
     //exclude all of this from displaying on the summary mouseover by default
     ?>
-    <hr style="width:50%;text-align:center;" />
-    <table style="margin:1 auto;" class="report_exam_group">
+     <table style="margin:1px auto;" class="report_exam_group">
       <tr>
         <td style="width:680px;text-align:center;margin:1 auto;">
         <?php
@@ -525,12 +524,12 @@ function narrative($pid, $encounter, $cols, $form_id, $choice = 'full')
         </td>
       </tr>
     </table>
-    <table class="borderShadow" >
-      <tr style="font-size:10px;">
+    <table class="borderShadow">
+      <tr>
         <!-- Start of the Vision box -->
-        <td class="report_vitals">
+        <td  class="report_vitals">
           <b class="underline"><?php echo xlt('Visual Acuities'); ?></b>
-          <table id="Additional_VA" cellspacing="2" style="text-align:center;font-size:1.0em;">
+          <table id="Additional_VA" cellspacing="2" style="text-align:center;">
             <tr style="font-weight:bold;">
               <td style="text-align:center;"></td>
               <td style="width:50px;text-align:center;text-decoration:underline;"><?php echo xlt('OD'); ?></td>
@@ -626,7 +625,7 @@ function narrative($pid, $encounter, $cols, $form_id, $choice = 'full')
         <!-- START OF THE PRESSURE BOX -->
         <td class="report_vitals">
           <b class="underline"><?php echo xlt('Intraocular Pressures'); ?></b>
-          <table cellspacing="2" style="margin:2;text-align:center;font-size:1.0em;">
+          <table cellspacing="2" style="margin:2px;text-align:center;">
             <tr style="font-weight:bold;">
               <td style="text-align:center;"></td>
               <td style="text-align:center;text-decoration:underline;"><?php echo xlt('OD'); ?></td>
@@ -690,15 +689,15 @@ function narrative($pid, $encounter, $cols, $form_id, $choice = 'full')
             ?>
             <?php
             if ($bad < '1') {  ?>
-          <td class="report_vitals">
+          <td  class="report_vitals">
               <b class="underline"><?php echo xlt('Fields{{visual fields}}'); ?></b>
                 <?php
-                echo "<br /><br />&nbsp;Full to CF OU&nbsp;<br /><br /><br />";
+                echo "<br /><br />Full to CF OU";
             } else {
                 ?>
             <td class="report_vitals">
                 <b class="underline"><?php echo xlt('Fields{{visual fields}}'); ?></b>
-            <table style="font-size:1.0em;text-align:center;">
+            <table style="text-align:center;">
               <tr style="font-weight:bold;">
                       <td style="width:0.5in;text-align:center;text-decoration:underline;" colspan="2"><b><?php echo xlt('OD'); ?></b>
                         <br />
@@ -763,7 +762,7 @@ function narrative($pid, $encounter, $cols, $form_id, $choice = 'full')
                     ($$zone[$i] >= '1') ? ($$zone[$i] = "-".$$zone[$i]) : ($$zone[$i] = '');
                 }
                 ?>
-              <table style="font-size:1.0em;">
+              <table cellspacing="2" style="margin:2px;text-align:center;">
                 <tr style="font-weight:bold;">
                 <td style="text-align:center;text-decoration:underline;"><?php echo xlt('OD'); ?></td>
                 <td style="text-align:center;text-decoration:underline;"><?php echo xlt('OS'); ?></td>
@@ -789,7 +788,7 @@ function narrative($pid, $encounter, $cols, $form_id, $choice = 'full')
                   </table>
                 </td>
                 <td style="text-align:center;font-weight:600;padding-left:20px;">
-                  <table style="background: <?php echo $background; ?> no-repeat center center;filter: progid:DXImageTransform.Microsoft.Alpha(opacity=50)              -moz-opacity: 0.5;              -webkit-opacity: 1.0;              opacity:0.5;              padding:1px;">
+                  <table style="background: <?php echo $background; ?> no-repeat center center;background-size: 100% auto; filter: progid:DXImageTransform.Microsoft.Alpha(opacity=50) -moz-opacity: 0.5; -webkit-opacity: 0.5; opacity:1.0;Xpadding-bottom:5px;">
                     <tr>
                       <td class="mot"><?php echo $MOTILITY_LRSO; ?></td>
                       <td class="mot"><?php echo $MOTILITY_LS; ?></td>
@@ -816,7 +815,7 @@ function narrative($pid, $encounter, $cols, $form_id, $choice = 'full')
             <?php
             if (($PUPIL_NORMAL =='1')|| $ODPUPILSIZE1||$OSPUPILSIZE1) {
                     ?>
-            <td class="report_vitals" style="border-right:0px;">
+            <td style="border-right:0px;">
                     <?php
                     if (($PUPIL_NORMAL =='1')&&(!$ODPUPILSIZE1||!$OSPUPILSIZE1)) { ?>
                       <b class="underline"><?php echo xlt('Pupils'); ?></b>&nbsp;&nbsp;
@@ -824,12 +823,12 @@ function narrative($pid, $encounter, $cols, $form_id, $choice = 'full')
                     }
 
                     if ($ODPUPILSIZE1||$OSPUPILSIZE1) { ?>
-                  <table cellspacing="0" style="margin:1px;text-align:center;font-size:9px;">
-                    <tr>
+                  <table cellspacing="0" style="margin:1px;text-align:center;">
+                    <tr class="report_vitals">
                       <!-- start of the Pupils box -->
                       <td>
                             <b class="underline"><?php echo xlt('Pupils'); ?></b>
-                        <table style="font-size: 8px;text-align:middle;">
+                        <table  class="report_vitals" style="text-align:middle;">
                             <tr>
                               <th> &nbsp;
                               </th>
@@ -886,7 +885,7 @@ function narrative($pid, $encounter, $cols, $form_id, $choice = 'full')
     if ($DIMODPUPILSIZE1||$DIMOSPUPILSIZE1||$PUPIL_COMMENTS||$AMSLEROD||$AMSLEROS) { ?>
       <!-- start of slide down pupils_panel -->
       <br />
-      <table class='borderShadow' style="margin:1px;text-align:center;font-size:9px;">
+      <table class='borderShadow' style="margin:1px;text-align:center;">
         <tr>
           <td>
             <b class="underline"><?php echo xlt('Pupils') ?>: <?php echo xlt('Dim'); ?></b>
@@ -916,7 +915,6 @@ function narrative($pid, $encounter, $cols, $form_id, $choice = 'full')
                 </td>
               </tr>
               <tr><td colspan="2" style="padding-left:2px;text-align:bottom;">
-
                     <?php echo text($PUPIL_COMMENTS); ?>
                 </td>
               </tr>
@@ -936,7 +934,7 @@ function narrative($pid, $encounter, $cols, $form_id, $choice = 'full')
                 $AMSLEROS= "0";
             }
             ?>
-            <table style="font-size:1.0em;">
+            <table style="font-size:10px;">
               <tr style="font-weight:bold;">
                 <td style="text-align:center;text-decoration:underline;"><?php echo xlt('OD'); ?></td>
                 <td></td>
@@ -974,16 +972,16 @@ function narrative($pid, $encounter, $cols, $form_id, $choice = 'full')
                   </td>
                 </tr>
                 <tr style="text-align:center;padding:5px;text-decoration:underline;">
-                      <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo xlt('Type').$count_rx; ?></td>
-                      <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo xlt('Eye'); ?></td>
-                      <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo xlt('Sph{{Sphere}}'); ?></td>
-                      <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo xlt('Cyl{{Cylinder}}'); ?></td>
-                      <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo xlt('Axis{{Axis of a glasses prescription}}'); ?></td>
-                      <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo xlt('Prism'); ?></td>
-                      <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo xlt('Acuity'); ?></td>
-                      <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo xlt('Mid{{Middle Distance Add}}'); ?></td>
-                      <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo xlt('ADD{{Near Add}}'); ?></td>
-                      <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo xlt('Acuity'); ?></td>
+                      <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo xlt('Type').$count_rx; ?></td>
+                      <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo xlt('Eye'); ?></td>
+                      <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo xlt('Sph{{Sphere}}'); ?></td>
+                      <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo xlt('Cyl{{Cylinder}}'); ?></td>
+                      <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo xlt('Axis{{Axis of a glasses prescription}}'); ?></td>
+                      <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo xlt('Prism'); ?></td>
+                      <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo xlt('Acuity'); ?></td>
+                      <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo xlt('Mid{{Middle Distance Add}}'); ?></td>
+                      <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo xlt('ADD{{Near Add}}'); ?></td>
+                      <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo xlt('Acuity'); ?></td>
                 </tr>
                     <?php
                       //$count_rx++;
@@ -1007,27 +1005,27 @@ function narrative($pid, $encounter, $cols, $form_id, $choice = 'full')
                         ?>
                   <tr>
                         <td style="font-weight:600;font-size:0.7em;text-align:right;"><?php echo xlt('Current RX')." #".$i.": "; ?></td>
-                      <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo xlt('OD{{right eye}}'); ?></td>
-                      <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text(${"ODSPH_$i"})?:"-"); ?></td>
-                      <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text(${"ODCYL_$i"})?:"-"); ?></td>
-                      <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text(${"ODAXIS_$i"})?:"-"); ?></td>
-                      <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text(${"ODPRISM_$i"})?:"-"); ?></td>
-                      <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text(${"ODVA_$i"})?:"-"); ?></td>
-                      <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text(${"ODMIDADD_$i"})?:"-"); ?></td>
-                      <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text(${"ODADD_$i"})?:"-"); ?></td>
-                      <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text(${"ODNEARVA_$i"})?:"-"); ?></td>
+                      <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo xlt('OD{{right eye}}'); ?></td>
+                      <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text(${"ODSPH_$i"})?:"-"); ?></td>
+                      <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text(${"ODCYL_$i"})?:"-"); ?></td>
+                      <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text(${"ODAXIS_$i"})?:"-"); ?></td>
+                      <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text(${"ODPRISM_$i"})?:"-"); ?></td>
+                      <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text(${"ODVA_$i"})?:"-"); ?></td>
+                      <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text(${"ODMIDADD_$i"})?:"-"); ?></td>
+                      <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text(${"ODADD_$i"})?:"-"); ?></td>
+                      <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text(${"ODNEARVA_$i"})?:"-"); ?></td>
                 </tr>
                 <tr>
                       <td style="font-weight:600;font-size:0.7em;text-align:right;"><?php echo $RX_TYPE; ?></td>
-                      <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo xlt('OS{{left eye}}'); ?></td>
-                      <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text(${"OSSPH_$i"})?:"-"); ?></td>
-                      <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text(${"OSCYL_$i"})?:"-"); ?></td>
-                      <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text(${"OSAXIS_$i"})?:"-"); ?></td>
-                      <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text(${"OSPRISM_$i"})?:"-");  ?></td>
-                      <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text(${"OSVA_$i"})?:"-"); ?></td>
-                      <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text(${"OSMIDADD_$i"})?:"-"); ?></td>
-                      <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text(${"OSADD_$i"})?:"-"); ?></td>
-                      <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text(${"OSNEARVA_$i"})?:"-"); ?></td>
+                      <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo xlt('OS{{left eye}}'); ?></td>
+                      <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text(${"OSSPH_$i"})?:"-"); ?></td>
+                      <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text(${"OSCYL_$i"})?:"-"); ?></td>
+                      <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text(${"OSAXIS_$i"})?:"-"); ?></td>
+                      <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text(${"OSPRISM_$i"})?:"-");  ?></td>
+                      <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text(${"OSVA_$i"})?:"-"); ?></td>
+                      <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text(${"OSMIDADD_$i"})?:"-"); ?></td>
+                      <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text(${"OSADD_$i"})?:"-"); ?></td>
+                      <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text(${"OSNEARVA_$i"})?:"-"); ?></td>
                 </tr>
                     <?php
                     if (${"COMMENTS_$i"}) {
@@ -1044,27 +1042,27 @@ function narrative($pid, $encounter, $cols, $form_id, $choice = 'full')
                     if ($ARODSPH||$AROSSPH) { ?>
                   <tr style="border-bottom:1pt solid black;">
                         <td style="font-weight:600;font-size:0.7em;text-align:right;"><?php echo xlt('Auto Refraction'); ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo xlt('OD{{right eye}}'); ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($ARODSPH)?:"-");  ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($ARODCYL)?:"-");  ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($ARODAXIS)?:"-");  ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($ARODPRISM)?:"-");  ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($ARODVA)?:"-");  ?></td>
-                    <td style="font-weight:400;font-size:1.0em;text-align:center;">-</td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($ARODADD)?:"-");  ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($ARNEARODVA)?:"-"); ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo xlt('OD{{right eye}}'); ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($ARODSPH)?:"-");  ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($ARODCYL)?:"-");  ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($ARODAXIS)?:"-");  ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($ARODPRISM)?:"-");  ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($ARODVA)?:"-");  ?></td>
+                    <td style="font-weight:400;font-size:10px;text-align:center;">-</td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($ARODADD)?:"-");  ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($ARNEARODVA)?:"-"); ?></td>
                   </tr>
                   <tr>
                     <td>&nbsp;</td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:right;"><?php echo xlt('OS{{left eye}}'); ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($AROSSPH)?:"-");  ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($AROSCYL)?:"-");  ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($AROSAXIS)?:"-");  ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($AROSPRISM)?:"-");  ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($AROSVA)?:"-");  ?></td>
-                    <td style="font-weight:400;font-size:1.0em;text-align:center;">-</td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($AROSADD)?:"-");  ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($ARNEAROSVA)?:"-"); ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:right;"><?php echo xlt('OS{{left eye}}'); ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($AROSSPH)?:"-");  ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($AROSCYL)?:"-");  ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($AROSAXIS)?:"-");  ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($AROSPRISM)?:"-");  ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($AROSVA)?:"-");  ?></td>
+                    <td style="font-weight:400;font-size:10px;text-align:center;">-</td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($AROSADD)?:"-");  ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($ARNEAROSVA)?:"-"); ?></td>
                   </tr>
                         <?php
                         if (${"COMMENTS_$i"}) {
@@ -1081,28 +1079,28 @@ function narrative($pid, $encounter, $cols, $form_id, $choice = 'full')
                     if ($MRODSPH||$MROSSPH) { ?>
                     <tr>
                           <td style="font-weight:600;font-size:0.7em;text-align:right;"><?php echo xlt('Manifest (Dry) Refraction'); ?></td>
-                          <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo xlt('OD{{right eye}}'); ?></td>
-                          <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($MRODSPH)?:"-");  ?></td>
-                          <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($MRODCYL)?:"-");  ?></td>
-                          <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($MRODAXIS)?:"-");  ?></td>
-                          <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($MRODPRISM)?:"-");  ?></td>
-                          <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($MRODVA)?:"-");  ?></td>
-                      <td style="font-weight:400;font-size:1.0em;text-align:center;">-</td>
-                          <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($MRODADD)?:"-");  ?></td>
-                          <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($MRNEARODVA)?:"-"); ?></td>
+                          <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo xlt('OD{{right eye}}'); ?></td>
+                          <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($MRODSPH)?:"-");  ?></td>
+                          <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($MRODCYL)?:"-");  ?></td>
+                          <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($MRODAXIS)?:"-");  ?></td>
+                          <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($MRODPRISM)?:"-");  ?></td>
+                          <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($MRODVA)?:"-");  ?></td>
+                      <td style="font-weight:400;font-size:10px;text-align:center;">-</td>
+                          <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($MRODADD)?:"-");  ?></td>
+                          <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($MRNEARODVA)?:"-"); ?></td>
                     </tr>
                     <tr></tr>
                     <tr>
                       <td></td>
-                          <td style="font-weight:400;font-size:1.0em;text-align:right;"><?php echo xlt('OS{{left eye}}'); ?></td>
-                          <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($MROSSPH)?:"-");  ?></td>
-                          <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($MROSCYL)?:"-");  ?></td>
-                          <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($MROSAXIS)?:"-");  ?></td>
-                          <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($MROSPRISM)?:"-");  ?></td>
-                          <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($MROSVA)?:"-");  ?></td>
-                      <td style="font-weight:400;font-size:1.0em;text-align:center;">-</td>
-                          <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($MROSADD)?:"-");  ?></td>
-                          <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($MRNEAROSVA)?:"-"); ?></td>
+                          <td style="font-weight:400;font-size:10px;text-align:right;"><?php echo xlt('OS{{left eye}}'); ?></td>
+                          <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($MROSSPH)?:"-");  ?></td>
+                          <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($MROSCYL)?:"-");  ?></td>
+                          <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($MROSAXIS)?:"-");  ?></td>
+                          <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($MROSPRISM)?:"-");  ?></td>
+                          <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($MROSVA)?:"-");  ?></td>
+                      <td style="font-weight:400;font-size:10px;text-align:center;">-</td>
+                          <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($MROSADD)?:"-");  ?></td>
+                          <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($MRNEAROSVA)?:"-"); ?></td>
                     </tr>
                         <?php
                     }
@@ -1110,27 +1108,27 @@ function narrative($pid, $encounter, $cols, $form_id, $choice = 'full')
                     if ($CRODSPH||$CROSSPH) { ?>
                   <tr>
                         <td style="font-weight:600;font-size:0.8em;text-align:right;"><?php echo xlt('Cycloplegic (Wet) Refraction'); ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo xlt('OD{{right eye}}'); ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($CRODSPH)?:"-");  ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($CRODCYL)?:"-");  ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($CRODAXIS)?:"-");  ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($CRODPRISM)?:"-");  ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($CRODVA)?:"-");  ?></td>
-                    <td style="font-weight:400;font-size:1.0em;text-align:center;">-</td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($CRODADD)?:"-");  ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($CRNEARODVA)?:"-"); ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo xlt('OD{{right eye}}'); ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($CRODSPH)?:"-");  ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($CRODCYL)?:"-");  ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($CRODAXIS)?:"-");  ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($CRODPRISM)?:"-");  ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($CRODVA)?:"-");  ?></td>
+                    <td style="font-weight:400;font-size:10px;text-align:center;">-</td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($CRODADD)?:"-");  ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($CRNEARODVA)?:"-"); ?></td>
                   </tr>
                   <tr>
                     <td></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:right;"><?php echo xlt('OS{{left eye}}'); ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($CROSSPH)?:"-");  ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($CROSCYL)?:"-");  ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($CROSAXIS)?:"-");  ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($CROSPRISM)?:"-");  ?>&nbsp;</td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($CROSVA)?:"-");  ?></td>
-                    <td style="font-weight:400;font-size:1.0em;text-align:center;">-</td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($CROSADD)?:"-");  ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($CRNEAROSVA)?:"-"); ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:right;"><?php echo xlt('OS{{left eye}}'); ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($CROSSPH)?:"-");  ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($CROSCYL)?:"-");  ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($CROSAXIS)?:"-");  ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($CROSPRISM)?:"-");  ?>&nbsp;</td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($CROSVA)?:"-");  ?></td>
+                    <td style="font-weight:400;font-size:10px;text-align:center;">-</td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($CROSADD)?:"-");  ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($CRNEAROSVA)?:"-"); ?></td>
                   </tr>
                         <?php
                     }
@@ -1149,40 +1147,40 @@ function narrative($pid, $encounter, $cols, $form_id, $choice = 'full')
                   </tr>
                   <tr>
                         <td style="font-weight:600;font-size:0.8em;text-align:right;"><?php echo xlt('Contact Lens'); ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo xlt('OD{{right eye}}'); ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($CTLODSPH)?:"-");  ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($CTLODCYL)?:"-");  ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($CTLODAXIS)?:"-");  ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($CTLODBC)?:"-");  ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($CTLODDIAM)?:"-");  ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($CTLODADD)?:"-");  ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($CTLODVA)?:"-"); ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo xlt('OD{{right eye}}'); ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($CTLODSPH)?:"-");  ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($CTLODCYL)?:"-");  ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($CTLODAXIS)?:"-");  ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($CTLODBC)?:"-");  ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($CTLODDIAM)?:"-");  ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($CTLODADD)?:"-");  ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($CTLODVA)?:"-"); ?></td>
                   </tr>
                   <tr style="font-size:0.6em;">
                     <td></td>
                     <td></td>
-                        <td colspan="3" style="font-weight:400;font-size:1.0em;text-align:left;"><?php echo xlt('Brand'); ?>:<?php echo (text($CTLBRANDOD)?:"-");  ?></td>
-                        <td colspan="3" style="font-weight:400;font-size:1.0em;text-align:left;"><?php echo xlt('by{{made by/manufacturer}}'); ?> <?php echo (text($CTLMANUFACTUREROD)?:"-");  ?></td>
-                        <td colspan="3" style="font-weight:400;font-size:1.0em;text-align:left;"><?php echo xlt('via{{shipped by/supplier}}'); ?> <?php echo (text($CTLSUPPLIEROD)?:"-");  ?></td>
+                        <td colspan="3" style="font-weight:400;font-size:10px;text-align:left;"><?php echo xlt('Brand'); ?>:<?php echo (text($CTLBRANDOD)?:"-");  ?></td>
+                        <td colspan="3" style="font-weight:400;font-size:10px;text-align:left;"><?php echo xlt('by{{made by/manufacturer}}'); ?> <?php echo (text($CTLMANUFACTUREROD)?:"-");  ?></td>
+                        <td colspan="3" style="font-weight:400;font-size:10px;text-align:left;"><?php echo xlt('via{{shipped by/supplier}}'); ?> <?php echo (text($CTLSUPPLIEROD)?:"-");  ?></td>
 
                   </tr>
                   <tr>
                     <td></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo xlt('OS{{left eye}}'); ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($CTLOSSPH)?:"-");  ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($CTLOSCYL)?:"-");  ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($CTLOSAXIS)?:"-");  ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($CTLOSBC)?:"-");  ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($CTLOSDIAM)?:"-");  ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo (text($CTLOSADD)?:"-");  ?></td>
-                        <td style="font-weight:400;font-size:1.0em;text-align:center;"><?php echo ($CTLOSVA?:"-"); ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo xlt('OS{{left eye}}'); ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($CTLOSSPH)?:"-");  ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($CTLOSCYL)?:"-");  ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($CTLOSAXIS)?:"-");  ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($CTLOSBC)?:"-");  ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($CTLOSDIAM)?:"-");  ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo (text($CTLOSADD)?:"-");  ?></td>
+                        <td style="font-weight:400;font-size:10px;text-align:center;"><?php echo ($CTLOSVA?:"-"); ?></td>
                   </tr>
-                  <tr style="font-size:0.6em;">
+                  <tr style="font-size:9px;">
                     <td></td>
                     <td></td>
-                        <td colspan="3" style="font-weight:400;font-size:1.0em;text-align:left;"><?php echo xlt('Brand'); ?>: <?php echo (text($CTLBRANDOS)?:"-");  ?></td>
-                        <td colspan="3" style="font-weight:400;font-size:1.0em;text-align:left;"><?php echo xlt('by{{made by/manufacturer}}'); ?> <?php echo (text($CTLMANUFACTUREROS)?:"-");  ?></td>
-                        <td colspan="3" style="font-weight:400;font-size:1.0em;text-align:left;"><?php echo xlt('via{{shipped by/supplier}}'); ?> <?php echo (text($CTLSUPPLIEROS)?:"-");  ?></td>
+                        <td colspan="3" style="font-weight:400;font-size:10px;text-align:left;"><?php echo xlt('Brand'); ?>: <?php echo (text($CTLBRANDOS)?:"-");  ?></td>
+                        <td colspan="3" style="font-weight:400;font-size:10px;text-align:left;"><?php echo xlt('by{{made by/manufacturer}}'); ?> <?php echo (text($CTLMANUFACTUREROS)?:"-");  ?></td>
+                        <td colspan="3" style="font-weight:400;font-size:10px;text-align:left;"><?php echo xlt('via{{shipped by/supplier}}'); ?> <?php echo (text($CTLSUPPLIEROS)?:"-");  ?></td>
                   </tr>
 
                         <?php
@@ -1197,8 +1195,8 @@ function narrative($pid, $encounter, $cols, $form_id, $choice = 'full')
     if ($GLAREODVA||$CONTRASTODVA||$ODK1||$ODK2||$LIODVA||$PAMODBA) { ?>
       <table>
         <tr>
-          <td id="LayerVision_ADDITIONAL" class="refraction <?php echo $display_Add; ?>" style="padding:10px;font-size:0.9em;">
-          <table id="Additional" style="padding:5;font-size:1.0em;">
+          <td id="LayerVision_ADDITIONAL" class="refraction <?php echo $display_Add; ?>" style="padding:10px;font-size:10px;">
+          <table id="Additional" style="padding:5;font-size:10px;">
             <tr><td colspan="9" style="text-align:left;text-decoration:underline;font-weight:bold;"><?php echo xlt('Additional Data Points'); ?></td></tr>
             <tr><td></td>
               <td><?php echo xlt('PH{{Pinhole}}'); ?></td>
@@ -1317,11 +1315,7 @@ function narrative($pid, $encounter, $cols, $form_id, $choice = 'full')
                 if ($EXT_COMMENTS) { ?>
                 <tr>
                   <td colspan="3">
-
-                      <b><?php echo xlt('Comments'); ?>:</b>
-                    <span style="height:3.0em;">
-                        <?php echo text($EXT_COMMENTS); ?>
-                    </span>
+                      <b><?php echo xlt('Comments'); ?>:</b> <?php echo text($EXT_COMMENTS); ?>
                   </td>
                 </tr>
                 <?php
@@ -1412,10 +1406,7 @@ function narrative($pid, $encounter, $cols, $form_id, $choice = 'full')
 if ($ANTSEG_COMMENTS) { ?>
                     <tr>
                       <td colspan="2">
-                        <b><?php echo xlt('Comments'); ?>:</b>
-                        <span style="height:3.0em;">
-                            <?php echo text($ANTSEG_COMMENTS); ?>
-                        </span>
+                        <b><?php echo xlt('Comments'); ?>:</b> <?php echo text($ANTSEG_COMMENTS); ?>
                       </td>
                     </tr>
 <?php } ?>
@@ -1721,12 +1712,7 @@ if ($ODCMT||$OSCMT) { ?>
                     <?php if ($RETINA_COMMENTS) { ?>
                     <tr>
                       <td colspan="2" class="report_text left">
-
-                        <b><?php echo xlt('Comments'); ?>:</b>
-                        <span style="height:3.0em;">
-                            <?php echo text($RETINA_COMMENTS); ?>
-                        </span>
-
+                        <b><?php echo xlt('Comments'); ?>:</b> <?php echo text($RETINA_COMMENTS); ?>
                       </td>
                     </tr>
                     <?php } ?>
@@ -1746,7 +1732,7 @@ if ($ODCMT||$OSCMT) { ?>
     </div>
     <?php
     if ($ACT !='on') { ?>
-                <table style="text-align:center;font-size:0.7em;">
+                <table style="text-align:center;font-size:10px;">
                   <tr>
                     <td colspan=3 style="">
                           <table>
@@ -1762,12 +1748,12 @@ if ($ODCMT||$OSCMT) { ?>
                                 if ($ACT5SCDIST) { ?>
                                   <td style="text-align:center;"> <!-- scDIST -->
                                     <table cellpadding="0"
-                                    style="position:relative;text-align:center;font-size:1.2em;margin: 7 5 10 5;">
+                                    style="position:relative;text-align:center;font-size:12px;margin: 7 5 10 5;">
                                       <tr>
                                           <td id="ACT_tab_SCDIST" name="ACT_tab_SCDIST" class="ACT_deselected"> <?php echo xlt('sc Distance{{without correction distance}}'); ?> </td>
                                       </tr>
                                       <tr>
-                                        <td colspan="4" style="text-align:center;font-size:0.9em;">
+                                        <td colspan="4" style="text-align:center;font-size:10px;">
                                             <table>
                                               <tr>
                                                   <td style="text-align:center;"><?php echo xlt('R{{right}}'); ?></td>
@@ -1801,12 +1787,12 @@ if ($ODCMT||$OSCMT) { ?>
                                 if ($ACT5CCDIST) {
                                     ?>
                                   <td style="text-align:center;"> <!-- ccDIST -->
-                                    <table cellpadding="0" style="position:relative;text-align:center;font-size:1.5em;margin: 7 5 10 5;border-collapse: separate;">
+                                    <table cellpadding="0" style="position:relative;text-align:center;font-size:12px;margin: 7 5 10 5;border-collapse: separate;">
                                     <tr>
                                       <td class="ACT_deselected"> <?php echo xlt('cc Distance{{with correction at distance}}'); ?> </td>
                                     </tr>
                                     <tr>
-                                      <td colspan="4" style="text-align:center;font-size:0.8em;">
+                                      <td colspan="4" style="text-align:center;font-size:10px;">
                                           <table>
                                             <tr>
                                               <td style="text-align:center;"><?php echo xlt('R{{right}}'); ?></td>
@@ -1844,12 +1830,12 @@ if ($ODCMT||$OSCMT) { ?>
                                     ?>
 
                                 <td style="text-align:center;"> <!-- scNEAR -->
-                                    <table cellpadding="0" style="position:relative;text-align:center;font-size:1.5em;margin: 7 5 10 5;border-collapse: separate;">
+                                    <table cellpadding="0" style="position:relative;text-align:center;font-size:10px;margin: 7 5 10 5;border-collapse: separate;">
                                     <tr>
                                       <td class="ACT_deselected"> <?php echo xlt('sc Near{{without correction near}}'); ?> </td>
                                     </tr>
                                     <tr>
-                                      <td colspan="4" style="text-align:center;font-size:0.8em;">
+                                      <td colspan="4" style="text-align:center;font-size:10px">
                                           <table>
                                             <tr>
                                               <td style="text-align:center;"><?php echo xlt('R{{right}}'); ?></td>
@@ -1885,12 +1871,12 @@ if ($ODCMT||$OSCMT) { ?>
                                     ?>
 
                                 <td style="text-align:center;"> <!-- ccNEAR -->
-                                    <table cellpadding="0" style="position:relative;text-align:center;font-size:1.5em;margin: 7 5 10 5;border-collapse: separate;">
+                                    <table cellpadding="0" style="position:relative;text-align:center;font-size:10px;margin: 7 5 10 5;border-collapse: separate;">
                                     <tr>
                                       <td class="ACT_deselected"> <?php echo xlt('cc Near{{with correction at Near}}'); ?> </td>
                                     </tr>
                                     <tr>
-                                      <td colspan="4" style="text-align:center;font-size:1.0em;">
+                                      <td colspan="4" style="text-align:center;font-size:10px;">
                                           <table>
                                             <tr>
                                               <td style="text-align:center;"><?php echo xlt('R{{right}}'); ?></td>
@@ -1927,11 +1913,7 @@ if ($ODCMT||$OSCMT) { ?>
                       <table>
                         <tr>
                           <td colspan="2">
-                            <b><?php echo xlt('Comments'); ?>:</b><br />
-                            <span style="height:3.0em;">
-                                <?php echo report_ACT($NEURO_COMMENTS); ?>
-                            </span>
-                            <br /><br />
+                            <b><?php echo xlt('Comments'); ?>:</b> <?php echo report_ACT($NEURO_COMMENTS); ?>
                           </td>
                         </tr>
                       </table>

--- a/interface/forms/eye_mag/view.php
+++ b/interface/forms/eye_mag/view.php
@@ -117,7 +117,7 @@ $fs = new FeeSheetHtml();
   If they stay in READ-ONLY mode, the fields are locked and submit_form is not allowed...
   In READ-ONLY mode, the form is refreshed via ajax every 15 seconds with changed fields' css
   background-color attribute set to purple.
-  Once the active user with write priviledges closes their instance of the form, the form_id is unlocked.
+  Once the active user with write privileges closes their instance of the form, the form_id is unlocked.
   READ-ONLY users stay read only if they do nothing.
  */
 
@@ -194,17 +194,18 @@ if ($refresh and $refresh != 'fullscreen') {
     }
     // This invokes the find-code popup.
     function sel_diagnosis(target,term) {
-      if (target =='') target = "0";
+      if (target =='') {
+          target = "0";
+      }
       IMP_target = target;
         <?php
-
         if ($irow['type'] == 'PMH') { //or POH
         ?>
-          dlgopen('<?php echo $rootdir ?>/patient_file/encounter/find_code_popup.php?codetype=<?php echo attr(collect_codetypes("medical_problem", "csv")) ?>&search_term='+escape(term), '_blank', 600, 400);
+          dlgopen('<?php echo $rootdir ?>/patient_file/encounter/find_code_popup.php?codetype=<?php echo attr(collect_codetypes("medical_problem", "csv")) ?>&search_term='+encodeURI(term), '_blank', 600, 400);
             <?php
         } else {
             ?>
-          dlgopen('<?php echo $rootdir ?>/patient_file/encounter/find_code_popup.php?codetype=<?php echo attr(collect_codetypes("diagnosis", "csv")) ?>&search_term='+escape(term), '_blank', 600, 400);
+          dlgopen('<?php echo $rootdir ?>/patient_file/encounter/find_code_popup.php?codetype=<?php echo attr(collect_codetypes("diagnosis", "csv")) ?>&search_term='+encodeURI(term), '_blank', 600, 400);
             <?php
         }
         ?>
@@ -1259,7 +1260,7 @@ if ($refresh and $refresh != 'fullscreen') {
                     <?php echo display_GlaucomaFlowSheet($pid); ?>
               </div>
               <!-- end IOP chart section -->
-
+                <br />
               <!-- start of the refraction box -->
               <span class="anchor" id="REFRACTION_anchor"></span>
               <div class="loading" id="EXAM_sections_loading" name="REFRACTION_sections_loading"><i class="fa fa-spinner fa-spin"></i></div>
@@ -1477,7 +1478,29 @@ if ($refresh and $refresh != 'fullscreen') {
                         <td><?php echo xlt('Cyl{{Cylinder}}'); ?></td>
                         <td><?php echo xlt('Axis{{Axis of a glasses prescription}}'); ?></td>
                         <td><?php echo xlt('Acuity'); ?></td>
-                        <td></td>
+                        <td rowspan="3">
+                            <ul>
+                                <li>
+                                    <input type="radio" name="WETTYPE" id="Streak" value="Streak" <?php if ($WETTYPE == "Streak") {
+                                        echo "checked='checked'";
+} ?>/>
+                                    <label for="Streak" class="input-helper input-helper--checkbox"><?php echo xlt('Streak'); ?></label>
+                                </li>
+                                <li>
+                                    <input type="radio" name="WETTYPE" id="Auto" value="Auto" <?php if ($WETTYPE == "Auto") {
+                                        echo "checked='checked'";
+} ?>>
+                                    <label for="Auto" class="input-helper input-helper--checkbox"><?php echo xlt('Auto{{autorefraction}}'); ?></label>
+                                </li>
+
+                                <li>
+                                    <input type="radio" name="WETTYPE" id="Manual" value="Manual" <?php if ($WETTYPE == "Manual") {
+                                        echo "checked='checked'";
+} ?>>
+                                    <label for="Manual" class="input-helper input-helper--checkbox"><?php echo xlt('Manual'); ?></label>
+                                </li>
+                            </ul>
+                        </td>
                         <td id="IOP_dil"><?php echo xlt('IOP Dilated{{Dilated Intraocular Pressure}}'); ?>
                           <input type="hidden" name="IOPPOSTTIME" id="IOPPOSTTIME" value="">
                         </td>
@@ -1489,29 +1512,6 @@ if ($refresh and $refresh != 'fullscreen') {
                         <td><input type="text" id="CRODCYL" name="CRODCYL" value="<?php echo attr($CRODCYL); ?>" tabindex="10184"></td>
                         <td><input type="text" id="CRODAXIS" name="CRODAXIS" value="<?php echo attr($CRODAXIS); ?>" tabindex="10185"></td>
                         <td><input type="text" id="CRODVA" name="CRODVA"  value="<?php echo attr($CRODVA); ?>" tabindex="10189"></td>
-                        <td rowspan="2">
-                          <ul>
-                            <li>
-                            <input type="radio" name="WETTYPE" id="Flash" value="Flash" <?php if ($WETTYPE == "Flash") {
-                                echo "checked='checked'";
-} ?>/>
-                            <label for="Flash" class="input-helper input-helper--checkbox"><?php echo xlt('Flash'); ?></label>
-                          </li>
-                          <li>
-                            <input type="radio" name="WETTYPE" id="Auto" value="Auto" <?php if ($WETTYPE == "Auto") {
-                                echo "checked='checked'";
-} ?>>
-                            <label for="Auto" class="input-helper input-helper--checkbox"><?php echo xlt('Auto{{autorefraction}}'); ?></label>
-                          </li>
-
-                            <li>
-                              <input type="radio" name="WETTYPE" id="Manual" value="Manual" <?php if ($WETTYPE == "Manual") {
-                                    echo "checked='checked'";
-} ?>>
-                              <label for="Manual" class="input-helper input-helper--checkbox"><?php echo xlt('Manual'); ?></label>
-                            </li>
-                          </ul>
-                        </td>
                         <td><input type="text" id="ODIOPPOST" name="ODIOPPOST"  value="<?php echo attr($ODIOPPOST); ?>">
                         </tr>
                         <tr>
@@ -1914,7 +1914,7 @@ if ($refresh and $refresh != 'fullscreen') {
                 <span class="BAR2_kb" title="<?php echo xla('Click to display shorthand field names.'); ?>" class="ke"><b><?php echo xlt('Shorthand'); ?></b>
                 </span>
 
-                <a onclick="top.restoreSession();goto_url('<?php echo $GLOBALS['webroot']; ?>/interface/forms/eye_mag/help.php?zone=all');">
+                <a  target="_shorthand" href="<?php echo $GLOBALS['webroot']; ?>/interface/forms/eye_mag/help.php">
                 <i title="<?php echo xla('Click for Shorthand Help.'); ?>" class="fa fa-info-circle fa-1"></i>
                 </a><br />
                 <textarea id="ALL_keyboard_left" name="ALL_keyboard_left" tabindex='1000'></textarea>
@@ -2254,35 +2254,35 @@ if ($refresh and $refresh != 'fullscreen') {
                                   </tr>
                                   <tr>
                                       <td>
-                                        <textarea name="ODCONJ" id="ODCONJ" class="right"><?php echo text($ODCONJ); ?></textarea></td>
+                                        <textarea name="ODCONJ" id="ODCONJ" class="right ANTSEG"><?php echo text($ODCONJ); ?></textarea></td>
                                       <td><div class="ident"><?php echo xlt('Conj{{Conjunctiva}}'); ?> / <?php echo xlt('Sclera'); ?></div>
                                         <div class="kb kb_left"><?php echo xlt('RC{{right conjunctiva}}'); ?></div>
                                         <div class="kb kb_right"><?php echo xlt('LC{{left conjunctiva}}'); ?></div></td>
                                       <td><textarea name="OSCONJ" id="OSCONJ" class="ANTSEG"><?php echo text($OSCONJ); ?></textarea></td>
                                   </tr>
                                   <tr>
-                                      <td><textarea name="ODCORNEA" id="ODCORNEA" class="right"><?php echo text($ODCORNEA); ?></textarea></td>
+                                      <td><textarea name="ODCORNEA" id="ODCORNEA" class="right ANTSEG"><?php echo text($ODCORNEA); ?></textarea></td>
                                       <td><div class="ident"><?php echo xlt('Cornea'); ?></div>
                                         <div class="kb kb_left"><?php echo xlt('RK{{right cornea}}'); ?></div>
                                         <div class="kb kb_right"><?php echo xlt('LK{{left cornea}}'); ?></div></td></td>
                                       <td><textarea name="OSCORNEA" id="OSCORNEA" class="ANTSEG"><?php echo text($OSCORNEA); ?></textarea></td>
                                   </tr>
                                   <tr>
-                                      <td><textarea name="ODAC" id="ODAC" class="right"><?php echo text($ODAC); ?></textarea></td>
+                                      <td><textarea name="ODAC" id="ODAC" class="right ANTSEG"><?php echo text($ODAC); ?></textarea></td>
                                       <td><div class="ident"><?php echo xlt('A/C{{anterior chamber}}'); ?></div>
                                         <div class="kb kb_left"><?php echo xlt('RAC{{right anterior chamber}}'); ?></div>
                                         <div class="kb kb_right"><?php echo xlt('LAC{{left anterior chamber}}'); ?></div></td></td>
                                       <td><textarea name="OSAC" id="OSAC" class="ANTSEG"><?php echo text($OSAC); ?></textarea></td>
                                   </tr>
                                   <tr>
-                                      <td><textarea name="ODLENS" id="ODLENS" class="right"><?php echo text($ODLENS); ?></textarea></td>
+                                      <td><textarea name="ODLENS" id="ODLENS" class="right ANTSEG"><?php echo text($ODLENS); ?></textarea></td>
                                       <td><div class="ident"><?php echo xlt('Lens'); ?></div>
                                         <div class="kb kb_left"><?php echo xlt('RL{{right lens}}'); ?></div>
                                         <div class="kb kb_right"><?php echo xlt('LL{{left lens}}'); ?></div></td></td>
                                       <td><textarea name="OSLENS" id="OSLENS" class="ANTSEG"><?php echo text($OSLENS); ?></textarea></td>
                                   </tr>
                                   <tr>
-                                      <td><textarea name="ODIRIS" id="ODIRIS" class="right"><?php echo text($ODIRIS); ?></textarea></td>
+                                      <td><textarea name="ODIRIS" id="ODIRIS" class="right ANTSEG"><?php echo text($ODIRIS); ?></textarea></td>
                                       <td><div class="ident"><?php echo xlt('Iris'); ?></div>
                                         <div class="kb kb_left"><?php echo xlt('RI{{right iris}}'); ?>RI</div><div class="kb kb_right"><?php echo xlt('LL{{left iris}}'); ?></div></td></td>
                                       <td><textarea name="OSIRIS" id="OSIRIS" class="ANTSEG"><?php echo text($OSIRIS); ?></textarea></td>
@@ -2374,10 +2374,10 @@ if ($refresh and $refresh != 'fullscreen') {
                                     <div class="kb kb_left"><?php echo 'CUP'; ?></div>
                                     <?php echo xlt('C/D Ratio{{cup to disc ration}}'); ?>:</td>
                                 <td>
-                                    <input type="text" name="ODCUP" size="4" id="ODCUP" value="<?php echo attr($ODCUP); ?>">
+                                    <input type="text" class="RETINA" name="ODCUP" size="4" id="ODCUP" value="<?php echo attr($ODCUP); ?>">
                                 </td>
                                 <td>
-                                    <input type="text" name="OSCUP" size="4" id="OSCUP" value="<?php echo attr($OSCUP); ?>">
+                                    <input type="text" class="RETINA" name="OSCUP" size="4" id="OSCUP" value="<?php echo attr($OSCUP); ?>">
                                 </td>
                             </tr>
 
@@ -2386,10 +2386,10 @@ if ($refresh and $refresh != 'fullscreen') {
                                     <div class="kb kb_left"><?php echo 'CMT'; ?></div>
                                     <?php echo xlt('CMT{{Central Macular Thickness}}'); ?>:</td>
                                 <td>
-                                    <input type="text" name="ODCMT" size="4" id="ODCMT" value="<?php echo attr($ODCMT); ?>">
+                                    <input class="RETINA" type="text" name="ODCMT" size="4" id="ODCMT" value="<?php echo attr($ODCMT); ?>">
                                 </td>
                                 <td>
-                                    <input type="text" name="OSCMT" size="4" id="OSCMT" value="<?php echo attr($OSCMT); ?>">
+                                    <input class="RETINA" type="text" name="OSCMT" size="4" id="OSCMT" value="<?php echo attr($OSCMT); ?>">
                                 </td>
                             </tr>
                         </table>
@@ -3304,7 +3304,7 @@ if ($refresh and $refresh != 'fullscreen') {
                   </div>
                 </div>
                 <!-- end Neuro -->
-         
+         <br />
                 <!-- start IMP/PLAN -->
                 <div class="size50 clear_both">
                   <div id="IMPPLAN_left" name="IMPPLAN_left" class="clear_both exam_section_left borderShadow">

--- a/interface/super/edit_list.php
+++ b/interface/super/edit_list.php
@@ -325,12 +325,27 @@ function writeOptionLine(
     echo "<input type='checkbox' name='opt[$opt_line_no][default]' value='1' " .
         "onclick='defClicked($opt_line_no)' class='optin'$checked />";
     echo "</td>\n";
-
-    echo "  <td>";
-    echo "<input type='checkbox' name='opt[$opt_line_no][activity]' value='1' " .
-        " class='optin'$checked_active />";
-    echo "</td>\n";
-
+    
+    if (preg_match('/Eye_QP_/', $list_id)) {
+        echo "  <td>";
+        echo "<select name='opt[$opt_line_no][activity]' class='optin'>";
+        foreach (array(
+                     1 => xl('Replace'),
+                     2 => xl('Append')
+                 ) as $key => $desc) {
+            echo "<option value='$key'";
+            if ($key == $active) {
+                echo " selected";
+            }
+            echo ">" . htmlspecialchars($desc) . "</option>";
+        }
+        echo "</select>";
+        echo "</td>";
+    } else {
+        echo "  <td>";
+        echo "<input type='checkbox' name='opt[$opt_line_no][activity]' value='1' " . " class='optin'$checked_active />";
+        echo "</td>\n";
+    }
     // Tax rates, contraceptive methods and LBF names have an additional attribute.
     //
     if ($list_id == 'taxrate' || $list_id == 'contrameth' || $list_id == 'lbfnames' || $list_id == 'transactions') {
@@ -436,6 +451,10 @@ function writeOptionLine(
         echo "  <td>";
         echo generate_select_list("opt[$opt_line_no][subtype]", 'issue_subtypes', $subtype, 'Subtype', ' ', 'optin');
         echo "</td>\n";
+    }
+    if (preg_match('/Eye_QP_/', $list_id)) {
+        echo "<input type='hidden' name='opt[$opt_line_no][subtype]' value='" . htmlspecialchars($subtype, ENT_QUOTES) . "' />";
+        echo "<input type='hidden' name='opt[$opt_line_no][mapping]' value='" . htmlspecialchars($mapping, ENT_QUOTES) . "' />";
     }
     echo " </tr>\n";
 }

--- a/interface/themes/ajax_calendar.css
+++ b/interface/themes/ajax_calendar.css
@@ -272,7 +272,6 @@ div.tiny { width:1px; height:1px; font-size:1px; }
 /* types of events */
 .event {
     position: absolute;
-    font-size: 0.8em;
     width: 100%;
 }
 .event img {

--- a/interface/themes/style_manila.css
+++ b/interface/themes/style_manila.css
@@ -822,10 +822,6 @@ text-decoration: none;
 border-radius: 8px 8px 0 0;
 box-shadow: 2px -1px 1px #c0c0c0;
  }
- form {
-    width: 95%;
-    margin: 0 auto;
- }
 ul.tabNav li.current a { background:#FFFFFF; }
 
 div.tabContainer {


### PR DESCRIPTION
Work on PDF creation and fax creation.
Lock Form improvements.

Signed-off-by: ophthal <magauran@ophthal.org>

More 5.0.1 Eye

Since DICOM viewer is in Documents now, move away from Anything slider to Documents to display images/docs.
Change “Flash” to “Streak”, improve AR box size.
Improve display for Linux Mint Firefox.
Create Default per provider lists from Eye Exam Defaults GENERAL list.
Update display of Eye QP lists to allow quick pick to append to field or Replace as desired by the end user.
Add Right Panel event to submenu.
Improve taskman faxing functions.
Improve Vitreous field usage.

Signed-off-by: ophthal <magauran@ophthal.org>

QP Clear fields

Fix bug to clear all ANTSEG fields when QP “Clear” is selected.

Signed-off-by: ophthal <magauran@ophthal.org>

DID NOT INCLUDE THE FOLLOWING COMMIT: User Experience tweak

Trim theme manila

Signed-off-by: ophthal <magauran@ophthal.org>

Documents list

This will make the left side of the documents window resizable, allowing the user to “drag” the divider to increase or decrease the size of the panes.  This is useful when a document has a very long name and the user would like more space/real estate to view a document inline.

Signed-off-by: ophthal <magauran@ophthal.org>

Calendar font size

This change makes the calendar font size the same as the base font, 12px.

Signed-off-by: ophthal <magauran@ophthal.org>

Display tweaks Eye Form and Report

Center tiles across eye form
Minor Report format issue

Signed-off-by: ophthal <magauran@ophthal.org>

psr2 fixes by bradymiller