### PR TITLE
Fixes Travis CI ControlStructureSpacing Build Issue

### DIFF
--- a/controllers/C_Document.class.php
+++ b/controllers/C_Document.class.php
@@ -148,7 +148,7 @@ class C_Document extends Controller
         $encrypted = $_POST['encrypted'];
         $passphrase = $_POST['passphrase'];
         if (!$GLOBALS['hide_document_encryption'] &&
-            $encrypted && $passphrase ) {
+            $encrypted && $passphrase) {
             $doDecryption = true;
         }
 
@@ -511,7 +511,7 @@ class C_Document extends Controller
         $doEncryption = false;
         if (!$GLOBALS['hide_document_encryption'] &&
             $encrypted == "true" &&
-            $passphrase ) {
+            $passphrase) {
             $doEncryption = true;
         }
 
@@ -1097,7 +1097,7 @@ class C_Document extends Controller
             $d = new Document($document_id);
             $file_name = $d->get_url_file();
             if ($docname != '' &&
-                 $docname != $file_name ) {
+                 $docname != $file_name) {
                 // Ready to rename - check for relocation
                 $old_url = $this->_check_relocation($d->get_url());
                 $new_url = $this->_check_relocation($d->get_url(), null, $docname);

--- a/interface/forms/vitals/report.php
+++ b/interface/forms/vitals/report.php
@@ -42,7 +42,7 @@ function vitals_report($pid, $encounter, $cols, $id, $print = true)
               $key == "user" || $key == "groupname" ||
               $key == "authorized" || $key == "activity" ||
               $key == "date" || $value == "" ||
-              $value == "0000-00-00 00:00:00" || $value == "0.0" ) {
+              $value == "0000-00-00 00:00:00" || $value == "0.0") {
                 // skip certain data
                 continue;
             }

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -410,7 +410,7 @@ if (!empty($glrow)) {
     $rtl_override = false;
     if (isset($_SESSION['language_direction'])) {
         if ($_SESSION['language_direction'] == 'rtl' &&
-        !strpos($GLOBALS['css_header'], 'rtl')  ) {
+        !strpos($GLOBALS['css_header'], 'rtl')) {
             // the $css_header_value is set above
             $rtl_override = true;
         }

--- a/interface/patient_file/encounter/find_code_dynamic_ajax.php
+++ b/interface/patient_file/encounter/find_code_dynamic_ajax.php
@@ -123,7 +123,7 @@ function feSearchSort($search = '', $column = 0, $reverse = false)
     $arr = array();
     foreach ($form_encounter_layout as $feitem) {
         if ($search && stripos($feitem['field_id'], $search) === false &&
-        stripos($feitem['title'], $search) === false ) {
+        stripos($feitem['title'], $search) === false) {
             continue;
         }
         $feitem['fld_length' ] = 20;

--- a/interface/patient_file/encounter/forms.php
+++ b/interface/patient_file/encounter/forms.php
@@ -541,7 +541,7 @@ $old_category = '';
 $encounterLocked = false;
 if ($esignApi->lockEncounters() &&
 isset($GLOBALS['encounter']) &&
-!empty($GLOBALS['encounter']) ) {
+!empty($GLOBALS['encounter'])) {
     $esign = $esignApi->createEncounterESign($GLOBALS['encounter']);
     if ($esign->isLocked()) {
         $encounterLocked = true;

--- a/interface/patient_file/encounter/superbill_custom_full.php
+++ b/interface/patient_file/encounter/superbill_custom_full.php
@@ -184,7 +184,7 @@ if (isset($mode) && $thisauthwrite) {
 
     // If codes history is enabled in the billing globals save data to codes history table
     if ($GLOBALS['save_codes_history'] && $alertmsg=='' &&
-        ( $mode == "add" || $mode == "modify_complete" || $mode == "delete" ) ) {
+        ( $mode == "add" || $mode == "modify_complete" || $mode == "delete" )) {
         $action_type= empty($_POST['code_id']) ? 'new' : $mode;
         $action_type= ($action_type=='add') ? 'update' : $action_type ;
         $code       = $_POST['code'];

--- a/library/ESign/Encounter/Controller.php
+++ b/library/ESign/Encounter/Controller.php
@@ -43,7 +43,7 @@ class Encounter_Controller extends Abstract_Controller
         $form->showLock = false;
         if ($signable->isLocked() === false &&
             $GLOBALS['lock_esign_all'] &&
-            $GLOBALS['esign_lock_toggle'] ) {
+            $GLOBALS['esign_lock_toggle']) {
             $form->showLock = true;
         }
 

--- a/library/ESign/Form/Controller.php
+++ b/library/ESign/Form/Controller.php
@@ -41,7 +41,7 @@ class Form_Controller extends Abstract_Controller
         $form->showLock = false;
         if ($signable->isLocked() === false &&
             $GLOBALS['lock_esign_individual'] &&
-            $GLOBALS['esign_lock_toggle'] ) {
+            $GLOBALS['esign_lock_toggle']) {
             $form->showLock = true;
         }
 

--- a/library/MedEx/API.php
+++ b/library/MedEx/API.php
@@ -196,7 +196,7 @@ class Practice extends Base
             //for custom installs, insert custom apptstatus here that mean appt is not happening/changed
             if ($result2['pc_apptstatus'] =='*' ||  //confirmed
                 $result2['pc_apptstatus'] =='%' ||  //cancelled < 24hour
-                $result2['pc_apptstatus'] =='x' ) { //cancelled
+                $result2['pc_apptstatus'] =='x') { //cancelled
                 $sqlUPDATE = "UPDATE medex_outgoing SET msg_reply = 'DONE',msg_extra_text=? WHERE msg_uid = ?";
                 sqlQuery($sqlUPDATE, array($result2['pc_apptstatus'],$result2['msg_uid']));
                 $tell_MedEx['DELETE_MSG'][] = $result1['msg_pc_eid'];

--- a/library/ajax/amc_misc_data.php
+++ b/library/ajax/amc_misc_data.php
@@ -23,6 +23,6 @@ if (!CsrfUtils::verifyCsrfToken($_POST["csrf_token_form"])) {
 if (!(empty($_POST['amc_id'])) &&
      !(empty($_POST['complete'])) &&
      !(empty($_POST['mode'])) &&
-     !(empty($_POST['patient_id'])) ) {
+     !(empty($_POST['patient_id']))) {
     processAmcCall($_POST['amc_id'], $_POST['complete'], $_POST['mode'], $_POST['patient_id'], $_POST['object_category'], $_POST['object_id'], $_POST['date_created']);
 }

--- a/library/classes/ClinicalTypes/LabResult.php
+++ b/library/classes/ClinicalTypes/LabResult.php
@@ -26,7 +26,7 @@ class LabResult extends ClinicalType
         
         $range = new Range(Range::NEG_INF, Range::POS_INF);
         if (isset($options[self::OPTION_RANGE]) &&
-            is_a($options[self::OPTION_RANGE], 'Range') ) {
+            is_a($options[self::OPTION_RANGE], 'Range')) {
             $range = $options[self::OPTION_RANGE];
         }
         

--- a/library/classes/ClinicalTypes/Medication.php
+++ b/library/classes/ClinicalTypes/Medication.php
@@ -84,10 +84,10 @@ class Medication extends ClinicalType
             }
             
             if (isset($options[self::OPTION_COUNT]) &&
-                count($rows) >= $options[self::OPTION_COUNT] ) {
+                count($rows) >= $options[self::OPTION_COUNT]) {
                 $return = true;
             } else if (!isset($options[self::OPTION_COUNT]) &&
-                count($rows) > 0 ) {
+                count($rows) > 0) {
                 $return = true;
             }
         }

--- a/library/classes/ClinicalTypes/Range.php
+++ b/library/classes/ClinicalTypes/Range.php
@@ -23,7 +23,7 @@ class Range
     public function test($val)
     {
         if ($val > $this->lowerBound &&
-            $val < $this->upperBound ) {
+            $val < $this->upperBound) {
             return true;
         }
         

--- a/library/classes/html2text.class.php
+++ b/library/classes/html2text.class.php
@@ -469,7 +469,7 @@ class html2text
     function _build_link_list($link, $display)
     {
         if (substr($link, 0, 7) == 'http://' || substr($link, 0, 8) == 'https://' ||
-             substr($link, 0, 7) == 'mailto:' ) {
+             substr($link, 0, 7) == 'mailto:') {
             $this->_link_count++;
             $this->_link_list .= "[" . $this->_link_count . "] $link\n";
             $additional = ' [' . $this->_link_count . ']';

--- a/library/classes/rulesets/Amc/reports/AMC_302f/Numerator.php
+++ b/library/classes/rulesets/Amc/reports/AMC_302f/Numerator.php
@@ -23,7 +23,7 @@ class AMC_302f_Numerator implements AmcFilterIF
              (exist_database_item($patient->id, 'form_vitals', 'weight', 'gt', '0', 'ge', 1, '', '', $endDate)) &&
              (exist_database_item($patient->id, 'form_vitals', 'bps', '', '', 'ge', 1, '', '', $endDate)) &&
              (exist_database_item($patient->id, 'form_vitals', 'bpd', '', '', 'ge', 1, '', '', $endDate)) &&
-             (exist_database_item($patient->id, 'form_vitals', 'BMI', 'gt', '0', 'ge', 1, '', '', $endDate)) ) {
+             (exist_database_item($patient->id, 'form_vitals', 'BMI', 'gt', '0', 'ge', 1, '', '', $endDate))) {
             return true;
         } else {
             return false;

--- a/library/classes/rulesets/Amc/reports/AMC_302f_1_STG1/Denominator.php
+++ b/library/classes/rulesets/Amc/reports/AMC_302f_1_STG1/Denominator.php
@@ -33,7 +33,7 @@ class AMC_302f_1_STG1_Denominator implements AmcFilterIF
         //Number of unique patients 2 years of age or older seen by the EP during the EHR reporting period (Effective through 2013 only)
         $options = array( Encounter::OPTION_ENCOUNTER_COUNT => 1 );
         if ((Helper::checkAnyEncounter($patient, $beginDate, $endDate, $options)) &&
-             ($patient->calculateAgeOnDate($endDate) >= 2) ) {
+             ($patient->calculateAgeOnDate($endDate) >= 2)) {
             return true;
         } else {
             return false;

--- a/library/classes/rulesets/Amc/reports/AMC_302f_1_STG1/Numerator.php
+++ b/library/classes/rulesets/Amc/reports/AMC_302f_1_STG1/Numerator.php
@@ -35,7 +35,7 @@ class AMC_302f_1_STG1_Numerator implements AmcFilterIF
              (exist_database_item($patient->id, 'form_vitals', 'weight', 'gt', '0', 'ge', 1, '', '', $endDate)) &&
              (exist_database_item($patient->id, 'form_vitals', 'bps', 'gt', '0', 'ge', 1, '', '', $endDate)) &&
               (exist_database_item($patient->id, 'form_vitals', 'bpd', 'gt', '0', 'ge', 1, '', '', $endDate))  &&
-             (exist_database_item($patient->id, 'form_vitals', 'BMI', 'gt', '0', 'ge', 1, '', '', $endDate)) ) {
+             (exist_database_item($patient->id, 'form_vitals', 'BMI', 'gt', '0', 'ge', 1, '', '', $endDate))) {
             return true;
         } else {
             return false;

--- a/library/classes/rulesets/Amc/reports/AMC_302f_3_STG1/Denominator.php
+++ b/library/classes/rulesets/Amc/reports/AMC_302f_3_STG1/Denominator.php
@@ -33,7 +33,7 @@ class AMC_302f_3_STG1_Denominator implements AmcFilterIF
         //Number of unique patients 3 years of age or older seen by the EP during the EHR reporting period (Effective through 2013 only)
         $options = array( Encounter::OPTION_ENCOUNTER_COUNT => 1 );
         if ((Helper::checkAnyEncounter($patient, $beginDate, $endDate, $options)) &&
-             ($patient->calculateAgeOnDate($endDate) >= 3) ) {
+             ($patient->calculateAgeOnDate($endDate) >= 3)) {
             return true;
         } else {
             return false;

--- a/library/classes/rulesets/Amc/reports/AMC_302f_4_STG1/Numerator.php
+++ b/library/classes/rulesets/Amc/reports/AMC_302f_4_STG1/Numerator.php
@@ -43,7 +43,7 @@ class AMC_302f_4_STG1_Numerator implements AmcFilterIF
            ( ($patient->calculateAgeOnDate($endDate) < 3) &&
              (exist_database_item($patient->id, 'form_vitals', 'height', 'gt', '0', 'ge', 1, '', '', $endDate)) &&
              (exist_database_item($patient->id, 'form_vitals', 'weight', 'gt', '0', 'ge', 1, '', '', $endDate))
-           ) ) {
+           )) {
             return true;
         } else {
             return false;

--- a/library/classes/rulesets/Amc/reports/AMC_302f_STG2/Denominator.php
+++ b/library/classes/rulesets/Amc/reports/AMC_302f_STG2/Denominator.php
@@ -59,7 +59,7 @@ class AMC_302f_STG2_Denominator implements AmcFilterIF
             // Number of unique patients 3 years of age or older seen by the EP during the EHR reporting period.
             $options = array( Encounter::OPTION_ENCOUNTER_COUNT => 1 );
             if ((Helper::checkAnyEncounter($patient, $beginDate, $endDate, $options)) &&
-                 ($patient->calculateAgeOnDate($endDate) >= 3) ) {
+                 ($patient->calculateAgeOnDate($endDate) >= 3)) {
                 return true;
             } else {
                 return false;

--- a/library/classes/rulesets/Amc/reports/AMC_302f_STG2/Numerator.php
+++ b/library/classes/rulesets/Amc/reports/AMC_302f_STG2/Numerator.php
@@ -40,7 +40,7 @@ class AMC_302f_STG2_Numerator implements AmcFilterIF
            ( ($patient->calculateAgeOnDate($endDate) < 3) &&
              (exist_database_item($patient->id, 'form_vitals', 'height', 'gt', '0', 'ge', 1, '', '', $endDate)) &&
              (exist_database_item($patient->id, 'form_vitals', 'weight', 'gt', '0', 'ge', 1, '', '', $endDate))
-           ) ) {
+           )) {
             return true;
         } else {
             return false;

--- a/library/classes/rulesets/Amc/reports/AMC_302g/Denominator.php
+++ b/library/classes/rulesets/Amc/reports/AMC_302g/Denominator.php
@@ -25,7 +25,7 @@ class AMC_302g_Denominator implements AmcFilterIF
         //  (basically needs an encounter within the report dates and needs to be 13 by the end report date)
         $options = array( Encounter::OPTION_ENCOUNTER_COUNT => 1 );
         if ((Helper::checkAnyEncounter($patient, $beginDate, $endDate, $options)) &&
-             ($patient->calculateAgeOnDate($endDate) >= 13) ) {
+             ($patient->calculateAgeOnDate($endDate) >= 13)) {
             return true;
         } else {
             return false;

--- a/library/classes/rulesets/Amc/reports/AMC_304a/Denominator.php
+++ b/library/classes/rulesets/Amc/reports/AMC_304a/Denominator.php
@@ -34,7 +34,7 @@ class AMC_304a_Denominator implements AmcFilterIF
         $check = sqlQuery($sql, array($patient->id,$beginDate,$endDate,$patient->id,$beginDate,$endDate));
         $options = array( Encounter::OPTION_ENCOUNTER_COUNT => 1 );
         if ((Helper::checkAnyEncounter($patient, $beginDate, $endDate, $options)) &&
-            !(empty($check)) ) {
+            !(empty($check))) {
             return true;
         } else {
             return false;

--- a/library/classes/rulesets/Amc/reports/AMC_304c/Numerator.php
+++ b/library/classes/rulesets/Amc/reports/AMC_304c/Numerator.php
@@ -23,7 +23,7 @@ class AMC_304c_Numerator implements AmcFilterIF
              (exist_database_item($patient->id, 'patient_data', 'sex', '', '', 'ge', 1)) &&
              (exist_database_item($patient->id, 'patient_data', 'race', '', '', 'ge', 1)) &&
              (exist_database_item($patient->id, 'patient_data', 'ethnicity', '', '', 'ge', 1)) &&
-             (exist_database_item($patient->id, 'patient_data', 'DOB', '', '', 'ge', 1)) ) {
+             (exist_database_item($patient->id, 'patient_data', 'DOB', '', '', 'ge', 1))) {
             return true;
         } else {
             return false;

--- a/library/classes/rulesets/Amc/reports/AMC_304d/Denominator.php
+++ b/library/classes/rulesets/Amc/reports/AMC_304d/Denominator.php
@@ -19,7 +19,7 @@ class AMC_304d_Denominator implements AmcFilterIF
         // All unique patients with age greater than or equal to 65
         //   or less than or equal to 5 at the end report date.
         if (($patient->calculateAgeOnDate($endDate) >= 65) ||
-             ($patient->calculateAgeOnDate($endDate) <= 5) ) {
+             ($patient->calculateAgeOnDate($endDate) <= 5)) {
             return true;
         } else {
             return false;

--- a/library/classes/rulesets/Amc/reports/AMC_304f/Denominator.php
+++ b/library/classes/rulesets/Amc/reports/AMC_304f/Denominator.php
@@ -28,7 +28,7 @@ class AMC_304f_Denominator implements AmcFilterIF
         $amccheck =  sqlQuery("SELECT * FROM `amc_misc_data` WHERE `amc_id`=? AND `pid`=? AND `date_created`>=? AND `date_created`<=?", array('provide_rec_pat_amc',$patient->id,$beginDate,$endDate));
         $options = array( Encounter::OPTION_ENCOUNTER_COUNT => 1 );
         if ((Helper::checkAnyEncounter($patient, $beginDate, $endDate, $options)) &&
-             !(empty($amccheck)) ) {
+             !(empty($amccheck))) {
             return true;
         } else {
             return false;

--- a/library/classes/rulesets/Cqm/reports/NQF_0013/InitialPatientPopulation.php
+++ b/library/classes/rulesets/Cqm/reports/NQF_0013/InitialPatientPopulation.php
@@ -34,7 +34,7 @@ class NQF_0013_InitialPatientPopulation implements CqmFilterIF
         if ($patient->calculateAgeOnDate($beginDate) >= 18 && $patient->calculateAgeOnDate($beginDate) < 85 &&
             ( Helper::check(ClinicalType::DIAGNOSIS, Diagnosis::HYPERTENSION, $patient, $beginDate, date('Y-m-d H:i:s', strtotime('+6 month', strtotime($beginDate)))) || (Helper::check(ClinicalType::DIAGNOSIS, Diagnosis::HYPERTENSION, $patient, $beginDate, $beginDate))  ) &&
             ( Helper::check(ClinicalType::ENCOUNTER, Encounter::ENC_OUTPATIENT, $patient, $beginDate, $endDate, $encounterCount) ||
-              Helper::check(ClinicalType::ENCOUNTER, Encounter::ENC_NURS_FAC, $patient, $beginDate, $endDate, $encounterCount) ) ) {
+              Helper::check(ClinicalType::ENCOUNTER, Encounter::ENC_NURS_FAC, $patient, $beginDate, $endDate, $encounterCount) )) {
             return true;
         }
         

--- a/library/classes/rulesets/Cqm/reports/NQF_0028_2014/InitialPatientPopulation.php
+++ b/library/classes/rulesets/Cqm/reports/NQF_0028_2014/InitialPatientPopulation.php
@@ -43,7 +43,7 @@ class NQF_0028_2014_InitialPatientPopulation implements CqmFilterIF
                Helper::check(ClinicalType::ENCOUNTER, Encounter::ENC_PRE_IND_COUNSEL, $patient, $beginDate, $endDate, $oneEncounter) ||
                Helper::check(ClinicalType::ENCOUNTER, Encounter::ENC_PRE_MED_GROUP_COUNSEL, $patient, $beginDate, $endDate, $oneEncounter) ||
                Helper::check(ClinicalType::ENCOUNTER, Encounter::ENC_PRE_MED_OTHER_SERV, $patient, $beginDate, $endDate, $oneEncounter)
-             ) ) {
+             )) {
             return true;
         }
 

--- a/library/classes/rulesets/Cqm/reports/NQF_0028_2014/Numerator.php
+++ b/library/classes/rulesets/Cqm/reports/NQF_0028_2014/Numerator.php
@@ -54,7 +54,7 @@ class NQF_0028_2014_Numerator implements CqmFilterIF
                     // TODO: how to check for the smoking cessation medication types (can also just be a smoking cessation order, ie. prescription)
                     if (!(empty($smoke_cess)) ||
                          Helper::checkMed(Medication::SMOKING_CESSATION, $patient, $beginMinus24Months, $date) ||
-                         Helper::checkMed(Medication::SMOKING_CESSATION_ORDER, $patient, $beginMinus24Months, $date) ) {
+                         Helper::checkMed(Medication::SMOKING_CESSATION_ORDER, $patient, $beginMinus24Months, $date)) {
                         return true;
                     }
                 } else if (Helper::check(ClinicalType::CHARACTERISTIC, Characteristic::TOBACCO_NON_USER, $patient, $beginMinus24Months, $date)) {

--- a/library/classes/rulesets/Cqm/reports/NQF_0028a/InitialPatientPopulation.php
+++ b/library/classes/rulesets/Cqm/reports/NQF_0028a/InitialPatientPopulation.php
@@ -27,7 +27,7 @@ class NQF_0028a_InitialPatientPopulation implements CqmFilterIF
                 Helper::check(ClinicalType::ENCOUNTER, Encounter::ENC_PRE_IND_COUNSEL, $patient, $beginDate, $endDate, $oneEncounter) ||
                 Helper::check(ClinicalType::ENCOUNTER, Encounter::ENC_PRE_MED_GROUP_COUNSEL, $patient, $beginDate, $endDate, $oneEncounter) ||
                 Helper::check(ClinicalType::ENCOUNTER, Encounter::ENC_PRE_MED_OTHER_SERV, $patient, $beginDate, $endDate, $oneEncounter)
-              ) ) {
+              )) {
             return true;
         }
 

--- a/library/classes/rulesets/Cqm/reports/NQF_0028a/Numerator.php
+++ b/library/classes/rulesets/Cqm/reports/NQF_0028a/Numerator.php
@@ -25,7 +25,7 @@ class NQF_0028a_Numerator implements CqmFilterIF
                 $beginMinus24Months = date('Y-m-d 00:00:00', $beginMinus24Months);
                 // this is basically a check to see if the patient's tobacco status has been evaluated in the two years previous to encounter.
                 if (Helper::check(ClinicalType::CHARACTERISTIC, Characteristic::TOBACCO_USER, $patient, $beginMinus24Months, $date) ||
-                    Helper::check(ClinicalType::CHARACTERISTIC, Characteristic::TOBACCO_NON_USER, $patient, $beginMinus24Months, $date) ) {
+                    Helper::check(ClinicalType::CHARACTERISTIC, Characteristic::TOBACCO_NON_USER, $patient, $beginMinus24Months, $date)) {
                     return true;
                 }
             }

--- a/library/classes/rulesets/Cqm/reports/NQF_0028b/InitialPatientPopulation.php
+++ b/library/classes/rulesets/Cqm/reports/NQF_0028b/InitialPatientPopulation.php
@@ -27,7 +27,7 @@ class NQF_0028b_InitialPatientPopulation implements CqmFilterIF
                Helper::check(ClinicalType::ENCOUNTER, Encounter::ENC_PRE_IND_COUNSEL, $patient, $beginDate, $endDate, $oneEncounter) ||
                Helper::check(ClinicalType::ENCOUNTER, Encounter::ENC_PRE_MED_GROUP_COUNSEL, $patient, $beginDate, $endDate, $oneEncounter) ||
                Helper::check(ClinicalType::ENCOUNTER, Encounter::ENC_PRE_MED_OTHER_SERV, $patient, $beginDate, $endDate, $oneEncounter)
-             ) ) {
+             )) {
             return true;
         }
         

--- a/library/classes/rulesets/Cqm/reports/NQF_0028b/Numerator.php
+++ b/library/classes/rulesets/Cqm/reports/NQF_0028b/Numerator.php
@@ -30,7 +30,7 @@ class NQF_0028b_Numerator implements CqmFilterIF
                 // TODO: how to check for the smoking cessation medication types (can also just be a smoking cessation order, ie. prescription)
                 if (!(empty($smoke_cess)) ||
                      Helper::checkMed(Medication::SMOKING_CESSATION, $patient, $beginMinus24Months, $date) ||
-                     Helper::checkMed(Medication::SMOKING_CESSATION_ORDER, $patient, $beginMinus24Months, $date) ) {
+                     Helper::checkMed(Medication::SMOKING_CESSATION_ORDER, $patient, $beginMinus24Months, $date)) {
                     return true;
                 }
             }

--- a/library/classes/rulesets/Cqm/reports/NQF_0038/InitialPatientPopulation.php
+++ b/library/classes/rulesets/Cqm/reports/NQF_0038/InitialPatientPopulation.php
@@ -18,7 +18,7 @@ class NQF_0038_InitialPatientPopulation implements CqmFilterIF
         // Rs_Patient characteristic: birth date (age) >=1 year and <2 years to capture all Rs_Patients who will reach 2 years during the 'measurement period';
         $age = $patient->calculateAgeOnDate($beginDate);
         if ($age >= 1 &&
-            $age < 2 ) {
+            $age < 2) {
             return true;
         }
         

--- a/library/classes/rulesets/Cqm/reports/NQF_0038/Numerator11.php
+++ b/library/classes/rulesets/Cqm/reports/NQF_0038/Numerator11.php
@@ -20,7 +20,7 @@ class NQF_0038_Numerator11 implements CqmFilterIF
              ( Immunizations::checkMmr($patient, $beginDate, $endDate) &&
                !Helper::checkAllergy(Allergy::POLYMYXIN, $patient, $patient->dob, $endDate) ) &&
              Immunizations::checkVzv($patient, $beginDate, $endDate) &&
-             Immunizations::checkHepB($patient, $beginDate, $endDate) ) {
+             Immunizations::checkHepB($patient, $beginDate, $endDate)) {
             return true;
         }
 

--- a/library/classes/rulesets/Cqm/reports/NQF_0038/Numerator12.php
+++ b/library/classes/rulesets/Cqm/reports/NQF_0038/Numerator12.php
@@ -21,7 +21,7 @@ class NQF_0038_Numerator12 implements CqmFilterIF
                !Helper::checkAllergy(Allergy::POLYMYXIN, $patient, $patient->dob, $endDate) ) &&
             Immunizations::checkVzv($patient, $beginDate, $endDate) &&
             Immunizations::checkHepB($patient, $beginDate, $endDate) &&
-            Immunizations::checkPheumococcal($patient, $beginDate, $endDate) ) {
+            Immunizations::checkPheumococcal($patient, $beginDate, $endDate)) {
             return true;
         }
         

