### PR TITLE
Fixes #1524 CCDA Warnings, Dependency resolution in modules

### DIFF
--- a/interface/modules/zend_modules/module/Application/src/Application/Controller/SendtoController.php
+++ b/interface/modules/zend_modules/module/Application/src/Application/Controller/SendtoController.php
@@ -51,6 +51,7 @@ class SendtoController extends AbstractActionController
                                 'selected_form'       => $selected_cform,
                                 'listenerObject'      => $this->listenerObject,
                                 'ccda_components'     => $ccda_components,
+                                'download_format'     => [] // empty array, can be populated by SendToHieHelper...
                             ));
         if ($button_only == 1) {
             $this->layout('layout/embedded_button');

--- a/interface/modules/zend_modules/module/Carecoordination/config/module.config.php
+++ b/interface/modules/zend_modules/module/Carecoordination/config/module.config.php
@@ -1,6 +1,7 @@
 <?php
 namespace Carecoordination;
 
+use Documents\Plugin\Documents;
 use Zend\ServiceManager\Factory\InvokableFactory;
 use Zend\Router\Http\Segment;
 use Carecoordination\Controller\CarecoordinationController;
@@ -160,5 +161,24 @@ return array(
             SetupController::class => SetupControllerFactory::class,
             EncounterccdadispatchController::class => EncounterccdadispatchControllerFactory::class
         ),
+    ]
+    // These plugins classes get added as methods onto the module controllers.  So you can reference inside a controller
+    // that extends AbstractActionController.  An example below:
+    // $this->Documents() as it uses (in ZF3) AbstractActionController->AbstractController->__call to call the plugin's code.  Similar to duck-typing or mixins
+    // from other frameworks/languages.
+    // @see https://olegkrivtsov.github.io/using-zend-framework-3-book/html/en/Model_View_Controller/Controller_Plugins.html for more details.
+    // TODO: Note this is a weird dependency used in the CarecoordinationController class that should be revisited
+    ,'controller_plugins' => array(
+        'factories' => array(
+            'Documents' => function (ContainerInterface $container, $requestedName) {
+                return new \Documents\Plugin\Documents($container);
+            }
+        )
+    )
+    ,'module_dependencies' => [
+        'Ccr'
+        ,'Immunization'
+        ,'Syndromicsurveillance'
+        , 'Documents'       // Handles the saving and retrieving of embedded documents in this module.
     ]
 );

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php
@@ -866,7 +866,8 @@ class CarecoordinationController extends AbstractActionController
      * @param $table_name
      * @return array
      */
