### PR TITLE
Add patient encounter PUT API

### DIFF
--- a/API_README.md
+++ b/API_README.md
@@ -196,6 +196,25 @@ curl -X POST 'http://localhost:8300/apis/api/patient/1/encounter' -d \
 }'
 ```
 
+
+#### PUT /api/patient/:pid/encounter/:eid
+
+```sh
+curl -X POST 'http://localhost:8300/apis/api/patient/1/encounter/1' -d \
+'{
+    "date":"2019-09-14",
+    "onset_date": "2019-04-20 00:00:00",
+    "reason": "Pregnancy Test",
+    "pc_catid": "5",
+    "facility_id": "3",
+    "billing_facility": "3",
+    "sensitivity": "normal",
+    "referral_source": "",
+    "pos_code": "0"
+}'
+```
+
+
 #### GET /api/patient/:pid/encounter
 
 ```sh

--- a/_rest_routes.inc.php
+++ b/_rest_routes.inc.php
@@ -94,6 +94,11 @@ RestConfig::$ROUTE_MAP = array(
         $data = (array)(json_decode(file_get_contents("php://input")));
         return (new EncounterRestController())->post($pid, $data);
     },
+    "PUT /api/patient/:pid/encounter/:eid" => function ($pid, $eid) {
+        RestConfig::authorization_check("encounters", "auth_a");
+        $data = (array)(json_decode(file_get_contents("php://input")));
+        return (new EncounterRestController())->put($pid, $eid, $data);
+    },
     "GET /api/patient/:pid/encounter/:eid" => function ($pid, $eid) {
         RestConfig::authorization_check("encounters", "auth_a");
         return (new EncounterRestController())->getOne($pid, $eid);

--- a/src/RestControllers/EncounterRestController.php
+++ b/src/RestControllers/EncounterRestController.php
@@ -33,9 +33,28 @@ class EncounterRestController
         if (is_array($validationHandlerResult)) {
             return $validationHandlerResult;
         }
-
+ 
         $serviceResult = $this->encounterService->insertEncounter($pid, $data);
         return RestControllerHelper::responseHandler($serviceResult, array("eid" => $serviceResult), 200);
+    }
+
+    public function put($pid, $eid, $data)
+    {
+        
+        $validationResult = $this->encounterService->validateEncounter($data);
+
+        $validationHandlerResult = RestControllerHelper::validationHandler($validationResult);
+        if (is_array($validationHandlerResult)) {
+            return $validationHandlerResult;
+        }
+ 
+        $serviceResult = $this->encounterService->updateEncounter($pid, $eid, $data);
+
+        if (is_string($serviceResult)) {
+            return RestControllerHelper::responseHandler($serviceResult, null, 200);
+        }
+
+        return RestControllerHelper::responseHandler($serviceResult, array("eid" => $eid), 200);
     }
 
     public function getOne($pid, $eid)


### PR DESCRIPTION
fixes #3194
#### Short description of what this resolves:
Add Update patient encounter AP
#### How to test
Test Endpoint http://localhost:8300/apis/api/patient/1/encounter/1
Test Payload

```
{
    "date":"2019-09-14",
    "onset_date": "0000-00-00 00:00:00",
    "reason": "Pregnancy Test",
    "pc_catid": "5",
    "facility_id": "3",
    "billing_facility": "3",
    "sensitivity": "normal",
    "referral_source": "",
    "pos_code": "0"

}
```
#### Behaviour
Returns Object on update instead of updated data eg 

```
{
    "dataProvider": "empty",
    "databaseType": false,
    "EOF": true,
    "_numOfRows": 0,
    "fields": false,
    "connection": false
}

```
In case where Encounter  sensitive field is normal, it returns string e.g
`"You are not authorized to see this encounter."`

Code replicated from https://github.com/openemr/openemr/blob/master/interface/forms/newpatient/save.php