### PR TITLE
Add userId to authentication response

### DIFF
--- a/src/RestControllers/AuthRestController.php
+++ b/src/RestControllers/AuthRestController.php
@@ -110,7 +110,7 @@ class AuthRestController
             return;
         }
         $encoded_token = base64_encode(json_encode(['token' => $encrypted_new_full_token, 'site_id' => trim($_SESSION['site_id']), 'api' => trim($_SESSION['api'])]));
-        $give = array("token_type" => "Bearer", "access_token" => $encoded_token, "expires_in" => "3600", "user_id" => $userId);
+        $give = array("token_type" => "Bearer", "access_token" => $encoded_token, "expires_in" => "3600", "user_data" => array("user_id" => $userId));
         $ip = collectIpAddresses();
         EventAuditLogger::instance()->newEvent('api', $authPayload["username"], $userGroup, 1, "API success for API token request: " . $ip['ip_string']);
         http_response_code(200);

--- a/src/RestControllers/AuthRestController.php
+++ b/src/RestControllers/AuthRestController.php
@@ -110,7 +110,7 @@ class AuthRestController
             return;
         }
         $encoded_token = base64_encode(json_encode(['token' => $encrypted_new_full_token, 'site_id' => trim($_SESSION['site_id']), 'api' => trim($_SESSION['api'])]));
-        $give = array("token_type" => "Bearer", "access_token" => $encoded_token, "expires_in" => "3600");
+        $give = array("token_type" => "Bearer", "access_token" => $encoded_token, "expires_in" => "3600", "user_id" => $userId);
         $ip = collectIpAddresses();
         EventAuditLogger::instance()->newEvent('api', $authPayload["username"], $userGroup, 1, "API success for API token request: " . $ip['ip_string']);
         http_response_code(200);


### PR DESCRIPTION
Hi

We started to develop with REST API and we have missing important information about the ID of the logged-in user. 
Every application needs to know who is the connected user for fetching only the relevant information.
I added it to the response of the authentication route, the client-side will store this data and can use it in every request it needed.

Thanks
Amiel