-    private function getRevAndApproveAuditArray($audit_master_id, $table_name) {
+    private function getRevAndApproveAuditArray($audit_master_id, $table_name)
+    {
         $audit = $this->getCarecoordinationTable()->createAuditArray($audit_master_id, $table_name);
         if (empty($audit[$table_name])) {
             $audit[$table_name] = []; // leave it empty so we don't fail in the template

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php
@@ -168,12 +168,10 @@ class CarecoordinationTable extends AbstractTableGateway
                     $func_name = $components_oids[$components[$i]['section']['templateId']['root']];
                     $this->$func_name($components[$i]);
                 }
-            }
-            else if (empty($components[$i]['section']['templateId'])) {
-		// uncomment for debugging information.
+            } else if (empty($components[$i]['section']['templateId'])) {
+                // uncomment for debugging information.
                 // error_log("section and template id empty for position $i " . var_export($components[$i], true));
-            }
-            else if (count($components[$i]['section']['templateId']) > 1) {
+            } else if (count($components[$i]['section']['templateId']) > 1) {
                 foreach ($components[$i]['section']['templateId'] as $key_1 => $value_1) {
                     if ($components_oids[$components[$i]['section']['templateId'][$key_1]['root']] != '') {
                         $func_name = $components_oids[$components[$i]['section']['templateId'][$key_1]['root']];
@@ -300,7 +298,6 @@ class CarecoordinationTable extends AbstractTableGateway
     {
         if ($allergy_array['act']['entryRelationship']['observation']['participant']['participantRole']['playingEntity']['code']['code'] != ''
             && $allergy_array['act']['entryRelationship']['observation']['participant']['participantRole']['playingEntity']['code']['code'] != 0) {
-
             $i = 1;
             // if there are already items here we want to add to them.
             if (!empty($this->ccda_data_array['field_name_value_array']['lists2'])) {
@@ -2653,7 +2650,7 @@ class CarecoordinationTable extends AbstractTableGateway
 
     public function InsertVitals($vitals_array, $pid, $revapprove = 1)
     {
-        if(empty($vitals_array)) {
+        if (empty($vitals_array)) {
             return;
         }
         $appTable = new ApplicationTable();

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php
@@ -29,6 +29,12 @@ class CarecoordinationTable extends AbstractTableGateway
 {
 
     protected $ccda_data_array;
+
+    public function __construct()
+    {
+        $this->ccda_data_array = [];
+    }
+
     /*
      * Fetch the category ID using category name
      *
@@ -154,19 +160,26 @@ class CarecoordinationTable extends AbstractTableGateway
             '2.16.840.1.113883.10.20.22.2.41'   => 'discharge_summary',
         );
 
-        for ($i = 0; $i <= count($components); $i++) {
-            if (count($components[$i]['section']['templateId']) > 1) {
+        for ($i = 0; $i < count($components); $i++) {
+            // the original code logic assumed there was more than one indexed array with a root key...
+            // however the new Zend XML reader returns a root value
+            if (!empty($components[$i]['section']['templateId']['root'])) {
+                if ($components_oids[$components[$i]['section']['templateId']['root']] != '') {
+                    $func_name = $components_oids[$components[$i]['section']['templateId']['root']];
+                    $this->$func_name($components[$i]);
+                }
+            }
+            else if (empty($components[$i]['section']['templateId'])) {
+		// uncomment for debugging information.
+                // error_log("section and template id empty for position $i " . var_export($components[$i], true));
+            }
+            else if (count($components[$i]['section']['templateId']) > 1) {
                 foreach ($components[$i]['section']['templateId'] as $key_1 => $value_1) {
                     if ($components_oids[$components[$i]['section']['templateId'][$key_1]['root']] != '') {
                         $func_name = $components_oids[$components[$i]['section']['templateId'][$key_1]['root']];
                         $this->$func_name($components[$i]);
                         break;
                     }
-                }
-            } else {
-                if ($components_oids[$components[$i]['section']['templateId']['root']] != '') {
-                    $func_name = $components_oids[$components[$i]['section']['templateId']['root']];
-                    $this->$func_name($components[$i]);
                 }
             }
         }
@@ -285,8 +298,15 @@ class CarecoordinationTable extends AbstractTableGateway
 
     public function fetch_allergy_value($allergy_array)
     {
-        if ($allergy_array['act']['entryRelationship']['observation']['participant']['participantRole']['playingEntity']['code']['code'] != '' && $allergy_array['act']['entryRelationship']['observation']['participant']['participantRole']['playingEntity']['code']['code'] != 0) {
-            $i = count($this->ccda_data_array['field_name_value_array']['lists2']) + 1;
+        if ($allergy_array['act']['entryRelationship']['observation']['participant']['participantRole']['playingEntity']['code']['code'] != ''
+            && $allergy_array['act']['entryRelationship']['observation']['participant']['participantRole']['playingEntity']['code']['code'] != 0) {
+
+            $i = 1;
+            // if there are already items here we want to add to them.
+            if (!empty($this->ccda_data_array['field_name_value_array']['lists2'])) {
+                $i += count($this->ccda_data_array['field_name_value_array']['lists2']);
+            }
+
             $this->ccda_data_array['field_name_value_array']['lists2'][$i]['type'] = 'allergy';
             $this->ccda_data_array['field_name_value_array']['lists2'][$i]['extension'] = $allergy_array['act']['id']['extension'];
             $this->ccda_data_array['field_name_value_array']['lists2'][$i]['begdate'] = $allergy_array['act']['effectiveTime']['low']['value'];
@@ -325,7 +345,11 @@ class CarecoordinationTable extends AbstractTableGateway
     public function fetch_medication_value($medication_data)
     {
         if ($medication_data['substanceAdministration']['consumable']['manufacturedProduct']['manufacturedMaterial']['code']['code'] != '' && $medication_data['substanceAdministration']['consumable']['manufacturedProduct']['manufacturedMaterial']['code']['code'] != 0) {
-            $i = count($this->ccda_data_array['field_name_value_array']['lists3']) + 1;
+            $i = 1;
+            if (!empty($this->ccda_data_array['field_name_value_array']['lists3'])) {
+                $i += count($this->ccda_data_array['field_name_value_array']['lists3']);
+            }
+
             $this->ccda_data_array['field_name_value_array']['lists3'][$i]['type'] = 'medication';
             $this->ccda_data_array['field_name_value_array']['lists3'][$i]['extension'] = $medication_data['substanceAdministration']['id']['extension'];
             $this->ccda_data_array['field_name_value_array']['lists3'][$i]['root'] = $medication_data['substanceAdministration']['id']['root'];
@@ -385,7 +409,10 @@ class CarecoordinationTable extends AbstractTableGateway
     public function fetch_medical_problem_value($medical_problem_data)
     {
         if ($medical_problem_data['act']['entryRelationship']['observation']['value']['code'] != '' && $medical_problem_data['act']['entryRelationship']['observation']['value']['code'] != 0) {
-            $i = count($this->ccda_data_array['field_name_value_array']['lists1']) + 1;
+            $i = 1;
+            if (!empty($this->ccda_data_array['field_name_value_array']['lists1'])) {
+                $i += count($this->ccda_data_array['field_name_value_array']['lists1']);
+            }
             $this->ccda_data_array['field_name_value_array']['lists1'][$i]['type'] = 'medical_problem';
             $this->ccda_data_array['field_name_value_array']['lists1'][$i]['extension'] = $medical_problem_data['act']['id']['extension'];
             $this->ccda_data_array['field_name_value_array']['lists1'][$i]['root'] = $medical_problem_data['act']['id']['root'];
@@ -421,7 +448,10 @@ class CarecoordinationTable extends AbstractTableGateway
     public function fetch_immunization_value($immunization_data)
     {
         if ($immunization_data['substanceAdministration']['consumable']['manufacturedProduct']['manufacturedMaterial']['code']['code'] != '' && $immunization_data['substanceAdministration']['consumable']['manufacturedProduct']['manufacturedMaterial']['code']['code'] != 0) {
-            $i = count($this->ccda_data_array['field_name_value_array']['immunization']) + 1;
+            $i = 1;
+            if (!empty($this->ccda_data_array['field_name_value_array']['immunization'])) {
+                $i += count($this->ccda_data_array['field_name_value_array']['immunization']);
+            }
             $this->ccda_data_array['field_name_value_array']['immunization'][$i]['extension'] = $immunization_data['substanceAdministration']['id']['extension'];
             $this->ccda_data_array['field_name_value_array']['immunization'][$i]['root'] = $immunization_data['substanceAdministration']['id']['root'];
             $this->ccda_data_array['field_name_value_array']['immunization'][$i]['administered_date'] = $immunization_data['substanceAdministration']['effectiveTime']['value'];
@@ -471,7 +501,10 @@ class CarecoordinationTable extends AbstractTableGateway
     public function fetch_procedure_value($procedure_data)
     {
         if ($procedure_data['procedure']['code']['code'] != '' && $procedure_data['procedure']['code']['code'] != 0) {
-            $i = count($this->ccda_data_array['field_name_value_array']['procedure']) + 1;
+            $i = 1;
+            if (!empty($this->ccda_data_array['field_name_value_array']['procedure'])) {
+                $i += count($this->ccda_data_array['field_name_value_array']['procedure']);
+            }
             $this->ccda_data_array['field_name_value_array']['procedure'][$i]['extension'] = $procedure_data['procedure']['id']['extension'];
             $this->ccda_data_array['field_name_value_array']['procedure'][$i]['root'] = $procedure_data['procedure']['id']['root'];
             $this->ccda_data_array['field_name_value_array']['procedure'][$i]['code'] = $procedure_data['procedure']['code']['code'];
@@ -515,7 +548,10 @@ class CarecoordinationTable extends AbstractTableGateway
 
     public function fetch_lab_result_value($lab_result_data)
     {
-                $i = count($this->ccda_data_array['field_name_value_array']['procedure_result']) + 1;
+        $i = 1;
+        if (!empty($this->ccda_data_array['field_name_value_array']['procedure_result'])) {
+            $i += count($this->ccda_data_array['field_name_value_array']['procedure_result']);
+        }
         foreach ($lab_result_data['organizer']['component'] as $key => $value) {
             if ($value['observation']['code']['code']) {
                 $this->ccda_data_array['field_name_value_array']['procedure_result'][$i]['extension'] = $lab_result_data['organizer']['id']['extension'];
@@ -565,7 +601,10 @@ class CarecoordinationTable extends AbstractTableGateway
     public function fetch_vital_sign_value($vital_sign_data)
     {
         if ($vital_sign_data['organizer']['component'][0]['observation']['effectiveTime']['value'] != '' && $vital_sign_data['organizer']['component'][0]['observation']['effectiveTime']['value'] != 0) {
-            $i = count($this->ccda_data_array['field_name_value_array']['vital_sign']) + 1;
+            $i = 1;
+            if (!empty($this->ccda_data_array['field_name_value_array']['vital_sign'])) {
+                $i += count($this->ccda_data_array['field_name_value_array']['vital_sign']);
+            }
             $this->ccda_data_array['field_name_value_array']['vital_sign'][$i]['extension'] = $vital_sign_data['organizer']['id']['extension'];
             $this->ccda_data_array['field_name_value_array']['vital_sign'][$i]['root'] = $vital_sign_data['organizer']['id']['root'];
             $this->ccda_data_array['field_name_value_array']['vital_sign'][$i]['date'] = $vital_sign_data['organizer']['component'][0]['observation']['effectiveTime']['value'];
@@ -620,11 +659,13 @@ class CarecoordinationTable extends AbstractTableGateway
             );
             $i = 0;
             $code = $social_history_data['observation']['templateId']['root'];
-            foreach ($this->ccda_data_array['field_name_value_array']['social_history'] as $key => $value) {
-                if (!array_key_exists($social_history_array[$code], $value)) {
-                    $i = $key;
-                } else {
-                    $i = count($this->ccda_data_array['field_name_value_array']['social_history']) + 1;
+            if (!empty($this->ccda_data_array['field_name_value_array']['social_history'])) {
+                foreach ($this->ccda_data_array['field_name_value_array']['social_history'] as $key => $value) {
+                    if (!array_key_exists($social_history_array[$code], $value)) {
+                        $i = $key;
+                    } else {
+                        $i = count($this->ccda_data_array['field_name_value_array']['social_history']) + 1;
+                    }
                 }
             }
 
@@ -658,7 +699,10 @@ class CarecoordinationTable extends AbstractTableGateway
     public function fetch_encounter_value($encounter_data)
     {
         if ($encounter_data['encounter']['effectiveTime']['value'] != 0 || $encounter_data['encounter']['effectiveTime']['low']['value'] != 0) {
-            $i = count($this->ccda_data_array['field_name_value_array']['encounter']) + 1;
+            $i = 1;
+            if (!empty($this->ccda_data_array['field_name_value_array']['encounter'])) {
+                $i += count($this->ccda_data_array['field_name_value_array']['encounter']);
+            }
             $this->ccda_data_array['field_name_value_array']['encounter'][$i]['extension'] = $encounter_data['encounter']['id']['extension'];
             $this->ccda_data_array['field_name_value_array']['encounter'][$i]['root'] = $encounter_data['encounter']['id']['root'];
             $this->ccda_data_array['field_name_value_array']['encounter'][$i]['date'] = $encounter_data['encounter']['effectiveTime']['value'] ? $encounter_data['encounter']['effectiveTime']['value'] : $encounter_data['encounter']['effectiveTime']['low']['value'];
@@ -706,7 +750,10 @@ class CarecoordinationTable extends AbstractTableGateway
     public function fetch_care_plan_value($care_plan_data)
     {
         if ($care_plan_data['act']['code']['code'] != '' && $care_plan_data['act']['code']['code'] != 0) {
-            $i = count($this->ccda_data_array['field_name_value_array']['care_plan']) + 1;
+            $i = 1;
+            if (!empty($this->ccda_data_array['field_name_value_array']['care_plan'])) {
+                $i += count($this->ccda_data_array['field_name_value_array']['care_plan']);
+            }
             $this->ccda_data_array['field_name_value_array']['care_plan'][$i]['extension'] = $care_plan_data['act']['templateId']['root'];
             $this->ccda_data_array['field_name_value_array']['care_plan'][$i]['root'] = $care_plan_data['act']['templateId']['root'];
             $this->ccda_data_array['field_name_value_array']['care_plan'][$i]['code'] = $care_plan_data['act']['code']['code'];
@@ -737,7 +784,10 @@ class CarecoordinationTable extends AbstractTableGateway
     public function fetch_functional_cognitive_status_value($functional_cognitive_status_data)
     {
         if ($functional_cognitive_status_data['observation']['value']['code'] != '' && $functional_cognitive_status_data['observation']['value']['code'] != 0) {
-            $i = count($this->ccda_data_array['field_name_value_array']['functional_cognitive_status']) + 1;
+            $i = 1;
+            if (!empty($this->ccda_data_array['field_name_value_array']['functional_cognitive_status'])) {
+                $i += count($this->ccda_data_array['field_name_value_array']['functional_cognitive_status']);
+            }
             $this->ccda_data_array['field_name_value_array']['functional_cognitive_status'][$i]['extension'] = $functional_cognitive_status_data['observation']['id']['extension'];
             $this->ccda_data_array['field_name_value_array']['functional_cognitive_status'][$i]['root'] = $functional_cognitive_status_data['observation']['id']['root'];
             $this->ccda_data_array['field_name_value_array']['functional_cognitive_status'][$i]['date'] = $functional_cognitive_status_data['observation']['effectiveTime']['low']['value'];
@@ -776,7 +826,10 @@ class CarecoordinationTable extends AbstractTableGateway
                 }
             }
         } else {
-            $i = count($this->ccda_data_array['field_name_value_array']['referral']) + 1;
+            $i = 1;
+            if (!empty($this->ccda_data_array['field_name_value_array']['referral'])) {
+                $i += count($this->ccda_data_array['field_name_value_array']['referral']);
+            }
             $this->ccda_data_array['field_name_value_array']['referral'][$i]['root'] = $referral_data['templateId']['root'];
             $this->ccda_data_array['field_name_value_array']['referral'][$i]['body'] = preg_replace("/\s+/", " ", $referral_data['text']['paragraph']);
 
@@ -804,7 +857,10 @@ class CarecoordinationTable extends AbstractTableGateway
 
     public function fetch_discharge_medications_value($discharge_medications_data)
     {
-                $i = count($this->ccda_data_array['field_name_value_array']['discharge_medication']) + 1;
+        $i = 1;
+        if (!empty($this->ccda_data_array['field_name_value_array']['discharge_medication'])) {
+            $i += count($this->ccda_data_array['field_name_value_array']['discharge_medication']);
+        }
                 $this->ccda_data_array['field_name_value_array']['discharge_medication'][$i]['extension']           = $discharge_medications_data['act']['id']['extension'];
                 $this->ccda_data_array['field_name_value_array']['discharge_medication'][$i]['root']                = $discharge_medications_data['act']['id']['root'];
                 $this->ccda_data_array['field_name_value_array']['discharge_medication'][$i]['begdate']             = $discharge_medications_data['act']['effectiveTime']['low']['value'];
@@ -851,7 +907,10 @@ class CarecoordinationTable extends AbstractTableGateway
 
     public function fetch_discharge_summary_value($discharge_summary_data)
     {
-        $i = count($this->ccda_data_array['field_name_value_array']['discharge_summary']) + 1;
+        $i = 1;
+        if (!empty($this->ccda_data_array['field_name_value_array']['discharge_summary'])) {
+            $i += count($this->ccda_data_array['field_name_value_array']['discharge_summary']);
+        }
         $this->ccda_data_array['field_name_value_array']['discharge_summary'][$i]['root'] = $discharge_summary_data['templateId']['root'];
                 $text =  preg_replace("/\s+/", " ", $discharge_summary_data['text']['content']);
         for ($j=0; $j<count($discharge_summary_data['text']['list']['item']); $j++) {
@@ -1234,7 +1293,7 @@ class CarecoordinationTable extends AbstractTableGateway
                        ORDER BY ad.entry_identification,ad.field_name";
             $result = $appTable->zQuery($query, array($table_name, $am_id));
         }
-
+        
         $records = array();
         foreach ($result as $res) {
             $records[$table_name][$res['entry_identification']][$res['field_name']] = $res['field_value'];
@@ -1896,6 +1955,11 @@ class CarecoordinationTable extends AbstractTableGateway
 
     public function buildLabArray($lab_array)
     {
+        // nothing to build if we are empty here.
+        if (empty($lab_array)) {
+            return [];
+        }
+
         $lab_results = array();
         $j = 0;
         foreach ($lab_array as $key => $value) {
@@ -1917,6 +1981,10 @@ class CarecoordinationTable extends AbstractTableGateway
 
     public function InsertLabResults($lab_results, $pid)
     {
+        if (empty($lab_results)) {
+            return;
+        }
+
         $appTable = new ApplicationTable();
         foreach ($lab_results as $key => $value) {
             $query_select_pro = "SELECT * FROM procedure_providers WHERE name = ?";
@@ -2390,6 +2458,10 @@ class CarecoordinationTable extends AbstractTableGateway
 
     public function InsertEncounter($enc_array, $pid, $revapprove = 1)
     {
+        if (empty($enc_array)) {
+            return;
+        }
+
         $appTable = new ApplicationTable();
         foreach ($enc_array as $key => $value) {
             $encounter_id = $appTable->generateSequenceID();
@@ -2581,6 +2653,9 @@ class CarecoordinationTable extends AbstractTableGateway
 
     public function InsertVitals($vitals_array, $pid, $revapprove = 1)
     {
+        if(empty($vitals_array)) {
+            return;
+        }
         $appTable = new ApplicationTable();
         foreach ($vitals_array as $key => $value) {
             if ($value['date'] != 0 && $revapprove == 0) {
@@ -2728,6 +2803,10 @@ class CarecoordinationTable extends AbstractTableGateway
 
     public function InsertProcedures($proc_array, $pid, $revapprove = 1)
     {
+        if (empty($proc_array)) {
+            return;
+        }
+
         $appTable = new ApplicationTable();
         foreach ($proc_array as $key => $value) {
             if ($value['date'] != 0 && $revapprove == 0) {
@@ -2863,6 +2942,11 @@ class CarecoordinationTable extends AbstractTableGateway
 
     public function InsertImmunization($imm_array, $pid, $revapprove = 1)
     {
+        // if we don't have any immunizations we aren't going to insert anything.
+        if (empty($imm_array)) {
+            return;
+        }
+
         $appTable = new ApplicationTable();
         $qc_select = "SELECT ct_id FROM code_types WHERE ct_key = ?";
         $c_result = $appTable->zQuery($qc_select, array('CVX'));
@@ -3104,6 +3188,10 @@ class CarecoordinationTable extends AbstractTableGateway
 
     public function InsertPrescriptions($pres_array, $pid, $revapprove = 1)
     {
+        if (empty($pres_array)) {
+            return;
+        }
+
         $appTable = new ApplicationTable();
         $oid_route = $unit_option_id = $oidu_unit = '';
         foreach ($pres_array as $key => $value) {
@@ -3352,6 +3440,10 @@ class CarecoordinationTable extends AbstractTableGateway
 
     public function InsertAllergies($allergy_array, $pid, $revapprove = 1)
     {
+        if (empty($allergy_array)) {
+            return;
+        }
+
         $appTable = new ApplicationTable();
         foreach ($allergy_array as $key => $value) {
             $active = 1;
@@ -3515,6 +3607,10 @@ class CarecoordinationTable extends AbstractTableGateway
 
     public function InsertMedicalProblem($med_pblm_array, $pid, $revapprove = 1)
     {
+        if (empty($med_pblm_array)) {
+            return;
+        }
+
         $appTable = new ApplicationTable();
         foreach ($med_pblm_array as $key => $value) {
             $activity = 1;
@@ -3636,6 +3732,10 @@ class CarecoordinationTable extends AbstractTableGateway
     }
     public function InsertCarePlan($care_plan_array, $pid, $revapprove = 1)
     {
+        if (empty($care_plan_array)) {
+            return;
+        }
+
         $newid = '';
         $appTable = new ApplicationTable();
         $res = $appTable->zQuery("SELECT MAX(id) as largestId FROM `form_care_plan`");
@@ -3679,6 +3779,9 @@ class CarecoordinationTable extends AbstractTableGateway
 
     public function InsertFunctionalCognitiveStatus($functional_cognitive_status_array, $pid, $revapprove = 1)
     {
+        if (empty($functional_cognitive_status_array)) {
+            return;
+        }
         $newid = '';
         $appTable = new ApplicationTable();
         $res = $appTable->zQuery("SELECT MAX(id) as largestId FROM `form_functional_cognitive_status`");
@@ -3728,6 +3831,10 @@ class CarecoordinationTable extends AbstractTableGateway
 
     public function InsertReferrals($arr_referral, $pid, $revapprove = 1)
     {
+        if (empty($arr_referral)) {
+            return;
+        }
+
         $appTable = new ApplicationTable();
         foreach ($arr_referral as $key => $value) {
             $query_insert = "INSERT INTO transactions(date,title,pid,groupname,user,authorized)VALUES(?,?,?,?,?,?)";

--- a/interface/modules/zend_modules/module/Carecoordination/view/carecoordination/carecoordination/upload.phtml
+++ b/interface/modules/zend_modules/module/Carecoordination/view/carecoordination/carecoordination/upload.phtml
@@ -173,6 +173,11 @@ echo $this->headScript()->prependFile($this->basePath() . '/js/autosuggest/autos
                     $('#form_ccda_import').submit();
                 }
             }
+            ,error: function(data) {
+                console.error("Error uploading one or more files. Data returned ", data);
+                $('#status1').hide('clip','',500,'');
+                alert("There was an error in uploading one or more of your files.  Please check your server logs")
+            }
         });
         status.setAbort(jqXHR);
     }
@@ -242,7 +247,10 @@ echo $this->headScript()->prependFile($this->basePath() . '/js/autosuggest/autos
             fd.append('upload','1');
 
             nameArr = files[i].name.split(".");
-            if(nameArr[1]!== 'xml') {
+
+            // if we have a file extension and it is not an XML file... then we're going to error out.
+            // this code handles cases like sample.ccd.xml which is why we don't just go strictly off array position.s
+            if(nameArr.length > 1 && nameArr.pop() !== 'xml') {
               if(fnames == '') {
                 fnames = files[i].name;
               }
@@ -437,7 +445,7 @@ echo $this->headScript()->prependFile($this->basePath() . '/js/autosuggest/autos
                 }
                 else{
                     ?>
-                    <div style="width: 60%; margin-left: auto; margin-right: auto; border: 1px solid #CCCCCC; text-align:center; padding: 30px; font-size: 15px; font-weight: bold; background: #f7f7f7;<?php if(count($this->details) > 0){ ?>display: none; <?php } ?>">
+                    <div style="width: 60%; margin-left: auto; margin-right: auto; border: 1px solid #CCCCCC; text-align:center; padding: 30px; font-size: 15px; font-weight: bold; background: #f7f7f7;<?php if(count($this->records) > 0){ ?>display: none; <?php } ?>">
                         <?php echo $this->listenerObject->z_xlt('Nothing to display');?>
                     </div>
                     <?php

--- a/interface/modules/zend_modules/module/Carecoordination/view/carecoordination/ccd/upload.phtml
+++ b/interface/modules/zend_modules/module/Carecoordination/view/carecoordination/ccd/upload.phtml
@@ -159,7 +159,10 @@
             fd.append('upload','1');
 
             nameArr = files[i].name.split(".");
-            if(nameArr[1]!== 'xml') {
+
+            // if we have a file extension and it is not an XML file... then we're going to error out.
+            // this code handles cases like sample.ccd.xml which is why we don't just go strictly off array position.s
+            if(nameArr.length > 1 && nameArr.pop() !== 'xml') {
               if(fnames == '') {
                 fnames = files[i].name;
               }
@@ -174,7 +177,8 @@
             sendFileToServer(fd,status);
         }
         if(fnames != '') {
-          alert('<?php echo $this->listenerObject->z_xlt("Can't upload");?> '+fnames);
+            console.error("Could not get file name. Files was of length " + files.length + ". Objects are: ", files);
+            alert('<?php echo $this->listenerObject->z_xlt("Can't upload");?> '+fnames);
         }
         $('#status1').show('clip','',500,'');
     }
@@ -249,7 +253,7 @@
                 }
                 else{
                     ?>
-                    <div style="width: 60%; margin-left: auto; margin-right: auto; border: 1px solid #CCCCCC; text-align:center; padding: 30px; font-size: 15px; font-weight: bold; background: #f7f7f7;<?php if(count($this->details) > 0){ ?>display: none; <?php } ?>">
+                    <div style="width: 60%; margin-left: auto; margin-right: auto; border: 1px solid #CCCCCC; text-align:center; padding: 30px; font-size: 15px; font-weight: bold; background: #f7f7f7;<?php if(count($this->records) > 0){ ?>display: none; <?php } ?>">
                         <?php echo $this->listenerObject->z_xlt('Nothing to display');?>
                     </div>
                     <?php

--- a/interface/modules/zend_modules/module/Ccr/config/module.config.php
+++ b/interface/modules/zend_modules/module/Ccr/config/module.config.php
@@ -71,4 +71,7 @@ return array(
 
         
     ]
+    ,'module_dependencies' => [
+        'Documents'       // Handles the saving and retrieving of embedded documents in this module.
+    ]
 );

--- a/interface/modules/zend_modules/module/Ccr/view/ccr/ccr/index.phtml
+++ b/interface/modules/zend_modules/module/Ccr/view/ccr/ccr/index.phtml
@@ -348,7 +348,7 @@ echo $this->headScript()->prependFile($this->basePath() . '/js/autosuggest/autos
       }
       else{
         ?>
-        <div style="width: 60%; margin-left: auto; margin-right: auto; border: 1px solid #CCCCCC; text-align:center; padding: 30px; font-size: 15px; font-weight: bold; background: #f7f7f7;<?php if(count($this->details) > 0){ ?>display: none; <?php } ?>">
+        <div style="width: 60%; margin-left: auto; margin-right: auto; border: 1px solid #CCCCCC; text-align:center; padding: 30px; font-size: 15px; font-weight: bold; background: #f7f7f7;<?php if(count($this->records) > 0){ ?>display: none; <?php } ?>">
             <?php echo $this->listenerObject->z_xlt('Nothing to display');?>
         </div>
         <?php

--- a/interface/modules/zend_modules/module/Documents/src/Documents/Controller/DocumentsController.php
+++ b/interface/modules/zend_modules/module/Documents/src/Documents/Controller/DocumentsController.php
@@ -37,6 +37,10 @@ class DocumentsController extends AbstractActionController
         return $this->documentsTable;
     }
 
+    public function getDocumentsPlugin() {
+        return $this->Documents();
+    }
+
   /*
   * Upload document
   */

--- a/interface/modules/zend_modules/module/Documents/src/Documents/Controller/DocumentsController.php
+++ b/interface/modules/zend_modules/module/Documents/src/Documents/Controller/DocumentsController.php
@@ -37,54 +37,55 @@ class DocumentsController extends AbstractActionController
         return $this->documentsTable;
     }
 
-    public function getDocumentsPlugin() {
+    public function getDocumentsPlugin()
+    {
         return $this->Documents();
     }
 
-  /*
-  * Upload document
-  */
+    /*
+    * Upload document
+    */
     public function uploadAction($request = null)
     {
         if (!$request) {
-            $request        = $this->getRequest();
+            $request = $this->getRequest();
         }
         if ($request->isPost()) {
-            $error          = false;
-            $files          = array();
-            $uploaddir      = $GLOBALS['OE_SITE_DIR'].'/documents/'.$request->getPost('file_location');
-            $pid            = $request->getPost('patient_id');
-            $encounter      = $request->getPost('encounter_id');
-            $batch_upload   = $request->getPost('batch_upload');
-            $category_id    = $request->getPost('document_category');
+            $error = false;
+            $files = array();
+            $uploaddir = $GLOBALS['OE_SITE_DIR'] . '/documents/' . $request->getPost('file_location');
+            $pid = $request->getPost('patient_id');
+            $encounter = $request->getPost('encounter_id');
+            $batch_upload = $request->getPost('batch_upload');
+            $category_id = $request->getPost('document_category');
             $encrypted_file = $request->getPost('encrypted_file');
             $encryption_key = $request->getPost('encryption_key');
             $storage_method = $GLOBALS['document_storage_method'];
             $documents = array();
-            $i         = 0;
+            $i = 0;
             foreach ($_FILES as $file) {
                 $i++;
-                $dateStamp      = date('Y-m-d-H-i-s');
-                $file_name      = $dateStamp."_".basename($file["name"]);
-                $file["name"]   = $file_name;
+                $dateStamp = date('Y-m-d-H-i-s');
+                $file_name = $dateStamp . "_" . basename($file["name"]);
+                $file["name"] = $file_name;
 
-                $documents[$i]  = array(
-                'name'        => $file_name,
-                'type'        => $file['type'],
-                'batch_upload'=> $batch_upload,
-                'storage'     => $storage_method,
-                'category_id' => $category_id,
-                'pid'         => $pid,
+                $documents[$i] = array(
+                    'name' => $file_name,
+                    'type' => $file['type'],
+                    'batch_upload' => $batch_upload,
+                    'storage' => $storage_method,
+                    'category_id' => $category_id,
+                    'pid' => $pid,
                 );
 
                 // Read File Contents
-                $tmpfile    = fopen($file['tmp_name'], "r");
-                $filetext   = fread($tmpfile, $file['size']);
+                $tmpfile = fopen($file['tmp_name'], "r");
+                $filetext = fread($tmpfile, $file['size']);
 
                 // Decrypt Encrypted File
                 if ($encrypted_file == '1') {
                     $cryptoGen = new CryptoGen();
-                    $plaintext  = $cryptoGen->decryptStandard($filetext, $encryption_key);
+                    $plaintext = $cryptoGen->decryptStandard($filetext, $encryption_key);
                     if ($plaintext === false) {
                         error_log("OpenEMR Error: Unable to decrypt a document since decryption failed.");
                         $plaintext = "";
@@ -99,15 +100,15 @@ class DocumentsController extends AbstractActionController
                     $file['size'] = filesize($file['tmp_name']);
                 }
 
-                $ob     = new \Document();
+                $ob = new \Document();
                 $ret = $ob->createDocument($pid, $category_id, $file_name, $file['type'], $filetext, '', 1, 0);
             }
         }
     }
 
-  /*
-  * Retrieve document
-  */
+    /*
+    * Retrieve document
+    */
     public function retrieveAction()
     {
 
@@ -119,25 +120,25 @@ class DocumentsController extends AbstractActionController
             'image/gif',
             'text/plain',
             'text/html',
-        'text/xml',
+            'text/xml',
         );
 
-        $request        = $this->getRequest();
-        $documentId     = $this->params()->fromRoute('id');
-        $doEncryption   = ($this->params()->fromRoute('doencryption') == '1') ? true : false;
-        $encryptionKey  = $this->params()->fromRoute('key');
-        $type           = ($this->params()->fromRoute('download') == '1') ? "attachment" : "inline";
+        $request = $this->getRequest();
+        $documentId = $this->params()->fromRoute('id');
+        $doEncryption = ($this->params()->fromRoute('doencryption') == '1') ? true : false;
+        $encryptionKey = $this->params()->fromRoute('key');
+        $type = ($this->params()->fromRoute('download') == '1') ? "attachment" : "inline";
 
-        $result         = $this->getDocumentsTable()->getDocument($documentId);
-        $skip_headers   = false;
-        $contentType    = $result['mimetype'];
+        $result = $this->getDocumentsTable()->getDocument($documentId);
+        $skip_headers = false;
+        $contentType = $result['mimetype'];
 
         // @see Documents/Plugin/Documents
-        $document       = $this->Documents()->getDocument($documentId, $doEncryption, $encryptionKey);
-        $categoryIds    = $this->getDocumentsTable()->getCategoryIDs(array('CCD','CCR','CCDA'));
-        if (in_array($result['category_id'], $categoryIds) && $contentType == 'text/xml'  && !$doEncryption) {
-            $xml          = simplexml_load_string($document);
-            $xsl          = new \DomDocument;
+        $document = $this->Documents()->getDocument($documentId, $doEncryption, $encryptionKey);
+        $categoryIds = $this->getDocumentsTable()->getCategoryIDs(array('CCD', 'CCR', 'CCDA'));
+        if (in_array($result['category_id'], $categoryIds) && $contentType == 'text/xml' && !$doEncryption) {
+            $xml = simplexml_load_string($document);
+            $xsl = new \DomDocument;
 
             switch ($result['category_id']) {
                 case $categoryIds['CCD']:
@@ -151,36 +152,36 @@ class DocumentsController extends AbstractActionController
                     break;
             };
 
-            $xsl->load(__DIR__.'/../../../../../public/xsl/'.$style);
-            $proc         = new \XSLTProcessor;
+            $xsl->load(__DIR__ . '/../../../../../public/xsl/' . $style);
+            $proc = new \XSLTProcessor;
             $proc->importStyleSheet($xsl);
-            $document     = $proc->transformToXML($xml);
+            $document = $proc->transformToXML($xml);
         }
 
-        if ($type=="inline" && !$doEncryption) {
+        if ($type == "inline" && !$doEncryption) {
             if (in_array($result['mimetype'], $previewAvailableFiles)) {
                 if (in_array($result['category_id'], $categoryIds) && $contentType == 'text/xml') {
-                    $contentType  = 'text/html';
+                    $contentType = 'text/html';
                 }
             } else {
                 $skip_headers = true;
             }
         } else {
             if ($doEncryption) {
-                $contentType  = "application/octet-stream";
+                $contentType = "application/octet-stream";
             } else {
-                $contentType  = $result['mimetype'];
+                $contentType = $result['mimetype'];
             }
         }
 
         if (!$skip_headers) {
-            $response       = $this->getResponse();
+            $response = $this->getResponse();
             $response->setContent($document);
-            $headers        = $response->getHeaders();
+            $headers = $response->getHeaders();
             $headers->clearHeaders()
-              ->addHeaderLine('Content-Type', $contentType)
-              ->addHeaderLine('Content-Disposition', $type . '; filename="' . $result['name'] . '"')
-              ->addHeaderLine('Content-Length', strlen($document));
+                ->addHeaderLine('Content-Type', $contentType)
+                ->addHeaderLine('Content-Disposition', $type . '; filename="' . $result['name'] . '"')
+                ->addHeaderLine('Content-Length', strlen($document));
             $response->setHeaders($headers);
             return $this->response;
         }

--- a/interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php
+++ b/interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php
@@ -195,7 +195,7 @@ class InstallerController extends AbstractActionController
         $postArr  = $request->getPost();
         //DELETE OLD HOOKS OF A MODULE
         $this->getInstallerTable()->deleteModuleHooks($postArr['mod_id']);
-        if (count($postArr['hook_hanger']) > 0) {
+        if (!empty($postArr['hook_hanger']) && count($postArr['hook_hanger']) > 0) {
             foreach ($postArr['hook_hanger'] as $hookId => $hooks) {
                 foreach ($hooks as $hangerId => $hookHanger) {
                     $this->getInstallerTable()->saveHooks($postArr['mod_id'], $hookId, $hangerId);

--- a/interface/modules/zend_modules/module/Installer/src/Installer/Model/InstModuleTable.php
+++ b/interface/modules/zend_modules/module/Installer/src/Installer/Model/InstModuleTable.php
@@ -35,6 +35,7 @@ class InstModuleTable
 
     /**
      * The path for the zend modules locations
+     *
      * @var string
      */
     private $module_zend_path;
@@ -51,7 +52,7 @@ class InstModuleTable
             . ".." . DIRECTORY_SEPARATOR . $GLOBALS['baseModDir'] . $GLOBALS['zendModDir'] . DIRECTORY_SEPARATOR . "module";
     }
 
-  /**
+    /**
    * Get All Modules Configuration Settings
    *
    * @return type
@@ -65,7 +66,7 @@ class InstModuleTable
         return $result;
     }
 
-  /**
+    /**
    *
    * @param type $dir
    * @return boolean
@@ -94,13 +95,14 @@ class InstModuleTable
         }
     }
 
-  /**
+    /**
    * Save Configuration Settings
-   *
    */
     public function saveSettings($fieldName, $fieldValue, $moduleId)
     {
-        /** Check the field exist */
+        /**
+ * Check the field exist
+*/
         $sql = "SELECT * FROM module_configuration
                       WHERE field_name = ?
                       AND module_id = ?";
@@ -130,12 +132,13 @@ class InstModuleTable
         }
     }
 
-  /**
+    /**
    * this will be used to register a module
-   * @param unknown_type $directory
-   * @param unknown_type $rel_path
-   * @param unknown_type $state
-   * @param unknown_type $base
+   *
+   * @param  unknown_type $directory
+   * @param  unknown_type $rel_path
+   * @param  unknown_type $state
+   * @param  unknown_type $base
    * @return boolean
    */
     public function register($directory, $rel_path, $state = 0, $base = "custom_modules")
@@ -212,8 +215,9 @@ class InstModuleTable
         return false;
     }
 
-  /**
+    /**
    * get the list of all modules
+   *
    * @return multitype:
    */
     public function allModules()
@@ -223,8 +227,9 @@ class InstModuleTable
         $result = $this->applicationTable->zQuery($sql, $params);
         return $result;
     }
-  /**
+    /**
    * get the list of all modules
+   *
    * @return multitype:
    */
     public function getInstalledModules()
@@ -244,8 +249,8 @@ class InstModuleTable
         return $all;
     }
 
-  /**
-   * @param int $id
+    /**
+   * @param int    $id
    * @param string $cols
    * @return Ambigous <boolean, unknown>
    */
@@ -265,10 +270,11 @@ class InstModuleTable
         return $mod;
     }
 
-  /**
+    /**
    * Function to enable/disable a module
-   * @param int         $id     Module PK
-   * @param string  $mod    Status
+   *
+   * @param int    $id  Module PK
+   * @param string $mod Status
    */
     public function updateRegistered($id, $mod = '', $values = '')
     {
@@ -311,9 +317,10 @@ class InstModuleTable
         return $resp;
     }
 
-  /**
+    /**
    * Function to get ACL objects for module
-   * @param int         $mod_id     Module PK
+   *
+   * @param int $mod_id Module PK
    */
     public function getSettings($type, $mod_id)
     {
@@ -343,7 +350,7 @@ class InstModuleTable
         return $all;
     }
 
-  /**
+    /**
    * Function to get Oemr User Group
    */
     public function getOemrUserGroup()
@@ -366,7 +373,7 @@ class InstModuleTable
 
         return $all;
     }
-  /**
+    /**
    * Function to get Oemr User Group and Aro Map
    */
     public function getOemrUserGroupAroMap()
@@ -392,7 +399,7 @@ class InstModuleTable
         return $all;
     }
 
-  /**
+    /**
    * Function to get Active Users
    */
     public function getActiveUsers()
@@ -430,7 +437,7 @@ class InstModuleTable
 
         return $all;
     }
-  /**
+    /**
    *Function To Get Active ACL for this Module
    */
     public function getActiveACL($mod_id)
@@ -463,7 +470,7 @@ class InstModuleTable
         return $arr;
     }
 
-  /**
+    /**
    *Function To Get Saved Hooks For this Module
    */
     public function getActiveHooks($mod_id)
@@ -482,7 +489,7 @@ class InstModuleTable
         return $all;
     }
 
-  /**
+    /**
    * Function to get Status of a Hook
    */
     public function getHookStatus($modId, $hookId, $hangerId)
@@ -505,7 +512,7 @@ class InstModuleTable
         }
     }
 
-  /**
+    /**
    * Function to Delete Hooks
    */
     public function saveHooks($modId, $hookId, $hangerId)
@@ -516,7 +523,7 @@ class InstModuleTable
         }
     }
 
-  /**
+    /**
    * Save Module Hook settings
    */
     public function saveModuleHookSettings($modId, $hook)
@@ -535,7 +542,7 @@ class InstModuleTable
         $this->applicationTable->zQuery($sql, $params);
     }
 
-  /**
+    /**
    * Function to Delete Hooks
    */
     public function DeleteHooks($post)
@@ -545,7 +552,7 @@ class InstModuleTable
         }
     }
 
