### PR TITLE
DICOM viewer mime detection update

### DIFF
--- a/controllers/C_Document.class.php
+++ b/controllers/C_Document.class.php
@@ -130,19 +130,55 @@ class C_Document extends Controller
 
             foreach ($_FILES['file']['name'] as $key => $value) {
                 $fname = $value;
-                $err = "";
+                $error = "";
                 if ($_FILES['file']['error'][$key] > 0 || empty($fname) || $_FILES['file']['size'][$key] == 0) {
                     $fname = $value;
                     if (empty($fname)) {
                         $fname = htmlentities("<empty>");
                     }
-                    $error = xl("Error number") .": " . $_FILES['file']['error'][$key] . " " . xl("occurred while uploading file named") . ": " . $fname . "\n";
+                    $error = xl("Error number") . ": " . $_FILES['file']['error'][$key] . " " . xl("occurred while uploading file named") . ": " . $fname . "\n";
                     if ($_FILES['file']['size'][$key] == 0) {
                         $error .= xl("The system does not permit uploading files of with size 0.") . "\n";
                     }
                 } elseif ($GLOBALS['secure_upload'] && !isWhiteFile($_FILES['file']['tmp_name'][$key])) {
-                       $error = xl("The system does not permit uploading files with MIME content type") . " - " . mime_content_type($_FILES['file']['tmp_name'][$key]) . ".\n";
+                    $error = xl("The system does not permit uploading files with MIME content type") . " - " . mime_content_type($_FILES['file']['tmp_name'][$key]) . ".\n";
                 } else {
+                    // Test for a zip of DICOM images
+                    if (stripos($_FILES['file']['type'][$key], 'zip') !== false) {
+                        $za = new ZipArchive();
+                        $handler = $za->open($_FILES['file']['tmp_name'][$key]);
+                        if ($handler) {
+                            $mimetype = "application/dicom+zip";
+                            for ($i = 0; $i < $za->numFiles; $i++) {
+                                $stat = $za->statIndex($i);
+                                $fp = $za->getStream($stat['name']);
+                                if ($fp) {
+                                    $head = fread($fp, 256);
+                                    fclose($fp);
+                                    if (strpos($head, 'DICM') === false) { // Fixed at offset 128. even one non DICOM makes zip invalid.
+                                        $mimetype = "application/zip";
+                                        break;
+                                    }
+                                    unset($head);
+                                    // if here -then a DICOM
+                                    $parts = pathinfo($stat['name']);
+                                    if (strtolower($parts['extension']) != "dcm") { // require extension for viewer
+                                        $new_name = $stat['name'] . ".dcm";
+                                        $za->renameIndex($i, $new_name); // only use index rename!
+                                    }
+                                } else { // Rarely here
+                                    $mimetype = "application/zip";
+                                    break;
+                                }
+                            }
+                            $za->close();
+                            if ($mimetype == "application/dicom+zip") {
+                                $_FILES['file']['type'][$key] = $mimetype;
+                                sleep(1); // Timing insurance in case of re-compression. Only acted on index so...!
+                                $_FILES['file']['size'][$key] = filesize($_FILES['file']['tmp_name'][$key]); // file may have grown.
+                            }
+                        }
+                    }
                     $tmpfile = fopen($_FILES['file']['tmp_name'][$key], "r");
                     $filetext = fread($tmpfile, $_FILES['file']['size'][$key]);
                     fclose($tmpfile);
@@ -152,25 +188,13 @@ class C_Document extends Controller
                     if ($_POST['destination'] != '') {
                         $fname = $_POST['destination'];
                     }
+                    // set mime, test for single DICOM and assign extension if missing.
                     $mimetype = $_FILES['file']['type'][$key];
-                    if ($mimetype == 'application/octet-stream') { // windows most likely...
+                    if (strpos($filetext, 'DICM') !== false) {
+                        $mimetype = 'application/dicom';
                         $parts = pathinfo($fname);
-                        if (strtolower($parts['extension']) == 'dcm') { // cheat for dicom on windows because MS must be different!!!
-                            $mimetype = 'application/dicom';
-                        }
-                    } elseif (stripos($mimetype, 'zip') !== false) {
-                        $za = new ZipArchive();
-                        $handler = $za->open($_FILES['file']['tmp_name'][$key]);
-                        if ($handler) {
-                            $mimetype = "application/dicom+zip";
-                            for ($i = 0; $i < $za->numFiles; $i++) {
-                                $stat = $za->statIndex($i);
-                                $parts = pathinfo($stat['name']);
-                                if (strtolower($parts['extension']) != "dcm") {
-                                    $mimetype = "application/zip";
-                                    break;
-                                }
-                            }
+                        if (!$parts['extension']) {
+                            $fname .= '.dcm';
                         }
                     }
                     $d = new Document();
@@ -286,7 +310,7 @@ class C_Document extends Controller
             if (!file_exists($temp_url)) {
                 echo xl('The requested document is not present at the expected location on the filesystem or there are not sufficient permissions to access it.', '', '', ' ') . $temp_url;
             }
-                        $url = $temp_url;
+            $url = $temp_url;
             $pdetails = getPatientData($patient_id);
             $pname = $pdetails['fname']." ".$pdetails['lname'];
             $this->document_send($_POST['provide_email'], $_POST['note'], $url, $pname);

--- a/library/dicom_frame.php
+++ b/library/dicom_frame.php
@@ -60,21 +60,57 @@ $web_path .= '&retrieve&patient_id=' . attr($patid) . '&document_id=' . attr($do
         color: rgb(255, 0, 0);
         font-size: 1.5em;
     }
+
     .ui-autocomplete {
         position: absolute;
         top: 0;
         left: 0;
-        min-width:200px;
+        min-width: 200px;
         cursor: default;
     }
-    .ui-menu-item{
-        min-width:200px;
+
+    .ui-menu-item {
+        min-width: 200px;
     }
-    .fixed-height{
-        min-width:200px;
+
+    .fixed-height {
+        min-width: 200px;
         padding: 1px;
         max-height: 35%;
         overflow: auto;
+    }
+
+    .loader {
+        position: absolute;
+        left: 25%;
+        top: 15%;
+        z-index: 1;
+        border: 12px solid #f3f3f3;
+        border-radius: 50%;
+        border-top: 12px solid #3498db;
+        width: 60px;
+        height: 60px;
+        -webkit-animation: spin 2s linear infinite; /* Safari */
+        animation: spin 2s linear infinite;
+    }
+
+    /* Safari */
+    @-webkit-keyframes spin {
+        0% {
+            -webkit-transform: rotate(0deg);
+        }
+        100% {
+            -webkit-transform: rotate(360deg);
+        }
+    }
+
+    @keyframes spin {
+        0% {
+            transform: rotate(0deg);
+        }
+        100% {
+            transform: rotate(360deg);
+        }
     }
 </style>
 <body>
@@ -82,14 +118,27 @@ $web_path .= '&retrieve&patient_id=' . attr($patid) . '&document_id=' . attr($do
 <div id="dwv" src='<?php echo $web_path ?>'>
     <!-- Toolbar -->
     <div class="toolbar"></div>
-    <div class="warn_diagnostic"><?php echo xlt('Not For Diagnostic Use') ?></div>
-    <!-- Layer Container -->
-    <div class="layerContainer">
-        <canvas class="imageLayer"><?php echo xlt('Only for HTML5 compatible browsers.') ?></canvas>
-    </div><!-- /layerContainer -->
-</div><!-- /dwv -->
-<!-- Main -->
-<script type="text/javascript" src="<?php echo $GLOBALS['web_root'] ?>/library/js/dwv/dicom_gui.js"></script>
-<script type="text/javascript" src="<?php echo $GLOBALS['web_root'] ?>/library/js/dwv/dicom_launcher.js"></script>
+    <div class="warn_diagnostic"><?php echo xlt('Not For Diagnostic Use') ?>
+        <!-- Layer Container -->
+        <div class="layerContainer">
+            <span class="loader"></span>
+            <canvas id="dwvimg" class="imageLayer"><?php echo xlt('Only for HTML5 compatible browsers.') ?></canvas>
+        </div>
+        <!-- /layerContainer -->
+    </div><!-- /dwv -->
+    <!-- Main -->
+    <script type="text/javascript" src="<?php echo $GLOBALS['web_root'] ?>/library/js/dwv/dicom_gui.js"></script>
+    <script type="text/javascript" src="<?php echo $GLOBALS['web_root'] ?>/library/js/dwv/dicom_launcher.js"></script>
+    <script>
+        var msg = '<?php echo xlt("Still Loading...") ?>';
+        var canvas = document.getElementById("dwvimg");
+        var ctx = canvas.getContext("2d");
+        ctx.font = "22px Arial";
+        ctx.fillStyle = "red";
+        $(window).on("load", function () {
+            ctx.fillText(msg, 10, 100);
+            $('.loader').toggle();
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
No longer requires .dcm extension in zips or single file to determine dicom. Detects mime from file header and will add extensions if appropriate.