### PR TITLE
add mysql8 option to development docker environment

### DIFF
--- a/contrib/util/docker/README.md
+++ b/contrib/util/docker/README.md
@@ -52,8 +52,8 @@ options to choose from:
 **Step 4.** Setup up OpenEMR. The first time you run OpenEMR (and whenever you clear and replace your
 synchronized openemr directory and restart the development docker). On the main
 setup input screen:
- - for `Server Host`, use either `mysql` or `mariadb` (you have both mysql/mariadb
-dockers ready to go to make testing either one easy)
+ - for `Server Host`, use either `mariadb` or `mysql` or `mysql-dev` (you have all mariadb/mysql/mysql-dev
+dockers ready to go to make testing either one easy; `mysql` is version 5.7 and `mysql-dev` is version 8)
  - for `Root Pass`, use `root`
  - for `User Hostname`, use `%`
 
@@ -76,13 +76,15 @@ Run `$ docker ps` to see the OpenEMR and MySQL containers in the following forma
 
 ```
 CONTAINER ID        IMAGE                       COMMAND                  CREATED             STATUS              PORTS                                         NAMES
-2da31c69a9dd        mariadb:10.2                "docker-entrypoint..."   6 seconds ago       Up 3 seconds        3306/tcp                                      openemr_mariadb_1
-808ff977858b        couchdb                     "tini -- /docker-e..."   6 seconds ago       Up 4 seconds        4369/tcp, 5984/tcp, 9100/tcp                  openemr_couchdb_1
-c3ae3ce3a2a0        phpmyadmin/phpmyadmin       "/run.sh phpmyadmin"     6 seconds ago       Up 4 seconds        0.0.0.0:8100->80/tcp                          openemr_phpmyadmin-mariadb_1
-796ae2e68dc2        openemr/openemr:flex        "./run_openemr.sh"       6 seconds ago       Up 3 seconds        0.0.0.0:8080->80/tcp, 0.0.0.0:8090->443/tcp   openemr_openemr-7-1_1
-a0f56b4e634c        openemr/openemr:flex-edge   "./run_openemr.sh"       6 seconds ago       Up 4 seconds        0.0.0.0:8081->80/tcp, 0.0.0.0:8091->443/tcp   openemr_openemr-7-2_1
-bd4d8c287931        phpmyadmin/phpmyadmin       "/run.sh phpmyadmin"     6 seconds ago       Up 4 seconds        0.0.0.0:8101->80/tcp                          openemr_phpmyadmin-mysql_1
-249770c5d4b2        mysql:5.7                   "docker-entrypoint..."   6 seconds ago       Up 4 seconds        3306/tcp                                      openemr_mysql_1
+92e106b066c8        mysql:8                     "docker-entrypoint..."   11 seconds ago      Up 7 seconds        3306/tcp                                      openemr_mysql-dev_1
+5e40d93bc1b2        couchdb                     "tini -- /docker-e..."   11 seconds ago      Up 8 seconds        4369/tcp, 5984/tcp, 9100/tcp                  openemr_couchdb_1
+041148eea3c4        phpmyadmin/phpmyadmin       "/run.sh phpmyadmin"     11 seconds ago      Up 9 seconds        0.0.0.0:8100->80/tcp                          openemr_phpmyadmin-mariadb_1
+8cab6f01d20a        phpmyadmin/phpmyadmin       "/run.sh phpmyadmin"     11 seconds ago      Up 9 seconds        0.0.0.0:8101->80/tcp                          openemr_phpmyadmin-mysql_1
+60afacc7a516        openemr/openemr:flex        "./run_openemr.sh"       11 seconds ago      Up 8 seconds        0.0.0.0:8080->80/tcp, 0.0.0.0:8090->443/tcp   openemr_openemr-7-1_1
+5016e0fef29e        openemr/openemr:flex-edge   "./run_openemr.sh"       11 seconds ago      Up 9 seconds        0.0.0.0:8081->80/tcp, 0.0.0.0:8091->443/tcp   openemr_openemr-7-2_1
+484e8b4e3b1c        mariadb:10.2                "docker-entrypoint..."   11 seconds ago      Up 9 seconds        3306/tcp                                      openemr_mariadb_1
+1838e30a3596        phpmyadmin/phpmyadmin       "/run.sh phpmyadmin"     11 seconds ago      Up 9 seconds        0.0.0.0:8102->80/tcp                          openemr_phpmyadmin-mysql-dev_1
+c3341def94d8        mysql:5.7                   "docker-entrypoint..."   11 seconds ago      Up 10 seconds       3306/tcp                                      openemr_mysql_1
 ```
  - Note the `NAMES` column is extremely important and how you run docker commands
 on specific containers. For example, to go into a shell script in the
