### PR TITLE
Display encounter data when Sensetivity is not set

### DIFF
--- a/interface/forms/newpatient/report.php
+++ b/interface/forms/newpatient/report.php
@@ -26,7 +26,7 @@ function newpatient_report($pid, $encounter, $cols, $id)
     print "<table><tr><td>\n";
     while ($result = sqlFetchArray($res)) {
         print "<span class=bold>" . xlt('Facility') . ": </span><span class=text>" . text($result{"facility_name"}) . "</span><br>\n";
-        if (acl_check('sensitivities', $result['sensitivity'])) {
+        if (empty($result['sensitivity']) || acl_check('sensitivities', $result['sensitivity'])) {
             print "<span class=bold>" . xlt('Reason') . ": </span><span class=text>" . nl2br(text($result{"reason"})) . "</span><br>\n";
         }
     }


### PR DESCRIPTION
Treat Sensetivity='None' as no restriction for display of encounter form data.