### PR TITLE
Drug name should be required

### DIFF
--- a/interface/drugs/add_edit_drug.php
+++ b/interface/drugs/add_edit_drug.php
@@ -148,7 +148,7 @@ if ($_POST['form_save']) {
     }
 
     $drugName = trim($_POST['form_name']);
-    if ($drugName === '' ) {
+    if ($drugName === '') {
         $alertmsg = xl('Drug name is required');
     } else {
         $crow = sqlQuery(

--- a/interface/drugs/add_edit_drug.php
+++ b/interface/drugs/add_edit_drug.php
@@ -147,25 +147,30 @@ if ($_POST['form_save']) {
         CsrfUtils::csrfNotVerified();
     }
 
-    $crow = sqlQuery(
-        "SELECT COUNT(*) AS count FROM drugs WHERE " .
-        "name = ? AND " .
-        "form = ? AND " .
-        "size = ? AND " .
-        "unit = ? AND " .
-        "route = ? AND " .
-        "drug_id != ?",
-        array(
-            trim($_POST['form_name']),
-            trim($_POST['form_form']),
-            trim($_POST['form_size']),
-            trim($_POST['form_unit']),
-            trim($_POST['form_route']),
-            $drug_id
-        )
-    );
-    if ($crow['count']) {
-        $alertmsg = xl('Cannot add this entry because it already exists!');
+    $drugName = trim($_POST['form_name']);
+    if ($drugName === '' ) {
+        $alertmsg = xl('Drug name is required');
+    } else {
+        $crow = sqlQuery(
+            "SELECT COUNT(*) AS count FROM drugs WHERE " .
+            "name = ? AND " .
+            "form = ? AND " .
+            "size = ? AND " .
+            "unit = ? AND " .
+            "route = ? AND " .
+            "drug_id != ?",
+            array(
+                trim($_POST['form_name']),
+                trim($_POST['form_form']),
+                trim($_POST['form_size']),
+                trim($_POST['form_unit']),
+                trim($_POST['form_route']),
+                $drug_id
+            )
+        );
+        if ($crow['count']) {
+            $alertmsg = xl('Cannot add this entry because it already exists!');
+        }
     }
 }
 


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
It's just a suggestion from my side

#### Short description of what this resolves:
If we won't check for drugname then a person can create drugname using `blank` `space` `double space`

#### Changes proposed in this pull request:
Person should always enter drug name