### PR TITLE
Implementing hooks for event listeners

### DIFF
--- a/interface/main/calendar/modules/PostCalendar/pnuserapi.php
+++ b/interface/main/calendar/modules/PostCalendar/pnuserapi.php
@@ -37,6 +37,9 @@ $pcDir = pnVarPrepForOS($pcModInfo['directory']);
 require_once("modules/$pcDir/common.api.php");
 unset($pcModInfo, $pcDir);
 
+use OpenEMR\Events\Appointments\CalendarFilterEvent;
+use OpenEMR\Services\UserService;
+
 /**
  *  postcalendar_userapi_buildView
  *
@@ -880,6 +883,12 @@ function &postcalendar_userapi_pcQueryEvents($args)
     "AND ((a.pc_endDate >= '" . pnVarPrepForStore($start) . "' AND a.pc_eventDate <= '" . pnVarPrepForStore($end) . "') OR " .
     "(a.pc_endDate = '0000-00-00' AND a.pc_eventDate >= '" . pnVarPrepForStore($start) . "' AND " .
     "a.pc_eventDate <= '" . pnVarPrepForStore($end) . "')) ";
+
+    // Custom filtering
+    $calFilterEvent = new CalendarFilterEvent(new UserService());
+    $calFilterEvent = $GLOBALS["kernel"]->getEventDispatcher()->dispatch(CalendarFilterEvent::EVENT_HANDLE, $calFilterEvent, 10);
+    $calFilter = $calFilterEvent->getCustomWhereFilter();
+    $sql .= " AND $calFilter ";
 
   //==================================
   //FACILITY FILTERING (lemonsoftware)(CHEMED)

--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -34,6 +34,9 @@ use OpenEMR\Core\Header;
 use OpenEMR\Menu\PatientMenuRole;
 use OpenEMR\Reminder\BirthdayReminder;
 use OpenEMR\OeUI\OemrUI;
+use OpenEMR\Services\UserService;
+use OpenEMR\Services\PatientService;
+use OpenEMR\Events\PatientDemographics\ViewEvent;
 
 if (isset($_GET['set_pid'])) {
     include_once("$srcdir/pid.inc");
@@ -705,6 +708,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
 
         <a href='../birthday_alert/birthday_pop.php?pid=<?php echo attr_url($pid); ?>&user_id=<?php echo attr_url($_SESSION['authId']); ?>' id='birthday_popup' style='display: none;' onclick='top.restoreSession()'></a>
         <?php
+
         $thisauth = acl_check('patients', 'demo');
         if ($thisauth) {
             if ($result['squad'] && ! acl_check('squads', $result['squad'])) {
@@ -712,7 +716,14 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
             }
         }
 
-        if (!$thisauth) {
+        // Create and fire the patient demographics view event
+        $patientService  = new PatientService();
+        $patientService->setPid($pid);
+        $viewEvent = new ViewEvent(new UserService(), $patientService);
+        $viewEvent = $GLOBALS["kernel"]->getEventDispatcher()->dispatch(ViewEvent::EVENT_HANDLE, $viewEvent, 10);
+
+        if (!$thisauth ||
+            !$viewEvent->authorized()) {
             echo "<p>(" . xlt('Demographics not authorized') . ")</p>\n";
             echo "</body>\n</html>\n";
             exit();

--- a/interface/patient_file/summary/demographics_full.php
+++ b/interface/patient_file/summary/demographics_full.php
@@ -20,6 +20,10 @@ require_once("$srcdir/patient.inc");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
+use OpenEMR\Services\UserService;
+use OpenEMR\Services\PatientService;
+use OpenEMR\Events\PatientDemographics\UpdateEvent;
+
 
 // Session pid must be right or bad things can happen when demographics are saved!
 //
@@ -33,6 +37,16 @@ $result2 = getEmployerData($pid);
 
  // Check authorization.
 if ($pid) {
+
+    // Create and fire the patient demographics update event
+    $patientService  = new PatientService();
+    $patientService->setPid($pid);
+    $updateEvent = new UpdateEvent(new UserService(), $patientService);
+    $updateEvent = $GLOBALS["kernel"]->getEventDispatcher()->dispatch(UpdateEvent::EVENT_HANDLE, $updateEvent, 10);
+    if (!$updateEvent->authorized()) {
+        die(xlt('Updating demographics is not authorized.'));
+    }
+
     if (!acl_check('patients', 'demo', '', 'write')) {
         die(xlt('Updating demographics is not authorized.'));
     }

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -77,6 +77,9 @@
 //   Urdu                           // xl('Urdu')
 //   Vietnamese                     // xl('Vietnamese')
 
+use \OpenEMR\Services\UserService;
+use \OpenEMR\Events\Globals\GlobalsInitializedEvent;
+
 // OS-dependent stuff.
 if (stristr(PHP_OS, 'WIN')) {
     // MS Windows
@@ -3571,3 +3574,6 @@ $GLOBALS_METADATA = array(
 
     ),
 );
+
+$globalsInitEvent = new GlobalsInitializedEvent(new UserService(),$GLOBALS_METADATA,$USER_SPECIFIC_GLOBALS,$USER_SPECIFIC_TABS);
+$globalsInitEvent = $GLOBALS["kernel"]->getEventDispatcher()->dispatch(GlobalsInitializedEvent::EVENT_HANDLE, $globalsInitEvent, 10);

--- a/src/Events/Appointments/AppointmentsFilterEvent.php
+++ b/src/Events/Appointments/AppointmentsFilterEvent.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * This file is part of OpenEMR.
+ *
+ * @link https://github.com/openemr/openemr/tree/master
+ * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\Appointments;
+
+use OpenEMR\Services\PatientService;
+use OpenEMR\Services\UserService;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Event object for creating custom appointment filters, affecting the queries for patient tracker
+ *
+ * @package OpenEMR\Events
+ * @subpackage Appointments
+ * @author Ken Chapple <ken@mi-squared.com>
+ * @copyright Copyright (c) 2019 Ken Chapple <ken@mi-squared.com>
+ */
+class AppointmentsFilterEvent extends Event
+{
+    /**
+     * The customFilter event occurs in the library/appointments.inc.php file in the fetchEvents()
+     * function, which fetches an array of all appointments. Setting this object's customWhereFilter
+     * can filter appointments that show up.
+     */
+    const EVENT_HANDLE = 'appointments.customFilter';
+
+    /**
+     * @var null|UserService
+     *
+     */
+    private $userService = null;
+
+    /**
+     * @var string
+     */
+    private $customWhereFilter= '1';
+
+    /**
+     *
+     */
+    public function __construct(UserService $userService)
+    {
+        $this->userService = $userService;
+    }
+
+    public function getUserService()
+    {
+        return $this->userService;
+    }
+
+    public function getCustomWhereFilter()
+    {
+        return $this->customWhereFilter;
+    }
+}

