### PR TITLE
Responsive Vertical Menu For Tab Based Layout Take 1

### DIFF
--- a/interface/main/tabs/js/application_view_model.js
+++ b/interface/main/tabs/js/application_view_model.js
@@ -21,3 +21,5 @@ app_view_model.application_data.user=ko.observable(null);
 app_view_model.application_data.therapy_group=ko.observable(null);
 
 app_view_model.attendant_template_type=ko.observable('patient-data-template');
+
+app_view_model.responsiveDisplay=null;

--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -6,8 +6,10 @@
  * @link      http://www.open-emr.org
  * @author    Kevin Yeh <kevin.y@integralemr.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Ranganath Pathak <pathak@scrs1.org>
  * @copyright Copyright (c) 2016 Kevin Yeh <kevin.y@integralemr.com>
  * @copyright Copyright (c) 2016 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2019 Ranganath Pathak <pathak@scrs1.org>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -33,6 +35,8 @@ $esignApi = new Api();
 <html>
 <head>
 <title><?php echo text($openemr_name); ?></title>
+
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 <script type="text/javascript">
 <?php require($GLOBALS['srcdir'] . "/restoreSession.php"); ?>
@@ -200,7 +204,11 @@ $GLOBALS['allow_issue_menu_link'] = ((acl_check('encounters', 'notes', '', 'writ
 <?php require_once("templates/therapy_group_template.php"); ?>
 <?php require_once("templates/user_data_template.php"); ?>
 <?php require_once("menu/menu_json.php"); ?>
-<?php $userQuery = sqlQuery("select * from users where username = ?", array($_SESSION['authUser'])); ?>
+<?php $userQuery = sqlQuery("select * from users where username = ?", array($_SESSION['authUser']));?>
+<?php $width = $GLOBALS['vertical_responsive_menu']; //will be vertical menu at and below this width
+
+
+?>
 <script type="text/javascript">
     <?php if (!empty($_SESSION['frame1url']) && !empty($_SESSION['frame1target'])) { ?>
         app_view_model.application_data.tabs.tabsList()[0].url(<?php echo json_encode("../".$_SESSION['frame1url']); ?>);
@@ -216,11 +224,54 @@ $GLOBALS['allow_issue_menu_link'] = ((acl_check('encounters', 'notes', '', 'writ
         .',' . json_encode($userQuery['fname'])
         .',' . json_encode($userQuery['lname'])
         .',' . json_encode($_SESSION['authGroup']); ?>));
-
+   
+</script>
+<script>
+    $(window).on('resize', function() {
+        
+     var win = $(this);
+     var winWidth = $(this).width();
+     console.log("Window width is: " + win.width());
+        if (winWidth >  <?php echo attr($width);?>) {
+            $("#tabs_div").removeClass('col-sm-10');
+            $("#mainFrames_div").removeClass('col-sm-10');
+            $("#menu_icon").addClass('fa-bars');
+            
+            $("#username div:first-child" ).addClass("userSection");
+            $(".appMenu_small").addClass('appMenu');
+            $(".appMenu_small").removeClass('appMenu_small');
+            
+        } else if (winWidth <=  <?php echo attr($width);?> ){
+            $("#username div:first-child" ).removeClass("userSection");
+            $(".appMenu").addClass('appMenu_small');
+            $(".appMenu").removeClass('appMenu');
+        } 
+    });
+    $(function() {
+        $(window).trigger('resize');// to avoid repeating code triggers above on page open
+    });
 </script>
 
+<style>
+@media only screen and (max-width: <?php echo attr($width);?>px) {
+    .patientDataColumn
+    {
+        width: 100% !important; //33%
+        float: left;
+        display: block;
+    }
+}
+
+html, body{
+    
+    min-height:100% !important;
+    height:100% !important;
+}
+
+</style>
+  
 </head>
-<body>
+<body data-bind="css: {'body_main' : responsiveDisplay.oeVerticalDisplay}">
 <!-- Below iframe is to support auto logout when timeout is reached -->
 <iframe name="timeout" style="visibility:hidden; position:absolute; left:0; top:0; height:0; width:0; border:none;" src="timeout_iframe.php"></iframe>
 <?php // mdsupport - app settings
@@ -237,21 +288,138 @@ if (isset($_SESSION['app1'])) {
     }
 }
 ?>
-<div id="mainBox" <?php echo $disp_mainBox ?>>
+<div id="mainBox" <?php echo $disp_mainBox ?> data-bind='attr: {id: responsiveDisplay.objWidth().mainBoxId}  '>
     <div id="dialogDiv"></div>
-    <div class="body_top">
-        <a href="https://www.open-emr.org" title="OpenEMR <?php echo xla("Website"); ?>" rel="noopener" target="_blank"><img class="logo" alt="openEMR small logo"  border="0" src="<?php echo $GLOBALS['images_static_relative']; ?>/menu-logo.png"></a>
-        <span id="menu logo" data-bind="template: {name: 'menu-template', data: application_data} "></span>
-        <span id="userData" data-bind="template: {name: 'user-data-template', data:application_data} "></span>
+    
+    <div class="body_top" id="body_top_div" data-bind='css: responsiveDisplay.objWidth().bodyTopDivWidth'>
+        <div id="logo_menu" >
+        <a href="https://www.open-emr.org" title="OpenEMR <?php echo xla("Website"); ?>" rel="noopener" target="_blank"><img class="logo" id='oemr_logo' alt="openEMR small logo"  style="width:20px" border="0" src="<?php echo $GLOBALS['images_static_relative']; ?>/menu-logo.png"></a>
+        <div>
+        <i class="fa fa-2x fa-bars oe-hidden col-sm-2" aria-hidden="true" id='menu_icon' data-bind='css: responsiveDisplay.objWidth().menuIconHide, click: function(){ responsiveDisplay.verticalMenuObservable(); responsiveDisplay.menuIconObservable()}, css2: {"fa-bars" : !responsiveDisplay.oeMenuIcon(), "fa-eye-slash" : responsiveDisplay.oeMenuIcon}'></i>
+        </div>
+        <div class="clearfix" data-bind="css: {'clearfix' : responsiveDisplay.winWidth() <= <?php echo attr($width);?>}"></div>
+        </div>
+        <div id="menu_items" class="oe-hidden" data-bind=" css2: {'oe-hidden' : !responsiveDisplay.oeVerticalMenu() && responsiveDisplay.winWidth() <= <?php echo attr($width);?>}">
+            <span id="menu_logo" data-bind="template: {name: 'menu-template', data: application_data} "></span>
+            <div>
+            <span id="userData" data-bind="template: {name: 'user-data-template', data:application_data} "></span>
+            <a href="../../logout.php" rel="noopener" id="logout_link" onclick="top.restoreSession()" data-bind="css: {'oe-hidden' :responsiveDisplay.oeLogoutIcon}" title="<?php echo xla("Logout");?>"><i class="fa fa-2x fa-sign-out" aria-hidden="true" id="logout_icon"></i></a>
+            </div>
+        </div>
+        <div class="clearfix" data-bind="css: {'clearfix' : responsiveDisplay.winWidth() <= <?php echo attr($width);?>}"></div>
     </div>
-    <div id="attendantData" class="body_title acck" data-bind="template: {name: app_view_model.attendant_template_type, data: application_data} ">
+    <div id="attendantData" class="body_title acck"  data-bind="template: {name: app_view_model.attendant_template_type, data: application_data}, css: responsiveDisplay.objWidth().attendantDataWidth + ' '  + responsiveDisplay.objWidth().attendantDataClear ">
     </div>
-    <div class="body_title" data-bind="template: {name: 'tabs-controls', data: application_data} "> </div>
+   
+    <div class="body_title" id="tabs_div" data-bind="template: {name: 'tabs-controls', data: application_data}, css: responsiveDisplay.objWidth().tabsDivWidth"> </div>
 
-    <div class="mainFrames">
-        <div id="framesDisplay" data-bind="template: {name: 'tabs-frames', data: application_data}"> </div>
+    <div class="mainFrames" id="mainFrames_div" style="display: flex;" data-bind="css: responsiveDisplay.objWidth().mainFramesDivWidth  + ' ' +  responsiveDisplay.objWidth().mainFramesDivFill">
+        <div id="framesDisplay" data-bind="template: {name: 'tabs-frames', data: application_data}, css: responsiveDisplay.objWidth().framesDisplayFill"> </div>
     </div>
 </div>
+<script>
+    
+var displayViewModel = {
+   winWidth: ko.observable(),
+   winHeight: ko.observable(),
+   winDevice: ko.observable(),
+   objWidth: {}
+  
+};
+
+displayViewModel.objWidth = ko.computed(function() {
+        if(this.winWidth() <= <?php echo attr($width);?>){
+            currWidth = {
+               mainBoxId: "mainBox_vertical",
+               mainFramesDivFill: "oe-fill",
+               framesDisplayFill: "oe-fill",
+               menuItemsHide: "oe-hidden",
+               menuIconHide: "",
+               menuHideHide: "oe-hidden"
+            }
+            if(this.winWidth() > 1440){
+                currWidth.bodyTopDivWidth = "col-sm-1";
+            } else {
+                currWidth.bodyTopDivWidth = "col-sm-2"; 
+            }
+            if(this.oeVerticalMenu()){
+                if(this.winWidth() > 1440){
+                    currWidth.tabsDivWidth = "col-sm-11";
+                    currWidth.mainFramesDivWidth = "col-sm-11";
+                    currWidth.bodyTopDivWidth = "col-sm-1";
+                } else {
+                    currWidth.tabsDivWidth = "col-sm-10";
+                    currWidth.mainFramesDivWidth = "col-sm-10";
+                    currWidth.bodyTopDivWidth = "col-sm-2";
+                }
+            } else {
+               currWidth.tabsDivWidth = "col-sm-12";
+               currWidth.mainFramesDivWidth = "col-sm-12";
+            }
+            if (this.winWidth() <= 767){
+                currWidth.attendantDataClear = "clearfix";
+                currWidth.attendantDataWidth = "";
+            } else if (this.winWidth() > 767){
+                currWidth.attendantDataClear = "";
+                if(this.winWidth() > 1440){
+                    currWidth.attendantDataWidth = "col-sm-11";
+                } else{
+                    currWidth.attendantDataWidth = "col-sm-10";
+                }
+            }
+        } else {
+            currWidth = {
+               mainBoxId: "mainBox",
+               bodyTopDivWidth : "",
+               tabsDivWidth: "",
+               mainFramesDivWidth: "",
+               mainFramesDivFill: "",
+               framesDisplayFill: "",
+               menuItemsHide: "",
+               menuIconHide: "oe-hidden",
+               menuHideHide: "oe-hidden",
+               attendantDataClear: "",
+               attendantDataWidth: ""
+            }
+        }
+    return currWidth;
+}, displayViewModel);
+
+displayViewModel.oeVerticalMenu = ko.observable(false);
+displayViewModel.oeVerticalDisplay = ko.computed(function(){
+    var vertDispl = displayViewModel.winWidth() > <?php echo attr($width);?> ? false : true;
+    return vertDispl;
+}, displayViewModel);
+
+displayViewModel.verticalMenuObservable = function() {
+    displayViewModel.oeVerticalMenu(!displayViewModel.oeVerticalMenu());
+ };
+displayViewModel.oeMenuIcon = ko.observable(false);
+displayViewModel.menuIconObservable = function() {
+    displayViewModel.oeMenuIcon(!displayViewModel.oeMenuIcon());
+ };
+
+ displayViewModel.oeLogoutIcon = ko.computed(function(){
+    var logoutIcon =  this.winWidth() > <?php echo attr($width);?>  ? true : false; 
+    return logoutIcon;
+ }, displayViewModel);
+var $window = $(window);
+$window.resize(function () { 
+    displayViewModel.winWidth($window.width());
+    displayViewModel.winHeight($window.height());
+    if($window.width() > <?php echo attr($width);?>){
+    displayViewModel.winDevice('ipad');
+    } else {
+    displayViewModel.winDevice('bipad');
+    }
+    
+});
+$(function() {
+        $(window).trigger('resize');// to avoid repeating code triggers above on page open
+    });
+ko.bindingHandlers['css2'] = ko.bindingHandlers.css;    
+app_view_model.responsiveDisplay = displayViewModel;
+</script>
 <script>
     $("#dialogDiv").hide();
     ko.applyBindings(app_view_model);
@@ -265,5 +433,15 @@ if (isset($_SESSION['app1'])) {
         });
     });
 </script>
+<script>
+    // $('#username').hover(function() {
+        // $('.hideaway').show();
+    // });
+   // $('#username').on ('click', function() {
+        // $('.hideaway').toggle('1000');
+        // $(this).parent().parent().parent().focus();
+    // });
+</script>
+
 </body>
 </html>

--- a/interface/main/tabs/templates/user_data_template.php
+++ b/interface/main/tabs/templates/user_data_template.php
@@ -19,10 +19,11 @@
         <div id="username" class="appMenu">
             <div class="menuSection userSection">
                 <div class='menuLabel' id="username" title="<?php echo xla('Current user') ?>">
+                    <div><i class="fa fa-2x fa-user oe-show" aria-hidden="true" id="user_icon"></i></div>
                     <span data-bind="text:fname"></span>
                     <span data-bind="text:lname"></span>
                 </div>
-                <ul class="userfunctions menuEntries">
+                <ul class="userfunctions menuEntries hideaway">
                     <li class="menuLabel" data-bind="click: editSettings"><?php echo xlt("Settings");?></li>
                     <li class="menuLabel" data-bind="click: changePassword"><?php echo xlt("Change Password");?></li>
                     <li class="menuLabel" data-bind="click: changeMFA"><?php echo xlt("MFA Management");?></li>

--- a/interface/themes/color_base.scss
+++ b/interface/themes/color_base.scss
@@ -125,6 +125,10 @@ body {
 .body_top {
 	background-color: $paler;
 }
+.body_main {
+    background-color: $midpale !important;
+    border-top: solid 8px $dark;
+}
 /* $top_bg_line RP_MODIFIED 2/8/15 $paler*/
 
 .bgcolor2 {

--- a/interface/themes/colors/openemr5/tabs-full.scss
+++ b/interface/themes/colors/openemr5/tabs-full.scss
@@ -3,6 +3,9 @@
 #mainBox>.body_top, .body_top_tabs {
     background-color: $dark !important;
 }
+#mainBox_vertical > .body_top, .body_top_tabs {
+    background-color: $midpale !important;
+}
 .tabSpan, .tabSpan_tabs {
     border-top: 5px solid $dark !important;
     border-left: 1px solid $dark !important;
@@ -138,3 +141,8 @@ img[src *="show_calendar.gif"] {
     margin-bottom: 3px;
 }
 /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~openemr5 calendar icon*~~~~~~~~~~~~~~~~~~~~~~*/
+
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~openemr5 tabs menu , user and logout icon~~~~*/
+#menu_icon, #logout_icon, #user_icon {
+    color:$darker !important;
+}

--- a/interface/themes/oe-common/all-common-import.scss
+++ b/interface/themes/oe-common/all-common-import.scss
@@ -3,3 +3,4 @@
 @import "messages-common";
 @import "acl-common";
 @import "procedures-common";
+@import "main-common";

--- a/interface/themes/oe-common/main-common.scss
+++ b/interface/themes/oe-common/main-common.scss
@@ -1,0 +1,7 @@
+.oe-fill {
+    min-height:100% !important;
+    height:100% !important;
+}
+.oe-hidden {
+    display: none!important;
+}

--- a/interface/themes/oe-common/procedures-common.scss
+++ b/interface/themes/oe-common/procedures-common.scss
@@ -27,10 +27,10 @@
     padding-#{$left}: 30px;
 }
 .oe-pl40 {
-    padding-#{$left}t: 40px;
+    padding-#{$left}: 40px;
 }
 .oe-pl50 {
-    padding-#{$left}t: 50px;
+    padding-#{$left}: 50px;
 }
 .oe-pl60 {
     padding-#{$left}: 60px;

--- a/interface/themes/style_light.scss
+++ b/interface/themes/style_light.scss
@@ -314,6 +314,11 @@ div.category-display {
 	margin-top: 25px;
 }
 
+/*~~openemr5 tabs menu , user and logout icon~~*/
+#menu_icon, #logout_icon, #user_icon {
+    color:#676666 !important;
+}
+
 @import "oe-bootstrap";
 @import "oe-common/all-common-import";
 

