### PR TITLE
fix: upgrade datatables to bootstrap 4 theme

### DIFF
--- a/interface/main/finder/dynamic_finder.php
+++ b/interface/main/finder/dynamic_finder.php
@@ -60,6 +60,10 @@ $loading = "<i class='fa fa-refresh fa-2x fa-spin'></i>";
 <head>
     <?php Header::setupHeader(['datatables', 'datatables-colreorder', 'datatables-dt']); ?>
     <title><?php echo xlt("Patient Finder"); ?></title>
+
+
+    <link rel="stylesheet" href="./../../../public/assets/datatables.net-bs4/css/dataTables.bootstrap4.min.css">
+    <script src="./../../../public/assets/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
 <style>
     /* Finder Processing style */
     div.dataTables_wrapper div.dataTables_processing {
@@ -177,51 +181,6 @@ $loading = "<i class='fa fa-refresh fa-2x fa-spin'></i>";
 
     table.dataTable.no-footer {
         border-bottom: 1px solid var(--gray900) !important;
-    }
-
-    .dataTables_wrapper .dataTables_paginate .paginate_button {
-        color: var(--dark) !important;
-    }
-
-    .dataTables_wrapper .dataTables_paginate .paginate_button.current,
-    .dataTables_wrapper .dataTables_paginate .paginate_button.current:hover {
-        color: var(--dark) !important;
-        border: 1px solid var(--gray600) !important;
-        background-color: var(--white) !important;
-        background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, var(--white)), color-stop(100%, var(--gray300))) !important;
-        background: -webkit-linear-gradient(top, var(--white) 0%, var(--gray300) 100%) !important;
-        background: -moz-linear-gradient(top, var(--white) 0%, var(--gray300) 100%) !important;
-        background: -ms-linear-gradient(top, var(--white) 0%, var(--gray300) 100%) !important;
-        background: -o-linear-gradient(top, var(--white) 0%, var(--gray300) 100%) !important;
-        background: linear-gradient(to bottom, var(--white) 0%, var(--gray300) 100%) !important;
-    }
-
-    .dataTables_wrapper .dataTables_paginate .paginate_button.disabled. .dataTables_wrapper .dataTables_paginate .paginate_button.disabled:hover,
-    .dataTables_wrapper .dataTables_paginate .paginate_button.disabled:active {
-        color: var(--gray700) !important;
-    }
-
-    .dataTables_wrapper .dataTables_paginate .paginate_button:hover {
-        color: var(--white) !important;
-        border: 1px solid var(--gray900) !important;
-        background-color: var(--gray700) !important;
-        background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #585858), color-stop(100%, var(--gray900))) !important;
-        background: -webkit-linear-gradient(top, var(--gray700) 0%, var(--gray900) 100%) !important;
-        background: -moz-linear-gradient(top, var(--gray700) 0%, var(--gray900) 100%) !important;
-        background: -ms-linear-gradient(top, var(--gray700) 0%, var(--gray900) 100%) !important;
-        background: -o-linear-gradient(top, var(--gray700) 0%, var(--gray900) 100%) !important;
-        background: linear-gradient(to bottom, var(--gray700) 0%, var(--gray900) 100%) !important;
-    }
-
-    .dataTables_wrapper .dataTables_paginate .paginate_button:active {
-        background-color: var(--dark) !important;
-        background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, var(--dark)), color-stop(100%, var(--gray900))) !important;
-        background: -webkit-linear-gradient(top, var(--dark) 0%, var(--gray900) 100%) !important;
-        background: -moz-linear-gradient(top, var(--dark) 0%, var(--gray900) 100%) !important;
-        background: -ms-linear-gradient(top, var(--dark) 0%, var(--gray900) 100%) !important;
-        background: -o-linear-gradient(top, var(--dark) 0%, var(--gray900) 100%) !important;
-        background: linear-gradient(to bottom, var(--dark) 0%, var(--gray900) 100%) !important;
-        box-shadow: inset 0 0 3px var(--gray900) !important;
     }
 
     .dataTables_wrapper .dataTables_processing {

--- a/interface/main/finder/dynamic_finder.php
+++ b/interface/main/finder/dynamic_finder.php
@@ -58,12 +58,8 @@ $loading = "<i class='fa fa-refresh fa-2x fa-spin'></i>";
 ?>
 <html>
 <head>
-    <?php Header::setupHeader(['datatables', 'datatables-colreorder', 'datatables-dt']); ?>
+    <?php Header::setupHeader(['datatables', 'datatables-colreorder', 'datatables-dt', 'datatables-bs']); ?>
     <title><?php echo xlt("Patient Finder"); ?></title>
-
-
-    <link rel="stylesheet" href="./../../../public/assets/datatables.net-bs4/css/dataTables.bootstrap4.min.css">
-    <script src="./../../../public/assets/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
 <style>
     /* Finder Processing style */
     div.dataTables_wrapper div.dataTables_processing {
@@ -179,6 +175,11 @@ $loading = "<i class='fa fa-refresh fa-2x fa-spin'></i>";
         background-color: var(--gray200) !important;
     }
 
+    table.dataTable.display tbody .odd:hover,
+    table.dataTable.display tbody .even:hover {
+        background-color: var(--gray200) !important;
+    }
+
     table.dataTable.no-footer {
         border-bottom: 1px solid var(--gray900) !important;
     }
@@ -203,6 +204,23 @@ $loading = "<i class='fa fa-refresh fa-2x fa-spin'></i>";
 
     .dataTables_wrapper.no-footer .dataTables_scrollBody {
         border-bottom: 1px solid var(--gray900) !important;
+    }
+
+    /* Pagination button Overrides for jQuery-DT */
+    .dataTables_wrapper .dataTables_paginate .paginate_button {
+        padding: 0 !important;
+        margin: 0 !important;
+        border: 0 !important;
+    }
+
+    /* Sort indicator Overrides for jQuery-DT */
+    table thead .sorting::before,
+    table thead .sorting_asc::before,
+    table thead .sorting_asc::after,
+    table thead .sorting_desc::before,
+    table thead .sorting_desc::after,
+    table thead .sorting::after {
+        display: none !important;
     }
 </style>
 <script>


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #3147 

#### Short description of what this resolves:
Remove pt_table_next style.
Upgrade datatables to Bootstrap theme. 

![image](https://user-images.githubusercontent.com/22230889/76624823-f470d800-6570-11ea-8fd6-c33fae0800c0.png)
