### PR TITLE
Update of P.R #1612 by Daniel Pflieger to 5.0.2

### DIFF
--- a/interface/billing/sl_eob_search.php
+++ b/interface/billing/sl_eob_search.php
@@ -17,6 +17,9 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+// Updated by Growlingflea Software.  now generates correct service and billing facility on statement.
+// any questions contact Daniel Pflieger at daniel@growlingflea.com
+
 require_once("../globals.php");
 require_once("$srcdir/patient.inc");
 require_once("$srcdir/invoice_summary.inc.php");
@@ -370,7 +373,7 @@ if (($_REQUEST['form_print'] || $_REQUEST['form_download'] || $_REQUEST['form_em
 
     $res = sqlStatement("SELECT " .
         "f.id, f.date, f.pid, f.encounter, f.stmt_count, f.last_stmt_date, f.last_level_closed, f.last_level_billed, f.billing_note as enc_billing_note, " .
-        "p.fname, p.mname, p.lname, p.street, p.city, p.state, p.postal_code, p.billing_note as pat_billing_note " .
+        "p.fname, p.mname, p.lname, p.street, p.city, p.state, p.postal_code, p.billing_note as pat_billing_note, f.provider_id " .
         "FROM form_encounter AS f, patient_data AS p " .
         "WHERE $where " .
         "p.pid = f.pid " .
@@ -450,7 +453,7 @@ if (($_REQUEST['form_print'] || $_REQUEST['form_download'] || $_REQUEST['form_em
             if (!empty($stmt)) {
                 ++$stmt_count;
             }
-
+            $stmt['fid'] = $row['id'];
             $stmt['cid'] = $row['pid'];
             $stmt['pid'] = $row['pid'];
             $stmt['dun_count'] = $row['stmt_count'];
@@ -460,6 +463,7 @@ if (($_REQUEST['form_print'] || $_REQUEST['form_download'] || $_REQUEST['form_em
             $stmt['level_closed'] = $row['last_level_closed'];
             $stmt['patient'] = $row['fname'] . ' ' . $row['lname'];
             $stmt['encounter'] = $row['encounter'];
+            $stmt['provider_id'] = $row['provider_id'];
 #If you use the field in demographics layout called
 #guardiansname this will allow you to send statements to the parent
 #of a child or a guardian etc

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -1171,6 +1171,13 @@ $GLOBALS_METADATA = array(
             xl('This feature will allow the default POS facility code to be overriden from the encounter.')
         ),
 
+        'statement_logo' => array(
+            xl('Statement Logo GIF Filename'),
+            'text',                           // data type
+            'practice_logo.gif',                               // data type
+            xl('Place your logo in sites/default/images and type the filename including gif extension here.')
+        ),
+
         'use_custom_statement' => array(
             xl('Use Custom Statement'),
             'bool',                           // data type


### PR DESCRIPTION
 - Statement reflects the service facility and billing facility specified in encounter. The default logo if a logo is selected is 'practice_logo.gif' but the end user has the ability to change this. The logo has been placed left. Formatting issues if the service facility has a long name should auto size up to 40-50% of header width.
 - statement header should now auto size w/w/o logo.
 - moved logo to left where most logo appear on letterheads.
 - added insurance names to adjustment notes.
 - changed logo file logic.