### PR TITLE
Removing InnerHtml and updating text content

### DIFF
--- a/library/custom_template/add_template.php
+++ b/library/custom_template/add_template.php
@@ -61,20 +61,22 @@ $list_id = $_REQUEST['list_id'];
                      source: "add_template"
                 },
                 async: false,
+                    //returning Aync Promise and then calling unnamed  function with Post Req. Response.  
                 success: function(thedata){
                         if(thedata=="Fail"){
                             alert(document.getElementById('template_name').value+" <?php echo addslashes(xl('already exists'));?>");
                             return false;
                         }
                         else{
-                            mainform.getElementById('templateDD').innerHTML = thedata;
+                            //@TODO- Make Sure Post Req. is not sending HTML to be parsed ? 
+                            mainform.getElementById('templateDD').textContent = thedata;
                             alert("<?php echo addslashes(xl('Successfully added category'));?> "+document.getElementById('template_name').value);
                             //window.opener.opener.location.reload();
                             dlgclose();
                         }
                             },
                 error:function(){
-
+                        //Throw new Error ? 
                 }
                 });
                 }


### PR DESCRIPTION
Removing Inner Html, and Updating with Text Content.  I attempted to send a post request on my local machine to find this specific end point, and see the return data. So long as return data is not any Html to be parsed this should update it. If there is html, we can change the post response, or add the elements to the DOM, prior to the text content. 