### PR TITLE
Custom message to client side validation

### DIFF
--- a/library/validation/validation_script.js.php
+++ b/library/validation/validation_script.js.php
@@ -158,7 +158,9 @@ function submitme(new_validate,e,form_id, constraints) {
                     }
                 }
                 //show error message
-                var error_msg = getErrorMessage(message);
+                //Validate.js enables to overwrite the error messages by adding 'message' to constraints json. if you want to use your custom message instead
+                //default message you need to add boolean property to the constraints json - 'custom_messages':true.
+                var error_msg = (typeof constraints.custom_messages !== 'undefined' && constraints.custom_messages) ? message : getErrorMessage(message);
 
                 var title= $(input).attr('title');
                 //if it's long title remove it from error message (this could destroy the UI)


### PR DESCRIPTION
Hi.

Here I did minor change that enable flexibility with the message of the client side validation (Validate.js).
Currently except the specific messages in the 'getErrorMessage' (line 230) all the errors are 'is not valid',
With the new option in the constraints we can add new messages to the errors in the customer language.

Thanks.

Amiel   