### PR TITLE
UX - Expandable Search Patient By Any Demographics - Take 3

### DIFF
--- a/interface/main/finder/dynamic_finder.php
+++ b/interface/main/finder/dynamic_finder.php
@@ -22,6 +22,7 @@ require_once "$srcdir/options.inc.php";
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
+use OpenEMR\OeUI\OemrUI;
 
 $uspfx = 'patient_finder.'; //substr(__FILE__, strlen($webserver_root)) . '.';
 $patient_finder_exact_search = prevSetting($uspfx, 'patient_finder_exact_search', 'patient_finder_exact_search', ' ');
@@ -71,6 +72,13 @@ $loading = "<i class='fa fa-refresh fa-2x fa-spin'></i>";
         color: red;
         transform: translateX(-50%);
     }
+    @media screen and (max-width: 640px) {
+        .dataTables_wrapper .dataTables_length, .dataTables_wrapper .dataTables_filter {
+            float: inherit;
+            text-align: justify;
+        }
+    }
+    
 </style>
 <script language="JavaScript">
 
@@ -164,34 +172,36 @@ $loading = "<i class='fa fa-refresh fa-2x fa-spin'></i>";
 
 </script>
 <?php
-//to determine and set the page to open in the desired state - expanded or centered, any selection the user makes will
-//become the user-specific default for that page. collectAndOrganizeExpandSetting() takes a single indexed array as an
-//argument, containing one or more elements, the name of the current file is the first element, if there are linked
-//files they should be listed thereafter, please add _xpd suffix to the file name
-$arr_files_php = array("dynamic_finder_xpd");
-$current_state = collectAndOrganizeExpandSetting($arr_files_php);
-require_once("$srcdir/expand_contract_inc.php");
-?>
-<script>
-<?php require_once("$include_root/expand_contract_js.php");//jQuery to provide expand/contract icon toggle if page is expandable ?>
-</script>
-
+    $arrOeUiSettings = array(
+    'heading_title' => xl('Patient Finder'),
+    'include_patient_name' => false,
+    'expandable' => true,
+    'expandable_files' => array('dynamic_finder_xpd'),//all file names need suffix _xpd
+    'action' => "search",//conceal, reveal, search, reset, link or back
+    'action_title' => "",//only for action link, leave empty for conceal, reveal, search
+    'action_href' => "",//only for actions - reset, link or back
+    'show_help_icon' => false,
+    'help_file_name' => ""
+    );
+    $oemr_ui = new OemrUI($arrOeUiSettings);
+    ?>
 </head>
 <body class="body_top">
-    <div class="<?php echo $container;?> expandable">
-        <div class="row">
-            <div class="col-sm-10">
-                <h2>
-                <?php echo xlt('Patient Finder') ?> <i id="exp_cont_icon" class="fa <?php echo attr($expand_icon_class);?> oe-superscript-small expand_contract"
-                title="<?php echo attr($expand_title); ?>" aria-hidden="true"></i> <i id="show_hide" class="fa fa-search-plus fa-2x small" title="<?php echo xla('Click to show advanced search'); ?>"></i>
-                </h2>
-            </div>
-            <div class="col-sm-2">
-                <?php if (acl_check('patients', 'demo', '', array('write','addonly'))) { ?>
-                    <button id="create_patient_btn" onclick="top.restoreSession();top.RTop.location = '<?php echo $web_root ?>/interface/new/new.php'"><?php echo xlt('Create Patient'); ?></button>
-                <?php } ?>
+    <div id="container_div" class="<?php echo attr($oemr_ui->oeContainer()); ?>">
+         <div class="row">
+            <div class="col-sm-12">
+                <div class="page-header">
+                    <?php echo $oemr_ui->pageHeading() . "\r\n"; ?>
+                </div>
             </div>
         </div>
+        <div class="row">
+            <div class="col-sm-12">
+                <?php if (acl_check('patients', 'demo', '', array('write','addonly'))) { ?>
+                    <button id="create_patient_btn1" class="btn btn-default btn-add" onclick="top.restoreSession();top.RTop.location = '<?php echo $web_root ?>/interface/new/new.php'"><?php echo xlt('Add New Patient'); ?></button>
+                <?php } ?>
+            </div>
+            </div>
         <br>
         <div class="row">
             <div class="col-sm-12">
