### PR TITLE
removed deprecated jquery's ready function

### DIFF
--- a/interface/code_systems/dataloads_ajax.php
+++ b/interface/code_systems/dataloads_ajax.php
@@ -229,7 +229,6 @@ $activeAccordionSection = isset($_GET['aas']) ? $_GET['aas'] : '0';
                 success: function(data) {
                     $(stg_load_id).hide();
                     $(stg_dets_id).html(data);
-                    $(document).ready(function() {});
                     $(`#${dbName}_instrmsg`).click( function() {
                         dlgopen(`${dbName.toLowerCase()}_howto.php`, '', 800, 250, false, `${dbName} <?php echo xla("Installation Details"); ?>`, {
                             buttons: [{

--- a/interface/forms/fee_sheet/review/initialize_review.js
+++ b/interface/forms/fee_sheet/review/initialize_review.js
@@ -63,4 +63,4 @@ function initialize_review() {
     get_fee_sheet_options('standard');
     ko.applyBindings(view_model, review.get(0));
 }
-$(document).ready(initialize_review);
+$(initialize_review);

--- a/interface/modules/zend_modules/public/js/installer/action.js
+++ b/interface/modules/zend_modules/public/js/installer/action.js
@@ -140,7 +140,7 @@ function SaveMe(frmId,mod_id){
 				$.each(data, function(jsonIndex, jsonValue){
 					if (jsonValue['return'] == 1) {
 						$("#hook_response"+mod_id).html(jsonValue['msg']).fadeIn().fadeOut(1000);
-						$(document).ready(function(){
+						$(function(){
 						if(Tabtitle)
 						$('#tab'+mod_id).tabs('select',Tabtitle);
 						});
@@ -171,7 +171,7 @@ function DeleteACL(aclID,user,mod_id,msg){
 							$("#ConfigRow_"+mod_id).hide();
 							configure(mod_id,'');
 							alert(jsonValue['msg']);
-							$(document).ready(function(){
+							$(function(){
 								if(Acctitle)
 									$('#configaccord'+mod_id).accordion('select',Acctitle);
 							});
@@ -199,7 +199,7 @@ function DeleteHooks(hooksID,mod_id,msg){
            $("#ConfigRow_"+mod_id).hide();
            configure(mod_id,'');
            alert(jsonValue['msg']);
-           $(document).ready(function(){
+           $(function(){
            if(Tabtitle)
            $('#tab'+mod_id).tabs('select',Tabtitle);
            });

--- a/tests/api/InternalApiTest.php
+++ b/tests/api/InternalApiTest.php
@@ -59,7 +59,7 @@ use OpenEMR\Core\Header;
             .catch(error => console.error(error))
         }
 
-        $(document).ready(function(){
+        $(function(){
             testAjaxApi();
             testFetchApi();
         });


### PR DESCRIPTION
This PR Fixes #2314

This PR remove `$( document ).ready(function() {
});` to `$(function () { }); ` as it is no longer recommended in jquery 3+.

@bradymiller Please review this PR
