### PR TITLE
Lessen display alerts for when remove document

### DIFF
--- a/interface/patient_file/deleter.php
+++ b/interface/patient_file/deleter.php
@@ -414,7 +414,7 @@ if ($_POST['form_submit']) {
     echo "<script language='JavaScript'>\n";
     if (!$encounterid) {
         if ($info_msg) {
-            echo " alert('" . addslashes($info_msg) . "');\n";
+        //    echo " alert('" . addslashes($info_msg) . "');\n";
         }
         echo " dlgclose('imdeleted',false);\n";
     } else {


### PR DESCRIPTION
This commit is by @ophthal 

When deleting a document, a modal pop-up asks the user to confirm the action, warning that the action is logged.  On choosing yes, the Modal changes to show mysql data and then a js alert pops-up to confirm the file was deleted.

This change eliminates the last two steps - once the user selects “Yes” to delete the document, the modal simply closes.  No need for a deletion confirmation via ls alert.