### PR TITLE
The find_action method in C_PAtient_finder class was returning an err…

### DIFF
--- a/controllers/C_PatientFinder.class.php
+++ b/controllers/C_PatientFinder.class.php
@@ -30,7 +30,7 @@ class C_PatientFinder extends Controller
     * Function that will display a patient finder widged, allowing
     *   the user to input search parameters to find a patient id.
     */
-    function find_action($form_id, $form_name, $pid)
+    function find_action($form_id, $form_name, $pid = '')
     {
         $isPid = false;
 


### PR DESCRIPTION
…or in the case a pid was not sent to it.  Default value of '' addresses this.  This fixes the inablity to search for a patient when moving a document to a different patient file