-  /**
+    /**
    * Function to Delete Module Hooks
    */
     public function deleteModuleHooks($modId)
@@ -741,7 +748,7 @@ class InstModuleTable
         }
     }
 
-  //GET MODULE HOOKS FROM A FUNCTION IN CONFIGURATION MODEL CLASS
+    //GET MODULE HOOKS FROM A FUNCTION IN CONFIGURATION MODEL CLASS
     public function getModuleHooks($moduleDirectory)
     {
         $objHooks = $this->getObject($moduleDirectory, $option = 'Controller');
@@ -756,7 +763,7 @@ class InstModuleTable
     }
 
 
-  //GET MODULE ACL SECTIONS FROM A FUNCTION IN CONFIGURATION MODEL CLASS
+    //GET MODULE ACL SECTIONS FROM A FUNCTION IN CONFIGURATION MODEL CLASS
     public function getModuleAclSections($moduleDirectory)
     {
         $objHooks = $this->getObject($moduleDirectory, $option = 'Controller');
@@ -833,7 +840,7 @@ class InstModuleTable
         $obj->zQuery($sql, array($module_id));
     }
 
-  //GET DEPENDED MODULES OF A MODULE FROM A FUNCTION IN CONFIGURATION MODEL CLASS
+    //GET DEPENDED MODULES OF A MODULE FROM A FUNCTION IN CONFIGURATION MODEL CLASS
     public function getDependedModulesByDirectoryName($moduleDirectory)
     {
         $retArr = [];
@@ -846,7 +853,7 @@ class InstModuleTable
         return $retArr;
     }
 