--- a/library/classes/rulesets/Cqm/reports/NQF_0041/Denominator.php
+++ b/library/classes/rulesets/Cqm/reports/NQF_0041/Denominator.php
@@ -18,7 +18,7 @@ class NQF_0041_Denominator implements CqmFilterIF
         $periodPlus89Days = date('Y-m-d 00:00:00', strtotime('+89 day', strtotime($beginDate)));
         $periodMinus92Days = date('Y-m-d 00:00:00', strtotime('-92 day', strtotime($endDate)));
         if (Helper::checkEncounter(Encounter::ENC_INFLUENZA, $patient, $beginDate, $periodPlus89Days) ||
-            Helper::checkEncounter(Encounter::ENC_INFLUENZA, $patient, $periodMinus92Days, $endDate) ) {
+            Helper::checkEncounter(Encounter::ENC_INFLUENZA, $patient, $periodMinus92Days, $endDate)) {
             return true;
         }
         

--- a/library/classes/rulesets/Cqm/reports/NQF_0041/Exclusions.php
+++ b/library/classes/rulesets/Cqm/reports/NQF_0041/Exclusions.php
@@ -26,7 +26,7 @@ class NQF_0041_Exclusions implements CqmFilterIF
                 Helper::checkMed(Medication::NO_INFLUENZA_PATIENT, $patient, $encDate, $encDate) ||
                 Helper::checkMed(Medication::NO_INFLUENZA_MEDICAL, $patient, $encDate, $encDate) ||
                 Helper::checkMed(Medication::NO_INFLUENZA_SYSTEM, $patient, $encDate, $encDate) ||
