### PR TITLE
Decrease encounter tab container height to prevent scroll bar.

### DIFF
--- a/interface/patient_file/encounter/encounter_top.php
+++ b/interface/patient_file/encounter/encounter_top.php
@@ -18,6 +18,7 @@ require_once("$srcdir/encounter.inc");
 require_once("$srcdir/forms.inc");
 
 use OpenEMR\Tabs\TabsWrapper;
+use OpenEMR\Core\Header;
 
 if (isset($_GET["set_encounter"])) {
     // The billing page might also be setting a new pid.
@@ -39,7 +40,7 @@ if (isset($_GET["set_encounter"])) {
 $tabset = new TabsWrapper('enctabs');
 $tabset->declareInitialTab(
     xl('Summary'),
-    "<iframe frameborder='0' style='height:100%;width:100%;' src='forms.php'>Oops</iframe>"
+    "<iframe frameborder='0' style='height:95.5%;width:100%;' src='forms.php'>Oops</iframe>"
 );
 // We might have been invoked to load a particular encounter form.
 // In that case it will be the second tab, and removable.
@@ -47,7 +48,7 @@ if (!empty($_GET['formname'])) {
     $url = $rootdir . "/patient_file/encounter/load_form.php?formname=" . attr_url($_GET['formname']);
     $tabset->declareInitialTab(
         $_GET['formdesc'],
-        "<iframe name='enctabs-2' frameborder='0' style='height:100%;width:100%;' src='$url'>Oops</iframe>",
+        "<iframe name='enctabs-2' frameborder='0' style='height:95.5%;width:100%;' src='$url'>Oops</iframe>",
         true
     );
 }
@@ -56,17 +57,12 @@ if (!empty($_GET['formname'])) {
 $dateres = getEncounterDateByEncounter($encounter);
 $encounter_date = date("Y-m-d", strtotime($dateres["date"]));
 ?>
+
 <html>
 <head>
 <title><?php echo text(oeFormatShortDate($encounter_date)) . ' ' . xlt('Encounter'); ?></title>
-<?php html_header_show(); ?>
-<link href="<?php echo $GLOBALS['assets_static_relative']; ?>/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css" />
-    <?php if ($_SESSION['language_direction'] == 'rtl') { ?>
-     <link rel="stylesheet" href="<?php echo $GLOBALS['assets_static_relative'] ?>/bootstrap-rtl/dist/css/bootstrap-rtl.min.css">
-    <?php } ?>
+    <?php Header::setupHeader(); ?>
 <?php echo $tabset->genCss(); ?>
-<script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/jquery-1-9-1/jquery.min.js"></script>
-<script src="<?php echo $GLOBALS['assets_static_relative']; ?>/bootstrap/dist/js/bootstrap.min.js" type="text/javascript"></script>
 <?php echo $tabset->genJavaScript(); ?>
 <script>
 

--- a/interface/patient_file/encounter/encounter_top.php
+++ b/interface/patient_file/encounter/encounter_top.php
@@ -40,7 +40,7 @@ if (isset($_GET["set_encounter"])) {
 $tabset = new TabsWrapper('enctabs');
 $tabset->declareInitialTab(
     xl('Summary'),
-    "<iframe frameborder='0' style='height:95.5%;width:100%;' src='forms.php'>Oops</iframe>"
+    "<iframe frameborder='0' style='height:95.3%;width:100%;' src='forms.php'>Oops</iframe>"
 );
 // We might have been invoked to load a particular encounter form.
 // In that case it will be the second tab, and removable.
@@ -48,7 +48,7 @@ if (!empty($_GET['formname'])) {
     $url = $rootdir . "/patient_file/encounter/load_form.php?formname=" . attr_url($_GET['formname']);
     $tabset->declareInitialTab(
         $_GET['formdesc'],
-        "<iframe name='enctabs-2' frameborder='0' style='height:95.5%;width:100%;' src='$url'>Oops</iframe>",
+        "<iframe name='enctabs-2' frameborder='0' style='height:95.3%;width:100%;' src='$url'>Oops</iframe>",
         true
     );
 }

--- a/library/tabs/src/TabsWrapper.php
+++ b/library/tabs/src/TabsWrapper.php
@@ -158,7 +158,7 @@ function twAddFrameTab(tabsid, label, url) {
   twAddTab(
     tabsid,
     label,
-    "<iframe name='" + panelId + "' frameborder='0' style='height:100%;width:100%;' src='" + url + "'>Oops</iframe>"
+    "<iframe name='" + panelId + "' frameborder='0' style='height:95.5%;width:100%;' src='" + url + "'>Oops</iframe>"
   );
   return panelId;
 }

--- a/library/tabs/src/TabsWrapper.php
+++ b/library/tabs/src/TabsWrapper.php
@@ -158,7 +158,7 @@ function twAddFrameTab(tabsid, label, url) {
   twAddTab(
     tabsid,
     label,
-    "<iframe name='" + panelId + "' frameborder='0' style='height:95.5%;width:100%;' src='" + url + "'>Oops</iframe>"
+    "<iframe name='" + panelId + "' frameborder='0' style='height:95.3%;width:100%;' src='" + url + "'>Oops</iframe>"
   );
   return panelId;
 }

--- a/portal/patient/templates/OnsiteDocumentListView.tpl.php
+++ b/portal/patient/templates/OnsiteDocumentListView.tpl.php
@@ -84,9 +84,6 @@ echo "<script>var msgDelete='" . xlt("Delete Successful") . "';</script>";
         document.body.innerHTML = printContents;
         window.print();
         document.body.innerHTML = originalContents;
-        $('.sigPad').signaturePad({
-            drawOnly: true
-        });
         location.reload();
     }
 
@@ -162,7 +159,6 @@ echo "<script>var msgDelete='" . xlt("Delete Successful") . "';</script>";
     function restoreCheckMarks() {
         $('.checkMark').each(function () {
             var ckid = $(this).data('id');
-            //var v = $('#'+ckid).data('value');
             if ($('#' + ckid).data('value') == 'Yes')
                 $('#' + ckid).prop('checked', true);
             else
@@ -225,8 +221,8 @@ body {
 <script type="text/template" id="onsiteDocumentModelTemplate">
     <aside class="col-sm-2 col-xs-3" id="sidebar-pills">
         <ul class="nav nav-pills  nav-stacked" id="sidebar">
-            <li data-toggle="pill" class="bg-info"><a type="patient-signature" id="signTemplate"  href="#openSignModal"
-                data-toggle="modal" data-backdrop="true" data-target="#openSignModal"><span><?php echo xlt('Signature');?></span></a></li>
+            <li data-toggle="pill" class="bg-info"><a id="signTemplate" href="#openSignModal"
+                data-toggle="modal" data-backdrop="true" data-target="#openSignModal"data-type="patient-signature"><span><?php echo xlt('Signature');?></span></a></li>
             <li data-toggle="pill" class="bg-info"><a id="saveTemplate" href="#"><span"><?php echo xlt('Save');?></span></a></li>
             <li data-toggle="pill" class="bg-info"><a id="printTemplate" href="javascript:;" onclick="printaDoc('templatecontent');"><span"><?php echo xlt('Print');?></span></a></li>
             <li data-toggle="pill" class="bg-info"><a id="submitTemplate"  href="#"><span"><?php echo xlt('Download');?></span></a></li>


### PR DESCRIPTION
umm, this was driving me nuts. Seems giving tab panels content iframe 100% height doesn't account for the tabs headers height so tabbed encounter UI always displays with an overflow.
 