### PR TITLE
Documents list window resizable

### DIFF
--- a/templates/documents/general_list.html
+++ b/templates/documents/general_list.html
@@ -63,7 +63,7 @@ overflow: auto;
   <body class="body_top">
 {/if}
 
-<div id="documents_list">
+<div id="documents_list" style="width:unset;padding:10px;height:unset;float:left;resize:horizontal;">
     <div class="ui-widget"style="float:right;">
         <button id='pid' class="pBtn" type="button" style="float:right;">0</button>
          <input id="selectPatient" type="text" placeholder="{$place_hld|escape:'html'}">
@@ -72,8 +72,8 @@ overflow: auto;
 <div class="title">{xl t='Documents'|escape:'html'}</div>
 {$tree_html}
 </div>
-<div id="documents_actions">
-		{if $message}
+<div id="documents_actions" style="width:unset;float:unset;">
+{if $message}
 			<div class='text' style="margin-bottom:-10px; margin-top:-8px"><i>{$message|escape:'html'}</i></div><br>
 		{/if}
 		{if $messages}


### PR DESCRIPTION
This code is from @ophthal

This will make the left side of the documents window resizable, allowing the user to “drag” the divider to increase or decrease the size of the panes.  This is useful when a document has a very long name and the user would like more space/real estate to view a document inline.