### PR TITLE
fix low php version warning message

### DIFF
--- a/common/compatibility/Checker.php
+++ b/common/compatibility/Checker.php
@@ -18,15 +18,6 @@ class Checker
 {
     private static $minimumPhpVersion = "7.1.2";
 
-    private static function xlDelegate($value)
-    {
-        if (function_exists("xl")) {
-            return xl($value);
-        }
-
-        return $value;
-    }
-
     /**
      * Checks to see if minimum PHP version is met.
      *
@@ -38,7 +29,7 @@ class Checker
         $response = "";
 
         if (!$phpCheck) {
-            $response .= self::xlDelegate("PHP version needs to be at least") . " " . self::$minimumPhpVersion . ".";
+            $response .= "PHP version needs to be at least" . " " . self::$minimumPhpVersion . ".";
         } else {
             $response = true;
         }


### PR DESCRIPTION
Should not try to translate this message since that overcomplicates things and goal is to do the least amount of stuff (assuming that database connections to translate to work is not a good assumption).