### PR TITLE
CAMOS fix

### DIFF
--- a/interface/forms/CAMOS/ajax_save.php
+++ b/interface/forms/CAMOS/ajax_save.php
@@ -21,7 +21,7 @@ if (preg_match("/^[\s\\r\\n\\\\r\\\\n]*$/", $field_names['content']) == 0) { //m
   //   before being submitted to the database. Will also continue to support placeholder conversion on report
   //   views to support notes within database that still contain placeholders (ie. notes that were created previous to
   //   version 4.0).
-    $field_names['content'] = add_escape_custom(replace($pid, $encounter, $field_names['content']));
+    $field_names['content'] = replace($pid, $encounter, $field_names['content']);
     reset($field_names);
     $newid = formSubmit("form_CAMOS", $field_names, $_GET["id"], $userauthorized);
     addForm($encounter, $CAMOS_form_name, $newid, "CAMOS", $pid, $userauthorized);

--- a/interface/forms/CAMOS/report.php
+++ b/interface/forms/CAMOS/report.php
@@ -28,6 +28,6 @@ function CAMOS_report($pid, $encounter, $cols, $id)
         echo "<a href='" . $GLOBALS['webroot'] .
         "/interface/forms/CAMOS/notegen.php' target=_new>" . xl('Print Any Encounter') . "</a></div>\n";
     //    echo "<pre>".wordwrap(stripslashes(content_parser($data['content'])))."</pre><hr>\n";
-        echo "<pre>".wordwrap(stripslashes(replace($pid, $encounter, $data['content'])))."</pre><hr>\n";
+        echo "<pre>".wordwrap(str_replace("\\n", "\n", (replace($pid, $encounter, $data['content']))))."</pre><hr>\n";
     }
 }


### PR DESCRIPTION
1. Main issue was that CAMOS content was getting double escaped, so removing this will fix new entries.
2. To fix old entries will require the replacing of \\n to \n whenever the content from a double escaped note is collected. I did this in one spot so far.