### PR TITLE
Apply limit to names shown in document helper

### DIFF
--- a/library/ajax/document_helpers.php
+++ b/library/ajax/document_helpers.php
@@ -25,7 +25,7 @@ require_once(dirname(__FILE__) . "/../../interface/globals.php");
 
 $req = array(
     'term' => (isset($_GET["term"]) ? filter_input(INPUT_GET, 'term') : ''),
-    'sql_limit' => (isset($_GET["limit"]) ? filter_input(INPUT_GET, 'limit') : 20),
+    'sql_limit' => (isset($_GET["limit"]) ? escape_limit(filter_input(INPUT_GET, 'limit')) : 20),
 );
 
 function get_patients_list($req)

--- a/library/ajax/document_helpers.php
+++ b/library/ajax/document_helpers.php
@@ -23,13 +23,22 @@
 
 require_once(dirname(__FILE__) . "/../../interface/globals.php");
 
-$term = isset($_GET["term"]) ? filter_input(INPUT_GET, 'term') : '';
+$req = array(
+    'term' => (isset($_GET["term"]) ? filter_input(INPUT_GET, 'term') : ''),
+    'sql_limit' => (isset($_GET["limit"]) ? filter_input(INPUT_GET, 'limit') : 20),
+);
 
-function get_patients_list($term)
+function get_patients_list($req)
 {
-    $term = "%" . $term . "%";
+    $term = "%" . $req['term'] . "%";
     $clear = "- " . xl("Reset to no patient") . " -";
-    $response = sqlStatement("SELECT Concat(patient_data.fname, ' ',patient_data.lname) as label, patient_data.pid as value FROM patient_data HAVING label LIKE ? ORDER BY patient_data.lname ASC", array($term));
+    $response = sqlStatement("
+        SELECT CONCAT(fname, ' ',lname,IF(IFNULL(deceased_date,0)=0,'','*')) as label, pid as value
+            FROM patient_data 
+            HAVING label LIKE ?
+            ORDER BY IF(IFNULL(deceased_date,0)=0, 0, 1) ASC, IFNULL(deceased_date,0) DESC, lname ASC, fname ASC
+            LIMIT ?", 
+        array($term, $req['sql_limit']));    
     $resultpd[] = array(
         'label' => $clear,
         'value' => '00'
@@ -46,4 +55,4 @@ function get_patients_list($term)
     echo json_encode($resultpd);
 }
 
-get_patients_list($term);
+get_patients_list($req);

--- a/library/ajax/document_helpers.php
+++ b/library/ajax/document_helpers.php
@@ -25,7 +25,7 @@ require_once(dirname(__FILE__) . "/../../interface/globals.php");
 
 $req = array(
     'term' => (isset($_GET["term"]) ? filter_input(INPUT_GET, 'term') : ''),
-    'sql_limit' => (isset($_GET["limit"]) ? escape_limit(filter_input(INPUT_GET, 'limit')) : 20),
+    'sql_limit' => (isset($_GET["limit"]) ? filter_input(INPUT_GET, 'limit') : 20),
 );
 
 function get_patients_list($req)
@@ -37,8 +37,8 @@ function get_patients_list($req)
             FROM patient_data 
             HAVING label LIKE ?
             ORDER BY IF(IFNULL(deceased_date,0)=0, 0, 1) ASC, IFNULL(deceased_date,0) DESC, lname ASC, fname ASC
-            LIMIT ?", 
-        array($term, $req['sql_limit']));    
+            LIMIT " . escape_limit($req['sql_limit']), 
+        array($term);    
     $resultpd[] = array(
         'label' => $clear,
         'value' => '00'


### PR DESCRIPTION
1. Limit number of autocomplete entries as specified in the request (default=20).
2. Display deceased patients' names last.