### PR TITLE
Fix issue with being unable to import pharmacies due to ssl cipher mi…

### DIFF
--- a/src/Common/Http/oeHttpRequest.php
+++ b/src/Common/Http/oeHttpRequest.php
@@ -149,6 +149,14 @@ class oeHttpRequest extends oeOAuth
         ]);
     }
 
+    public function getCurlOptions($url, $queryParams = [], $curlOptions = [])
+    {
+        return $this->send('GET', $url, [
+            'query' => $queryParams,
+            'curl' => $curlOptions
+        ]);     
+    }
+
     public function post($url, $params = [])
     {
         return $this->send('POST', $url, [

--- a/src/Common/Http/oeHttpRequest.php
+++ b/src/Common/Http/oeHttpRequest.php
@@ -149,6 +149,17 @@ class oeHttpRequest extends oeOAuth
         ]);
     }
 
+    /**
+     * The getCurlOptions() function was added in PR#3172 to be able to pass a specific cipher to curl
+     * in order to handle an issue in 5.0.2 (1) with OpenSSL 1.1.1c and 1.1.1d where attempting to import
+     * the pharmacies from https://npiregistry.cms.hhs.gov/api/ results in the error:
+     *   PHP Fatal error: Uncaught GuzzleHttp\Exception\ConnectException: cURL error 35: 
+     *   error:141A318A:SSL routines:tls_process_ske_dhe:dh key too small
+     *   (see http://curl.haxx.se/libcurl/c/libcurl-errors.html)
+     * The latest versions of OpenSSL have deprecated the use of the 512-bit Diffie–Hellman key that is 
+     * apparently still used by the CMS server.  Once CMS updates their encryption it may be possible to
+     * remove this additional function.
+     */
     public function getCurlOptions($url, $queryParams = [], $curlOptions = [])
     {
         return $this->send('GET', $url, [

--- a/src/Pharmacy/Services/ImportPharmacies.php
+++ b/src/Pharmacy/Services/ImportPharmacies.php
@@ -50,7 +50,20 @@ class ImportPharmacies
             'skip' => '',
             'version' => '2.1',
         ];
-        $response = oeHttpRequest::getCurlOptions('https://npiregistry.cms.hhs.gov/api/', $query,
+        
+        /**
+         * The function call was changed in PR#3172 from oeHttp::get() to oeHttpRequest::getCurlOptions()
+         * with the 'ECDHE-RSA-AES256-GCM-SHA384' cipher passed to curl in order to handle an issue in 
+         * 5.0.2 (1) with OpenSSL 1.1.1c and 1.1.1d where attempting to import the pharmacies from 
+         * https://npiregistry.cms.hhs.gov/api/ results in the error:
+         *   PHP Fatal error: Uncaught GuzzleHttp\Exception\ConnectException: cURL error 35: 
+         *   error:141A318A:SSL routines:tls_process_ske_dhe:dh key too small
+         *   (see http://curl.haxx.se/libcurl/c/libcurl-errors.html)
+         * The latest versions of OpenSSL have deprecated the use of the 512-bit Diffie–Hellman key that is 
+         * apparently still used by the CMS server.  Once CMS updates their encryption it may be possible to
+         * revert this back to the original call.
+         */
+         $response = oeHttpRequest::getCurlOptions('https://npiregistry.cms.hhs.gov/api/', $query,
             [CURLOPT_SSL_CIPHER_LIST => 'ECDHE-RSA-AES256-GCM-SHA384']);
 
         $body = $response->body(); // already should be json.

--- a/src/Pharmacy/Services/ImportPharmacies.php
+++ b/src/Pharmacy/Services/ImportPharmacies.php
@@ -50,7 +50,8 @@ class ImportPharmacies
             'skip' => '',
             'version' => '2.1',
         ];
-        $response = oeHttp::get('https://npiregistry.cms.hhs.gov/api/', $query);
+        $response = oeHttpRequest::getCurlOptions('https://npiregistry.cms.hhs.gov/api/', $query,
+            [CURLOPT_SSL_CIPHER_LIST => 'ECDHE-RSA-AES256-GCM-SHA384']);
 
         $body = $response->body(); // already should be json.
 


### PR DESCRIPTION
…smatch.

<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:
In OpenEMR 5.0.2 (1) on Debian 10 with OpenSSL 1.1.1c attempting to import pharmacies from https://npiregistry.cms.hhs.gov/api/ results in:
PHP Fatal error:  Uncaught GuzzleHttp\\Exception\\ConnectException: cURL error 35: error:141A318A:SSL routines:tls_process_ske_dhe:dh key too small (see http://curl.haxx.se/libcurl/c/libcurl-errors.html)
This is apparently an issue when using the latest versions of OpenSSL with the encryption that is being used by the cms.hhs.gov server (the error can be reproduced using curl alone).  To fix it a mutually compatible SSL cipher needs to be passed (via the GuzzleHttp client) as an option to curl (at least until cms.hhs.gov updates its encryption). 


#### Changes proposed in this pull request:
1. Add a new getCurlOptions() function to oeHttpRequest.php that allows passing an array of options for curl.
2. Change the call to get() in the importPharmacies() function in ImportPharmacies.php to use the getCurlOptions() function and pass an appropriate ssl cipher option to curl. 
-
-
-