### PR TITLE
Fixed session/cookie bug and other related work

### DIFF
--- a/ccdaservice/ccda_gateway.php
+++ b/ccdaservice/ccda_gateway.php
@@ -8,6 +8,7 @@
  * @copyright Copyright (c) 2016-2017 Jerry Padgett <sjpadgett@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
+
 //authencate for portal or main- never know where it gets used
 session_start();
 if (isset($_SESSION['pid']) && isset($_SESSION['patient_portal_onsite_two'])) {
@@ -82,7 +83,7 @@ function portalccdafetching($pid, $server_url, $parameterArray)
     $parameters = http_build_query($parameterArray); // future use
     try {
         $ch = curl_init();
-        $url = $server_url . "/interface/modules/zend_modules/public/encounterccdadispatch/index?site=$site_id&me=" . session_id() . "&param=1&view=1&combination=$pid&recipient=patient";
+        $url = $server_url . "/interface/modules/zend_modules/public/encounterccdadispatch/index?site=$site_id&me=" . urlencode(session_id()) . "&param=1&view=1&combination=$pid&recipient=patient";
         curl_setopt($ch, CURLOPT_URL, $url);
         curl_setopt($ch, CURLOPT_HEADER, 0); // set true for look see
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -102,9 +102,30 @@ $GLOBALS['OE_SITES_BASE'] = "$webserver_root/sites";
 if (session_status() === PHP_SESSION_NONE) {
     // Only can run these when do not have an active session yet
     // (for example, need to skip this in the portal where the session is already active)
-    ini_set('session.gc_maxlifetime', '14400');
-    ini_set('session.cookie_path', $web_root ? $web_root : '/');
-    session_name("OpenEMR");
+    if (version_compare(phpversion(), '7.3.0', '>=')) {
+        // For php 7.3.0 versions and greater, have support for cookie_samesite
+        //  to prevent csrf
+        session_start([
+            'cookie_samesite' => "Strict",
+            'name'=> 'OpenEMR',
+            'use_strict_mode' => true,
+            'cookie_httponly' => false,
+            'sid_bits_per_character' => 6,
+            'sid_length' => 48,
+            'gc_maxlifetime' => 14400,
+            'cookie_path' => $web_root ? $web_root : '/'
+        ]);
+    } else {
+        session_start([
+            'name' => 'OpenEMR',
+            'use_strict_mode' => true,
+            'cookie_httponly' => false,
+            'sid_bits_per_character' => 6,
+            'sid_length' => 48,
+            'gc_maxlifetime' => 14400,
+            'cookie_path' => $web_root ? $web_root : '/'
+        ]);
+    }
 }
 session_start();
 

--- a/interface/login/login.php
+++ b/interface/login/login.php
@@ -160,7 +160,7 @@ if (count($emr_app)) {
                 // This forces the server to create a new session ID.
                 var olddate = new Date();
                 olddate.setFullYear(olddate.getFullYear() - 1);
-                document.cookie = '<?php echo session_name() . '=' . session_id() ?>; path=<?php echo($web_root ? $web_root : '/');?>; expires=' + olddate.toGMTString();
+                document.cookie = '<?php echo urlencode(session_name()) . '=' . urlencode(session_id()) ?>; path=<?php echo($web_root ? $web_root : '/');?>; expires=' + olddate.toGMTString();
             <?php } ?>
             return false; //Currently the submit action is handled by the encrypt_form().
         }

--- a/interface/modules/zend_modules/module/Installer/config/module.config.php
+++ b/interface/modules/zend_modules/module/Installer/config/module.config.php
@@ -62,9 +62,7 @@ return array(
         'layout' => 'site/layout',
     ),
     'session' => array(
-                    'remember_me_seconds' => 2419200,
-                    'use_cookies' => true,
-                    'cookie_httponly' => true,
+
     ),
     'moduleconfig' => array(
 

--- a/library/restoreSession.php
+++ b/library/restoreSession.php
@@ -36,7 +36,7 @@ function restoreSession() {
 <?php if ($GLOBALS['restore_sessions'] == 2) { ?>
    alert('Changing session ID from\n"' + c[1] + '" to\n"' + oemr_session_id + '"');
 <?php } ?>
-   document.cookie = oemr_session_name + '=' + oemr_session_id + '; path=<?php echo($web_root ? $web_root : '/');?>';
+   document.cookie = encodeURIComponent(oemr_session_name) + '=' + encodeURIComponent(oemr_session_id) + '; path=<?php echo($web_root ? $web_root : '/');?>';
   }
  }
 <?php } ?>


### PR DESCRIPTION
Updated OpenEMR session/cookie strategy

1. If a session does not yet exist, then will start the OpenEMR session, which
    will create a cookie with OpenEMR name. If a session already exists, then
    this means portal is being used and will bypass setting of the OpenEMR session/cookie.
2. If using php version 7.3.0 or above, then will set the cookie_samesite in order
    to prevent csrf vulnerabilities. Setting it to Strict for now; if this is to
    strict on testing, then will instead set it to Lax.
3. Need to set cookie_httponly to false, since javascript needs to be able to
    access/modify the cookie to support separate logins into OpenEMR. This is important
    to support in OpenEMR since the application needs to robustly support access of
    separate patients via separate logins by same users. This is done via custom
    restore_session() javascript function; session IDs are effectively saved in the
    top level browser window.
4. Using use_strict_mode to optimize security.
5. Using sid_bits_per_character of 6 to optimize security. This does allow comma to
    be used in the session id, so need to ensure properly escape it when modify it in
    cookie.
6. Using sid_length of 48 to optimize security.
7. Setting gc_maxlifetime to 14400 since defaults for session.gc_maxlifetime is
    often too small.
8. Setting cookie_path to improve security when using different OpenEMR instances
    on same server to prevent session conflicts.
