### PR TITLE
Portal credential enhancements

### DIFF
--- a/interface/patient_file/summary/create_portallogin.php
+++ b/interface/patient_file/summary/create_portallogin.php
@@ -150,7 +150,7 @@ if (isset($_POST['form_save']) && $_POST['form_save']=='SUBMIT') {
     $clear_pass=$_POST['pwd'];
 
     $res = sqlStatement("SELECT * FROM patient_access_" . escape_identifier($portalsite, array("on","off"), true) . "site WHERE pid=?", array($pid));
-    $query_parameters=array($_POST['uname'],$_POST['uname']);
+    $query_parameters=array($_POST['uname'],'');
     $salt_clause="";
     if ($portalsite=='on') {
         // For onsite portal create a blowfish based hash and salt.
@@ -167,7 +167,7 @@ if (isset($_POST['form_save']) && $_POST['form_save']=='SUBMIT') {
     if (sqlNumRows($res)) {
         sqlStatement("UPDATE patient_access_" . escape_identifier($portalsite, array("on","off"), true) . "site SET portal_username=?,portal_login_username=?,portal_pwd=?,portal_pwd_status=0 " . $salt_clause . " WHERE pid=?", $query_parameters);
     } else {
-        sqlStatement("INSERT INTO patient_access_" . escape_identifier($portalsite, array("on","off"), true) . "site SET portal_username=?,portal_pwd=?,portal_pwd_status=0" . $salt_clause . " ,pid=?", $query_parameters);
+        sqlStatement("INSERT INTO patient_access_" . escape_identifier($portalsite, array("on","off"), true) . "site SET portal_username=?,portal_login_username=?,portal_pwd=?,portal_pwd_status=0" . $salt_clause . " ,pid=?", $query_parameters);
     }
 
     // Create the message

--- a/interface/patient_file/summary/create_portallogin.php
+++ b/interface/patient_file/summary/create_portallogin.php
@@ -150,7 +150,7 @@ if (isset($_POST['form_save']) && $_POST['form_save']=='SUBMIT') {
     $clear_pass=$_POST['pwd'];
 
     $res = sqlStatement("SELECT * FROM patient_access_" . escape_identifier($portalsite, array("on","off"), true) . "site WHERE pid=?", array($pid));
-    $query_parameters=array($_POST['uname'],'');
+    $query_parameters=array($_POST['uname'],$_POST['uname']);
     $salt_clause="";
     if ($portalsite=='on') {
         // For onsite portal create a blowfish based hash and salt.

--- a/portal/_header.php
+++ b/portal/_header.php
@@ -98,7 +98,7 @@ use OpenEMR\Core\Header;
                             <?php if ($GLOBALS['allow_portal_chat']) { ?>
                                 <a href="<?php echo $GLOBALS['web_root']; ?>/portal/messaging/secure_chat.php?fullscreen=true"> <i class="fa fa-user fa-fw pull-right"></i><?php echo xlt('Chat'); ?></a>
                                 <?php } ?>
-                                <a href="#openSignModal" data-toggle="modal" data-backdrop="true" data-target="#openSignModal" data-type="patient-signature"> <i class="fa fa-cog fa-fw pull-right"></i> <?php echo xlt('Settings'); ?></a></li>
+                                <a href="javascript:changeCredentials(event)"> <i class="fa fa-cog fa-fw pull-right"></i> <?php echo xlt('Change Credentials'); ?></a></li>
 
                             <li class="divider"></li>
 

--- a/portal/account/account.lib.php
+++ b/portal/account/account.lib.php
@@ -165,7 +165,7 @@ function doCredentials($pid)
     $token_new = RandomGenUtils::createUniqueToken(32);
     $pin = RandomGenUtils::createUniqueToken(6);
 
-    $token = $crypto->encryptStandard($token_new, '', 'database');
+    $token = $crypto->encryptStandard($token_new, '', 'file');
     $one_time = $token_new . $pin . bin2hex($expiry->format('U'));
     $encoded_link = sprintf("%s?%s", attr($GLOBALS['portal_onsite_two_address']), http_build_query([
         'forward' => $token,
@@ -179,9 +179,9 @@ function doCredentials($pid)
     array_push($query_parameters, oemr_password_hash($clear_pass, $new_salt), $new_salt);
     array_push($query_parameters, $pid);
     if (sqlNumRows($res)) {
-        sqlStatement("UPDATE patient_access_onsite SET portal_username=?,portal_login_username=?,portal_pwd=?,portal_pwd_status=0 " . $salt_clause . " WHERE pid=?", $query_parameters);
+        sqlStatement("UPDATE patient_access_onsite SET portal_username=?,portal_onetime=?,portal_pwd=?,portal_pwd_status=0 " . $salt_clause . " WHERE pid=?", $query_parameters);
     } else {
-        sqlStatement("INSERT INTO patient_access_onsite SET portal_username=?,portal_login_username=?,portal_pwd=?,portal_pwd_status=0" . $salt_clause . " ,pid=?", $query_parameters);
+        sqlStatement("INSERT INTO patient_access_onsite SET portal_username=?,portal_onetime=?,portal_pwd=?,portal_pwd_status=0" . $salt_clause . " ,pid=?", $query_parameters);
     }
 
     if (!validEmail($newpd['email_direct'])) {

--- a/portal/account/account.lib.php
+++ b/portal/account/account.lib.php
@@ -133,7 +133,7 @@ function validEmail($email)
 
 function messageCreate($uname, $pass, $encoded_link = '')
 {
-    $message = '<p>' . xlt("We recieved a credentials reset request. The link to reset your credentials is below.") . '</p>';
+    $message = '<p>' . xlt("We received a credentials reset request. The link to reset your credentials is below.") . '</p>';
     $message .= '<p>' . xlt("Please ignore this email if you did not make this request") . '</p>';
     $message .= '<p><strong>' . xlt("Credentials Reset. Live time is one hour.") . ": </strong></p>";
     $message .= sprintf('<a href="%s">%s</a>', attr($encoded_link), text($encoded_link));
@@ -161,11 +161,10 @@ function doCredentials($pid)
     $clear_pass = generatePassword();
 
     $token = RandomGenUtils::createUniqueToken(32);
-    $one_time = hash('sha256', $token);
+    $one_time = hash('sha256', $token) . bin2hex($expiry->format('U'));
 
     $encoded_link = sprintf("%s?%s", attr($GLOBALS['portal_onsite_two_address']), http_build_query([
-        'forward' => bin2hex($token),
-        'validate' => bin2hex($expiry->format('U')),
+        'forward' => $one_time,
         'site' => $_SESSION['site_id']
     ]));
 

--- a/portal/account/account.php
+++ b/portal/account/account.php
@@ -15,11 +15,13 @@
 require_once(dirname(__FILE__) . "/../../src/Common/Session/SessionUtil.php");
 OpenEMR\Common\Session\SessionUtil::portalSessionStart();
 
-if ($_SESSION['register'] === true && isset($_SESSION['pid'])) {
+if ($_SESSION['register'] === true && isset($_SESSION['pid']) ||
+    ($_SESSION['credentials_update'] === 1 && isset($_SESSION['pid'])) ||
+    ($_SESSION['itsme'] === 1 && isset($_SESSION['password_update']))) {
     $ignoreAuth_onsite_portal_two = true;
 }
 
-require_once("../../interface/globals.php");
+require_once(dirname(__FILE__) . "/../../interface/globals.php");
 require_once("$srcdir/patient.inc");
 require_once(dirname(__FILE__) . "/../lib/portal_mail.inc");
 require_once("$srcdir/pnotes.inc");
@@ -31,6 +33,22 @@ if ($action == 'set_lang') {
     $_SESSION['language_choice'] = (int) $_REQUEST['value'];
     echo 'okay';
     exit();
+} elseif ($action == 'userIsUnique') {
+    if (empty(trim($_REQUEST['account']))) {
+        echo "0";
+        exit;
+    }
+    $auth = sqlQueryNoLog("Select * From patient_access_onsite Where portal_login_username = ?", array(trim($_REQUEST['loginUname'])));
+    if ($auth === false) {
+        echo "1";
+        exit;
+    } elseif ($auth['portal_username'] === trim($_REQUEST['account'])) {
+        echo "1";
+        exit;
+    }
+    echo "0";
+
+    exit;
 } elseif ($action == 'get_newpid') {
     $email = isset($_REQUEST['email']) ? $_REQUEST['email'] : '';
     $rtn = isNew($_REQUEST['dob'], $_REQUEST['last'], $_REQUEST['first'], $email);

--- a/portal/account/account.php
+++ b/portal/account/account.php
@@ -38,7 +38,12 @@ if ($action == 'set_lang') {
         echo "0";
         exit;
     }
-    $auth = sqlQueryNoLog("Select * From patient_access_onsite Where portal_login_username = ?", array(trim($_REQUEST['loginUname'])));
+    $tmp = trim($_REQUEST['loginUname']);
+    if (empty($tmp)) {
+        echo "0";
+        exit;
+    }
+    $auth = sqlQueryNoLog("Select * From patient_access_onsite Where portal_login_username = ? Or portal_username = ?", array($tmp, $tmp));
     if ($auth === false) {
         echo "1";
         exit;

--- a/portal/account/index_reset.php
+++ b/portal/account/index_reset.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * Credential Changes
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright Copyright (c) 2019 Jerry Padgett <sjpadgett@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+// Will start the (patient) portal OpenEMR session/cookie.
+require_once(dirname(__FILE__) . "/../../src/Common/Session/SessionUtil.php");
+OpenEMR\Common\Session\SessionUtil::portalSessionStart();
+
+$landingpage = "./../index.php?site=" . urlencode($_SESSION['site_id']);
+// kick out if patient not authenticated
+if (isset($_SESSION['pid']) && isset($_SESSION['patient_portal_onsite_two'])) {
+    $ignoreAuth = 1;
+} else {
+    OpenEMR\Common\Session\SessionUtil::portalSessionCookieDestroy();
+    header('Location: ' . $landingpage . '&w');
+    exit;
+}
+require_once(dirname(__FILE__) . '/../../interface/globals.php');
+require_once("$srcdir/authentication/common_operations.php");
+
+use OpenEMR\Core\Header;
+
+//exit if portal is turned off
+if (!(isset($GLOBALS['portal_onsite_two_enable'])) || !($GLOBALS['portal_onsite_two_enable'])) {
+    echo xlt('Patient Portal is turned off');
+    exit;
+}
+
+$_SESSION['credentials_update'] = 1;
+DEFINE("TBL_PAT_ACC_ON", "patient_access_onsite");
+DEFINE("COL_PID", "pid");
+DEFINE("COL_POR_PWD", "portal_pwd");
+DEFINE("COL_POR_USER", "portal_username");
+DEFINE("COL_POR_LOGINUSER", "portal_login_username");
+DEFINE("COL_POR_SALT", "portal_salt");
+DEFINE("COL_POR_PWD_STAT", "portal_pwd_status");
+
+$sql = "SELECT " . implode(",", array(COL_ID, COL_PID, COL_POR_PWD, COL_POR_USER, COL_POR_LOGINUSER, COL_POR_SALT, COL_POR_PWD_STAT)) .
+    " FROM " . TBL_PAT_ACC_ON . " WHERE pid = ?";
+$auth = privQuery($sql, array($_SESSION['pid']));
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title><?php echo xlt('Change Portal Credentials'); ?></title>
+    <?php
+    Header::setupHeader(['opener']);
+    ?>
+    <script type="text/javascript">
+        function process_new_pass() {
+            if (document.getElementById('login_uname').value != document.getElementById('confirm_uname').value) {
+                alert(<?php echo xlj('The Username fields are not the same.'); ?>);
+                return false;
+            }
+            if (document.getElementById('pass_new').value != document.getElementById('pass_new_confirm').value) {
+                alert(<?php echo xlj('The new password fields are not the same.'); ?>);
+                return false;
+            }
+            if (document.getElementById('pass_new').value == document.getElementById('pass_new_confirm').value) {
+                if (!confirm(<?php echo xlj('The new password is the same as the current password. Click Okay to accept anyway.'); ?>)) {
+                    return false;
+                }
+            }
+        }
+    </script>
+    <style>
+        .table > tbody > tr > td {
+            border-top: 0px;
+        }
+    </style>
+</head>
+<body>
+    <br><br>
+    <div class="container">
+        <?php if (empty($_POST['submit'])) { ?>
+            <form action="" method="POST" onsubmit="return process_new_pass()">
+                <input style="display:none" type="text" name="dummyuname"/>
+                <input style="display:none" type="password" name="dummypassword"/>
+                <table class="table table-condensed" style="border-bottom:0px;width:100%">
+                    <tr>
+                        <td width="35%"><strong><?php echo xlt('Account Name'); ?><strong></td>
+                        <td><input class="form-control" name="uname" id="uname" type="text" readonly
+                                value="<?php echo attr($auth['portal_username']); ?>" /></td>
+                    </tr>
+                    <tr>
+                        <td><strong><?php echo xlt('New or Current Username'); ?><strong></td>
+                        <td><input class="form-control" name="login_uname" id="login_uname" type="text" required
+                                title="<?php echo xla('Change or keep current. Enter 8 to 20 characters'); ?>" pattern=".{8,20}"
+                                value="<?php echo attr($auth['portal_login_username']); ?>" />
+                        </td>
+                    </tr>
+                    <tr>
+                    <tr>
+                        <td><strong><?php echo xlt('Confirm Username'); ?><strong></td>
+                        <td><input class="form-control" name="confirm_uname" id="confirm_uname" type="text" required
+                                title="<?php echo xla('You must confirm this Username.'); ?>"
+                                autocomplete="none" pattern=".{8,20}" value="" />
+                        </td>
+                    </tr>
+                    </tr>
+                    <tr>
+                        <td><strong><?php echo xlt('New or Current Password'); ?><strong></td>
+                        <td>
+                            <input class="form-control" name="pass_new" id="pass_new" type="text" required
+                                placeholder="<?php echo xla('Min length is 8 with upper,lowercase,numbers mix'); ?>"
+                                title="<?php echo xla('You must enter a new or reenter current password to keep it.'); ?>"
+                                pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><strong><?php echo xlt('Confirm Password'); ?><strong></td>
+                        <td>
+                            <input class="form-control" name="pass_new_confirm" id="pass_new_confirm" type="password"
+                                pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}" autocomplete="none" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <td colspan="2"><br><input class="btn btn-primary pull-right" type="submit" name="submit" value="<?php echo xla('Save'); ?>" /></td>
+                    </tr>
+                </table>
+                <div><?php echo '* ' . xlt("All credential fields are case sensitive!") ?></div>
+            </form>
+        <?php } elseif (isset($_POST['submit'])) {
+            if ($auth === false) {
+                unset($_POST['submit']);
+                header("Location: " . $_SERVER['PHP_SELF']);
+            }
+            $plain_code = trim($_POST['pass_new']);
+            $new_salt = oemr_password_salt();
+            $new_hash = oemr_password_hash($plain_code, $new_salt);
+            $sqlUpdatePwd = " UPDATE " . TBL_PAT_ACC_ON . " SET " . COL_POR_PWD . "=?, " . COL_POR_SALT . "=?, " . COL_POR_LOGINUSER . "=?" . " WHERE " . COL_ID . "=?";
+            privStatement($sqlUpdatePwd, array(
+                $new_hash,
+                $new_salt,
+                $_POST['login_uname'],
+                $auth[COL_ID]
+            ));
+            echo "<script>dlgclose();</script>\n";
+        } ?>
+    </div><!-- container -->
+</body>
+</html>

--- a/portal/account/index_reset.php
+++ b/portal/account/index_reset.php
@@ -66,7 +66,6 @@ if (isset($_POST['submit'])) {
         $logit->portalLog('Credential update attempt', '', ($_POST['uname'] . ':unknown'), '', '0');
         die($errmsg);
     }
-    $code_current = trim($_POST['pass_current']);
     $plain_code = trim($_POST['pass_new']);
     $new_salt = oemr_password_salt();
     $new_hash = oemr_password_hash($plain_code, $new_salt);
@@ -124,7 +123,7 @@ if (isset($_POST['submit'])) {
                 alert(<?php echo xlj('The new password fields are not the same.'); ?>);
                 return false;
             }
-            if (document.getElementById('pass_new').value == document.getElementById('pass_new_confirm').value) {
+            if (document.getElementById('pass_current').value == document.getElementById('pass_new_confirm').value) {
                 if (!confirm(<?php echo xlj('The new password is the same as the current password. Click Okay to accept anyway.'); ?>)) {
                     return false;
                 }
@@ -153,8 +152,8 @@ if (isset($_POST['submit'])) {
                 </tr>
                 <tr>
                     <td><strong><?php echo xlt('New or Current Username'); ?><strong></td>
-                    <td><input class="form-control" name="login_uname" id="login_uname" type="text" required onchange="checkUserName()"
-                            title="<?php echo xla('Change or keep current. Enter 8 to 20 characters'); ?>" pattern=".{8,20}"
+                    <td><input class="form-control" name="login_uname" id="login_uname" type="text" required onblur="checkUserName()"
+                            title="<?php echo xla('Change or keep current. Enter 12 to 80 characters. Recommended to include symbols and numbers but not required.'); ?>" pattern=".{12,80}"
                             value="<?php echo attr($auth['portal_login_username']); ?>" />
                     </td>
                 </tr>

--- a/portal/account/register.php
+++ b/portal/account/register.php
@@ -299,7 +299,8 @@ function checkRegistration(pid) {
 }
 
 function callServer(action, value, value2, last, first) {
-    var data = {
+    let message = '';
+    let data = {
         'action' : action,
         'value' : value,
         'dob' : value2,
@@ -349,9 +350,10 @@ function callServer(action, value, value2, last, first) {
             }
         }
         else if (action == 'do_signup') {
-            if (rtn == "") {
-                let message = <?php echo xlj('Unable to either create credentials or send email.'); ?>;
-                alert(message);
+            if (rtn.indexOf('ERROR') !== -1) {
+                message = <?php echo xlj('Unable to either create credentials or send email.'); ?>;
+                message += "<br><br>" + <?php echo xlj('Here is what we do know.'); ?> + ": " + rtn + "<br>";
+                eModal.alert(message);
                 return false;
             }
             // For production. Here we're finished so do signup closing alert and then cleanup.
@@ -359,11 +361,12 @@ function callServer(action, value, value2, last, first) {
             // alert below for ease of testing.
             //alert(rtn); // sync alert.. rtn holds username and password for testing.
 
-            let message = <?php echo xlj("Your new credentials have been sent. Check your email inbox and also possibly your spam folder. Once you log into your patient portal feel free to make an appointment or send us a secure message. We look forward to seeing you soon."); ?>;
+            message = <?php echo xlj("Your new credentials have been sent. Check your email inbox and also possibly your spam folder. Once you log into your patient portal feel free to make an appointment or send us a secure message. We look forward to seeing you soon."); ?>;
             eModal.alert(message); // This is an async call. The modal close event exits us to portal landing page after cleanup.
+            return false;
         }
     }).fail(function (err) {
-        let message = <?php echo xlj('Something went wrong.') ?>;
+        message = <?php echo xlj('Something went wrong.') ?>;
         alert(message);
     });
 }

--- a/portal/add_edit_event_user.php
+++ b/portal/add_edit_event_user.php
@@ -732,7 +732,7 @@ if ($starttimeh >= 12) { // p.m. starts at noon and not 12:01
                 </td>
                 <td nowrap style='font-size:8pt'>
                 </td>
-                <td><input type='button' class='btn btn-danger btn-sm' value='<?php echo xla('Openings'); ?>' onclick='find_available()' /></td>
+                <td><input type='button' class='btn btn-success btn-sm' value='<?php echo xla('Openings'); ?>' onclick='find_available()' /></td>
                 <td></td>
             </tr>
             <tr>
@@ -745,9 +745,12 @@ if ($starttimeh >= 12) { // p.m. starts at noon and not 12:01
             </tr>
         </table>
         <div class="form-group">
-            <input type='button' name='form_save' class='btn btn-success btn-md' onsubmit='return false' value='<?php echo xla('Save'); ?>' onclick="validate()" />
-            <input type='button' id='form_cancel' class='btn btn-danger btn-md' onsubmit='return false' value='<?php echo xla('Cancel Appointment'); ?>' onclick="cancel_appointment()" />
-            &nbsp;
+            <br />
+            <?php if ($_GET['eid'] && $row['pc_apptstatus'] !== 'x') { ?>
+                <input type='button' id='form_cancel' class='btn btn-danger' onsubmit='return false' value='<?php echo xla('Cancel Appointment'); ?>' onclick="cancel_appointment()" />
+            <?php } ?>
+            <input type='button' name='form_save' class='btn btn-success' onsubmit='return false' value='<?php echo xla('Save'); ?>' onclick="validate()" />
+
         </div>
     </form>
     <script>

--- a/portal/get_patient_info.php
+++ b/portal/get_patient_info.php
@@ -70,6 +70,8 @@ $password_update = isset($_SESSION['password_update']) ? $_SESSION['password_upd
 unset($_SESSION['password_update']);
 $plain_code = $_POST['pass'];
 
+use OpenEMR\Common\Csrf\CsrfUtils;
+
 $authorizedPortal = false; // flag
 DEFINE("TBL_PAT_ACC_ON", "patient_access_onsite");
 DEFINE("COL_PID", "pid");
@@ -232,6 +234,11 @@ if ($userData = sqlQuery($sql, array(
         $_SESSION['sessionUser'] = '-patient-'; // $_POST['uname'];
         $_SESSION['providerId'] = $userData['providerID'] ? $userData['providerID'] : 'undefined';
         $_SESSION['ptName'] = $userData['fname'] . ' ' . $userData['lname'];
+
+        // Set up the csrf private_key (for the paient portal)
+        //  Note this key always remains private and never leaves server session. It is used to create
+        //  the csrf tokens.
+        CsrfUtils::setupCsrfKey();
 
         $logit->portalLog('login', $_SESSION['pid'], ($_SESSION['portal_username'] . ': ' . $_SESSION['ptName'] . ':success'));
     } else {

--- a/portal/get_patient_info.php
+++ b/portal/get_patient_info.php
@@ -66,7 +66,7 @@ require_once(dirname(__FILE__) . "/lib/appsql.class.php");
 $logit = new ApplicationTable();
 require_once("$srcdir/authentication/common_operations.php");
 require_once("$srcdir/user.inc");
-$password_update = isset($_SESSION['password_update']);
+$password_update = isset($_SESSION['password_update']) ? $_SESSION['password_update'] : 0;
 unset($_SESSION['password_update']);
 $plain_code = $_POST['pass'];
 
@@ -86,7 +86,9 @@ $sql = "SELECT " . implode(",", array(
 $auth = privQuery($sql, array(
     $_POST['uname']
 ));
-
+if ($password_update === 2) {
+    $auth[COL_POR_LOGINUSER] = '';
+}
 // real username
 if ($auth !== false && !empty($auth[COL_POR_LOGINUSER])) {
     $sql = "SELECT " . implode(",", array(
@@ -129,6 +131,9 @@ if (empty($auth[COL_POR_SALT])) {
     ));
 } else {
     $tmp = oemr_password_hash($plain_code, $auth[COL_POR_SALT]);
+    if ($password_update === 2) {
+        $tmp = $plain_code;
+    }
     if ($tmp != $auth[COL_POR_PWD]) {
         $logit->portalLog('login attempt', '', ($_POST['uname'] . ':invalid password'), '', '0');
         OpenEMR\Common\Session\SessionUtil::portalSessionCookieDestroy();

--- a/portal/home.php
+++ b/portal/home.php
@@ -152,8 +152,12 @@ function editAppointment(mode,deid){
     };
 
     dlgopen('', 'apptModal', 675, 325, '', title, params);
-};
+}
 
+function changeCredentials(e) {
+    title = <?php echo xlj('Please Enter New Credentials'); ?>;
+    dlgopen("./account/index_reset.php", '', 600, 360, null, title, {});
+}
 </script>
     <!-- Right side column. Contains content of the page -->
     <aside class="right-side">

--- a/portal/index.php
+++ b/portal/index.php
@@ -224,10 +224,9 @@ if (!(isset($_SESSION['password_update']) || isset($_GET['requestNew']))) {
                 <tr>
                     <td><strong><?php echo xlt('Current Password');?><strong></td>
                     <td>
-                        <input class="form-control" name="pass" id="pass" type="password" <?php echo $_SESSION['onetime'] ? 'readonly ':''; ?>
-                            autocomplete="none" value="<?php echo attr($_SESSION['onetime']);
-                            unset($_SESSION['onetime']);
-                            $_SESSION['password_update']=2; ?>" required />
+                        <input class="form-control" name="pass" id="pass" type="password" <?php echo $_SESSION['onetime'] ? ' readonly ': ''; ?>
+                            autocomplete="none" value="<?php echo attr($_SESSION['onetime']); $_SESSION['password_update']=$_SESSION['onetime'] ? 2 : 1;
+                            unset($_SESSION['onetime']); ?>" required />
                     </td>
                 </tr>
                 <tr>
@@ -299,7 +298,8 @@ if (!(isset($_SESSION['password_update']) || isset($_GET['requestNew']))) {
                                 </div>
                             </div>
                         </div>
-                        <button id="submitRequest" class="btn btn-primary nextBtn btn-sm pull-right" type="submit"><?php echo xlt('Verify') ?></button>
+                        <button id="submitRequest" class="btn btn-primary nextBtn pull-right" type="submit"><?php echo xlt('Verify') ?></button>
+                        <input class="btn pull-right" type="button" onclick="document.location.replace('./index.php?woops=1');" value="<?php echo xla('Cancel');?>" />
                     </fieldset>
                 </div>
             </div>
@@ -436,11 +436,6 @@ if (isset($_GET['logout'])) { ?>
 
 return false;
 });
-/* Test Data
-$("#emailInput").val("me@me.com");
-$("#fname").val("Jerry");
-$("#lname").val("Padgett");
-$("#dob").val("1919-03-03"); */
 
 function callServer(action, value, value2, last, first) {
     var data = {
@@ -478,7 +473,7 @@ function callServer(action, value, value2, last, first) {
             window.location.href = "./index.php" // Goto landing page.
         }
         else if (action == "is_new") {
-            if (parseInt(rtn) > 0) {
+            if (parseInt(rtn) !== 0) {
                 var yes = confirm(<?php echo xlj("Account is validated. Send new credentials?") ?>);
                 if(!yes)
                     callServer('cleanup');
@@ -487,19 +482,23 @@ function callServer(action, value, value2, last, first) {
             }
             else {
                 // After error alert app exit to landing page.
-                var message = <?php echo xlj('Unable to find your records. Be sure to use your correct Dob, First and Last name and Email of record. If you have opted out of email with none on file then leave blank.'); ?>;
+                var message = <?php echo xlj('Unable to find your records. Be sure to use your correct Dob, First and Last name and Email of record.') ?>;
+                message += "<br>" + <?php echo xlj('All search inputs are case sensitive and must match entries in your profile.'); ?>;
                 eModal.alert(message);
+                return false;
             }
         }
         else if (action == 'do_signup') {
-            if (rtn == "") {
+            if (rtn.indexOf('ERROR') !== -1) {
                 var message = <?php echo xlj('Unable to either create credentials or send email.'); ?>;
-                alert(message);
+                message += "<br><br>" + <?php echo xlj('Here is what we do know.'); ?> + ": " + rtn + "<br>";
+                eModal.alert(message);
                 return false;
             }
             //alert(rtn); // sync alert.. rtn holds username and password for testing.
             var message = <?php echo xlj("Your new credentials have been sent. Check your email inbox and also possibly your spam folder. Once you log into your patient portal feel free to make an appointment or send us a secure message. We look forward to seeing you soon."); ?>;
             eModal.alert(message); // This is an async call. The modal close event exits us to portal landing page after cleanup.
+            return false;
         }
     }).fail(function (err) {
         var message = <?php echo xlj('Something went wrong.') ?>;

--- a/portal/index.php
+++ b/portal/index.php
@@ -35,7 +35,10 @@ if (!(isset($GLOBALS['portal_onsite_two_enable'])) || !($GLOBALS['portal_onsite_
     echo xlt('Patient Portal is turned off');
     exit;
 }
-
+if (isset($_GET['woops'])) {
+    unset($_GET['woops']);
+    unset($_SESSION['password_update']);
+}
 // security measure -- will check on next page.
 $_SESSION['itsme'] = 1;
 //
@@ -101,10 +104,11 @@ if (!(isset($_SESSION['password_update']) || isset($_GET['requestNew']))) {
     ?>
     <script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/gritter/js/jquery.gritter.min.js"></script>
     <link rel="stylesheet" type="text/css" href="<?php echo $GLOBALS['assets_static_relative']; ?>/gritter/css/jquery.gritter.css" />
-    <script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/emodal/dist/eModal.min.js"></script>
+
     <link rel="stylesheet" type="text/css" href="assets/css/base.css?v=<?php echo $v_js_includes; ?>" />
     <link rel="stylesheet" type="text/css" href="assets/css/register.css?v=<?php echo $v_js_includes; ?>" />
 <script type="text/javascript">
+    var landing = <?php echo js_url($landingpage) ?>;
     function process() {
         if (!(validate())) {
             alert (<?php echo xlj('Field(s) are missing!'); ?>);
@@ -159,6 +163,11 @@ if (!(isset($_SESSION['password_update']) || isset($_GET['requestNew']))) {
         return pass;
     }
 </script>
+<style>
+    .table > tbody > tr > td {
+        border-top: 0px;
+    }
+</style>
 </head>
 <body class="skin-blue">
 <br><br>
@@ -166,46 +175,59 @@ if (!(isset($_SESSION['password_update']) || isset($_GET['requestNew']))) {
     <?php if (isset($_SESSION['password_update']) || isset($_GET['password_update'])) {
         $_SESSION['password_update']=1;
         ?>
-      <div id="wrapper" class="centerwrapper" style="text-align:center;">
-        <h2 class="title"><?php echo xlt('Please Enter a New Password'); ?></h2>
+      <div id="wrapper" class="centerwrapper text-center">
+        <h2 class="title"><?php echo xlt('Please Enter New Credentials'); ?></h2>
         <form action="get_patient_info.php" method="POST" onsubmit="return process_new_pass()" >
-            <table style="width:100%">
+            <input style="display:none" type="text" name="fakeusername"/>
+            <input style="display:none" type="password" name="fakepassword"/>
+            <table class="table table-condensed" style="border-bottom:0px;width:100%">
                 <tr>
-                    <td class="algnRight"><?php echo xlt('User Name'); ?></td>
-                    <td><input name="uname" id="uname" type="text" readonly autocomplete="off" value="<?php echo attr($_SESSION['portal_username']); ?>"/></td>
+                    <td width="35%"><strong><?php echo xlt('Account Name'); ?><strong></td>
+                    <td><input class="form-control" name="uname" id="uname" type="text" readonly autocomplete="none"
+                            value="<?php echo attr($_SESSION['portal_username']); ?>"/></td>
                 </tr>
                 <tr>
-                    <td class="algnRight"><?php echo xlt('Current Password');?></td>
-                    <td>
-                        <input name="pass" id="pass" type="password" autocomplete="off" value="" required />
+                    <td><strong><?php echo xlt('New User Name'); ?><strong></td>
+                    <td><input class="form-control" name="login_uname" id="login_uname" type="text" required autocomplete="none"
+                            placeholder="<?php echo xla('Must be 8 to 20 characters'); ?>" pattern=".{8,20}"
+                            value="<?php echo attr($_SESSION['portal_login_username']); ?>" />
                     </td>
                 </tr>
                 <tr>
-                    <td class="algnRight"><?php echo xlt('New Password');?></td>
+                    <td><strong><?php echo xlt('Current Password');?><strong></td>
                     <td>
-                        <input name="pass_new" id="pass_new" type="password" required />
+                        <input class="form-control" name="pass" id="pass" type="password" autocomplete="none" value="" required />
                     </td>
                 </tr>
                 <tr>
-                    <td class="algnRight"><?php echo xlt('Confirm New Password');?></td>
+                    <td><strong><?php echo xlt('New Password');?><strong></td>
                     <td>
-                        <input name="pass_new_confirm" id="pass_new_confirm" type="password" required />
+                        <input class="form-control" name="pass_new" id="pass_new" type="password" required
+                            placeholder="<?php echo xla('Min length is 8 with upper,lowercase,numbers mix'); ?>" pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}" />
+                    </td>
+                </tr>
+                <tr>
+                    <td><strong><?php echo xlt('Confirm New Password');?><strong></td>
+                    <td>
+                        <input class="form-control" name="pass_new_confirm" id="pass_new_confirm" type="password" required pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}" />
                     </td>
                 </tr>
                 <?php if ($GLOBALS['enforce_signin_email']) { ?>
                      <tr>
-                        <td class="algnRight"><?php echo xlt('Confirm Email Address');?></td>
+                        <td><strong><?php echo xlt('Confirm Email Address');?><strong></td>
                         <td>
-                            <input name="passaddon" id="passaddon" required placeholder="<?php echo xla('Your on file email address'); ?>" type="email" autocomplete="off" value=""  />
+                            <input class="form-control" name="passaddon" id="passaddon" required placeholder="<?php echo xla('Current on record trusted email'); ?>" type="email" autocomplete="none" value=""  />
                         </td>
                     </tr>
                 <?php } ?>
                 <tr>
-                    <td colspan=2><br><input class="pull-right" type="submit" value="<?php echo xla('Log In');?>" /></td>
+
                 </tr>
             </table>
+            <input class="btn btn-primary pull-right" type="submit" value="<?php echo xla('Log In');?>" />
+            <input class="btn pull-right" type="button" onclick="document.location.replace('./index.php?woops=1');" value="<?php echo xla('Cancel');?>" />
         </form>
-        <div class="copyright"><?php echo xlt('Powered by');?> OpenEMR</div>
+        <div class="copyright"><?php echo xlt('Powered by');?> OpenEMR Since 2004</div>
       </div>
     <?php } elseif (isset($_GET['requestNew'])) { ?>
     <div id="wrapper" class="centerwrapper" style="text-align:center;" >
@@ -232,7 +254,7 @@ if (!(isset($_SESSION['password_update']) || isset($_GET['requestNew']))) {
                                 <label class="control-label" for="dob"><?php echo xlt('Birth Date')?></label>
                                 <div class="controls inline-inputs">
                                     <div class="input-group">
-                                        <input id="dob" type="text" required class="form-control datepicker" placeholder="<?php echo xla('YYYY-MM-DD'); ?>" />
+                                        <input id="dob" type="date" required class="form-control datepicker" placeholder="<?php echo xla('YYYY-MM-DD'); ?>" />
                                     </div>
                                 </div>
                             </div></div>
@@ -241,7 +263,7 @@ if (!(isset($_SESSION['password_update']) || isset($_GET['requestNew']))) {
                                     <label class="control-label" for="emailInput"><?php echo xlt('Enter E-Mail Address')?></label>
                                     <div class="controls inline-inputs">
                                         <input id="emailInput" type="email" class="form-control" style="width: 100%" required
-                                            placeholder="<?php echo xla('Must be current email address on file.'); ?>" maxlength="100">
+                                            placeholder="<?php echo xla('Current trusted email address on record.'); ?>" maxlength="100">
                                     </div>
                                 </div>
                             </div>
@@ -267,13 +289,13 @@ if (!(isset($_SESSION['password_update']) || isset($_GET['requestNew']))) {
                                     <div class="form-group inline">
                                         <label class="control-label" for="uname"><?php echo xlt('Username')?></label>
                                         <div class="controls inline-inputs">
-                                            <input type="text" class="form-control" name="uname" id="uname" type="text" autocomplete="on" required>
+                                            <input type="text" class="form-control" name="uname" id="uname" type="text" autocomplete="none" required>
                                         </div>
                                     </div>
                                     <div class="form-group inline">
                                         <label class="control-label" for="pass"><?php echo xlt('Password')?></label>
                                         <div class="controls inline-inputs">
-                                            <input class="form-control" name="pass" id="pass" type="password" required autocomplete="on">
+                                            <input class="form-control" name="pass" id="pass" type="password" required autocomplete="none">
                                         </div>
                                     </div>
                                 </div>
@@ -283,7 +305,7 @@ if (!(isset($_SESSION['password_update']) || isset($_GET['requestNew']))) {
                                     <div class="col-sm-12 form-group">
                                         <label class="control-label" for="passaddon"><?php echo xlt('E-Mail Address')?></label>
                                         <div class="controls inline-inputs">
-                                            <input class="form-control" style="width: 100%" name="passaddon" id="passaddon" placeholder="<?php echo xla('on file email'); ?>" type="email" autocomplete="on" />
+                                            <input class="form-control" style="width: 100%" name="passaddon" id="passaddon" placeholder="<?php echo xla('Current on file trusted email'); ?>" type="email" autocomplete="none" />
                                         </div>
                                     </div>
                                 <?php } ?>

--- a/portal/index.php
+++ b/portal/index.php
@@ -19,7 +19,6 @@
 require_once(dirname(__FILE__) . "/../src/Common/Session/SessionUtil.php");
 OpenEMR\Common\Session\SessionUtil::portalSessionStart();
 
-
 //don't require standard openemr authorization in globals.php
 $ignoreAuth = 1;
 
@@ -31,6 +30,7 @@ require_once('../interface/globals.php');
 require_once(dirname(__FILE__) . "/lib/appsql.class.php");
 $logit = new ApplicationTable();
 
+use OpenEMR\Common\Crypto\CryptoGen;
 use OpenEMR\Core\Header;
 
 //exit if portal is turned off
@@ -44,27 +44,34 @@ if (isset($_GET['woops'])) {
     unset($_SESSION['password_update']);
 }
 if (isset($_GET['forward'])) {
-    $auth = sqlQueryNoLog("Select * From patient_access_onsite Where portal_login_username = ?", array($_GET['forward']));
+    $auth = false;
+    if (strlen($_GET['forward']) >= 64) {
+        $crypto = new CryptoGen();
+        $one_time = $crypto->decryptStandard($_GET['forward'], '', 'database');
+        $auth = sqlQueryNoLog("Select * From patient_access_onsite Where portal_login_username Like BINARY ?", array(($one_time . '%')));
+    }
     if ($auth === false) {
         error_log("PORTAL ERROR: " . errorLogEscape('One time reset:' . $_GET['forward']), 0);
-        $logit->portalLog('login attempt', '', ($_GET['forward']. ':invalid one time'), '', '0');
+        $logit->portalLog('login attempt', '', ($_GET['forward'] . ':invalid one time'), '', '0');
         OpenEMR\Common\Session\SessionUtil::portalSessionCookieDestroy();
         header('Location: ' . $landingpage . '&w&u');
         exit();
     }
-    $aToken = substr($auth['portal_login_username'], 0, 64);
-    $validate = hex2bin(substr($auth['portal_login_username'], 64));
+    $parse = str_replace($one_time, '', $auth['portal_login_username']);
+    $validate = hex2bin(substr($parse, 6));
     if ($validate <= time()) {
         error_log("PORTAL ERROR: " . errorLogEscape('One time reset link expired. Dying.'), 0);
         $logit->portalLog('password reset attempt', '', ($_POST['uname'] . ':link expired'), '', '0');
         OpenEMR\Common\Session\SessionUtil::portalSessionCookieDestroy();
-        die(xlt("Your one time credential reset link has expired. Reset and try again.") . "time:$validate time:".time());
+        die(xlt("Your one time credential reset link has expired. Reset and try again.") . "time:$validate time:" . time());
     }
-    $_SESSION['forward'] = $_GET['forward'];
+    $_SESSION['pin'] = substr($parse, 0, 6);
+    $_SESSION['forward'] = $auth['portal_login_username'];
     $_SESSION['portal_username'] = $auth['portal_username'];
     $_SESSION['portal_login_username'] = '';
     $_SESSION['password_update'] = 2;
     $_SESSION['onetime'] = $auth['portal_pwd'];
+    unset($auth);
 }
 // security measure -- will check on next page.
 $_SESSION['itsme'] = 1;
@@ -97,24 +104,24 @@ if (!(isset($_SESSION['password_update']) || isset($_GET['requestNew']))) {
         $mainLangID = empty($_SESSION['language_choice']) ? '1' : $_SESSION['language_choice'];
         if ($mainLangID == '1' && !empty($GLOBALS['skip_english_translation'])) {
             $sql = "SELECT * FROM lang_languages ORDER BY lang_description, lang_id";
-            $res3=SqlStatement($sql);
+            $res3 = SqlStatement($sql);
         } else {
-          // Use and sort by the translated language name.
+            // Use and sort by the translated language name.
             $sql = "SELECT ll.lang_id, " .
-                 "IF(LENGTH(ld.definition),ld.definition,ll.lang_description) AS trans_lang_description, " .
-                 "ll.lang_description " .
-                 "FROM lang_languages AS ll " .
-                 "LEFT JOIN lang_constants AS lc ON lc.constant_name = ll.lang_description " .
-                 "LEFT JOIN lang_definitions AS ld ON ld.cons_id = lc.cons_id AND " .
-                 "ld.lang_id = ? " .
-                 "ORDER BY IF(LENGTH(ld.definition),ld.definition,ll.lang_description), ll.lang_id";
-            $res3=SqlStatement($sql, array($mainLangID));
+                "IF(LENGTH(ld.definition),ld.definition,ll.lang_description) AS trans_lang_description, " .
+                "ll.lang_description " .
+                "FROM lang_languages AS ll " .
+                "LEFT JOIN lang_constants AS lc ON lc.constant_name = ll.lang_description " .
+                "LEFT JOIN lang_definitions AS ld ON ld.cons_id = lc.cons_id AND " .
+                "ld.lang_id = ? " .
+                "ORDER BY IF(LENGTH(ld.definition),ld.definition,ll.lang_description), ll.lang_id";
+            $res3 = SqlStatement($sql, array($mainLangID));
         }
         for ($iter = 0; $row = sqlFetchArray($res3); $iter++) {
             $result3[$iter] = $row;
         }
         if (count($result3) == 1) {
-          //default to english if only return one language
+            //default to english if only return one language
             $hiddenLanguageField = "<input type='hidden' name='languageChoice' value='1' />\n";
         }
     } else {
@@ -127,416 +134,425 @@ if (!(isset($_SESSION['password_update']) || isset($_GET['requestNew']))) {
 <head>
     <title><?php echo xlt('Patient Portal Login'); ?></title>
     <?php
-        Header::setupHeader(['no_main-theme', 'datetime-picker']);
+    Header::setupHeader(['no_main-theme', 'datetime-picker']);
     ?>
     <script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/gritter/js/jquery.gritter.min.js"></script>
     <link rel="stylesheet" type="text/css" href="<?php echo $GLOBALS['assets_static_relative']; ?>/gritter/css/jquery.gritter.css" />
     <script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/emodal/dist/eModal.min.js"></script>
     <link rel="stylesheet" type="text/css" href="assets/css/base.css?v=<?php echo $v_js_includes; ?>" />
     <link rel="stylesheet" type="text/css" href="assets/css/register.css?v=<?php echo $v_js_includes; ?>" />
-<script type="text/javascript">
-    function checkUserName() {
-        let vacct = document.getElementById('uname').value;
-        let vsuname = document.getElementById('login_uname').value;
-        if (vsuname.length < 12) {
-            alert (<?php echo xlj('User Name must be at least 12 characters!'); ?>);
-            document.getElementById('login_uname').focus();
-            return false;
-        }
-        let data = {
-            'action': 'userIsUnique',
-            'account': vacct,
-            'loginUname': vsuname
-        };
-        $.ajax({
-            type: 'GET',
-            url: './account/account.php',
-            data: data
-        }).done(function (rtn) {
-            if (rtn === '1') {
-                return true;
+    <script type="text/javascript">
+        function checkUserName() {
+            let vacct = document.getElementById('uname').value;
+            let vsuname = document.getElementById('login_uname').value;
+            if (vsuname.length < 12) {
+                alert(<?php echo xlj('User Name must be at least 12 characters!'); ?>);
+                document.getElementById('login_uname').focus();
+                return false;
             }
-            alert (<?php echo xlj('Log In Name is unavailable. Try again!'); ?>);
-            document.getElementById('login_uname').value = '';
-            document.getElementById('login_uname').focus();
-            return false;
-        });
-    }
-    function process() {
-        if (!(validate())) {
-            alert (<?php echo xlj('Field(s) are missing!'); ?>);
-            return false;
+            let data = {
+                'action': 'userIsUnique',
+                'account': vacct,
+                'loginUname': vsuname
+            };
+            $.ajax({
+                type: 'GET',
+                url: './account/account.php',
+                data: data
+            }).done(function (rtn) {
+                if (rtn === '1') {
+                    return true;
+                }
+                alert(<?php echo xlj('Log In Name is unavailable. Try again!'); ?>);
+                document.getElementById('login_uname').value = '';
+                document.getElementById('login_uname').focus();
+                return false;
+            });
         }
-        return true;
-    }
-    function validate() {
-        let pass=true;
 
-        if (document.getElementById('uname').value == "") {
-        document.getElementById('uname').style.border = "1px solid red";
-                pass=false;
+        function process() {
+            if (!(validate())) {
+                alert(<?php echo xlj('Field(s) are missing!'); ?>);
+                return false;
+            }
+            return true;
         }
-        if (document.getElementById('pass').value == "") {
-        document.getElementById('pass').style.border = "1px solid red";
-                pass=false;
-        }
+
+        function validate() {
+            let pass = true;
+
+            if (document.getElementById('uname').value == "") {
+                document.getElementById('uname').style.border = "1px solid red";
+                pass = false;
+            }
+            if (document.getElementById('pass').value == "") {
+                document.getElementById('pass').style.border = "1px solid red";
+                pass = false;
+            }
             return pass;
-    }
-    function process_new_pass() {
-        if (!(validate_new_pass())) {
-            alert (<?php echo xlj('Field(s) are missing!'); ?>);
-            return false;
         }
-        if (document.getElementById('pass_new').value != document.getElementById('pass_new_confirm').value) {
-            alert (<?php echo xlj('The new password fields are not the same.'); ?>);
-            return false;
-        }
-        if (document.getElementById('pass').value == document.getElementById('pass_new').value) {
-            alert (<?php echo xlj('The new password can not be the same as the current password.'); ?>);
-            return false;
-        }
-    }
 
-    function validate_new_pass() {
-        var pass=true;
-        if (document.getElementById('uname').value == "") {
-            document.getElementById('uname').style.border = "1px solid red";
-            pass=false;
+        function process_new_pass() {
+            if (!(validate_new_pass())) {
+                alert(<?php echo xlj('Field(s) are missing!'); ?>);
+                return false;
+            }
+            if (document.getElementById('pass_new').value != document.getElementById('pass_new_confirm').value) {
+                alert(<?php echo xlj('The new password fields are not the same.'); ?>);
+                return false;
+            }
+            if (document.getElementById('pass').value == document.getElementById('pass_new').value) {
+                alert(<?php echo xlj('The new password can not be the same as the current password.'); ?>);
+                return false;
+            }
         }
-        if (document.getElementById('pass').value == "") {
-            document.getElementById('pass').style.border = "1px solid red";
-            pass=false;
+
+        function validate_new_pass() {
+            var pass = true;
+            if (document.getElementById('uname').value == "") {
+                document.getElementById('uname').style.border = "1px solid red";
+                pass = false;
+            }
+            if (document.getElementById('pass').value == "") {
+                document.getElementById('pass').style.border = "1px solid red";
+                pass = false;
+            }
+            if (document.getElementById('pass_new').value == "") {
+                document.getElementById('pass_new').style.border = "1px solid red";
+                pass = false;
+            }
+            if (document.getElementById('pass_new_confirm').value == "") {
+                document.getElementById('pass_new_confirm').style.border = "1px solid red";
+                pass = false;
+            }
+            return pass;
         }
-        if (document.getElementById('pass_new').value == "") {
-            document.getElementById('pass_new').style.border = "1px solid red";
-            pass=false;
+    </script>
+    <style>
+        .table > tbody > tr > td {
+            border-top: 0px;
         }
-        if (document.getElementById('pass_new_confirm').value == "") {
-            document.getElementById('pass_new_confirm').style.border = "1px solid red";
-            pass=false;
-        }
-        return pass;
-    }
-</script>
-<style>
-    .table > tbody > tr > td {
-        border-top: 0px;
-    }
-</style>
+    </style>
 </head>
 <body class="skin-blue">
-<br><br>
-<div class="container text-center">
-    <?php if (isset($_SESSION['password_update']) || isset($_GET['password_update'])) {
-        $_SESSION['password_update']=1;
-        ?>
-      <div id="wrapper" class="centerwrapper text-center">
-        <h2 class="title"><?php echo xlt('Please Enter New Credentials'); ?></h2>
-        <form action="get_patient_info.php" method="POST" onsubmit="return process_new_pass()" >
-            <input style="display:none" type="text" name="dummyuname"/>
-            <input style="display:none" type="password" name="dummypass"/>
-            <table class="table table-condensed" style="border-bottom:0px;width:100%">
-                <tr>
-                    <td width="35%"><strong><?php echo xlt('Account Name'); ?><strong></td>
-                    <td><input class="form-control" name="uname" id="uname" type="text" readonly autocomplete="none"
-                            value="<?php echo attr($_SESSION['portal_username']); ?>"/></td>
-                </tr>
-                <tr>
-                    <td><strong><?php echo xlt('New User Name'); ?><strong></td>
-                    <td><input class="form-control" name="login_uname" id="login_uname" type="text" autofocus autocomplete="none"
-                            title="<?php echo xla('Please enter a username of 12 to 80 characters. Recommended to include symbols and numbers but not required.'); ?>"
-                            placeholder="<?php echo xla('Must be 12 to 80 characters'); ?>" pattern=".{12,80}"
-                            value="<?php echo attr($_SESSION['portal_login_username']); ?>" onblur="checkUserName()" />
-                    </td>
-                </tr>
-                <tr>
-                    <td><strong><?php echo xlt('Current Password');?><strong></td>
-                    <td>
-                        <input class="form-control" name="pass" id="pass" type="password" <?php echo $_SESSION['onetime'] ? ' readonly ': ''; ?>
-                            autocomplete="none" value="<?php echo attr($_SESSION['onetime']);
-                            $_SESSION['password_update']=$_SESSION['onetime'] ? 2 : 1;
-                            unset($_SESSION['onetime']); ?>" required />
-                    </td>
-                </tr>
-                <tr>
-                    <td><strong><?php echo xlt('New Password');?><strong></td>
-                    <td>
-                        <input class="form-control" name="pass_new" id="pass_new" type="password" required
-                            placeholder="<?php echo xla('Min length is 8 with upper,lowercase,numbers mix'); ?>" pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}" />
-                    </td>
-                </tr>
-                <tr>
-                    <td><strong><?php echo xlt('Confirm New Password');?><strong></td>
-                    <td>
-                        <input class="form-control" name="pass_new_confirm" id="pass_new_confirm" type="password" required pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}" />
-                    </td>
-                </tr>
-                <?php if ($GLOBALS['enforce_signin_email']) { ?>
-                     <tr>
-                        <td><strong><?php echo xlt('Confirm Email Address');?><strong></td>
-                        <td>
-                            <input class="form-control" name="passaddon" id="passaddon" required placeholder="<?php echo xla('Current on record trusted email'); ?>" type="email" autocomplete="none" value=""  />
-                        </td>
-                    </tr>
-                <?php } ?>
-                <tr>
+    <br><br>
+    <div class="container text-center">
+        <?php if (isset($_SESSION['password_update']) || isset($_GET['password_update'])) {
+            $_SESSION['password_update'] = 1;
+            ?>
+            <div id="wrapper" class="centerwrapper text-center">
+                <h2 class="title"><?php echo xlt('Please Enter New Credentials'); ?></h2>
+                <form action="get_patient_info.php" method="POST" onsubmit="return process_new_pass()">
+                    <input style="display:none" type="text" name="dummyuname" />
+                    <input style="display:none" type="password" name="dummypass" />
+                    <table class="table table-condensed" style="border-bottom:0px;width:100%">
+                        <tr>
+                            <td width="35%"><strong><?php echo xlt('Account Name'); ?><strong></td>
+                            <td><input class="form-control" name="uname" id="uname" type="text" readonly autocomplete="none"
+                                    value="<?php echo attr($_SESSION['portal_username']); ?>" /></td>
+                        </tr>
+                        <tr>
+                            <td><strong><?php echo xlt('New User Name'); ?><strong></td>
+                            <td><input class="form-control" name="login_uname" id="login_uname" type="text" autofocus autocomplete="none"
+                                    title="<?php echo xla('Please enter a username of 12 to 80 characters. Recommended to include symbols and numbers but not required.'); ?>"
+                                    placeholder="<?php echo xla('Must be 12 to 80 characters'); ?>" pattern=".{12,80}"
+                                    value="<?php echo attr($_SESSION['portal_login_username']); ?>" onblur="checkUserName()" />
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><strong><?php echo !$_SESSION['onetime'] ? xlt('Current Password') : ''; ?><strong></td>
+                            <td>
+                                <input class="form-control" name="pass" id="pass" <?php echo $_SESSION['onetime'] ? 'type="hidden" ' : 'type="password" '; ?>
+                                    autocomplete="none" value="<?php echo attr($_SESSION['onetime']);
+                                    $_SESSION['password_update'] = $_SESSION['onetime'] ? 2 : 1;
+                                    unset($_SESSION['onetime']); ?>" required />
+                            </td>
+                        </tr>
+                        <?php if ($_SESSION['pin']) { ?>
+                            <tr>
+                                <td><strong><?php echo xlt('One Time PIN'); ?><strong></td>
+                                <td>
+                                    <input class="form-control" name="token_pin" id="token_pin" type="password" autocomplete="none" value="" required pattern=".{6,20}" />
+                                </td>
+                            </tr>
+                        <?php } ?>
+                        <tr>
+                            <td><strong><?php echo xlt('New Password'); ?><strong></td>
+                            <td>
+                                <input class="form-control" name="pass_new" id="pass_new" type="password" required
+                                    placeholder="<?php echo xla('Min length is 8 with upper,lowercase,numbers mix'); ?>" pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}" />
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><strong><?php echo xlt('Confirm New Password'); ?><strong></td>
+                            <td>
+                                <input class="form-control" name="pass_new_confirm" id="pass_new_confirm" type="password" required pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}" />
+                            </td>
+                        </tr>
+                        <?php if ($GLOBALS['enforce_signin_email']) { ?>
+                            <tr>
+                                <td><strong><?php echo xlt('Confirm Email Address'); ?><strong></td>
+                                <td>
+                                    <input class="form-control" name="passaddon" id="passaddon" required placeholder="<?php echo xla('Current on record trusted email'); ?>" type="email" autocomplete="none" value="" />
+                                </td>
+                            </tr>
+                        <?php } ?>
+                        <tr>
 
-                </tr>
-            </table>
-            <input class="btn btn-primary pull-right" type="submit" value="<?php echo xla('Log In');?>" />
-            <input class="btn pull-right" type="button" onclick="document.location.replace('./index.php?woops=1');" value="<?php echo xla('Cancel');?>" />
-        </form>
-        <div class="copyright"><?php echo xlt('Powered by');?> OpenEMR Since 2004</div>
-      </div>
-    <?php } elseif (isset($_GET['requestNew'])) { ?>
-    <div id="wrapper" class="centerwrapper" style="text-align:center;" >
-        <form  class="form-inline" id="resetPass" action="#" method="post" >
-            <div class="row">
-                <div class="col-sm-10 col-md-offset-1 text-center">
-                    <fieldset>
-                        <legend class='bg-primary'><h3><?php echo xlt('Patient Credentials Reset') ?></h3></legend>
-                        <div class="well">
-                        <div class="row">
-                            <div class="form-group inline">
-                                <label class="control-label" for="fname"><?php echo xlt('First{{Name}}')?></label>
-                                <div class="controls inline-inputs">
-                                    <input type="text" class="form-control" id="fname" required placeholder="<?php echo xla('First Name'); ?>">
-                                </div>
-                            </div>
-                            <div class="form-group inline">
-                                <label class="control-label" for="lname"><?php echo xlt('Last Name')?></label>
-                                <div class="controls inline-inputs">
-                                    <input type="text" class="form-control" id="lname" required placeholder="<?php echo xla('Enter Last'); ?>">
-                                </div>
-                            </div>
-                            <div class="form-group inline">
-                                <label class="control-label" for="dob"><?php echo xlt('Birth Date')?></label>
-                                <div class="controls inline-inputs">
-                                    <div class="input-group">
-                                        <input id="dob" type="text" required class="form-control datepicker" placeholder="<?php echo xla('YYYY-MM-DD'); ?>" />
-                                    </div>
-                                </div>
-                            </div></div>
-                            <div class="row">
-                                <div class="col-sm-12 form-group">
-                                    <label class="control-label" for="emailInput"><?php echo xlt('Enter E-Mail Address')?></label>
-                                    <div class="controls inline-inputs">
-                                        <input id="emailInput" type="email" class="form-control" style="width: 100%" required
-                                            placeholder="<?php echo xla('Current trusted email address on record.'); ?>" maxlength="100">
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <button id="submitRequest" class="btn btn-primary nextBtn pull-right" type="submit"><?php echo xlt('Verify') ?></button>
-                        <input class="btn pull-right" type="button" onclick="document.location.replace('./index.php?woops=1');" value="<?php echo xla('Cancel');?>" />
-                    </fieldset>
-                </div>
+                        </tr>
+                    </table>
+                    <input class="btn btn-primary pull-right" type="submit" value="<?php echo xla('Log In'); ?>" />
+                    <input class="btn pull-right" type="button" onclick="document.location.replace('./index.php?woops=1');" value="<?php echo xla('Cancel'); ?>" />
+                </form>
+                <div class="copyright"><?php echo xlt('Powered by'); ?> OpenEMR Since 2004</div>
             </div>
-        </form>
-    </div>
-    <?php } else {
-        ?>  <!-- Main logon -->
-    <div id="wrapper" class="row centerwrapper text-center">
-    <img style="width:65%" src='<?php echo $GLOBALS['images_static_relative']; ?>/login-logo.png'/>
-    <form  class="form-inline text-center" action="get_patient_info.php" method="POST" onsubmit="return process()">
-        <div class="row">
-                <div class="col-sm-12 text-center">
-                    <fieldset>
-                        <legend class="bg-primary"><h3><?php echo xlt('Patient Portal Login'); ?></h3></legend>
-                        <div class="well">
-                        <div class="row">
-                                <div class="col-sm-12">
-                                    <div class="form-group inline">
-                                        <label class="control-label" for="uname"><?php echo xlt('Username')?></label>
-                                        <div class="controls inline-inputs">
-                                            <input type="text" class="form-control" name="uname" id="uname" type="text" autocomplete="none" required>
+        <?php } elseif (isset($_GET['requestNew'])) { ?>
+            <div id="wrapper" class="centerwrapper" style="text-align:center;">
+                <form class="form-inline" id="resetPass" action="#" method="post">
+                    <div class="row">
+                        <div class="col-sm-10 col-md-offset-1 text-center">
+                            <fieldset>
+                                <legend class='bg-primary'><h3><?php echo xlt('Patient Credentials Reset') ?></h3></legend>
+                                <div class="well">
+                                    <div class="row">
+                                        <div class="form-group inline">
+                                            <label class="control-label" for="fname"><?php echo xlt('First{{Name}}') ?></label>
+                                            <div class="controls inline-inputs">
+                                                <input type="text" class="form-control" id="fname" required placeholder="<?php echo xla('First Name'); ?>">
+                                            </div>
+                                        </div>
+                                        <div class="form-group inline">
+                                            <label class="control-label" for="lname"><?php echo xlt('Last Name') ?></label>
+                                            <div class="controls inline-inputs">
+                                                <input type="text" class="form-control" id="lname" required placeholder="<?php echo xla('Enter Last'); ?>">
+                                            </div>
+                                        </div>
+                                        <div class="form-group inline">
+                                            <label class="control-label" for="dob"><?php echo xlt('Birth Date') ?></label>
+                                            <div class="controls inline-inputs">
+                                                <div class="input-group">
+                                                    <input id="dob" type="text" required class="form-control datepicker" placeholder="<?php echo xla('YYYY-MM-DD'); ?>" />
+                                                </div>
+                                            </div>
                                         </div>
                                     </div>
-                                    <div class="form-group inline">
-                                        <label class="control-label" for="pass"><?php echo xlt('Password')?></label>
-                                        <div class="controls inline-inputs">
-                                            <input class="form-control" name="pass" id="pass" type="password" required autocomplete="none">
+                                    <div class="row">
+                                        <div class="col-sm-12 form-group">
+                                            <label class="control-label" for="emailInput"><?php echo xlt('Enter E-Mail Address') ?></label>
+                                            <div class="controls inline-inputs">
+                                                <input id="emailInput" type="email" class="form-control" style="width: 100%" required
+                                                    placeholder="<?php echo xla('Current trusted email address on record.'); ?>" maxlength="100">
+                                            </div>
                                         </div>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="row">
-                                <?php if ($GLOBALS['enforce_signin_email']) { ?>
-                                    <div class="col-sm-12 form-group">
-                                        <label class="control-label" for="passaddon"><?php echo xlt('E-Mail Address')?></label>
-                                        <div class="controls inline-inputs">
-                                            <input class="form-control" style="width: 100%" name="passaddon" id="passaddon" placeholder="<?php echo xla('Current on file trusted email'); ?>" type="email" autocomplete="none" />
+                                <button id="submitRequest" class="btn btn-primary nextBtn pull-right" type="submit"><?php echo xlt('Verify') ?></button>
+                                <input class="btn pull-right" type="button" onclick="document.location.replace('./index.php?woops=1');" value="<?php echo xla('Cancel'); ?>" />
+                            </fieldset>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        <?php } else {
+            ?>  <!-- Main logon -->
+            <div id="wrapper" class="row centerwrapper text-center">
+                <img style="width:65%" src='<?php echo $GLOBALS['images_static_relative']; ?>/login-logo.png' />
+                <form class="form-inline text-center" action="get_patient_info.php" method="POST" onsubmit="return process()">
+                    <div class="row">
+                        <div class="col-sm-12 text-center">
+                            <fieldset>
+                                <legend class="bg-primary"><h3><?php echo xlt('Patient Portal Login'); ?></h3></legend>
+                                <div class="well">
+                                    <div class="row">
+                                        <div class="col-sm-12">
+                                            <div class="form-group inline">
+                                                <label class="control-label" for="uname"><?php echo xlt('Username') ?></label>
+                                                <div class="controls inline-inputs">
+                                                    <input type="text" class="form-control" name="uname" id="uname" type="text" autocomplete="none" required>
+                                                </div>
+                                            </div>
+                                            <div class="form-group inline">
+                                                <label class="control-label" for="pass"><?php echo xlt('Password') ?></label>
+                                                <div class="controls inline-inputs">
+                                                    <input class="form-control" name="pass" id="pass" type="password" required autocomplete="none">
+                                                </div>
+                                            </div>
                                         </div>
                                     </div>
-                                <?php } ?>
-                            </div>
-                        <?php if ($GLOBALS['language_menu_login']) { ?>
-                            <?php if (count($result3) != 1) { ?>
-                        <div class="form-group row">
-                            <label for="selLanguage"><?php echo xlt('Language'); ?></label>
-                            <select class="form-control" id="selLanguage" name="languageChoice">
-                                <?php
-                                echo "<option selected='selected' value='" . attr($defaultLangID) . "'>" .
-                                     text(xl('Default') . " - " . xl($defaultLangName)) . "</option>\n";
-                                foreach ($result3 as $iter) {
-                                    if ($GLOBALS['language_menu_showall']) {
-                                        if (! $GLOBALS['allow_debug_language'] && $iter['lang_description'] == 'dummy') {
-                                            continue; // skip the dummy language
-                                        }
-                                        echo "<option value='" . attr($iter['lang_id']) . "'>" .
-                                        text($iter['trans_lang_description']) . "</option>\n";
-                                    } else {
-                                        if (in_array($iter['lang_description'], $GLOBALS['language_menu_show'])) {
-                                            if (! $GLOBALS['allow_debug_language'] && $iter['lang_description'] == 'dummy') {
-                                                continue; // skip the dummy language
-                                            }
-                                            echo "<option value='" . attr($iter['lang_id']) . "'>" .
-                                            text($iter['trans_lang_description']) . "</option>\n";
-                                        }
-                                    }
-                                }
-                                ?>
-                          </select>
+                                    <div class="row">
+                                        <?php if ($GLOBALS['enforce_signin_email']) { ?>
+                                            <div class="col-sm-12 form-group">
+                                                <label class="control-label" for="passaddon"><?php echo xlt('E-Mail Address') ?></label>
+                                                <div class="controls inline-inputs">
+                                                    <input class="form-control" style="width: 100%" name="passaddon" id="passaddon" placeholder="<?php echo xla('Current on file trusted email'); ?>" type="email" autocomplete="none" />
+                                                </div>
+                                            </div>
+                                        <?php } ?>
+                                    </div>
+                                    <?php if ($GLOBALS['language_menu_login']) { ?>
+                                        <?php if (count($result3) != 1) { ?>
+                                            <div class="form-group row">
+                                                <label for="selLanguage"><?php echo xlt('Language'); ?></label>
+                                                <select class="form-control" id="selLanguage" name="languageChoice">
+                                                    <?php
+                                                    echo "<option selected='selected' value='" . attr($defaultLangID) . "'>" .
+                                                        text(xl('Default') . " - " . xl($defaultLangName)) . "</option>\n";
+                                                    foreach ($result3 as $iter) {
+                                                        if ($GLOBALS['language_menu_showall']) {
+                                                            if (!$GLOBALS['allow_debug_language'] && $iter['lang_description'] == 'dummy') {
+                                                                continue; // skip the dummy language
+                                                            }
+                                                            echo "<option value='" . attr($iter['lang_id']) . "'>" .
+                                                                text($iter['trans_lang_description']) . "</option>\n";
+                                                        } else {
+                                                            if (in_array($iter['lang_description'], $GLOBALS['language_menu_show'])) {
+                                                                if (!$GLOBALS['allow_debug_language'] && $iter['lang_description'] == 'dummy') {
+                                                                    continue; // skip the dummy language
+                                                                }
+                                                                echo "<option value='" . attr($iter['lang_id']) . "'>" .
+                                                                    text($iter['trans_lang_description']) . "</option>\n";
+                                                            }
+                                                        }
+                                                    }
+                                                    ?>
+                                                </select>
+                                            </div>
+                                        <?php }
+                                    } ?>
+                                </div>
+                                <div class="col-sm-12 col-md-12">
+                                    <?php if ($GLOBALS['portal_onsite_two_register']) { ?>
+                                        <button class="btn btn-default pull-left" onclick="location.replace('./account/register.php')"><?php echo xlt('Register'); ?></button>
+                                    <?php } ?>
+                                    <?php if ($GLOBALS['portal_two_pass_reset'] && isset($_GET['w']) && (isset($_GET['u']) || isset($_GET['p']))) { ?>
+                                        <button class="btn btn-danger" onclick="location.replace('./index.php?requestNew=1')" style="margin-left:10px"><?php echo xlt('Reset Credentials'); ?></button>
+                                    <?php } ?>
+                                    <button class="btn btn-success pull-right" type="submit"><?php echo xlt('Log In'); ?></button>
+                                </div>
+                            </fieldset>
                         </div>
-                        <?php } } ?>
-                        </div>
-                        <div class="col-sm-12 col-md-12">
-                            <?php if ($GLOBALS['portal_onsite_two_register']) { ?>
-                                <button class="btn btn-default pull-left"  onclick="location.replace('./account/register.php')"><?php echo xlt('Register');?></button>
-                            <?php } ?>
-                            <?php if ($GLOBALS['portal_two_pass_reset'] && isset($_GET['w']) && (isset($_GET['u']) || isset($_GET['p']))) { ?>
-                               <button class="btn btn-danger" onclick="location.replace('./index.php?requestNew=1')" style="margin-left:10px"><?php echo xlt('Reset Credentials');?></button>
-                            <?php } ?>
-                                <button  class="btn btn-success pull-right" type="submit" ><?php echo xlt('Log In');?></button>
-                        </div>
-                    </fieldset>
-                </div>
-          </div>
-            <?php if (!(empty($hiddenLanguageField))) {
-                echo $hiddenLanguageField; } ?>
-    </form>
-    </div><!-- div wrapper -->
-    <?php } ?> <!--  logon wrapper -->
-</div><!-- container -->
+                    </div>
+                    <?php if (!(empty($hiddenLanguageField))) {
+                        echo $hiddenLanguageField;
+                    } ?>
+                </form>
+            </div><!-- div wrapper -->
+        <?php } ?> <!--  logon wrapper -->
+    </div><!-- container -->
 
-<script type="text/javascript">
-$(function() {
+    <script type="text/javascript">
+        $(function () {
 
-<?php // if something went wrong
-if (isset($_GET['requestNew'])) {
-    $_SESSION['register'] = true;
-    $_SESSION['authUser'] = 'portal-user';
-    $_SESSION['pid'] = true;
-    ?>
-    $('.datepicker').datetimepicker({
-        <?php $datetimepicker_timepicker = false; ?>
-        <?php $datetimepicker_showseconds = false; ?>
-        <?php $datetimepicker_formatInput = false; ?>
-        <?php require($GLOBALS['srcdir'] . '/js/xl/jquery-datetimepicker-2-5-4.js.php'); ?>
-     });
-    $(document.body).on('hidden.bs.modal', function () {
-        callServer('cleanup');
-    });
-    $("#resetPass").on('submit', function (e) {
-        e.preventDefault();
-        callServer('is_new', '');
-        return false;
-    });
-<?php } ?>
-<?php if (isset($_GET['w'])) { ?>
-    var unique_id = $.gritter.add({
-        title: '<span class="red">' + <?php echo xlj('Oops!');?> + '</span>',
-        text: <?php echo xlj('Something went wrong. Please try again.'); ?>,
-        sticky: false,
-        time: '5000',
-        class_name: 'my-nonsticky-class'
-    });
-<?php } ?>
-<?php // if successfully logged out
-if (isset($_GET['logout'])) { ?>
-    var unique_id = $.gritter.add({
-        title: '<span class="green">' + <?php echo xlj('Success');?> + '</span>',
-        text: <?php echo xlj('You have been successfully logged out.');?>,
-        sticky: false,
-        time: '5000',
-        class_name: 'my-nonsticky-class'
-    });
-<?php } ?>
-
-return false;
-});
-
-function callServer(action, value, value2, last, first) {
-    var data = {
-        'action' : action,
-        'value' : value,
-        'dob' : $("#dob").val(),
-        'last' : $("#lname").val(),
-        'first' : $("#fname").val(),
-        'email' : $("#emailInput").val()
-    };
-    if (action == 'do_signup') {
-        data = {
-            'action': action,
-            'pid': value
-        };
-    }
-    else if (action == 'notify_admin') {
-        data = {
-            'action': action,
-            'pid': value,
-            'provider': value2
-        };
-    }
-    else if (action == 'cleanup') {
-        data = {
-            'action': action
-        }
-    };
-    $.ajax({
-        type : 'GET',
-        url : './account/account.php',
-        data : data
-    }).done(function (rtn) {
-        if (action == "cleanup") {
-            window.location.href = "./index.php" // Goto landing page.
-        }
-        else if (action == "userIsUnique") {
-            return rtn === '1' ? true : false;
-        }
-        else if (action == "is_new") {
-            if (parseInt(rtn) !== 0) {
-                var yes = confirm(<?php echo xlj("Account is validated. Send new credentials?") ?>);
-                if(!yes)
-                    callServer('cleanup');
-                else
-                    callServer('do_signup', parseInt(rtn));
-            }
-            else {
-                // After error alert app exit to landing page.
-                var message = <?php echo xlj('Unable to find your records. Be sure to use your correct Dob, First and Last name and Email of record.') ?>;
-                message += "<br>" + <?php echo xlj('All search inputs are case sensitive and must match entries in your profile.'); ?>;
-                eModal.alert(message);
+            <?php // if something went wrong
+            if (isset($_GET['requestNew'])) {
+                $_SESSION['register'] = true;
+                $_SESSION['authUser'] = 'portal-user';
+                $_SESSION['pid'] = true;
+                ?>
+            $('.datepicker').datetimepicker({
+                <?php $datetimepicker_timepicker = false; ?>
+                <?php $datetimepicker_showseconds = false; ?>
+                <?php $datetimepicker_formatInput = false; ?>
+                <?php require($GLOBALS['srcdir'] . '/js/xl/jquery-datetimepicker-2-5-4.js.php'); ?>
+            });
+            $(document.body).on('hidden.bs.modal', function () {
+                callServer('cleanup');
+            });
+            $("#resetPass").on('submit', function (e) {
+                e.preventDefault();
+                callServer('is_new', '');
                 return false;
-            }
-        }
-        else if (action == 'do_signup') {
-            if (rtn.indexOf('ERROR') !== -1) {
-                var message = <?php echo xlj('Unable to either create credentials or send email.'); ?>;
-                message += "<br><br>" + <?php echo xlj('Here is what we do know.'); ?> + ": " + rtn + "<br>";
-                eModal.alert(message);
-                return false;
-            }
-            //alert(rtn); // sync alert.. rtn holds username and password for testing.
-            var message = <?php echo xlj("Your new credentials have been sent. Check your email inbox and also possibly your spam folder. Once you log into your patient portal feel free to make an appointment or send us a secure message. We look forward to seeing you soon."); ?>;
-            eModal.alert(message); // This is an async call. The modal close event exits us to portal landing page after cleanup.
+            });
+            <?php } ?>
+            <?php if (isset($_GET['w'])) { ?>
+            var unique_id = $.gritter.add({
+                title: '<span class="red">' + <?php echo xlj('Oops!');?> +'</span>',
+                text: <?php echo xlj('Something went wrong. Please try again.'); ?>,
+                sticky: false,
+                time: '5000',
+                class_name: 'my-nonsticky-class'
+            });
+            <?php } ?>
+            <?php // if successfully logged out
+            if (isset($_GET['logout'])) { ?>
+            var unique_id = $.gritter.add({
+                title: '<span class="green">' + <?php echo xlj('Success');?> +'</span>',
+                text: <?php echo xlj('You have been successfully logged out.');?>,
+                sticky: false,
+                time: '5000',
+                class_name: 'my-nonsticky-class'
+            });
+            <?php } ?>
+
             return false;
+        });
+
+        function callServer(action, value, value2, last, first) {
+            var data = {
+                'action': action,
+                'value': value,
+                'dob': $("#dob").val(),
+                'last': $("#lname").val(),
+                'first': $("#fname").val(),
+                'email': $("#emailInput").val()
+            };
+            if (action == 'do_signup') {
+                data = {
+                    'action': action,
+                    'pid': value
+                };
+            } else if (action == 'notify_admin') {
+                data = {
+                    'action': action,
+                    'pid': value,
+                    'provider': value2
+                };
+            } else if (action == 'cleanup') {
+                data = {
+                    'action': action
+                }
+            }
+            ;
+            $.ajax({
+                type: 'GET',
+                url: './account/account.php',
+                data: data
+            }).done(function (rtn) {
+                if (action == "cleanup") {
+                    window.location.href = "./index.php" // Goto landing page.
+                } else if (action == "userIsUnique") {
+                    return rtn === '1' ? true : false;
+                } else if (action == "is_new") {
+                    if (parseInt(rtn) !== 0) {
+                        var yes = confirm(<?php echo xlj("Account is validated. Send new credentials?") ?>);
+                        if (!yes)
+                            callServer('cleanup');
+                        else
+                            callServer('do_signup', parseInt(rtn));
+                    } else {
+                        // After error alert app exit to landing page.
+                        var message = <?php echo xlj('Unable to find your records. Be sure to use your correct Dob, First and Last name and Email of record.') ?>;
+                        message += "<br>" + <?php echo xlj('All search inputs are case sensitive and must match entries in your profile.'); ?>;
+                        eModal.alert(message);
+                        return false;
+                    }
+                } else if (action == 'do_signup') {
+                    if (rtn.indexOf('ERROR') !== -1) {
+                        var message = <?php echo xlj('Unable to either create credentials or send email.'); ?>;
+                        message += "<br><br>" + <?php echo xlj('Here is what we do know.'); ?> +": " + rtn + "<br>";
+                        eModal.alert(message);
+                        return false;
+                    }
+                    //alert(rtn); // sync alert.. rtn holds username and password for testing.
+                    var message = <?php echo xlj("Your new credentials have been sent. Check your email inbox and also possibly your spam folder. Once you log into your patient portal feel free to make an appointment or send us a secure message. We look forward to seeing you soon."); ?>;
+                    eModal.alert(message); // This is an async call. The modal close event exits us to portal landing page after cleanup.
+                    return false;
+                }
+            }).fail(function (err) {
+                var message = <?php echo xlj('Something went wrong.') ?>;
+                alert(message);
+            });
         }
-    }).fail(function (err) {
-        var message = <?php echo xlj('Something went wrong.') ?>;
-        alert(message);
-    });
-}
-</script>
+    </script>
 </body>
 </html>

--- a/portal/index.php
+++ b/portal/index.php
@@ -108,7 +108,6 @@ if (!(isset($_SESSION['password_update']) || isset($_GET['requestNew']))) {
     <link rel="stylesheet" type="text/css" href="assets/css/base.css?v=<?php echo $v_js_includes; ?>" />
     <link rel="stylesheet" type="text/css" href="assets/css/register.css?v=<?php echo $v_js_includes; ?>" />
 <script type="text/javascript">
-    var landing = <?php echo js_url($landingpage) ?>;
     function process() {
         if (!(validate())) {
             alert (<?php echo xlj('Field(s) are missing!'); ?>);
@@ -178,8 +177,8 @@ if (!(isset($_SESSION['password_update']) || isset($_GET['requestNew']))) {
       <div id="wrapper" class="centerwrapper text-center">
         <h2 class="title"><?php echo xlt('Please Enter New Credentials'); ?></h2>
         <form action="get_patient_info.php" method="POST" onsubmit="return process_new_pass()" >
-            <input style="display:none" type="text" name="fakeusername"/>
-            <input style="display:none" type="password" name="fakepassword"/>
+            <input style="display:none" type="text" name="dummyuname"/>
+            <input style="display:none" type="password" name="dummypass"/>
             <table class="table table-condensed" style="border-bottom:0px;width:100%">
                 <tr>
                     <td width="35%"><strong><?php echo xlt('Account Name'); ?><strong></td>

--- a/portal/index.php
+++ b/portal/index.php
@@ -60,6 +60,7 @@ if (isset($_GET['forward'])) {
         OpenEMR\Common\Session\SessionUtil::portalSessionCookieDestroy();
         die(xlt("Your one time credential reset link has expired. Reset and try again.") . "time:$validate time:".time());
     }
+    $_SESSION['forward'] = $_GET['forward'];
     $_SESSION['portal_username'] = $auth['portal_username'];
     $_SESSION['portal_login_username'] = '';
     $_SESSION['password_update'] = 2;
@@ -80,8 +81,8 @@ if (!(isset($_SESSION['password_update']) || isset($_GET['requestNew']))) {
     }
 
     if (count($result2) == 1) {
-        $defaultLangID = $result2[0]{"lang_id"};
-        $defaultLangName = $result2[0]{"lang_description"};
+        $defaultLangID = $result2[0]["lang_id"];
+        $defaultLangName = $result2[0]["lang_description"];
     } else {
         //default to english if any problems
         $defaultLangID = 1;
@@ -137,6 +138,11 @@ if (!(isset($_SESSION['password_update']) || isset($_GET['requestNew']))) {
     function checkUserName() {
         let vacct = document.getElementById('uname').value;
         let vsuname = document.getElementById('login_uname').value;
+        if (vsuname.length < 12) {
+            alert (<?php echo xlj('User Name must be at least 12 characters!'); ?>);
+            document.getElementById('login_uname').focus();
+            return false;
+        }
         let data = {
             'action': 'userIsUnique',
             'account': vacct,
@@ -237,9 +243,10 @@ if (!(isset($_SESSION['password_update']) || isset($_GET['requestNew']))) {
                 </tr>
                 <tr>
                     <td><strong><?php echo xlt('New User Name'); ?><strong></td>
-                    <td><input class="form-control" name="login_uname" id="login_uname" type="text" required autocomplete="none"
-                            placeholder="<?php echo xla('Must be 8 to 20 characters'); ?>" pattern=".{8,20}"
-                            value="<?php echo attr($_SESSION['portal_login_username']); ?>" onchange="checkUserName()" />
+                    <td><input class="form-control" name="login_uname" id="login_uname" type="text" autofocus autocomplete="none"
+                            title="<?php echo xla('Please enter a username of 12 to 80 characters. Recommended to include symbols and numbers but not required.'); ?>"
+                            placeholder="<?php echo xla('Must be 12 to 80 characters'); ?>" pattern=".{12,80}"
+                            value="<?php echo attr($_SESSION['portal_login_username']); ?>" onblur="checkUserName()" />
                     </td>
                 </tr>
                 <tr>

--- a/portal/index.php
+++ b/portal/index.php
@@ -225,7 +225,8 @@ if (!(isset($_SESSION['password_update']) || isset($_GET['requestNew']))) {
                     <td><strong><?php echo xlt('Current Password');?><strong></td>
                     <td>
                         <input class="form-control" name="pass" id="pass" type="password" <?php echo $_SESSION['onetime'] ? ' readonly ': ''; ?>
-                            autocomplete="none" value="<?php echo attr($_SESSION['onetime']); $_SESSION['password_update']=$_SESSION['onetime'] ? 2 : 1;
+                            autocomplete="none" value="<?php echo attr($_SESSION['onetime']);
+                            $_SESSION['password_update']=$_SESSION['onetime'] ? 2 : 1;
                             unset($_SESSION['onetime']); ?>" required />
                     </td>
                 </tr>

--- a/portal/index.php
+++ b/portal/index.php
@@ -47,8 +47,8 @@ if (isset($_GET['forward'])) {
     $auth = false;
     if (strlen($_GET['forward']) >= 64) {
         $crypto = new CryptoGen();
-        $one_time = $crypto->decryptStandard($_GET['forward'], '', 'database');
-        $auth = sqlQueryNoLog("Select * From patient_access_onsite Where portal_login_username Like BINARY ?", array(($one_time . '%')));
+        $one_time = $crypto->decryptStandard($_GET['forward'], '', 'file');
+        $auth = sqlQueryNoLog("Select * From patient_access_onsite Where portal_onetime Like BINARY ?", array(($one_time . '%')));
     }
     if ($auth === false) {
         error_log("PORTAL ERROR: " . errorLogEscape('One time reset:' . $_GET['forward']), 0);
@@ -57,7 +57,7 @@ if (isset($_GET['forward'])) {
         header('Location: ' . $landingpage . '&w&u');
         exit();
     }
-    $parse = str_replace($one_time, '', $auth['portal_login_username']);
+    $parse = str_replace($one_time, '', $auth['portal_onetime']);
     $validate = hex2bin(substr($parse, 6));
     if ($validate <= time()) {
         error_log("PORTAL ERROR: " . errorLogEscape('One time reset link expired. Dying.'), 0);
@@ -66,7 +66,7 @@ if (isset($_GET['forward'])) {
         die(xlt("Your one time credential reset link has expired. Reset and try again.") . "time:$validate time:" . time());
     }
     $_SESSION['pin'] = substr($parse, 0, 6);
-    $_SESSION['forward'] = $auth['portal_login_username'];
+    $_SESSION['forward'] = $auth['portal_onetime'];
     $_SESSION['portal_username'] = $auth['portal_username'];
     $_SESSION['portal_login_username'] = '';
     $_SESSION['password_update'] = 2;

--- a/sql/5_0_2-to-5_0_3_upgrade.sql
+++ b/sql/5_0_2-to-5_0_3_upgrade.sql
@@ -310,3 +310,7 @@ INSERT INTO `supported_external_dataloads` (`load_type`, `load_source`, `load_re
 INSERT INTO `supported_external_dataloads` (`load_type`, `load_source`, `load_release_date`, `load_filename`, `load_checksum`) VALUES
 ('ICD10', 'CMS', '2019-10-01', '2020-ICD-10-PCS-Order.zip', '8dc136d780ec60916e9e1fc999837bc8');
 #EndIf
+
+#IfMissingColumn patient_access_onsite portal_login_username
+ALTER TABLE `patient_access_onsite`  ADD `portal_login_username` VARCHAR(100) DEFAULT NULL COMMENT 'User entered username',  ADD `question1_answer` VARCHAR(255) DEFAULT NULL,  ADD `question2_answer` VARCHAR(255) DEFAULT NULL,  ADD `question3_answer` VARCHAR(255) DEFAULT NULL;
+#EndIf

--- a/sql/5_0_2-to-5_0_3_upgrade.sql
+++ b/sql/5_0_2-to-5_0_3_upgrade.sql
@@ -312,5 +312,5 @@ INSERT INTO `supported_external_dataloads` (`load_type`, `load_source`, `load_re
 #EndIf
 
 #IfMissingColumn patient_access_onsite portal_login_username
-ALTER TABLE `patient_access_onsite`  ADD `portal_login_username` VARCHAR(100) DEFAULT NULL COMMENT 'User entered username',  ADD `question1_answer` VARCHAR(255) DEFAULT NULL,  ADD `question2_answer` VARCHAR(255) DEFAULT NULL,  ADD `question3_answer` VARCHAR(255) DEFAULT NULL;
+ALTER TABLE `patient_access_onsite`  ADD `portal_login_username` VARCHAR(100) DEFAULT NULL COMMENT 'User entered username';
 #EndIf

--- a/sql/5_0_2-to-5_0_3_upgrade.sql
+++ b/sql/5_0_2-to-5_0_3_upgrade.sql
@@ -312,6 +312,6 @@ INSERT INTO `supported_external_dataloads` (`load_type`, `load_source`, `load_re
 #EndIf
 
 #IfMissingColumn patient_access_onsite portal_login_username
-ALTER TABLE `patient_access_onsite`  ADD `portal_login_username` VARCHAR(100) DEFAULT NULL COMMENT 'User entered username';
+ALTER TABLE `patient_access_onsite`  ADD `portal_login_username` VARCHAR(100) DEFAULT NULL COMMENT 'User entered username', ADD `portal_onetime` VARCHAR(255) DEFAULT NULL;
 UPDATE `patient_access_onsite` SET `portal_pwd_status` = '0', `portal_login_username` = `portal_username`;
 #EndIf

--- a/sql/5_0_2-to-5_0_3_upgrade.sql
+++ b/sql/5_0_2-to-5_0_3_upgrade.sql
@@ -313,4 +313,5 @@ INSERT INTO `supported_external_dataloads` (`load_type`, `load_source`, `load_re
 
 #IfMissingColumn patient_access_onsite portal_login_username
 ALTER TABLE `patient_access_onsite`  ADD `portal_login_username` VARCHAR(100) DEFAULT NULL COMMENT 'User entered username';
+UPDATE `patient_access_onsite` SET `portal_pwd_status` = '0', `portal_login_username` = `portal_username`;
 #EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -5323,7 +5323,8 @@ CREATE TABLE `patient_access_onsite`(
   `portal_pwd` VARCHAR(100),
   `portal_pwd_status` TINYINT DEFAULT '1' COMMENT '0=>Password Created Through Demographics by The provider or staff. Patient Should Change it at first time it.1=>Pwd updated or created by patient itself',
   `portal_salt` VARCHAR(100),
-  `portal_login_username` varchar(100) DEFAULT NULL COMMENT 'User entered username',
+  `portal_login_username` VARCHAR(100) DEFAULT NULL COMMENT 'User entered username',
+  `portal_onetime`  VARCHAR(255) DEFAULT NULL,
   PRIMARY KEY (`id`)
 )ENGINE=InnoDB AUTO_INCREMENT=1;
 

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -5324,9 +5324,6 @@ CREATE TABLE `patient_access_onsite`(
   `portal_pwd_status` TINYINT DEFAULT '1' COMMENT '0=>Password Created Through Demographics by The provider or staff. Patient Should Change it at first time it.1=>Pwd updated or created by patient itself',
   `portal_salt` VARCHAR(100),
   `portal_login_username` varchar(100) DEFAULT NULL COMMENT 'User entered username',
-  `question1_answer` varchar(255) DEFAULT NULL,
-  `question2_answer` varchar(255) DEFAULT NULL,
-  `question3_answer` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`)
 )ENGINE=InnoDB AUTO_INCREMENT=1;
 

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -5317,12 +5317,16 @@ CREATE TABLE `openemr_postcalendar_events` (
 
 DROP TABLE IF EXISTS `patient_access_onsite`;
 CREATE TABLE `patient_access_onsite`(
-  `id` INT NOT NULL AUTO_INCREMENT ,
+  `id` INT NOT NULL AUTO_INCREMENT,
   `pid` bigint(20),
-  `portal_username` VARCHAR(100) ,
-  `portal_pwd` VARCHAR(100) ,
+  `portal_username` VARCHAR(100),
+  `portal_pwd` VARCHAR(100),
   `portal_pwd_status` TINYINT DEFAULT '1' COMMENT '0=>Password Created Through Demographics by The provider or staff. Patient Should Change it at first time it.1=>Pwd updated or created by patient itself',
-  `portal_salt` VARCHAR(100) ,
+  `portal_salt` VARCHAR(100),
+  `portal_login_username` varchar(100) DEFAULT NULL COMMENT 'User entered username',
+  `question1_answer` varchar(255) DEFAULT NULL,
+  `question2_answer` varchar(255) DEFAULT NULL,
+  `question3_answer` varchar(255) DEFAULT NULL
   PRIMARY KEY (`id`)
 )ENGINE=InnoDB AUTO_INCREMENT=1;
 

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -5326,7 +5326,7 @@ CREATE TABLE `patient_access_onsite`(
   `portal_login_username` varchar(100) DEFAULT NULL COMMENT 'User entered username',
   `question1_answer` varchar(255) DEFAULT NULL,
   `question2_answer` varchar(255) DEFAULT NULL,
-  `question3_answer` varchar(255) DEFAULT NULL
+  `question3_answer` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`)
 )ENGINE=InnoDB AUTO_INCREMENT=1;
 


### PR DESCRIPTION
Some cool credential enhancements
- Fix demographic portal credential printout/mailer to reflect trusted email if globals Enforce email on login is on.
- Allow patient to change username and password between 8-20 chars each on credential reset/new. Old username is now patients portal account id.
- Add to portal top status bar menu item popup so patient can change credentials while logged in.

huh, for the amount of time I put into this, you'd think there'd be more to say. Wait, how about some pictures!
![image](https://user-images.githubusercontent.com/1859985/66600805-5f5a5500-eb74-11e9-9685-294d77fa63e8.png)

![image (2)](https://user-images.githubusercontent.com/1859985/66600850-7e58e700-eb74-11e9-9a43-8632ddeecae9.png)

![image (3)](https://user-images.githubusercontent.com/1859985/66600879-8ca70300-eb74-11e9-81d5-1c36d7f30a3a.png)