--- a/src/Events/Appointments/CalendarFilterEvent.php
+++ b/src/Events/Appointments/CalendarFilterEvent.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * This file is part of OpenEMR.
+ *
+ * @link https://github.com/openemr/openemr/tree/master
+ * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\Appointments;
+
+use OpenEMR\Services\PatientService;
+use OpenEMR\Services\UserService;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Event object for creating custom filters on calendar events
+ *
+ * @package OpenEMR\Events
+ * @subpackage Appointments
+ * @author Ken Chapple <ken@mi-squared.com>
+ * @copyright Copyright (c) 2019 Ken Chapple <ken@mi-squared.com>
+ */
+class CalendarFilterEvent extends Event
+{
+    /**
+     * The customWhereFilter event occurs in interface/main/calendar/modules/PostCalendar/pnuserapi.php and allows
+     * filtering the display calendar events
+     */
+    const EVENT_HANDLE = 'calendar.customFilter';
+
+    /**
+     * @var null|UserService
+     *
+     */
+    private $userService = null;
+
+    /**
+     * @var array
+     *
+     *
+     */
+    private $patientService = null;
+
+    /**
+     * @var bool
+     */
+    private $customWhereFilter = '1';
+
+    /**
+     *
+     */
+    public function __construct(UserService $userService)
+    {
+        $this->userService = $userService;
+    }
+
+    public function getUserService()
+    {
+        return $this->userService;
+    }
+
+    public function getCustomWhereFilter()
+    {
+        return $this->customWhereFilter;
+    }
+}

--- a/src/Events/Globals/GlobalSetting.php
+++ b/src/Events/Globals/GlobalSetting.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * This file is part of OpenEMR.
+ *
+ * @link https://github.com/openemr/openemr/tree/master
+ * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\Globals;
+
+/**
+ * Represents a global setting
+ *
+ * @package OpenEMR\Events
+ * @subpackage Globals
+ * @author Ken Chapple <ken@mi-squared.com>
+ * @copyright Copyright (c) 2019 Ken Chapple <ken@mi-squared.com>
+ */
+class GlobalSetting
+{
+    protected $label = null;
+    protected $dataType = null;
+    protected $default = null;
+    protected $description = null;
+    protected $isUserSetting = false;
+    
+    public function __construct( $label, $dataType, $default, $description, $isUserSetting = false )
+    {
+        $this->label = $label;
+        $this->dataType = $dataType;
+        $this->default = $default;
+        $this->description = $description;
+        $this->isUserSetting = $isUserSetting;
+    }
+    
+    public function format()
+    {
+        return array(
+        	xl( $this->label ),
+            $this->dataType,
+            $this->default,
+            xl( $this->description )
+        );
+    }
+
+    public function isUserSetting()
+    {
+        return $this->isUserSetting;
+    }
+}

