### PR TITLE
Fix bug in the permission of group in the add/edit event popup

### DIFF
--- a/interface/main/calendar/add_edit_event.php
+++ b/interface/main/calendar/add_edit_event.php
@@ -129,8 +129,8 @@ if (empty($collectthis)) {
     $collectthis = $collectthis[array_keys($collectthis)[0]]["rules"];
 }
 ?>
-<?php $disabled = (!$g_edit && $have_group_global_enabled )?' disabled=true; ':'';?>
-<?php if ($disabled) {
+<?php $group_disabled = ($_GET['group'] && !$g_edit && $have_group_global_enabled )?' disabled=true; ':'';?>
+<?php if ($group_disabled) {
     echo '<script>$( document ).ready(function(){
     $("input").prop("disabled", true);
     $("select").prop("disabled", true);


### PR DESCRIPTION
Hi.

Here I fixed bug that happen if user has only view permission for events of therapy group - `acl_check("groups", "gcalendar", false, 'view')`.
In this case (if global of group is turn on), all the inputs are disabled also for patient and provider tabs, so I changed it only for group tab.  

Thanks

Amiel