### PR TITLE
added acl check for create new patient link

### DIFF
--- a/interface/main/calendar/find_patient_popup.php
+++ b/interface/main/calendar/find_patient_popup.php
@@ -176,9 +176,14 @@ if (isset($_GET["res"])) {
 <div id="searchstatus" class="noResults"><?php echo htmlspecialchars(xl('No records found. Please expand your search criteria.'), ENT_NOQUOTES); ?>
 <br>
 <!--VicarePlus :: If pflag is set the new patient create link will not be displayed -->
-<a class="noresult" href='find_patient_popup.php?res=noresult' <?php if (isset($_GET['pflag'])) {
-?> style="display:none;" <?php
-} ?>  ><?php echo htmlspecialchars(xl('Click Here to add a new patient.'), ENT_NOQUOTES); ?></a>
+<a class="noresult" href='find_patient_popup.php?res=noresult' 
+<?php 
+if (isset($_GET['pflag']) || (!acl_check('patients', 'demo', '', array('write','addonly')))) {
+?> style="display:none;" 
+<?php
+} 
+?>  >
+<?php echo htmlspecialchars(xl('Click Here to add a new patient.'), ENT_NOQUOTES); ?></a>
 </div>
 <?php elseif (count($result)>=100) : ?>
 <div id="searchstatus" class="tooManyResults"><?php echo htmlspecialchars(xl('More than 100 records found. Please narrow your search criteria.'), ENT_NOQUOTES); ?></div>


### PR DESCRIPTION
in find_patient_popup, if no patients are found a link to create a new patient is shown.  It was not protected by an acl check for demographics write or addonly.  I added this to the existing if created by VicarePlus.

I am finding bugs because I am a novice php coder, and I don't know what I am doing.  It makes me read and think and do things that no user or coder with experience with openemr would think to try.