--- a/interface/themes/style_manila.scss
+++ b/interface/themes/style_manila.scss
@@ -461,6 +461,16 @@ body dl {
 .chevron_color {
     color: #063f80;
 }
+
+/* main.php*/
+.body_main{
+  background-color:#C9DBF2;
+}
+/*~~openemr5 tabs menu , user and logout icon~~*/
+#menu_icon, #logout_icon, #user_icon {
+    color:#676666 !important;
+}
+
 @import "oe-bootstrap";
 @import "oe-common/all-common-import";
 

--- a/interface/themes/tabs_style_compact.css
+++ b/interface/themes/tabs_style_compact.css
@@ -47,12 +47,26 @@ body
     margin: 0;
     padding: 0;
 }
+#mainBox_vertical {
+    align-items: stretch;
+    align-content: space-between;
+    flex: 1 0 auto;
+    margin: 0;
+    padding: 0;
+}
 
 #mainBox  .logo{
     float: left;
-    margin:3px 4px 0px 10px;
+    margin:7px 4px 0px 10px;
     width:20px;
     z-index:10000;
+}
+
+#mainBox_vertical .logo {
+    float: left;
+    margin: 13px 4px 0px 12px;
+    width: 30px;
+    z-index: 10000;
 }
 
 #mainBox > div
