### PR TITLE
Fetch only active visit categories in the flow board

### DIFF
--- a/library/appointments.inc.php
+++ b/library/appointments.inc.php
@@ -650,7 +650,7 @@ function compareAppointmentsByCompletedDrugScreen($appointment1, $appointment2)
 function fetchAppointmentCategories()
 {
      $catSQL= " SELECT pc_catid as id, pc_catname as category "
-            . " FROM openemr_postcalendar_categories WHERE pc_recurrtype=0 and pc_cattype=0";
+            . " FROM openemr_postcalendar_categories WHERE pc_active=1 and pc_recurrtype=0 and pc_cattype=0";
     if ($GLOBALS['enable_group_therapy']) {
         $catSQL .= " OR pc_cattype=3";
     }


### PR DESCRIPTION
Hi.

Minor fix in the flow board. fetch from 'openemr_postcalendar_categories' only active categories.

Thanks
Amiel