-                Helper::checkDiagActive(Diagnosis::INFLUENZA_IMMUN_CONTRADICT, $patient, $encDate, $encDate) ) {
+                Helper::checkDiagActive(Diagnosis::INFLUENZA_IMMUN_CONTRADICT, $patient, $encDate, $encDate)) {
                 return true;
             }
         }

--- a/library/classes/rulesets/Cqm/reports/NQF_0041/InitialPatientPopulation.php
+++ b/library/classes/rulesets/Cqm/reports/NQF_0041/InitialPatientPopulation.php
@@ -26,7 +26,7 @@ class NQF_0041_InitialPatientPopulation implements CqmFilterIF
                Helper::check(ClinicalType::ENCOUNTER, Encounter::ENC_PRE_IND_COUNSEL, $patient, $beginDate, $endDate, $oneEncounter) ||
                Helper::check(ClinicalType::ENCOUNTER, Encounter::ENC_PRE_MED_GROUP_COUNSEL, $patient, $beginDate, $endDate, $oneEncounter) ||
                Helper::check(ClinicalType::ENCOUNTER, Encounter::ENC_PRE_MED_OTHER_SERV, $patient, $beginDate, $endDate, $oneEncounter)
-             ) ) {
+             )) {
             return true;
         }
         

--- a/library/classes/rulesets/Cqm/reports/NQF_0101/InitialPatientPopulation.php
+++ b/library/classes/rulesets/Cqm/reports/NQF_0101/InitialPatientPopulation.php
@@ -32,7 +32,7 @@ class NQF_0101_InitialPatientPopulation implements CqmFilterIF
     {
         $oneEncounter = array( Encounter::OPTION_ENCOUNTER_COUNT => 1 );
         if (($patient->calculateAgeOnDate($beginDate) >= 65) &&
-             ( Helper::check(ClinicalType::ENCOUNTER, Encounter::ENC_OFF_VIS, $patient, $beginDate, $endDate, $oneEncounter) ) ) {
+             ( Helper::check(ClinicalType::ENCOUNTER, Encounter::ENC_OFF_VIS, $patient, $beginDate, $endDate, $oneEncounter) )) {
             return true;
         }
         

--- a/library/classes/rulesets/Cqm/reports/NQF_0421/Exclusion.php
+++ b/library/classes/rulesets/Cqm/reports/NQF_0421/Exclusion.php
@@ -28,7 +28,7 @@ class NQF_0421_Exclusion implements CqmFilterIF
         if (Helper::check(ClinicalType::DIAGNOSIS, Diagnosis::PREGNANCY, $patient, $beginDate, $endDate) ||
             Helper::check(ClinicalType::PHYSICAL_EXAM, PhysicalExam::NOT_DONE_PATIENT, $patient, $beginDate, $endDate) ||
             Helper::check(ClinicalType::PHYSICAL_EXAM, PhysicalExam::NOT_DONE_MEDICAL, $patient, $beginDate, $endDate) ||
-            Helper::check(ClinicalType::PHYSICAL_EXAM, PhysicalExam::NOT_DONE_SYSTEM, $patient, $beginDate, $endDate) ) {
+            Helper::check(ClinicalType::PHYSICAL_EXAM, PhysicalExam::NOT_DONE_SYSTEM, $patient, $beginDate, $endDate)) {
             return true;
         }
         

--- a/library/classes/rulesets/Cqm/reports/NQF_0421/Numerator1.php
+++ b/library/classes/rulesets/Cqm/reports/NQF_0421/Numerator1.php
@@ -56,7 +56,7 @@ class NQF_0421_Numerator1 implements CqmFilterIF
             $number = sqlNumRows($res);
             if ($number >= 1 &&
                 ( Helper::check(ClinicalType::CARE_GOAL, CareGoal::FOLLOW_UP_PLAN_BMI_MGMT, $patient) ||
-                  Helper::check(ClinicalType::COMMUNICATION, Communication::DIET_CNSLT, $patient) ) ) {
+                  Helper::check(ClinicalType::COMMUNICATION, Communication::DIET_CNSLT, $patient) )) {
                 $return = true;
                 break;
             }