@@ -258,9 +272,13 @@ body
 .appMenu > span
 {
     float: left;
-    padding:0px 0px;
+    padding:0;
     white-space: nowrap;
     text-shadow: none;
+}
+.appMenu_small > span {
+    padding: 0;
+    white-space: nowrap;
 }
 .appMenu > span:hover
 {
@@ -269,9 +287,10 @@ body
     background-color: #1C5ECF;
     text-shadow: none;
 }
-.appMenu ul
+.appMenu ul,
+.appMenu_small ul
 {
-    list-style:none;
+    list-style: none;
     margin:0;
     padding: 1px 5px 2px 1px;
 }
@@ -289,6 +308,12 @@ body
 .appMenu li:hover > .menuDisabled
  {
     background-color: transparent;
+}
+.appMenu  .oe-show {
+    display: none;
+}
+.appMenu_small .oe-show {
+    display: block;
 }
 .menuSection{
     position: relative;
@@ -348,6 +373,10 @@ body
     box-shadow:0 0 10px #939393;
     z-index:10;
 }
+#mainBox_vertical>.body_top {
+    box-shadow:0 0 0 #939393;
+    margin: 0 !important;
+}
 .body_title {
     color: black;
     background-color: #c9dbf2;
@@ -392,4 +421,19 @@ body
 
 .float-element {
     float: left;
+}
+
+/* main.php*/
+.body_main{
+  background-color:#C9DBF2;
+}
+#logout_icon{
+    float:left;
+    margin:12px 5px 0 10px;
+    cursor: pointer;
+}
+#menu_icon {
+    float:right;
+    margin:12px 14px 0 0;
+    cursor: pointer;
 }

