### PR TITLE
Add brand bloc to jQ UI tabswrapper class

### DIFF
--- a/library/tabs/src/TabsWrapper.php
+++ b/library/tabs/src/TabsWrapper.php
@@ -26,7 +26,7 @@ class TabsWrapper
     }
 
     /**
-     * Set brand / arbitrary element managed by parent 
+     * Set brand / arbitrary element managed by parent
      * @param string $htm : Valid html code
      */
     public function setBrand($htm)
@@ -195,7 +195,7 @@ EOD;
             ++$i;
             $s .= "<li>";
             if ($i == 1) {
-            	$s .= $this->htmBrand;
+                $s .= $this->htmBrand;
             }
             $s = "<a href='#{$this->tabsid}-$i'>" . text($val['title']) . "</a>";
             if ($val['closeable']) {

--- a/library/tabs/src/TabsWrapper.php
+++ b/library/tabs/src/TabsWrapper.php
@@ -197,7 +197,7 @@ EOD;
             if ($i == 1) {
                 $s .= $this->htmBrand;
             }
-            $s = "<a href='#{$this->tabsid}-$i'>" . text($val['title']) . "</a>";
+            $s .= "<a href='#{$this->tabsid}-$i'>" . text($val['title']) . "</a>";
             if ($val['closeable']) {
                 $s .= " <span class='ui-icon ui-icon-close' role='presentation'>" . xlt('Remove Tab') . "</span>";
             }

--- a/library/tabs/src/TabsWrapper.php
+++ b/library/tabs/src/TabsWrapper.php
@@ -151,6 +151,7 @@ function twAddTab(tabsid, label, content) {
   var panelId = tabsid + '-' + (++twObject[tabsid].counter);
   var li = "<li><a href='#" + panelId + "'>" + label + "</a> <span class='ui-icon ui-icon-close' role='presentation'>Remove Tab</span></li>";
   twObject[tabsid].tabs.find(".ui-tabs-nav").append(li);
+  top.restoreSession();
   twObject[tabsid].tabs.append("<div id='" + panelId + "'>" + content + "</div>");
   twObject[tabsid].tabs.tabs("refresh");
   twObject[tabsid].tabs.tabs("option", "active", oldcount);
@@ -160,6 +161,7 @@ function twAddTab(tabsid, label, content) {
 // Add a new tab using an iframe loading a specified URL.
 function twAddFrameTab(tabsid, label, url) {
   var panelId = twNextTabId(tabsid);
+  top.restoreSession();
   twAddTab(
     tabsid,
     label,
@@ -172,6 +174,7 @@ function twAddFrameTab(tabsid, label, url) {
 function twCloseTab(tabsid, panelId) {
   twObject[tabsid].tabs.find("[href='#" + panelId + "']").closest("li").remove();
   twObject[tabsid].tabs.find("#" + panelId).remove();
+  top.restoreSession();
   twObject[tabsid].tabs.tabs("refresh");
 }
 
@@ -191,7 +194,7 @@ EOD;
         foreach ($this->tabs as $val) {
             ++$i;
             $s .= "<li>";
-            if ($i == 0) {
+            if ($i == 1) {
             	$s .= $this->htmBrand;
             }
             $s = "<a href='#{$this->tabsid}-$i'>" . text($val['title']) . "</a>";

--- a/library/tabs/src/TabsWrapper.php
+++ b/library/tabs/src/TabsWrapper.php
@@ -16,11 +16,22 @@ namespace OpenEMR\Tabs;
 class TabsWrapper
 {
     public $tabsid;
+    private $htmBrand;
     public $tabs = array();
 
     function __construct($tabsid = 'tabs')
     {
         $this->tabsid = $tabsid;
+        $this->htmBrand = '';
+    }
+
+    /**
+     * Set brand / arbitrary element managed by parent 
+     * @param string $htm : Valid html code
+     */
+    public function setBrand($htm)
+    {
+        $this->htmBrand = $htm;
     }
 
     // Declare an initial tab that will not be dynamically created.
@@ -140,7 +151,6 @@ function twAddTab(tabsid, label, content) {
   var panelId = tabsid + '-' + (++twObject[tabsid].counter);
   var li = "<li><a href='#" + panelId + "'>" + label + "</a> <span class='ui-icon ui-icon-close' role='presentation'>Remove Tab</span></li>";
   twObject[tabsid].tabs.find(".ui-tabs-nav").append(li);
-  top.restoreSession();
   twObject[tabsid].tabs.append("<div id='" + panelId + "'>" + content + "</div>");
   twObject[tabsid].tabs.tabs("refresh");
   twObject[tabsid].tabs.tabs("option", "active", oldcount);
@@ -150,7 +160,6 @@ function twAddTab(tabsid, label, content) {
 // Add a new tab using an iframe loading a specified URL.
 function twAddFrameTab(tabsid, label, url) {
   var panelId = twNextTabId(tabsid);
-  top.restoreSession();
   twAddTab(
     tabsid,
     label,
@@ -163,7 +172,6 @@ function twAddFrameTab(tabsid, label, url) {
 function twCloseTab(tabsid, panelId) {
   twObject[tabsid].tabs.find("[href='#" + panelId + "']").closest("li").remove();
   twObject[tabsid].tabs.find("#" + panelId).remove();
-  top.restoreSession();
   twObject[tabsid].tabs.tabs("refresh");
 }
 
@@ -182,7 +190,11 @@ EOD;
         $i = 0;
         foreach ($this->tabs as $val) {
             ++$i;
-            $s .= "<li><a href='#{$this->tabsid}-$i'>" . text($val['title']) . "</a>";
+            $s .= "<li>";
+            if ($i == 0) {
+            	$s .= $this->htmBrand;
+            }
+            $s = "<a href='#{$this->tabsid}-$i'>" . text($val['title']) . "</a>";
             if ($val['closeable']) {
                 $s .= " <span class='ui-icon ui-icon-close' role='presentation'>" . xlt('Remove Tab') . "</span>";
             }


### PR DESCRIPTION
Adds 'brand' to jQ-ui version of bootstrap navbar.  Brand would typically be an icon or small text.  Caller script is expected to handle all events related to this element.