@@ -79,7 +79,7 @@ class NQF_0421_Numerator1 implements CqmFilterIF
             $number = sqlNumRows($res);
             if ($number >= 1 &&
                 ( Helper::check(ClinicalType::CARE_GOAL, CareGoal::FOLLOW_UP_PLAN_BMI_MGMT, $patient) ||
-                  Helper::check(ClinicalType::COMMUNICATION, Communication::DIET_CNSLT, $patient) ) ) {
+                  Helper::check(ClinicalType::COMMUNICATION, Communication::DIET_CNSLT, $patient) )) {
                 $return = true;
                 break;
             }

--- a/library/classes/rulesets/Cqm/reports/NQF_0421/Numerator2.php
+++ b/library/classes/rulesets/Cqm/reports/NQF_0421/Numerator2.php
@@ -56,7 +56,7 @@ class NQF_0421_Numerator2 implements CqmFilterIF
             $number = sqlNumRows($res);
             if ($number >= 1 &&
                 ( Helper::check(ClinicalType::CARE_GOAL, CareGoal::FOLLOW_UP_PLAN_BMI_MGMT, $patient) ||
-                  Helper::check(ClinicalType::COMMUNICATION, Communication::DIET_CNSLT, $patient) ) ) {
+                  Helper::check(ClinicalType::COMMUNICATION, Communication::DIET_CNSLT, $patient) )) {
                 $return = true;
                 break;
             }

