### PR TITLE
[ISSUE-1350] Modify all table references of `patient_id` to type bigint

### DIFF
--- a/sql/5_0_1-to-5_0_2_upgrade.sql
+++ b/sql/5_0_1-to-5_0_2_upgrade.sql
@@ -784,3 +784,28 @@ ALTER TABLE `notification_log`
 ALTER TABLE `documents`
     MODIFY `foreign_id` bigint(20) default NULL;
 #EndIf
+
+#IfNotColumnType batchcom patient_id bigint(20)
+ALTER TABLE `batchcom`
+    MODIFY `patient_id` bigint(20) NOT NULL default '0';
+#EndIf
+
+#IfNotColumnType claims patient_id bigint(20)
+ALTER TABLE `claims`
+    MODIFY `patient_id` bigint(20) NOT NULL;
+#EndIf
+
+#IfNotColumnType immunizations patient_id bigint(20)
+ALTER TABLE `immunizations`
+    MODIFY `patient_id` bigint(20) default NULL;
+#EndIf
+
+#IfNotColumnType prescriptions patient_id bigint(20)
+ALTER TABLE `prescriptions`
+    MODIFY `patient_id` bigint(20) default NULL;
+#EndIf
+
+#IfNotColumnType ar_session patient_id bigint(20)
+ALTER TABLE `ar_session`
+    MODIFY `patient_id` bigint(20) NOT NULL;
+#EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -168,7 +168,7 @@ INSERT INTO `background_services` (`name`, `title`, `active`, `running`, `next_r
 DROP TABLE IF EXISTS `batchcom`;
 CREATE TABLE `batchcom` (
   `id` bigint(20) NOT NULL auto_increment,
-  `patient_id` int(11) NOT NULL default '0',
+  `patient_id` bigint(20) NOT NULL default '0',
   `sent_by` bigint(20) NOT NULL default '0',
   `msg_type` varchar(60) default NULL,
   `msg_subject` varchar(255) default NULL,
@@ -311,7 +311,7 @@ CREATE TABLE `categories_to_documents` (
 
 DROP TABLE IF EXISTS `claims`;
 CREATE TABLE `claims` (
-  `patient_id` int(11) NOT NULL,
+  `patient_id` bigint(20) NOT NULL,
   `encounter_id` int(11) NOT NULL,
   `version` int(10) unsigned NOT NULL COMMENT 'Claim version, incremented in code',
   `payer_id` int(11) NOT NULL default '0',
@@ -2868,7 +2868,7 @@ CREATE TABLE `icd10_reimbr_pcs_9_10` (
 DROP TABLE IF EXISTS `immunizations`;
 CREATE TABLE `immunizations` (
   `id` bigint(20) NOT NULL auto_increment,
-  `patient_id` int(11) default NULL,
+  `patient_id` bigint(20) default NULL,
   `administered_date` datetime default NULL,
   `immunization_id` int(11) default NULL,
   `cvx_code` varchar(10) default NULL,
@@ -6112,7 +6112,7 @@ CREATE TABLE `pnotes` (
 DROP TABLE IF EXISTS `prescriptions`;
 CREATE TABLE `prescriptions` (
   `id` int(11) NOT NULL auto_increment,
-  `patient_id` int(11) default NULL,
+  `patient_id` bigint(20) default NULL,
   `filled_by_id` int(11) default NULL,
   `pharmacy_id` int(11) default NULL,
   `date_added` date default NULL,
@@ -7374,7 +7374,7 @@ CREATE TABLE ar_session (
   description text,
   adjustment_code varchar( 50 ) NOT NULL ,
   post_to_date date NOT NULL ,
-  patient_id int( 11 ) NOT NULL ,
+  patient_id bigint(20) NOT NULL,
   payment_method varchar( 25 ) NOT NULL,
   PRIMARY KEY (session_id),
   KEY user_closed (user_id, closed),

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@ $v_realpatch = '0';
 // is a database change in the course of development.  It is used
 // internally to determine when a database upgrade is needed.
 //
-$v_database = 281;
+$v_database = 282;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
## Issue: #1350 

## Overview
This is a small follow up to PR #2234. All database tables that hold `patient_id` should have a column type of bigint.  

### Commit
[ISSUE-1350] Modify all table references of `patient_id` to type bigint

## Technical Notes
Per the "Database Table Changes" section of the [Development Policies](https://www.open-emr.org/wiki/index.php/Development_Policies#Commit_Messages), I made the following changes 
- Made database changes in `database.sql` 
- Alter statements added in `5_0_1-to-5_0_2_upgrade.sql`
- Increment database version in `version.php`

## Reviewers
@bradymiller 