--- a/interface/themes/tabs_style_full.css
+++ b/interface/themes/tabs_style_full.css
@@ -50,6 +50,14 @@ body
     padding: 0;
 }
 
+#mainBox_vertical {
+    align-items: stretch;
+    align-content: space-between;
+    flex: 1 0 auto;
+    margin: 0;
+    padding: 0;
+}
+
 #mainBox > div
 {
     flex: 0 1 auto;
@@ -71,6 +79,13 @@ float: left;
 margin:3px 4px 0px 10px;
 width:20px;
 z-index:10000;
+}
+
+#mainBox_vertical .logo {
+    float: left;
+    margin: 3px 4px 0px 12px;
+    width: 30px;
+    z-index: 10000;
 }
 
 #framesDisplay
@@ -273,7 +288,11 @@ z-index:10000;
 .appMenu > span
 {
     float: left;
-    padding: 0px;
+    padding: 0;
+    white-space: nowrap;
+}
+.appMenu_small > span {
+    padding: 0;
     white-space: nowrap;
 }
 
@@ -285,7 +304,8 @@ z-index:10000;
     background-color: #1C5ECF;
     text-shadow: none;
 }
-.appMenu ul
+.appMenu ul,
+.appMenu_small ul
 {
     list-style:none;
     margin:0;
@@ -295,6 +315,15 @@ z-index:10000;
 .appMenu li:hover > .menuDisabled
  {
     background-color: transparent;
+}
+.appMenu_small .menuLabel {
+    padding: 10px 10px;
+}
+.appMenu  .oe-show {
+    display: none;
+}
+.appMenu_small .oe-show {
+    display: block;
 }
 .menuSection{
     position: relative;
@@ -421,4 +450,15 @@ div.menuLabel:hover {
 
 .float-element {
     float: left;
+}
+
+#logout_icon{
+    float:left;
+    margin:12px 5px 0 10px;
+    cursor: pointer;
+}
+#menu_icon {
+    float:right;
+    margin:12px 14px 0 0;
+    cursor: pointer;
 }

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -115,6 +115,7 @@ $USER_SPECIFIC_GLOBALS = array('default_top_pane',
     'new_tabs_layout',
     'theme_tabs_layout',
     'css_header',
+    'vertical_responsive_menu',
     'menu_styling_vertical',
     'default_encounter_view',
     'gbl_pt_list_page_size',
@@ -187,7 +188,7 @@ $GLOBALS_METADATA = array(
         ),
 
         'new_tabs_layout' => array(
-            xl('Layout (need to logout/login after change this setting)'),
+            xl('Layout (need to logout/login after changing this setting)'),
             array(
                 '0' => xl('Frame'),
                 '1' => xl('Tabs'),
@@ -197,17 +198,17 @@ $GLOBALS_METADATA = array(
         ),
 
         'theme_tabs_layout' => array(
-            xl('Tabs Layout Theme (need to logout/login after change this setting)'),
+            xl('Tabs Layout Theme (need to logout/login after changing this setting)'),
             'tabs_css',
             'tabs_style_full.css',
             xl('Theme of the tabs layout (need to logout and then login to see this new setting). Note this is only applicable if use the Light or Manila general theme below.')
         ),
 
         'css_header' => array(
-            xl('General Theme (need to logout/login after change this setting)'),
+            xl('General Theme (need to logout/login after changing this setting)'),
             'css',
-            'style_light.css',
-            xl('Pick a general theme (need to logout/login after change this setting).')
+            'style_dune.css',
+            xl('Pick a general theme (need to logout/login after changing this setting).')
         ),
 
         'font-family' => array(
@@ -228,7 +229,7 @@ $GLOBALS_METADATA = array(
         ),
 
         'font-size' => array(
-            xl('Default font size (need to logout/login after change this setting)'),
+            xl('Default font size (need to logout/login after changing this setting)'),
             array(
                 '__default__' => 'Use Theme Font Size',
                 '10px' => '10px',
@@ -240,15 +241,41 @@ $GLOBALS_METADATA = array(
             '__default__',
             xl("Select the default font size"),
         ),
+        
+        'vertical_responsive_menu' => array(
+            xl('Responsive Vertical Menu Style for Tabs (need to logout/login after changing this setting)'),
+            array(
+                '736' => xl('iPhone 6/7/8 Plus') . " - " . attr('736 X 414 px'),
+                '740' => xl('Galaxy S9/S9 Plus') . " - " . attr('740 X 360 px'),
+                '812' => xl('iPhone X/XS') . " - " . attr('812 X 375 px'),
+                '896' => xl('iPhone XR/XS Max') . " - " . attr('896 X 414 px'),
+                '1024' => xl('iPad/iPad Mini, XGA') . " - " . attr('1024 X 768 px'),
+                '1112' => xl('iPad Pro 10.5 inches') . " - " . attr('1112 X 834 px'),
+                '1280' => xl('Kindle Fire HDX, Laptop MDPI , WXGA') . " - " . attr('1280 X 800 px'),
+                '1336' => xl('iPad Pro 12.5 inches') . " - " . attr('1336 X 1024 px'),
+                '1366' => xl('HD') . " - " . attr('1366 X 768 px'),
+                '1440' => xl('Laptop HiDPI, WXGA+') . " - " . attr('1440 X 900 px'),
+                '1600' => xl('HD+') . " - " . attr('1600 X 900 px'),
+                '1680' => xl('WSXGA+') . " - " . attr('1680 X 1050 px'),
+                '1920' => xl('FHD, WUXGA') . " - " . attr('1920 X 1080').", ". attr('1920 X 1200 px'),
+                '2048' => xl('QWXGA') . " - " . attr('2048 X 1152 px'),
+                '2560' => xl('QHD') . " - " . attr('2560 X 1440 px'),
+                '3840' => xl('4K UHD') . " - " . attr('3840 X 2160 px'),
+                
+            ),
+             
+            '1024', //default iPad/iPad mini
+            xl('Selecting the width for responsive vertical style menus in tab based layout (need to logout/login after change this setting)')
+        ),
 
         'menu_styling_vertical' => array(
-            xl('Vertical Menu Style'),
+            xl('Vertical Menu Style for Frames'),
             array(
                 '0' => xl('Tree'),
                 '1' => xl('Sliding'),
             ),
             '1',
-            xl('Vertical Menu Style')
+            xl('Vertical Menu Style for frame based layouts')
         ),
 
         'default_encounter_view' => array(
@@ -262,10 +289,10 @@ $GLOBALS_METADATA = array(
         ),
 
         'gbl_nav_area_width' => array(
-            xl('Navigation Area Width'),
+            xl('Navigation Area Width for Frames'),
             'num',
             '175',
-            xl('Width in pixels of the left navigation frame.')
+            xl('Width in pixels of the left navigation frame in frame based layout.')
         ),
 
         'openemr_name' => array(


### PR DESCRIPTION
Creates a responsive vertical menu for tab based layout using Bootstrap classes

Done entirely by manipulating the DOM of the existing `main.php` using Knockout JS
and a bit of jQuery and adjusting the CSS stylesheets

Useful for display in tablets and Smartphones

Will allow workable access to OpenEMR from tablets and Smartphones

By default it is set to display the vertical menu for Tablets with screen resolution
of 1024 x 768px - iPad/iPadMini or XGA display and below

Will automatically adjust display while switching from Portrait to
Landscape mode in tablets and Smartphones

Below 767px all divs will automatically occupy 100% of display width

If desired the default display width for Vertical Menu can be set for
any screen width up to 4K UHD 3840 X 2160px

This is done in Administration  > Globals > Appearance > Responsive Vertical Menu Style for Tabs

Can be individualized per user User name > Settings > Appearance > Responsive Vertical
Menu Style for Tabs

Works well in iOS 10 and above and Android 8.0 and above  Fire OS 5.3.6.4

Works well in all modern browsers as well as IE 11 for Desktops and Laptops

Simulation using chrome devtools:

**Default Display on desktop**

![responsive_verical_01-](https://user-images.githubusercontent.com/12654295/57597249-82200900-7503-11e9-9064-96802c52323e.png)

**iPad mini - Portrait with hidden vertical menu**

![responsive_verical_02-](https://user-images.githubusercontent.com/12654295/57597303-b72c5b80-7503-11e9-900d-cdecf15c57a7.png)

**iPad mini - Landscape with hidden vertical menu**

![responsive_verical_03-](https://user-images.githubusercontent.com/12654295/57597323-c7dcd180-7503-11e9-8eda-f9f572a8614b.png)

**iPad mini - Landscape with visible vertical menu**

![responsive_verical_04-](https://user-images.githubusercontent.com/12654295/57597330-d4f9c080-7503-11e9-8bff-3fde0a4ddaca.png)

**iPad mini - Landscape with visible vertical menu - patient chart - long name,long MRN**

![responsive_verical_05-](https://user-images.githubusercontent.com/12654295/57597362-f9559d00-7503-11e9-8a0a-9c6ea60d6782.png)

**iPhone X - Landscape mode**

![responsive_verical_06-](https://user-images.githubusercontent.com/12654295/57597400-19855c00-7504-11e9-92e8-4091242246c0.png)

**iPhone 6/7/8  - Landscape mode**

![responsive_verical_07-](https://user-images.githubusercontent.com/12654295/57597445-4b96be00-7504-11e9-980e-72e6483ada65.png)


**iPhone 5  - Landscape mode**

![responsive_verical_08-](https://user-images.githubusercontent.com/12654295/57597458-55b8bc80-7504-11e9-8e9d-c8208115b156.png)

**iPhone 5  - Landscape mode - block level menu**

![responsive_verical_09-](https://user-images.githubusercontent.com/12654295/57597483-6701c900-7504-11e9-9476-73d17b17e70f.png)


Please test in Tablets/Smartphones running earlier versions of iOS and Android :)

Does not appear to work in Android 4.0 and iOS 9.3.5 :(

below added by bradymiller:
Up For Grabs demo for this PR is at:
https://www.open-emr.org/wiki/index.php/Development_Demo#Zeta_-_Up_For_Grabs_Demo