### PR TITLE
Fixes for appointments in the Onsite Patient Portal

### DIFF
--- a/portal/assets/css/style.css
+++ b/portal/assets/css/style.css
@@ -84,6 +84,26 @@ a:focus {
     color: #72afd2;
 }
 
+a.portal_appt:link {
+    color: #000000;
+    text-decoration: none;
+}
+
+a.portal_appt:visited {
+    color: #000000;
+    text-decoration: none;
+}
+
+a.portal_appt:hover {
+    color: #000000;
+    text-decoration: none;
+}
+
+a.portal_appt:active {
+    color: green;
+    text-decoration: none;
+}
+
 /* Layouts */
 .wrapper {
     min-height: 100%;


### PR DESCRIPTION
Deals with...
- Recurring appointments cannot be displayed (except for first date in sequence if greater than or
  equal to current date (displayed regardless of whether exdate or not))
- The appearance of the first date of recurring appointments allows editing causing all other dates in
  sequence to become inaccessible and not able to be displayed anywhere in OpenEMR
- (Added indicators)
- Moving the cursor over displayed appointments causes severe flickering

(EDIT - My mistake about Provider string)
