### PR TITLE
removed jquery's deprecated  ready method

### DIFF
--- a/interface/main/tabs/js/custom_bindings.js
+++ b/interface/main/tabs/js/custom_bindings.js
@@ -28,7 +28,7 @@ ko.bindingHandlers.location={
                 }
 
                 if ( cwDocument ) {
-                    $(cwDocument).ready(function () {
+                    $(function () {
                             var jqDocument = $(cwDocument);
                             var titleDocument = jqDocument.attr('title');
                             var titleText = "Unknown";

--- a/interface/reports/daily_summary_report.php
+++ b/interface/reports/daily_summary_report.php
@@ -67,7 +67,7 @@ $selectedProvider = isset($_POST['form_provider']) ? $_POST['form_provider'] : "
                 }
             }
 
-            $( document ).ready(function(){
+            $(function(){
                 $('.datepicker').datetimepicker({
                     <?php $datetimepicker_timepicker = false; ?>
                     <?php $datetimepicker_showseconds = false; ?>

--- a/interface/super/rules/www/js/bucket.js
+++ b/interface/super/rules/www/js/bucket.js
@@ -56,7 +56,7 @@ var bucket = function( args ) {
 
     return {
             init: function() {
-                $( document ).ready( function() {
+                $( function() {
                     fn_wire_events();
                     fn_work();
                 });

--- a/interface/super/rules/www/js/custom.js
+++ b/interface/super/rules/www/js/custom.js
@@ -38,7 +38,7 @@ var custom = function( args ) {
 
     return {
             init: function() {
-                $( document ).ready( function() {
+                $( function() {
                     fn_wire_events();
                     fn_work();
                 });

--- a/interface/super/rules/www/js/detail.js
+++ b/interface/super/rules/www/js/detail.js
@@ -31,7 +31,7 @@ var rule_detail = function( args ) {
 
     return {
             init: function() {
-                $( document ).ready( function() {
+                $( function() {
                     fn_wire_events();
                     fn_work();
                 });

--- a/interface/super/rules/www/js/edit.js
+++ b/interface/super/rules/www/js/edit.js
@@ -89,7 +89,7 @@ var rule_edit = function( args ) {
 
     return {
             init: function() {
-                $( document ).ready( function() {
+                $( function() {
                     fn_wire_events();
                     fn_work();
                 });

--- a/interface/super/rules/www/js/list.js
+++ b/interface/super/rules/www/js/list.js
@@ -58,7 +58,7 @@ var list_rules = function( args ) {
 
     return {
             init: function() {
-                $( document ).ready( function() {
+                $( function() {
                     fn_wire_events();
                     fn_work();
                 });

--- a/interface/super/rules/www/js/typeahead.js
+++ b/interface/super/rules/www/js/typeahead.js
@@ -26,7 +26,7 @@ var type_ahead = function( args ) {
 
     return {
             init: function() {
-                $( document ).ready( function() {
+                $( function() {
                     fn_wire_events();
                     fn_work();
                 });

--- a/library/options_listadd.inc
+++ b/library/options_listadd.inc
@@ -62,7 +62,7 @@ use OpenEMR\Common\Csrf\CsrfUtils;
 
 // jQuery makes life easier (sometimes)
 
-$(document).ready(function(){
+$(function(){
 
     /********************************************************/
     /************ List-box modification functions ***********/

--- a/portal/sign/assets/signer_api.js
+++ b/portal/sign/assets/signer_api.js
@@ -570,7 +570,7 @@ function initSignerApi() {
 
         // this offsets signature image to center on element somewhat
         // on any form (css) box height:70px length:auto center at 20px.
-        $("body").ready(function (e) {
+        $(function (e) {
             let els = this.querySelectorAll("img[data-action=fetch_signature]");
             let i; // caution using let in for
             for (i = 0; i < els.length; i++) {


### PR DESCRIPTION
This PR Fixes #2314

This PR remove remaining $( document ).ready(function() { }); to $(function () { }); as it is no longer recommended in jquery 3+.

@bradymiller As commented in PR https://github.com/openemr/openemr/pull/3158 I have created a new branch removed deprecated method. Please review this one.