### PR TITLE
Enable drowpdown tab in the patient menu

### DIFF
--- a/library/menu/src/PatientMenuRole.php
+++ b/library/menu/src/PatientMenuRole.php
@@ -29,6 +29,7 @@ class PatientMenuRole extends MenuRole
         //   to functions in this class.
         parent::__construct();
         $this->menu_update_map["Modules"]="updateModulesDemographicsMenu";
+
     }
 
     /**
@@ -195,7 +196,7 @@ EOT;
             } else {
                 $link = ($value->pid != "true") ? $value->url : $value->url . attr($pid);
                 $class = isset($value->class) ? $value->class : '';
-                $list = '<li class="oe-bold-black' . attr($class) . '" id="' . attr($value->menu_id) . '">';
+                $list = '<li class="oe-bold-black ' . attr($class) . '" id="' . attr($value->menu_id) . '">';
                 $list .= '<a href="' . attr($link) . '" onclick="' . $value->on_click .'"> ' . text($value->label) . ' </a>';
                 $list .= '</li>';
             }

--- a/library/menu/src/PatientMenuRole.php
+++ b/library/menu/src/PatientMenuRole.php
@@ -29,7 +29,6 @@ class PatientMenuRole extends MenuRole
         //   to functions in this class.
         parent::__construct();
         $this->menu_update_map["Modules"]="updateModulesDemographicsMenu";
-
     }
 
     /**

--- a/library/menu/src/PatientMenuRole.php
+++ b/library/menu/src/PatientMenuRole.php
@@ -55,9 +55,11 @@ class PatientMenuRole extends MenuRole
         }
         //to make the url absolute to web root and to account for external urls i.e. those beginning with http or https
         foreach ($menu_parsed as $menu_obj) {
-            $rel_url = $menu_obj -> url;
-            if ($rel_url && !strpos($rel_url, "://")) {
-                $menu_obj -> url = $GLOBALS['webroot'] ."/". $rel_url;
+            $menu_obj -> url = $this->getAbsoluteWebRoot($menu_obj -> url);
+            if (!empty($menu_obj->children)) {
+                foreach ($menu_obj->children as $menu_obj) {
+                    $menu_obj -> url = $this->getAbsoluteWebRoot($menu_obj -> url);
+                }
             }
         }
         $menu_parsed = json_decode(json_encode($menu_parsed));
@@ -178,19 +180,22 @@ EOT;
         echo $str_top. "\r\n";
         foreach ($menu_restrictions as $key => $value) {
             if (!empty($value->children)) {
-                // flatten to only show children items
+                // create dropdown if there are children (bootstrap3 horizontal nav bar with dropdown)
+                $class = isset($value->class) ? $value->class : '';
+                $list = '<li class="dropdown"><a href="#"  id="' . attr($value->menu_id) . '" class="dropdown-toggle oe-bold-black ' . attr($class) . '" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">' . text($value->label) . ' <span class="caret"></span></a>';
+                $list .='<ul class="dropdown-menu">';
                 foreach ($value->children as $children_key => $children_value) {
                     $link = ($children_value->pid != "true") ? $children_value->url : $children_value->url . attr($pid);
                     $class = isset($children_value->class) ? $children_value->class : '';
-                    $list = '<li class="oe-bold-black ' . attr($class) . '" id="' . attr($children_value->menu_id) . '">';
-                    $list .= '<a href="' . attr($link) . '" onclick="' . $children_value->on_click .'"> ' . text($children_value->label) . ' </a>';
+                    $list .= '<li class="oe-bold-black ' . attr($class) . '" id="' . attr($children_value->menu_id) . '">';
+                    $list .= '<a class="oe-bold-black"  href="' . attr($link) . '" onclick="' . $children_value->on_click .'"> ' . text($children_value->label) . ' </a>';
                     $list .= '</li>';
                 }
-                echo $list. "\r\n";
+                $list .= '</ul>';
             } else {
                 $link = ($value->pid != "true") ? $value->url : $value->url . attr($pid);
                 $class = isset($value->class) ? $value->class : '';
-                $list = '<li class="oe-bold-black ' . attr($class) . '" id="' . attr($value->menu_id) . '">';
+                $list = '<li class="oe-bold-black' . attr($class) . '" id="' . attr($value->menu_id) . '">';
                 $list .= '<a href="' . attr($link) . '" onclick="' . $value->on_click .'"> ' . text($value->label) . ' </a>';
                 $list .= '</li>';
             }
@@ -205,5 +210,19 @@ EOT;
 EOB;
         echo $str_bot. "\r\n";
         return;
+    }
+
+    /**
+     * make the url absolute to web root
+     * @param $rel_url
+     *
+     * @return string
+     */
+    private function getAbsoluteWebRoot($rel_url)
+    {
+        if ($rel_url && !strpos($rel_url, "://")) {
+            return $GLOBALS['webroot'] . "/" . $rel_url;
+        }
+        return $rel_url;
     }
 }


### PR DESCRIPTION
Hi.

Here I added option to make dropdown menu in the patient file (In the new style the amount of the tabs is limited in the case you have a lot of modules.. like us ;) ).
From now if there are children in the patient menu json, they will created in dropdown, like the main menu (but with regular bootstrap style and only for single level) 

![image](https://user-images.githubusercontent.com/17809866/50180496-704e8700-0312-11e9-8048-6f12f2869b08.png)

Thanks
Amiel