### PR TITLE
Proof of concept adding Twig templating 

### DIFF
--- a/interface/main/tabs/menu/menus/standard.json
+++ b/interface/main/tabs/menu/menus/standard.json
@@ -1682,7 +1682,19 @@
               "acct",
               "rep_a"
             ]
-          }
+          },
+            {
+                "label": "Insurance Payment Summary",
+                "menu_id": "rep0",
+                "target": "rep",
+                "url": "/interface/reports/insurance.php",
+                "children": [],
+                "requirement": 0,
+                "acl_req": [
+                    "acct",
+                    "rep_a"
+                ]
+            }
         ],
         "requirement": 0
       },

--- a/interface/reports/insurance.php
+++ b/interface/reports/insurance.php
@@ -9,10 +9,9 @@
  * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once '../../vendor/autoload.php';
 require_once '../globals.php';
 
-use OpenEMR\Finance\Reports\FinancialSummaryByInsuranceController;
+use OpenEMR\FinancialReports\FinancialSummaryByInsuranceController;
 
 $page = new FinancialSummaryByInsuranceController();
 echo $page->insurancepaid();

--- a/interface/reports/insurance.php
+++ b/interface/reports/insurance.php
@@ -15,5 +15,3 @@ use OpenEMR\FinancialReports\FinancialSummaryByInsuranceController;
 
 $page = new FinancialSummaryByInsuranceController();
 echo $page->insurancepaid();
-
-

--- a/interface/reports/insurance.php
+++ b/interface/reports/insurance.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Financial Report initial page
+ *
+ * @package OpenEMR
+ * @link    http://www.open-emr.org
+ * @author  Sherwin Gaddis <sherwingaddis@gmail.com>
+ * @copyright Copyright (c) 2016-2017 Sherwin Gaddis <sherwingaddis@gmail.com>
+ * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+require_once '../../vendor/autoload.php';
+require_once '../globals.php';
+
+use OpenEMR\Finance\Reports\FinancialSummaryByInsuranceController;
+
+$page = new FinancialSummaryByInsuranceController();
+echo $page->insurancepaid();
+
+
+?>

--- a/interface/reports/insurance.php
+++ b/interface/reports/insurance.php
@@ -17,4 +17,3 @@ $page = new FinancialSummaryByInsuranceController();
 echo $page->insurancepaid();
 
 
-?>

