### PR TITLE
Quick-Fix: Get all patient API correction

### DIFF
--- a/src/Services/PatientService.php
+++ b/src/Services/PatientService.php
@@ -217,7 +217,7 @@ class PatientService
                    state,
                    country_code,
                    phone_contact,
-                   email
+                   email,
                    DOB,
                    sex,
                    race,


### PR DESCRIPTION
Missing comma causing the email to behave as dob(alias) and thus missing dob when `get all patient data` API is called.
P.S.: First API fix PR :wink: 