### PR TITLE
Add hover over background colour transition in .menuLabel

### DIFF
--- a/interface/main/tabs/templates/menu_template.php
+++ b/interface/main/tabs/templates/menu_template.php
@@ -14,13 +14,13 @@
 
 <script type="text/html" id="menu-action">
     <i data-bind="css: icon,text:helperText" class="fa closeButton"></i>
-    <div class='menuLabel' data-bind="text:label,click: menuActionClick,css: {menuDisabled: ! enabled()}"></div>
+    <div class='menuLabel oe-pull-toward-unimportant' data-bind="text:label,click: menuActionClick,css: {menuDisabled: ! enabled()}"></div>
 
 </script>
 <script type="text/html" id="menu-header">
     <i data-bind="css: icon" class="fa closeButton"></i>
     <div class="menuSection">
-        <div class='menuLabel' data-bind="text:label"></div>
+        <div class='menuLabel oe-pull-toward-unimportant' data-bind="text:label"></div>
         <ul class="menuEntries" name="menuEntries" data-bind="foreach: children">
            <li data-bind="template: {name:header ? 'menu-header' : 'menu-action', data: $data }"></li>
         </ul>

--- a/interface/main/tabs/templates/user_data_template.php
+++ b/interface/main/tabs/templates/user_data_template.php
@@ -18,12 +18,12 @@
     <!-- ko with: user -->
         <div id="username" class="appMenu">
             <div class="menuSection userSection">
-                <div class='menuLabel' id="username" title="<?php echo xla('Current user') ?>">
+                <div class='menuLabel oe-pull-toward-unimportant' id="username" title="<?php echo xla('Current user') ?>">
                     <div><i class="fa fa-2x fa-user oe-show" aria-hidden="true" id="user_icon"></i></div>
                     <span data-bind="text:fname"></span>
                     <span data-bind="text:lname"></span>
                 </div>
-                <ul class="userfunctions menuEntries hideaway">
+                <ul class="userfunctions menuEntries hideaway oe-pull-toward-unimportant">
                     <li class="menuLabel" data-bind="click: editSettings"><?php echo xlt("Settings");?></li>
                     <li class="menuLabel" data-bind="click: changePassword"><?php echo xlt("Change Password");?></li>
                     <li class="menuLabel" data-bind="click: changeMFA"><?php echo xlt("MFA Management");?></li>

--- a/interface/themes/oe-common/help-files-common.scss
+++ b/interface/themes/oe-common/help-files-common.scss
@@ -46,8 +46,14 @@ font-size: 50%!important;
 .oe-pull-toward {
     float:$left !important;
 }
+.oe-pull-toward-unimportant {
+    float:$left;
+}
 .oe-pull-away {
     float: $right !important;
+}
+.oe-pull-away-unimportant {
+    float: $right;
 }
 .oe-margin-toward {
     margin-#{$left}:30px;

--- a/interface/themes/rtl_style_pdf.css
+++ b/interface/themes/rtl_style_pdf.css
@@ -1147,8 +1147,14 @@ body {
 .oe-pull-toward {
     float:right !important;
 }
+.oe-pull-toward-unimportant {
+    float:right;
+}
 .oe-pull-away {
     float:left !important;
+}
+.oe-pull-away-unimportant {
+    float:left;
 }
 .oe-margin-toward {
     margin-right:30px;

--- a/interface/themes/tabs_style_compact.css
+++ b/interface/themes/tabs_style_compact.css
@@ -353,6 +353,9 @@ body
 {
     cursor: pointer;
     padding: 5px 12px 5px;
+    transition: background-color 0.1s ease;
+    width: 100%;
+    float: none;
 }
 .menuDisabled
 {

--- a/interface/themes/tabs_style_full.css
+++ b/interface/themes/tabs_style_full.css
@@ -360,7 +360,7 @@ z-index:10000;
     color: #333;
     padding: 15px 10px;
     font-weight: 700;
-    transition: background-color 0.5s ease;
+    transition: background-color 0.1s ease;
     width: 100%;
 }
 .menuLabel:hover {

--- a/interface/themes/tabs_style_full.css
+++ b/interface/themes/tabs_style_full.css
@@ -361,7 +361,6 @@ z-index:10000;
     padding: 15px 10px;
     font-weight: 700;
     transition: background-color 0.5s ease;
-    float: left;
     width: 100%;
 }
 .menuLabel:hover {

--- a/interface/themes/tabs_style_full.css
+++ b/interface/themes/tabs_style_full.css
@@ -361,6 +361,8 @@ z-index:10000;
     padding: 15px 10px;
     font-weight: 700;
     transition: background-color 0.5s ease;
+    float: left;
+    width: 100%;
 }
 .menuLabel:hover {
     background: #CCE3F8;
@@ -376,6 +378,7 @@ div.menuLabel:hover {
 .menuEntries li .menuLabel {
     display: block;
     padding: 10px 20px;
+    float: none;
 }
 .menuEntries li .menuLabel:hover {
     background-color: #CCE3F8;

--- a/interface/themes/tabs_style_full.css
+++ b/interface/themes/tabs_style_full.css
@@ -360,6 +360,7 @@ z-index:10000;
     color: #333;
     padding: 15px 10px;
     font-weight: 700;
+    transition: background-color 0.5s ease;
 }
 .menuLabel:hover {
     background: #CCE3F8;


### PR DESCRIPTION
To whom it may concern,

The menu buttons in the header now have a transition time of **0.5** seconds for a better user experience. However, I noticed that the transition would not appear if you immediately go onto a button that has a dropdown. 

Note that this is my first PR, so do correct me if I made any mistakes. Thank you.

below added by bradymiller:
Up For Grabs demo to demo this PR is here:
https://www.open-emr.org/wiki/index.php/Development_Demo#Mu_-_Up_For_Grabs_Demo