@@ -225,29 +235,40 @@ require_once("$srcdir/expand_contract_inc.php");
                 </form>
             </div>
         </div>
-    </div><!--end of container div-->
+    </div> <!--End of Container div-->
+    <?php $oemr_ui->oeBelowContainerDiv();?>
+
     <script>
         $(function () {
-            $("#pt_table").removeAttr("style");
             $("#exp_cont_icon").click(function () {
                 $("#pt_table").removeAttr("style");
             });
         });
+        $(window).on("resize", function() { //portrait vs landscape
+           $("#pt_table").removeAttr("style");
+        });
     </script>
     <script>
-    $('#show_hide').click(function () {
-        var elementTitle = $('#show_hide').prop('title');
-        var hideTitle = '<?php echo xla('Click to hide advanced search'); ?>';
-        var showTitle = '<?php echo xla('Click to show advanced search'); ?>';
-        $('.hideaway').toggle();
-        $(this).toggleClass('fa-search-plus fa-search-minus');
-        if (elementTitle == hideTitle) {
-            elementTitle = showTitle;
-        } else if (elementTitle == showTitle) {
-            elementTitle = hideTitle;
-        }
-        $('#show_hide').prop('title', elementTitle);
-    });
+        $(window).on('resize', function() {//hide superfluous elements on Smartphones
+            var winWidth = $(this).width();
+            if (winWidth <  750) {
+                $("#pt_table_filter").addClass ("hidden");
+                $("#pt_table_length").addClass ("hidden");
+                $("#show_hide").addClass ("hidden");
+                $("#search_hide").addClass ("hidden");
+                
+                
+            } else {
+                $("#pt_table_filter").removeClass ("hidden");
+                $("#pt_table_length").removeClass ("hidden");
+                $("#show_hide").removeClass ("hidden");
+                $("#search_hide").addClass ("hidden");
+            }
+        });
+    </script>
+    
+    <script>
+        document.addEventListener('touchstart', {});
     </script>
 </body>
 </html>

--- a/interface/main/tabs/js/user_data_view_model.js
+++ b/interface/main/tabs/js/user_data_view_model.js
@@ -33,24 +33,37 @@ function user_data_view_model(username,fname,lname,authGrp)
 
 }
 
