### PR TITLE
Set up nginx as reverse proxy for Orthanc

### DIFF
--- a/contrib/util/docker/dockers/dev-nginx/nginx.conf
+++ b/contrib/util/docker/dockers/dev-nginx/nginx.conf
@@ -119,6 +119,18 @@ http {
         }
         # end globals.conf configuration file.
 
+        # enable CORS for orthanc dicom server
+        location  /orthanc/  {
+            proxy_pass http://localhost:8042;
+            proxy_set_header HOST $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            rewrite /orthanc(.*) $1 break;
+            add_header 'Access-Control-Allow-Credentials' 'true';
+            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+            add_header 'Access-Control-Allow-Origin' '*';
+        }
+
         # deny access to writable files/directories
         location ~* ^/sites/*/(documents|edi|era) {
             deny all;


### PR DESCRIPTION
Orthanc doesn't allow for cross origin resource sharing by default. If we use nginx as a reverse proxy we can add CORS headers to all the requests coming from Orthanc. See http://book.orthanc-server.com/faq/nginx.html and https://groups.google.com/forum/#!topic/orthanc-users/GG-dFIn2LQ0 for more. The default url of `http://localhost:8042` is okay since we are already specifying that in our docker-compose file. 