### PR TITLE
when recall disabled recall elements still visible

### DIFF
--- a/interface/main/messages/messages.php
+++ b/interface/main/messages/messages.php
@@ -171,7 +171,14 @@ if (!empty($_REQUEST['go'])) { ?>
     <div class="container">
         <div class="row">
             <div class="page-header clearfix">
-                <h2 id="header_title" class="clearfix"><span id='header_text'><?php echo xlt('Messages, Reminders'); if ($GLOBALS['disable_rcb'] != '1') { echo ", " . xlt('Recalls'); }?></span><?php echo $help_icon; ?></h2>
+                <h2 id="header_title" class="clearfix"><span id='header_text'>
+                        <?php
+                        echo xlt('Messages, Reminders');
+                        if ($GLOBALS['disable_rcb'] != '1') {
+                            echo ", " . xlt('Recalls');
+                        }
+                        ?>
+                    </span><?php echo $help_icon; ?></h2>
             </div>
         </div>
         <div class="row" >
@@ -188,7 +195,7 @@ if (!empty($_REQUEST['go'])) { ?>
                             <li class="oe-bold-black" id='li-remi' >
                                 <a href='#' id='reminders-li' style="font-weight:700; color:#000000"><?php echo xlt('Reminders'); ?></a>
                             </li>
-                            <?php if($GLOBALS['disable_rcb'] != '1'){ ?>
+                            <?php if ($GLOBALS['disable_rcb'] != '1') { ?>
                             <li class="oe-bold-black" id='li-reca'>
                                 <a href='#' id='recalls-li' style="font-weight:700; color:#000000"><?php echo xlt('Recalls'); ?></a>
                             </li>

--- a/interface/main/messages/messages.php
+++ b/interface/main/messages/messages.php
@@ -171,7 +171,7 @@ if (!empty($_REQUEST['go'])) { ?>
     <div class="container">
         <div class="row">
             <div class="page-header clearfix">
-                <h2 id="header_title" class="clearfix"><span id='header_text'><?php echo xlt('Messages, Reminders, Recalls'); ?></span><?php echo $help_icon; ?></h2>
+                <h2 id="header_title" class="clearfix"><span id='header_text'><?php echo xlt('Messages, Reminders'); if ($GLOBALS['disable_rcb'] != '1') { echo ", " . xlt('Recalls'); }?></span><?php echo $help_icon; ?></h2>
             </div>
         </div>
         <div class="row" >
@@ -188,9 +188,11 @@ if (!empty($_REQUEST['go'])) { ?>
                             <li class="oe-bold-black" id='li-remi' >
                                 <a href='#' id='reminders-li' style="font-weight:700; color:#000000"><?php echo xlt('Reminders'); ?></a>
                             </li>
+                            <?php if($GLOBALS['disable_rcb'] != '1'){ ?>
                             <li class="oe-bold-black" id='li-reca'>
                                 <a href='#' id='recalls-li' style="font-weight:700; color:#000000"><?php echo xlt('Recalls'); ?></a>
                             </li>
+                            <?php }?>
                             <?php if ($logged_in) { ?>
                             <li class="oe-bold-black" id='li-sms'>
                                 <a href='#' id='sms-li' style="font-weight:700; color:#000000"><?php echo xlt('SMS Zone'); ?></a>

--- a/interface/main/messages/messages.php
+++ b/interface/main/messages/messages.php
@@ -121,7 +121,7 @@ if (($_POST['setting_bootstrap_submenu']) ||
         </style>
     
 <?php
-if (($GLOBALS['medex_enable'] == '1') && (empty($_REQUEST['nomenu']))) {
+if (($GLOBALS['medex_enable'] == '1') && (empty($_REQUEST['nomenu'])) && ($GLOBALS['disable_rcb'] != '1')) {
     $MedEx->display->navigation($logged_in);
     echo "<br />";
 }


### PR DESCRIPTION
Issue fixed by PR:
When disabling recall global, the recall title & tab are still visible in the messages center.