### PR TITLE
Added styles to buttons in issue popup and minor issue template fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,7 @@ about: Report a bug and help us improve
 
 ### Describe the bug
 
-- write concise description of what the bug is.
+write concise description of what the bug is.
 
 ### To Reproduce
 <!-- if Applicable add screenshots -->
@@ -19,7 +19,7 @@ Steps to reproduce the behavior:
 
 ### Expected behavior
 
-- 
+
 
 
 ### Client configuration

--- a/.github/ISSUE_TEMPLATE/security_report.md
+++ b/.github/ISSUE_TEMPLATE/security_report.md
@@ -9,3 +9,6 @@ about: Privately report a security vulnerability
 Send an email to brady.g.miller@gmail.com . If possible, please encrypt your email via PGP with this [public key](https://keybase.io/bradymiller/pgp_keys.asc?fingerprint=8a93ddec0e320d5eb8a7994827def05b1a8a6d4f).
 
 Thank you for the help!
+
+<!-- Love openemr? Please consider supporting our collective:
+👉  https://opencollective.com/openemr/donate -->

--- a/interface/patient_file/problem_encounter.php
+++ b/interface/patient_file/problem_encounter.php
@@ -340,9 +340,9 @@ while ($row = sqlFetchArray($eres)) {
 
  <tr>
   <td colspan='2' align='center'>
-   <input type='submit' name='form_save' value='<?php echo xla('Save'); ?>' disabled /> &nbsp;
-   <input type='button' value='<?php echo xla('Add Issue'); ?>' onclick='newIssue()' />
-   <input type='button' value='<?php echo xla('Cancel'); ?>' onclick='dlgclose()' />
+   <input type='submit' class='btn btn-secondary btn-sm btn-save' name='form_save' value='<?php echo xla('Save'); ?>' disabled /> &nbsp;
+   <input type='button' class='btn btn-primary btn-sm' value='<?php echo xla('Add Issue'); ?>' onclick='newIssue()' />
+   <button  class='btn btn-link btn-cancel' onclick='dlgclose()'><?php echo xla('Cancel'); ?></button>
   </td>
  </tr>
 


### PR DESCRIPTION
**Screenshot:**
![image](https://user-images.githubusercontent.com/42006277/75157118-7ff90500-5739-11ea-8383-a60d6e58c3c3.png)

Note:
I have also added some minor changes in issue template: ' - ' is used to add a bullet and it doesn't make sense keeping it by default, I have also added missing footer comment to the security report template. 