### PR TITLE
Syling Calendar modal buttons

### DIFF
--- a/interface/main/calendar/add_edit_event.php
+++ b/interface/main/calendar/add_edit_event.php
@@ -1756,11 +1756,11 @@ if ($_GET['prov'] != true) { ?>
 <div class="form-row mx-2 mt-3">
     <input class="col-sm mx-sm-2 my-2 my-sm-auto btn btn-primary" type='button' name='form_save' id='form_save' value='<?php echo xla('Save'); ?>' />
     <?php if (!($GLOBALS['select_multi_providers'])) { //multi providers appt is not supported by check slot avail window, so skip ?>
-        <input class="col-sm mx-sm-2 my-2 my-sm-auto btn btn-primary" type='button' id='find_available' value='<?php echo xla('Find Available{{Provider}}'); ?>' />
+        <input class="col-sm mx-sm-2 my-2 my-sm-auto btn btn-secondary" type='button' id='find_available' value='<?php echo xla('Find Available{{Provider}}'); ?>' />
     <?php } ?>
-    <input class="col-sm mx-sm-2 my-2 my-sm-auto btn btn-primary" type='button' name='form_delete' id='form_delete' value='<?php echo xla('Delete'); ?>'<?php echo (!$eid) ? " disabled" : ""; ?> />
-    <input class="col-sm mx-sm-2 my-2 my-sm-auto btn btn-primary" type='button' id='cancel' value='<?php echo xla('Cancel'); ?>' />
-    <input class="col-sm mx-sm-2 my-2 my-sm-auto btn btn-primary" type='button' name='form_duplicate' id='form_duplicate' value='<?php echo xla('Create Duplicate'); ?>' />
+    <input class="col-sm mx-sm-2 my-2 my-sm-auto btn btn-danger" type='button' name='form_delete' id='form_delete' value='<?php echo xla('Delete'); ?>'<?php echo (!$eid) ? " disabled" : ""; ?> />
+    <input class="col-sm mx-sm-2 my-2 my-sm-auto btn btn-secondary" type='button' id='cancel' value='<?php echo xla('Cancel'); ?>' />
+    <input class="col-sm mx-sm-2 my-2 my-sm-auto btn btn-secondary" type='button' name='form_duplicate' id='form_duplicate' value='<?php echo xla('Create Duplicate'); ?>' />
 </div>
 <?php if ($informant) {
     echo "<label><p class='text'>" . xlt('Last update by') . " " .


### PR DESCRIPTION

<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #3262 

#### Short description of what this resolves:
According to #3160 , buttons should be styled using BS4 Classes. This commit does exactly that for the Calendar modal 

![image](https://user-images.githubusercontent.com/62647966/77851341-54a68180-71e1-11ea-8a55-04411db78a16.png)


#### Changes proposed in this pull request:

-Keeping the "Save" button as btn-primary
-Changing the "Delete" button to btn-danger
-Changing all other buttons of the modal to btn-secondary