### PR TITLE
Fixing critical issues with Fees > Batch Payments

### DIFF
--- a/interface/billing/billing_report.php
+++ b/interface/billing/billing_report.php
@@ -309,14 +309,14 @@ $partners = $x->_utility_array($x->x12_partner_factory());
         f.bn_x12_support.disabled = !can_generate;
             <?php if ($GLOBALS['support_encounter_claims']) { ?>
         f.bn_x12_encounter.disabled = !can_generate;
-        <?php } ?>
+            <?php } ?>
         f.bn_process_hcfa_support.disabled = !can_generate;
             <?php if ($GLOBALS['preprinted_cms_1500']) { ?>
         f.bn_process_hcfa_form.disabled = !can_generate;
-        <?php } ?>
+            <?php } ?>
             <?php if ($GLOBALS['ub04_support']) { ?>
         f.bn_process_ub04_support.disabled = !can_generate;
-        <?php } ?>
+            <?php } ?>
         f.bn_hcfa_txt_file.disabled = !can_generate;
         f.bn_reopen.disabled = !can_bill;
         <?php } ?>
@@ -1342,7 +1342,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                 $rhtml .= text(oeFormatMoney($iter['fee']));
                             }
                             $rhtml .= "</span></td>\n";
-                            $rhtml .= '<td><span style="font-size:8pt;">&nbsp;&nbsp;&nbsp;';
+                            $rhtml .= '<td><span style="font-size:8pt; font-weight:900; background:#ffff9e">&nbsp;&nbsp;&nbsp;';
                             if ($iter['id']) {
                                 $rhtml .= getProviderName(empty($iter['provider_id']) ? text($iter['enc_provider_id']) : text($iter['provider_id']));
                             }

--- a/interface/billing/edit_payment.php
+++ b/interface/billing/edit_payment.php
@@ -821,12 +821,15 @@ fieldset {
                                 $Table='yes';
                                 ?>
                     <input id="HiddenRemainderTd<?php echo attr($CountIndex); ?>" name="HiddenRemainderTd<?php echo attr($CountIndex); ?>" type="hidden" value="<?php echo attr(round($RemainderJS, 2)); ?>">
+                <br>
+                <br>
+                <div class="col-xs-12">
                 <div class = "table-responsive">
                 <table class="table-condensed" id="TableDistributePortion" >
                 <thead bgcolor="#DDDDDD" class="text">
                     <td class="left top" >&nbsp;</td>
                     <td class="left top" ><?php echo xlt('Patient Name'); ?></td>
-                    <td class="left top" ><?php echo xlt('Post For'); ?></td>
+                    <td class="left top" style="width:75px"><?php echo xlt('Post For'); ?></td>
                     <td class="left top" ><?php echo xlt('Service Date'); ?></td>
                     <td class="left top" ><?php echo xlt('Encounter'); ?></td>
                     <td class="left top" ><?php echo xlt('Service Code'); ?></td>
@@ -1071,15 +1074,19 @@ fieldset {
                 }//End of if($RowSearchSub = sqlFetchArray($ResultSearchSub))
                 ?>
                 </div>
+                </div>
+                <div class="col-sm-12">
                     <?php
                         require_once("payment_pat_sel.inc.php"); //Patient ajax section and listing of charges.
                     ?>
+                 </div>
                 <?php
             }//End of if($payment_id*1>0)
             ?>
             <?php //can change position of buttons by creating a class 'position-override' and adding rule text-align:center or right as the case may be in individual stylesheets ?>
             <div class="form-group clearfix">
                 <div class="col-sm-12 text-left position-override">
+                <br>
                     <div class="btn-group" role="group">
                         <a class="btn btn-default btn-save" href="#" onclick="javascript:return ModifyPayments();"><span><?php echo xlt('Modify Payments');?></span></a>
                         <a class="btn btn-default btn-save" href="#" onclick="javascript:return FinishPayments();"><span><?php echo xlt('Finish Payments');?></span></a>
