### PR TITLE
Fix rtl style of the tabs

### DIFF
--- a/interface/themes/rtl_tabs_style_compact.css
+++ b/interface/themes/rtl_tabs_style_compact.css
@@ -620,3 +620,74 @@ div.formname{
     float: right !important;
     padding-left: 10px !important;
 }
+
+#mainBox
+{
+    padding: 0px 5px 0px 0px;
+}
+
+#mainBox .logo {
+    margin:3px 10px 0px 4px;
+    float: right;
+}
+
+#attendantData .patientDataColumn:nth-child(1) span {
+    float: right;
+    margin-right: 5px;
+    margin-left: 12px;
+}
+
+#attendantData .patientDataColumn{
+    float:right;
+}
+
+#attendantData .patientDataColumn:nth-child(1) .patientInfo .ptName span {
+    float: none;
+}
+
+#attendantData .patientDataColumn:nth-child(1) .patientInfo .ptName span:nth-child(2) {
+    margin: 2px;
+}
+
+.appMenu {
+    position: relative;
+    float: right;
+    margin-right: 0px;
+    display: flex;
+    flex-direction: row;
+}
+
+.btn-group.dropdown {
+    float: right;
+    direction: ltr;
+}
+
+.closeButton {
+    display: inline-block;
+    float: left;
+    position: relative;
+    top: 12px;
+    left: 5px;
+    right: 0;
+    transform: scaleX(-1);
+    padding-right: 7px;
+}
+
+#userData
+{
+    float: left;
+}
+.userSection
+{
+    right: 0;
+}
+
+.messagesColumn
+{
+    float: left;
+    padding-left: 20px;
+}
+
+.float-element {
+    float: right;
+}

--- a/interface/themes/rtl_tabs_style_full.css
+++ b/interface/themes/rtl_tabs_style_full.css
@@ -620,3 +620,74 @@ div.formname{
     float: right !important;
     padding-left: 10px !important;
 }
+
+#mainBox
+{
+    padding: 0px 5px 0px 0px;
+}
+
+#mainBox .logo {
+    margin:3px 10px 0px 4px;
+    float: right;
+}
+
+#attendantData .patientDataColumn:nth-child(1) span {
+    float: right;
+    margin-right: 5px;
+    margin-left: 12px;
+}
+
+#attendantData .patientDataColumn{
+    float:right;
+}
+
+#attendantData .patientDataColumn:nth-child(1) .patientInfo .ptName span {
+    float: none;
+}
+
+#attendantData .patientDataColumn:nth-child(1) .patientInfo .ptName span:nth-child(2) {
+    margin: 2px;
+}
+
+.appMenu {
+    position: relative;
+    float: right;
+    margin-right: 0px;
+    display: flex;
+    flex-direction: row;
+}
+
+.btn-group.dropdown {
+    float: right;
+    direction: ltr;
+}
+
+.closeButton {
+    display: inline-block;
+    float: left;
+    position: relative;
+    top: 12px;
+    left: 5px;
+    right: 0;
+    transform: scaleX(-1);
+    padding-right: 7px;
+}
+
+#userData
+{
+    float: left;
+}
+.userSection
+{
+    right: 0;
+}
+
+.messagesColumn
+{
+    float: left;
+    padding-left: 20px;
+}
+
+.float-element {
+    float: right;
+}


### PR DESCRIPTION
Hi.

In the last commit of the new style  #1651 has regression of the rtl style for the tabs menu.
I put back the style from the old commits.
![image](https://user-images.githubusercontent.com/17809866/41531629-9ccb8522-72fc-11e8-9600-c53dcd85fbd6.png)


Another issue - all the styles of the `rtl.css` are duplicated in the `interface/themes/rtl_tabs_style_compact.css` and `interface/themes/rtl_tabs_style_full.css` , why it's necessary? These files should contain style only for menus, do not?      

Thanks
Amiel