@@ -135,8 +137,9 @@ PHP 7.1 host machine and port 8081 on the PHP 7.2 host machine.
 - HTTPS is running on port 443 in the OpenEMR containers and port 8090 on the
 PHP 7.1 host machine and port 8091 on the PHP 7.2 host machine.
 - HTTP is running on port 80 in the PhpMyADMIN containers and port 8100 on the
-MariaDB GUI host machine and port 8101 on the MySQL GUI host machine.
-- MySQL is running on port 3306 in the MySQL/MariaDB containers.
+MariaDB GUI host machine and port 8101 on the MySQL GUI host machine and port
+8102 on the MySQL-dev GUI host machine.
+- MySQL is running on port 3306 in the MariaDB/MySQL/MySQL-dev containers.
 
 All host machine ports can be changed by editing the `docker-compose.yml` file.
 Host ports differ from the internal container ports by default to avoid conflicts

--- a/contrib/util/docker/README.md
+++ b/contrib/util/docker/README.md
@@ -52,8 +52,10 @@ options to choose from:
 **Step 4.** Setup up OpenEMR. The first time you run OpenEMR (and whenever you clear and replace your
 synchronized openemr directory and restart the development docker). On the main
 setup input screen:
- - for `Server Host`, use either `mariadb` or `mysql` or `mysql-dev` (you have all mariadb/mysql/mysql-dev
-dockers ready to go to make testing either one easy; `mysql` is version 5.7 and `mysql-dev` is version 8)
+ - for `Server Host`, use either `mariadb` or `mysql` or `mariadb-dev` or `mysql-dev` (you have all
+ mariadb/mysql/mariadb-dev/mysql-dev dockers ready to go to make testing either one easy;
+ `mysql` is version 5.7 and `mysql-dev` is version 8; `mariadb` is version 10.2 and
+ `mariadb-dev` is version 10.3)
  - for `Root Pass`, use `root`
  - for `User Hostname`, use `%`
 