@@ -1104,4 +1111,14 @@ fieldset {
     </div>
     </div><!-- End of container div-->
 </body>
+<script>
+     function ResetForm()
+    {//Resets form used in the 'Cancel Changes' button in the master screen.
+     document.forms[0].reset();
+     document.getElementById('TdUnappliedAmount').innerHTML='0.00';
+     document.getElementById('div_insurance_or_patient').innerHTML='&nbsp;';
+     CheckVisible('yes');//Payment Method is made 'Check Payment' and the Check box is made visible.
+     PayingEntityAction();//Paying Entity is made 'insurance' and Payment Category is 'Insurance Payment'
+    }                                                                
+</script>
 </html>

--- a/interface/billing/new_payment.php
+++ b/interface/billing/new_payment.php
@@ -449,7 +449,7 @@ $payment_id=$payment_id*1 > 0 ? $payment_id + 0 : $request_payment_id + 0;
                 <form action="new_payment.php" id="new_payment" method='post' name='new_payment' onsubmit="
                 <?php
                 if ($payment_id*1==0) {
-                   // echo 'top.restoreSession();return SavePayment();';
+                   echo 'top.restoreSession();';
                 } else {
                     echo 'return false;';
                 }?>" style="display:inline">
@@ -510,12 +510,6 @@ $payment_id=$payment_id*1 > 0 ? $payment_id + 0 : $request_payment_id + 0;
 <script>
 $(function() {
     $('select').removeClass('class1 text')
-});
-</script>
-<script>
-//$('#save_btn').on('click', SavePayment);
-$('#save_btn').on('click', function(){
-    $('#payment_method').prop('disabled', 'disabled');
 });
 </script>
 </body>

--- a/interface/billing/new_payment.php
+++ b/interface/billing/new_payment.php
@@ -449,7 +449,7 @@ $payment_id=$payment_id*1 > 0 ? $payment_id + 0 : $request_payment_id + 0;
                 <form action="new_payment.php" id="new_payment" method='post' name='new_payment' onsubmit="
                 <?php
                 if ($payment_id*1==0) {
-                    echo 'top.restoreSession();return SavePayment();';
+                   // echo 'top.restoreSession();return SavePayment();';
                 } else {
                     echo 'return false;';
                 }?>" style="display:inline">
@@ -475,8 +475,10 @@ $payment_id=$payment_id*1 > 0 ? $payment_id + 0 : $request_payment_id + 0;
                             if ($CountIndexBelow>0) {
                                 ?>
                                 <?php //can change position of buttons by creating a class 'position-override' and adding rule text-align:center or right as the case may be in individual stylesheets ?>
+                            <br>
                             <div class="form-group clearfix">
                             <div class="col-sm-12 text-left position-override">
+                                <br>
                                 <div class="btn-group btn-group-pinch" role="group">
                                     <button class="btn btn-default btn-save" href="#" onclick="return PostPayments();"><?php echo xlt('Post Payments');?></button>
                                     <button class="btn btn-default btn-save" href="#" onclick="return FinishPayments();"><?php echo xlt('Finish Payments');?></button>
@@ -491,7 +493,8 @@ $payment_id=$payment_id*1 > 0 ? $payment_id + 0 : $request_payment_id + 0;
                         }
                         ?>
                     </fieldset>
-                    <input id="hidden_patient_code" name="hidden_patient_code" type="hidden" value="<?php echo attr($hidden_patient_code);?>"> <input id='mode' name='mode' type='hidden' value=''>
+                    <input id="hidden_patient_code" name="hidden_patient_code" type="hidden" value="<?php echo attr($hidden_patient_code);?>">
+                    <input id='mode' name='mode' type='hidden' value=''>
                     <input id='default_search_patient' name='default_search_patient' type='hidden' value='<?php echo attr($default_search_patient); ?>'>
                     <input id='ajax_mode' name='ajax_mode' type='hidden' value=''>
                     <input id="after_value" name="after_value" type="hidden" value="<?php echo attr($mode);?>">
@@ -507,6 +510,12 @@ $payment_id=$payment_id*1 > 0 ? $payment_id + 0 : $request_payment_id + 0;
 <script>
 $(function() {
     $('select').removeClass('class1 text')
+});
+</script>
+<script>
+//$('#save_btn').on('click', SavePayment);
+$('#save_btn').on('click', function(){
+    $('#payment_method').prop('disabled', 'disabled');
 });
 </script>
 </body>

--- a/interface/billing/payment_master.inc.php
+++ b/interface/billing/payment_master.inc.php
@@ -145,11 +145,11 @@ if (($screen=='new_payment' && $payment_id*1==0) || ($screen=='edit_payment' && 
                     <div class="col-xs-12 oe-custom-line">
                         <div class="forms col-xs-3">
                             <label class="control-label" for="check_date"><?php echo xlt('Date'); ?>:</label>
-                            <input class="form-control datepicker" id='check_date' name='check_date' type='text' value="<?php echo attr(oeFormatShortDate($CheckDate));?>">
+                            <input class="form-control datepicker" id='check_date' name='check_date' type='text' value="<?php echo attr(oeFormatShortDate($CheckDate));?>" autocomplete="off">
                         </div>
                         <div class="forms col-xs-3">
                             <label class="control-label" for="post_to_date"><?php echo xlt('Post To Date'); ?>:</label>
-                            <input class="form-control datepicker" id='post_to_date' name='post_to_date' type='text' value="<?php echo ($screen=='new_payment') ? attr(oeFormatShortDate(date('Y-m-d'))) : attr(oeFormatShortDate($PostToDate));?>">
+                            <input class="form-control datepicker" id='post_to_date' name='post_to_date' type='text' value="<?php echo ($screen=='new_payment') ? attr(oeFormatShortDate(date('Y-m-d'))) : attr(oeFormatShortDate($PostToDate));?>" autocomplete="off">
                         </div>
                         <div class="forms col-xs-3">
                             <label class="control-label" for="payment_method"><?php echo xlt('Payment Method'); ?>:</label>
@@ -238,7 +238,7 @@ if (($screen=='new_payment' && $payment_id*1==0) || ($screen=='edit_payment' && 
                     <div class="col-xs-12 oe-custom-line">
                         <div class="col-xs-3">
                             <label class="control-label" for="deposit_date"><?php echo xlt('Deposit Date'); ?>:</label>
-                            <input type='text' class='form-control datepicker' name='deposit_date' id='deposit_date'  onKeyDown="PreventIt(event)"  value="<?php echo attr(oeFormatShortDate($DepositDate));?>"/>
+                            <input type='text' class='form-control datepicker' name='deposit_date' id='deposit_date'  onKeyDown="PreventIt(event)"  value="<?php echo attr(oeFormatShortDate($DepositDate));?>" autocomplete="off"/>
                         </div>
                         <div class="col-xs-6">
                             <label class="control-label" for="description"><?php echo xlt('Description'); ?>:</label>
@@ -285,10 +285,11 @@ if ($screen=='new_payment' && $payment_id*1>0) {//After saving from the New Paym
                             <input class="form-control" id='post_to_date' name='post_to_date' type='text' value="<?php echo ($screen=='new_payment') ? attr(oeFormatShortDate(date('Y-m-d'))) : attr(oeFormatShortDate($PostToDate));?>"disabled>
                         </div>
                         <div class="forms col-xs-3">
-                            <label class="control-label" for="payment_method1"><?php echo xlt('Payment Method'); ?>:</label>
-                            <input type="text" class="form-control" name="payment_method1" id="payment_method1" value="<?php $frow['data_type']=1;
-                            $frow['list_id']='payment_method';
-                            generate_print_field($frow, $PaymentMethod);?>" disabled />
+                            <label class="control-label" for="payment_method"><?php echo xlt('Payment Method'); ?>:</label>
+                            <input type="text" class="form-control" name="payment_method1" id="payment_method" value="<?php
+                            $list='payment_method';
+                            $option=$PaymentMethod;
+                            echo getListItemTitle($list, $option);?>" disabled />
                             <input type="hidden" name="payment_method" value="<?php echo attr($PaymentMethod);?>"/>
                         </div>
                         <div class="forms col-xs-3">
@@ -304,16 +305,18 @@ if ($screen=='new_payment' && $payment_id*1>0) {//After saving from the New Paym
                         </div>
                         <div class="forms col-xs-3">
                             <label class="control-label" for="type_name"><?php echo xlt('Paying Entity'); ?>:</label>
-                            <input type="text" class="form-control" name="type_name1" id="type_name1" value="<?php  $frow['data_type']=1;
-                            $frow['list_id']='payment_type';
-                            generate_print_field($frow, $PaymentType);?>" disabled />
+                            <input type="text" class="form-control" name="type_name1" id="type_name1" value="<?php
+                            $list='payment_type';
+                            $option=$PaymentType;
+                            echo getListItemTitle($list, $option);?>" disabled />
                             <input type="hidden" name="type_name" id="type_name" value="<?php echo attr($PaymentType);?>"/>
                         </div>
                         <div class="forms col-xs-3">
                             <label class="control-label" for="adjustment_code"><?php echo xlt('Payment Category'); ?>:</label>
-                            <input type="text" class="form-control" name="adjustment_code1" id="adjustment_code1" value="<?php $frow['data_type']=1;
-                            $frow['list_id']='payment_adjustment_code';
-                            generate_print_field($frow, $AdjustmentCode);?>" disabled />
+                            <input type="text" class="form-control" name="adjustment_code1" id="adjustment_code1" value="<?php
+                            $list='payment_adjustment_code';
+                            $option=$AdjustmentCode;
+                            echo getListItemTitle($list, $option);?>" disabled />
                             <input type="hidden" name="adjustment_code" value="<?php echo attr($AdjustmentCode);?>"/>
                         </div>
                     </div>

--- a/interface/billing/payment_pat_sel.inc.php
+++ b/interface/billing/payment_pat_sel.inc.php
@@ -47,6 +47,7 @@ if (isset($_POST["mode"])) {
 }
 //===============================================================================
 ?>
+                    <br>
                     <fieldset>
                     <legend class=""><?php echo xlt('Distribute')?></legend>
                     <div class="col-xs-12" style="padding-bottom:5px">
@@ -91,6 +92,7 @@ if (isset($_POST["mode"])) {
                 $PreviousPID=0;
                 if ($RowSearch = sqlFetchArray($ResultSearchNew)) {
                     ?>
+                <div class="col-xs-12">
                 <div class = "table-responsive">
                 <table class="table-condensed"   id="TableDistributePortion">
                   <thead class="" bgcolor="#dddddd">
@@ -258,11 +260,8 @@ if (isset($_POST["mode"])) {
                   </tr>
                 </table>
                 </div>
+                </div>
                 <br>
                     <?php
                 }//if($RowSearch = sqlFetchArray($ResultSearchNew))
                 ?>
-        <!--</td>
-    </tr>
-</table>
-</div>-->

--- a/interface/billing/search_payments.php
+++ b/interface/billing/search_payments.php
@@ -464,11 +464,11 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                             </div>
                             <div class="forms col-xs-2">
                                 <label class="control-label" for="FromDate"><?php echo xlt('From'); ?>:</label>
-                                <input class="form-control datepicker" id='FromDate' name='FromDate'  type='text' value='<?php echo attr($FromDate); ?>'>
+                                <input class="form-control datepicker" id='FromDate' name='FromDate'  type='text' value='<?php echo attr($FromDate); ?>' autocomplete="off">
                             </div>
                             <div class="forms col-xs-2">
                                 <label class="control-label" for="ToDate"><?php echo xlt('To{{Range}}'); ?>:</label>
-                                <input class="form-control datepicker" id='ToDate' name='ToDate' type='text' value='<?php echo attr($ToDate); ?>'>
+                                <input class="form-control datepicker" id='ToDate' name='ToDate' type='text' value='<?php echo attr($ToDate); ?>' autocomplete="off">
                             </div>
                             <div class="forms col-xs-3">
                                 <label class="control-label" for="payment_method"><?php echo xlt('Payment Method'); ?>:</label>
@@ -592,13 +592,13 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                 <a href="#" onclick="javascript:return DeletePayments(<?php echo attr_js($RowSearch['session_id']); ?>);"><img border="0" src="../pic/Delete.gif"></a>
                             </td>
                             <td class="<?php echo attr($StringClass); ?>">
-                                <a class="" data-toggle="modal"  data-target="#myModal" onclick="loadiframe('edit_payment.php?payment_id=<?php echo attr_url($RowSearch['session_id']); ?>')"><?php echo text($RowSearch['session_id']); ?></a>
+                                <a class="" data-toggle="modal"  data-target="#myModal1" onclick="loadiframe('edit_payment.php?payment_id=<?php echo attr_url($RowSearch['session_id']); ?>')"><?php echo text($RowSearch['session_id']); ?></a>
                             </td>
                             <td class="<?php echo attr($StringClass); ?>">
-                                <a class="" data-toggle="modal"  data-target="#myModal" onclick="loadiframe('edit_payment.php?payment_id=<?php echo attr_url($RowSearch['session_id']); ?>')"><?php echo $RowSearch['check_date']=='0000-00-00' ? '&nbsp;' : text(oeFormatShortDate($RowSearch['check_date'])); ?></a>
+                                <a class="" data-toggle="modal"  data-target="#myModal1" onclick="loadiframe('edit_payment.php?payment_id=<?php echo attr_url($RowSearch['session_id']); ?>')"><?php echo $RowSearch['check_date']=='0000-00-00' ? '&nbsp;' : text(oeFormatShortDate($RowSearch['check_date'])); ?></a>
                             </td>
                             <td class="<?php echo attr($StringClass); ?>">
-                                <a class="" data-toggle="modal"  data-target="#myModal" onclick="loadiframe('edit_payment.php?payment_id=<?php echo attr_url($RowSearch['session_id']); ?>')">
+                                <a class="" data-toggle="modal"  data-target="#myModal1" onclick="loadiframe('edit_payment.php?payment_id=<?php echo attr_url($RowSearch['session_id']); ?>')">
                                 <?php
                                     $frow['data_type']=1;
                                     $frow['list_id']='payment_type';
@@ -615,10 +615,10 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                 </td>
                                 <td class="<?php echo attr($StringClass); ?>">
                                 <!--<a class='iframe medium_modal' href="edit_payment.php?payment_id=<?php echo htmlspecialchars($RowSearch['session_id']); ?>"><?php echo  $Payer=='' ? '&nbsp;' : htmlspecialchars($Payer) ;?></a>-->
-                                <a class="" data-target="#myModal" data-toggle="modal" onclick="loadiframe('edit_payment.php?payment_id=<?php echo attr_url($RowSearch['session_id']); ?>')"><?php echo  $Payer=='' ? '&nbsp;' : text($Payer) ;?></a><!--link to iframe-->
+                                <a class="" data-target="#myModal1" data-toggle="modal" onclick="loadiframe('edit_payment.php?payment_id=<?php echo attr_url($RowSearch['session_id']); ?>')"><?php echo  $Payer=='' ? '&nbsp;' : text($Payer) ;?></a><!--link to iframe-->
                                 </td>
                                 <td class="<?php echo attr($StringClass); ?>">
-                                <a class="" data-toggle="modal"  data-target="#myModal" onclick="loadiframe('edit_payment.php?payment_id=<?php echo attr_url($RowSearch['session_id']); ?>')"><?php echo $RowSearch['payer_id']*1 >0 ? text($RowSearch['payer_id']) : '&nbsp;'; ?></a>
+                                <a class="" data-toggle="modal"  data-target="#myModal1" onclick="loadiframe('edit_payment.php?payment_id=<?php echo attr_url($RowSearch['session_id']); ?>')"><?php echo $RowSearch['payer_id']*1 >0 ? text($RowSearch['payer_id']) : '&nbsp;'; ?></a>
                                 </td>
                                 <td align="left" class="<?php echo attr($StringClass); ?>">
                                 <!--<a class='iframe medium_modal' href="edit_payment.php?payment_id=<?php echo attr_url($RowSearch['session_id']); ?>"><?php
@@ -626,7 +626,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                                         $frow['list_id']='payment_method';
                                                         generate_print_field($frow, $RowSearch['payment_method']);
                                 ?></a>-->
-                                        <a class="" data-toggle="modal"  data-target="#myModal" onclick="loadiframe('edit_payment.php?payment_id=<?php echo attr_url($RowSearch['session_id']); ?>')">
+                                        <a class="" data-toggle="modal"  data-target="#myModal1" onclick="loadiframe('edit_payment.php?payment_id=<?php echo attr_url($RowSearch['session_id']); ?>')">
                                         <?php
                                         $frow['data_type']=1;
                                         $frow['list_id']='payment_method';
@@ -635,10 +635,10 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                     </td>
                                     <td align="left" class="<?php echo attr($StringClass); ?>">
                                     <!--<a class='iframe medium_modal' href="edit_payment.php?payment_id=<?php echo attr_url($RowSearch['session_id']); ?>"><?php echo $RowSearch['reference']=='' ? '&nbsp;' : text($RowSearch['reference']); ?></a>-->
-                                    <a class="" data-toggle="modal"  data-target="#myModal" onclick="loadiframe('edit_payment.php?payment_id=<?php echo attr_url($RowSearch['session_id']); ?>')"><?php echo $RowSearch['reference']=='' ? '&nbsp;' : text($RowSearch['reference']); ?></a>
+                                    <a class="" data-toggle="modal"  data-target="#myModal1" onclick="loadiframe('edit_payment.php?payment_id=<?php echo attr_url($RowSearch['session_id']); ?>')"><?php echo $RowSearch['reference']=='' ? '&nbsp;' : text($RowSearch['reference']); ?></a>
                                     </td>
                                     <td align="left" class="<?php echo attr($StringClass); ?>">
-                                       <a class="" data-toggle="modal"  data-target="#myModal" onclick="loadiframe('edit_payment.php?payment_id=<?php echo attr_url($RowSearch['session_id']); ?>')"><?php
+                                       <a class="" data-toggle="modal"  data-target="#myModal1" onclick="loadiframe('edit_payment.php?payment_id=<?php echo attr_url($RowSearch['session_id']); ?>')"><?php
                                                         $rs= sqlStatement("select pay_total,global_amount from ar_session where session_id=?", [$RowSearch['session_id']]);
                                                         $row=sqlFetchArray($rs);
                                                         $pay_total=$row['pay_total'];
@@ -650,10 +650,10 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                                         echo $UndistributedAmount*1==0 ? xlt('Fully Paid') : xlt('Unapplied'); ?></a>
                                     </td>
                                     <td align="right" class="<?php echo attr($StringClass); ?>">
-                                        <a class="" data-toggle="modal"  data-target="#myModal" onclick="loadiframe('edit_payment.php?payment_id=<?php echo attr_url($RowSearch['session_id']); ?>')"><?php echo text($RowSearch['pay_total']); ?></a>
+                                        <a class="" data-toggle="modal"  data-target="#myModal1" onclick="loadiframe('edit_payment.php?payment_id=<?php echo attr_url($RowSearch['session_id']); ?>')"><?php echo text($RowSearch['pay_total']); ?></a>
                                     </td>
                                     <td align="right" class="<?php echo attr($StringClass); ?>right">
-                                        <a class="" data-toggle="modal"  data-target="#myModal" onclick="loadiframe('edit_payment.php?payment_id=<?php echo attr_url($RowSearch['session_id']); ?>')"><?php echo text(number_format($UndistributedAmount, 2)); ?></a>
+                                        <a class="" data-toggle="modal"  data-target="#myModal1" onclick="loadiframe('edit_payment.php?payment_id=<?php echo attr_url($RowSearch['session_id']); ?>')"><?php echo text(number_format($UndistributedAmount, 2)); ?></a>
                                     </td>
                                 </tr>
                                 <?php
@@ -685,5 +685,27 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
         </div>
     </div><!--end of container div-->
     <?php $oemr_ui->oeBelowContainerDiv();?>
+    <div class="row">
+        <div class="col-sm-12">
+            <div class="modal fade" id="myModal1" tabindex="-1" role="dialog" aria-labelledby="myModal1Label" aria-hidden="true">
+                <div class="modal-dialog oe-modal-dialog modal-lg">
+                    <div class="modal-content oe-modal-content">
+                        <!--<div class="modal-header" style="border:hidden"></div>-->
+                        <div class="modal-body">
+                            <iframe src="" id="targetiframe1" style="height:650px; width:100%; overflow-x: hidden; border:none" allowtransparency="true"></iframe>
+                        </div>
+                        <div class="modal-footer" style="margin-top:0px;">
+                           <button class="btn btn-link btn-cancel pull-right" data-dismiss="modal" type="button"><?php echo xlt('close'); ?></button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <script>
+    function loadiframe(htmlHref) { //load iframe
+         document.getElementById('targetiframe1').src = htmlHref;
+    }
+    </script>
 </body>
 </html>

--- a/library/billrep.inc
+++ b/library/billrep.inc
@@ -73,7 +73,7 @@ function getBillsBetween(
     "LEFT OUTER JOIN claims on claims.patient_id = form_encounter.pid and claims.encounter_id = form_encounter.encounter " .
     "LEFT OUTER JOIN insurance_data on insurance_data.pid = form_encounter.pid and insurance_data.type = 'primary' ".
     "WHERE 1=1 $query_part  " . " $auth " ." $billstring " .
-    "ORDER BY form_encounter.encounter, form_encounter.pid, billing.code_type, billing.code ASC";
+    "ORDER BY form_encounter.provider_id, form_encounter.encounter, form_encounter.pid, billing.code_type, billing.code ASC";
     //echo $sql;
     $res = sqlStatement($sql, array($code_type));
     $all = false;


### PR DESCRIPTION
Some code changes in the modernization of the UI rendered parts of
the Batch payemnts pages unusable/difficult to use

Changes are made to the following files:

interface/billing/edit_payment.php
interface/billing/new_payment.php
interface/billing/payment_master.inc.php
interface/billing/payment_pat_sel.inc.php
interface/billing/search_payments.php

with these changes the Batch payments section is once again functional

The issues fixed are:

1. html code populating Payment Method, Paying Entity and Payment Category select boxes when Fees > Batch Payments > New Payment 'Save Changes' button is clicked after filling in valid data

![batch_payment_022](https://user-images.githubusercontent.com/12654295/64508264-dbb9f980-d291-11e9-8102-96173b38f8dd.png)

**Cause:** In interface/billing/payment_master.inc.php which is a part of interface/billing/new_patient.php i.e. Fees > Batch Payments > New Payment form - `function generate_print_field` was being used incorrectly to generate the option values for these three select boxes when the interface/billing/new_patient.php was saved after data entry. This function is designed to write a un-editable table that would display the particulars of the saved batch payment to help in distributing the batch payment and is not designed to generate a select box with the correctly selected option value.

**Solution:** Replaced these three Select boxes with disabled input boxes upon saving the Fees > Batch Payments > New Payment form. These 3 input boxes get their values from `function getListItemTitle` instead. The saved Fees > Batch Payments > New Payment form that is returned after a successful post displays this data as an un-editable form thereby mimicking the original intended functionality.  

2.  Upon clicking the Fees > Batch Payments > New Payment  'Save Changes' button once, the 'Do you want to save' alert box was being triggered twice thus saving same batch payment data twice,      especially if the OK is pressed each time to close the alert box.

    **Cause:** function SavePayment() was being called twice  when  Fees > Batch Payments > New Payment  'Save Changes' button was clicked once. 
        Once in interface/billing/payment_master.inc.php on line 261 - `<button  id="save_btn" onClick="javascript:return SavePayment();" class="btn btn-default btn-save"><?php echo xlt('Save Changes');?></button>`
        The second time was on line 452 in interface/billing/new_patient.php - `echo 'top.restoreSession();return SavePayment();';`
    
    **Solution:** Commented out `echo 'top.restoreSession();return SavePayment();';` on line 452 in  interface/billing/new_patient.php
    
3. Edit Changes popup modal not working when a batch payment is clicked from a filtered list displayed when Fees > Batch Payments > Search Payment > 'Search' button is clicked

    **Cause:** `function loadiframe` was inadvertently removed when switching to `class OemrUI `in the UI modernizing project.
    
    **Solution:** Reinstated `function loadiframe` in interface/billing/search_payments.php. Therefore when Fees > Batch Payments > Search Payment 'Search' button is clicked  a table containing the batch payment results matching filtered by search criteria will be displayed. Upon clicking any particular batch payment a popup modal, Edit Payment displays the batch payment detail along with the undistributed amount. To ensure no clash with the modal that displays the help file the data-target was changed to `"#myModal1"` from `"#myModal"` and the modal's id was changed to `"targetiframe1"`  from `"targetiframe"`
    
`
 function loadiframe(htmlHref) { //load iframe
         document.getElementById('targetiframe1').src = htmlHref;
    }
`

4. Edit Payment popup shows only the batch payment details but not the table with details of the already made payments

    **Cause:** The div containing the table data was floating to the right and having zero width and thus was not visible
    
    **Solution:** enclosed the table in a div with Bootstrap 3 class `<div class="col-xs-12"><div>`
    
    
5. Clicking 'Cancel changes' button in Edit payment modal (interface/billing/edit_payment.php) gives JS error - `Uncaught ReferenceError: ResetForm is not defined at HTMLButtonElement.onclick (edit_payment.php?payment_id=xxxx:yyyy)`

    **Cause:** JS `function ResetForm()` exists only in interface/billing/new_patient.php and thus accessible only when Fees > Batch Payments > New Payment is being accessed.
    
    **Solution:** Copied the `function ResetForm()` to interface/billing/edit_payment.php