### PR TITLE
Capitalization typo fix in left navigation menu

### DIFF
--- a/contrib/util/language_translations/currentConstants.txt
+++ b/contrib/util/language_translations/currentConstants.txt
@@ -8440,7 +8440,7 @@ Review and Approve
 Review Audits
 Review of PMH:
 Review of System
-Review Of Systems
+Review of Systems
 Review of Systems Checks
 Review Status
 Review UB04


### PR DESCRIPTION
"of" instead of "Of" in the left navigation menu. 

This needs to be edited in the `registry` table `name` column as well, presumably in the installation database creation and upgrade scripts. How can I make those edits?