### PR TITLE
possible security improvement

### DIFF
--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -24,6 +24,8 @@ if ((empty($_SESSION['token_main_php'])) ||
     ($_GET['token_main'] != $_SESSION['token_main_php'])) {
     die(xlt('Authentication Error'));
 }
+// this will not allow copy/paste of the link to this main.php page or a refresh of this main.php page
+unset($_SESSION['token_main_php']);
 
 $esignApi = new Api();
 


### PR DESCRIPTION
hi @stephenwaite and @sjpadgett ,
Was hoping to get your thoughts on this change. This will basically not allow users to copy/paste the main.php link or even do a browser refresh to the main.php page. Is this overly invasive? If do this should I throw up a warning if a user tries to do a page refresh from browser (via window.onbeforeunload) to prevent user from doing a browser refresh and losing their work?
thanks,
-brady