### PR TITLE
proposed mpdf version 7 tmp directory fix

### DIFF
--- a/interface/forms/LBF/printable.php
+++ b/interface/forms/LBF/printable.php
@@ -74,6 +74,7 @@ $PDF_OUTPUT = ($formid && $isform) ? false : true;
 
 if ($PDF_OUTPUT) {
     $config_mpdf = array(
+        'tempDir' => $GLOBALS['MPDF_WRITE_DIR'],
         'mode' => $GLOBALS['pdf_language'],
         'format' => $GLOBALS['pdf_size'],
         'default_font_size' => '',

--- a/interface/forms/eye_mag/php/taskman_functions.php
+++ b/interface/forms/eye_mag/php/taskman_functions.php
@@ -325,6 +325,7 @@ function make_document($task)
     }
 
     $config_mpdf = array(
+        'tempDir' => $GLOBALS['MPDF_WRITE_DIR'],
         'mode' => $GLOBALS['pdf_language'],
         'format' => $GLOBALS['pdf_size'],
         'default_font_size' => '9',

--- a/interface/forms/eye_mag/save.php
+++ b/interface/forms/eye_mag/save.php
@@ -363,6 +363,7 @@ if ($_REQUEST["mode"] == "new") {
             $_SESSION['language_direction'] == 'rtl' ? true : false
         );*/
         $config_mpdf = array(
+            'tempDir' => $GLOBALS['MPDF_WRITE_DIR'],
             'mode' => $GLOBALS['pdf_language'],
             'format' => $GLOBALS['pdf_size'],
             'default_font_size' => '9',

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -196,23 +196,11 @@ $GLOBALS['login_screen'] = $GLOBALS['rootdir'] . "/login_screen.php";
 // Variable set for Eligibility Verification [EDI-271] path
 $GLOBALS['edi_271_file_path'] = $GLOBALS['OE_SITE_DIR'] . "/edi/";
 
-//  Check necessary writeable paths exist for mPDF tool
-if (is_dir($GLOBALS['OE_SITE_DIR'] . '/documents/mpdf/')) {
-    if (! is_dir($GLOBALS['OE_SITE_DIR'] . '/documents/mpdf/ttfontdata/')) {
-        mkdir($GLOBALS['OE_SITE_DIR'] . '/documents/mpdf/ttfontdata/', 0755);
-    }
-
-    if (! is_dir($GLOBALS['OE_SITE_DIR'] . '/documents/mpdf/pdf_tmp/')) {
-        mkdir($GLOBALS['OE_SITE_DIR'] . '/documents/mpdf/pdf_tmp/', 0755);
-    }
-} else {
-    mkdir($GLOBALS['OE_SITE_DIR'] . '/documents/mpdf/ttfontdata/', 0755, true);
-    mkdir($GLOBALS['OE_SITE_DIR'] . '/documents/mpdf/pdf_tmp/', 0755);
+//  Set and check that necessary writeable path exist for mPDF tool
+$GLOBALS['MPDF_WRITE_DIR'] = $GLOBALS['OE_SITE_DIR'] . '/documents/mpdf/pdf_tmp';
+if (! is_dir($GLOBALS['MPDF_WRITE_DIR'])) {
+    mkdir($GLOBALS['MPDF_WRITE_DIR'], 0755, true);
 }
-
-// Safe bet support directories exist, define them.
-define("_MPDF_TEMP_PATH", $GLOBALS['OE_SITE_DIR'] . '/documents/mpdf/pdf_tmp/');
-define("_MPDF_TTFONTDATAPATH", $GLOBALS['OE_SITE_DIR'] . '/documents/mpdf/ttfontdata/');
 
 // Includes composer autoload
 // Note this also brings in following library files:

--- a/interface/patient_file/report/custom_report.php
+++ b/interface/patient_file/report/custom_report.php
@@ -43,6 +43,7 @@ $PDF_OUTPUT = empty($_POST['pdf']) ? 0 : intval($_POST['pdf']);
 
 if ($PDF_OUTPUT) {
     $config_mpdf = array(
+        'tempDir' => $GLOBALS['MPDF_WRITE_DIR'],
         'mode' => $GLOBALS['pdf_language'],
         'format' => $GLOBALS['pdf_size'],
         'default_font_size' => '9',


### PR DESCRIPTION
The mechanism for mpdf version 7 has changed for declaring the tmp directory:
https://mpdf.github.io/installation-setup/folders-for-temporary-files.html