### PR TITLE
Fixed "double scroll-bar" bug on modals

### DIFF
--- a/library/dialog.js
+++ b/library/dialog.js
@@ -518,7 +518,7 @@ const dlgopen = (url, winname, width, height, forceNewWindow, title, opts) => {
         ('<iframe id="modalframe" class="w-100 h-100 modalIframe" name="%winname%" %url% frameborder=0></iframe>')
         .replace('%winname%', winname).replace('%url%', fullURL ? 'src=' + fullURL : '');
 
-    var bodyStyles = (' style="overflow-y:auto;height:%initHeight%;max-height:92vh;"')
+    var bodyStyles = (' style="height:%initHeight%;max-height:92vh;"')
         .replace('%initHeight%', opts.sizeHeight !== 'full' ? mHeight : '80vh');
 
     var altClose = '<div class="closeDlgIframe" data-dismiss="modal" ></div>';


### PR DESCRIPTION

<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:
As you can see in the following image, a double vertical scrollbar appears in iFrame modals. 
The issue seems to appear in Google Chrome and not in Firefox.
![image](https://user-images.githubusercontent.com/62647966/77851037-350e5980-71df-11ea-93ee-64756bce7a31.png)

This commit resolves this issue as seen below
![image](https://user-images.githubusercontent.com/62647966/77851113-ce3d7000-71df-11ea-9f5c-fb0d8c876442.png)


#### Changes proposed in this pull request:

- Removing double scrollbar from modals containing iFrames