### PR TITLE
fix: modal dialog close icon broken.

### DIFF
--- a/interface/themes/core/closeDlgIframe.scss
+++ b/interface/themes/core/closeDlgIframe.scss
@@ -16,8 +16,8 @@ div.closeDlgIframe {
 div.closeDlgIframe:before {
     color: $white;
     content: "\f00d";
-    font-family: "FontAwesome";
-    font-weight: bold;
+    font-family: "Font Awesome 5 Free";
+    font-weight: 900;
     display: inline-block;
     width: 100%;
     text-align: center;


### PR DESCRIPTION
#### Short description of what this resolves:
Fix modal dialog close icon broken.

![image](https://user-images.githubusercontent.com/22230889/77270606-5fe04580-6ce7-11ea-95be-0055f624e2c5.png)