--- a/src/Core/HeaderExtension.php
+++ b/src/Core/HeaderExtension.php
@@ -15,7 +15,8 @@ use Twig\Extension\AbstractExtension;
 
 class HeaderExtension extends AbstractExtension
 {
-    public function getFunctions() {
+    public function getFunctions()
+    {
         return [
             new TwigFunction(
                 'header_setup',

--- a/src/Core/HeaderExtension.php
+++ b/src/Core/HeaderExtension.php
@@ -9,7 +9,7 @@
  * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-namespace OpenEMR\FinancialReports;
+namespace OpenEMR\Core;
 
 use Twig\Extension\AbstractExtension;
 

--- a/src/FinancialReports/FinancialSummaryByInsuranceController.php
+++ b/src/FinancialReports/FinancialSummaryByInsuranceController.php
@@ -57,7 +57,6 @@ class FinancialSummaryByInsuranceController extends Controller
         $twig->addExtension( new HeaderExtension());
 
         return $twig->render('summaryinsurancepaid.html.twig', [
-            'header' => new HeaderExtension('header_setup'),
             'name' => 'Fabien Roger'
 
         ]);

--- a/src/FinancialReports/FinancialSummaryByInsuranceController.php
+++ b/src/FinancialReports/FinancialSummaryByInsuranceController.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Financial Report controller class.
+ *
+ * @package OpenEMR
+ * @link    http://www.open-emr.org
+ * @author  Sherwin Gaddis <sherwingaddis@gmail.com>
+ * @copyright Copyright (c) 2016-2017 Sherwin Gaddis <sherwingaddis@gmail.com>
+ * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Finance\Reports;   //This will function as my controller event though not named controller
+
+require_once "../../vendor/autoload.php";
+
+
+//use OpenEMR\Common\Database\Connector;
+use OpenEMR\Core\Header;
+use OpenEMR\Core\Controller;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+use Twig\HeaderExtension;
+
+
+
+class FinancialSummaryByInsuranceController extends Controller
+{
+    /**
+     * The user repository to be used for db CRUD operations.
+     */
+    private $repository;
+
+    /**
+     * FinancialSummaryByInsuranceController constructor.
+     */
+    public function __construct()
+    {
+
+        /*
+        $database = Connector::Instance();
+        $entityManager = $database->entityManager;
+        $this->repository = $entityManager->getRepository('\OpenEMR\Entities\ArSession');
+        */
+    }
+
+    /**
+     * @return string
+     * @throws \Twig\Error\LoaderError
+     * @throws \Twig\Error\RuntimeError
+     * @throws \Twig\Error\SyntaxError
+     */
+    public function insurancepaid()
+    {
+
+        $loader = new FilesystemLoader('../../templates/financialreports/insurance');
+        $twig = new Environment($loader, [
+            'cache' => 'C:\tempt',
+        ]);
+        $twig->addExtension( new HeaderExtension());
+
+        return $twig->render('summaryinsurancepaid.html.twig', [
+            'header' => new HeaderExtension('header_setup'),
+            'name' => 'Fabien Roger'
+
+        ]);
+
+    }
+
+}

--- a/src/FinancialReports/FinancialSummaryByInsuranceController.php
+++ b/src/FinancialReports/FinancialSummaryByInsuranceController.php
@@ -18,7 +18,6 @@ use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 use Twig\HeaderExtension;
 
-
 class FinancialSummaryByInsuranceController extends Controller
 {
     /**
@@ -51,7 +50,7 @@ class FinancialSummaryByInsuranceController extends Controller
         $twig = new Environment($loader, [
             'cache' => 'C:\tempt',
         ]);
-        $twig->addExtension( new HeaderExtension());
+        $twig->addExtension(new HeaderExtension());
 
         return $twig->render('summaryinsurancepaid.html.twig', [
             'name' => 'Fabien Roger'

--- a/src/FinancialReports/FinancialSummaryByInsuranceController.php
+++ b/src/FinancialReports/FinancialSummaryByInsuranceController.php
@@ -21,8 +21,6 @@ use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 use Twig\HeaderExtension;
 
-
-
 class FinancialSummaryByInsuranceController extends Controller
 {
     /**
@@ -63,7 +61,5 @@ class FinancialSummaryByInsuranceController extends Controller
             'name' => 'Fabien Roger'
 
         ]);
-
     }
-
 }

--- a/src/FinancialReports/FinancialSummaryByInsuranceController.php
+++ b/src/FinancialReports/FinancialSummaryByInsuranceController.php
@@ -9,17 +9,15 @@
  * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-namespace OpenEMR\Finance\Reports;   //This will function as my controller event though not named controller
-
-require_once "../../vendor/autoload.php";
-
+namespace OpenEMR\FinancialReports;   //This will function as my controller event though not named controller
 
 //use OpenEMR\Common\Database\Connector;
-use OpenEMR\Core\Header;
+
 use OpenEMR\Core\Controller;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 use Twig\HeaderExtension;
+
 
 class FinancialSummaryByInsuranceController extends Controller
 {
@@ -49,7 +47,6 @@ class FinancialSummaryByInsuranceController extends Controller
      */
     public function insurancepaid()
     {
-
         $loader = new FilesystemLoader('../../templates/financialreports/insurance');
         $twig = new Environment($loader, [
             'cache' => 'C:\tempt',

--- a/src/FinancialReports/HeaderExtension.php
+++ b/src/FinancialReports/HeaderExtension.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Header Extension.
+ * This file goes in the twig/twig/src folder
+ * @package OpenEMR
+ * @link    http://www.open-emr.org
+ * @author  Sherwin Gaddis <sherwingaddis@gmail.com>
+ * @copyright Copyright (c) 2019 Sherwin Gaddis <sherwingaddis@gmail.com>
+ * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace Twig;
+
+use Twig\Extension\AbstractExtension;
+
+class HeaderExtension extends AbstractExtension
+{
+    public function getFunctions() {
+        return [
+            new TwigFunction(
+                'header_setup',
+                [\OpenEMR\Core\Header::class, 'setupHeader']
+            ),
+            // add more if needed
+        ];
+    }
+}

--- a/src/FinancialReports/HeaderExtension.php
+++ b/src/FinancialReports/HeaderExtension.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Header Extension.
- * This file goes in the twig/twig/src folder
+ *
  * @package OpenEMR
  * @link    http://www.open-emr.org
  * @author  Sherwin Gaddis <sherwingaddis@gmail.com>
@@ -9,7 +9,7 @@
  * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-namespace Twig;
+namespace OpenEMR\FinancialReports;
 
 use Twig\Extension\AbstractExtension;
 

--- a/templates/financialreports/insurance/layout.html.twig
+++ b/templates/financialreports/insurance/layout.html.twig
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Insurance Payments</title>
+    {{ header_setup(['common', 'report-helper']) }}
+
+</head>
+<body>
+{% block body %}{% endblock %}
+</body>
+</html>

--- a/templates/financialreports/insurance/summaryinsurancepaid.html.twig
+++ b/templates/financialreports/insurance/summaryinsurancepaid.html.twig
@@ -1,0 +1,22 @@
+{% extends 'layout.html.twig' %}
+
+{% block body %}
+
+{{ name }}
+    <div class="container center">
+        <h3>Insurance Payments</h3>
+        <form class="form-inline">
+            <div class="form-group">
+                <label>From Date :</label>
+                <input type="text" size="10" value="" class="datepicker input-sm" name="fromDate"
+                       title="event date or starting date">
+            </div>
+            <div class="form-group">
+                <label>To Date:</label>
+                <input type="text" size="10" value="" class="datepicker input-sm" name="toDate"
+                       title="event date or starting date">
+            </div>
+        </form>
+    </div>{# --end of container div--  #}
+
+{% endblock %}


### PR DESCRIPTION
There is a file missing from this commit that should go in the vendor/twig/twig/src folder. 
It is the HeaderExtension.php file. 

     <?php
     /**
      *  Twig Extention class.
      *
      * @package OpenEMR
      * @link    http://www.open-emr.org
      * @author  Sherwin Gaddis <sherwingaddis@gmail.com>
      * @copyright Copyright (c) 2016-2017 Sherwin Gaddis <sherwingaddis@gmail.com>
      * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
      */

      namespace Twig;

      use Twig\Extension\AbstractExtension;

      class HeaderExtension extends AbstractExtension
      {
          public function getFunctions() {
            return [
            new TwigFunction(
                'header_setup',
                [\OpenEMR\Core\Header::class, 'setupHeader']
            ),
            // add more if needed
         ];
       }
     }


I added a folder but the folder would not show when I tried to upload it. 

    
![image](https://user-images.githubusercontent.com/834958/67167092-c7bee880-f363-11e9-9811-8c38ee0a6f3e.png)

This is a big step for me. 
Anyway, this is how I got Twig to use the setupHeader class

Comments are welcome. I am sure there are other ways this could have been done. But from the videos that I watched and the advice, I got from StackOverflow. This was what I came up with and it works. 


