### PR TITLE
PHP_CodeSniffer fix for rel502

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -24,7 +24,7 @@ function sniff {
     if [ -d $HOME/.config/composer ]; then
         BIN_DIR="$HOME/.config/composer/vendor/bin"
     fi
-    composer global require "squizlabs/php_codesniffer=3.*"
+    composer global require "squizlabs/php_codesniffer=3.4.2"
     cd $DIR
     $BIN_DIR/phpcs -p -n --extensions=php,inc --report-width=120 $@
 }


### PR DESCRIPTION
This is only for rel502 in order to not require psr2 specific code changes in new PHP_CodeSniffer 3.5 version.