### PR TITLE
Fixes in the loading of default tabs 

### DIFF
--- a/interface/main/main_screen.php
+++ b/interface/main/main_screen.php
@@ -93,7 +93,7 @@ if ($is_expired) {
     $map_paths_to_targets = array(
         'main_info.php' => ('cal'),
         '../new/new.php' => ('pat'),
-        '../../interface/main/finder/dynamic_finder.php' => ('pat'),
+        '../../interface/main/finder/dynamic_finder.php' => ('fin'),
         '../../interface/patient_tracker/patient_tracker.php?skip_timeout_reset=1' => ('flb'),
         '../../interface/main/messages/messages.php?form_active=1' => ('msg')
     );

--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -165,14 +165,11 @@ $GLOBALS['allow_issue_menu_link'] = ((acl_check('encounters', 'notes', '', 'writ
         app_view_model.application_data.tabs.tabsList()[0].url(<?php echo json_encode("../".$_SESSION['frame1url']); ?>);
         app_view_model.application_data.tabs.tabsList()[0].name(<?php echo json_encode($_SESSION['frame1target']); ?>);
     <?php } ?>
-    <?php unset($_SESSION['frame1url']); ?>
-    <?php unset($_SESSION['frame1target']); ?>
+
     <?php if (!empty($_SESSION['frame2url']) && !empty($_SESSION['frame2target'])) { ?>
     app_view_model.application_data.tabs.tabsList()[1].url(<?php echo json_encode("../".$_SESSION['frame2url']); ?>);
     app_view_model.application_data.tabs.tabsList()[1].name(<?php echo json_encode($_SESSION['frame2target']); ?>);
     <?php } ?>
-    <?php unset($_SESSION['frame2url']); ?>
-    <?php unset($_SESSION['frame2target']); ?>
 
     app_view_model.application_data.user(new user_data_view_model(<?php echo json_encode($_SESSION{"authUser"})
         .',' . json_encode($userQuery['fname'])


### PR DESCRIPTION
Hi.

Her 2 minor fixes:  
1. If you select patient list for default top pane (in the globals) the screen is opened splited because the target of tab is incorrect in the code.
2. The process of login unsets the sessions of frame1url and frame2url, and if you refresh the screen the clinic is opened with calendar instead the url is saved in the globals. (I haven't found any problem with this removing, hopefully it's ok) .

Thanks
Amiel

 