### PR TITLE
remove EditNote function 2

### DIFF
--- a/interface/patient_file/summary/pnotes_full.php
+++ b/interface/patient_file/summary/pnotes_full.php
@@ -758,16 +758,8 @@ $(document).ready(function(){
 
     $(".noterow").mouseover(function() { $(this).toggleClass("highlight"); });
     $(".noterow").mouseout(function() { $(this).toggleClass("highlight"); });
-    $(".notecell").click(function() { EditNote(this); });
 
     $("#note").focus();
-
-    var EditNote = function(note) {
-        top.restoreSession();
-        $("#noteid").val(note.id);
-        $("#mode").val("");
-        $("#new_note").submit();
-    }
 
     var NewNote = function () {
         top.restoreSession();


### PR DESCRIPTION
Continue of #1865.
Clicking the row in the table in the patient message screen still leads to Unknown window. 
remove also from interface/patient_file/summary/pnotes_full.php.

Thanks

Amiel