### PR TITLE
Zend Module Event Dispatcher w/ Consolidated Menu

### DIFF
--- a/interface/globals.php
+++ b/interface/globals.php
@@ -604,10 +604,10 @@ try {
     // TODO: why do we have 3 different directories we need to pass in for the zend dir path. shouldn't zendModDir already have all the paths set up?
     /** @var ModulesApplication */
     $GLOBALS['modules_application'] = new ModulesApplication(
-        $GLOBALS["kernel"]
-        , $GLOBALS['fileroot']
-        , $GLOBALS['baseModDir']
-        , $GLOBALS['zendModDir']
+        $GLOBALS["kernel"],
+        $GLOBALS['fileroot'],
+        $GLOBALS['baseModDir'],
+        $GLOBALS['zendModDir']
     );
 } catch (\Exception $ex) {
     error_log($ex->getMessage() . $ex->getTraceAsString());

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -17,6 +17,7 @@ if ($response !== true) {
 }
 
 use OpenEMR\Core\Kernel;
+use OpenEMR\Core\ModulesApplication;
 use Dotenv\Dotenv;
 
 // Throw error if the php openssl module is not installed.
@@ -595,6 +596,20 @@ $SMTP_Auth = !empty($GLOBALS['SMTP_USER']);
 $GLOBALS['baseModDir'] = "interface/modules/"; //default path of modules
 $GLOBALS['customModDir'] = "custom_modules"; //non zend modules
 $GLOBALS['zendModDir'] = "zend_modules"; //zend modules
+
+try {
+    // load up the modules system and bootstrap them.
+    // This has to be fast, so any modules that tie into the bootstrap must be kept lightweight
+    // registering event listeners, etc.
+    // TODO: why do we have 3 different directories we need to pass in for the zend dir path. shouldn't zendModDir already have all the paths set up?
+    /** @var ModulesApplication */
+    $GLOBALS['modules_application'] = new ModulesApplication($GLOBALS["kernel"], 
+        $GLOBALS['fileroot'], $GLOBALS['baseModDir'], $GLOBALS['zendModDir']);
+}
+catch (\Exception $ex) {
+    error_log($ex->getMessage() . $ex->getTraceAsString());
+    die();
+}
 
 // Don't change anything below this line. ////////////////////////////
 

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -603,10 +603,13 @@ try {
     // registering event listeners, etc.
     // TODO: why do we have 3 different directories we need to pass in for the zend dir path. shouldn't zendModDir already have all the paths set up?
     /** @var ModulesApplication */
-    $GLOBALS['modules_application'] = new ModulesApplication($GLOBALS["kernel"], 
-        $GLOBALS['fileroot'], $GLOBALS['baseModDir'], $GLOBALS['zendModDir']);
-}
-catch (\Exception $ex) {
+    $GLOBALS['modules_application'] = new ModulesApplication(
+        $GLOBALS["kernel"]
+        , $GLOBALS['fileroot']
+        , $GLOBALS['baseModDir']
+        , $GLOBALS['zendModDir']
+    );
+} catch (\Exception $ex) {
     error_log($ex->getMessage() . $ex->getTraceAsString());
     die();
 }

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -610,7 +610,7 @@ try {
         $GLOBALS['zendModDir']
     );
 } catch (\Exception $ex) {
-    error_log($ex->getMessage() . $ex->getTraceAsString());
+    error_log(errorLogEscape($ex->getMessage() . $ex->getTraceAsString()));
     die();
 }
 

--- a/interface/main/left_nav.php
+++ b/interface/main/left_nav.php
@@ -93,6 +93,7 @@ require_once $GLOBALS['srcdir'].'/ESign/Api.php';
 require_once $GLOBALS['srcdir'].'/user.inc';
 
 use ESign\Api;
+use OpenEMR\Menu\MenuEvent;
 
 // Fetch user preferences saved from prior session
 $uspfx = substr(__FILE__, strlen($GLOBALS['fileroot']."/")) . '.';
@@ -381,6 +382,70 @@ function genFindBlock()
 </table>
 <?php
 } // End function genFindBlock()
+
+/**
+ * Module URLs have an absolute URL and need to have the /interface part removed
+ * as the rest of the menu item code relies on that.
+ * @param $modUrl The full absolute url for the module
+ */
+function genModUrl($modUrl) {
+    return substr($modUrl, strlen('/interface') +1);
+}
+
+/**
+ * Given a module name and id, create the associated stdClass object that we can use
+ * for the menu event system.  We use these objects in other parts of OpenEMR so we
+ * conform to the same interface.
+ * @param $moduleName The name of the module
+ * @param $modId The unique id of the module.
+ * @return stdClass
+ */
+function genModuleMenuObject($moduleName, $modId) {
+    $moduleMenuContainer=new \stdClass();
+    $moduleMenuContainer->label=xlt($moduleName);
+    $moduleMenuContainer->url= '';
+    $moduleMenuContainer->menu_id = $modId;
+    $moduleMenuContainer->requirement=0;
+    $moduleMenuContainer->target='mod';
+    $moduleMenuContainer->children = [];
+    return $moduleMenuContainer;
+
+}
+
+/**
+ * Given a tree object structure of navigation items go through and generate the side navigation
+ * items for the given tree.  If the user is not an administrator than hook menu items are hidden.
+ * @param $navMenuItems  The tree object structure.  @see genModuleMenuObject for the structure of this array.
+ * @param $disallowed A hashmap of acl restrictions.
+ */
+function genModuleMenuFromMenuItems($navMenuItems, $disallowed) {
+    // there's only one menu item in this case
+    if (!empty($navMenuItems[0])) {
+        foreach ($navMenuItems[0]->children as $menuItem) {
+            $acl_section = $menuItem->menu_id; // we use the url as the key since it's unique...
+            if (empty($menuItem->children)) {
+                genMiscLink2('RTop', $acl_section, '0', $menuItem->label, genModUrl($menuItem->url));
+            } else if (!$disallowed['adm']) { // admin are not allowed hook settings...
+                ?>
+                <li><a class="collapsed_lv2"><span><?= $menuItem->label; ?></span></a>
+
+                    <ul>
+                        <?php
+                        foreach ($menuItem->children as $childHookContainer) :
+                            $acl_section = $childHookContainer->url;
+                            // li closed in genMiscLink
+                            genMiscLink('RTop', $acl_section, '0', $childHookContainer->label, genModUrl($childHookContainer->url));
+                        endforeach; ?>
+                    </ul>
+                </li>
+                <?php
+            }
+        }
+    }
+    else {
+        error_log("System error.  MENU_UPDATE event did not return a valid menu object back");
+    }
+}
 ?>
 <!DOCTYPE html>
 <html>
