### PR TITLE
Fix box 17 qualifier check

### DIFF
--- a/src/Billing/X12_5010_837P.php
+++ b/src/Billing/X12_5010_837P.php
@@ -1373,7 +1373,7 @@ class X12_5010_837P
             // Loop 2420E, Ordering Provider.
             // for Medicare DME claims esp @joe on chat.open-emr.org :)
 
-            if ($claim->Box17Qualifier() == "DK" && ($claim->claimType() === 'MB')) {
+            if (!empty($claim->Box17Qualifier()) && ($claim->claimType() === 'MB')) {
                 ++$edicount;
                 $out .= "NM1" .
                     "*" . $claim->Box17Qualifier() .


### PR DESCRIPTION
This is a follow on to the Claim fix that changed the default type from DK to ''.

The 837 generator is currently only adding a referring/ordering/supervising physician if the qualifier value is DK. The logic should be to check that the qualifier is not empty first and if not then add the user selected qualifier and physician information.