### PR TITLE
Installer Bug fix

### DIFF
--- a/library/classes/Installer.class.php
+++ b/library/classes/Installer.class.php
@@ -197,6 +197,19 @@ class Installer
     {
         return $this->execute_sql("CREATE USER '" . $this->escapeSql($this->login) . "'@'" . $this->escapeSql($this->loginhost) . "' IDENTIFIED BY '" . $this->escapeSql($this->pass) . "'");
     }
+    
+    public function check_database_user()
+    {
+        $sql = "USE mysql";
+        $this->execute_sql($sql);
+        $sql = "SELECT User from user WHERE User = '" . $this->escapeSql($this->login) ."'";
+        $result = $this->execute_sql($sql);
+        if ($result->num_rows > 0) {
+            return true;
+        } else {
+            return false;
+        }
+    }
 
     public function grant_privileges()
     {
@@ -522,12 +535,15 @@ if ($it_died != 0) {
                 if (! $this->create_database()) {
                     return false;
                 }
-
-                // Create the mysql user
-                if (! $this->create_database_user()) {
-                    return false;
+                
+                //if ($this->check_database_user() === false) {
+                if (!$this->check_database_user()) {
+                    // Create the mysql user if not exists
+                    if (! $this->create_database_user()) {
+                        return false;
+                    }
                 }
-
+                
                 // Grant user privileges to the mysql database
                 if (! $this->grant_privileges()) {
                     return false;

--- a/setup.php
+++ b/setup.php
@@ -498,12 +498,16 @@ if (($config == 1) && ($state < 4)) {
                 echo "Creating user with permissions for database...\n";
                 flush();
                 $user_mysql_error = true;
-                if (! $installer->create_database_user()) {
-                    echo "ERROR when creating specified user.\n";
-                    echo $installer->error_message;
-                    break;
+                if (!$installer->check_database_user()) {
+                    if (! $installer->create_database_user()) {
+                        echo "ERROR when creating specified user.\n";
+                        echo $installer->error_message;
+                        break;
+                    } else {
+                        $user_mysql_error = false;
+                    }
                 } else {
-                    $user_mysql_error = false;
+                    echo "User '" . $installer->login . "' already exists, granting privileges...";
                 }
                 if (! $installer->grant_privileges()) {
                     echo "ERROR when granting privileges to the specified user.\n";


### PR DESCRIPTION
The installer script fails at OpenEMR Setup Step 3 on a new installation of openEMR
if the user already exists in mysql. This is caused by the public function create_database_user()
that was created to allow the script to execute in mysql8.

In order to account for an existing user a new function has been added public function check_database_user()
that will check to see if user exists and will add user only if it does not exist

openemr/setup.php
openemr/library/classes/Installer.class.php