### PR TITLE
Restore X12_5010_837P.php

### DIFF
--- a/src/Billing/X12_5010_837P.php
+++ b/src/Billing/X12_5010_837P.php
@@ -1117,7 +1117,7 @@ class X12_5010_837P
             } else {
                 $log .= "*** Missing other insco payer name.\n";
             }
-            $out .= "*";
+            $out .= "*" .
             "*" .
             "*" .
             "*" .


### PR DESCRIPTION
Someone had a semi-colon in the 2330B loop that was breaking systems. This restores it to the string concatenation.