### PR TITLE
Remove therapy group forms from menu (patient -> visit forms)

### DIFF
--- a/library/menu/src/MainMenuRole.php
+++ b/library/menu/src/MainMenuRole.php
@@ -275,7 +275,7 @@ class MainMenuRole extends MenuRole
         }
 
         // Traditional forms
-        $reg = getRegistered();
+        $reg = getRegistered(1, 'unlimited', 0, 'patient');
         if (!empty($reg)) {
             foreach ($reg as $entry) {
                 $option_id = $entry['directory'];

--- a/library/registry.inc
+++ b/library/registry.inc
@@ -42,7 +42,7 @@ function getRegistered($state = "1", $limit = "unlimited", $offset = "0", $encou
 {
     $sql = "select * from registry where state like ? ";
     if ($encounterType !== 'all') {
-        switch ($encounterType){
+        switch ($encounterType) {
             case 'patient':
                 $sql .= 'AND patient_encounter = 1 ';
                 break;

--- a/library/registry.inc
+++ b/library/registry.inc
@@ -32,9 +32,26 @@ function updateRegistered($id, $mod)
     return sqlInsert("update registry set $mod, date=NOW() where id=?", array($id));
 }
 
-function getRegistered($state = "1", $limit = "unlimited", $offset = "0")
+/**
+ * @param string $state
+ * @param string $limit
+ * @param string $offset
+ * @param string $encounterType all|patient|therapy_group
+ */
+function getRegistered($state = "1", $limit = "unlimited", $offset = "0", $encounterType = 'all')
 {
-    $sql = "select * from registry where state like ? order by priority, name";
+    $sql = "select * from registry where state like ? ";
+    if ($encounterType !== 'all') {
+        switch ($encounterType){
+            case 'patient':
+                $sql .= 'AND patient_encounter = 1 ';
+                break;
+            case 'therapy_group':
+                $sql .= 'AND therapy_group_encounter = 1 ';
+                break;
+        }
+    }
+    $sql .= "order by priority, name ";
     if ($limit != "unlimited") {
         $sql .= " limit " . escape_limit($limit) . ", " . escape_limit($offset);
     }


### PR DESCRIPTION
Hi.

Now all the active forms are shown in the patient menu (patient -> visit forms).
I added parameter to 'getRegistered'  function that filters only patient encounter forms. 

Thanks
Amiel