### PR TITLE
authentication: fix undefined ``$provider`` variable in ``verify_user_gacl_group``

### DIFF
--- a/library/auth.inc
+++ b/library/auth.inc
@@ -44,7 +44,8 @@ if (isset($_GET['auth']) && ($_GET['auth'] == "login") && isset($_POST['authUser
     // set language direction according to language choice. Later in globals.php we'll override main theme name if needed.
     $_SESSION['language_direction'] = getLanguageDir($_SESSION['language_choice']);
 
-    if (!validate_user_password($_POST['authUser'], $clearPass, $_POST['authProvider']) ||  !verify_user_gacl_group($_POST['authUser'])) {
+    if (!validate_user_password($_POST['authUser'], $clearPass, $_POST['authProvider'])
+     || !verify_user_gacl_group($_POST['authUser'], $_POST['authProvider'])) {
         $_SESSION['loginfailure'] = 1;
         authLoginScreen();
     }

--- a/library/authentication/login_operations.php
+++ b/library/authentication/login_operations.php
@@ -112,7 +112,7 @@ function validate_user_password($username, &$password, $provider)
     return $valid;
 }
 
-function verify_user_gacl_group($user)
+function verify_user_gacl_group($user, $provider)
 {
     global $phpgacl_location;
 


### PR DESCRIPTION
This one is pretty simple. The call to ``newEvent`` in ``verify_user_gacl_group`` appears to have been refactored out of ``validate_user_password``, but the ``$provider`` variable was not passed to the new function. This fixes that.

On a side note, how I discovered this was by going thru the setup: the created admin account does not get a corresponding ARO created for it in phpGACL. I had to add the ARO manually. I will open a separate issue about this.