@@ -1362,62 +1427,14 @@ if ($reglastcat) {
 
         <?php //genTreeLink('RTop','ort',xl('Settings')); ?>
         <?php
-        $module_query = sqlStatement("select mod_id, mod_directory,mod_name,mod_nick_name,mod_relative_link,type from modules where mod_active = 1 AND sql_run= 1 order by mod_ui_order asc");
-        if (sqlNumRows($module_query)) {
-            while ($modulerow = sqlFetchArray($module_query)) {
-                  $module_hooks =  sqlStatement("SELECT msh.*,ms.obj_name,ms.menu_name,ms.path,m.mod_ui_name,m.type FROM modules_hooks_settings AS msh LEFT OUTER JOIN modules_settings AS ms ON
-                                    obj_name=enabled_hooks AND ms.mod_id=msh.mod_id LEFT OUTER JOIN modules AS m ON m.mod_id=ms.mod_id
-                                    WHERE m.mod_id = ? AND fld_type=3 AND mod_active=1 AND sql_run=1 AND attached_to='modules' ORDER BY m.mod_id", array($modulerow['mod_id']));
 
-                  $modulePath = "";
-                  $added        = "";
-                if ($modulerow['type'] == 0) {
-                    $modulePath = $GLOBALS['customModDir'];
-                    $added        = "";
-                } else {
-                    $added      = "index";
-                    $modulePath = $GLOBALS['zendModDir'];
-                }
-
-                if (sqlNumRows($module_hooks) == 0) {
-                    // module without hooks in module section
-                    $acl_section = strtolower($modulerow['mod_directory']);
-                    $disallowed[$acl_section] = zh_acl_check($_SESSION['authUserID'], $acl_section) ?  "" : "1";
-
-                    $relative_link ="modules/".$modulePath."/".$modulerow['mod_relative_link'].$added;
-                    $mod_nick_name = $modulerow['mod_nick_name'] ? $modulerow['mod_nick_name'] : $modulerow['mod_name'];
-                     genMiscLink2('RTop', $acl_section, '0', xl($mod_nick_name), $relative_link);
-                } else {
-                  // module with hooks in module section
-                    $jid = 0;
-                    $modid = '';
-                    while ($hookrow = sqlFetchArray($module_hooks)) {
-                        $disallowed[$hookrow['obj_name']] = !$disallowed['adm'] || zh_acl_check($_SESSION['authUserID'], $hookrow['obj_name']) ?  "" : "1";
-
-                        $relative_link ="modules/".$modulePath."/".$hookrow['mod_relative_link'].$hookrow['path'];
-                        $mod_nick_name = $hookrow['menu_name'] ? $hookrow['menu_name'] : 'NoName';
-
-                        if ($jid==0 || ($modid!=$hookrow['mod_id'])) {
-                            if ($modid!='') {
-                                echo "</ul>";
-                            }
-                            ?>
-                          <li><a class="collapsed_lv2"><span><?php echo xlt($hookrow['mod_ui_name']); ?></span></a>
-                            <ul>
-                                <?php
-                        }
-
-                          $jid++;
-                          $modid = $hookrow['mod_id'];
-                          genMiscLink('RTop', $hookrow['obj_name'], '0', xl($mod_nick_name), $relative_link);
-                    }
-
-                      echo "</ul>";
-                }
-            }
-                    ?>
-            <?php
-        } ?>
+        $moduleMenuContainer = genModuleMenuObject('Modules', 'modimg');
+        // updated menu's have already been filtered for security
+        $updatedMenuEvent = $GLOBALS["kernel"]->getEventDispatcher()->dispatch(MenuEvent::MENU_UPDATE, new MenuEvent([$moduleMenuContainer]));
+        $updatedSecurityEvent = $GLOBALS["kernel"]->getEventDispatcher()->dispatch(MenuEvent::MENU_RESTRICT, new MenuEvent($updatedMenuEvent->getMenu()));
+        $updatedMenuItems = $updatedSecurityEvent->getMenu();
+        genModuleMenuFromMenuItems($updatedSecurityEvent->getMenu(), $disallowed);
+        ?>
     </ul>
    </li>
 
@@ -1581,45 +1598,13 @@ if ($reglastcat) {
   <li><a class="collapsed" id="repimg" ><span><?php echo xlt('Reports') ?></span></a>
     <ul>
                 <?php
-                $module_query = sqlStatement("SELECT msh.*,ms.obj_name,ms.menu_name,ms.path,m.mod_ui_name,m.type FROM modules_hooks_settings AS msh LEFT OUTER JOIN modules_settings AS ms ON
-                                    obj_name=enabled_hooks AND ms.mod_id=msh.mod_id LEFT OUTER JOIN modules AS m ON m.mod_id=ms.mod_id
-                                    WHERE fld_type=3 AND mod_active=1 AND sql_run=1 AND attached_to='reports' ORDER BY mod_id");
-                if (sqlNumRows($module_query)) {
-                    $jid = 0;
-                    $modid = '';
-                    while ($modulerow = sqlFetchArray($module_query)) {
-                        $modulePath = "";
-                        $added      = "";
-                        if ($modulerow['type'] == 0) {
-                            $modulePath = $GLOBALS['customModDir'];
-                            $added      = "";
-                        } else {
-                            $added      = "index";
-                            $modulePath = $GLOBALS['zendModDir'];
-                        }
-
-                        $disallowed[$modulerow['obj_name']] = !$disallowed['adm'] || zh_acl_check($_SESSION['authUserID'], $modulerow['obj_name']) ?  "" : "1";
-
-                        $relative_link ="modules/".$modulePath."/".$modulerow['mod_relative_link'].$modulerow['path'];
-                        $mod_nick_name = $modulerow['menu_name'] ? $modulerow['menu_name'] : 'NoName';
-
-                        if ($jid==0 || ($modid!=$modulerow['mod_id'])) {
-                            if ($modid!='') {
-                                echo "</ul>";
-                            }
-                        ?>
-                        <li><a class="collapsed_lv2"><span><?php echo xlt($modulerow['mod_ui_name']); ?></span></a>
-                            <ul>
-                        <?php
-                        }
-
-                        $jid++;
-                        $modid = $modulerow['mod_id'];
-                        genMiscLink('RTop', $modulerow['obj_name'], '0', xl($mod_nick_name), $relative_link);
-                    }
-
-                    echo "</ul>";
-                } ?>
+                $moduleMenuContainer = genModuleMenuObject('Reports', 'repimg');
+                // updated menu's have already been filtered for security
+                $updatedMenuEvent = $GLOBALS["kernel"]->getEventDispatcher()->dispatch(MenuEvent::MENU_UPDATE, new MenuEvent([$moduleMenuContainer]));
+                $updatedSecurityEvent = $GLOBALS["kernel"]->getEventDispatcher()->dispatch(MenuEvent::MENU_RESTRICT, new MenuEvent($updatedMenuEvent->getMenu()));
+                $updatedMenuItems = $updatedSecurityEvent->getMenu();
+                genModuleMenuFromMenuItems($updatedSecurityEvent->getMenu(), $disallowed);
+         ?>
 
         <?php if (acl_check('patients', 'demo') || acl_check('patients', 'med') ||
         (acl_check('patients', 'rx') && !$GLOBALS['disable_prescriptions'])) { ?>

--- a/interface/main/left_nav.php
+++ b/interface/main/left_nav.php
@@ -388,7 +388,8 @@ function genFindBlock()
  * as the rest of the menu item code relies on that.
  * @param $modUrl The full absolute url for the module
  */
-function genModUrl($modUrl) {
+function genModUrl($modUrl)
+{
     return substr($modUrl, strlen('/interface') +1);
 }
 
@@ -400,7 +401,8 @@ function genModUrl($modUrl) {
  * @param $modId The unique id of the module.
  * @return stdClass
  */
-function genModuleMenuObject($moduleName, $modId) {
+function genModuleMenuObject($moduleName, $modId)
+{
     $moduleMenuContainer=new \stdClass();
     $moduleMenuContainer->label=xlt($moduleName);
     $moduleMenuContainer->url= '';
@@ -409,7 +411,6 @@ function genModuleMenuObject($moduleName, $modId) {
     $moduleMenuContainer->target='mod';
     $moduleMenuContainer->children = [];
     return $moduleMenuContainer;
-
 }
 
 /**
@@ -418,7 +419,8 @@ function genModuleMenuObject($moduleName, $modId) {
  * @param $navMenuItems  The tree object structure.  @see genModuleMenuObject for the structure of this array.
  * @param $disallowed A hashmap of acl restrictions.
  */
-function genModuleMenuFromMenuItems($navMenuItems, $disallowed) {
+function genModuleMenuFromMenuItems($navMenuItems, $disallowed)
+{
     // there's only one menu item in this case
     if (!empty($navMenuItems[0])) {
         foreach ($navMenuItems[0]->children as $menuItem) {
@@ -441,8 +443,7 @@ function genModuleMenuFromMenuItems($navMenuItems, $disallowed) {
                 <?php
             }
         }
-    }
-    else {
+    } else {
         error_log("System error.  MENU_UPDATE event did not return a valid menu object back");
     }
 }
@@ -1604,7 +1605,7 @@ if ($reglastcat) {
                 $updatedSecurityEvent = $GLOBALS["kernel"]->getEventDispatcher()->dispatch(MenuEvent::MENU_RESTRICT, new MenuEvent($updatedMenuEvent->getMenu()));
                 $updatedMenuItems = $updatedSecurityEvent->getMenu();
                 genModuleMenuFromMenuItems($updatedSecurityEvent->getMenu(), $disallowed);
-         ?>
+?>
 
         <?php if (acl_check('patients', 'demo') || acl_check('patients', 'med') ||
         (acl_check('patients', 'rx') && !$GLOBALS['disable_prescriptions'])) { ?>

--- a/interface/main/left_nav.php
+++ b/interface/main/left_nav.php
@@ -404,7 +404,7 @@ function genModUrl($modUrl)
 function genModuleMenuObject($moduleName, $modId)
 {
     $moduleMenuContainer=new \stdClass();
-    $moduleMenuContainer->label=xlt($moduleName);
+    $moduleMenuContainer->label=xl($moduleName);
     $moduleMenuContainer->url= '';
     $moduleMenuContainer->menu_id = $modId;
     $moduleMenuContainer->requirement=0;
@@ -429,7 +429,7 @@ function genModuleMenuFromMenuItems($navMenuItems, $disallowed)
                 genMiscLink2('RTop', $acl_section, '0', $menuItem->label, genModUrl($menuItem->url));
             } else if (!$disallowed['adm']) { // admin are not allowed hook settings...
                 ?>
-                <li><a class="collapsed_lv2"><span><?= $menuItem->label; ?></span></a>
+                <li><a class="collapsed_lv2"><span><?php echo text($menuItem->label); ?></span></a>
 
                     <ul>
                         <?php

--- a/interface/main/tabs/menu/menu_json.php
+++ b/interface/main/tabs/menu/menu_json.php
@@ -15,7 +15,7 @@
 use OpenEMR\Menu\MainMenuRole;
 
 // Collect the menu then build it
-$menuMain = new MainMenuRole();
+$menuMain = new MainMenuRole($GLOBALS['kernel']->getEventDispatcher());
 $menu_restrictions = $menuMain->getMenu();
 ?>
 <script type="text/javascript">

--- a/interface/modules/zend_modules/module/Application/Module.php
+++ b/interface/modules/zend_modules/module/Application/Module.php
@@ -16,11 +16,20 @@ use Application\Model\ApplicationTable;
 use Application\Model\SendtoTable;
 use Zend\Mvc\ModuleRouteListener;
 use Zend\Mvc\MvcEvent;
+use Application\Listener\ModuleMenuSubscriber;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class Module
 {
     public function onBootstrap(MvcEvent $e)
     {
+        // @see https://stackoverflow.com/a/21601229/7884612 for how to debug this.
+        // UNCOMMENT THESE TWO LINES IF YOU WANT TO SEE THE REGISTERED FACTORIES FOR DEBUGGING
+        // $config = $e->getApplication()->getServiceManager()->get('Config');
+        // echo "<pre><h1>Factories</h1>";
+        // var_dump(array_keys($config['service_manager']['factories']));
+        // echo "</pre>";
+
         /**
          * Determines if the module namespace should be prepended to the controller name.
          * This is the case if the route match contains a parameter key matching the MODULE_NAMESPACE constant.
@@ -29,10 +38,10 @@ class Module
         $moduleRouteListener = new ModuleRouteListener();
         $moduleRouteListener->attach($eventManager);
 
-        // @see https://stackoverflow.com/a/21601229/7884612 for how to debug this.
-        // UNCOMMENT THESE TWO LINES IF YOU WANT TO SEE THE REGISTERED FACTORIES FOR DEBUGGING
-        // $config = $e->getApplication()->getServiceManager()->get('Config');
-        // error_log("Factories: " . var_export(array_keys($config['service_manager']['factories']), true));
+        $serviceManager = $e->getApplication()->getServiceManager();
+        $oemrDispatcher = $serviceManager->get(EventDispatcherInterface::class);
+        $menuSubscriber = $serviceManager->get(ModuleMenuSubscriber::class);
+        $oemrDispatcher->addSubscriber($menuSubscriber);
     }
 
     public function getConfig()

--- a/interface/modules/zend_modules/module/Application/config/module.config.php
+++ b/interface/modules/zend_modules/module/Application/config/module.config.php
@@ -13,11 +13,14 @@ namespace Application;
 
 use Application\Controller\IndexController;
 use Application\Listener\Listener;
+use Application\Listener\ModuleMenuSubscriber;
 use Zend\Router\Http\Literal;
 use Zend\Router\Http\Segment;
 use Zend\ServiceManager\Factory\InvokableFactory;
 use Zend\Mvc\I18n\TranslatorFactory;
 use Interop\Container\ContainerInterface;
+use OpenEmr\Core\Kernel;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 //
 return array(
@@ -136,7 +139,8 @@ return array(
             },
             \Application\Controller\SendtoController::class => function (ContainerInterface $container, $requestedName) {
                 return new \Application\Controller\SendtoController($container->get(\Application\Model\ApplicationTable::class), $container->get(\Application\Model\SendtoTable::class));
-            }
+            },
+            ModuleMenuSubscriber::class => InvokableFactory::class
         ),
     ),
     'view_manager' => array(

--- a/interface/modules/zend_modules/module/Application/src/Application/Listener/ModuleMenuSubscriber.php
+++ b/interface/modules/zend_modules/module/Application/src/Application/Listener/ModuleMenuSubscriber.php
@@ -29,9 +29,8 @@ use OpenEMR\Menu\MenuEvent;
  */
 class ModuleMenuSubscriber implements EventSubscriberInterface
 {
-
-    public function __construct() {
-
+    public function __construct()
+    {
     }
 
     public static function getSubscribedEvents()
@@ -50,16 +49,16 @@ class ModuleMenuSubscriber implements EventSubscriberInterface
      * @param MenuEvent $menu
      * @return MenuEvent
      */
-    public function onMenuUpdate(MenuEvent $menu) {
+    public function onMenuUpdate(MenuEvent $menu)
+    {
         $menuItems = $menu->getMenu();
         // we are working with objects so this will modify the objects in memory
         foreach ($menuItems as $menuItem) {
             // We don't use the label as the menu's have been translated at this point
             // We want to update the modules
-            if ($menuItem->menu_id === 'modimg') { 
+            if ($menuItem->menu_id === 'modimg') {
                 $this->updateModulesModulesMenu($menuItem);
-            }
-            else if ($menuItem->menu_id === 'repimg') {
+            } elseif ($menuItem->menu_id === 'repimg') {
                 $this->updateModulesReportsMenu($menuItem);
             }
         }
@@ -70,18 +69,19 @@ class ModuleMenuSubscriber implements EventSubscriberInterface
      * If we need to adjust anything in the menu's permissions for the modules
      * we can do that work here..
      */
-    public function onMenuRestrict(MenuEvent $menu) {
+    public function onMenuRestrict(MenuEvent $menu)
+    {
         return $menu;
     }
 
-     /**
-      * Load modules created by modules system  This was originally in the core codebase but has been moved into the
-      * module system as it really deals with module code.
-      * @param $menu_list
-      */
+    /**
+     * Load modules created by modules system  This was originally in the core codebase but has been moved into the
+     * module system as it really deals with module code.
+     * @param $menu_list
+     */
     private function updateModulesModulesMenu(&$menu_list)
     {
-        // TODO: there's a lot of globals here.. these really need to be injected or extracted 
+        // TODO: there's a lot of globals here.. these really need to be injected or extracted
         // out so we can test these things...
         $module_query = sqlStatement("select mod_id,mod_directory,mod_name,mod_nick_name,mod_relative_link,type from modules where mod_active = 1 AND sql_run= 1 order by mod_ui_order asc");
         if (sqlNumRows($module_query)) {

--- a/interface/modules/zend_modules/module/Application/src/Application/Listener/ModuleMenuSubscriber.php
+++ b/interface/modules/zend_modules/module/Application/src/Application/Listener/ModuleMenuSubscriber.php
@@ -1,0 +1,211 @@
+<?php
+
+/**
+ * MainMenuRole class.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2017-2018 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2019 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace Application\Listener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use OpenEMR\Menu\MenuEvent;
+
+/**
+ * Class ModuleMenuSubscriber
+ * @package Application\Listener
+ *
+ * Listens to OpenEMR menu events and adds menu items to the menu structure based upon which modules
+ * have been installed through the Zend Module system.
+ *
+ * This can be used as an example of how to use the OpenEMR event dispatcher and the module system to extend the
+ * codebase without modifying the core OpenEMR files.  This facilitates easier upgrading and clean separations of concerns.
+ */
+class ModuleMenuSubscriber implements EventSubscriberInterface
+{
+
+    public function __construct() {
+
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            MenuEvent::MENU_UPDATE => 'onMenuUpdate',
+            MenuEvent::MENU_RESTRICT => 'onMenuRestrict'
+        ];
+    }
+
+    /**
+     * We inject our module system menu updates when the OpenEMR menu system has been updated.
+     * In this case we add any modules that have registered as 'hook's to the Modules sub menu
+     * and the reports sub menu.
+     *
+     * @param MenuEvent $menu
+     * @return MenuEvent
+     */
+    public function onMenuUpdate(MenuEvent $menu) {
+        $menuItems = $menu->getMenu();
+        // we are working with objects so this will modify the objects in memory
+        foreach ($menuItems as $menuItem) {
+            // We don't use the label as the menu's have been translated at this point
+            // We want to update the modules
+            if ($menuItem->menu_id === 'modimg') { 
+                $this->updateModulesModulesMenu($menuItem);
+            }
+            else if ($menuItem->menu_id === 'repimg') {
+                $this->updateModulesReportsMenu($menuItem);
+            }
+        }
+        return $menu;
+    }
+
+    /**
+     * If we need to adjust anything in the menu's permissions for the modules
+     * we can do that work here..
+     */
+    public function onMenuRestrict(MenuEvent $menu) {
+        return $menu;
+    }
+
+     /**
+      * Load modules created by modules system  This was originally in the core codebase but has been moved into the
+      * module system as it really deals with module code.
+      * @param $menu_list
+      */
+    private function updateModulesModulesMenu(&$menu_list)
+    {
+        // TODO: there's a lot of globals here.. these really need to be injected or extracted 
+        // out so we can test these things...
+        $module_query = sqlStatement("select mod_id,mod_directory,mod_name,mod_nick_name,mod_relative_link,type from modules where mod_active = 1 AND sql_run= 1 order by mod_ui_order asc");
+        if (sqlNumRows($module_query)) {
+            while ($modulerow = sqlFetchArray($module_query)) {
+                $module_hooks =  sqlStatement("SELECT msh.*,ms.obj_name,ms.menu_name,ms.path,m.mod_ui_name,m.type, m.mod_relative_link FROM modules_hooks_settings AS msh LEFT OUTER JOIN modules_settings AS ms ON
+                                    obj_name=enabled_hooks AND ms.mod_id=msh.mod_id LEFT OUTER JOIN modules AS m ON m.mod_id=ms.mod_id
+                                    WHERE m.mod_id = ? AND fld_type=3 AND mod_active=1 AND sql_run=1 AND attached_to='modules' ORDER BY m.mod_id", array($modulerow['mod_id']));
+
+                $modulePath = "";
+                $added      = "";
+                if ($modulerow['type'] == 0) {
+                    $modulePath = $GLOBALS['customModDir'];
+                    $added      = "";
+                } else {
+                    $added      = "index";
+                    $modulePath = $GLOBALS['zendModDir'];
+                }
+
+                $relative_link ="/interface/modules/".$modulePath."/".$modulerow['mod_relative_link'].$added;
+                $mod_nick_name = $modulerow['mod_nick_name'] ? $modulerow['mod_nick_name'] : $modulerow['mod_name'];
+
+                if (sqlNumRows($module_hooks) == 0) {
+                    // module without hooks in module section
+                    $acl_section = strtolower($modulerow['mod_directory']);
+                    if (zh_acl_check($_SESSION['authUserID'], $acl_section) ?  "" : "1") {
+                        continue;
+                    }
+
+                    $newEntry=new \stdClass();
+                    $newEntry->label=xlt($mod_nick_name);
+                    $newEntry->url=$relative_link;
+                    $newEntry->requirement=0;
+                    $newEntry->target='mod';
+                    array_push($menu_list->children, $newEntry);
+                } else {
+                    // module with hooks in module section
+                    $newEntry=new \stdClass();
+                    $newEntry->requirement=0;
+                    $newEntry->icon="fa-caret-right";
+                    $newEntry->label=xlt($mod_nick_name);
+                    $newEntry->children=array();
+                    $jid = 0;
+                    $modid = '';
+                    while ($hookrow = sqlFetchArray($module_hooks)) {
+                        if (zh_acl_check($_SESSION['authUserID'], $hookrow['obj_name']) ?  "" : "1") {
+                            continue;
+                        }
+
+                        $relative_link ="/interface/modules/".$modulePath."/".$hookrow['mod_relative_link'].$hookrow['path'];
+                        $mod_nick_name = $hookrow['menu_name'] ? $hookrow['menu_name'] : 'NoName';
+
+                        if ($jid==0 || ($modid!=$hookrow['mod_id'])) {
+                            $subEntry=new \stdClass();
+                            $subEntry->requirement=0;
+                            $subEntry->target='mod';
+                            $subEntry->menu_id='mod0';
+                            $subEntry->label=xlt($mod_nick_name);
+                            $subEntry->url=$relative_link;
+                            $newEntry->children[] = $subEntry;
+                        }
+
+                        $jid++;
+                    }
+
+                    array_push($menu_list->children, $newEntry);
+                }
+            }
+        }
+    }
+
+    /**
+     * load reports created by modules system
+     * @param $menu_list  A tree of stdClass objects that represent a menu.
+     */
+    private function updateModulesReportsMenu(&$menu_list)
+    {
+        $module_query = sqlStatement("SELECT msh.*,ms.obj_name,ms.menu_name,ms.path,m.mod_ui_name,m.type FROM modules_hooks_settings AS msh LEFT OUTER JOIN modules_settings AS ms ON
+                                    obj_name=enabled_hooks AND ms.mod_id=msh.mod_id LEFT OUTER JOIN modules AS m ON m.mod_id=ms.mod_id
+                                    WHERE fld_type=3 AND mod_active=1 AND sql_run=1 AND attached_to='reports' ORDER BY mod_id");
+        $reportsHooks = array();
+        if (sqlNumRows($module_query)) {
+            $jid = 0;
+            $modid = '';
+
+            while ($hookrow = sqlFetchArray($module_query)) {
+                if ($hookrow['type'] == 0) {
+                    $modulePath = $GLOBALS['customModDir'];
+                    $added = "";
+                } else {
+                    $added = "index";
+                    $modulePath = $GLOBALS['zendModDir'];
+                }
+
+                if ($jid == 0 || ($modid != $hookrow['mod_id'])) {
+                    //create new label
+                    $newEntry = new \stdClass();
+                    $newEntry->requirement = 0;
+                    $newEntry->icon = "fa-caret-right";
+                    $newEntry->label = xlt($hookrow['mod_ui_name']);
+                    $newEntry->children = array();
+
+                    $reportsHooks[] = $newEntry;
+                    array_unshift($menu_list->children, $newEntry);
+                }
+
+                if (zh_acl_check($_SESSION['authUserID'], $hookrow['obj_name']) ?  "" : "1") {
+                    continue;
+                }
+
+                $relative_link = "/interface/modules/" . $modulePath . "/" . $hookrow['mod_relative_link'] . $hookrow['path'];
+                $mod_nick_name = $hookrow['menu_name'] ? $hookrow['menu_name'] : 'NoName';
+
+                $subEntry = new \stdClass();
+                $subEntry->requirement = 0;
+                $subEntry->target = 'rep';
+                $subEntry->menu_id = 'rep0';
+                $subEntry->label = xlt($mod_nick_name);
+                $subEntry->url = $relative_link;
+
+                $reportsHooks[count($reportsHooks)-1]->children[] = $subEntry;
+
+                $jid++;
+                $modid = $hookrow['mod_id'];
+            }
+        }
+    }
+}

--- a/interface/modules/zend_modules/public/index.php
+++ b/interface/modules/zend_modules/public/index.php
@@ -49,10 +49,9 @@ chdir(dirname(__DIR__));
 if (!empty($GLOBALS['modules_application'])) {
     // $time_start = microtime(true);
     // run the request lifecycle.  The application has already inited in the globals.php
-    $GLOBALS['modules_application']->run(); 
+    $GLOBALS['modules_application']->run();
     // $time_end = microtime(true);
     // echo "App runtime: " . ($time_end - $time_start) . "<br />";
-}
-else {
+} else {
     die("global modules_application is not defined.  Cannot run zend module request");
 }

--- a/interface/modules/zend_modules/public/index.php
+++ b/interface/modules/zend_modules/public/index.php
@@ -43,4 +43,16 @@ require_once(dirname(__FILE__)."/../../../../library/acl.inc");
 chdir(dirname(__DIR__));
 
 // Run the application!
-Zend\Mvc\Application::init(require 'config/application.config.php')->run();
+/** @var OpenEMR/Core/ModulesApplication
+ * Defined in globals.php
+*/
+if (!empty($GLOBALS['modules_application'])) {
+    // $time_start = microtime(true);
+    // run the request lifecycle.  The application has already inited in the globals.php
+    $GLOBALS['modules_application']->run(); 
+    // $time_end = microtime(true);
+    // echo "App runtime: " . ($time_end - $time_start) . "<br />";
+}
+else {
+    die("global modules_application is not defined.  Cannot run zend module request");
+}

--- a/interface/usergroup/user_admin.php
+++ b/interface/usergroup/user_admin.php
@@ -429,7 +429,7 @@ foreach (array(1 => xl('None'), 2 => xl('Only Mine'), 3 => xl('All')) as $key =>
   </td>
   <td>
     <?php
-    $menuMain = new MainMenuRole();
+    $menuMain = new MainMenuRole($GLOBALS['kernel']->getEventDispatcher());
     echo $menuMain->displayMenuRoleSelector($iter["main_menu_role"]);
     ?>
   </td>

--- a/interface/usergroup/usergroup_admin_add.php
+++ b/interface/usergroup/usergroup_admin_add.php
@@ -309,7 +309,7 @@ foreach (array(1 => xl('None'), 2 => xl('Only Mine'), 3 => xl('All')) as $key =>
   </td>
   <td>
     <?php
-    $menuMain = new MainMenuRole();
+    $menuMain = new MainMenuRole($GLOBALS['kernel']->getEventDispatcher());
     echo $menuMain->displayMenuRoleSelector();
     ?>
   </td>

--- a/src/Core/ModulesApplication.php
+++ b/src/Core/ModulesApplication.php
@@ -12,13 +12,15 @@
  */
 
 namespace OpenEMR\Core;
+
 use OpenEMR\Core\Kernel;
 use Zend\Mvc\Application;
 use Zend\Mvc\Service\ServiceManagerConfig;
 use Zend\ServiceManager\ServiceManager;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class ModulesApplication {
+class ModulesApplication
+{
     
     /**
      * The application reference pointer for the zend mvc modules application
@@ -26,13 +28,13 @@ class ModulesApplication {
      */
     private $application;
 
-    public function __construct(Kernel $kernel, $webRootPath, $modulePath, $zendModulePath) {
-
+    public function __construct(Kernel $kernel, $webRootPath, $modulePath, $zendModulePath)
+    {
         $zendConfigurationPath = $webRootPath . DIRECTORY_SEPARATOR . $modulePath . DIRECTORY_SEPARATOR . $zendModulePath;
         $configuration = require $zendConfigurationPath . DIRECTORY_SEPARATOR . 'config/application.config.php';
         
         // Prepare the service manager
-        // We customize this and skip using the static Zend\Mvc\Application::init in order to inject the 
+        // We customize this and skip using the static Zend\Mvc\Application::init in order to inject the
         // Symfony Kernel's EventListener that way we can bridge the two frameworks.
         $smConfig = isset($configuration['service_manager']) ? $configuration['service_manager'] : [];
         $smConfig = new ServiceManagerConfig($smConfig);
@@ -55,7 +57,8 @@ class ModulesApplication {
         $this->application = $serviceManager->get('Application')->bootstrap($listeners);
     }
 
-    public function run() {
+    public function run()
+    {
         $this->application->run();
     }
 }

--- a/src/Core/ModulesApplication.php
+++ b/src/Core/ModulesApplication.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * MainMenuRole class.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ *
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2019 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Core;
+use OpenEMR\Core\Kernel;
+use Zend\Mvc\Application;
+use Zend\Mvc\Service\ServiceManagerConfig;
+use Zend\ServiceManager\ServiceManager;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class ModulesApplication {
+    
+    /**
+     * The application reference pointer for the zend mvc modules application
+     * @var \Zend\Mvc\Application
+     */
+    private $application;
+
+    public function __construct(Kernel $kernel, $webRootPath, $modulePath, $zendModulePath) {
+
+        $zendConfigurationPath = $webRootPath . DIRECTORY_SEPARATOR . $modulePath . DIRECTORY_SEPARATOR . $zendModulePath;
+        $configuration = require $zendConfigurationPath . DIRECTORY_SEPARATOR . 'config/application.config.php';
+        
+        // Prepare the service manager
+        // We customize this and skip using the static Zend\Mvc\Application::init in order to inject the 
+        // Symfony Kernel's EventListener that way we can bridge the two frameworks.
+        $smConfig = isset($configuration['service_manager']) ? $configuration['service_manager'] : [];
+        $smConfig = new ServiceManagerConfig($smConfig);
+
+        $serviceManager = new ServiceManager();
+        $smConfig->configureServiceManager($serviceManager);
+        $serviceManager->setService('ApplicationConfig', $configuration);
+        $serviceManager->setService(EventDispatcherInterface::class, $kernel->getEventDispatcher());
+
+        // Load modules
+        $serviceManager->get('ModuleManager')->loadModules();
+
+        // Prepare list of listeners to bootstrap
+        $listenersFromAppConfig     = isset($configuration['listeners']) ? $configuration['listeners'] : [];
+        $config                     = $serviceManager->get('config');
+        $listenersFromConfigService = isset($config['listeners']) ? $config['listeners'] : [];
+
+        $listeners = array_unique(array_merge($listenersFromConfigService, $listenersFromAppConfig));
+
+        $this->application = $serviceManager->get('Application')->bootstrap($listeners);
+    }
+
+    public function run() {
+        $this->application->run();
+    }
+}

--- a/src/Menu/MainMenuRole.php
+++ b/src/Menu/MainMenuRole.php
@@ -12,14 +12,20 @@
 namespace OpenEMR\Menu;
 
 use OpenEMR\Services\UserService;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class MainMenuRole extends MenuRole
 {
 
     /**
+     * @var EventDispatcher
+     */
+    private $dispatcher;
+
+    /**
      * Constructor
      */
-    public function __construct()
+    public function __construct(EventDispatcherInterface $dispatcher)
     {
         // This is where the magic happens to support special menu items.
         //   An empty menu_update_map array is created in MenuRole class
@@ -27,8 +33,7 @@ class MainMenuRole extends MenuRole
         //   to functions in this class.
         parent::__construct();
         $this->menu_update_map["Visit Forms"]="updateVisitForms";
-        $this->menu_update_map["Modules"]="updateModulesModulesMenu";
-        $this->menu_update_map["Reports"]="updateModulesReportsMenu";
+        $this->dispatcher = $dispatcher;
     }
 
     /**
@@ -56,9 +61,13 @@ class MainMenuRole extends MenuRole
         }
 
         $this->menuUpdateEntries($menu_parsed);
+        $updatedMenuEvent = $this->dispatcher->dispatch(MenuEvent::MENU_UPDATE, new MenuEvent($menu_parsed));
+
         $menu_restrictions=array();
-        $this->menuApplyRestrictions($menu_parsed, $menu_restrictions);
-        return $menu_restrictions;
+        $this->menuApplyRestrictions($updatedMenuEvent->getMenu(), $menu_restrictions);
+        $updatedRestrictions = $this->dispatcher->dispatch(MenuEvent::MENU_RESTRICT, new MenuEvent($menu_restrictions));
+
+        return $updatedRestrictions->getMenu();
     }
 
     /**
@@ -109,138 +118,6 @@ class MainMenuRole extends MenuRole
         }
 
         return $mainMenuRole;
-    }
-
-    /**
-     * load modules created by modules system
-     * @param $menu_list
-     */
-    protected function updateModulesModulesMenu(&$menu_list)
-    {
-        $module_query = sqlStatement("select mod_id,mod_directory,mod_name,mod_nick_name,mod_relative_link,type from modules where mod_active = 1 AND sql_run= 1 order by mod_ui_order asc");
-        if (sqlNumRows($module_query)) {
-            while ($modulerow = sqlFetchArray($module_query)) {
-                $module_hooks =  sqlStatement("SELECT msh.*,ms.obj_name,ms.menu_name,ms.path,m.mod_ui_name,m.type, m.mod_relative_link FROM modules_hooks_settings AS msh LEFT OUTER JOIN modules_settings AS ms ON
-                                    obj_name=enabled_hooks AND ms.mod_id=msh.mod_id LEFT OUTER JOIN modules AS m ON m.mod_id=ms.mod_id
-                                    WHERE m.mod_id = ? AND fld_type=3 AND mod_active=1 AND sql_run=1 AND attached_to='modules' ORDER BY m.mod_id", array($modulerow['mod_id']));
-
-                $modulePath = "";
-                $added      = "";
-                if ($modulerow['type'] == 0) {
-                    $modulePath = $GLOBALS['customModDir'];
-                    $added      = "";
-                } else {
-                    $added      = "index";
-                    $modulePath = $GLOBALS['zendModDir'];
-                }
-
-                $relative_link ="/interface/modules/".$modulePath."/".$modulerow['mod_relative_link'].$added;
-                $mod_nick_name = $modulerow['mod_nick_name'] ? $modulerow['mod_nick_name'] : $modulerow['mod_name'];
-
-                if (sqlNumRows($module_hooks) == 0) {
-                    // module without hooks in module section
-                    $acl_section = strtolower($modulerow['mod_directory']);
-                    if (zh_acl_check($_SESSION['authUserID'], $acl_section) ?  "" : "1") {
-                        continue;
-                    }
-
-                    $newEntry=new \stdClass();
-                    $newEntry->label=xlt($mod_nick_name);
-                    $newEntry->url=$relative_link;
-                    $newEntry->requirement=0;
-                    $newEntry->target='mod';
-                    array_push($menu_list->children, $newEntry);
-                } else {
-                    // module with hooks in module section
-                    $newEntry=new \stdClass();
-                    $newEntry->requirement=0;
-                    $newEntry->icon="fa-caret-right";
-                    $newEntry->label=xlt($mod_nick_name);
-                    $newEntry->children=array();
-                    $jid = 0;
-                    $modid = '';
-                    while ($hookrow = sqlFetchArray($module_hooks)) {
-                        if (zh_acl_check($_SESSION['authUserID'], $hookrow['obj_name']) ?  "" : "1") {
-                            continue;
-                        }
-
-                        $relative_link ="/interface/modules/".$modulePath."/".$hookrow['mod_relative_link'].$hookrow['path'];
-                        $mod_nick_name = $hookrow['menu_name'] ? $hookrow['menu_name'] : 'NoName';
-
-                        if ($jid==0 || ($modid!=$hookrow['mod_id'])) {
-                            $subEntry=new \stdClass();
-                            $subEntry->requirement=0;
-                            $subEntry->target='mod';
-                            $subEntry->menu_id='mod0';
-                            $subEntry->label=xlt($mod_nick_name);
-                            $subEntry->url=$relative_link;
-                            $newEntry->children[] = $subEntry;
-                        }
-
-                        $jid++;
-                    }
-
-                    array_push($menu_list->children, $newEntry);
-                }
-            }
-        }
-    }
-
-    /**
-     * load reports created by modules system
-     * @param $menu_list
-     */
-    protected function updateModulesReportsMenu(&$menu_list)
-    {
-        $module_query = sqlStatement("SELECT msh.*,ms.obj_name,ms.menu_name,ms.path,m.mod_ui_name,m.type FROM modules_hooks_settings AS msh LEFT OUTER JOIN modules_settings AS ms ON
-                                    obj_name=enabled_hooks AND ms.mod_id=msh.mod_id LEFT OUTER JOIN modules AS m ON m.mod_id=ms.mod_id
-                                    WHERE fld_type=3 AND mod_active=1 AND sql_run=1 AND attached_to='reports' ORDER BY mod_id");
-        $reportsHooks = array();
-        if (sqlNumRows($module_query)) {
-            $jid = 0;
-            $modid = '';
-
-            while ($hookrow = sqlFetchArray($module_query)) {
-                if ($hookrow['type'] == 0) {
-                    $modulePath = $GLOBALS['customModDir'];
-                    $added = "";
-                } else {
-                    $added = "index";
-                    $modulePath = $GLOBALS['zendModDir'];
-                }
-
-                if ($jid == 0 || ($modid != $hookrow['mod_id'])) {
-                    //create new label
-                    $newEntry = new \stdClass();
-                    $newEntry->requirement = 0;
-                    $newEntry->icon = "fa-caret-right";
-                    $newEntry->label = xlt($hookrow['mod_ui_name']);
-                    $newEntry->children = array();
-
-                    $reportsHooks[] = $newEntry;
-                    array_unshift($menu_list->children, $newEntry);
-                }
-
-                if (zh_acl_check($_SESSION['authUserID'], $hookrow['obj_name']) ?  "" : "1") {
-                    continue;
-                }
-
-                $relative_link = "/interface/modules/" . $modulePath . "/" . $hookrow['mod_relative_link'] . $hookrow['path'];
-                $mod_nick_name = $hookrow['menu_name'] ? $hookrow['menu_name'] : 'NoName';
-
-                $subEntry = new \stdClass();
-                $subEntry->requirement = 0;
-                $subEntry->target = 'rep';
-                $subEntry->menu_id = 'rep0';
-                $subEntry->label = xlt($mod_nick_name);
-                $subEntry->url = $relative_link;
-
-                $reportsHooks[count($reportsHooks)-1]->children[] = $subEntry;
-
-                $jid++;
-                $modid = $hookrow['mod_id'];
-            }
-        }
     }
 
     // This creates menu entries for all encounter forms.

--- a/src/Menu/MenuEvent.php
+++ b/src/Menu/MenuEvent.php
@@ -10,9 +10,11 @@
  */
 
 namespace OpenEMR\Menu;
+
 use Symfony\Component\EventDispatcher\Event;
 
-class MenuEvent extends Event {
+class MenuEvent extends Event
+{
 
      /**
      * The UPDATE event occurs once a menu has been created and had it's update
@@ -51,7 +53,8 @@ class MenuEvent extends Event {
         return $this->menu;
     }
 
-    public function setMenu(array $menu) {
+    public function setMenu(array $menu)
+    {
         $this->menu = $menu;
     }
 }

--- a/src/Menu/MenuEvent.php
+++ b/src/Menu/MenuEvent.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * MainMenuRole class.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2019 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Menu;
+use Symfony\Component\EventDispatcher\Event;
+
+class MenuEvent extends Event {
+
+     /**
+     * The UPDATE event occurs once a menu has been created and had it's update
+     * menu map function called.  This allows other listeners to apply additional updates
+     * to the menu.
+     *
+     * This event allows you to change the controller that will handle the
+     * request.
+     *
+     */
+    const MENU_UPDATE = 'menu.update';
+
+    /**
+     * The RESTRICT event occurs once a menu has been created, updated, and now is applying security ACLs or
+     * filters against the menu to decide if the menu should be shown or not.
+     */
+    const MENU_RESTRICT = 'menu.restrict';
+
+
+
+    /** @var array The menu list */
+    private $menu;
+
+    public function __construct($menu = [])
+    {
+        $this->menu = $menu;
+    }
+
+    /**
+     * Get a list of menu items
+     *
+     * @return array Array of menu items
+     */
+    public function getMenu()
+    {
+        return $this->menu;
+    }
+
+    public function setMenu(array $menu) {
+        $this->menu = $menu;
+    }
+}


### PR DESCRIPTION
Event Dispatcher integration with Tab Menu system.  Moved all of the module menu code into the same code area as the rest of the module code.

Made it so we integrate the event dispatcher code in the OpenEMR system with the ZF3 module code.

Moved the module menu code outside of the core OpenEMR codebase into the module system which is where the code should belong as it creates and defines the module database code.

Added the Update and Restrict menu events (defined in Menu/MenuEvent) and tied them into the tabs interface as an example of how to use the EventDispatcher to hook into the main codebase to extend it.

All of this moves the code to be more S.O.L.I.D (https://en.wikipedia.org/wiki/SOLID) by modifying the module menu system.  The menu files in Core are closed for modification but Open for extension as well as better moving to Single Responsibility (SRP).

Change side nav to use tabs module code

The side navigation uses a different codebase that uses inline code instead of in memory objects for the initial menu structure.  Refactored the module code to leverage the existing Zend Module listener code that the tabs menu system uses.

This de-duplicates the module hooks code and centralizes it into the zend modules codebase.

This also illustrates the effectiveness of the event dispatcher as multiple places in the code can fire off the event and the same listeners can respond appropriately which decouples the systems.

below added by bradymiller:
Up for Grabs demo of this PR is here:
https://www.open-emr.org/wiki/index.php/Development_Demo#Lambda_-_Up_For_Grabs_Demo