### PR TITLE
fix array count

### DIFF
--- a/library/user.inc
+++ b/library/user.inc
@@ -158,7 +158,7 @@ function collectAndOrganizeExpandSetting($filenames = array())
         $current_state = 0;
     }
 
-    if ($filenames.length) {
+    if (count($filenames)) {
         foreach ($filenames as $filename) {
             setUserSetting($filename, $current_state);
         }


### PR DESCRIPTION
found this error

[Sun Oct 21 13:41:03.850345 2018] [php7:warn] [pid 604] [client 172.18.0.1:46614] PHP Warning:  Use of undefined constant length - assumed 'length' (this will throw an Error in a future version of PHP) in /var/www/localhost/htdocs/openemr/library/user.inc on line 161, referer: http://localhost:8300/interface/billing/sl_eob_search.php