### PR TITLE
Added NPI to NewCrop eRx for midlevel prescribers

### DIFF
--- a/interface/eRxXMLBuilder.php
+++ b/interface/eRxXMLBuilder.php
@@ -532,6 +532,7 @@ class eRxXMLBuilder
         }
 
         $element->appendChild($this->createElementText('licenseNumber', $userDetails['state_license_number']));
+        $element->appendChild($this->createElementTextFieldEmpty('npi', $userDetails['npi'], xl('Midlevel Prescriber NPI')));
 
         return $element;
     }


### PR DESCRIPTION
NewCrop is now requiring midlevel prescribers to provide NPI. This also needs to be ported to 501. 
Thanks, 
Ken
ken@mi-squared.com