### PR TITLE
Recall Board+API

### DIFF
--- a/library/MedEx/API.php
+++ b/library/MedEx/API.php
@@ -925,7 +925,7 @@ class Events extends Base
         if (!empty($appt3)) {
             $this->process($token, $appt3);
         }
-        $responses['deletes'] = $hipaa;
+        $responses['deletes'] = $deletes;
         $responses['count_appts'] = $count_appts;
         $responses['count_recalls'] = $count_recalls;
         $responses['count_announcements'] = $count_announcements;


### PR DESCRIPTION
Add button to “Add Recall” to make Recall Board not be “totally useless”.
More style removal.
Autofill with PID in session’s info.
Clean up API logging methodology.
SQL logic to pick up NoShows and
Add SMS capacity to GoGreen Messaging.

Signed-off-by: ophthal <magauran@ophthal.org>