### PR TITLE
Fix #2904 undefined method in chart traker entity

### DIFF
--- a/src/Entities/ChartTracker.php
+++ b/src/Entities/ChartTracker.php
@@ -151,9 +151,9 @@ class ChartTracker
     public function __toString()
     {
         return "pid: '" . $this->getPid() . "' " .
-               "date: '" . $this->getDate() . "' " .
+               "date: '" . $this->getWhen()->format('Y-m-m') . "' " .
                "userId: '" . $this->getUserId() . "' " .
-               "location" . $this->getLocation() . "' " ;
+               "location: '" . $this->getLocation() . "'" ;
     }
 
     /**

--- a/src/Entities/ChartTracker.php
+++ b/src/Entities/ChartTracker.php
@@ -151,7 +151,7 @@ class ChartTracker
     public function __toString()
     {
         return "pid: '" . $this->getPid() . "' " .
-               "date: '" . $this->getWhen()->format('Y-m-m') . "' " .
+               "date: '" . $this->getWhen()->format('Y-m-d') . "' " .
                "userId: '" . $this->getUserId() . "' " .
                "location: '" . $this->getLocation() . "'" ;
     }

--- a/tests/Tests/Unit/Entity/ChartTrackerTest.php
+++ b/tests/Tests/Unit/Entity/ChartTrackerTest.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+use OpenEMR\Entities\ChartTracker;
+use PHPUnit\Framework\TestCase;
+
+class ChartTrackerTest extends TestCase
+{
+    /** @test */
+    public function can_be_created(): void
+    {
+        $chartTracker = new ChartTracker();
+
+        self::assertInstanceOf(ChartTracker::class, $chartTracker);
+        self::assertNull($chartTracker->getPid());
+        self::assertNull($chartTracker->getWhen());
+        self::assertNull($chartTracker->getUserId());
+        self::assertNull($chartTracker->getLocation());
+    }
+
+    /** @test */
+    public function can_assign_a_Pid_value(): void
+    {
+        $pId = 1;
+        $chartTracker = new ChartTracker();
+
+        $chartTracker->setPid($pId);
+
+        self::assertEquals($pId, $chartTracker->getPid());
+    }
+
+    /** @test */
+    public function can_assign_a_When_value(): void
+    {
+        $whenValue = new DateTime('now');
+        $chartTracker = new ChartTracker();
+
+        $chartTracker->setWhen($whenValue);
+
+        self::assertEquals($whenValue, $chartTracker->getWhen());
+    }
+
+    /** @test */
+    public function can_assign_a_userId(): void
+    {
+        $userId = 100;
+        $chartTracker = new ChartTracker();
+
+        $chartTracker->setUserId($userId);
+
+        self::assertEquals($userId, $chartTracker->getUserId());
+    }
+
+    /** @test */
+    public function can_assign_a_Location(): void
+    {
+        $location = 'irrelevant';
+        $chartTracker = new ChartTracker();
+
+        $chartTracker->setLocation($location);
+
+        self::assertEquals($location, $chartTracker->getLocation());
+    }
+}

--- a/tests/Tests/Unit/Entity/ChartTrackerTest.php
+++ b/tests/Tests/Unit/Entity/ChartTrackerTest.php
@@ -61,4 +61,39 @@ class ChartTrackerTest extends TestCase
 
         self::assertEquals($location, $chartTracker->getLocation());
     }
+
+    /** @test */
+    public function can_be_serialized(): void
+    {
+        $chartTracker = new ChartTracker();
+        $chartTracker->setPid($pId = 1);
+        $chartTracker->setWhen($whenValue = new DateTime('2020-01-01'));
+        $chartTracker->setUserId($userId = 100);
+        $chartTracker->setLocation($location = 'irrelevant');
+
+        $expectedSerializedObject = [
+            "pid" => $pId,
+            "when" => $whenValue,
+            "userId" => $userId,
+            "location" => $location,
+        ];
+
+        self::assertEquals($expectedSerializedObject, $chartTracker->toSerializedObject());
+    }
+
+    /** @test */
+    public function can_be_converted_to_string(): void
+    {
+        $chartTracker = new ChartTracker();
+        $chartTracker->setPid($pId = 1);
+        $chartTracker->setWhen($whenValue = new DateTime('2020-01-01'));
+        $chartTracker->setUserId($userId = 100);
+        $chartTracker->setLocation($location = 'irrelevant');
+
+        $expectedString = "pid: '1' date: '2020-01-01' userId: '100' location: 'irrelevant'";
+
+        self::assertEquals($expectedString, $chartTracker->__toString());
+
+        echo $chartTracker->__toString();
+    }
 }

--- a/tests/Tests/Unit/Entity/ChartTrackerTest.php
+++ b/tests/Tests/Unit/Entity/ChartTrackerTest.php
@@ -93,7 +93,5 @@ class ChartTrackerTest extends TestCase
         $expectedString = "pid: '1' date: '2020-01-01' userId: '100' location: 'irrelevant'";
 
         self::assertEquals($expectedString, $chartTracker->__toString());
-
-        echo $chartTracker->__toString();
     }
 }


### PR DESCRIPTION
I have changed the __toString() method, the undefined call "$this->getDate()" is moved to "$this->getWhen()".
I'm not sure about the string format of the date object.

Should be fine I guess.