--- a/library/classes/rulesets/Cqm/reports/common/DiabetesDenominator.php
+++ b/library/classes/rulesets/Cqm/reports/common/DiabetesDenominator.php
@@ -22,7 +22,7 @@ class DiabetesDenominator implements CqmFilterIF
             Helper::checkMed(Medication::ACTIVE_DIABETES, $patient, $beginMinus2Years, $endDate) ||
             ( Helper::checkDiagActive(Diagnosis::DIABETES, $patient, $beginMinus2Years, $endDate) &&
                 ( Helper::checkEncounter(Encounter::ENC_ACUTE_INP_OR_ED, $patient, $beginDate, $endDate) ||
-                  Helper::checkEncounter(Encounter::ENC_NONAC_INP_OUT_OR_OPTH, $patient, $beginDate, $endDate, array( Encounter::OPTION_ENCOUNTER_COUNT => 2 )) ) ) ) {
+                  Helper::checkEncounter(Encounter::ENC_NONAC_INP_OUT_OR_OPTH, $patient, $beginDate, $endDate, array( Encounter::OPTION_ENCOUNTER_COUNT => 2 )) ) )) {
                       return true;
         }
         

--- a/library/classes/rulesets/Cqm/reports/common/DiabetesExclusions.php
+++ b/library/classes/rulesets/Cqm/reports/common/DiabetesExclusions.php
@@ -27,7 +27,7 @@ class DiabetesExclusions implements CqmFilterIF
                  Helper::checkMed(Medication::ACTIVE_DIABETES, $patient, $beginMinus2Years, $endDate) ) &&
               !( Helper::checkDiagActive(Diagnosis::DIABETES, $patient, $beginMinus2Years, $endDate) &&
                  ( Helper::checkEncounter(Encounter::ENC_ACUTE_INP_OR_ED, $patient, $beginMinus2Years, $endDate) ||
-                   Helper::checkEncounter(Encounter::ENC_NONAC_INP_OUT_OR_OPTH, $patient, $beginMinus2Years, $endDate) ) ) ) ) {
+                   Helper::checkEncounter(Encounter::ENC_NONAC_INP_OUT_OR_OPTH, $patient, $beginMinus2Years, $endDate) ) ) )) {
             return true;
         }
         

