### PR TITLE
README: fix dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ composer dump-autoload -o
 ### Contributors
 
 This project exists thanks to all the people who contribute. [[Contribute]](CONTRIBUTING.md).
-<a href="graphs/contributors"><img src="https://opencollective.com/openemr/contributors.svg?width=890" /></a>
+<a href="https://github.com/openemr/openemr/graphs/contributors"><img src="https://opencollective.com/openemr/contributors.svg?width=890" /></a>
 
 ### Backers
 


### PR DESCRIPTION
Something with how GitHub handles relative paths must have changed, so I changed it to an absolute URL instead.

Best,

Jack