### PR TITLE
Fix Creation of SSL Certificates

### DIFF
--- a/interface/usergroup/ssl_certificates_admin.php
+++ b/interface/usergroup/ssl_certificates_admin.php
@@ -181,6 +181,14 @@ function create_client_cert()
         $error_msg .= xl('Error, User Certificate Authentication is not enabled in OpenEMR');
         return;
     }
+    if(!file_exists($GLOBALS['certificate_authority_crt'])) {
+        $error_msg .= xl('Error, the CA Certificate File doesn\'t exist');
+        return;
+    }
+    if(!file_exists($GLOBALS['certificate_authority_key'])) {
+        $error_msg .= xl('Error, the CA Key File doesn\'t exist');
+        return;
+    }
 
     if ($_POST["client_cert_user"]) {
         $user = trim($_POST['client_cert_user']);
@@ -206,7 +214,7 @@ function create_client_cert()
     }
 
     $filename = $GLOBALS['temporary_files_dir'] . "/openemr_client_cert.p12";
-    $handle = fopen($filename, 'wt');
+    $handle = fopen($filename, 'w');
     fwrite($handle, $data);
     fclose($handle);
 
@@ -253,6 +261,15 @@ function create_and_download_certificates()
         unlink($zipName);
     }
 
+    $commonName             = false;
+    $emailAddress           = false;
+    $countryName            = false;
+    $stateOrProvinceName    = false;
+    $localityName           = false;
+    $organizationName       = false;
+    $organizationalUnitName = false;
+    $clientCertValidity     = false;
+
     /* Retrieve the certificate name settings from the form input */
     if ($_POST["commonName"]) {
         $commonName = trim($_POST['commonName']);
@@ -288,7 +305,14 @@ function create_and_download_certificates()
 
 
     /* Create the Certficate Authority (CA) */
-    $arr = create_csr("OpenEMR CA for " . $commonName, $emailAddress, $countryName, $stateOrProvinceName, $localityName, $organizationName, $organizationalUnitName);
+    $arr = create_csr("OpenEMR CA for " . $commonName,
+        $emailAddress,
+        $countryName,
+        $stateOrProvinceName,
+        $localityName,
+        $organizationName,
+        $organizationalUnitName
+    );
 
     if ($arr === false) {
         $error_msg .= xl('Error, unable to create the Certificate Authority certificate.');
@@ -298,14 +322,15 @@ function create_and_download_certificates()
 
     $ca_csr = $arr[0];
     $ca_key = $arr[1];
-    $ca_crt = create_crt($ca_key, $ca_csr, null, $ca_key);
+    $config = $arr[2];
+    $ca_crt = create_crt($ca_csr, null, $ca_key);
     if ($ca_crt === false) {
         $error_msg .= xl('Error, unable to create the Certificate Authority certificate.');
         delete_certificates();
         return;
     }
 
-    openssl_pkey_export_to_file($ca_key, $tempDir . "/CertificateAuthority.key");
+    openssl_pkey_export_to_file($ca_key, $tempDir . "/CertificateAuthority.key", null, $config);
     openssl_x509_export_to_file($ca_crt, $tempDir . "/CertificateAuthority.crt");
 
     /* Create the Server certificate */
@@ -326,7 +351,8 @@ function create_and_download_certificates()
 
     $server_csr = $arr[0];
     $server_key = $arr[1];
-    $server_crt = create_crt($server_key, $server_csr, $ca_crt, $ca_key);
+    $config     = $arr[2];
+    $server_crt = create_crt($server_csr, $ca_crt, $ca_key);
 
     if (server_crt === false) {
         $error_msg .= xl('Error, unable to create the Server certificate.');
@@ -334,7 +360,7 @@ function create_and_download_certificates()
         return;
     }
 
-    openssl_pkey_export_to_file($server_key, $tempDir . "/Server.key");
+    openssl_pkey_export_to_file($server_key, $tempDir . "/Server.key", null, $config);
     openssl_x509_export_to_file($server_crt, $tempDir . "/Server.crt");
 
     /* Create the client certificate for the 'admin' user */

--- a/library/create_ssl_certificate.php
+++ b/library/create_ssl_certificate.php
@@ -88,24 +88,27 @@ function create_csr(
         return false;
     }
 
-    return array($csr, $privkey);
+    return array($csr, $privkey, $config);
 }
 
 
 /**
  * Create a certificate, signed by the given Certificate Authority.
- * @param $privkey - The certificate private key
  * @param $csr     - The certificate signing request
  * @param $cacert  - The Certificate Authority to sign with, or NULL if not used.
  * @param $cakey   - The Certificate Authority private key data to sign with.
  * @return data    - A signed certificate, or false on error.
  */
-function create_crt($privkey, $csr, $cacert, $cakey)
+function create_crt($csr, $cacert, $cakey)
 {
 
     $opensslConf = $GLOBALS['fileroot'] . "/library/openssl.cnf";
     $config = array('config' => $opensslConf);
 
+    // Fix server certificate is a CA certificate (BasicConstraints: CA == TRUE !?)
+    if($cacert) {
+        $config["x509_extensions"] = "v3_req";
+    }
     $cert = openssl_csr_sign($csr, $cacert, $cakey, 3650, $config, rand(1000, 9999));
     return $cert;
 }


### PR DESCRIPTION
List of fixes:  
In `create_and_download_certificates`
- initialize the variables, just to avoid a few warnings
- `openssl_pkey_export_to_file`: if the path to the OpenSSL's config file isn't passed as an argument ($config), then it uses the value of the environment variable OPENSSL_CONF. With my Xampp install, that variable was set to the wrong location, and I ended up with the error message "Error, unable to create the admin.p12 certificate."

In `create_crt`  
- the parameter $privkey isn't used, just remove it
- was creating a CA certificate even when it was supposed to be a server certificate signed by a Certificate Authority we just created. If the user wants to trust the CA instead of adding an exception in his browser, Firefox refuses the server certificate (MOZILLA_PKIX_ERROR_CA_CERT_USED_AS_END_ENTITY). Apparently Chrome accepts it but I didn't try.

In `create_client_cert`
- test if the paths set in global settings exist or not
- not quite sure what the mode "wt" does to fopen but it corrupt the key for sure, the .p12 generated this way didn't work. Use "w" instead - like in `create_and_download_certificates`