### PR TITLE
Initial Custom Module support and installer.

### DIFF
--- a/interface/modules/zend_modules/config/application.config.php
+++ b/interface/modules/zend_modules/config/application.config.php
@@ -26,7 +26,7 @@ $core_modules = [
 function oemr_zend_load_modules_from_db()
 {
     // we skip the audit log as it has no bearing on user activity and is core system related...
-    $resultSet = sqlStatementNoLog($statement = "SELECT mod_name FROM modules WHERE mod_active = 1 ORDER BY `mod_ui_order`, `date`");
+    $resultSet = sqlStatementNoLog($statement = "SELECT mod_name FROM modules WHERE mod_active = 1 AND type = 1 ORDER BY `mod_ui_order`, `date`");
     $db_modules = [];
     while ($row = sqlFetchArray($resultSet)) {
         $db_modules[] = $row["mod_name"];

--- a/interface/modules/zend_modules/module/Installer/view/installer/installer/index.phtml
+++ b/interface/modules/zend_modules/module/Installer/view/installer/installer/index.phtml
@@ -192,7 +192,7 @@ $depObj 	= $this->dependencyObject;
 	        			<?php
 	                		$form_title_file = @file($GLOBALS['srcdir']."/../{$baseModuleDir}{$customDir}/$fname/info.txt");
 				            if ($form_title_file)
-	                        	$form_title = $form_title_file[0];
+	                        	$form_title = trim($form_title_file[0]);
 	                        else
 	                            $form_title = $fname;
 	                		echo $listener->z_xlt($form_title);

--- a/interface/patient_file/report/patient_report.php
+++ b/interface/patient_file/report/patient_report.php
@@ -16,8 +16,11 @@ require_once("$srcdir/forms.inc");
 require_once("$srcdir/patient.inc");
 
 use OpenEMR\Core\Header;
+use OpenEMR\Events\PatientReport\PatientReportEvent;
 use OpenEMR\Menu\PatientMenuRole;
 use OpenEMR\OeUI\OemrUI;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 if (!acl_check('patients', 'pat_rep')) {
     die(xlt('Not authorized'));
@@ -30,6 +33,11 @@ $auth_coding   = acl_check('encounters', 'coding');
 $auth_relaxed  = acl_check('encounters', 'relaxed');
 $auth_med      = acl_check('patients', 'med');
 $auth_demo     = acl_check('patients', 'demo');
+
+/**
+ * @var EventDispatcherInterface $eventDispatcher  The event dispatcher / listener object
+ */
+$eventDispatcher = $GLOBALS['kernel']->getEventDispatcher();
 
 $cmsportal = false;
 if ($GLOBALS['gbl_portal_cms_enable']) {
@@ -256,9 +264,12 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
             <br>
             <button type="button" class="genreport btn btn-default btn-save btn-sm" value="<?php echo xla('Generate Report'); ?>" ><?php echo xlt('Generate Report'); ?></button>
             <button type="button" class="genpdfrep btn btn-default btn-download btn-sm" value="<?php echo xla('Download PDF'); ?>" ><?php echo xlt('Download PDF'); ?></button>
-            <?php if ($cmsportal) { ?>
+                <?php if ($cmsportal) { ?>
             <button type="button" class="genportal btn btn-default btn-send-msg btn-sm" value="<?php echo xla('Send to Portal'); ?>" ><?php echo xlt('Send to Portal'); ?></button>
             <?php } ?>
+            <?php
+            $eventDispatcher->dispatch(OpenEMR\Events\PatientReport::ACTIONS_RENDER_POST, new GenericEvent());
+            ?>
             <input type='hidden' name='pdf' value='0'>
             <br>
 
@@ -738,6 +749,10 @@ if ($GLOBALS['phimail_enable']==true && $GLOBALS['phimail_ccd_enable']==true) { 
                 }
         });
 <?php } ?>
+
+    <?php
+    $eventDispatcher->dispatch(PatientReportEvent::JAVASCRIPT_READY_POST, new GenericEvent());
+    ?>
 
 });
 

--- a/src/Core/ModulesApplication.php
+++ b/src/Core/ModulesApplication.php
@@ -21,18 +21,21 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class ModulesApplication
 {
-    
+
     /**
      * The application reference pointer for the zend mvc modules application
      * @var \Zend\Mvc\Application
      */
     private $application;
 
+    const CUSTOM_MODULE_BOOSTRAP_NAME = 'openemr.bootstrap.php';
+
     public function __construct(Kernel $kernel, $webRootPath, $modulePath, $zendModulePath)
     {
         $zendConfigurationPath = $webRootPath . DIRECTORY_SEPARATOR . $modulePath . DIRECTORY_SEPARATOR . $zendModulePath;
+        $customModulePath = $webRootPath . DIRECTORY_SEPARATOR . $modulePath . DIRECTORY_SEPARATOR . "custom_modules" . DIRECTORY_SEPARATOR;
         $configuration = require $zendConfigurationPath . DIRECTORY_SEPARATOR . 'config/application.config.php';
-        
+
         // Prepare the service manager
         // We customize this and skip using the static Zend\Mvc\Application::init in order to inject the
         // Symfony Kernel's EventListener that way we can bridge the two frameworks.
@@ -55,6 +58,46 @@ class ModulesApplication
         $listeners = array_unique(array_merge($listenersFromConfigService, $listenersFromAppConfig));
 
         $this->application = $serviceManager->get('Application')->bootstrap($listeners);
+
+        // we skip the audit log as it has no bearing on user activity and is core system related...
+        $resultSet = sqlStatementNoLog($statement = "SELECT mod_name FROM modules WHERE mod_active = 1 AND type != 1 ORDER BY `mod_ui_order`, `date`");
+        $db_modules = [];
+        while ($row = sqlFetchArray($resultSet)) {
+            $db_modules[] = $row["mod_name"];
+        }
+
+        $this->bootstrapCustomModules($kernel->getEventDispatcher(), $customModulePath);
+    }
+
+    private function bootstrapCustomModules($eventDispatcher, $customModulePath) {
+        // we skip the audit log as it has no bearing on user activity and is core system related...
+        $resultSet = sqlStatementNoLog($statement = "SELECT mod_name, mod_directory FROM modules WHERE mod_active = 1 AND type != 1 ORDER BY `mod_ui_order`, `date`");
+        $db_modules = [];
+        while ($row = sqlFetchArray($resultSet)) {
+            $db_modules[] = ["name" => $row["mod_name"], "directory" => $row['mod_directory'], "path" => $customModulePath . $row['mod_directory'] ];
+        }
+        foreach ($db_modules as $module) {
+            $this->loadCustomModule($module, $eventDispatcher);
+        }
+        // TODO: stephen we should fire an event saying we've now loaded all the modules here.
+    }
+
+    private function loadCustomModule($module, $eventDispatcher) {
+        if (!is_readable($module['path'] . DIRECTORY_SEPARATOR . self::CUSTOM_MODULE_BOOSTRAP_NAME)) {
+            // TODO: stephen need to escape filename here.
+            error_log("Custom module file path " . errorLogEscape($module['path'] )
+                . DIRECTORY_SEPARATOR . self::CUSTOM_MODULE_BOOSTRAP_NAME
+                . " is not readable.  Check directory permissions");
+        }
+        try {
+            // the only thing in scope here is $module and $eventDispatcher which is ok for our bootstrap piece.
+            // do we really want to just include a file??  Should we go all zend and actually force a class instantiation
+            // here and then inject the EventDispatcher or even possibly the Symfony Kernel here?
+            include $module['path'] . DIRECTORY_SEPARATOR . self::CUSTOM_MODULE_BOOSTRAP_NAME;
+        }
+        catch (Exception $exception) {
+            error_log(errorLogEscape($exception->getMessage()));
+        }
     }
 
     public function run()

--- a/src/Events/PatientReport/PatientReportEvent.php
+++ b/src/Events/PatientReport/PatientReportEvent.php
@@ -1,0 +1,20 @@
+<?php
+namespace OpenEMR\Events\PatientReport;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class PatientReportEvent extends Event {
+
+    /**
+     * This event fires after the action buttons for the report have rendered.
+     * It allows listeners to render additional content or buttons.
+     */
+    const ACTIONS_RENDER_POST = 'patientReport.actions.render.post';
+
+    /**
+     * This event fires after the document.ready event has fired in javascript and all of the javascript functions
+     * that we want to execute on that ready event have rendered to the screen.  Listeners can insert additional
+     * javascript onto the screen for the patient report.
+     */
+    const JAVASCRIPT_READY_POST = 'patientReport.javascript.load.post';
+}


### PR DESCRIPTION
This pull request contains the work for both zend and custom modules to be used and installed via composer.  Its intent is to continue to allow customization and vendor support of the OpenEMR codebase without requiring all the changes to be done directly in the core system files.

Before this code, the only workable modules were zend modules and developers were finding it cumbersome to implement.  This work makes it possible to have a custom module that connects to OpenEMR via a single file the openemr.bootstrap.php file.  Module developers can now use either whatever programming style they want (procedural, oop, functional, etc) as well as whatever framework they want without impacting the core OpenEMR code.

I changed the ModuleApplications class to load the openemr.bootstrap.php file for each enabled custom module.  

I also changed the zend application code so that the custom modules are not loaded as zend applications.

In testing this code on the docker environment you may have to manually apply the changes to interface/modules/zend_modules/application.config.php as the docker images pulls that file as readonly from the openemr master code.
 
To have modules auto install via composer you have to have your composer package type be 'openemr-module'  You can see an example of this in the composer.json file for the sample openemr module oe-module-faxsms.

You can see how the sample works by doing the following command:
```
composer require openemr/oe-module-faxsms:@dev
```

You can then go on the Admin GUI and from the Modules Installer menu item you can install the faxmodule and enable it just like you would the Carecoordination module.

The fax/SMS module gets added and its appropriate hooks are executed.  You will have to logout and login again to see the menu change take effect which is the easiest hook to verify.

A future improvement for this is to have the OpenEMR module installer grab the descriptive name of the module from the composer.json file.  Right now it grabs a descriptive name from the first line of a Info.txt file at the root of the module folder.

Also important to note is that right now all of the zend modules will execute first before the custom modules. 