-  /**
+    /**
    * Function to Save Module Hooks
    */
     public function saveModuleHooks($modId, $hookId, $hookTitle, $hookPath)
@@ -857,9 +864,8 @@ class InstModuleTable
         }
     }
 
-  /**
+    /**
    * Function to Save Module Hooks
-   *
    */
     public function deleteModuleHookSettings($modId)
     {
@@ -898,14 +904,14 @@ class InstModuleTable
         return $setup;
     }
 
-  /**
+    /**
    * Function getObject
    * Dynamically create Module Controller / Form / Setup Object
    * TODO: we should make sure the controller conforms to an interface as we are calling methods on here that are dynamic such as getAcl
    *
-   * @param string $moduleDirectory Module Directory Name
-   * @param string $option Controller / Form / Setup to create an Object
-   * @param type $adapter
+   * @param  string $moduleDirectory Module Directory Name
+   * @param  string $option          Controller / Form / Setup to create an Object
+   * @param  type   $adapter
    * @return type
    */
     public function getObject($moduleDirectory, $option = 'Controller', $adapter = '')
@@ -927,11 +933,11 @@ class InstModuleTable
         return $obj;
     }
 
-  /**
+    /**
    * validateNickName
-   * @param String $name nickname
-   * @return boolean Nickname available or not.
    *
+   * @param  String $name nickname
+   * @return boolean Nickname available or not.
    **/
     public function validateNickName($name)
     {
@@ -943,10 +949,12 @@ class InstModuleTable
 
     /**
      * Returns true if the given module at the module directory actually exists in the codebase
-     * @param $moduleDirectory The directory path of the module
+     *
+     * @param  $moduleDirectory The directory path of the module
      * @return bool
      */
-    private function existsModuleConfigFile($moduleDirectory) {
+    private function existsModuleConfigFile($moduleDirectory)
+    {
         $filePath = $this->getModuleConfigFilePathForDirectory($moduleDirectory);
         return file_exists($filePath);
     }
@@ -954,10 +962,12 @@ class InstModuleTable
     /**
      * Given a module directory we load the config file for the module.  This assumes a the config file exists
      * Use existsModuleConfigFile before calling this method.
-     * @param $moduleDirectory The directory path of the module
+     *
+     * @param  $moduleDirectory The directory path of the module
      * @return array|null  Array of the module config that was loaded or null if the file could not be loaded
      */
-    private function loadModuleConfigFile($moduleDirectory) {
+    private function loadModuleConfigFile($moduleDirectory)
+    {
         $filePath = $this->getModuleConfigFilePathForDirectory($moduleDirectory);
         if ($filePath === null) {
             error_log("Module config file does not exist for module directory " . errorLogEscape($moduleDirectory));
@@ -973,10 +983,12 @@ class InstModuleTable
 
     /**
      * For the given module directory return the file path for the config class
-     * @param $moduleDirectory The directory path of the module.
+     *
+     * @param  $moduleDirectory The directory path of the module.
      * @return string|null The filepath of the directory for the config file or null if there is none found
      */
-    private function getModuleConfigFilePathForDirectory($moduleDirectory) {
+    private function getModuleConfigFilePathForDirectory($moduleDirectory)
+    {
         // could add the custom here, but it doesn't use the ModuleConfig syntax..
         $searchDirectories = [
             $moduleDirectory
@@ -984,7 +996,7 @@ class InstModuleTable
         ];
         $fileSuffix = DIRECTORY_SEPARATOR . "config" . DIRECTORY_SEPARATOR . "module.config.php";
         foreach ($searchDirectories as $dir) {
-            if (file_exists($dir . $fileSuffix )) {
+            if (file_exists($dir . $fileSuffix)) {
                 return $dir . $fileSuffix;
             }
         }

--- a/interface/modules/zend_modules/module/Syndromicsurveillance/view/syndromicsurveillance/syndromicsurveillance/index.phtml
+++ b/interface/modules/zend_modules/module/Syndromicsurveillance/view/syndromicsurveillance/syndromicsurveillance/index.phtml
@@ -160,7 +160,7 @@ $provider   = $this->provider;
         }
         else{
         ?>
-            <div style="width: 60%; margin-left: auto; margin-right: auto; border: 1px solid #CCCCCC; text-align:center; padding: 30px; font-size: 15px; font-weight: bold; background: #f7f7f7;<?php if(count($res) > 0){ ?>display: none; <?php } ?>">
+            <div style="width: 60%; margin-left: auto; margin-right: auto; border: 1px solid #CCCCCC; text-align:center; padding: 30px; font-size: 15px; font-weight: bold; background: #f7f7f7;<?php if(count($this->result) > 0){ ?>display: none; <?php } ?>">
                 <?php echo $this->listenerObject->z_xlt('Nothing to display');?>
             </div>
         <?php


### PR DESCRIPTION
Fixed a bunch of warnings in the CareCoordination module and broken code.  We broke the dependency resolution when we made modules load from the database so I fixed that.

It looks like the preview of data in the CCDA import process was broken and quite a few areas just didn't load any data.  Improved that significantly so both the review and approve as well as the import process do much more than basic demographics. Detailed breakdown is listed below.

- Fix deprecation, warnings,bugs, in CCDA module.
- Several bug fixes, deprecation, and warning fixes to make the ccda work in modern PHP version.
- Fix count php warning in installer. If you emptied the number of enabled hooks it threw a warning.
- Made it so the rev and approve errors thrown are now fixed in the care coordination and syndromic surveillance code.
- Replaced a number of static calls that use the $this parameter with their instance equivalents.  Had to introduce the Documents plugin as a dependency
to CareCoordination which is ok since it was being called statically anyway.
- Fix broken dependency modules.
When we moved the loading of the modules to be database driven the detection of dependencies was no longer working.
It looks like ZH at one point wanted to use an INI file to read those but that wasn't being used at all.

Since we already have a module.config.php file I put the dependencies in the array of that file and key off that
in the InstModuleTable piece since it just returns an array as part of that file.

I originally wanted to go down the route of using the ModuleConfigController but instantiating that in the correct
namespace and everything else was a problem, plus future controllers could have injected dependencies which we can't
know about beforehand.  The config file seems to be the best place for this.  At some point we may be able to deprecate
the ModuleconfigController class alltogether.