### PR TITLE
Convert LDAP / Active Directory authentication to use native PHP LDAP…

### DIFF
--- a/interface/globals.php
+++ b/interface/globals.php
@@ -5,6 +5,7 @@
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2018-2019 Brady Miller <brady.g.miller@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
@@ -618,6 +619,23 @@ function strterm($string, $length)
     } else {
         return $string;
     }
+}
+
+// Check if the current or a specified user logs in with LDAP.
+function useActiveDirectory($user='') {
+    if (empty($GLOBALS['gbl_ldap_enabled'])) {
+        return false;
+    }
+    if ($user == '') {
+        $user = $_SESSION['authUser'];
+    }
+    $exarr = explode(',', $GLOBALS['gbl_ldap_exclusions']);
+    foreach ($exarr as $ex) {
+        if ($user == trim($ex)) {
+            return false;
+        }
+    }
+    return true;
 }
 
 // Override temporary_files_dir

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -622,7 +622,8 @@ function strterm($string, $length)
 }
 
 // Check if the current or a specified user logs in with LDAP.
-function useActiveDirectory($user='') {
+function useActiveDirectory($user = '')
+{
     if (empty($GLOBALS['gbl_ldap_enabled'])) {
         return false;
     }

--- a/interface/usergroup/user_admin.php
+++ b/interface/usergroup/user_admin.php
@@ -85,7 +85,7 @@ function submitform() {
 
     top.restoreSession();
     var flag=0;
-<?php if(empty($GLOBALS['gbl_ldap_enabled']) || empty($GLOBALS['gbl_ldap_exclusions'])) { ?>
+<?php if (empty($GLOBALS['gbl_ldap_enabled']) || empty($GLOBALS['gbl_ldap_exclusions'])) { ?>
     if(document.forms[0].clearPass.value!="")
     {
         //Checking for the strong password if the 'secure password' feature is enabled
@@ -281,12 +281,12 @@ if ($password_exp != "0000-00-00") {
 <TR>
     <TD style="width:180px;"><span class=text><?php echo xlt('Username'); ?>: </span></TD>
     <TD style="width:270px;"><input type=entry name=username style="width:150px;" class="form-control" value="<?php echo attr($iter["username"]); ?>" disabled></td>
-<?php if(empty($GLOBALS['gbl_ldap_enabled']) || empty($GLOBALS['gbl_ldap_exclusions'])) { ?>
+<?php if (empty($GLOBALS['gbl_ldap_enabled']) || empty($GLOBALS['gbl_ldap_exclusions'])) { ?>
         <TD style="width:200px;"><span class=text>*<?php echo xlt('Your Password'); ?>*: </span></TD>
         <TD class='text' style="width:280px;"><input type='password' name=adminPass style="width:150px;"  class="form-control" value="" autocomplete='off'><font class="mandatory"></font></TD>
 <?php } ?>
 </TR>
-<?php if(empty($GLOBALS['gbl_ldap_enabled']) || empty($GLOBALS['gbl_ldap_exclusions'])) { ?>
+<?php if (empty($GLOBALS['gbl_ldap_enabled']) || empty($GLOBALS['gbl_ldap_exclusions'])) { ?>
 <TR>
     <TD style="width:180px;"><span class=text></span></TD>
     <TD style="width:270px;"></td>

--- a/interface/usergroup/user_admin.php
+++ b/interface/usergroup/user_admin.php
@@ -5,6 +5,7 @@
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2018 Brady Miller <brady.g.miller@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
@@ -84,7 +85,7 @@ function submitform() {
 
     top.restoreSession();
     var flag=0;
-    <?php if (!$GLOBALS['use_active_directory']) { ?>
+<?php if(empty($GLOBALS['gbl_ldap_enabled']) || empty($GLOBALS['gbl_ldap_exclusions'])) { ?>
     if(document.forms[0].clearPass.value!="")
     {
         //Checking for the strong password if the 'secure password' feature is enabled
@@ -116,7 +117,7 @@ function submitform() {
         }
 
     }//If pwd null ends here
-    <?php } ?>
+<?php } ?>
     //Request to reset the user password if the user was deactived once the password expired.
     if((document.forms[0].pwd_expires.value != 0) && (document.forms[0].clearPass.value == "")) {
         if((document.forms[0].user_type.value != "Emergency Login") && (document.forms[0].pre_active.value == 0) && (document.forms[0].active.checked == 1) && (document.forms[0].grace_time.value != "") && (document.forms[0].current_date.value) > (document.forms[0].grace_time.value))
@@ -280,19 +281,19 @@ if ($password_exp != "0000-00-00") {
 <TR>
     <TD style="width:180px;"><span class=text><?php echo xlt('Username'); ?>: </span></TD>
     <TD style="width:270px;"><input type=entry name=username style="width:150px;" class="form-control" value="<?php echo attr($iter["username"]); ?>" disabled></td>
-    <?php if (!$GLOBALS['use_active_directory']) { ?>
+<?php if(empty($GLOBALS['gbl_ldap_enabled']) || empty($GLOBALS['gbl_ldap_exclusions'])) { ?>
         <TD style="width:200px;"><span class=text>*<?php echo xlt('Your Password'); ?>*: </span></TD>
         <TD class='text' style="width:280px;"><input type='password' name=adminPass style="width:150px;"  class="form-control" value="" autocomplete='off'><font class="mandatory"></font></TD>
-    <?php } ?>
+<?php } ?>
 </TR>
-    <?php if (!$GLOBALS['use_active_directory']) { ?>
+<?php if(empty($GLOBALS['gbl_ldap_enabled']) || empty($GLOBALS['gbl_ldap_exclusions'])) { ?>
 <TR>
     <TD style="width:180px;"><span class=text></span></TD>
     <TD style="width:270px;"></td>
     <TD style="width:200px;"><span class=text><?php echo xlt('User\'s New Password'); ?>: </span></TD>
     <TD class='text' style="width:280px;">    <input type=text name=clearPass style="width:150px;"  class="form-control" value=""><font class="mandatory"></font></td>
 </TR>
-    <?php } ?>
+<?php } ?>
 
 <TR height="30" style="valign:middle;">
   <td class='text'>

--- a/interface/usergroup/user_info.php
+++ b/interface/usergroup/user_info.php
@@ -7,6 +7,7 @@
  * @author    Roberto Vasquez <robertogagliotta@gmail.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
  * @author    Ranganath Pathak <pathak@scrs1.org>
+ * @author    Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2017 Roberto Vasquez <robertogagliotta@gmail.com>
  * @copyright Copyright (c) 2017-2018 Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2019 Ranganath Pathak <pathak@scrs1.org>
@@ -21,7 +22,7 @@ use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
 use OpenEMR\OeUI\OemrUI;
 
-if ($GLOBALS['use_active_directory']) {
+if (useActiveDirectory()) {
     exit();
 }
 $userid = $_SESSION['authId'];

--- a/interface/usergroup/usergroup_admin_add.php
+++ b/interface/usergroup/usergroup_admin_add.php
@@ -5,6 +5,7 @@
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2017-2018 Brady Miller <brady.g.miller@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
@@ -218,11 +219,11 @@ function authorized_clicked() {
 <table border=0 cellpadding=0 cellspacing=0 style="width:600px;">
 <tr>
 <td style="width:150px;"><span class="text"><?php echo xlt('Username'); ?>: </span></td><td  style="width:220px;"><input type=entry name="rumple" style="width:120px;" class="form-control"><span class="mandatory"></span></td>
-    <?php if (!$GLOBALS['use_active_directory']) { ?>
+<?php if(empty($GLOBALS['gbl_ldap_enabled']) || empty($GLOBALS['gbl_ldap_exclusions'])) { ?>
 <td style="width:150px;"><span class="text"><?php echo xlt('Password'); ?>: </span></td><td style="width:250px;"><input type="password" style="width:120px;" name="stiltskin" class="form-control"><span class="mandatory"></span></td>
-    <?php } else { ?>
+<?php } else { ?>
         <td> <input type="hidden" value="124" name="stiltskin" /></td>
-    <?php } ?>
+<?php } ?>
 </tr>
 <tr>
     <td style="width:150px;"></td><td  style="width:220px;"></span></td>

--- a/interface/usergroup/usergroup_admin_add.php
+++ b/interface/usergroup/usergroup_admin_add.php
@@ -219,7 +219,7 @@ function authorized_clicked() {
 <table border=0 cellpadding=0 cellspacing=0 style="width:600px;">
 <tr>
 <td style="width:150px;"><span class="text"><?php echo xlt('Username'); ?>: </span></td><td  style="width:220px;"><input type=entry name="rumple" style="width:120px;" class="form-control"><span class="mandatory"></span></td>
-<?php if(empty($GLOBALS['gbl_ldap_enabled']) || empty($GLOBALS['gbl_ldap_exclusions'])) { ?>
+<?php if (empty($GLOBALS['gbl_ldap_enabled']) || empty($GLOBALS['gbl_ldap_exclusions'])) { ?>
 <td style="width:150px;"><span class="text"><?php echo xlt('Password'); ?>: </span></td><td style="width:250px;"><input type="password" style="width:120px;" name="stiltskin" class="form-control"><span class="mandatory"></span></td>
 <?php } else { ?>
         <td> <input type="hidden" value="124" name="stiltskin" /></td>

--- a/library/ESign/Form/Controller.php
+++ b/library/ESign/Form/Controller.php
@@ -21,6 +21,7 @@ namespace ESign;
  * @package OpenEMR
  * @author  Ken Chapple <ken@mi-squared.com>
  * @author  Medical Information Integration, LLC
+ * @author    Rod Roark <rod@sunsetsystems.com>
  * @link    http://www.open-emr.org
  **/
 
@@ -90,7 +91,7 @@ class Form_Controller extends Abstract_Controller
 
         $amendment = $this->getRequest()->getParam('amendment', '');
 
-        if ($GLOBALS['use_active_directory']) {
+        if (useActiveDirectory()) {
             $valid = active_directory_validation($_SESSION['authUser'], $password);
         } else {
             $valid = confirm_user_password($_SESSION['authUser'], $password);

--- a/library/auth.inc
+++ b/library/auth.inc
@@ -111,7 +111,7 @@ function authCheckSession()
 {
     if (isset($_SESSION['authId'])) {
          // If active directory was used, check a different session variable (as there is no password in database).
-        if ($GLOBALS['use_active_directory']) {
+        if (useActiveDirectory()) {
             if ($_SESSION['active_directory_auth']) {
                 return true;
             } else {

--- a/library/authentication/login_operations.php
+++ b/library/authentication/login_operations.php
@@ -157,6 +157,9 @@ function active_directory_validation($user, $pass)
         if (!ldap_set_option($ldapconn, LDAP_OPT_PROTOCOL_VERSION, 3)) {
             error_log("Setting LDAP v3 protocol failed");
         }
+        if (!ldap_set_option($ldapconn, LDAP_OPT_REFERRALS, 0)) {
+            error_log("Disabling LDAP referrals failed");
+        }
         $ldapbind = ldap_bind(
             $ldapconn,
             str_replace('{login}', $user, $GLOBALS['gbl_ldap_dn']),

--- a/library/authentication/login_operations.php
+++ b/library/authentication/login_operations.php
@@ -145,7 +145,8 @@ function verify_user_gacl_group($user, $provider)
 
 /* Validation of user and password using LDAP. */
 
-function active_directory_validation($user, $pass) {
+function active_directory_validation($user, $pass)
+{
     // Make sure the connection is not anonymous.
     if ($pass === '' || preg_match('/^\0/', $pass) || !preg_match('/^[\w]+$/', $user)) {
         error_log("Empty user or password for active_directory_validation()");

--- a/library/authentication/login_operations.php
+++ b/library/authentication/login_operations.php
@@ -148,7 +148,7 @@ function verify_user_gacl_group($user, $provider)
 function active_directory_validation($user, $pass)
 {
     // Make sure the connection is not anonymous.
-    if ($pass === '' || preg_match('/^\0/', $pass) || !preg_match('/^[\w]+$/', $user)) {
+    if ($pass === '' || preg_match('/^\0/', $pass) || !preg_match('/^[\w.-]+$/', $user)) {
         error_log("Empty user or password for active_directory_validation()");
         return false;
     }

--- a/library/authentication/login_operations.php
+++ b/library/authentication/login_operations.php
@@ -6,6 +6,7 @@
  * @link      https://www.open-emr.org
  * @author    Kevin Yeh <kevin.y@integralemr.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2013 Kevin Yeh <kevin.y@integralemr.com>
  * @copyright Copyright (c) 2013 OEMR <www.oemr.org>
  * @copyright Copyright (c) 2018 Brady Miller <brady.g.miller@gmail.com>
@@ -31,7 +32,7 @@ function validate_user_password($username, &$password, $provider)
     $valid=false;
 
     //Active Directory Authentication added by shachar zilbershlag <shaharzi@matrix.co.il>
-    if ($GLOBALS['use_active_directory']) {
+    if (useActiveDirectory($username)) {
         $valid = active_directory_validation($username, $password);
         $_SESSION['active_directory_auth'] = $valid;
     } else {
@@ -142,43 +143,35 @@ function verify_user_gacl_group($user, $provider)
     return true;
 }
 
-/* Validation of user and password using active directory. */
-function active_directory_validation($user, $pass)
-{
-    $valid = false;
+/* Validation of user and password using LDAP. */
 
-    // Create class instance
-    $ad = new Adldap\Adldap();
-
-    // Create a configuration array.
-    $config = array(
-        // Your account suffix, for example: jdoe@corp.acme.org
-        'account_suffix'        => $GLOBALS['account_suffix'],
-
-        // You can use the host name or the IP address of your controllers.
-        'hosts'    => [$GLOBALS['domain_controllers']],
-
-        // Your base DN.
-        'base_dn'               => $GLOBALS['base_dn'],
-
-        // The account to use for querying / modifying users. This
-        // does not need to be an actual admin account.
-        'username'        => $user,
-        'password'        => $pass,
-    );
-
-    // Add a connection provider to Adldap.
-    $ad->addProvider($config);
-
-    // If a successful connection is made, the provider will be returned.
-    try {
-        $prov = $ad->connect('', $user.$GLOBALS['account_suffix'], $pass);
-        $valid = $prov->auth()->attempt($user, $pass, true);
-    } catch (Exception $e) {
-        error_log(errorLogEscape($e->getMessage()));
+function active_directory_validation($user, $pass) {
+    // Make sure the connection is not anonymous.
+    if ($pass === '' || preg_match('/^\0/', $pass) || !preg_match('/^[\w]+$/', $user)) {
+        error_log("Empty user or password for active_directory_validation()");
+        return false;
     }
-
-    return $valid;
+    $ldapconn = ldap_connect($GLOBALS['gbl_ldap_host']);
+    if ($ldapconn) {
+        if (!ldap_set_option($ldapconn, LDAP_OPT_PROTOCOL_VERSION, 3)) {
+            error_log("Setting LDAP v3 protocol failed");
+        }
+        $ldapbind = ldap_bind(
+            $ldapconn,
+            str_replace('{login}', $user, $GLOBALS['gbl_ldap_dn']),
+            $pass
+        );
+        if ($ldapbind) {
+            ldap_unbind($ldapconn);
+            error_log("ldap_bind() for user $user successful"); // debugging
+            return true;
+        } else {
+            error_log("ldap_bind() for user $user failed"); // debugging
+        }
+    } else {
+        error_log("ldap_connect() failed");
+    }
+    return false;
 }
 
 function resetLoginFailedCounter($user)
@@ -193,7 +186,7 @@ function incrementLoginFailedCounter($user)
 
 function checkLoginFailedCounter($user)
 {
-    if ($GLOBALS['password_max_failed_logins'] == 0 || $GLOBALS['use_active_directory']) {
+    if ($GLOBALS['password_max_failed_logins'] == 0 || useActiveDirectory($user)) {
         // skip the check if turned off or using active directory for login
         return true;
     }

--- a/library/authentication/password_change.php
+++ b/library/authentication/password_change.php
@@ -18,6 +18,7 @@
  *
  * @package OpenEMR
  * @author  Kevin Yeh <kevin.y@integralemr.com>
+ * @author  Rod Roark <rod@sunsetsystems.com>
  * @link    https://www.open-emr.org
  */
 require_once("$srcdir/authentication/common_operations.php");
@@ -92,7 +93,7 @@ function update_password($activeUser, $targetUser, &$currentPwd, &$newPwd, &$err
         }
     } else {
         // If this is an administrator changing someone else's password, then check that they have the password right
-        if ($GLOBALS['use_active_directory']) {
+        if (useActiveDirectory()) {
             $valid = active_directory_validation($_SESSION['authUser'], $currentPwd);
             if (!$valid) {
                 $errMsg=xl("Incorrect password!");
@@ -122,7 +123,7 @@ function update_password($activeUser, $targetUser, &$currentPwd, &$newPwd, &$err
 
     
     //Test password validity
-    if (strlen($newPwd)==0) {
+    if (strlen($newPwd) == 0 && empty($GLOBALS['gbl_ldap_enabled'])) {
         $errMsg=xl("Empty Password Not Allowed");
         return false;
     }

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -1994,32 +1994,29 @@ $GLOBALS_METADATA = array(
             xl('Key for multiple database credentials encryption')
         ),
 
-        'use_active_directory' => array(
-            xl('Use Active Directory'),
+        'gbl_ldap_enabled' => array(
+            xl('Use LDAP for Authentication'),
             'bool',
             '0',
-            xl('If enabled, uses the specified active directory for login and authentication.')
+            xl('If enabled, use LDAP for login and authentication.')
         ),
-
-        'account_suffix' => array(
-            xl('Active Directory - Suffix Of Account'),
+        'gbl_ldap_host' => array(
+            xl('LDAP - Server Name or URI'),
             'text',
             '',
-            xl('The suffix of the account.')
-        ),
-
-        'base_dn' => array(
-            xl('Active Directory - Domains Base'),
+            xl('The hostname or URI of your LDAP or Active Directory server.')
+        ), 
+        'gbl_ldap_dn' => array(
+            xl('LDAP - Distinguished Name of User'),
             'text',
             '',
-            xl('Users is the standard windows CN, replace the DC stuff with your domain.')
+            xl('Embed {login} where the OpenEMR login name of the user is to be; for example: uid={login},dc=example,dc=com')
         ),
-
-        'domain_controllers' => array(
-            xl('Active Directory - Domains Controllers'),
+        'gbl_ldap_exclusions' => array(
+            xl('LDAP - Login Exclusions'),
             'text',
             '',
-            xl('The IP address of your domain controller(s).')
+            xl('Comma-separated list of login names to use normal authentication instead of LDAP; useful for setup and debugging.')
         ),
 
     ),

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -2005,7 +2005,7 @@ $GLOBALS_METADATA = array(
             'text',
             '',
             xl('The hostname or URI of your LDAP or Active Directory server.')
-        ), 
+        ),
         'gbl_ldap_dn' => array(
             xl('LDAP - Distinguished Name of User'),
             'text',


### PR DESCRIPTION
… instead of adldap2.

I vaguely remember Matrix is using LDAP? If so would be nice to have their input.

This PR comes from my inability to make adldap2 work for a particular client using an OpenLDAP server. Likely I was doing something wrong but the lack of documentation and useful error messages for adldap2 made this solution easier for me.

A benefit here is that you can exclude a list of users from LDAP authentication, making setup and troubleshooting easier.

Also note that you are to put "{login}" into the Distinguished Name field (in Globals) as a placeholder for the OpenEMR username.

For testing you can use the sample LDAP server described here:
  http://www.forumsys.com/tutorials/integration-how-to/ldap/online-ldap-test-server/
Use these values in globals:
  LDAP - Server Name or URI         : ldap.forumsys.com
  LDAP - Distinguished Name of User : uid={login},dc=example,dc=com
  LDAP - Login Exclusions           : administrator (or whatever your admin login is)

Then create a user named "tesla".
When you enable LDAP and log in as that user, the password is "password".

Note the Adldap class can now be removed from the project.