### PR TITLE
new feature - custom assets

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -10,6 +10,7 @@
 #         script: null filename or null
 #         link: jquery-ui.min.css filename or null
 #         autoload: true (defaults to false)
+#         loadInFile: relative path to file, load always in specific file (defaults to false) for custom assets.
 assets:
     jquery:
         basePath: %assets_static_relative%/jquery/dist/

--- a/custom/assets/README
+++ b/custom/assets/README
@@ -1,0 +1,23 @@
+This folder holds custom js and css files.
+
+The files can be loaded into every page in the system using \OpenEMR\Core\Header::setupHeader function.
+
+How to use -
+
+1. Add you custom code into js and css folders
+
+2. create custom.yaml file (Like custom.yaml.example) with configuration of your custom assets,
+you can load it in every page with 'autoload' option or in specific page with loadInFile option.
+More instructions about optional configuration found at custom.yaml.example file.
+
+3. The assets will loaded in the screens after openemr assets.
+If you create custom modules with custom html you can load your assets with setupHeader function.
+for example - `<?php Header::setupHeader('custom-key-name'); ?>`
+
+Important!
+If you plan to upgrade your project with future versions of OpenEMR do not inject major changes
+to the screens.
+
+
+
+

--- a/custom/assets/css/README
+++ b/custom/assets/css/README
@@ -1,0 +1,1 @@
+This folder holds custom css files

--- a/custom/assets/custom.yaml.example
+++ b/custom/assets/custom.yaml.example
@@ -1,0 +1,31 @@
+---
+# In the case that custom.yaml file found It's parse by \OpenEMR\Core\Header::includeAsset
+# after config/config.yaml. the structure of custom.yaml is equal to config.yaml.
+#
+# Use %KEY-NAME% in this file and it will be replaced with the value of
+# $GLOBALS['KEY-NAME'] if it exists. If the key name does not exist, this script
+# won't work (Need to build in proper error handling @TODO RD 2017-05-16
+#
+# Basic example usage (from config.yaml):
+# assets: Top-level key name (Required)
+#     asset-short-name: Short name
+#         basePath: %assets_static_relative%/full/path/to/deepest/common/file
+#         script: null filename or null
+#         link: jquery-ui.min.css filename or null
+#         autoload: true (defaults to false)
+#         loadInFile: relative path to file
+#
+# Inject custom assets example
+# assets:
+#     always-load:
+#         basePath: %webroot%/custom/assets/
+#         script: js/add_custom_link.js
+#         link: css/add_custom_link.css
+#         autoload: true
+#     fix-only-messages:
+#         basePath: %webroot%/custom/assets/
+#         script: js/fix_messages.js
+#         loadInFile: interface/main/messages/messages.php
+#
+
+

--- a/custom/assets/js/README
+++ b/custom/assets/js/README
@@ -1,0 +1,1 @@
+This folder holds custom js files

--- a/library/core/src/Header.php
+++ b/library/core/src/Header.php
@@ -109,8 +109,8 @@ class Header
         self::parseConfigFile($map, $assets);
 
         /* adding custom assets in addition */
-        if (is_file("{$GLOBALS['fileroot']}/config/custom.yaml")) {
-            $customMap = self::readConfigFile("{$GLOBALS['fileroot']}/config/custom.yaml");
+        if (is_file("{$GLOBALS['fileroot']}/custom/assets/custom.yaml")) {
+            $customMap = self::readConfigFile("{$GLOBALS['fileroot']}/custom/assets/custom.yaml");
             self::parseConfigFile($customMap);
         }
 
@@ -299,7 +299,7 @@ class Header
     private static function getCurrentFile()
     {
         //remove web root and query string
-        return str_replace($GLOBALS['webroot'].'/', '', strtok($_SERVER["REQUEST_URI"],'?'));
+        return str_replace($GLOBALS['webroot'].'/', '', strtok($_SERVER["REQUEST_URI"], '?'));
     }
 
 }

