### PR TITLE
seed for the error log escape project

### DIFF
--- a/library/htmlspecialchars.inc.php
+++ b/library/htmlspecialchars.inc.php
@@ -44,6 +44,14 @@ function js_url($text)
 }
 
 /**
+ * Escape variables that are outputted into the php error log.
+ */
+function errorLogEscape($text)
+{
+    return attr($text);
+}
+
+/**
  * Escape a PHP string for use as (part of) an HTML / XML text node.
  *
  * It only escapes a few special chars: the ampersand (&) and both the left-

--- a/portal/account/account.lib.php
+++ b/portal/account/account.lib.php
@@ -199,7 +199,7 @@ function doCredentials($pid)
         $sent = true;
     } else {
         $email_status = $mail->ErrorInfo;
-        error_log("EMAIL ERROR: " . $email_status, 0);
+        error_log("EMAIL ERROR: " . errorLogEscape($email_status), 0);
         $sent = false;
     }
     if ($sent) {


### PR DESCRIPTION
From this issue:
https://github.com/openemr/openemr/issues/2356

Note this is now a wrapper for simply attr(), but we can change this in the future as needed (guessing some more escaping will be needed, but important to just have the wrappers in place).

I am going to dedicate this new escaping function to @sjpadgett 
:)