### PR TITLE
Set Valid Message On Product Registration Modal To Red

### DIFF
--- a/interface/themes/login.css
+++ b/interface/themes/login.css
@@ -55,3 +55,8 @@ body.login {
     height: 43px;
     margin-bottom: 10px;
 }
+
+#ui-id-1 > .message {
+    color: #ff0400;
+    font-weight: bold;
+}


### PR DESCRIPTION
Just an minor enhancement to where when the invalid message in the "Product Registration" modal appears, it should be display more clearly, in this case, I set it to red and bold. 

After:  
![2019-10-28_00-24-12](https://user-images.githubusercontent.com/8636946/67637953-c325a180-f91a-11e9-8876-dc36cea5b947.png)

Let me know if this works. 

Cheers!
