### PR TITLE
Set secure_upload on as default

### DIFF
--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -1829,7 +1829,7 @@ $GLOBALS_METADATA = array(
         'secure_upload' => array(
             xl('Secure Upload Files with White List'),
             'bool',                           // data type
-            '0',                              // default
+            '1',                              // default
             xl('Block all files types that are not found in the White List. Can find interface to edit the White List at Administration->Files.')
         ),
         'secure_password' => array(

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -5132,6 +5132,10 @@ INSERT INTO list_options ( list_id, option_id, title, seq, is_default ) VALUES (
 -- Files type white list
 
 INSERT INTO list_options (`list_id`, `option_id`, `title`) VALUES ('lists', 'files_white_list', 'Files type white list');
+INSERT INTO list_options (`list_id`, `option_id`, `title`, `activity`)  VALUES ('files_white_list', 'image/*', 'image/*', 1);
+INSERT INTO list_options (`list_id`, `option_id`, `title`, `activity`)  VALUES ('files_white_list', 'text/*', 'text/*', 1);
+INSERT INTO list_options (`list_id`, `option_id`, `title`, `activity`)  VALUES ('files_white_list', 'audio/*', 'audio/*', 1);
+INSERT INTO list_options (`list_id`, `option_id`, `title`, `activity`)  VALUES ('files_white_list', 'video/*', 'video/*', 1);
 
 -- Sample Apps (Disabled)
 

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -5132,10 +5132,14 @@ INSERT INTO list_options ( list_id, option_id, title, seq, is_default ) VALUES (
 -- Files type white list
 
 INSERT INTO list_options (`list_id`, `option_id`, `title`) VALUES ('lists', 'files_white_list', 'Files type white list');
-INSERT INTO list_options (`list_id`, `option_id`, `title`, `activity`)  VALUES ('files_white_list', 'image/*', 'image/*', 1);
-INSERT INTO list_options (`list_id`, `option_id`, `title`, `activity`)  VALUES ('files_white_list', 'text/*', 'text/*', 1);
-INSERT INTO list_options (`list_id`, `option_id`, `title`, `activity`)  VALUES ('files_white_list', 'audio/*', 'audio/*', 1);
-INSERT INTO list_options (`list_id`, `option_id`, `title`, `activity`)  VALUES ('files_white_list', 'video/*', 'video/*', 1);
+INSERT INTO list_options (`list_id`, `option_id`, `title`, `activity`)  VALUES ('files_white_list', 'application/dicom+zip', 'application/dicom+zip', 1);
+INSERT INTO list_options (`list_id`, `option_id`, `title`, `activity`)  VALUES ('files_white_list', 'application/dicom', 'application/dicom', 1);
+INSERT INTO list_options (`list_id`, `option_id`, `title`, `activity`)  VALUES ('files_white_list', 'application/pdf', 'application/pdf', 1);
+INSERT INTO list_options (`list_id`, `option_id`, `title`, `activity`)  VALUES ('files_white_list', 'application/zip', 'application/zip', 1);
+INSERT INTO list_options (`list_id`, `option_id`, `title`, `activity`)  VALUES ('files_white_list', 'image/gif', 'image/gif', 1);
+INSERT INTO list_options (`list_id`, `option_id`, `title`, `activity`)  VALUES ('files_white_list', 'image/jpeg', 'image/jpeg', 1);
+INSERT INTO list_options (`list_id`, `option_id`, `title`, `activity`)  VALUES ('files_white_list', 'image/png', 'image/png', 1);
+INSERT INTO list_options (`list_id`, `option_id`, `title`, `activity`)  VALUES ('files_white_list', 'text/plain', 'text/plain', 1);
 
 -- Sample Apps (Disabled)
 


### PR DESCRIPTION
Fixes #2242.

- Set `secure_upload` on as default
- Whitelist `image/*`, `text/*`, `audio/*`, `video/*` as default  
  [Full list of MIME types](https://cdn.rawgit.com/jshttp/mime-db/master/db.json)

Is that correct?