--- a/library/classes/rulesets/Cqm/reports/common/DiabetesInitialPatientPopulation.php
+++ b/library/classes/rulesets/Cqm/reports/common/DiabetesInitialPatientPopulation.php
@@ -17,7 +17,7 @@ class DiabetesInitialPatientPopulation implements CqmFilterIF
     {
         $age = $patient->calculateAgeOnDate($beginDate);
         if ($age >= 17 &&
-            $age <= 74 ) {
+            $age <= 74) {
             return true;
         }
         

--- a/library/classes/rulesets/Cqm/reports/common/Immunizations.php
+++ b/library/classes/rulesets/Cqm/reports/common/Immunizations.php
@@ -16,7 +16,7 @@ class Immunizations
         if (Helper::checkMed(Medication::DTAP_VAC, $patient, $dobPlus42Days, $dobPlus2Years, $fourCount) &&
             !( Helper::checkAllergy(Allergy::DTAP_VAC, $patient, $patient->dob, $endDate) ||
                Helper::checkDiagActive(Diagnosis::ENCEPHALOPATHY, $patient, $beginDate, $endDate) ||
-               Helper::checkDiagActive(Diagnosis::PROG_NEURO_DISORDER, $patient, $beginDate, $endDate) ) ) {
+               Helper::checkDiagActive(Diagnosis::PROG_NEURO_DISORDER, $patient, $beginDate, $endDate) )) {
             return true;
         }
         
