### PR TITLE
Patient menu fixes

### DIFF
--- a/interface/patient_file/history/history.php
+++ b/interface/patient_file/history/history.php
@@ -95,7 +95,7 @@ if (!empty($grparr['']['grp_size'])) {
         <div class="row">
             <div class="col-sm-12">
                 <?php
-                $list_id = "nav-list2"; // to indicate nav item is active, count and give correct id
+                $list_id = "history"; // to indicate nav item is active, count and give correct id
                 $menuPatient = new PatientMenuRole();
                 $menuPatient->displayHorizNavBarMenu();
                 ?>

--- a/interface/patient_file/report/patient_report.php
+++ b/interface/patient_file/report/patient_report.php
@@ -72,7 +72,7 @@ function show_date_fun(){
         <div class="row" >
             <div class="col-sm-12">
                 <?php
-                $list_id = "nav-list3"; // to indicate nav item is active, count and give correct id
+                $list_id = "report"; // to indicate nav item is active, count and give correct id
                 // Collect the patient menu then build it
                 $menuPatient = new PatientMenuRole();
                 $menuPatient->displayHorizNavBarMenu();

--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -682,7 +682,7 @@ if (!empty($grparr['']['grp_size'])) {
         <div class="row" >
             <div class="col-sm-12">
                 <?php
-                    $list_id = "nav-list1"; // to indicate nav item is active, count and give correct id
+                    $list_id = "dashboard"; // to indicate nav item is active, count and give correct id
                     // Collect the patient menu then build it
                     $menuPatient = new PatientMenuRole();
                     $menuPatient->displayHorizNavBarMenu();

--- a/interface/patient_file/summary/stats_full.php
+++ b/interface/patient_file/summary/stats_full.php
@@ -106,7 +106,7 @@ require_once("$include_root/expand_contract_js.php");//jQuery to provide expand/
 </script>
 </head>
 
-<body class="body_top">
+<body class="body_top patient-medical-issues">
     <div class="<?php echo $container;?> expandable">
         <?php $header_title = xl('Medical Issues for');?>
         <div class="row">
@@ -120,7 +120,7 @@ require_once("$include_root/expand_contract_js.php");//jQuery to provide expand/
         <div class="row" >
             <div class="col-sm-12">
                 <?php
-                $list_id = "nav-list6"; // to indicate nav item is active, count and give correct id
+                $list_id = "issues"; // to indicate nav item is active, count and give correct id
                 // Collect the patient menu then build it
                 $menuPatient = new PatientMenuRole();
                 $menuPatient->displayHorizNavBarMenu();

--- a/interface/patient_file/transaction/transactions.php
+++ b/interface/patient_file/transaction/transactions.php
@@ -39,7 +39,7 @@ use OpenEMR\Menu\PatientMenuRole;
         <div class="row" >
             <div class="col-sm-12">
                 <?php
-                $list_id = "nav-list5"; // to indicate nav item is active, count and give correct id
+                $list_id = "transactions"; // to indicate nav item is active, count and give correct id
                 // Collect the patient menu then build it
                 $menuPatient = new PatientMenuRole();
                 $menuPatient->displayHorizNavBarMenu();

--- a/interface/reports/external_data.php
+++ b/interface/reports/external_data.php
@@ -152,7 +152,7 @@ $records2 = array();
                     <div class="col-sm-12">
                         <div class="col-sm-12">
                             <?php
-                            $list_id = "nav-list8"; // to indicate nav item is active, count and give correct id
+                            $list_id = "external_data"; // to indicate nav item is active, count and give correct id
                             // Collect the patient menu then build it
                             $menuPatient = new PatientMenuRole();
                             $menuPatient->displayHorizNavBarMenu();

--- a/interface/reports/pat_ledger.php
+++ b/interface/reports/pat_ledger.php
@@ -485,7 +485,7 @@ if ($_REQUEST['form_csvexport']) {
         <div class="row">
             <div class="col-sm-12">
                 <?php
-                $list_id = "nav-list7"; // to indicate nav item is active, count and give correct id
+                $list_id = "ledger"; // to indicate nav item is active, count and give correct id
                 // Collect the patient menu then build it
                 $menuPatient = new PatientMenuRole();
                 $menuPatient->displayHorizNavBarMenu();

--- a/library/menu/src/PatientMenuRole.php
+++ b/library/menu/src/PatientMenuRole.php
@@ -182,16 +182,16 @@ EOT;
                 foreach ($value->children as $children_key => $children_value) {
                     $link = ($children_value->pid != "true") ? $children_value->url : $children_value->url . attr($pid);
                     $class = isset($children_value->class) ? $children_value->class : '';
-                    $list = '<li class="oe-bold-black ' . $class . '" id="' . $children_value->menu_id . '">';
-                    $list .= '<a href="' . $link . '" onclick="' . $children_value->on_click .'"> ' . text($children_value->label) . ' </a>';
+                    $list = '<li class="oe-bold-black ' . attr($class) . '" id="' . attr($children_value->menu_id) . '">';
+                    $list .= '<a href="' . attr($link) . '" onclick="' . attr($children_value->on_click) .'"> ' . text($children_value->label) . ' </a>';
                     $list .= '</li>';
                 }
                 echo $list. "\r\n";
             } else {
                 $link = ($value->pid != "true") ? $value->url : $value->url . attr($pid);
                 $class = isset($value->class) ? $value->class : '';
-                $list = '<li class="oe-bold-black ' . $class . '" id="' . $value->menu_id . '">';
-                $list .= '<a href="' . $link . '" onclick="' . $value->on_click .'"> ' . text($value->label) . ' </a>';
+                $list = '<li class="oe-bold-black ' . attr($class) . '" id="' . attr($value->menu_id) . '">';
+                $list .= '<a href="' . attr($link) . '" onclick="' . attr($value->on_click) .'"> ' . text($value->label) . ' </a>';
                 $list .= '</li>';
             }
             echo $list. "\r\n";

--- a/library/menu/src/PatientMenuRole.php
+++ b/library/menu/src/PatientMenuRole.php
@@ -167,7 +167,7 @@ class PatientMenuRole extends MenuRole
         $menu_restrictions = $this->getMenu();
         $li_id = 1;
         $str_top = <<<EOT
-        <nav class="navbar navbar-default navbar-color navbar-static-top">
+        <nav class="navbar navbar-default navbar-color navbar-static-top patient-menu">
             <div class="container-fluid">
                 <div class="navbar-header">
                     <button class="navbar-toggle" data-target="#myNavbar" data-toggle="collapse" type="button"><span class="icon-bar"></span> <span class="icon-bar"></span> <span class="icon-bar"></span></button>
@@ -181,14 +181,16 @@ EOT;
                 // flatten to only show children items
                 foreach ($value->children as $children_key => $children_value) {
                     $link = ($children_value->pid != "true") ? $children_value->url : $children_value->url . attr($pid);
-                    $list = '<li class="oe-bold-black" id="nav-list'. $li_id.'">';
+                    $class = isset($children_value->class) ? $children_value->class : '';
+                    $list = '<li class="oe-bold-black ' . $class . '" id="' . $children_value->menu_id . '">';
                     $list .= '<a href="' . $link . '" onclick="' . $children_value->on_click .'"> ' . text($children_value->label) . ' </a>';
                     $list .= '</li>';
                 }
                 echo $list. "\r\n";
             } else {
                 $link = ($value->pid != "true") ? $value->url : $value->url . attr($pid);
-                $list = '<li class="oe-bold-black"id="nav-list'. $li_id.'">';
+                $class = isset($value->class) ? $value->class : '';
+                $list = '<li class="oe-bold-black ' . $class . '" id="' . $value->menu_id . '">';
                 $list .= '<a href="' . $link . '" onclick="' . $value->on_click .'"> ' . text($value->label) . ' </a>';
                 $list .= '</li>';
             }

--- a/library/menu/src/PatientMenuRole.php
+++ b/library/menu/src/PatientMenuRole.php
@@ -183,7 +183,7 @@ EOT;
                     $link = ($children_value->pid != "true") ? $children_value->url : $children_value->url . attr($pid);
                     $class = isset($children_value->class) ? $children_value->class : '';
                     $list = '<li class="oe-bold-black ' . attr($class) . '" id="' . attr($children_value->menu_id) . '">';
-                    $list .= '<a href="' . attr($link) . '" onclick="' . attr($children_value->on_click) .'"> ' . text($children_value->label) . ' </a>';
+                    $list .= '<a href="' . attr($link) . '" onclick="' . $children_value->on_click .'"> ' . text($children_value->label) . ' </a>';
                     $list .= '</li>';
                 }
                 echo $list. "\r\n";
@@ -191,7 +191,7 @@ EOT;
                 $link = ($value->pid != "true") ? $value->url : $value->url . attr($pid);
                 $class = isset($value->class) ? $value->class : '';
                 $list = '<li class="oe-bold-black ' . attr($class) . '" id="' . attr($value->menu_id) . '">';
-                $list .= '<a href="' . attr($link) . '" onclick="' . attr($value->on_click) .'"> ' . text($value->label) . ' </a>';
+                $list .= '<a href="' . attr($link) . '" onclick="' . $value->on_click .'"> ' . text($value->label) . ' </a>';
                 $list .= '</li>';
             }
             echo $list. "\r\n";

