### PR TITLE
$GLOBALS['webserver_root']  being used in Kernel class..

### DIFF
--- a/library/core/src/Kernel.php
+++ b/library/core/src/Kernel.php
@@ -68,7 +68,7 @@ class Kernel
      */
     private function loadServiceConfig(ContainerBuilder $builder)
     {
-        $loader = new YamlFileLoader($builder, new FileLocator($GLOBALS['webserver_root']));
+        $loader = new YamlFileLoader($builder, new FileLocator($GLOBALS['fileroot']));
         $loader->load('config/services.yml');
     }
 


### PR DESCRIPTION
@bradymiller @robertdown 
 Global no longer exist.
edit: appears $webserver_root is not set explicit in globals so there is a chance $GLOBALS['webserver_root'] can be not in scope depending how globals.php is called.
To be safe going to leave this changed to $GLOBALS['fileroot'] because I know it will always be in scope.