--- a/src/Events/Globals/GlobalsInitializedEvent.php
+++ b/src/Events/Globals/GlobalsInitializedEvent.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * This file is part of OpenEMR.
+ *
+ * @link https://github.com/openemr/openemr/tree/master
+ * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\Globals;
+
+use OpenEMR\Services\UserService;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Event object for creating custom global settings
+ *
+ * @package OpenEMR\Events
+ * @subpackage Globals
+ * @author Ken Chapple <ken@mi-squared.com>
+ * @copyright Copyright (c) 2019 Ken Chapple <ken@mi-squared.com>
+ */
+class GlobalsInitializedEvent extends Event
+{
+    /**
+     * The global.init event occurs after globals have been set up in globals.inc.php
+     */
+    const EVENT_HANDLE = 'globals.initialized';
+
+    /**
+     * @var null|UserService
+     *
+     */
+    private $userService = null;
+
+    /**
+     * @var array
+     *
+     *
+     */
+    private $globalsMetadata = [];
+
+    /**
+     * @var array
+     *
+     *
+     */
+    private $userSpecificGlobals = [];
+
+    /**
+     * @var array
+     *
+     *
+     */
+    private $userSpecificTabs = [];
+
+    /**
+     * GlobalsInitEvent constructor.
+     * @param $userService
+     * @param $GLOBALS_METADATA
+     * @param $USER_SPECIFIC_GLOBALS
+     * @param $USER_SPECIFIC_TABS
+     */
+    public function __construct($userService ,$GLOBALS_METADATA,$USER_SPECIFIC_GLOBALS,$USER_SPECIFIC_TABS)
+    {
+        $this->userService = $userService;
+        $this->globalsMetadata = $GLOBALS_METADATA;
+        $this->userSpecificGlobals = $USER_SPECIFIC_GLOBALS;
+        $this->userSpecificTabs = $USER_SPECIFIC_TABS;
+    }
+
+    public function getUserService()
+    {
+        return $this->userService;
+    }
+
+    public function save()
+    {
+        global $GLOBALS_METADATA, $USER_SPECIFIC_GLOBALS, $USER_SPECIFIC_TABS;
+        $GLOBALS_METADATA = $this->globalsMetadata;
+        $USER_SPECIFIC_GLOBALS = $this->userSpecificGlobals;
+        $USER_SPECIFIC_TABS = $this->userSpecificTabs;
+    }
+
+    public function createSection($section, $beforeSection = false)
+    {
+        if (!isset($this->globalsMetadata[$section])) {
+            if ($beforeSection !== false &&
+                isset($this->globalsMetadata[$beforeSection])) {
+
+                $beforeSectionIndex = array_search($beforeSection, array_keys($this->globalsMetadata));
+                $this->globalsMetadata = array_slice($this->globalsMetadata, 0, $beforeSectionIndex, true) +
+                    array($section => []) +
+                    array_slice($this->globalsMetadata, $beforeSectionIndex, count($this->globalsMetadata) - 1, true) ;
+
+            } else {
+                $this->globalsMetadata[$section] = [];
+            }
+        } else {
+            throw new \Exception("Section already exists and cannot be created");
+        }
+    }
+
+    public function appendToSection($section, $key, GlobalSetting $global)
+    {
+        $this->globalsMetadata[$section][$key] = $global->format();
+        if ( $global->isUserSetting() ) {
+            $this->userSpecificGlobals[]= $key;
+        }
+    }
+
+    public function getGlobalsMetadata()
+    {
+        return $this->globalsMetadata;
+    }
+}

