### PR TITLE
Fix to Billing Options

### DIFF
--- a/src/Billing/Claim.php
+++ b/src/Billing/Claim.php
@@ -1377,7 +1377,7 @@ class Claim
     {
         //If no box qualifier specified use "DK" for ordering provider
         //someday might make mbo form the place to set referring instead of demographics under choices
-        return empty($this->billing_options['provider_qualifier_code']) ? 'DK' :
+        return empty($this->billing_options['provider_qualifier_code']) ? '' :
             $this->billing_options['provider_qualifier_code'];
     }
 


### PR DESCRIPTION
Changed the default qualifier to '' from 'DK'.

The problem with 'DK' is that the 837P generator sees a non-empty value and assumes some sort of reference provider is being supplied (Referring, Ordering, Supervising).

With this as empty, if there is no auxillary provider then the NM1, N3 and N4 fields are not added to the EDI file.

P.S. sorry about the typo in the commit comment. I didn't see it until after the push.