### PR TITLE
Ken patient finder and tab settings

### DIFF
--- a/interface/main/finder/dynamic_finder.php
+++ b/interface/main/finder/dynamic_finder.php
@@ -40,9 +40,10 @@ $coljson = "";
 $orderjson = "";
 $res = sqlStatement("SELECT option_id, title, toggle_setting_1 FROM list_options WHERE " .
     "list_id = 'ptlistcols' AND activity = 1 ORDER BY seq, title");
+$sort_dir_map = generate_list_map('Sort_Direction');
 while ($row = sqlFetchArray($res)) {
     $colname = $row['option_id'];
-    $colorder = generate_display_field(array('data_type'=>'1','list_id'=>'Sort_Direction'), $row['toggle_setting_1']);
+    $colorder = $sort_dir_map[$row['toggle_setting_1']]; // Get the title 'asc' or 'desc' using the value
     $title = xl_list_label($row['title']);
     $title1 = ($title == xl('Full Name'))? xl('Name'): $title;
     $header .= "   <th>";

--- a/interface/main/finder/dynamic_finder.php
+++ b/interface/main/finder/dynamic_finder.php
@@ -37,10 +37,12 @@ $colcount = 0;
 $header0 = "";
 $header = "";
 $coljson = "";
-$res = sqlStatement("SELECT option_id, title FROM list_options WHERE " .
+$orderjson = "";
+$res = sqlStatement("SELECT option_id, title, toggle_setting_1 FROM list_options WHERE " .
     "list_id = 'ptlistcols' AND activity = 1 ORDER BY seq, title");
 while ($row = sqlFetchArray($res)) {
     $colname = $row['option_id'];
+    $colorder = generate_display_field(array('data_type'=>'1','list_id'=>'Sort_Direction'), $row['toggle_setting_1']);
     $title = xl_list_label($row['title']);
     $title1 = ($title == xl('Full Name'))? xl('Name'): $title;
     $header .= "   <th>";
@@ -52,6 +54,10 @@ while ($row = sqlFetchArray($res)) {
         $coljson .= ", ";
     }
     $coljson .= "{\"sName\": \"" . addcslashes($colname, "\t\r\n\"\\") . "\"}";
+    if ($orderjson) {
+        $orderjson .= ", ";
+    }
+    $orderjson .= "[\"$colcount\", \"" . addcslashes($colorder, "\t\r\n\"\\") . "\"]";
     ++$colcount;
 }
 $loading = "<i class='fa fa-refresh fa-2x fa-spin'></i>";
@@ -275,6 +281,7 @@ $loading = "<i class='fa fa-refresh fa-2x fa-spin'></i>";
             // See: http://datatables.net/usage/columns and
             // http://datatables.net/release-datatables/extras/ColReorder/server_side.html
             "columns": [ <?php echo $coljson; ?> ],
+            "order": [ <?php echo $orderjson; ?> ],
             "lengthMenu": [10, 25, 50, 100],
             "pageLength": <?php echo empty($GLOBALS['gbl_pt_list_page_size']) ? '10' : $GLOBALS['gbl_pt_list_page_size']; ?>,
             <?php // Bring in the translations ?>

--- a/interface/main/main_screen.php
+++ b/interface/main/main_screen.php
@@ -459,8 +459,9 @@ if ($is_expired) {
             $frame2target = "msc";
         }
     } else {
-        $frame2url = "../../interface/main/messages/messages.php?form_active=1";
-        $frame2target = "msg";
+        // In the case where no second default tab is specified, set these session variables to null
+        $frame2url = null;
+        $frame2target = null;
     }
 }
 

--- a/interface/main/tabs/js/tabs_view_model.js
+++ b/interface/main/tabs/js/tabs_view_model.js
@@ -23,13 +23,15 @@ function tabStatus(title,url,name,closable,visible,locked)
     return this;
 }
 
+/**
+ *
+ * @returns {tabs_view_model}
+ *
+ * Initial setup of the tabs view model to be an observable array
+ */
 function tabs_view_model()
 {
     this.tabsList=ko.observableArray();
-    this.tabsList.push(new tabStatus("Loading...",webroot_url+"/interface/main/main_info.php","cal",true,true,false));
-    this.tabsList.push(new tabStatus("Loading...",webroot_url+"/interface/main/messages/messages.php?form_active=1","msg",true,false,false));
-//    this.tabsList.push(new tabStatus("Three"));
-    this.text=ko.observable("Test");
     return this;
 }
 

