### PR TITLE
Fix style of disabled tab

### DIFF
--- a/interface/themes/tabs_style_compact.css
+++ b/interface/themes/tabs_style_compact.css
@@ -330,7 +330,7 @@ body
 }
 .menuDisabled
 {
-    color:gray;
+    color:gray !important;
 }
 
 #username

--- a/interface/themes/tabs_style_full.css
+++ b/interface/themes/tabs_style_full.css
@@ -359,7 +359,7 @@ div.menuLabel:hover {
 
 .menuDisabled
 {
-    color: #d7d7d7;
+    color: #d7d7d7 !important;
 }
 .menuDisabled:hover {
     color: #d7d7d7 !important;


### PR DESCRIPTION
Hi.

The bug - the style of disabled tab works only on hover.
![image](https://user-images.githubusercontent.com/17809866/53887503-1913a500-402b-11e9-97e8-a38f9483b664.png)

I added !important to fix it.

Thanks
Amiel