### PR TITLE
Fix #2949: add diagnostics to navbar

### DIFF
--- a/interface/main/tabs/menu/menus/standard.json
+++ b/interface/main/tabs/menu/menus/standard.json
@@ -1085,6 +1085,18 @@
               "admin",
               "users"
             ]
+          },
+          {
+            "label": "Diagnostics",
+            "menu_id": "adm0",
+            "target": "adm",
+            "url": "/interface/main/calendar/index.php?module=PostCalendar&type=admin&func=testSystem",
+            "children": [],
+            "requirement": 0,
+            "acl_req": [
+              "admin",
+              "users"
+            ]
           }
         ],
         "requirement": 0,

--- a/interface/main/tabs/menu/menus/standard.json
+++ b/interface/main/tabs/menu/menus/standard.json
@@ -1095,7 +1095,7 @@
             "requirement": 0,
             "acl_req": [
               "admin",
-              "users"
+              "super"
             ]
           }
         ],


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #2949 

#### Short description of what this resolves:
Add diagnostics in navbar Administration->System

![image](https://user-images.githubusercontent.com/22230889/77221926-5a6ce900-6b89-11ea-8214-9704bd1884a1.png)
