### PR TITLE
some session fixes

### DIFF
--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -59,12 +59,12 @@ function allFramesLoaded() {
 }
 
 function goRepeaterServices(){
-    top.restoreSession();
     // Ensure send the skip_timeout_reset parameter to not count this as a manual entry in the
     //  timing out mechanism in OpenEMR.
 
     // Send the skip_timeout_reset parameter to not count this as a manual entry in the
     //  timing out mechanism in OpenEMR.
+    top.restoreSession();
     $.post("<?php echo $GLOBALS['webroot']; ?>/library/ajax/dated_reminders_counter.php",
         { skip_timeout_reset: "1" },
         function(data) {
@@ -73,6 +73,7 @@ function goRepeaterServices(){
         }
     );
 
+    top.restoreSession();
     // run background-services
     $.post("<?php echo $GLOBALS['webroot']; ?>/library/ajax/execute_background_services.php",
         { skip_timeout_reset: "1", ajax: "1" }

--- a/interface/patient_file/encounter/forms.php
+++ b/interface/patient_file/encounter/forms.php
@@ -296,6 +296,7 @@ function openEncounterForm(formdir, formname, formid) {
   var url = '<?php echo "$rootdir/patient_file/encounter/view_form.php?formname=" ?>' +
     formdir + '&id=' + formid;
   if (formdir == 'newpatient' || !parent.twAddFrameTab) {
+    top.restoreSession();
     location.href = url;
   }
   else {

--- a/library/ESign/js/jquery.esign.js
+++ b/library/ESign/js/jquery.esign.js
@@ -1,7 +1,7 @@
 /**
  * jQuery plugin to enable esign functionality on a DOM object.
- * Pass in a selector to enable esign on the objects that match    
- * 
+ * Pass in a selector to enable esign on the objects that match
+ *
  * Copyright (C) 2013 OEMR 501c3 www.oemr.org
  *
  * LICENSE: This program is free software; you can redistribute it and/or
@@ -22,12 +22,12 @@
  **/
 
 (function( $ ) {
-	
+
 	$.fn.esign = function( customSettings, customEvents ) {
-		
+
 		// Initialize settings
 		var settings = $.extend({
-			
+
 			// These are the defaults.
 			module : "default",
 			baseUrl : "/interface/esign/index.php",
@@ -35,11 +35,12 @@
 			formViewAction : "/interface/esign/index.php?method=esign_form_view",
 			formSubmitAction : "/interface/esign/index.php?method=esign_form_submit"
 		}, customSettings );
-			
+
 		var events = $.extend({
-			
+
 			afterFormSuccess : function( response ) {
 				var logId = "esign-signature-log-"+response.formDir+"-"+response.formId;
+                top.restoreSession();
 				$.post( settings.logViewAction, response, function( html ) {
 					$("#"+logId).replaceWith( html );
 				});
@@ -47,58 +48,59 @@
 				$("#"+editButtonId).replaceWith( response.editButtonHtml );
 			}
 		}, customEvents );
-		
+
 		// Set up the page with the masking div and form container
 		$('body').append( "<div id='esign-mask-content' class='window rounded'></div>" );
 		$('body').append( "<div id='esign-mask'></div>" );
-		
+
 		// Initialize mask event handlers
 		$(document).on( 'click', '#esign-mask', function() {
 			$(this).hide();
 			$('.window').hide();
 			return false;
-		});			
+		});
 
 		$(window).resize( function() {
-			
+
 	 		var box = $('.window');
-	 
+
 	        //Get the screen height and width
 	        var maskHeight = $(document).height();
 	        var maskWidth = $(window).width();
-	      
+
 	        //Set height and width to mask to fill up the whole screen
 	        $('#esign-mask').css({'width':maskWidth,'height':maskHeight});
-	        
+
 	        //Get the window height and width
 			var w=window,d=document,e=d.documentElement,g=d.getElementsByTagName('body')[0],x=w.innerWidth||e.clientWidth||g.clientWidth,y=w.innerHeight||e.clientHeight||g.clientHeight;
 
 	        //Set the popup window to center
 	        box.css('top',  y/2 - box.height()/2);
 	        box.css('left', x/2 - box.width()/2);
-		 
+
 	        return false;
 		});
-		
+
 		// Initialize the signature form event handlers
 	    $(document).on( 'click', '#esign-back-button', function( e ) {
-	    	
+
 	    	e.preventDefault();
 	    	$(".window").hide();
 	        $("#esign-mask").hide();
-	        
+
 	        return false;
 	    });
-	
+
 	    $(document).on( 'click', '#esign-sign-button-'+settings.module, function( e ) {
-	    	
+
 	        e.preventDefault();
 	        var formData = $('#esign-signature-form').serialize();
-	        $.post( 
+            top.restoreSession();
+	        $.post(
 	        	settings.formSubmitAction,
 	        	formData,
 	        	function( response ) {
-	        		if ( response.status != 'success' ) { 
+	        		if ( response.status != 'success' ) {
 	        			$("#esign-form-error-container").remove();
 	        			$("#esign-mask-content").find("form").append("<div id='esign-form-error-container' class='error'>"+response.message+"</div>");
 	        		} else {
@@ -110,15 +112,15 @@
 	        	},
 	        	'json'
 	        );
-	    	
+
 	    	return false;
 	    });
 
 		function initElement( element ) {
-			
+
 			// Override the anchor
 			element.attr( 'href', '#esign-mask-content' );
-			
+
 			element.click( function( e ) {
 
 				e.preventDefault();
@@ -126,40 +128,41 @@
 				//Get the screen height and width
 				var maskHeight = $(document).height();
 				var maskWidth = $(window).width();
-			
+
 				// Set heigth and width to mask to fill up the whole screen
 				$('#esign-mask').css({'width':maskWidth,'height':maskHeight});
-				
-				//transition effect		
-				$('#esign-mask').fadeIn(200);	
-				$('#esign-mask').fadeTo("fast",0.5);	
-			
+
+				//transition effect
+				$('#esign-mask').fadeIn(200);
+				$('#esign-mask').fadeTo("fast",0.5);
+
 				// Get the window height (y) and width (x)
 				var w=window,d=document,e=d.documentElement,g=d.getElementsByTagName('body')[0],x=w.innerWidth||e.clientWidth||g.clientWidth,y=w.innerHeight||e.clientHeight||g.clientHeight;
-						                  
+
 				//Set the popup window to center
 				$('#esign-mask-content').css( 'top', Math.min( y/4-$('#esign-mask-content').height()/4, 100 ) );
 				$('#esign-mask-content').css( 'left', x/2-$('#esign-mask-content').width()/2 );
-				
+
 				// Get a list of all the data-* attributes
-				var params = element.data(); 
-				
+				var params = element.data();
+
 				// Load the form
+                top.restoreSession();
 				$.post( settings.formViewAction, params, function( response ) {
 					$('#esign-mask-content').html( response );
 				});
-			
+
 				//transition effect
-				$('#esign-mask-content').fadeIn(200); 
+				$('#esign-mask-content').fadeIn(200);
 		    });
-			
+
 			return false;
 		}
-		
+
 		return this.each( function() {
 			var element = $(this);
         	initElement( element );
         });
 	};
-	
+
 }( jQuery ));

--- a/library/tabs/src/TabsWrapper.php
+++ b/library/tabs/src/TabsWrapper.php
@@ -124,6 +124,7 @@ function twSetup(tabsid) {
   tabs.on("click", "span.ui-icon-close", function() {
     var mytabsid = $(this).closest("div").attr("id");
     var panelId = $(this).prev().attr("href").substring(1);
+    top.restoreSession();
     twCloseTab(mytabsid, panelId);
   });
 }
@@ -140,6 +141,7 @@ function twAddTab(tabsid, label, content) {
   var panelId = tabsid + '-' + (++twObject[tabsid].counter);
   var li = "<li><a href='#" + panelId + "'>" + label + "</a> <span class='ui-icon ui-icon-close' role='presentation'>Remove Tab</span></li>";
   twObject[tabsid].tabs.find(".ui-tabs-nav").append(li);
+  top.restoreSession();
   twObject[tabsid].tabs.append("<div id='" + panelId + "'>" + content + "</div>");
   twObject[tabsid].tabs.tabs("refresh");
   twObject[tabsid].tabs.tabs("option", "active", oldcount);
@@ -149,6 +151,7 @@ function twAddTab(tabsid, label, content) {
 // Add a new tab using an iframe loading a specified URL.
 function twAddFrameTab(tabsid, label, url) {
   var panelId = twNextTabId(tabsid);
+  top.restoreSession();
   twAddTab(
     tabsid,
     label,
@@ -161,6 +164,7 @@ function twAddFrameTab(tabsid, label, url) {
 function twCloseTab(tabsid, panelId) {
   twObject[tabsid].tabs.find("[href='#" + panelId + "']").closest("li").remove();
   twObject[tabsid].tabs.find("#" + panelId).remove();
+  top.restoreSession();
   twObject[tabsid].tabs.tabs("refresh");
 }
 


### PR DESCRIPTION
@sjpadgett , @ophthal 
Hopefully this hits on all the critical session lelaking vulnerabilities. This just goes to show how important top.restoreSession(); call is before every single page call/refresh. TabsWrapper.php is likely what caused the marked worsening of this in 5.0.1 and note esign stuff has been in there for ages. the main.php was just done for good measure (we need to get in habit of making the top.restoreSession(); call right before each page call/refresh)