### PR TITLE
Added capability for custom filter on patient finder

### DIFF
--- a/interface/main/finder/dynamic_finder_ajax.php
+++ b/interface/main/finder/dynamic_finder_ajax.php
@@ -78,14 +78,21 @@ if (isset($_GET['iSortCol_0'])) {
     }
 }
 
+// Custom filtering, before datatables filtering created by the user
+// This allows a module to subscribe to a 'patient-finder.filter' event and
+// add filtering before data ever gets to the user
+$patientFinderFilterEvent = new \OpenEMR\PatientFinder\Event\PatientFinderFilterEvent( $aColumns, $columnFilters );
+$patientFinderFilterEvent = $GLOBALS["kernel"]->getEventDispatcher()->dispatch(\OpenEMR\PatientFinder\Event\PatientFinderFilterEvent::EVENT_HANDLE, $patientFinderFilterEvent, 10);
+$customWhere = $patientFinderFilterEvent->getCustomWhereFilter();
+
 // Global filtering.
 //
-$where = '';
+$where = "";
 $srch_bind = array();
 if (isset($_GET['sSearch']) && $_GET['sSearch'] !== "") {
     $sSearch = add_escape_custom(trim($_GET['sSearch']));
     foreach ($aColumns as $colname) {
-        $where .= $where ? "OR " : "WHERE ( ";
+        $where .= $where ? " OR " : " ( ";
         if ($colname == 'name') {
             $where .=
                 "lname LIKE ? OR " .
@@ -115,11 +122,14 @@ if (isset($_GET['sSearch']) && $_GET['sSearch'] !== "") {
 
 // Column-specific filtering.
 //
+$columnFilters = [];
 for ($i = 0; $i < count($aColumns); ++$i) {
     $colname = $aColumns[$i];
     if (isset($_GET["bSearchable_$i"]) && $_GET["bSearchable_$i"] == "true" && $_GET["sSearch_$i"] != '') {
-        $where .= $where ? ' AND ' : 'WHERE ';
+        $where .= ' AND ';
         $sSearch = add_escape_custom($_GET["sSearch_$i"]);
+        $columnFilters[] = new \OpenEMR\PatientFinder\ColumnFilter( $colname, $sSearch );
+
         if ($colname == 'name') {
             $where .=
                 "lname LIKE ? OR " .
@@ -162,12 +172,17 @@ foreach ($aColumns as $colname) {
 
 // Get total number of rows in the table.
 //
-$row = sqlQuery("SELECT COUNT(id) AS count FROM patient_data");
+$row = sqlQuery("SELECT COUNT(id) AS count FROM patient_data WHERE $customWhere");
 $iTotal = $row['count'];
 
 // Get total number of rows in the table after filtering.
 //
-$row = sqlQuery("SELECT COUNT(id) AS count FROM patient_data $where", $srch_bind);
+$whereFilter = "WHERE $customWhere";
+if ( $where ) {
+    $whereFilter .= " AND $where";
+}
+
+$row = sqlQuery("SELECT COUNT(id) AS count FROM patient_data $whereFilter", $srch_bind);
 $iFilteredTotal = $row['count'];
 
 // Build the output data array.
@@ -187,7 +202,7 @@ while ($row = sqlFetchArray($res)) {
     $fieldsInfo[$row['field_id']] = $row;
 }
 
-$query = "SELECT $sellist FROM patient_data $where $orderby $limit";
+$query = "SELECT $sellist FROM patient_data $whereFilter $orderby $limit";
 $res = sqlStatement($query, $srch_bind);
 while ($row = sqlFetchArray($res)) {
     // Each <tr> will have an ID identifying the patient.

--- a/src/PatientFinder/ColumnFilter.php
+++ b/src/PatientFinder/ColumnFilter.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * This file is part of OpenEMR.
+ *
+ * @link https://github.com/openemr/openemr/tree/master
+ * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\PatientFinder;
+
+/**
+ * Holds a column filter
+ *
+ * @package OpenEMR\PatientFinder
+ * @subpackage Event
+ * @author Ken Chapple <ken@mi-squared.com>
+ * @copyright Copyright (c) 2019 Ken Chapple <ken@mi-squared.com>
+ *
+ */
+class ColumnFilter
+{
+    private $name;
+    private $value;
+
+    public function __construct( $name, $value )
+    {
+        $this->name = $name;
+        $this->value = $value;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param mixed $name
+     */
+    public function setName( $name )
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public function setValue( $value )
+    {
+        $this->value = $value;
+    }
+
+
+}

--- a/src/PatientFinder/Event/PatientFinderFilterEvent.php
+++ b/src/PatientFinder/Event/PatientFinderFilterEvent.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * This file is part of OpenEMR.
+ *
+ * @link https://github.com/openemr/openemr/tree/master
+ * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\PatientFinder\Event;
+
+use OpenEMR\PatientFinder\ColumnFilter;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Event object for creating custom patient filters for patient finder
+ *
+ * @package OpenEMR\PatientFinder
+ * @subpackage Event
+ * @author Ken Chapple <ken@mi-squared.com>
+ * @copyright Copyright (c) 2019 Ken Chapple <ken@mi-squared.com>
+ */
+class PatientFinderFilterEvent extends Event
+{
+    const EVENT_HANDLE = 'patient-finder.filter';
+
+    /**
+     * @var array
+     *
+     * Array of columns displayed on the UI of patient finder
+     */
+    private $displayedColumns = [];
+
+    /**
+     * @var array
+     *
+     * Array of ColumnFilters that the end-user has created through UI
+     */
+    private $userColumnFilters = [];
+
+    /**
+     * @var array
+     *
+     * Custom where filter, applied "before" the user-generated filters through the UI.
+     * This filters are hidden from the end user.
+     *
+     * This defaults to "1" so that effectively no filter is applied
+     */
+    private $customWhereFilter = "1";
+
+    public function __construct( $displayedColumns, $userColumnFilters = [] )
+    {
+        $this->displayedColumns = $displayedColumns;
+        $this->userColumnFilters = $userColumnFilters;
+    }
+
+    public function getDisplayedColumns()
+    {
+        return $this->displayedColumns;
+    }
+
+    /**
+     * Get an array of column filters
+     *
+     * @return array Array of user-generated column filters
+     */
+    public function getUserColumnFilters()
+    {
+        return $this->userColumnFilters;
+    }
+
+    /**
+     * Get an string representing a patinet filter
+     *
+     * @return string
+     */
+    public function getCustomWhereFilter()
+    {
+        return $this->customWhereFilter;
+    }
+
+    public function setCustomWhereFilter( $customWhereFilter )
+    {
+        $this->customWhereFilter = $customWhereFilter;
+    }
+
+    /**
+     * Add a column filter.
+     *
+     * Used by listeners to add additional column filters
+     *
+     */
+    public function addCustomColumnFilter( ColumnFilter $columnFilter )
+    {
+        $this->customColumnFilters[]= $columnFilter;
+    }
+}


### PR DESCRIPTION
@bradymiller @adunsulag This is the code to enable custom filters from modules. The module returns the $customWhere as a string like "patient_data.DOB < 2001" for example if you don't want the current logged-in user to see minors. This if fine, but can get messy, and may be difficult to understand utilize for other developers. It would be better to build the query as an object (ORM or hand-rolled utilizing the src/Services/PatientService,) pass the object into the module, and have it returned with any modifications. Let me know what you think.