@@ -76,15 +78,17 @@ Run `$ docker ps` to see the OpenEMR and MySQL containers in the following forma
 
 ```
 CONTAINER ID        IMAGE                       COMMAND                  CREATED             STATUS              PORTS                                         NAMES
-92e106b066c8        mysql:8                     "docker-entrypoint..."   11 seconds ago      Up 7 seconds        3306/tcp                                      openemr_mysql-dev_1
-5e40d93bc1b2        couchdb                     "tini -- /docker-e..."   11 seconds ago      Up 8 seconds        4369/tcp, 5984/tcp, 9100/tcp                  openemr_couchdb_1
-041148eea3c4        phpmyadmin/phpmyadmin       "/run.sh phpmyadmin"     11 seconds ago      Up 9 seconds        0.0.0.0:8100->80/tcp                          openemr_phpmyadmin-mariadb_1
-8cab6f01d20a        phpmyadmin/phpmyadmin       "/run.sh phpmyadmin"     11 seconds ago      Up 9 seconds        0.0.0.0:8101->80/tcp                          openemr_phpmyadmin-mysql_1
-60afacc7a516        openemr/openemr:flex        "./run_openemr.sh"       11 seconds ago      Up 8 seconds        0.0.0.0:8080->80/tcp, 0.0.0.0:8090->443/tcp   openemr_openemr-7-1_1
-5016e0fef29e        openemr/openemr:flex-edge   "./run_openemr.sh"       11 seconds ago      Up 9 seconds        0.0.0.0:8081->80/tcp, 0.0.0.0:8091->443/tcp   openemr_openemr-7-2_1
-484e8b4e3b1c        mariadb:10.2                "docker-entrypoint..."   11 seconds ago      Up 9 seconds        3306/tcp                                      openemr_mariadb_1
-1838e30a3596        phpmyadmin/phpmyadmin       "/run.sh phpmyadmin"     11 seconds ago      Up 9 seconds        0.0.0.0:8102->80/tcp                          openemr_phpmyadmin-mysql-dev_1
-c3341def94d8        mysql:5.7                   "docker-entrypoint..."   11 seconds ago      Up 10 seconds       3306/tcp                                      openemr_mysql_1
+6e9cc265cc50        openemr/openemr:flex        "./run_openemr.sh"       6 seconds ago       Up 3 seconds        0.0.0.0:8080->80/tcp, 0.0.0.0:8090->443/tcp   openemr_openemr-7-1_1
+a343e24faa3c        couchdb                     "tini -- /docker-e..."   6 seconds ago       Up 4 seconds        4369/tcp, 5984/tcp, 9100/tcp                  openemr_couchdb_1
+ed8a7e048e01        mariadb:10.3                "docker-entrypoint..."   6 seconds ago       Up 4 seconds        3306/tcp                                      openemr_mariadb-dev_1
+c7d035e86ce3        openemr/openemr:flex-edge   "./run_openemr.sh"       6 seconds ago       Up 4 seconds        0.0.0.0:8081->80/tcp, 0.0.0.0:8091->443/tcp   openemr_openemr-7-2_1
+24b71e4526ae        mysql:5.7                   "docker-entrypoint..."   6 seconds ago       Up 5 seconds        3306/tcp                                      openemr_mysql_1
+dee6b2216f6d        phpmyadmin/phpmyadmin       "/run.sh phpmyadmin"     6 seconds ago       Up 4 seconds        0.0.0.0:8102->80/tcp                          openemr_phpmyadmin-mariadb-dev_1
+5d9a8fcf8a3b        mysql:8                     "docker-entrypoint..."   6 seconds ago       Up 5 seconds        3306/tcp                                      openemr_mysql-dev_1
+4ed037f35c86        phpmyadmin/phpmyadmin       "/run.sh phpmyadmin"     6 seconds ago       Up 4 seconds        0.0.0.0:8101->80/tcp                          openemr_phpmyadmin-mysql_1
+7ef17b801312        phpmyadmin/phpmyadmin       "/run.sh phpmyadmin"     6 seconds ago       Up 5 seconds        0.0.0.0:8103->80/tcp                          openemr_phpmyadmin-mysql-dev_1
+27eaca4ced97        phpmyadmin/phpmyadmin       "/run.sh phpmyadmin"     6 seconds ago       Up 5 seconds        0.0.0.0:8100->80/tcp                          openemr_phpmyadmin-mariadb_1
+e1591a57cfd4        mariadb:10.2                "docker-entrypoint..."   6 seconds ago       Up 5 seconds        3306/tcp                                      openemr_mariadb_1
 ```
  - Note the `NAMES` column is extremely important and how you run docker commands
 on specific containers. For example, to go into a shell script in the
@@ -138,8 +142,9 @@ PHP 7.1 host machine and port 8081 on the PHP 7.2 host machine.
 PHP 7.1 host machine and port 8091 on the PHP 7.2 host machine.
 - HTTP is running on port 80 in the PhpMyADMIN containers and port 8100 on the
 MariaDB GUI host machine and port 8101 on the MySQL GUI host machine and port
-8102 on the MySQL-dev GUI host machine.
-- MySQL is running on port 3306 in the MariaDB/MySQL/MySQL-dev containers.
+8102 on the MariaDB-dev GUI host machine and port 8103 on the MySQL-dev GUI
+host machine.
+- MySQL is running on port 3306 in the MariaDB/MySQL/MariaDB-dev/MySQL-dev containers.
 
 All host machine ports can be changed by editing the `docker-compose.yml` file.
 Host ports differ from the internal container ports by default to avoid conflicts

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@
 #      or
 #      https://localhost:8091 to run setup in openemr with SSL (alpine edge with PHP 7.2)
 #  On the main setup input screen:
