### PR TITLE
enabling CORS request

### DIFF
--- a/apis/.htaccess
+++ b/apis/.htaccess
@@ -6,3 +6,6 @@ RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_FILENAME} !-l
 RewriteRule (.*) dispatch.php?_REWRITE_COMMAND=$1 [QSA,L]
+RewriteCond %{REQUEST_METHOD} OPTIONS
+RewriteRule ^(.*)$ $1 [R=200,L]
+


### PR DESCRIPTION
Hi.

Client-side applications can works from different domain/port, mainly in develop mode, for example, React opens local server in port 3000 for development.

In this case, the browser sends a preflight request with OPTIONS method, The recommended solution is to add code to .htaccess that return 200 for OPTIONS method.
https://blog.talentspear.com/cors-cross-origin-resource-sharing-setup-in-apache-86d9799f2cf7

Those lines can't be added to apache.cfg file because they part of RewriteEngine.

Thanks

Amiel
