### PR TITLE
added $ to regex

### DIFF
--- a/src/Common/Http/HttpRestRouteHandler.php
+++ b/src/Common/Http/HttpRestRouteHandler.php
@@ -23,7 +23,7 @@ class HttpRestRouteHandler
             $routePieces = explode(" ", $routePath);
             $method = $routePieces[0];
             $path = $routePieces[1];
-            $pattern = "@^" . preg_replace('/\\\:[a-zA-Z0-9\_\-]+/', '([a-zA-Z0-9\-\_]+)', preg_quote($path)) . "$@D";
+            $pattern = "@^" . preg_replace('/\\\:[a-zA-Z0-9\_\-]+/', '([a-zA-Z0-9\-\_\$]+)', preg_quote($path)) . "$@D";
             $matches = array();
             if ($method == $request_method && preg_match($pattern, $route, $matches)) {
                 array_shift($matches);


### PR DESCRIPTION
Hi, we are implementing the FHIR standard in our api, and the "operations" parameters in FHIR start with a "$" (e.g. $expand).
This is why we need to enable a "$" in the route parameters.