### PR TITLE
remove EditNote function

### DIFF
--- a/interface/patient_file/summary/pnotes.php
+++ b/interface/patient_file/summary/pnotes.php
@@ -194,19 +194,8 @@ if ($result != null) {
 $(document).ready(function(){
     $(".noterow").mouseover(function() { $(this).toggleClass("highlight"); });
     $(".noterow").mouseout(function() { $(this).toggleClass("highlight"); });
-    $(".noterow").click(function() { EditNote(this); });
 });
-
-var EditNote = function(note) {
-<?php if (acl_check('patients', 'notes', '', array('write','addonly'))) : ?>
-    top.restoreSession();
-    location.href = "pnotes_full.php?<?php echo $urlparms; ?>&noteid=" + note.id + "&active=1";
-<?php else : ?>
-    // no-op
-    alert("<?php echo htmlspecialchars(xl('You do not have access to view/edit this note'), ENT_QUOTES); ?>");
-<?php endif; ?>
-}
-
+    
 </script>
 
 </html>


### PR DESCRIPTION
Patient Messages: clicking the row in the table leads to Unknown window 
since there is an "edit" botton for each row the functionality can be removed 

![image](https://user-images.githubusercontent.com/20621444/45616385-fa6b2300-ba77-11e8-9548-c85ea51790a4.png)

on clicking the row 

![image](https://user-images.githubusercontent.com/20621444/45616397-09ea6c00-ba78-11e8-8fb3-1f02093942a2.png)



