### PR TITLE
fix apis route dispatcher

### DIFF
--- a/apis/dispatch.php
+++ b/apis/dispatch.php
@@ -133,8 +133,12 @@ if (!$isLocalApi) {
     $gbl::authentication_check($resource);
 }
 // dispatch $routes called by ref.
-HttpRestRouteHandler::dispatch($routes, $resource, $_SERVER["REQUEST_METHOD"]);
+$hasRoute = HttpRestRouteHandler::dispatch($routes, $resource, $_SERVER["REQUEST_METHOD"]);
 // Tear down session for security.
 if (!$isLocalApi) {
     $gbl::destroySession();
+}
+// prevent 200 if route doesn't exist
+if (!$hasRoute) {
+    http_response_code(404);
 }

--- a/src/Common/Http/HttpRestRouteHandler.php
+++ b/src/Common/Http/HttpRestRouteHandler.php
@@ -19,6 +19,7 @@ class HttpRestRouteHandler
     public static function dispatch(&$routes, $route, $request_method, $return_method = 'standard')
     {
         // Taken from https://stackoverflow.com/questions/11722711/url-routing-regex-php/11723153#11723153
+        $hasRoute = false;
         foreach ($routes as $routePath => $routeCallback) {
             $routePieces = explode(" ", $routePath);
             $method = $routePieces[0];
@@ -27,6 +28,7 @@ class HttpRestRouteHandler
             $matches = array();
             if ($method == $request_method && preg_match($pattern, $route, $matches)) {
                 array_shift($matches);
+                $hasRoute = true;
                 $result = call_user_func_array($routeCallback, $matches);
                 if ($return_method == 'standard') {
                     header('Content-Type: application/json');
@@ -38,5 +40,6 @@ class HttpRestRouteHandler
                 }
             }
         }
+        return $hasRoute;
     }
 }


### PR DESCRIPTION
- add logic to return a 404 if route doesn't exist

<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:
some reason we'd return a 200 http status if route did not exists.


#### Changes proposed in this pull request:
I stopped that nonsense forthwith. :)