### PR TITLE
put adj group codes on same line for 2ndary claims

### DIFF
--- a/library/billing/src/X12837P.php
+++ b/library/billing/src/X12837P.php
@@ -1189,32 +1189,39 @@ class X12837P
                 "~\n";
     
                 $tmpdate = $payerpaid[0];
-                $adj_group_code = '';
+                // new logic for putting same adjustment group codes
+                // on the same line
+                $adj_group_code[0] = '';
                 $adj_count = 0;
+                $aarr_count = count($aarr);
                 foreach ($aarr as $a) {
                     ++$adj_count;
-                    if ((count($aarr) !== 1) && ($adj_group_code !== $a[1])) {
-                        ++$edicount;
-                        $out .= "~\n";
-                    }
-                    if ($adj_group_code !== $a[1]) {
+                    $adj_group_code[$adj_count] = $a[1];
+                    // when the adj group code changes increment edi
+                    // counter and add line ending
+                    if ($adj_group_code[$adj_count] !== $adj_group_code[($adj_count - 1)]) {
+                        // increment when there was a prior segment with the
+                        // same adj group code
+                        if ($adj_count !== 1) {
+                            ++$edicount;
+                            $out .= "~\n";
+                        }
                         $out .= "CAS" . // Previous payer's line level adjustments. Page 558.
                         "*" . $a[1] .
                         "*" . $a[2] .
                         "*" . $a[3];
+                        if (($aarr_count == 1) || ($adj_count !== 1)) {
+                            ++$edicount;
+                            $out .= "~\n";
+                        } 
                     } else {
-                        $out = "*" . // since it's the same adj group code don't include it
+                        $out .= "*" . // since it's the same adj group code don't include it
                         "*" . $a[2] .
                         "*" . $a[3];
                     }
                     if (!$tmpdate) {
-                        $tmpdate = $a[0];
+                    $tmpdate = $a[0];
                     }
-                    if ((count($aarr) == 1) || (count($aarr) == $adj_count)) {
-                        ++$edicount;
-                        $out .= "~\n";
-                    }
-                    $adj_group_code = $a[1];
                 }
     
                 if ($tmpdate) {

--- a/library/billing/src/X12837P.php
+++ b/library/billing/src/X12837P.php
@@ -1194,15 +1194,15 @@ class X12837P
                 foreach ($aarr as $a) {
                     ++$adj_count;
                     if ((count($aarr) !== 1) && ($adj_group_code !== $a[1])) {
-					    ++$edicount;
+                        ++$edicount;
                         $out .= "~\n";
                     }
                     if ($adj_group_code !== $a[1]) {
-						$out .= "CAS" . // Previous payer's line level adjustments. Page 558.
-						"*" . $a[1] .
+                        $out .= "CAS" . // Previous payer's line level adjustments. Page 558.
+                        "*" . $a[1] .
                         "*" . $a[2] .
                         "*" . $a[3];
-					} else {
+                    } else {
 						$out = "*" . // since it's the same adj group code don't include it
 						"*" . $a[2] .
                         "*" . $a[3];
@@ -1214,7 +1214,7 @@ class X12837P
 						++$edicount;
                         $out .= "~\n";
                     }
-					$adj_group_code = $a[1];
+                    $adj_group_code = $a[1];
                 }
     
                 if ($tmpdate) {

--- a/library/billing/src/X12837P.php
+++ b/library/billing/src/X12837P.php
@@ -1218,6 +1218,10 @@ class X12837P
                         $out .= "*" . // since it's the same adj group code don't include it
                         "*" . $a[2] .
                         "*" . $a[3];
+                        if ($adj_count == $aarr_count) {
+                            ++$edicount;
+                            $out .= "~\n";
+                        }    
                     }
                     if (!$tmpdate) {
                         $tmpdate = $a[0];

--- a/library/billing/src/X12837P.php
+++ b/library/billing/src/X12837P.php
@@ -1213,14 +1213,14 @@ class X12837P
                         if (($aarr_count == 1) || ($adj_count !== 1)) {
                             ++$edicount;
                             $out .= "~\n";
-                        } 
+                        }
                     } else {
                         $out .= "*" . // since it's the same adj group code don't include it
                         "*" . $a[2] .
                         "*" . $a[3];
                     }
                     if (!$tmpdate) {
-                    $tmpdate = $a[0];
+                        $tmpdate = $a[0];
                     }
                 }
     

--- a/library/billing/src/X12837P.php
+++ b/library/billing/src/X12837P.php
@@ -1221,7 +1221,7 @@ class X12837P
                         if ($adj_count == $aarr_count) {
                             ++$edicount;
                             $out .= "~\n";
-                        }    
+                        }
                     }
                     if (!$tmpdate) {
                         $tmpdate = $a[0];

--- a/library/billing/src/X12837P.php
+++ b/library/billing/src/X12837P.php
@@ -1203,15 +1203,15 @@ class X12837P
                         "*" . $a[2] .
                         "*" . $a[3];
                     } else {
-						$out = "*" . // since it's the same adj group code don't include it
-						"*" . $a[2] .
+                        $out = "*" . // since it's the same adj group code don't include it
+                        "*" . $a[2] .
                         "*" . $a[3];
                     }
                     if (!$tmpdate) {
                         $tmpdate = $a[0];
                     }
                     if ((count($aarr) == 1) || (count($aarr) == $adj_count)) {
-						++$edicount;
+                        ++$edicount;
                         $out .= "~\n";
                     }
                     $adj_group_code = $a[1];

--- a/library/billing/src/X12837P.php
+++ b/library/billing/src/X12837P.php
@@ -1189,16 +1189,32 @@ class X12837P
                 "~\n";
     
                 $tmpdate = $payerpaid[0];
+                $adj_group_code = '';
+                $adj_count = 0;
                 foreach ($aarr as $a) {
-                    ++$edicount;
-                    $out .= "CAS" . // Previous payer's line level adjustments. Page 558.
-                    "*" . $a[1] .
-                    "*" . $a[2] .
-                    "*" . $a[3] .
-                    "~\n";
+                    ++$adj_count;
+                    if ((count($aarr) !== 1) && ($adj_group_code !== $a[1])) {
+					    ++$edicount;
+                        $out .= "~\n";
+                    }
+                    if ($adj_group_code !== $a[1]) {
+						$out .= "CAS" . // Previous payer's line level adjustments. Page 558.
+						"*" . $a[1] .
+                        "*" . $a[2] .
+                        "*" . $a[3];
+					} else {
+						$out = "*" . // since it's the same adj group code don't include it
+						"*" . $a[2] .
+                        "*" . $a[3];
+                    }
                     if (!$tmpdate) {
                         $tmpdate = $a[0];
                     }
+                    if ((count($aarr) == 1) || (count($aarr) == $adj_count)) {
+						++$edicount;
+                        $out .= "~\n";
+                    }
+					$adj_group_code = $a[1];
                 }
     
                 if ($tmpdate) {


### PR DESCRIPTION
clearinghouses like office ally have edited prior erroneous x12s on openemr user's behalf but need this fix if going str8 to payer