-#   1. for Server Host, use either 'mariadb' or 'mysql' or 'mysql-dev' (have both mariadb/mysql/mysql-dev dockers ready to go make testing either one easy; mysql is version 5.7; mysql-dev is version 8)
+#   1. for Server Host, use either 'mariadb' or 'mysql' or `mariadb-dev` or 'mysql-dev' (have both mariadb/mysql/mariadb-dev/mysql-dev dockers ready to go make testing either one easy; mysql is version 5.7; mysql-dev is version 8; mariadb is version 10.2 and mariadb-dev is version 10.3)
 #   2. for Root Pass, use 'root'
 #   3. for User Hostname, use '%'
 #  And when need to tear it down and restart it
@@ -23,7 +23,8 @@
 #  Can see databases via:
 #   -mariadb     via http://localhost:8100
 #   -mysql       via http://localhost:8101
-#   -mysql-dev   via http://localhost:8102
+#   -mariadb-dev via http://localhost:8102
+#   -mysql-dev   via http://localhost:8103
 #
 version: '3.1'
 services:
@@ -59,6 +60,12 @@ services:
     command: ['mysqld','--character-set-server=utf8']
     environment:
       MYSQL_ROOT_PASSWORD: root
+  mariadb-dev:
+    restart: always
+    image: mariadb:10.3
+    command: ['mysqld','--character-set-server=utf8']
+    environment:
+      MYSQL_ROOT_PASSWORD: root
   mysql-dev:
     restart: always
     image: mysql:8
@@ -79,11 +86,18 @@ services:
     - 8101:80
     environment:
       PMA_HOST: mysql
-  phpmyadmin-mysql-dev:
+  phpmyadmin-mariadb-dev:
     restart: always
     image: phpmyadmin/phpmyadmin
     ports:
     - 8102:80
+    environment:
+      PMA_HOST: mariadb-dev
+  phpmyadmin-mysql-dev:
+    restart: always
+    image: phpmyadmin/phpmyadmin
+    ports:
+    - 8103:80
     environment:
       PMA_HOST: mysql-dev
   couchdb:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,15 +14,16 @@
 #      or
 #      https://localhost:8091 to run setup in openemr with SSL (alpine edge with PHP 7.2)
 #  On the main setup input screen:
-#   1. for Server Host, use either 'mysql' or 'mariadb' (have both mysql/mariadb dockers ready to go make testing either one easy)
+#   1. for Server Host, use either 'mariadb' or 'mysql' or 'mysql-dev' (have both mariadb/mysql/mysql-dev dockers ready to go make testing either one easy; mysql is version 5.7; mysql-dev is version 8)
 #   2. for Root Pass, use 'root'
 #   3. for User Hostname, use '%'
 #  And when need to tear it down and restart it
 #   1. docker-compose down -v
 #   2. docker-compose up -d
 #  Can see databases via:
-#   -mariadb via http://localhost:8100
-#   -mysql   via http://localhost:8101
+#   -mariadb     via http://localhost:8100
+#   -mysql       via http://localhost:8101
+#   -mysql-dev   via http://localhost:8102
 #
 version: '3.1'
 services:
@@ -58,6 +59,12 @@ services:
     command: ['mysqld','--character-set-server=utf8']
     environment:
       MYSQL_ROOT_PASSWORD: root
+  mysql-dev:
+    restart: always
+    image: mysql:8
+    command: ['mysqld','--character-set-server=utf8']
+    environment:
+      MYSQL_ROOT_PASSWORD: root
   phpmyadmin-mariadb:
     restart: always
     image: phpmyadmin/phpmyadmin
@@ -72,6 +79,13 @@ services:
     - 8101:80
     environment:
       PMA_HOST: mysql
+  phpmyadmin-mysql-dev:
+    restart: always
+    image: phpmyadmin/phpmyadmin
+    ports:
+    - 8102:80
+    environment:
+      PMA_HOST: mysql-dev
   couchdb:
     restart: always
     image: couchdb


### PR DESCRIPTION
Note mysql8 does not work with OpenEMR at this time. This will add mysql8 as an option in the docker development environment, so we can work on this.