### PR TITLE
Styling "Add new" Procedure provider modal buttons

### DIFF
--- a/interface/main/calendar/add_edit_event.php
+++ b/interface/main/calendar/add_edit_event.php
@@ -1756,11 +1756,11 @@ if ($_GET['prov'] != true) { ?>
 <div class="form-row mx-2 mt-3">
     <input class="col-sm mx-sm-2 my-2 my-sm-auto btn btn-primary" type='button' name='form_save' id='form_save' value='<?php echo xla('Save'); ?>' />
     <?php if (!($GLOBALS['select_multi_providers'])) { //multi providers appt is not supported by check slot avail window, so skip ?>
-        <input class="col-sm mx-sm-2 my-2 my-sm-auto btn btn-primary" type='button' id='find_available' value='<?php echo xla('Find Available{{Provider}}'); ?>' />
+        <input class="col-sm mx-sm-2 my-2 my-sm-auto btn btn-secondary" type='button' id='find_available' value='<?php echo xla('Find Available{{Provider}}'); ?>' />
     <?php } ?>
-    <input class="col-sm mx-sm-2 my-2 my-sm-auto btn btn-primary" type='button' name='form_delete' id='form_delete' value='<?php echo xla('Delete'); ?>'<?php echo (!$eid) ? " disabled" : ""; ?> />
-    <input class="col-sm mx-sm-2 my-2 my-sm-auto btn btn-primary" type='button' id='cancel' value='<?php echo xla('Cancel'); ?>' />
-    <input class="col-sm mx-sm-2 my-2 my-sm-auto btn btn-primary" type='button' name='form_duplicate' id='form_duplicate' value='<?php echo xla('Create Duplicate'); ?>' />
+    <input class="col-sm mx-sm-2 my-2 my-sm-auto btn btn-danger" type='button' name='form_delete' id='form_delete' value='<?php echo xla('Delete'); ?>'<?php echo (!$eid) ? " disabled" : ""; ?> />
+    <input class="col-sm mx-sm-2 my-2 my-sm-auto btn btn-secondary" type='button' id='cancel' value='<?php echo xla('Cancel'); ?>' />
+    <input class="col-sm mx-sm-2 my-2 my-sm-auto btn btn-secondary" type='button' name='form_duplicate' id='form_duplicate' value='<?php echo xla('Create Duplicate'); ?>' />
 </div>
 <?php if ($informant) {
     echo "<label><p class='text'>" . xlt('Last update by') . " " .

--- a/interface/orders/procedure_provider_edit.php
+++ b/interface/orders/procedure_provider_edit.php
@@ -435,10 +435,10 @@ function invalue($name)
                     <div class="form-group clearfix" id="button-container">
                         <div class="col-sm-12 text-left position-override">
                             <div class="btn-group btn-group-pinch" role="group">
-                                <button type='submit' name='form_save'  class="btn btn-secondary btn-save"  value='<?php echo xla('Save'); ?>'><?php echo xlt('Save'); ?></button>
-                                <button type="button" class="btn btn-link btn-cancel btn-separate-left" onclick='window.close()';><?php echo xlt('Cancel');?></button>
+                                <button type='submit' name='form_save'  class="btn btn-primary btn-save"  value='<?php echo xla('Save'); ?>'><?php echo xlt('Save'); ?></button>
+                                <button type="button" class="btn btn-secondary btn-cancel btn-separate-left" onclick='window.close()';><?php echo xlt('Cancel');?></button>
                                 <?php if ($ppid) { ?>
-                                    <button type='submit' name='form_delete' class="btn btn-secondary btn-cancel btn-delete btn-separate-left" value='<?php echo xla('Delete'); ?>'><?php echo xlt('Delete'); ?></button>
+                                    <button type='submit' name='form_delete' class="btn btn-danger btn-cancel btn-delete btn-separate-left" value='<?php echo xla('Delete'); ?>'><?php echo xlt('Delete'); ?></button>
                                 <?php } ?>
                             </div>
                         </div>


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:
According to #3160 , buttons should be styled using BS4 Classes. This commit does exactly that for the "Add new" modal in the Procedure provider page.
Before:
![image](https://user-images.githubusercontent.com/62647966/77851917-6b020c80-71e4-11ea-9a36-1048710e4a6e.png)

After:
![image](https://user-images.githubusercontent.com/62647966/77851979-ccc27680-71e4-11ea-8684-5bfde914a2e4.png)



#### Changes proposed in this pull request:

-Changing the "Save" button to primary
-Changing the "Cancel" button from btn-link to btn-secondary