### PR TITLE
Minor fixes for internationalization of new style of patient file

### DIFF
--- a/interface/main/tabs/menu/menus/patient_menus/standard.json
+++ b/interface/main/tabs/menu/menus/patient_menus/standard.json
@@ -1,5 +1,5 @@
 [	{
-        "label": "Medical Record",
+        "label": "Dashboard{{patient file}}",
         "menu_id": "dashboard",
         "target": "main",
         "on_click":"top.restoreSession()",

--- a/interface/main/tabs/menu/menus/patient_menus/standard.json
+++ b/interface/main/tabs/menu/menus/patient_menus/standard.json
@@ -1,5 +1,5 @@
 [	{
-        "label": "Dashboard",
+        "label": "Medical Record",
         "menu_id": "dashboard",
         "target": "main",
         "on_click":"top.restoreSession()",

--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -646,7 +646,7 @@ if (!empty($grparr['']['grp_size'])) {
 <?php } ?>
 
 </style>
-<title><?php echo xlt("Medical Record"); ?></title>
+<title><?php echo xlt("Dashboard{{patient file}}"); ?></title>
 </head>
 
 <body class="body_top patient-demographics">

--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -646,7 +646,7 @@ if (!empty($grparr['']['grp_size'])) {
 <?php } ?>
 
 </style>
-<title><?php echo xlt("Dashboard"); ?></title>
+<title><?php echo xlt("Medical Record"); ?></title>
 </head>
 
 <body class="body_top patient-demographics">

--- a/interface/themes/rtl.scss
+++ b/interface/themes/rtl.scss
@@ -8,6 +8,10 @@
 /* General RTL calsses */
 @mixin rtl_style {
 
+    body{
+        direction: rtl;
+    }
+
     tr, td, th{
         text-align: right !important;
 
@@ -95,7 +99,7 @@
         width: 55% !important;
     }
     .demographics-box>div:last-child{
-        margin-right: 55%
+        margin-right: 75%
     }
 
 

--- a/sites/default/documents/custom_menus/patient_menus/Custom.json
+++ b/sites/default/documents/custom_menus/patient_menus/Custom.json
@@ -1,5 +1,5 @@
 [	{
-        "label": "Medical Record",
+        "label": "Dashboard{{patient file}}",
         "menu_id": "dashboard",
         "target": "main",
         "on_click":"top.restoreSession()",

--- a/sites/default/documents/custom_menus/patient_menus/Custom.json
+++ b/sites/default/documents/custom_menus/patient_menus/Custom.json
@@ -1,5 +1,5 @@
 [	{
-        "label": "Dashboard",
+        "label": "Medical Record",
         "menu_id": "dashboard",
         "target": "main",
         "on_click":"top.restoreSession()",


### PR DESCRIPTION
Hi.

I send here 2 fixes we have found in the new style of patient file in our language.
1. rtl issue.
2. We have problem the translation of 'Dashboard', the meaning of dashboard is very general and not match  in Hebrew. I suggest to replace the title to 'Medical record' I think is more  understandable.   

Thanks

Amiel.