-function viewPtFinder()
+function viewPtFinder(myMessage, searchAnyType, event)
 {
+    event.stopImmediatePropagation;
+    event.preventDefault;
+    let srchBox = document.getElementById("anySearchBox");
+    var searchAnyType = searchAnyType;
+    srchBox.focus();
+    
     let finderUrl = webroot_url+"/interface/main/finder/dynamic_finder.php";
-    let srchBox = document.getElementById("anySearchBox").value;
-    if (srchBox) {
-        finderUrl += "?search_any=" + encodeURIComponent(srchBox);
+    let srchBoxVal = srchBox.value.trim();
+    let srchBoxWidth = srchBox.offsetWidth;
+    let srchBoxLength = srchBoxWidth < 50 ? 0 : srchBoxVal.length;// to let input box with values be displayed on mousedown on Smartphones
+    
+    if (srchBoxLength > 0 ) {
+        finderUrl += "?search_any=" + encodeURIComponent(srchBoxVal);
+        navigateTab(finderUrl,"fin", function () {
+            activateTabByName("fin",true);
+        });
+        srchBox.blur();
+    } else if (srchBoxLength == 0 && srchBoxWidth > 50) {
+        if (searchAnyType == 'dual') {
+            srchBox.blur();
+            navigateTab(finderUrl,"fin", function () {
+                activateTabByName("fin",true);
+            });
+        } else if (searchAnyType == 'comprehensive') {
+            alert(arguments[0]);
+            srchBox.focus();
+        }
     }
-    navigateTab(finderUrl,"fin", function () {
-        activateTabByName("fin",true);
-    });
-}
-
-function doAnySearch(event)
-{
-    if (event.which === 13 || event.keyCode === 13) {
-        document.getElementById("searchFinder").click();
-    }
-    return false;
+   
 }
 
 function viewTgFinder()

--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -157,6 +157,7 @@ var jsGlobals = {};
 
 <?php Header::setupHeader(["knockout","tabs-theme",'jquery-ui']); ?>
 
+
 <link rel="shortcut icon" href="<?php echo $GLOBALS['images_static_relative']; ?>/favicon.ico" />
 
 <script type="text/javascript" src="js/custom_bindings.js?v=<?php echo $v_js_includes; ?>"></script>
@@ -246,8 +247,6 @@ $GLOBALS['allow_issue_menu_link'] = ((acl_check('encounters', 'notes', '', 'writ
 <?php require_once("menu/menu_json.php"); ?>
 <?php $userQuery = sqlQuery("select * from users where username = ?", array($_SESSION['authUser']));?>
 <?php $width = $GLOBALS['vertical_responsive_menu']; //will be vertical menu at and below this width
-
-
 ?>
 <script type="text/javascript">
     <?php if (!empty($_SESSION['frame1url']) && !empty($_SESSION['frame1target'])) { ?>
@@ -289,6 +288,7 @@ $GLOBALS['allow_issue_menu_link'] = ((acl_check('encounters', 'notes', '', 'writ
     $(function() {
         $(window).trigger('resize');// to avoid repeating code triggers above on page open
     });
+    
 </script>
 
 <style>
@@ -302,11 +302,9 @@ $GLOBALS['allow_issue_menu_link'] = ((acl_check('encounters', 'notes', '', 'writ
 }
 
 html, body{
-
     min-height:100% !important;
     height:100% !important;
 }
-
 </style>
 
 </head>
@@ -333,9 +331,9 @@ if (isset($_SESSION['app1'])) {
 
     <div class="body_top" id="body_top_div" data-bind='css: responsiveDisplay.objWidth().bodyTopDivWidth'>
         <div id="logo_menu" >
-        <a href="https://www.open-emr.org" title="OpenEMR <?php echo xla("Website"); ?>" rel="noopener" target="_blank"><img class="logo" id='oemr_logo' alt="openEMR small logo"  style="width:20px" border="0" src="<?php echo $GLOBALS['images_static_relative']; ?>/menu-logo.png"></a>
+        <a href="https://www.open-emr.org" title="OpenEMR <?php echo xla("Website"); ?>" rel="noopener" target="_blank"><img class="logo oe-pull-toward" id='oemr_logo' alt="openEMR small logo"  style="width:20px" border="0" src="<?php echo $GLOBALS['images_static_relative']; ?>/menu-logo.png"></a>
         <div>
-        <i class="fa fa-2x fa-bars oe-hidden col-sm-2" aria-hidden="true" id='menu_icon' data-bind='css: responsiveDisplay.objWidth().menuIconHide, click: function(){ responsiveDisplay.verticalMenuObservable(); responsiveDisplay.menuIconObservable()}, css2: {"fa-bars" : !responsiveDisplay.oeMenuIcon(), "fa-eye-slash" : responsiveDisplay.oeMenuIcon}'></i>
+        <i class="fa fa-2x fa-bars oe-hidden col-sm-2 oe-pull-away" aria-hidden="true" id='menu_icon' data-bind='css: responsiveDisplay.objWidth().menuIconHide, click: function(){ responsiveDisplay.verticalMenuObservable(); responsiveDisplay.menuIconObservable()}, css2: {"fa-bars" : !responsiveDisplay.oeMenuIcon(), "fa-eye-slash" : responsiveDisplay.oeMenuIcon}'></i>
         </div>
         <div class="clearfix" data-bind="css: {'clearfix' : responsiveDisplay.winWidth() <= <?php echo attr($width); ?>}"></div>
         </div>
@@ -343,7 +341,7 @@ if (isset($_SESSION['app1'])) {
             <span id="menu_logo" data-bind="template: {name: 'menu-template', data: application_data} "></span>
             <div>
             <span id="userData" data-bind="template: {name: 'user-data-template', data:application_data} "></span>
-            <a href="../../logout.php" rel="noopener" id="logout_link" onclick="top.restoreSession()" data-bind="css: {'oe-hidden' :responsiveDisplay.oeLogoutIcon}" title="<?php echo xla("Logout");?>"><i class="fa fa-2x fa-sign-out" aria-hidden="true" id="logout_icon"></i></a>
+            <a href="../../logout.php" rel="noopener" id="logout_link" onclick="top.restoreSession()" data-bind="css: {'oe-hidden' :responsiveDisplay.oeLogoutIcon}" title="<?php echo xla("Logout");?>"><i class="fa fa-2x fa-sign-out oe-pull-toward" aria-hidden="true" id="logout_icon"></i></a>
             </div>
         </div>
         <div class="clearfix" data-bind="css: {'clearfix' : responsiveDisplay.winWidth() <= <?php echo attr($width); ?>}"></div>
@@ -364,7 +362,6 @@ var displayViewModel = {
    winHeight: ko.observable(),
    winDevice: ko.observable(),
    objWidth: {}
-
 };
 
 displayViewModel.objWidth = ko.computed(function() {
@@ -461,6 +458,8 @@ $(function() {
     });
 ko.bindingHandlers['css2'] = ko.bindingHandlers.css;
 app_view_model.responsiveDisplay = displayViewModel;
+
+
 </script>
 <script>
     $("#dialogDiv").hide();
@@ -475,5 +474,22 @@ app_view_model.responsiveDisplay = displayViewModel;
         });
     });
 </script>
+<script>
+$(function(){
+    $('#logo_menu').focus();
+});
+</script>
+<script>
+$('#anySearchBox').keypress(function(event){
+  if(event.which === 13 || event.keyCode === 13){
+    event.preventDefault();
+    $('#search_globals').mousedown();
+  }
+});
+</script>
+<script>
+document.addEventListener('touchstart', {}); //specifically added for iOS devices, especially in iframes
+</script>
+
 </body>
 </html>

--- a/interface/main/tabs/templates/patient_data_template.php
+++ b/interface/main/tabs/templates/patient_data_template.php
@@ -8,12 +8,29 @@
  * @author    Brady Miller <brady.g.miller@gmail.com>
  * @author    Robert Down <robertdown@live.com>
  * @author    Jerry Padgett <sjpadgett@gmail.com>
+ * @author    Ranganath Pathak <pathak@scrs1.org>
  * @copyright Copyright (c) 2016 Kevin Yeh <kevin.y@integralemr.com>
  * @copyright Copyright (c) 2016 Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2017 Robert Down <robertdown@live.com>
  * @copyright Copyright (c) 2018 Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright Copyright (c) 2019 Ranganath Pathak <pathak@scrs1.org>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
+?>
+<?php
+
+   $search_any_type = $GLOBALS['search_any_patient'];
+   //$search_any_type = 'comprehensive';
+   //$search_any_type = 'dual';
+   
+if ($search_any_type == 'dual') {
+    $any_search_class = "any-search-legacy";
+    $search_globals_class = "btn-globals-legacy";
+} elseif ($search_any_type == 'comprehensive') {
+    $any_search_class = "any-search-modern";
+    $search_globals_class = "btn-globals-modern";
+}
+
 ?>
 <script type="text/html" id="patient-data-template">
     <div>
@@ -48,11 +65,13 @@
             <!-- ko if: patient -->
                 <span data-bind="text:patient().str_dob()"></span>
                 <!-- /ko -->
-                <div>
-                    <span class="float-element">
-                        <input type="search" onkeypress="doAnySearch(event)" size="12" id="anySearchBox" placeholder="<?php echo xla("Any Demographic Search") ?>">
-                        <a id="searchFinder" data-bind="click: viewPtFinder" href="#" class="btn btn-default btn-xs"><i class="fa fa-search" aria-hidden="true"></i></a>
-                    </span>
+                <div class="oe-expandable-search" id="div-search-globals">
+                <?php //adapted from https://codepen.io/brandonkennedy/pen/yGjsi ?>
+                    <form name="frm_search_globals">
+                        <input type="text" id="anySearchBox"  class="<?php echo $any_search_class ?>" name="anySearchBox"  placeholder="<?php echo xla("Search by any demographics") ?>" autocomplete="off">
+                        <button type="button" id="search_globals" class="btn btn-default btn-search btn-search1 <?php echo $search_globals_class ?>" title='<?php echo xla("Search for patient by entering whole or part of any demographics field information"); ?>' data-bind="event: {mousedown: viewPtFinder.bind( $data, '<?php echo xla("The search field cannot be empty. Please enter a search term") ?>', '<?php echo attr($search_any_type); ?>')}">
+                        </button>
+                    </form>
                 </div>
             </div>
         </span>

--- a/interface/themes/buttons/_manilla.scss
+++ b/interface/themes/buttons/_manilla.scss
@@ -63,7 +63,6 @@ input[type="text"] {
     border: 1px solid #444;
     padding: 3px;
     margin: 3px;
-    text-align: left;
     display: inline-block;
     border: 1px solid #CCC !important;
     box-shadow: 0px 1px 3px #DDD inset;

--- a/interface/themes/color_base.scss
+++ b/interface/themes/color_base.scss
@@ -481,13 +481,38 @@ div.section, div.borderbox {
 	border-color: $darkest !important;
 }
 /* flow board filters*/
+/*openemr 5 patient-finder*/
+@media screen and (max-width: 750px) {
+    #pt_table {
+        font-size: .9rem;
+    }
+}
+/*openemr 5 patient-finder*/
 
+/*vertical main menu */
+
+.appMenu_small .menuSection > .menuEntries {
+    left:40px;
+    box-shadow:3px 5px 8px $darker !important;
+}
+/*vertical main menu */
+
+/*search any*/
+*.oe-expandable-search .any-search-legacy {
+    background: $paler;
+}
+/*search any*/
 @import "colors/openemr5/external-data";
 @import "colors/openemr5/ros";
 @import "colors/openemr5/codes";
 @import "colors/openemr5/bootstrap-nav-menu";
 @import "colors/openemr5/bootstrap";
 
+/*search any*/
+*.oe-expandable-search .any-search-legacy {
+    background: $paler;
+}
+/*search any*/
 
 th.currentvalues, th.historicalvalues {
 	background: $dark !important;
@@ -497,12 +522,18 @@ th.currentvalues, th.historicalvalues {
 	float: right;
 	margin-top: 35px;
 }
+/*search any*/
+*.oe-expandable-search .any-search-legacy {
+    background: $paler;
+}
+/*search any*/
 
 @import "colors/openemr5/batch-payments";
 @import "colors/openemr5/recall-flow-board";
 @import "colors/openemr5/help-files";
 @import "oe-common/all-common-import";
 @import "colors/openemr5/edit_globals_colors";
+
 
 @include if-rtl {
 	@include rtl_style;

--- a/interface/themes/oe-common/main-common.scss
+++ b/interface/themes/oe-common/main-common.scss
@@ -5,3 +5,56 @@
 .oe-hidden {
     display: none!important;
 }
+/*expandable patient search button in main.php*/
+.oe-expandable-search {
+  float: left;
+  margin: 0;
+  position: relative;
+  width: 100%;
+}
+
+.oe-expandable-search input {
+  border-radius: 15px;
+  transition: all .8s ease-in-out !important;
+  width: 30px;
+  height: 31px;
+  background: transparent;
+  outline: none;
+}
+.oe-expandable-search input:focus {
+  width: 275px;
+  height: 31px;
+  outline: none;
+  
+}
+.oe-expandable-search input:focus ~ button.btn-search1 {
+  left: 245px;
+  outline: none;
+}
+.oe-expandable-search button {
+  transition: all .8s ease-in-out;
+}
+.oe-expandable-search button.btn-search1 {
+  border: 1px solid #ccc;
+  border-radius: 50%;
+  height: 31px;
+  left: 0;
+  width: 30px;
+  margin: 3px;
+  padding: 4px;
+  padding-left: 8px;
+  position: absolute;
+  outline: none!important
+}
+.oe-expandable-search .any-search-legacy {
+    width: 140px;
+}
+.oe-expandable-search button.btn-globals-legacy {
+    left: 110px;
+}
+.oe-expandable-search .any-search-modern {
+    width: 30px;
+}
+.oe-expandable-search button.btn-globals-modern {
+    left: 0;
+}

--- a/interface/themes/rtl.scss
+++ b/interface/themes/rtl.scss
@@ -316,3 +316,26 @@
         float: left;
     }
 }
+/*expandable search rtl in main.php*/
+.oe-expandable-search button.btn-search1 {
+    right: 0;
+    padding: 4px 6px 4px 0 !important;
+}
+
+.oe-expandable-search input:focus~button.btn-search1 {
+    right: 245px;
+    outline: 0;
+}
+.oe-expandable-search button.btn-globals-legacy {
+    right: 110px;
+}
+.oe-expandable-search button.btn-globals-modern {
+    right: 0;
+}
+/*expandable search rtl in main.php*/
+/*vertical main menu */
+
+.appMenu_small .menuSection > .menuEntries {
+    right:40px ! important; 
+}
+/*vertical main menu */

--- a/interface/themes/style_light.scss
+++ b/interface/themes/style_light.scss
@@ -351,6 +351,40 @@ div.category-display {
 	color: #2672ec;
 }
 /*openrmr5.0.2 edit_globals vertical menu*/
+/*main.php expandable search*/
+#search_globals {
+    background: #e8e8e8 !important;
+}
+/*main.php expandable search*/
+/*bootstrap navbar */
+.navbar-collapse.collapse.in {
+    background-color: #F5F5F5!important;
+    color: #000!important;
+}
+.navbar-default .navbar-nav>li>a:focus, .navbar-default .navbar-nav>li>a:hover {
+    color: #333;
+    background-color: #eee;
+}
+/*bootstrap navbar */
+/*openemr 5 patient-finder*/
+@media screen and (max-width: 750px) {
+    #pt_table {
+        font-size: 1.2rem;
+    }
+}
+/*openemr 5 patient-finder*/
+/*vertical main menu */
+
+.appMenu_small .menuSection > .menuEntries {
+    left:40px;
+    box-shadow:3px 5px 8px #adadad;
+}
+/*vertical main menu */
+/*search any*/
+*.oe-expandable-search .any-search-legacy {
+    background: #FFFFFD;
+}
+/*search any*/
 @import "oe-bootstrap";
 @import "oe-common/all-common-import";
 

--- a/interface/themes/style_manila.scss
+++ b/interface/themes/style_manila.scss
@@ -515,6 +515,36 @@ body dl {
     border-right: none !important;
  }
 /*openrmr5.0.2 edit_globals vertical menu*/
+/*bootstrap navbar */
+.navbar-collapse.collapse.in {
+    background-color: #F5F5F5!important;
+    color: #000!important;
+}
+.navbar-default .navbar-nav>li>a:focus, .navbar-default .navbar-nav>li>a:hover {
+    color: #333;
+    background-color: #eee;
+}
+/*bootstrap navbar */
+/*openemr 5 patient-finder*/
+@media screen and (max-width: 750px) {
+    #pt_table {
+        font-size: 1.2rem;
+    }
+}
+/*openemr 5 patient-finder*/
+
+/*vertical main menu */
+
+.appMenu_small .menuSection > .menuEntries {
+    left:40px;
+    box-shadow:3px 5px 8px #adadad;
+}
+/*vertical main menu */
+/*search any*/
+*.oe-expandable-search .any-search-legacy {
+    background: #FFFFE0;
+}
+/*search any*/
 @import "oe-bootstrap";
 @import "oe-common/all-common-import";
 

--- a/interface/themes/tabs_style_compact.css
+++ b/interface/themes/tabs_style_compact.css
@@ -63,8 +63,7 @@ body
 }
 
 #mainBox_vertical .logo {
-    float: left;
-    margin: 13px 4px 0px 12px;
+    margin: 13px 12px;
     width: 30px;
     z-index: 10000;
 }
@@ -376,6 +375,7 @@ body
     z-index:10;
 }
 #mainBox_vertical>.body_top {
+    background-color: #C9DBF2;
     box-shadow:0 0 0 #939393;
     margin: 0 !important;
 }
@@ -430,12 +430,10 @@ body
   background-color:#C9DBF2;
 }
 #logout_icon{
-    float:left;
     margin:12px 5px 0 10px;
     cursor: pointer;
 }
 #menu_icon {
-    float:right;
-    margin:12px 14px 0 0;
+    margin: 12px 25px;
     cursor: pointer;
 }

