### PR TITLE
using request, session, global pid to select patient

### DIFF
--- a/interface/main/calendar/add_edit_event.php
+++ b/interface/main/calendar/add_edit_event.php
@@ -874,10 +874,8 @@ if (empty($collectthis)) {
     $patientid = '';
     if ($_REQUEST['patientid']) {
         $patientid = $_REQUEST['patientid'];
-    } elseif (isset($_SESSION['pid'])) {
+    } elseif (!empty($_SESSION['pid'])) {
         $patientid = ($_SESSION['pid']);
-    } elseif ($pid>0){
-        $patientid=$pid;
     }
 
     $patientname = null;

--- a/interface/main/calendar/add_edit_event.php
+++ b/interface/main/calendar/add_edit_event.php
@@ -874,6 +874,10 @@ if (empty($collectthis)) {
     $patientid = '';
     if ($_REQUEST['patientid']) {
         $patientid = $_REQUEST['patientid'];
+    } elseif (isset($_SESSION['pid'])) {
+        $patientid = ($_SESSION['pid']);
+    } elseif ($pid>0){
+        $patientid=$pid;
     }
 
     $patientname = null;


### PR DESCRIPTION
add_edit_event only used the request to gather pid.   This changes it to use session if no request pid, and global $pid if no session.  Sets no pid if all three fail.  Thanks @sjpadgett for confirming bug and suggested fix.  I'm still new to this:)