### PR TITLE
make php version checker more robust

### DIFF
--- a/acl_upgrade.php
+++ b/acl_upgrade.php
@@ -117,12 +117,9 @@
 
 // Checks if the server's PHP version is compatible with OpenEMR:
 require_once(dirname(__FILE__) . "/common/compatibility/Checker.php");
-
-use OpenEMR\Common\Checker;
-
-$response = Checker::checkPhpVersion();
+$response = OpenEMR\Common\Checker::checkPhpVersion();
 if ($response !== true) {
-    die($response);
+    die(htmlspecialchars($response));
 }
 
 $ignoreAuth = true; // no login required

--- a/admin.php
+++ b/admin.php
@@ -13,12 +13,9 @@
  */
 // Checks if the server's PHP version is compatible with OpenEMR:
 require_once(dirname(__FILE__) . "/common/compatibility/Checker.php");
-
-use OpenEMR\Common\Checker;
-
-$response = Checker::checkPhpVersion();
+$response = OpenEMR\Common\Checker::checkPhpVersion();
 if ($response !== true) {
-    die($response);
+    die(htmlspecialchars($response));
 }
 
 require_once "version.php";
@@ -95,7 +92,7 @@ function sqlQuery($statement, $link)
                 </div>
             </div>
         </div>
-        
+
         <div class="row">
             <div class="col-sm-12">
                 <table class='table table-striped'>
@@ -232,7 +229,7 @@ function sqlQuery($statement, $link)
                         </div>
                         <div class="modal-body" style="height:80%;">
                             <iframe src="" id="targetiframe" style="height:100%; width:100%; overflow-x: hidden; border:none"
-                            allowtransparency="true"></iframe>  
+                            allowtransparency="true"></iframe>
                         </div>
                         <div class="modal-footer" style="margin-top:0px;">
                            <button class="btn btn-link btn-cancel oe-pull-away" data-dismiss="modal" type="button">Close</button>

--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
     ],
     "autoload" : {
         "exclude-from-classmap" : [
+            "common/compatibility/Checker.php",
             "library/classes/ClinicalTypes/",
             "library/classes/rulesets/",
             "library/classes/smtp/",

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -11,15 +11,13 @@
 
 // Checks if the server's PHP version is compatible with OpenEMR:
 require_once(dirname(__FILE__) . "/../common/compatibility/Checker.php");
+$response = OpenEMR\Common\Checker::checkPhpVersion();
+if ($response !== true) {
+    die(htmlspecialchars($response));
+}
 
-use OpenEMR\Common\Checker;
 use OpenEMR\Core\Kernel;
 use Dotenv\Dotenv;
-
-$response = Checker::checkPhpVersion();
-if ($response !== true) {
-    die($response);
-}
 
 // Throw error if the php openssl module is not installed.
 if (!(extension_loaded('openssl'))) {

--- a/setup.php
+++ b/setup.php
@@ -13,6 +13,14 @@
  * @copyright Copyright (c) 2019 Ranganath Pathak <pathak@scrs1.org>
  * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
+
+// Checks if the server's PHP version is compatible with OpenEMR:
+require_once(dirname(__FILE__) . "/common/compatibility/Checker.php");
+$response = OpenEMR\Common\Checker::checkPhpVersion();
+if ($response !== true) {
+    die(htmlspecialchars($response));
+}
+
 // Set the maximum excution time and time limit to unlimited.
 ini_set('max_execution_time', 0);
 ini_set('display_errors', 0);
@@ -85,13 +93,6 @@ function recursive_writable_directory_test($dir)
 
 // Bring in standard libraries/classes
 require_once dirname(__FILE__) ."/vendor/autoload.php";
-
-use OpenEMR\Common\Checker;
-
-$response = Checker::checkPhpVersion();
-if ($response !== true) {
-    die($response);
-}
 
 $COMMAND_LINE = php_sapi_name() == 'cli';
 require_once(dirname(__FILE__) . '/library/authentication/password_hashing.php');

--- a/sql_patch.php
+++ b/sql_patch.php
@@ -12,12 +12,9 @@
 
 // Checks if the server's PHP version is compatible with OpenEMR:
 require_once(dirname(__FILE__) . "/common/compatibility/Checker.php");
-
-use OpenEMR\Common\Checker;
-
-$response = Checker::checkPhpVersion();
+$response = OpenEMR\Common\Checker::checkPhpVersion();
 if ($response !== true) {
-    die($response);
+    die(htmlspecialchars($response));
 }
 
 // Disable PHP timeout.  This will not work in safe mode.

--- a/sql_upgrade.php
+++ b/sql_upgrade.php
@@ -12,12 +12,9 @@
 
 // Checks if the server's PHP version is compatible with OpenEMR:
 require_once(dirname(__FILE__) . "/common/compatibility/Checker.php");
-
-use OpenEMR\Common\Checker;
-
-$response = Checker::checkPhpVersion();
+$response = OpenEMR\Common\Checker::checkPhpVersion();
 if ($response !== true) {
-    die($response);
+    die(htmlspecialchars($response));
 }
 
 // Disable PHP timeout.  This will not work in safe mode.


### PR DESCRIPTION
This will now work for any version of PHP (prior mechanism was breaking in php 5.6 on the setup script)