### PR TITLE
 Store globals.php path for session at login

### DIFF
--- a/interface/main/main_screen.php
+++ b/interface/main/main_screen.php
@@ -18,11 +18,23 @@
  * @link    http://www.open-emr.org
  */
 
+// This is gateway to emr session on desktop / large display devices.
+// Until unified session class is rolled out, lock globals here.
+session_name("OpenEMR");
+session_start();
 
+// When php 7 becomes minimum supported version, eliminate checking for version
+if (PHP_MAJOR_VERSION >= 7) {
+    $_SESSION['globals_if'] = dirname(__FILE__, 2).'/globals.php';
+} else {
+    $_SESSION['globals_if'] = dirname(dirname(__FILE__)).'/globals.php';
+}
 
+// Tell globals.php to take one time actions related to $_SESSION and reset flag
+$_SESSION['globals_init'] = TRUE;
 
 /* Include our required headers */
-require_once('../globals.php');
+require_once($_SESSION['globals_if']);
 
 // Creates a new session id when load this outer frame
 // (allows creations of separate OpenEMR frames to view patients concurrently

--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -23,11 +23,11 @@ use OpenEMR\Core\Header;
  * @link    http://www.open-emr.org
  */
 
-
-
+session_name("OpenEMR");
+session_start();
 
 /* Include our required headers */
-require_once('../../globals.php');
+require_once($_SESSION['globals_if']);
 require_once $GLOBALS['srcdir'].'/ESign/Api.php';
 
 $esignApi = new Api();


### PR DESCRIPTION
Store path to globals.php in $_SESSION after successful login.  This can be used by scripts called during that session without need for hard coding.