### PR TITLE
Fixes #2324 Rest API Fatal Error.

### DIFF
--- a/API_README.md
+++ b/API_README.md
@@ -28,6 +28,8 @@ _Example:_ `https://domain/apis/fhir/Patient` returns a Patients bundle resource
 #### POST /api/auth
 
 Obtain an API token with your login (returns an API token). For FHIR replace Uri component 'api' with 'fhir':
+Scope must match a site that has been setup in OpenEMR in the /sites/ directory.  If you haven't created additional sites
+then 'default' should be the scope.
 
 ```
 curl -X POST -H 'Content-Type: application/json' 'https://localhost:8300/apis/api/auth' \

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -134,9 +134,9 @@ if (empty($_SESSION['site_id']) || !empty($_GET['site'])) {
     // since this is user provided content we need to escape the value but we use htmlspecialchars instead
     // of text() as our helper functions are loaded in later on in this file.
     if (empty($tmp) || preg_match('/[^A-Za-z0-9\\-.]/', $tmp)) {
-	echo "Invalid URL";
+        echo "Invalid URL";
         error_log("Request with site id '". htmlspecialchars($tmp, ENT_NOQUOTES) . "' contains invalid characters.");
-	die();
+        die();
     }
 
     if (isset($_SESSION['site_id']) && ($_SESSION['site_id'] != $tmp)) {

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -134,7 +134,9 @@ if (empty($_SESSION['site_id']) || !empty($_GET['site'])) {
     // since this is user provided content we need to escape the value but we use htmlspecialchars instead
     // of text() as our helper functions are loaded in later on in this file.
     if (empty($tmp) || preg_match('/[^A-Za-z0-9\\-.]/', $tmp)) {
-        die("Site ID '". htmlspecialchars($tmp, ENT_NOQUOTES) . "' contains invalid characters.");
+	echo "Invalid URL";
+        error_log("Request with site id '". htmlspecialchars($tmp, ENT_NOQUOTES) . "' contains invalid characters.");
+	die();
     }
 
     if (isset($_SESSION['site_id']) && ($_SESSION['site_id'] != $tmp)) {

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -130,8 +130,11 @@ if (empty($_SESSION['site_id']) || !empty($_GET['site'])) {
         }
     }
 
+    // for both REST API and browser access we can't proceed unless we have a valid site id.
+    // since this is user provided content we need to escape the value but we use htmlspecialchars instead
+    // of text() as our helper functions are loaded in later on in this file.
     if (empty($tmp) || preg_match('/[^A-Za-z0-9\\-.]/', $tmp)) {
-        die("Site ID '". text($tmp) . "' contains invalid characters.");
+        die("Site ID '". htmlspecialchars($tmp, ENT_NOQUOTES) . "' contains invalid characters.");
     }
 
     if (isset($_SESSION['site_id']) && ($_SESSION['site_id'] != $tmp)) {


### PR DESCRIPTION
The Rest API was fatally failing if you sent an invalid site id.  The code was using the escape function of text() but that file is not loaded until later on in the codebase.  I could have moved the load order of the files so that composer (which in turn loads htmlspecialchars.inc.php) would load earlier, but this appeared to be the safer approach to minimize any system changes by just calling htmlspecialchars(..) directly.

Also documented what the scope parameter is supposed to be in the REST API as it was unclear with the example 'site id' for a newcomer to the system.