### PR TITLE
Enable encounter name with quotes

### DIFF
--- a/interface/forms/newpatient/save.php
+++ b/interface/forms/newpatient/save.php
@@ -165,7 +165,7 @@ $result4 = sqlStatement("SELECT fe.encounter,fe.date,openemr_postcalendar_catego
         ?>
         EncounterIdArray[Count]='<?php echo attr($rowresult4['encounter']); ?>';
     EncounterDateArray[Count]='<?php echo attr(oeFormatShortDate(date("Y-m-d", strtotime($rowresult4['date'])))); ?>';
-    CalendarCategoryArray[Count]='<?php echo attr(xl_appt_category($rowresult4['pc_catname'])); ?>';
+    CalendarCategoryArray[Count]='<?php echo text(addslashes(xl_appt_category($rowresult4['pc_catname']))); ?>';
             Count++;
     <?php
             }


### PR DESCRIPTION
Hi.

In the case there is category name with a double quote (") or singlequote (') , the name appears with html entities in the encounters list (only after create new encounter)
![image](https://user-images.githubusercontent.com/17809866/41507431-f5c167fe-723a-11e8-83a5-ee50bcac58ac.png)

I changed the code to right security function.

Thanks
Amiel
  