### PR TITLE
Rel 501 user admin fix

### DIFF
--- a/interface/usergroup/user_admin.php
+++ b/interface/usergroup/user_admin.php
@@ -309,7 +309,7 @@ for ($i=0; $i<$bg_count; $i++) {
 <td><span class=text><?php echo xlt('Last Name'); ?>: </span></td><td><input type=entry name=lname id=lname style="width:150px;"  class="form-control" value="<?php echo attr($iter["lname"]); ?>"><span class="mandatory"></span></td>
 <td><span class=text><?php echo xlt('Default Facility'); ?>: </span></td><td><select name=facility_id style="width:150px;" class="form-control">
 <?php
-$fres = $facilityService->getAllBillingLocations();
+$fres = $facilityService->getAllServiceLocations();
 if ($fres) {
     for ($iter2 = 0; $iter2 < sizeof($fres); $iter2++) {
                 $result[$iter2] = $fres[$iter2];


### PR DESCRIPTION
User admin menu only allowed default facility to be billing facility.  This fix populates the drop-down with service facilities, not billing facilities. 