@@ -31,7 +31,7 @@ class Immunizations
         if (Helper::checkMed(Medication::IPV, $patient, $dobPlus42Days, $dobPlus2Years, $threeCount) &&
             !( Helper::checkAllergy(Allergy::IPV, $patient, $patient->dob, $endDate) ||
                Helper::checkAllergy(Allergy::NEOMYCIN, $patient, $patient->dob, $endDate) ||
-               Helper::checkAllergy(Allergy::STREPTOMYCIN, $patient, $patient->dob, $endDate) ) ) {
+               Helper::checkAllergy(Allergy::STREPTOMYCIN, $patient, $patient->dob, $endDate) )) {
             return true;
         }
 
@@ -71,7 +71,7 @@ class Immunizations
                  Helper::checkDiagActive(Diagnosis::MULT_MYELOMA, $patient, $beginDate, $endDate) ||
                  Helper::checkDiagActive(Diagnosis::LUKEMIA, $patient, $beginDate, $endDate) ||
                  Helper::checkAllergy(Allergy::MMR, $patient, $patient->dob, $dateMinus2Years) ||
-                 Helper::checkDiagActive(Diagnosis::IMMUNODEF, $patient, $beginDate, $endDate) ) ) {
+                 Helper::checkDiagActive(Diagnosis::IMMUNODEF, $patient, $beginDate, $endDate) )) {
             return true;
         }
         
@@ -84,7 +84,7 @@ class Immunizations
         $dobPlus42Days = date('Y-m-d 00:00:00', strtotime('+42 day', strtotime($patient->dob)));
         $dobPlus2Years = date('Y-m-d 00:00:00', strtotime('+2 year', strtotime($patient->dob)));
         if (Helper::checkMed(Medication::HIB, $patient, $dobPlus42Days, $dobPlus2Years, $options) &&
-            !Helper::checkAllergy(Allergy::HIB, $patient, $patient->dob, $endDate) ) {
+            !Helper::checkAllergy(Allergy::HIB, $patient, $patient->dob, $endDate)) {
             return true;
         }
 
@@ -98,7 +98,7 @@ class Immunizations
         if (Helper::checkMed(Medication::HEP_B_VAC, $patient, $patient->dob, $dobPlus2Years, $options) ||
             Helper::checkDiagResolved(Diagnosis::HEP_B, $patient, $patient->dob, $endDate) &&
             !( Helper::checkAllergy(Allergy::HEP_B_VAC, $patient, $patient->dob, $endDate) ||
-               Helper::checkAllergy(Allergy::BAKERS_YEAST, $patient, $patient->dob, $endDate) ) ) {
+               Helper::checkAllergy(Allergy::BAKERS_YEAST, $patient, $patient->dob, $endDate) )) {
             return true;
         }
         
@@ -117,7 +117,7 @@ class Immunizations
                   Helper::checkDiagActive(Diagnosis::MULT_MYELOMA, $patient, $beginDate, $endDate) ||
                   Helper::checkDiagActive(Diagnosis::LUKEMIA, $patient, $beginDate, $endDate) ||
                   Helper::checkAllergy(Allergy::VZV, $patient, $patient->dob, $endDate) ||
-                  Helper::checkDiagActive(Diagnosis::IMMUNODEF, $patient, $beginDate, $endDate) ) ) ) {
+                  Helper::checkDiagActive(Diagnosis::IMMUNODEF, $patient, $beginDate, $endDate) ) )) {
             return true;
         }
         
@@ -130,7 +130,7 @@ class Immunizations
         $dobPlus42Days = date('Y-m-d 00:00:00', strtotime('+42 day', strtotime($patient->dob)));
         $dobPlus2Years = date('Y-m-d 00:00:00', strtotime('+2 year', strtotime($patient->dob)));
         if (Helper::checkMed(Medication::PNEUMOCOCCAL_VAC, $patient, $dobPlus42Days, $dobPlus2Years, $options) &&
-            !Helper::checkAllergy(Allergy::PNEUM_VAC, $patient) ) {
+            !Helper::checkAllergy(Allergy::PNEUM_VAC, $patient)) {
             return true;
         }
         
@@ -144,7 +144,7 @@ class Immunizations
         $dobPlus2Years = date('Y-m-d 00:00:00', strtotime('+2 year', strtotime($patient->dob)));
         if (Helper::checkMed(Medication::HEP_A_VAC, $patient, $dobPlus42Days, $dobPlus2Years, $options) ||
             ( Helper::checkDiagResolved(Diagnosis::HEP_A, $patient, $patient->dob, $endDate) &&
-              !Helper::checkAllergy(Allergy::HEP_A_VAC, $patient, $patient->dob, $endDate) ) ) {
+              !Helper::checkAllergy(Allergy::HEP_A_VAC, $patient, $patient->dob, $endDate) )) {
             return true;
         }
         
