### PR TITLE
remove constructors in prescriptions template controller

### DIFF
--- a/interface/modules/zend_modules/module/PrescriptionTemplates/src/PrescriptionTemplates/Controller/HtmlTemplatesController.php
+++ b/interface/modules/zend_modules/module/PrescriptionTemplates/src/PrescriptionTemplates/Controller/HtmlTemplatesController.php
@@ -35,11 +35,6 @@ use Laminas\View\Model\ViewModel;
  */
 class HtmlTemplatesController extends PrescriptionTemplatesController
 {
-    public function __construct(ContainerInterface $container)
-    {
-             parent::__construct($container);
-    }
-
     public function defaultAction()
     {
         $id = $this->params()->fromQuery('id');

--- a/interface/modules/zend_modules/module/PrescriptionTemplates/src/PrescriptionTemplates/Controller/PdfTemplatesController.php
+++ b/interface/modules/zend_modules/module/PrescriptionTemplates/src/PrescriptionTemplates/Controller/PdfTemplatesController.php
@@ -40,7 +40,6 @@ class PdfTemplatesController extends PrescriptionTemplatesController
 
     public function __construct(ContainerInterface $container)
     {
-        parent::__construct($container);
         $this->renderer = $container->get(\Laminas\View\Renderer\PhpRenderer::class);
     }
 


### PR DESCRIPTION
for #2915 seems like the zend PrescriptionTemplates module is a little different from the others...
in the config there is no service manager so maybe that's why there's no need to call the parent constructor

only @matrix-amiel and @adunsulag can make sense of this really :) please no more links to martin fowler articles :smile: 

it's testing well and the html print is pretty cool