--- a/library/core/src/Header.php
+++ b/library/core/src/Header.php
@@ -25,6 +25,8 @@ use Symfony\Component\Yaml\Exception\ParseException;
  */
 class Header
 {
+    private static $scripts;
+    private static $links;
 
     /**
      * Setup various <head> elements.
@@ -101,17 +103,41 @@ class Header
 
         // @TODO Hard coded the path to the config file, not good RD 2017-05-27
         $map = self::readConfigFile("{$GLOBALS['fileroot']}/config/config.yaml");
-        $scripts = [];
-        $links = [];
+        self::$scripts = [];
+        self::$links = [];
 
+        self::parseConfigFile($map, $assets);
+
+        /* adding custom assets in addition */
+        if (is_file("{$GLOBALS['fileroot']}/config/custom.yaml")) {
+            $customMap = self::readConfigFile("{$GLOBALS['fileroot']}/config/custom.yaml");
+            self::parseConfigFile($customMap);
+        }
+
+        $linksStr = implode("", self::$links);
+        $scriptsStr = implode("", self::$scripts);
+        return "\n{$linksStr}\n{$scriptsStr}\n";
+    }
+
+    /**
+     * Parse assets from config file
+     *
+     * @param array $map Assets to parse into self::$scripts and self::$links
+     * @param array $selectedAssets
+     * @return void
+     */
+    private static function parseConfigFile($map, $selectedAssets = array())
+    {
         foreach ($map as $k => $opts) {
             $autoload = (isset($opts['autoload'])) ? $opts['autoload'] : false;
             $allowNoLoad= (isset($opts['allowNoLoad'])) ? $opts['allowNoLoad'] : false;
             $alreadyBuilt = (isset($opts['alreadyBuilt'])) ? $opts['alreadyBuilt'] : false;
+            $loadInFile = (isset($opts['loadInFile'])) ? $opts['loadInFile'] : false;
             $rtl = (isset($opts['rtl'])) ? $opts['rtl'] : false;
-            if ($autoload === true || in_array($k, $assets)) {
+
+            if ($autoload === true || in_array($k, $selectedAssets) || ($loadInFile && $loadInFile === self::getCurrentFile())) {
                 if ($allowNoLoad === true) {
-                    if (in_array("no_" . $k, $assets)) {
+                    if (in_array("no_" . $k, $selectedAssets)) {
                         continue;
                     }
                 }
@@ -119,29 +145,25 @@ class Header
                 $tmp = self::buildAsset($opts, $alreadyBuilt);
 
                 foreach ($tmp['scripts'] as $s) {
-                    $scripts[] = $s;
+                    self::$scripts[] = $s;
                 }
 
                 foreach ($tmp['links'] as $l) {
-                    $links[] = $l;
+                    self::$links[] = $l;
                 }
 
                 if ($rtl && $_SESSION['language_direction'] == 'rtl') {
                     $tmpRtl = self::buildAsset($rtl, $alreadyBuilt);
                     foreach ($tmpRtl['scripts'] as $s) {
-                        $scripts[] = $s;
+                        self::$scripts[] = $s;
                     }
 
                     foreach ($tmpRtl['links'] as $l) {
-                        $links[] = $l;
+                        self::$links[] = $l;
                     }
                 }
             }
         }
-
-        $linksStr = implode("", $links);
-        $scriptsStr = implode("", $scripts);
-        return "\n{$linksStr}\n{$scriptsStr}\n";
     }
 
     /**
@@ -268,4 +290,16 @@ class Header
             // @TODO need to handle this better. RD 2017-05-24
         }
     }
+
+    /**
+     * Return relative path to current file
+     *
+     * @return string The  current file
+     */
+    private static function getCurrentFile()
+    {
+        //remove web root and query string
+        return str_replace($GLOBALS['webroot'].'/', '', strtok($_SERVER["REQUEST_URI"],'?'));
+    }
+
 }


### PR DESCRIPTION
Hi.

Here I add option to inject custom js and css into any file in the system.
How to use - 
Add new file config/custom.yaml with same syntax as  config/config.yaml.
In that file you can add links to your custom assets.
I add new attribute called `loadInFile` for config file, This attribute enables to inject js and css only in specific file.
Example of custom.yaml
```
assets:
    custom:
        basePath: %webroot%/custom/public/
        script: js/fix_messages.js
        link: css/custom.css
        loadInFile: interface/main/messages/messages.php

```
Files js/fix_messages.js and css/custom.css will inject into interface/main/messages/messages.php


Thanks
Amiel