@@ -157,7 +157,7 @@ class Immunizations
         $dobPlus42Days = date('Y-m-d 00:00:00', strtotime('+42 day', strtotime($patient->dob)));
         $dobPlus2Years = date('Y-m-d 00:00:00', strtotime('+2 year', strtotime($patient->dob)));
         if (Helper::checkMed(Medication::ROTAVIRUS_VAC, $patient, $dobPlus42Days, $dobPlus2Years, $options) &&
-            !Helper::checkAllergy(Allergy::ROTAVIRUS_VAC, $patient, $patient->dob, $endDate) ) {
+            !Helper::checkAllergy(Allergy::ROTAVIRUS_VAC, $patient, $patient->dob, $endDate)) {
             return true;
         }
 
@@ -176,7 +176,7 @@ class Immunizations
                Helper::checkDiagActive(Diagnosis::ASYMPTOMATIC_HIV, $patient, $patient->dob, $endDate) ||
                Helper::checkDiagActive(Diagnosis::MULT_MYELOMA, $patient, $patient->dob, $endDate) ||
                Helper::checkDiagActive(Diagnosis::LUKEMIA, $patient, $patient->dob, $endDate) ||
-               Helper::checkDiagActive(Diagnosis::IMMUNODEF, $patient, $patient->dob, $endDate) ) ) {
+               Helper::checkDiagActive(Diagnosis::IMMUNODEF, $patient, $patient->dob, $endDate) )) {
             return true;
         }
         
@@ -189,7 +189,7 @@ class Immunizations
         $dobPlus42Days = date('Y-m-d 00:00:00', strtotime('+42 day', strtotime($patient->dob)));
         $dobPlus2Years = date('Y-m-d 00:00:00', strtotime('+2 year', strtotime($patient->dob)));
         if (Helper::checkMed(Medication::ROTAVIRUS_VAC, $patient, $dobPlus42Days, $dobPlus2Years, $options) &&
-            !Helper::checkAllergy(Allergy::ROTAVIRUS_VAC, $patient, $patient->dob, $endDate) ) {
+            !Helper::checkAllergy(Allergy::ROTAVIRUS_VAC, $patient, $patient->dob, $endDate)) {
             return true;
         }
 

--- a/library/classes/rulesets/ReportManager.php
+++ b/library/classes/rulesets/ReportManager.php
@@ -49,7 +49,7 @@ class ReportManager
         
         $results = array();
         if ($report instanceof RsReportIF &&
-            !$report instanceof RsUnimplementedIF ) {
+            !$report instanceof RsUnimplementedIF) {
             $report->execute();
             $results = $report->getResults();
         }

--- a/library/clinical_rules.php
+++ b/library/clinical_rules.php
@@ -508,7 +508,7 @@ function test_rules_clinic_batch_method($provider = '', $type = '', $dateTarget 
   // Set ability to itemize report if this feature is turned on
     if (( ($type == "active_alert" || $type == "passive_alert")          && ($GLOBALS['report_itemizing_standard']) ) ||
        ( ($type == "cqm" || $type == "cqm_2011" || $type == "cqm_2014") && ($GLOBALS['report_itemizing_cqm'])      ) ||
-       ( ($type == "amc" || $type == "amc_2011" || $type == "amc_2014" || $type == "amc_2014_stage1" || $type == "amc_2014_stage2") && ($GLOBALS['report_itemizing_amc'])      ) ) {
+       ( ($type == "amc" || $type == "amc_2011" || $type == "amc_2014" || $type == "amc_2014_stage1" || $type == "amc_2014_stage2") && ($GLOBALS['report_itemizing_amc'])      )) {
         $GLOBALS['report_itemizing_temp_flag_and_id'] = $report_id;
     } else {
         $GLOBALS['report_itemizing_temp_flag_and_id'] = 0;
@@ -2130,7 +2130,7 @@ function exist_lifestyle_item($patient_id, $lifestyle, $status, $dateTarget)
 
     if ($history[$lifestyle] &&
        $history[$lifestyle] != '|0|' &&
-       $stringFlag ) {
+       $stringFlag) {
         return true;
     } else {
         return false;

--- a/library/reminders.php
+++ b/library/reminders.php
@@ -298,7 +298,7 @@ function update_reminders($dateTarget = '', $patient_id = '', $start = null, $ba
             if (($row['pid'] == $reminder['pid']) &&
                ($row['category'] == $reminder['category']) &&
                ($row['item'] == $reminder['item']) &&
-               ($row['due_status'] == $reminder['due_status']) ) {
+               ($row['due_status'] == $reminder['due_status'])) {
                 // The sql reminder has been confirmed, so do not inactivate it
                 $inactivateFlag = false;
                 break;

--- a/library/report_database.inc
+++ b/library/report_database.inc
@@ -151,7 +151,7 @@ function beginReportDatabase($type, $fields, $report_id = null)
              ($key == "total_items") ||
              ($key == "date_report") ||
              ($key == "date_report_complete") ||
-             ($key == "bookmark") ) {
+             ($key == "bookmark")) {
                 continue;
             }
 

--- a/modules/sms_email_reminder/cron_functions.php
+++ b/modules/sms_email_reminder/cron_functions.php
@@ -129,7 +129,7 @@ function cron_SendMail($to, $subject, $vBody, $from)
                 "Date Time :". date("d M, Y  h:i:s")
                 ),
             $vBody
-        ) ) {
+        )) {
             echo "Message sent to " . text($to) . " OK.\n";
             $mstatus = true;
         } else {


### PR DESCRIPTION
The reason that Travis CI is failing is due to PHP CodeSniffer's 3.5.3 update that makes `PSR2.ControlStructures.ControlStructureSpacing` work differently from the previous version. The recommended action that we should take is to PHPCBF this as it doesn't really do much of anything but remove white space between parentheses.