### PR TITLE
fix: search-plus and search-minus icons broken

### DIFF
--- a/interface/themes/core/FontAwesome.scss
+++ b/interface/themes/core/FontAwesome.scss
@@ -1,7 +1,6 @@
 /* fix for H2 Tags */
 .fa-oe-sm {
     @include font-size("1.3rem !important");
-    font-weight: 400 !important;
     line-height: 1 !important;
     color: $gray !important;
 }


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

#### Short description of what this resolves:
Fix search-plus and search-minus icons broken

Before:
![image](https://user-images.githubusercontent.com/22230889/77368159-9d4fdc00-6d96-11ea-966f-e2147fa4909f.png)


After:
![image](https://user-images.githubusercontent.com/22230889/77368191-ae005200-6d96-11ea-9a16-d647bd89a3b6.png)
