### PR TITLE
Fix #2914 Increased Maxlength for mime types

### DIFF
--- a/interface/super/edit_list.php
+++ b/interface/super/edit_list.php
@@ -314,13 +314,13 @@ function writeOptionLine(
     echo "  <td>";
     //New line for hidden input, for update items
     echo "<input type='hidden' name='opt[" . attr($opt_line_no) . "][real_id]' value='" .
-        attr($option_id) . "' size='12' maxlength='70' class='optin' />";
+        attr($option_id) . "' size='12' maxlength='127' class='optin' />";
     echo "<input type='text' name='opt[" . attr($opt_line_no) . "][id]' value='" .
-        attr($option_id) . "' size='12' maxlength='70' class='optin' />";
+        attr($option_id) . "' size='12' maxlength='127' class='optin' />";
     echo "</td>\n";
     echo "  <td>";
     echo "<input type='text' name='opt[" . attr($opt_line_no) . "][title]' value='" .
-        attr($title) . "' size='20' maxlength='70' class='optin' />";
+        attr($title) . "' size='20' maxlength='127' class='optin' />";
     echo "</td>\n";
 
     // if not english and translating lists then show the translation

--- a/interface/super/edit_list.php
+++ b/interface/super/edit_list.php
@@ -314,13 +314,13 @@ function writeOptionLine(
     echo "  <td>";
     //New line for hidden input, for update items
     echo "<input type='hidden' name='opt[" . attr($opt_line_no) . "][real_id]' value='" .
-        attr($option_id) . "' size='12' maxlength='63' class='optin' />";
+        attr($option_id) . "' size='12' maxlength='70' class='optin' />";
     echo "<input type='text' name='opt[" . attr($opt_line_no) . "][id]' value='" .
-        attr($option_id) . "' size='12' maxlength='63' class='optin' />";
+        attr($option_id) . "' size='12' maxlength='70' class='optin' />";
     echo "</td>\n";
     echo "  <td>";
     echo "<input type='text' name='opt[" . attr($opt_line_no) . "][title]' value='" .
-        attr($title) . "' size='20' maxlength='63' class='optin' />";
+        attr($title) . "' size='20' maxlength='70' class='optin' />";
     echo "</td>\n";
 
     // if not english and translating lists then show the translation


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #2914

#### Short description of what this resolves:

Increased the max length to 127 for the storage of mime types in the file types list
#### Changes proposed in this pull request:

- Just increase the max length to 127(btw 127 is not chosen out of random, reason for increasing to 127 -> https://stackoverflow.com/questions/643690/maximum-mimetype-length-when-storing-type-in-db
-
-