### PR TITLE
Control Document Tree Category Order

### DIFF
--- a/library/classes/Tree.class.php
+++ b/library/classes/Tree.class.php
@@ -71,7 +71,7 @@ class Tree
         $right = array();
 
         // now, retrieve all descendants of the root node
-        $sql = "SELECT * FROM " . $this->_table . " WHERE lft BETWEEN ? AND ? ORDER BY parent,name ASC;";
+        $sql = "SELECT * FROM " . $this->_table . " WHERE lft BETWEEN ? AND ? ORDER BY parent,parent_seq,name ASC;";
         $result = $this->_db->Execute($sql, [$row['lft'], $row['rght']]);
         $this->_id_name = array();
 

--- a/sql/patch.sql
+++ b/sql/patch.sql
@@ -47,3 +47,8 @@
 
 --  #EndIf
 --    all blocks are terminated with and #EndIf statement.
+
+#IfMissingColumn categories parent_seq
+ALTER TABLE categories
+  ADD parent_seq TINYINT DEFAULT '0' AFTER parent COMMENT 'Display seq within parent node';
+#EndIf


### PR DESCRIPTION
Allow option to override current display order of document categories within a node of document tree.