--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -274,12 +274,12 @@ $GLOBALS['allow_issue_menu_link'] = ((AclMain::aclCheckCore('encounters', 'notes
 <script type="text/javascript">
     <?php if (!empty($_SESSION['frame1url']) && !empty($_SESSION['frame1target'])) { ?>
         // Use session variables and tabStatus object to set up initial/default first tab
-        app_view_model.application_data.tabs.tabsList.push(new tabStatus("Loading...",<?php echo json_encode("../".$_SESSION['frame1url']); ?>,<?php echo json_encode($_SESSION['frame1target']); ?>,true,true,false));
+        app_view_model.application_data.tabs.tabsList.push(new tabStatus(<?php echo xlj("Loading"); ?> + "...",<?php echo json_encode("../".$_SESSION['frame1url']); ?>,<?php echo json_encode($_SESSION['frame1target']); ?>,true,true,false));
     <?php } ?>
 
     <?php if (!empty($_SESSION['frame2url']) && !empty($_SESSION['frame2target'])) { ?>
         // Use session variables and tabStatus object to set up initial/default second tab, if none is set in globals, this tab will not be displayed initially
-        app_view_model.application_data.tabs.tabsList.push(new tabStatus("Loading...",<?php echo json_encode("../".$_SESSION['frame2url']); ?>,<?php echo json_encode($_SESSION['frame2target']); ?>,true,false,false));
+        app_view_model.application_data.tabs.tabsList.push(new tabStatus(<?php echo xlj("Loading"); ?> + "...",<?php echo json_encode("../".$_SESSION['frame2url']); ?>,<?php echo json_encode($_SESSION['frame2target']); ?>,true,false,false));
     <?php } ?>
 
     app_view_model.application_data.user(new user_data_view_model(<?php echo json_encode($_SESSION["authUser"])

--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -273,13 +273,13 @@ $GLOBALS['allow_issue_menu_link'] = ((AclMain::aclCheckCore('encounters', 'notes
 ?>
 <script type="text/javascript">
     <?php if (!empty($_SESSION['frame1url']) && !empty($_SESSION['frame1target'])) { ?>
-        app_view_model.application_data.tabs.tabsList()[0].url(<?php echo json_encode("../".$_SESSION['frame1url']); ?>);
-        app_view_model.application_data.tabs.tabsList()[0].name(<?php echo json_encode($_SESSION['frame1target']); ?>);
+        // Use session variables and tabStatus object to set up initial/default first tab
+        app_view_model.application_data.tabs.tabsList.push(new tabStatus("Loading...",<?php echo json_encode("../".$_SESSION['frame1url']); ?>,<?php echo json_encode($_SESSION['frame1target']); ?>,true,true,false));
     <?php } ?>
 
     <?php if (!empty($_SESSION['frame2url']) && !empty($_SESSION['frame2target'])) { ?>
-    app_view_model.application_data.tabs.tabsList()[1].url(<?php echo json_encode("../".$_SESSION['frame2url']); ?>);
-    app_view_model.application_data.tabs.tabsList()[1].name(<?php echo json_encode($_SESSION['frame2target']); ?>);
+        // Use session variables and tabStatus object to set up initial/default second tab, if none is set in globals, this tab will not be displayed initially
+        app_view_model.application_data.tabs.tabsList.push(new tabStatus("Loading...",<?php echo json_encode("../".$_SESSION['frame2url']); ?>,<?php echo json_encode($_SESSION['frame2target']); ?>,true,false,false));
     <?php } ?>
 
     app_view_model.application_data.user(new user_data_view_model(<?php echo json_encode($_SESSION["authUser"])
@@ -353,7 +353,7 @@ if (isset($_SESSION['app1'])) {
 <div id="mainBox" <?php echo $disp_mainBox ?> data-bind='attr: {id: responsiveDisplay.objWidth().mainBoxId}  '>
 
     <div id="dialogDiv"></div>
-    
+
     <div class="body_top" id="body_top_div" data-bind='css: responsiveDisplay.objWidth().bodyTopDivWidth'>
         <div id="logo_menu">
             <a href="https://www.open-emr.org" title="OpenEMR <?php echo xla("Website"); ?>" rel="noopener" target="_blank">
@@ -374,7 +374,7 @@ if (isset($_SESSION['app1'])) {
     </div>
     <div id="attendantData" class="body_title acck"  data-bind="template: {name: app_view_model.attendant_template_type, data: application_data}, css: responsiveDisplay.objWidth().attendantDataClear ">
     </div>
-    
+
     <div class="body_title" id="tabs_div" data-bind="template: {name: 'tabs-controls', data: application_data}, css: responsiveDisplay.objWidth().tabsDivWidth"> </div>
 
     <div class="mainFrames d-flex" id="mainFrames_div">

--- a/interface/super/edit_list.php
+++ b/interface/super/edit_list.php
@@ -408,6 +408,10 @@ function writeOptionLine(
             "value='" . attr($value) . "' onclick='sel_cvxcode(this)' " .
             "title='" . xla('Click to select or change CVX code') . "'/>";
         echo "</td>\n";
+    } elseif ($list_id == 'ptlistcols') {
+        echo "  <td>";
+        echo generate_select_list("opt[$opt_line_no][toggle_setting_1]", 'Sort_Direction', $tog1, 'Sort Direction', null, 'option');
+        echo "</td>\n";
     }
 
     // IPPF includes the ability to map each list item to a "master" identifier.
@@ -1199,6 +1203,8 @@ function writeITLine($it_array)
                 <th class="font-weight-bold"><?php echo xlt('Type'); ?></th>
             <?php } elseif ($list_id == 'immunizations') { ?>
                 <th class="font-weight-bold">&nbsp;&nbsp;&nbsp;&nbsp;<?php echo xlt('CVX Code Mapping'); ?></th>
+            <?php } else if ($list_id == 'ptlistcols') { ?>
+                <th class="font-weight-bold">&nbsp;&nbsp;&nbsp;&nbsp;<?php echo xlt('Default Sort Direction'); ?></th>
             <?php }
             if ($GLOBALS['ippf_specific']) { ?>
     <th class="font-weight-bold"><?php echo xlt('Global ID'); ?></th>

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -183,6 +183,7 @@ $GLOBALS_METADATA = array(
         'default_second_tab' => array(
             xl('Default Second Tab'),       // descriptive name
             array(
+                '' => xl('None'),
                 '../../interface/main/messages/messages.php?form_active=1' => xl('Messages Screen'),
                 'main_info.php' => xl('Calendar Screen'),
                 '../new/new.php' => xl('Patient Search/Add Screen'),

--- a/library/options.inc.php
+++ b/library/options.inc.php
@@ -1336,7 +1336,7 @@ function generate_form_field($frow, $currvalue)
             $datatype = 'admin-signature';
         }
         echo "<input type='hidden' id='form_$field_id_esc' name='form_$field_id_esc' value='' />\n";
-        echo "<img class='signature' id='form_{$field_id_esc}_img' title='$description' 
+        echo "<img class='signature' id='form_{$field_id_esc}_img' title='$description'
             data-pid='$cpid' data-user='$cuser' data-type='$datatype'
             data-action='fetch_signature' alt='Get Signature' src='" . attr($currvalue) . "'>\n";
     }
@@ -2694,6 +2694,10 @@ function generate_plaintext_field($frow, $currvalue)
 
             $s .= $resdate;
         }
+    } elseif ($data_type == 35) { // Facility, so facility can be listed in plain-text, as in patient finder column
+        $facilityService = new FacilityService();
+        $facility = $facilityService->getById($currvalue);
+        $s = $facility['name'];
     } elseif ($data_type == 36) { // Multi select. Supports backup lists
         $values_array = explode("|", $currvalue);
 

--- a/library/options.inc.php
+++ b/library/options.inc.php
@@ -2037,7 +2037,6 @@ function generate_list_map($list_id, $translate = false)
     $result = sqlStatement("SELECT option_id, title FROM list_options WHERE list_id = ?", [$list_id]);
     $map = [];
     while ($row = sqlFetchArray($result)) {
-
         if ($translate === true) {
             $title = xl_list_label($row['title']);
         } else {

--- a/library/options.inc.php
+++ b/library/options.inc.php
@@ -2020,6 +2020,35 @@ function generate_print_field($frow, $currvalue)
     }
 }
 
+/**
+ * @param $list_id
+ * @param bool $translate
+ * @return array
+ *
+ * Generate a key-value array containing each row of the specified list,
+ * with the option ID as the index, and the title as the element
+ *
+ * Pass in the list_id to specify this list.
+ *
+ * Use the translate flag to run the title element through the translator
+ */
+function generate_list_map($list_id, $translate = false)
+{
+    $result = sqlStatement("SELECT option_id, title FROM list_options WHERE list_id = ?", [$list_id]);
+    $map = [];
+    while ($row = sqlFetchArray($result)) {
+
+        if ($translate === true) {
+            $title = xl_list_label($row['title']);
+        } else {
+            $title = $row['title'];
+        }
+        $map[$row['option_id']] = $title;
+    }
+
+    return $map;
+}
+
 function generate_display_field($frow, $currvalue)
 {
     global $ISSUE_TYPES, $facilityService;

--- a/sql/5_0_2-to-5_0_3_upgrade.sql
+++ b/sql/5_0_2-to-5_0_3_upgrade.sql
@@ -421,13 +421,13 @@ CREATE TABLE `pro_assessments` (
 INSERT INTO `list_options` (`list_id`,`option_id`,`title`,`notes`, `seq`) VALUES ('LBF_Validations','future_date','Future Date','{\"futureDate\":{\"message\":\"must be future date\"}}','32');
 
 #IfNotRow2D list_options list_id lists option_id Sort_Direction
-INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `activity`) VALUES ('lists', 'Sort_Direction', 'Sort Direction', 306, 1, 1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `activity`) VALUES ('lists', 'Sort_Direction', 'Sort Direction', 1, 0, 1);
 #EndIf
 
 #IfNotRow2D list_options list_id Sort_Direction option_id 0
-INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `activity`) VALUES ('Sort_Direction', '0', 'asc', 1, 1, 1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `activity`) VALUES ('Sort_Direction', '0', 'asc', 10, 1, 1);
 #EndIf
 
 #IfNotRow2D list_options list_id Sort_Direction option_id 1
-INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `activity`) VALUES ('Sort_Direction', '1', 'desc', 2, 0, 1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `activity`) VALUES ('Sort_Direction', '1', 'desc', 20, 0, 1);
 #EndIf

--- a/sql/5_0_2-to-5_0_3_upgrade.sql
+++ b/sql/5_0_2-to-5_0_3_upgrade.sql
@@ -419,4 +419,15 @@ CREATE TABLE `pro_assessments` (
 
 #IfNotRow2D list_options list_id LBF_Validations option_id future_date
 INSERT INTO `list_options` (`list_id`,`option_id`,`title`,`notes`, `seq`) VALUES ('LBF_Validations','future_date','Future Date','{\"futureDate\":{\"message\":\"must be future date\"}}','32');
+
+#IfNotRow2D list_options list_id lists option_id Sort_Direction
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `activity`) VALUES ('lists', 'Sort_Direction', 'Sort Direction', 306, 1, 1);
+#EndIf
+
+#IfNotRow2D list_options list_id Sort_Direction option_id 0
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `activity`) VALUES ('Sort_Direction', '0', 'asc', 1, 1, 1);
+#EndIf
+
+#IfNotRow2D list_options list_id Sort_Direction option_id 1
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `activity`) VALUES ('Sort_Direction', '1', 'desc', 2, 0, 1);
 #EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -4748,9 +4748,9 @@ INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUE
 
 -- Sort Directions
 
-INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `activity`) VALUES ('lists', 'Sort_Direction', 'Sort Direction', 306, 1, 1);
-INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `activity`) VALUES ('Sort_Direction', '0', 'asc', 1, 1, 1);
-INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `activity`) VALUES ('Sort_Direction', '1', 'desc', 2, 0, 1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `activity`) VALUES ('lists', 'Sort_Direction', 'Sort Direction', 1, 0, 1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `activity`) VALUES ('Sort_Direction', '0', 'asc', 10, 1, 1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `activity`) VALUES ('Sort_Direction', '1', 'desc', 20, 0, 1);
 
 -----------------------------------------------------------
 

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -4746,6 +4746,12 @@ INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUE
 INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('apps','Calendar','main/calendar/index.php',20,0,0);
 INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('apps','oeSignerRemote','./../portal/sign/assets/signit.php',30,0,0);
 
+-- Sort Directions
+
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `activity`) VALUES ('lists', 'Sort_Direction', 'Sort Direction', 306, 1, 1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `activity`) VALUES ('Sort_Direction', '0', 'asc', 1, 1, 1,);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `activity`) VALUES ('Sort_Direction', '1', 'desc', 2, 0, 1);
+
 -----------------------------------------------------------
 
 --

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -4749,7 +4749,7 @@ INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUE
 -- Sort Directions
 
 INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `activity`) VALUES ('lists', 'Sort_Direction', 'Sort Direction', 306, 1, 1);
-INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `activity`) VALUES ('Sort_Direction', '0', 'asc', 1, 1, 1,);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `activity`) VALUES ('Sort_Direction', '0', 'asc', 1, 1, 1);
 INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `activity`) VALUES ('Sort_Direction', '1', 'desc', 2, 0, 1);
 
 -----------------------------------------------------------


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:
This pull request addresses 3 issues:
1- When creating a "Facility" field in the patient demographics layout, and adding it to the patient finder columns, the facility name would not be displayed. This was because there was not a facility type implemented in the options function that generated a plain text field. This was added by using the facility service to map the facility ID to the facility name so it can be displayed.

2- There is currently no way to specify default column ordering (sort direction) on patient list columns. This pull request addresses this issue by adding a list option for Sort_Direction, as well as adding a sort direction column to the Patient List Columns list, so the user can specify the default sort direction (for a date-created for example.) This does not change the default behavior, which is "asc" for all columns.

3- There was not the ability to have None as an option for the second default tab. I added the ability to select "None" in globals settings for the second default tab, and also cleaned up some of the dead code in the tabs view model. This does not change the default behavior.



#### Changes proposed in this pull request:

-
-
-