### PR TITLE
Add horizontal scroll to PostCalendar Day template

### DIFF
--- a/interface/main/calendar/modules/PostCalendar/pntemplates/default/views/day/ajax_template.html
+++ b/interface/main/calendar/modules/PostCalendar/pntemplates/default/views/day/ajax_template.html
@@ -391,7 +391,7 @@ echo "   <tr><td><div class='view1' style=background-color:".$f['color'].";font-
     </div>
 </div> <!-- end bottomLeft -->
 
-    <div id="bigCal">
+    <div id="bigCal" style="overflow-x: auto;">
 [-php-]
 /* used in debugging
     foreach ($A_EVENTS as $date => $events) {


### PR DESCRIPTION
If you have many providers, the calendar day view only shows the
first however many fit in the bigCal div (depending on your screen
size). If you have a large number of providers, the only way
to see their schedules is to select individuals in the
"pc_username" box.

When blocking out time for vacations, it is useful for us to
be able to get a quick overview of what is going on with all
the providers.

This just adds "overflow-x: auto;" to the "bigCal" div style
on the Day template, allowing us to view the provider schedules
that render past the right-hand limit of the div.