--- a/library/options.inc.php
+++ b/library/options.inc.php
@@ -2036,7 +2036,7 @@ function generate_display_field($frow, $currvalue)
         }
         // If match is not found in main and backup lists, return the key with exclamation mark
         if ($s == '') {
-            $s = nl2br(text(xl_list_label($currvalue), ENT_NOQUOTES)).
+            $s = nl2br(text(xl_list_label($currvalue))).
             '<sup> <i class="fa fas fa-exclamation-circle ml-1"></i></sup>';
         }
     } // simple text field

--- a/library/options.inc.php
+++ b/library/options.inc.php
@@ -2036,7 +2036,7 @@ function generate_display_field($frow, $currvalue)
         }
         // If match is not found in main and backup lists, return the key with exclamation mark
         if ($s == '') {
-            $s = nl2br(xlt($currvalue)).
+            $s = nl2br(text(xl_list_label($currvalue), ENT_NOQUOTES)).
             '<sup> <i class="fa fas fa-exclamation-circle ml-1"></i></sup>';
         }
     } // simple text field

--- a/library/options.inc.php
+++ b/library/options.inc.php
@@ -2036,7 +2036,7 @@ function generate_display_field($frow, $currvalue)
         }
         // If match is not found in main and backup lists, return the key with exclamation mark
         if ($s == '') {
-            $s = nl2br(htmlspecialchars($currvalue, ENT_NOQUOTES)).
+            $s = nl2br(xlt($currvalue)).
             '<sup> <i class="fa fas fa-exclamation-circle ml-1"></i></sup>';
         }
     } // simple text field


### PR DESCRIPTION
Hi.

In the our clinics we change the standard patient menu and remove part of the links, I found that in the new style of menu the ID's of links is numeric in ascending order and it is hardcode so there is problem with the mark as active of the current page.
 (For example - I remove History tab so issues is number 2 but the id is still 'nav-list3' therefore the  'Documenst' tab marks as active)
I changed it to the Id from the json and now it is dynamic.   

In additional I added option to add class to link (in the json), we need it because we need change the style of the links (we have extra modules and no space in the one line with current style)   

And more translation fix..

Thanks

Amiel (Matrix)
