### PR TITLE
fixed cancel link in groups encounters

### DIFF
--- a/interface/forms/newGroupEncounter/common.php
+++ b/interface/forms/newGroupEncounter/common.php
@@ -121,14 +121,30 @@ ajax_bill_loc(pid,dte,facility);
 
 // Handler for Cancel clicked when creating a new encounter.
 // Show demographics or encounters list depending on what frame we're in.
-function cancelClicked() {
- if (window.name == 'RBot') {
-  parent.left_nav.loadFrame('ens1', window.name, 'patient_file/history/encounters.php');
- }
- else {
-  parent.left_nav.loadFrame('dem1', window.name, 'patient_file/summary/demographics.php');
- }
- return false;
+function cancelClickedNew() {
+    if (top.tab_mode) {
+        window.parent.left_nav.loadFrame('ens1', window.name, 'patient_file/history/encounters.php');
+    }
+    var target = window;
+    while (target != top) {
+        if (target.name == 'RBot') {
+            target.parent.left_nav.loadFrame('ens1', window.name, 'patient_file/history/encounters.php');
+            break;
+        }
+        else if (target.name == 'RTop') {
+            target.parent.left_nav.loadFrame('dem1', window.name, 'patient_file/summary/demographics.php');
+            break;
+        }
+        target = target.parent;
+    }
+    return false;
+}
+
+// Handler for cancel clicked when not creating a new encounter.
+// Just reload the view mode.
+function cancelClickedOld() {
+    location.href = '<?php echo "$rootdir/patient_file/encounter/forms.php"; ?>';
+    return false;
 }
 
 </script>
@@ -164,9 +180,9 @@ function cancelClicked() {
     </div>
     <div style = 'float:left; margin-top:-3px'>
       <a href="<?php echo $GLOBALS['form_exit_url']; ?>"
-        class="css_button link_submit" onClick="top.restoreSession()"><span><?php echo xlt('Cancel'); ?></span></a>
+        class="css_button link_submit" onClick="return cancelClickedOld()"><span><?php echo xlt('Cancel'); ?></span></a>
         <?php } else { // not $viewmode ?>
-      <a href="" class="css_button link_submit" onClick="return cancelClicked()">
+      <a href="" class="css_button link_submit" onClick="return cancelClickedNew()">
       <span><?php echo xlt('Cancel'); ?></span></a>
         <?php } // end not $viewmode ?>
     </div>


### PR DESCRIPTION
Fix for following issue:
When clicking cancel in a new encounter for therapy groups, user is redirected to a patient file demographics screen.
