### PR TITLE
fix typo in an 837 claim function call

### DIFF
--- a/src/Billing/X12_5010_837P.php
+++ b/src/Billing/X12_5010_837P.php
@@ -507,7 +507,7 @@ class X12_5010_837P
                 $log .= "*** Missing patient last name.\n";
             }
             $out .=  "*";
-            if ($claim->patientFirstName) {
+            if ($claim->patientFirstName()) {
                 $out .= $claim->patientFirstName();
             } else {
                 $log .= "*** Missing patient first name.\n";


### PR DESCRIPTION
thanks to @ophthal, https://github.com/openemr/openemr/pull/2664, here's something for the next patch