--- a/interface/themes/tabs_style_full.css
+++ b/interface/themes/tabs_style_full.css
@@ -82,8 +82,7 @@ z-index:10000;
 }
 
 #mainBox_vertical .logo {
-    float: left;
-    margin: 3px 4px 0px 12px;
+    margin: 6px 12px;
     width: 30px;
     z-index: 10000;
 }
@@ -453,12 +452,10 @@ div.menuLabel:hover {
 }
 
 #logout_icon{
-    float:left;
     margin:12px 5px 0 10px;
     cursor: pointer;
 }
 #menu_icon {
-    float:right;
-    margin:12px 14px 0 0;
+    margin: 12px 25px;
     cursor: pointer;
 }

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -117,6 +117,7 @@ $USER_SPECIFIC_GLOBALS = array('default_top_pane',
     'css_header',
     'vertical_responsive_menu',
     'menu_styling_vertical',
+    'search_any_patient',
     'default_encounter_view',
     'gbl_pt_list_page_size',
     'gbl_pt_list_new_window',
@@ -207,7 +208,7 @@ $GLOBALS_METADATA = array(
         'css_header' => array(
             xl('General Theme') .'*',
             'css',
-            'style_light.css',
+            'style_mustard_green.css',
             xl('Pick a general theme (need to logout/login after changing this setting).')
         ),
 
@@ -276,6 +277,16 @@ $GLOBALS_METADATA = array(
             ),
             '1',
             xl('Vertical Menu Style for frame based layouts')
+        ),
+        
+        'search_any_patient' => array(
+            xl('Search Patient By Any Demographics'),
+            array(
+                'dual' => xl('Dual'),
+                'comprehensive' => xl('Comprehensive'),
+            ),
+            'dual', // default
+            xl('Search Patient By Any Demographics, Dual additionally lets direct access to Patient Finder, Comprehensive has collapsed input box')
         ),
 
         'default_encounter_view' => array(

--- a/src/OeUI/OemrUI.php
+++ b/src/OeUI/OemrUI.php
@@ -322,6 +322,18 @@ JQD;
         $collectToken = js_escape(CsrfUtils::collectCsrfToken());
         $header_expand_js = <<<EXP
         <script>
+        $(window).on('resize', function() {//hide icon on smaller devices as width is almost 100%
+            var winWidth = $(this).width();
+            if (winWidth <  900) {
+                $("#exp_cont_icon").addClass ("hidden");
+            } else {
+                $("#exp_cont_icon").removeClass ("hidden");
+            }
+        });
+        $(function() {
+            $(window).trigger('resize');// to avoid repeating code triggers above on page open
+        });
+        
         $(function () {
             $('.expand_contract').click(function () {
                 var elementTitle;


### PR DESCRIPTION
After a lively discussion in the previous PR #2513 here is a solution to address the key issues raised
 1 - Whether or not to have the Search Any button have dual behavior
    - to open a filtered set of results in Patient Finder based on a non-empty search string in the search any text box
    - to directly open Patient Finder and display the entire patient list 
 2 - Whether or not to hide the entire input box behind the search button and to only allow filtered results if the 
 search any text box contained a non-empty string
 
 There is a case to be made for and against both these arguments and the current solution is to have both these options available
 and let the administrator or individual user choose what they want.
 
 The two options are called 'Dual' and 'Comprehensive'.
 
 Dual - lets the user either access the Patient Finder directly by clicking the Search Button or open a filtered set of results 
 in Patient Finder based on a non-empty search string in the search any text box.
 
 Comprehensive - hides the input search box behind the search button and only allows filtered results if the 
 search any text box contains a non-empty string
 
 The default option is 'Dual';)
 
 To change the option as an administrator go to 
 Administration > Globals > Appearance > Search Patient By Any Demographics
 
 To change the option as an individual user go to 
 User Name > Settings > Appearance > Search Patient By Any Demographics

below added by bradymiller:
Up For Grabs demo for this PR is at: https://www.open-emr.org/wiki/index.php/Development_Demo#Zeta_-_Up_For_Grabs_Demo