### PR TITLE
Activate a tab when it's created

### DIFF
--- a/interface/main/tabs/js/tabs_view_model.js
+++ b/interface/main/tabs/js/tabs_view_model.js
@@ -311,6 +311,7 @@ function menuActionClick(data,evt)
           for (var i = 0; i < frames.length; ++i) {
             if (frames[i].twAddFrameTab) {
               frames[i].twAddFrameTab('enctabs', data.label(), webroot_url + dataurl);
+              activateTabByName(data.target,true);
               return;
             }
           }


### PR DESCRIPTION
Related to #1804 

**Previous behavior**: If the encounter frameset already exists, just tell it to add a tab for this form. 
**Expected behavior**: Add a tab and activate it so the client won't get confused about the action result.
**Result Video**
https://www.loom.com/share/dec847fe2ae54db984049ae6b177cdf7