--- a/src/Events/PatientDemographics/UpdateEvent.php
+++ b/src/Events/PatientDemographics/UpdateEvent.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * This file is part of OpenEMR.
+ *
+ * @link https://github.com/openemr/openemr/tree/master
+ * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\PatientDemographics;
+
+use OpenEMR\Services\PatientService;
+use OpenEMR\Services\UserService;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Event object for restricting access to users updating patients
+ *
+ * @package OpenEMR\Events
+ * @subpackage PatientDemographics
+ * @author Ken Chapple <ken@mi-squared.com>
+ * @copyright Copyright (c) 2019 Ken Chapple <ken@mi-squared.com>
+ */
+class UpdateEvent extends Event
+{
+    /**
+     * The checkUpdateAuth event occurs when a user attempts to update a
+     * patient record from the demographics screen
+     */
+    const EVENT_HANDLE = 'patientDemographics.update';
+
+    /**
+     * @var null|UserService
+     *
+     */
+    private $userService = null;
+
+    /**
+     * @var array
+     *
+     *
+     */
+    private $patientService = null;
+
+    /**
+     * @var bool
+     */
+    private $authorized = true;
+
+    /**
+     *
+     */
+    public function __construct(UserService $userService, PatientService $patientService)
+    {
+        $this->userService = $userService;
+        $this->patientService = $patientService;
+    }
+
+    public function getUserService()
+    {
+        return $this->userService;
+    }
+
+    public function authorized()
+    {
+        return $this->authorized;
+    }
+}

--- a/src/Events/PatientDemographics/ViewEvent.php
+++ b/src/Events/PatientDemographics/ViewEvent.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * This file is part of OpenEMR.
+ *
+ * @link https://github.com/openemr/openemr/tree/master
+ * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\PatientDemographics;
+
+use OpenEMR\Services\PatientService;
+use OpenEMR\Services\UserService;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ *  Event object for restricting access to users viewing patients' demographics screen
+ *
+ * @package OpenEMR\Events
+ * @subpackage PatientDemographics
+ * @author Ken Chapple <ken@mi-squared.com>
+ * @copyright Copyright (c) 2019 Ken Chapple <ken@mi-squared.com>
+ */
+class ViewEvent extends Event
+{
+    /**
+     * The checkViewAuth event occurs when a user attempts to view a
+     * patient record from the demographics screen
+     */
+    const EVENT_HANDLE = 'patientDemographics.view';
+
+    /**
+     * @var null|UserService
+     *
+     */
+    private $userService = null;
+
+    /**
+     * @var array
+     *
+     *
+     */
+    private $patientService = null;
+
+    /**
+     * @var bool
+     */
+    private $authorized = true;
+
+    /**
+     *
+     */
+    public function __construct(UserService $userService, PatientService $patientService)
+    {
+        $this->userService = $userService;
+        $this->patientService = $patientService;
+    }
+
+    public function getUserService()
+    {
+        return $this->userService;
+    }
+
+    public function authorized()
+    {
+        return $this->authorized;
+    }
+}

