### PR TITLE
Quick fix for encounter expand/collpase all

### DIFF
--- a/interface/patient_file/encounter/forms.php
+++ b/interface/patient_file/encounter/forms.php
@@ -780,7 +780,10 @@ if ($esign->isButtonViewable()) {
 <?php if ($GLOBALS['enable_follow_up_encounters']) { ?>
     <a href='#' class='btn btn-primary' onclick='return createFollowUpEncounter()'><?php echo xlt('Create follow-up encounter') ?></a>
 <?php } ?>
-<button style="margin-left:50px;"  type="button" onClick="$('.collapse').collapse('toggle');" class="btn btn-primary btn-sm" ><?php echo xlt('Expand / Collapse'); ?></button>
+<div class='btn-group' role="group">
+<button  type="button" onClick="$('.collapse').collapse('hide');" class="btn btn-primary btn-sm ml-3" ><?php echo xlt('Collapse All'); ?></button>
+<button  type="button" onClick="$('.collapse').collapse('show');" class="btn btn-primary btn-sm" ><?php echo xlt('Expand All'); ?></button>
+</div>
 </div>
 </div>
 


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #3109 

#### Short description of what this resolves:
In encounter tab current `collpase/expand button` toggle(if a tab is collapsed then it will it to show and vice versa) tabs instead of what is expected of him.
https://www.loom.com/share/051965df4c064af98e3f0c0868e14a80

#### Changes proposed in this pull request:
Introducing two button inplace of `Expand/Collapse` which can perform Expand all and Collpase all.
https://www.loom.com/share/f386c90fd6c74c87b110ee750e981fea