### PR TITLE
log ip improve

### DIFF
--- a/interface/usergroup/user_info.php
+++ b/interface/usergroup/user_info.php
@@ -59,7 +59,6 @@ function update_password()
 
 <?php
 
-$ip=$_SERVER['REMOTE_ADDR'];
 $res = sqlStatement("select fname,lname,username from users where id=?", array($_SESSION["authId"]));
 $row = sqlFetchArray($res);
       $iter=$row;

--- a/library/auth.inc
+++ b/library/auth.inc
@@ -57,7 +57,6 @@ if (isset($_GET['auth']) && ($_GET['auth'] == "login") && isset($_POST['authUser
         }
     }
 
-    $ip=$_SERVER['REMOTE_ADDR'];
     $_SESSION['loginfailure'] = null;
     unset($_SESSION['loginfailure']);
     //store the very first initial timestamp for timeout errors

--- a/library/authentication/login_operations.php
+++ b/library/authentication/login_operations.php
@@ -89,7 +89,7 @@ function validate_user_password($username, &$password, $provider)
     $userInfo = privQuery($getUserSQL, array($username));
 
     if ($userInfo['active'] != 1) {
-        newEvent('login', $username, $provider, 0, "failure: $ip. user not active or not found in users table");
+        newEvent('login', $username, $provider, 0, "failure: " . $ip['ip_string'] . ". user not active or not found in users table");
         $password='';
         return false;
     }

--- a/library/authentication/login_operations.php
+++ b/library/authentication/login_operations.php
@@ -33,7 +33,7 @@ require_once("$srcdir/authentication/common_operations.php");
  */
 function validate_user_password($username, &$password, $provider)
 {
-    $ip=$_SERVER['REMOTE_ADDR'];
+    $ip = collectIpAddresses();
 
     $valid=false;
 
@@ -110,10 +110,10 @@ function validate_user_password($username, &$password, $provider)
                 $_SESSION['userauthorized'] = '1';
             }
 
-            newEvent('login', $username, $provider, 1, "success: $ip");
+            newEvent('login', $username, $provider, 1, "success: " . $ip['ip_string']);
             $valid=true;
         } else {
-            newEvent('login', $username, $provider, 0, "failure: $ip. user not in group: $provider");
+            newEvent('login', $username, $provider, 0, "failure: " . $ip['ip_string'] . ". user not in group: $provider");
             $valid=false;
         }
     }
@@ -124,9 +124,12 @@ function validate_user_password($username, &$password, $provider)
 function verify_user_gacl_group($user)
 {
     global $phpgacl_location;
+
+    $ip = collectIpAddresses();
+
     if (isset($phpgacl_location)) {
         if (acl_get_group_titles($user) == 0) {
-            newEvent('login', $user, $provider, 0, "failure: $ip. user not in any phpGACL groups. (bad username?)");
+            newEvent('login', $user, $provider, 0, "failure: " . $ip['ip_string'] . ". user not in any phpGACL groups. (bad username?)");
             return false;
         }
     }

--- a/library/sanitize.inc.php
+++ b/library/sanitize.inc.php
@@ -13,6 +13,24 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+// Function to collect ip address(es)
+function collectIpAddresses()
+{
+    $mainIp = $_SERVER['REMOTE_ADDR'];
+    $stringIp = $mainIp;
+
+    if (!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+        $forwardIp = $_SERVER['HTTP_X_FORWARDED_FOR'];
+        $stringIp .= " (" . $forwardIp . ")";
+    }
+
+    return array(
+        'ip_string' => $stringIp,
+        'ip' => $mainIp,
+        'forward_ip' => $forwardIp
+    );
+}
+
 // Function to create a random unique token
 // Length is in bytes that the openssl_random_pseudo_bytes() function will create
 function createUniqueToken($length = 32)


### PR DESCRIPTION
When collecting ip address.

$_SERVER['REMOTE_ADDR'] is not always correct (for example, when behind a reverse-proxy), however it can't really be spoofed.
$_SERVER['HTTP_X_FORWARDED_FOR'] will get correct ip address when behind a correctly set reverse-proxy, however it can be spoofed.

So set it up in log that $_SERVER['REMOTE_ADDR'] is always collected and then will also record if $_SERVER['HTTP_X_FORWARDED_FOR']  if exists.

Encapsulated this in a function, so we can fix it up as needed in the future.