### PR TITLE
CAMOS critical bug fix

### DIFF
--- a/interface/forms/CAMOS/ajax_save.php
+++ b/interface/forms/CAMOS/ajax_save.php
@@ -5,7 +5,7 @@ include_once("../../../library/api.inc");
 include_once("../../../library/forms.inc");
 include_once("content_parser.php");
 
-$field_names = array('category' => formData("category"), 'subcategory' => formData("subcategory"), 'item' => formData("item"), 'content' => strip_escape_custom($_POST['content']));
+$field_names = array('category' => $_POST["category"], 'subcategory' => $_POST["subcategory"], 'item' => $_POST["item"], 'content' => $_POST['content']);
 $camos_array = array();
 process_commands($field_names['content'], $camos_array);
 
@@ -21,7 +21,7 @@ if (preg_match("/^[\s\\r\\n\\\\r\\\\n]*$/", $field_names['content']) == 0) { //m
   //   before being submitted to the database. Will also continue to support placeholder conversion on report
   //   views to support notes within database that still contain placeholders (ie. notes that were created previous to
   //   version 4.0).
-    $field_names['content'] = add_escape_custom(replace($pid, $encounter, $field_names['content']));
+    $field_names['content'] = replace($pid, $encounter, $field_names['content']);
     reset($field_names);
     $newid = formSubmit("form_CAMOS", $field_names, $_GET["id"], $userauthorized);
     addForm($encounter, $CAMOS_form_name, $newid, "CAMOS", $pid, $userauthorized);
@@ -36,7 +36,7 @@ foreach ($camos_array as $val) {
             //   before being submitted to the database. Will also continue to support placeholder conversion on report
             //   views to support notes within database that still contain placeholders (ie. notes that were created previous to
             //   version 4.0).
-            $val[$k] = trim(add_escape_custom(replace($pid, $encounter, $v)));
+            $val[$k] = trim(replace($pid, $encounter, $v));
         }
 
         $CAMOS_form_name = "CAMOS-".$val['category'].'-'.$val['subcategory'].'-'.$val['item'];

--- a/interface/forms/CAMOS/content_parser.php
+++ b/interface/forms/CAMOS/content_parser.php
@@ -269,7 +269,8 @@ function replace($pid, $enc, $content)
         array($name,$age,strtolower($gender),$doctorname),
         $content
     );
-    return $ret;
+    //Below will fix blocks that were inadvertently double escaped in openemr versions 5.0.1.0 - 5.0.1.5
+    return str_replace("\\n", "\n", $ret);
 }
 function patient_age($birthday, $date)
 {


### PR DESCRIPTION
Fixes double escaping of entries in CAMOS. Also can fix the "bad" entries prior to this commit by editing them and saving them.