--- a/src/Events/PatientFinder/ColumnFilter.php
+++ b/src/Events/PatientFinder/ColumnFilter.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * This file is part of OpenEMR.
+ *
+ * @link https://github.com/openemr/openemr/tree/master
+ * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\PatientFinder;
+
+/**
+ * Holds a column filter
+ *
+ * @package OpenEMR\Events
+ * @subpackage PatientFinder
+ * @author Ken Chapple <ken@mi-squared.com>
+ * @copyright Copyright (c) 2019 Ken Chapple <ken@mi-squared.com>
+ *
+ */
+class ColumnFilter
+{
+    private $name;
+    private $value;
+
+    public function __construct($name, $value)
+    {
+        $this->name = $name;
+        $this->value = $value;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param mixed $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public function setValue($value)
+    {
+        $this->value = $value;
+    }
+}

--- a/src/Events/PatientFinder/PatientFinderFilterEvent.php
+++ b/src/Events/PatientFinder/PatientFinderFilterEvent.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * This file is part of OpenEMR.
+ *
+ * @link https://github.com/openemr/openemr/tree/master
+ * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\PatientFinder;
+
+use OpenEMR\Services\UserService;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Event object for creating custom patient filters for patient finder
+ *
+ * @package OpenEMR\Events
+ * @subpackage PatientFinder
+ * @author Ken Chapple <ken@mi-squared.com>
+ * @copyright Copyright (c) 2019 Ken Chapple <ken@mi-squared.com>
+ */
+class PatientFinderFilterEvent extends Event
+{
+    /**
+     * The customWhereFilter event occurs in the dynamic_finder_ajax.php script that generates
+     * results for the patient finder. Subscribe to this event and set a customWhereFilter to
+     * alter the results of the patient finder query
+     */
+    const EVENT_HANDLE = 'patientFinder.customFilter';
+
+    /**
+     * @var null|UserService
+     *
+     */
+    private $userService = null;
+
+    /**
+     * @var array
+     *
+     * Array of columns displayed on the UI of patient finder
+     */
+    private $displayedColumns = [];
+
+    /**
+     * @var array
+     *
+     * Array of ColumnFilters that the end-user has created through UI
+     */
+    private $userColumnFilters = [];
+
+    /**
+     * @var array
+     *
+     * Custom where filter, applied "before" the user-generated filters through the UI.
+     * This filters are hidden from the end user.
+     *
+     * This defaults to "1" so that effectively no filter is applied
+     */
+    private $customWhereFilter = "1";
+
+    /**
+     * PatientFinderFilterEvent constructor.
+     * @param $displayedColumns
+     * @param array of ColumnFilter objects $userColumnFilters
+     */
+    public function __construct(UserService $userService, $displayedColumns, $userColumnFilters = [])
+    {
+        $this->userService = $userService;
+        $this->displayedColumns = $displayedColumns;
+        $this->userColumnFilters = $userColumnFilters;
+    }
+
+    public function getUserService()
+    {
+        return $this->userService;
+    }
+
+    public function getDisplayedColumns()
+    {
+        return $this->displayedColumns;
+    }
+
+    /**
+     * Get an array of column filters
+     *
+     * @return array Array of user-generated column filters
+     */
+    public function getUserColumnFilters()
+    {
+        return $this->userColumnFilters;
+    }
+
+    /**
+     * Get an string representing a patinet filter
+     *
+     * @return string
+     */
+    public function getCustomWhereFilter()
+    {
+        return $this->customWhereFilter;
+    }
+
+    public function setCustomWhereFilter($customWhereFilter)
+    {
+        $this->customWhereFilter = $customWhereFilter;
+    }
+}

--- a/src/Events/PatientSelect/PatientSelectFilterEvent.php
+++ b/src/Events/PatientSelect/PatientSelectFilterEvent.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * This file is part of OpenEMR.
+ *
+ * @link https://github.com/openemr/openemr/tree/master
+ * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\PatientSelect;
+
+use OpenEMR\Services\UserService;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Event object for creating custom patient filters for patient select (New/Search) results
+ *
+ * @package OpenEMR\Events
+ * @subpackage PatinetSelect
+ * @author Ken Chapple <ken@mi-squared.com>
+ * @copyright Copyright (c) 2019 Ken Chapple <ken@mi-squared.com>
+ */
+class PatientSelectFilterEvent extends Event
+{
+    /**
+     * The customWhereFilter event occurs in the patient_select.php script that generates
+     * results for the legacy patient new/search dialog. Subscribe to this event and set a customWhereFilter to
+     * alter the results of the patient finder query
+     */
+    const EVENT_HANDLE = 'patientSelect.customFilter';
+
+    /**
+     * @var null|UserService
+     *
+     */
+    private $userService = null;
+
+    /**
+     * @var array
+     *
+     * Custom where filter, applied "before" the user-generated filters through the UI.
+     * This filters are hidden from the end user.
+     *
+     * This defaults to "1" so that effectively no filter is applied
+     */
+    private $customWhereFilter = "1";
+
+    /**
+     * PatientSelectFilterEvent constructor.
+     *
+     * @param UserService $userService
+     */
+    public function __construct(UserService $userService)
+    {
+        $this->userService = $userService;
+    }
+
+    public function getUserService()
+    {
+        return $this->userService;
+    }
+
+    /**
+     * Get an string representing a patinet filter
+     *
+     * @return string
+     */
+    public function getCustomWhereFilter()
+    {
+        return $this->customWhereFilter;
+    }
+
+    public function setCustomWhereFilter($customWhereFilter)
+    {
+        $this->customWhereFilter = $customWhereFilter;
+    }
+}


### PR DESCRIPTION
Added events which enable 3rd party developers to add patient filtering, appointment filtering and custom globals using the built-in event dispatcher and Zend modules.

For example, you can filter out certain patients from results for some users, like if you didn't want User X to have access to patients with October birthdays, you could create a filter like this in your module's event handler:

if ($user == "User X") {
  $customFilter = DOB like "%-10-%";
}
$event->setCustomWhereFilter( $customFilter );

To dynamically add a global setting from within a module, you could do something like this in your module's event handler:

$event->createSection("My Custom Tab");
$setting = new GlobalSetting( 'My Custom Age Setting', 'text', '18', 'The default for something.' );
$event->appendToSection( "My Custom Tab", 'my_dafault_key', $setting );
$event->save();

