### PR TITLE
Bug fix.  Skip 2301C if billing facility and service facility are the…

### DIFF
--- a/src/Billing/X12_5010_837P.php
+++ b/src/Billing/X12_5010_837P.php
@@ -871,7 +871,7 @@ class X12_5010_837P
         // End of Loop 2310B
 
         // Loop 2310C is omitted in the case of home visits (POS=12).
-        if ($claim->facilityPOS() != 12) {
+        if ($claim->facilityPOS() != 12  && ($claim->facilityNPI() != $claim->billingFacilityNPI())) {
             ++$edicount;
             $out .= "NM1" .       // Loop 2310C Service Location
             "*" . "77" .


### PR DESCRIPTION
This fixes the bug where the x12 generation file prints 2310C (billing facility info) even if the billing facility is the same as the service facility.  Although clearing houses will parse this error before sending claims to insurance companies, error checking by companies like BCBS will reject the claim.  