### PR TITLE
weno-pass-fix

### DIFF
--- a/interface/weno/jsonScript.php
+++ b/interface/weno/jsonScript.php
@@ -88,7 +88,7 @@ foreach ($fill as $data) {
                 "facilityzip"     => $proData[0]['postal_code'],
                 "qualifier"       => $GLOBALS['weno_provider_id'] . ':' . $proData[0]['weno_prov_id'],
                 "wenoAccountId"   => $GLOBALS['weno_account_id'],
-                "wenoAccountPass" => $cryptoGen->decryptStandard($GLOBALS['weno_account_pass']),
+                "wenoAccountPass" => (($cryptoGen->cryptCheckStandard($GLOBALS['weno_account_pass'])) ? $cryptoGen->decryptStandard($GLOBALS['weno_account_pass']) : $GLOBALS['weno_account_pass']),
                 "wenoClinicId"    => $GLOBALS['weno_provider_id'] . ':' . $proData[0]['weno_prov_id']
             )
         ),


### PR DESCRIPTION
@sjpadgett ,
This is a quick fix to the weno password. The weno password is odd since it is included on install/upgrade in a decrypted form. And it will then get encrypted when the user does a save in Administration->Globals. So, this bug only shows up prior to that first save in Administration->Globals. I posted the fix for this issue and will bring it in when it passes travis.