### PR TITLE
[ISSUE-470] Update Federal Drug ID span text to DEA Number

### DIFF
--- a/interface/usergroup/user_admin.php
+++ b/interface/usergroup/user_admin.php
@@ -371,7 +371,7 @@ if ($fres) {
 
 <TR>
 <TD><span class=text><?php echo xlt('Federal Tax ID'); ?>: </span></TD><TD><input type=text name=taxid style="width:150px;"  class="form-control" value="<?php echo attr($iter["federaltaxid"]); ?>"></td>
-<TD><span class=text><?php echo xlt('Federal Drug ID'); ?>: </span></TD><TD><input type=text name=drugid style="width:150px;"  class="form-control" value="<?php echo attr($iter["federaldrugid"]); ?>"></td>
+<TD><span class=text><?php echo xlt('DEA Number'); ?>: </span></TD><TD><input type=text name=drugid style="width:150px;"  class="form-control" value="<?php echo attr($iter["federaldrugid"]); ?>"></td>
 </TR>
 
 <tr>

--- a/interface/usergroup/usergroup_admin_add.php
+++ b/interface/usergroup/usergroup_admin_add.php
@@ -276,7 +276,7 @@ if ($fres) {
 </tr>
 <tr>
 <td><span class="text"><?php echo xlt('Federal Tax ID'); ?>: </span></td><td><input type=entry name='federaltaxid' style="width:120px;" class="form-control"></td>
-<td><span class="text"><?php echo xlt('Federal Drug ID'); ?>: </span></td><td><input type=entry name='federaldrugid' style="width:120px;" class="form-control"></td>
+<td><span class="text"><?php echo xlt('DEA number'); ?>: </span></td><td><input type=entry name='federaldrugid' style="width:120px;" class="form-control"></td>
 </tr>
 <tr>
 <td><span class="text"><?php echo xlt('UPIN'); ?>: </span></td><td><input type="entry" name="upin" style="width:120px;" class="form-control"></td>


### PR DESCRIPTION
## Issue: [https://github.com/openemr/openemr/issues/470](https://github.com/openemr/openemr/issues/470)
## Overview
The term 'Federal Drug ID' is used on the User Add and User Edit forms in the Administration section.  The term 'DEA Number' better describes the field.  

### Commits
- Update User Add and User Edit administration forms to display 'DEA Number', rather than 'Federal Drug ID'.

## Reviewers
@bradymiller There are references to `federaldrugid` throughout the app, but I wasn't sure if changing those to `deanumber` was part of the scope of this issue, or if this was literally just a request to change the text of the span elements.  Please take a look when you have a moment.