### PR TITLE
remove twig

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -79,8 +79,6 @@
         <delete dir="${dir.vendor}/symfony/process/Tests" verbose="true"/>
         <delete dir="${dir.vendor}/symfony/translation/Tests" verbose="true"/>
         <delete dir="${dir.vendor}/symfony/yaml/Tests" verbose="true"/>
-        <delete dir="${dir.vendor}/twig/twig/doc" verbose="true"/>
-        <delete dir="${dir.vendor}/twig/twig/test" verbose="true"/>
         <delete dir="${dir.vendor}/yubico/u2flib-server/examples" verbose="true"/>
         <delete dir="${dir.vendor}/yubico/u2flib-server/tests" verbose="true"/>
     </target>

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
         "symfony/event-dispatcher" : "3.4.27",
         "symfony/http-foundation" : "3.4.27",
         "symfony/yaml" : "3.4.27",
-        "twig/twig" : "2.7.4",
         "vlucas/phpdotenv" : "3.3.3",
         "yubico/u2flib-server" : "1.0.2",
         "zendframework/zend-db" : "2.10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cc805e7a1e50752341e0b88dd2c5f6c2",
+    "content-hash": "0b8c97df42495a72f25b262c9eb3fbec",
     "packages": [
         {
             "name": "academe/authorizenet-objects",
@@ -4760,73 +4760,6 @@
                 "laravel"
             ],
             "time": "2019-02-05T01:37:29+00:00"
-        },
-        {
-            "name": "twig/twig",
-            "version": "v2.7.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/twigphp/Twig.git",
-                "reference": "ed9c49220e09bfaeb1ba4d48077c08a7b09908dd"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/ed9c49220e09bfaeb1ba4d48077c08a7b09908dd",
-                "reference": "ed9c49220e09bfaeb1ba4d48077c08a7b09908dd",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0",
-                "symfony/polyfill-ctype": "^1.8",
-                "symfony/polyfill-mbstring": "^1.3"
-            },
-            "require-dev": {
-                "psr/container": "^1.0",
-                "symfony/debug": "^2.7",
-                "symfony/phpunit-bridge": "^3.4.19|^4.1.8"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.7-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Twig_": "lib/"
-                },
-                "psr-4": {
-                    "Twig\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com",
-                    "homepage": "http://fabien.potencier.org",
-                    "role": "Lead Developer"
-                },
-                {
-                    "name": "Armin Ronacher",
-                    "email": "armin.ronacher@active-4.com",
-                    "role": "Project Founder"
-                },
-                {
-                    "name": "Twig Team",
-                    "homepage": "https://twig.symfony.com/contributors",
-                    "role": "Contributors"
-                }
-            ],
-            "description": "Twig, the flexible, fast, and secure template language for PHP",
-            "homepage": "https://twig.symfony.com",
-            "keywords": [
-                "templating"
-            ],
-            "time": "2019-03-23T14:28:58+00:00"
         },
         {
             "name": "vlucas/phpdotenv",

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -261,32 +261,6 @@ if (file_exists("{$webserver_root}/.env")) {
     $dotenv->load();
 }
 
-// @TODO This needs to be broken out to it's own function, but for time's sake
-// @TODO putting it here until we land on a good place. RD 2017-05-02
-
-$twigOptions = [
-    'debug' => false,
-];
-
-$twigLoader = new Twig_Loader_Filesystem();
-$twigEnv = new Twig_Environment($twigLoader, $twigOptions);
-
-if (array_key_exists('debug', $twigOptions) && $twigOptions['debug'] == true) {
-    $twigEnv->addExtension(new Twig_Extension_Debug());
-}
-
-$twigEnv->addGlobal('assets_dir', $GLOBALS['assets_static_relative']);
-$twigEnv->addGlobal('srcdir', $GLOBALS['srcdir']);
-$twigEnv->addGlobal('rootdir', $GLOBALS['rootdir']);
-$twigEnv->addFilter(new Twig_SimpleFilter('translate', function ($string) {
-    return xl($string);
-}));
-
-/** Twig_Loader */
-$GLOBALS['twigLoader'] = $twigLoader;
-/** Twig_Environment */
-$GLOBALS['twig'] = $twigEnv;
-
 // This will open the openemr mysql connection.
 require_once(dirname(__FILE__) . "/../library/sql.inc");
 

--- a/src/Core/Header.php
+++ b/src/Core/Header.php
@@ -52,11 +52,6 @@ class Header
      * Header::setupHeader('no_main-theme');
      * ```
      *
-     * Inside of a twig template (Parameters same as before):
-     * ```html
-     * {{ includeAsset() }}
-     * ```
-     *
      * Inside of a smarty template, use | (pipe) delimited string of key names
      * ```php
      * {headerTemplate}


### PR DESCRIPTION
This is throwing php deprecation errors in php 7.4(alpha), and realized we are not using twig anywhere in the current codebase. Seems easiest thing to do is to remove it (we can always add it back by reverting this commit in the future if anybody wishes to use twig).

@robertdown , making sure you are ok with this