### PR TITLE
Option - show only one insurance 

### DIFF
--- a/interface/new/new_comprehensive.php
+++ b/interface/new/new_comprehensive.php
@@ -598,12 +598,17 @@ $constraints = LBF_Validation::generate_validate_constraints("DEM");
                     if (!$GLOBALS['simplified_demographics']) {
                         $insurancei = getInsuranceProviders();
                         $pid = 0;
+                    if($GLOBALS['insurance_only_one']){
+                        $insurance_headings = array(xl("Primary Insurance Provider"));
+                        $insurance_info = array();
+                        $insurance_info[1] = getInsuranceData($pid, "primary");
+                    }else{
                         $insurance_headings = array(xl("Primary Insurance Provider"), xl("Secondary Insurance Provider"), xl("Tertiary Insurance provider"));
                         $insurance_info = array();
                         $insurance_info[1] = getInsuranceData($pid, "primary");
                         $insurance_info[2] = getInsuranceData($pid, "secondary");
                         $insurance_info[3] = getInsuranceData($pid, "tertiary");
-
+                    }
                         echo "<br /><span class='bold'><input type='checkbox' name='form_cb_ins' value='1' " .
                         "onclick='return divclick(this,\"div_ins\");'";
                         if ($display_style == 'block') {
@@ -613,7 +618,7 @@ $constraints = LBF_Validation::generate_validate_constraints("DEM");
                         echo " /><b>" . xlt('Insurance') . "</b></span>\n";
                         echo "<div id='div_ins' class='section' style='display: $display_style;'>\n";
 
-                        for ($i=1; $i<=3; $i++) {
+                        for ($i=1; $i<=sizeof($insurance_info); $i++) {
                             $result3 = $insurance_info[$i];
                             ?>
                         <table class="border-0">

--- a/interface/new/new_comprehensive_save.php
+++ b/interface/new/new_comprehensive_save.php
@@ -126,74 +126,76 @@ newInsuranceData(
     filter_input(INPUT_POST, 'i1accept_assignment')
 );
 
+//Dont save more than one insurance since only one is allowed / save space in DB
+if(!$GLOBALS['insurance_only_one']) {
+    $i2dob = DateToYYYYMMDD(filter_input(INPUT_POST, "i2subscriber_DOB"));
+    $i2date = DateToYYYYMMDD(filter_input(INPUT_POST, "i2effective_date"));
 
-$i2dob = DateToYYYYMMDD(filter_input(INPUT_POST, "i2subscriber_DOB"));
-$i2date = DateToYYYYMMDD(filter_input(INPUT_POST, "i2effective_date"));
+    newInsuranceData(
+        $pid,
+        "secondary",
+        filter_input(INPUT_POST, "i2provider"),
+        filter_input(INPUT_POST, "i2policy_number"),
+        filter_input(INPUT_POST, "i2group_number"),
+        filter_input(INPUT_POST, "i2plan_name"),
+        filter_input(INPUT_POST, "i2subscriber_lname"),
+        filter_input(INPUT_POST, "i2subscriber_mname"),
+        filter_input(INPUT_POST, "i2subscriber_fname"),
+        filter_input(INPUT_POST, "form_i2subscriber_relationship"),
+        filter_input(INPUT_POST, "i2subscriber_ss"),
+        $i2dob,
+        filter_input(INPUT_POST, "i2subscriber_street"),
+        filter_input(INPUT_POST, "i2subscriber_postal_code"),
+        filter_input(INPUT_POST, "i2subscriber_city"),
+        filter_input(INPUT_POST, "form_i2subscriber_state"),
+        filter_input(INPUT_POST, "form_i2subscriber_country"),
+        filter_input(INPUT_POST, "i2subscriber_phone"),
+        filter_input(INPUT_POST, "i2subscriber_employer"),
+        filter_input(INPUT_POST, "i2subscriber_employer_street"),
+        filter_input(INPUT_POST, "i2subscriber_employer_city"),
+        filter_input(INPUT_POST, "i2subscriber_employer_postal_code"),
+        filter_input(INPUT_POST, "form_i2subscriber_employer_state"),
+        filter_input(INPUT_POST, "form_i2subscriber_employer_country"),
+        filter_input(INPUT_POST, 'i2copay'),
+        filter_input(INPUT_POST, 'form_i2subscriber_sex'),
+        $i2date,
+        filter_input(INPUT_POST, 'i2accept_assignment')
+    );
 
-newInsuranceData(
-    $pid,
-    "secondary",
-    filter_input(INPUT_POST, "i2provider"),
-    filter_input(INPUT_POST, "i2policy_number"),
-    filter_input(INPUT_POST, "i2group_number"),
-    filter_input(INPUT_POST, "i2plan_name"),
-    filter_input(INPUT_POST, "i2subscriber_lname"),
-    filter_input(INPUT_POST, "i2subscriber_mname"),
-    filter_input(INPUT_POST, "i2subscriber_fname"),
-    filter_input(INPUT_POST, "form_i2subscriber_relationship"),
-    filter_input(INPUT_POST, "i2subscriber_ss"),
-    $i2dob,
-    filter_input(INPUT_POST, "i2subscriber_street"),
-    filter_input(INPUT_POST, "i2subscriber_postal_code"),
-    filter_input(INPUT_POST, "i2subscriber_city"),
-    filter_input(INPUT_POST, "form_i2subscriber_state"),
-    filter_input(INPUT_POST, "form_i2subscriber_country"),
-    filter_input(INPUT_POST, "i2subscriber_phone"),
-    filter_input(INPUT_POST, "i2subscriber_employer"),
-    filter_input(INPUT_POST, "i2subscriber_employer_street"),
-    filter_input(INPUT_POST, "i2subscriber_employer_city"),
-    filter_input(INPUT_POST, "i2subscriber_employer_postal_code"),
-    filter_input(INPUT_POST, "form_i2subscriber_employer_state"),
-    filter_input(INPUT_POST, "form_i2subscriber_employer_country"),
-    filter_input(INPUT_POST, 'i2copay'),
-    filter_input(INPUT_POST, 'form_i2subscriber_sex'),
-    $i2date,
-    filter_input(INPUT_POST, 'i2accept_assignment')
-);
+    $i3dob = DateToYYYYMMDD(filter_input(INPUT_POST, "i3subscriber_DOB"));
+    $i3date = DateToYYYYMMDD(filter_input(INPUT_POST, "i3effective_date"));
 
-$i3dob  = DateToYYYYMMDD(filter_input(INPUT_POST, "i3subscriber_DOB"));
-$i3date = DateToYYYYMMDD(filter_input(INPUT_POST, "i3effective_date"));
-
-newInsuranceData(
-    $pid,
-    "tertiary",
-    filter_input(INPUT_POST, "i3provider"),
-    filter_input(INPUT_POST, "i3policy_number"),
-    filter_input(INPUT_POST, "i3group_number"),
-    filter_input(INPUT_POST, "i3plan_name"),
-    filter_input(INPUT_POST, "i3subscriber_lname"),
-    filter_input(INPUT_POST, "i3subscriber_mname"),
-    filter_input(INPUT_POST, "i3subscriber_fname"),
-    filter_input(INPUT_POST, "form_i3subscriber_relationship"),
-    filter_input(INPUT_POST, "i3subscriber_ss"),
-    $i3dob,
-    filter_input(INPUT_POST, "i3subscriber_street"),
-    filter_input(INPUT_POST, "i3subscriber_postal_code"),
-    filter_input(INPUT_POST, "i3subscriber_city"),
-    filter_input(INPUT_POST, "form_i3subscriber_state"),
-    filter_input(INPUT_POST, "form_i3subscriber_country"),
-    filter_input(INPUT_POST, "i3subscriber_phone"),
-    filter_input(INPUT_POST, "i3subscriber_employer"),
-    filter_input(INPUT_POST, "i3subscriber_employer_street"),
-    filter_input(INPUT_POST, "i3subscriber_employer_city"),
-    filter_input(INPUT_POST, "i3subscriber_employer_postal_code"),
-    filter_input(INPUT_POST, "form_i3subscriber_employer_state"),
-    filter_input(INPUT_POST, "form_i3subscriber_employer_country"),
-    filter_input(INPUT_POST, 'i3copay'),
-    filter_input(INPUT_POST, 'form_i3subscriber_sex'),
-    $i3date,
-    filter_input(INPUT_POST, 'i3accept_assignment')
-);
+    newInsuranceData(
+        $pid,
+        "tertiary",
+        filter_input(INPUT_POST, "i3provider"),
+        filter_input(INPUT_POST, "i3policy_number"),
+        filter_input(INPUT_POST, "i3group_number"),
+        filter_input(INPUT_POST, "i3plan_name"),
+        filter_input(INPUT_POST, "i3subscriber_lname"),
+        filter_input(INPUT_POST, "i3subscriber_mname"),
+        filter_input(INPUT_POST, "i3subscriber_fname"),
+        filter_input(INPUT_POST, "form_i3subscriber_relationship"),
+        filter_input(INPUT_POST, "i3subscriber_ss"),
+        $i3dob,
+        filter_input(INPUT_POST, "i3subscriber_street"),
+        filter_input(INPUT_POST, "i3subscriber_postal_code"),
+        filter_input(INPUT_POST, "i3subscriber_city"),
+        filter_input(INPUT_POST, "form_i3subscriber_state"),
+        filter_input(INPUT_POST, "form_i3subscriber_country"),
+        filter_input(INPUT_POST, "i3subscriber_phone"),
+        filter_input(INPUT_POST, "i3subscriber_employer"),
+        filter_input(INPUT_POST, "i3subscriber_employer_street"),
+        filter_input(INPUT_POST, "i3subscriber_employer_city"),
+        filter_input(INPUT_POST, "i3subscriber_employer_postal_code"),
+        filter_input(INPUT_POST, "form_i3subscriber_employer_state"),
+        filter_input(INPUT_POST, "form_i3subscriber_employer_country"),
+        filter_input(INPUT_POST, 'i3copay'),
+        filter_input(INPUT_POST, 'form_i3subscriber_sex'),
+        $i3date,
+        filter_input(INPUT_POST, 'i3accept_assignment')
+    );
+}
 ?>
 <html>
 <body>

--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -63,6 +63,12 @@ if ($GLOBALS['enable_cdr']) {
         }
     }
 }
+//Check to see is only one insurance is allowed
+if($GLOBALS['insurance_only_one']){
+    $insurance_array = array('primary');
+} else {
+    $insurance_array = array('primary', 'secondary', 'tertiary');
+}
 
 function print_as_money($money)
 {
@@ -909,7 +915,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                 <ul class="tabNav"><?php
                                             ///////////////////////////////// INSURANCE SECTION
                                             $first = true;
-                                foreach (array('primary','secondary','tertiary') as $instype) {
+                                foreach ($insurance_array as $instype) {
                                     $query = "SELECT * FROM insurance_data WHERE " .
                                     "pid = ? AND type = ? " .
                                     "ORDER BY date DESC";
@@ -942,7 +948,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                         <div class="tabContainer">
                                             <?php
                                             $first = true;
-                                            foreach (array('primary','secondary','tertiary') as $instype) {
+                                            foreach ($insurance_array  as $instype) {
                                                 $enddate = 'Present';
 
                                                 $query = "SELECT * FROM insurance_data WHERE " .

--- a/interface/patient_file/summary/demographics_full.php
+++ b/interface/patient_file/summary/demographics_full.php
@@ -60,6 +60,12 @@ if ($GLOBALS['insurance_information'] != '0') {
 } else {
     $insurancei = getInsuranceProviders();
 }
+//Check to see if only one insurance is allowed
+if($GLOBALS['insurance_only_one']){
+    $insurance_array = array('primary');
+} else {
+    $insurance_array = array('primary', 'secondary', 'tertiary');
+}
 
 $fres = sqlStatement("SELECT * FROM layout_options " .
   "WHERE form_id = 'DEM' AND uor > 0 " .
@@ -554,11 +560,19 @@ $condition_str = '';
 
 <?php
 if (! $GLOBALS['simplified_demographics']) {
-    $insurance_headings = array(xl("Primary Insurance Provider"), xl("Secondary Insurance Provider"), xl("Tertiary Insurance provider"));
-    $insurance_info = array();
-    $insurance_info[1] = getInsuranceData($pid, "primary");
-    $insurance_info[2] = getInsuranceData($pid, "secondary");
-    $insurance_info[3] = getInsuranceData($pid, "tertiary");
+    //Check to see if only one insurance is allowed
+    if($GLOBALS['insurance_only_one']){
+        $insurance_headings = array(xl("Primary Insurance Provider"));
+        $insurance_info = array();
+        $insurance_info[1] = getInsuranceData($pid, "primary");
+    }else{
+        $insurance_headings = array(xl("Primary Insurance Provider"), xl("Secondary Insurance Provider"), xl("Tertiary Insurance provider"));
+        $insurance_info = array();
+        $insurance_info[1] = getInsuranceData($pid, "primary");
+        $insurance_info[2] = getInsuranceData($pid, "secondary");
+        $insurance_info[3] = getInsuranceData($pid, "tertiary");
+    }
+
 
     ?>
     <div class="section-header">
@@ -567,7 +581,7 @@ if (! $GLOBALS['simplified_demographics']) {
     <div id="INSURANCE" >
        <ul class="tabNav">
         <?php
-        foreach (array('primary','secondary','tertiary') as $instype) {
+        foreach ($insurance_array as $instype) {
             ?><li <?php echo $instype == 'primary' ? 'class="current"' : '' ?>><a href="#"><?php $CapInstype=ucfirst($instype);
 echo xlt($CapInstype); ?></a></li><?php
         }
@@ -852,26 +866,28 @@ echo xlt($CapInstype); ?></a></li><?php
                 <td colspan='2'></td>
                 <td></td>
             </tr>
-      <tr>
-        <td>
-            <label class='bold'><?php echo xlt('Secondary Medicare Type'); ?></label>
-          </td>
-        <td class='bold'>:</td>
-        <td colspan='6'>
-          <select class='form-control sel2' name='i<?php echo attr($i); ?>policy_type'>
-        <?php
-        foreach ($policy_types as $key => $value) {
-            echo "            <option value ='" . attr($key) . "'";
-            if ($key == $result3['policy_type']) {
-                echo " selected";
-            }
+            <?php if (!$GLOBALS['insurance_only_one']): ?>
+                <tr>
+                    <td>
+                        <label class='bold'><?php echo xlt('Secondary Medicare Type'); ?></label>
+                    </td>
+                    <td class='bold'>:</td>
+                    <td colspan='6'>
+                        <select class='form-control sel2' name='i<?php echo attr($i); ?>policy_type'>
+                            <?php
+                            foreach ($policy_types as $key => $value) {
+                                echo "            <option value ='" . attr($key) . "'";
+                                if ($key == $result3['policy_type']) {
+                                    echo " selected";
+                                }
 
-            echo ">" . text($value) . "</option>\n";
-        }
-        ?>
-        </select>
-      </td>
-    </tr>
+                                echo ">" . text($value) . "</option>\n";
+                            }
+                            ?>
+                        </select>
+                    </td>
+                </tr>
+            <?php endif ?>
       </table>
 
     </div>

--- a/interface/patient_file/summary/demographics_save.php
+++ b/interface/patient_file/summary/demographics_save.php
@@ -105,75 +105,77 @@ newInsuranceData(
     filter_input(INPUT_POST, 'i1policy_type')
 );
 
-$i2dob = DateToYYYYMMDD(filter_input(INPUT_POST, "i2subscriber_DOB"));
-$i2date = DateToYYYYMMDD(filter_input(INPUT_POST, "i2effective_date"));
+//Dont save more than one insurance since only one is allowed / save space in DB
+if(!$GLOBALS['insurance_only_one']) {
+    $i2dob = DateToYYYYMMDD(filter_input(INPUT_POST, "i2subscriber_DOB"));
+    $i2date = DateToYYYYMMDD(filter_input(INPUT_POST, "i2effective_date"));
 
 
-newInsuranceData(
-    $pid,
-    "secondary",
-    filter_input(INPUT_POST, "i2provider"),
-    filter_input(INPUT_POST, "i2policy_number"),
-    filter_input(INPUT_POST, "i2group_number"),
-    filter_input(INPUT_POST, "i2plan_name"),
-    filter_input(INPUT_POST, "i2subscriber_lname"),
-    filter_input(INPUT_POST, "i2subscriber_mname"),
-    filter_input(INPUT_POST, "i2subscriber_fname"),
-    filter_input(INPUT_POST, "form_i2subscriber_relationship"),
-    filter_input(INPUT_POST, "i2subscriber_ss"),
-    $i2dob,
-    filter_input(INPUT_POST, "i2subscriber_street"),
-    filter_input(INPUT_POST, "i2subscriber_postal_code"),
-    filter_input(INPUT_POST, "i2subscriber_city"),
-    filter_input(INPUT_POST, "form_i2subscriber_state"),
-    filter_input(INPUT_POST, "form_i2subscriber_country"),
-    filter_input(INPUT_POST, "i2subscriber_phone"),
-    filter_input(INPUT_POST, "i2subscriber_employer"),
-    filter_input(INPUT_POST, "i2subscriber_employer_street"),
-    filter_input(INPUT_POST, "i2subscriber_employer_city"),
-    filter_input(INPUT_POST, "i2subscriber_employer_postal_code"),
-    filter_input(INPUT_POST, "form_i2subscriber_employer_state"),
-    filter_input(INPUT_POST, "form_i2subscriber_employer_country"),
-    filter_input(INPUT_POST, 'i2copay'),
-    filter_input(INPUT_POST, 'form_i2subscriber_sex'),
-    $i2date,
-    filter_input(INPUT_POST, 'i2accept_assignment'),
-    filter_input(INPUT_POST, 'i2policy_type')
-);
+    newInsuranceData(
+        $pid,
+        "secondary",
+        filter_input(INPUT_POST, "i2provider"),
+        filter_input(INPUT_POST, "i2policy_number"),
+        filter_input(INPUT_POST, "i2group_number"),
+        filter_input(INPUT_POST, "i2plan_name"),
+        filter_input(INPUT_POST, "i2subscriber_lname"),
+        filter_input(INPUT_POST, "i2subscriber_mname"),
+        filter_input(INPUT_POST, "i2subscriber_fname"),
+        filter_input(INPUT_POST, "form_i2subscriber_relationship"),
+        filter_input(INPUT_POST, "i2subscriber_ss"),
+        $i2dob,
+        filter_input(INPUT_POST, "i2subscriber_street"),
+        filter_input(INPUT_POST, "i2subscriber_postal_code"),
+        filter_input(INPUT_POST, "i2subscriber_city"),
+        filter_input(INPUT_POST, "form_i2subscriber_state"),
+        filter_input(INPUT_POST, "form_i2subscriber_country"),
+        filter_input(INPUT_POST, "i2subscriber_phone"),
+        filter_input(INPUT_POST, "i2subscriber_employer"),
+        filter_input(INPUT_POST, "i2subscriber_employer_street"),
+        filter_input(INPUT_POST, "i2subscriber_employer_city"),
+        filter_input(INPUT_POST, "i2subscriber_employer_postal_code"),
+        filter_input(INPUT_POST, "form_i2subscriber_employer_state"),
+        filter_input(INPUT_POST, "form_i2subscriber_employer_country"),
+        filter_input(INPUT_POST, 'i2copay'),
+        filter_input(INPUT_POST, 'form_i2subscriber_sex'),
+        $i2date,
+        filter_input(INPUT_POST, 'i2accept_assignment'),
+        filter_input(INPUT_POST, 'i2policy_type')
+    );
 
-$i3dob  = DateToYYYYMMDD(filter_input(INPUT_POST, "i3subscriber_DOB"));
-$i3date = DateToYYYYMMDD(filter_input(INPUT_POST, "i3effective_date"));
+    $i3dob = DateToYYYYMMDD(filter_input(INPUT_POST, "i3subscriber_DOB"));
+    $i3date = DateToYYYYMMDD(filter_input(INPUT_POST, "i3effective_date"));
 
-newInsuranceData(
-    $pid,
-    "tertiary",
-    filter_input(INPUT_POST, "i3provider"),
-    filter_input(INPUT_POST, "i3policy_number"),
-    filter_input(INPUT_POST, "i3group_number"),
-    filter_input(INPUT_POST, "i3plan_name"),
-    filter_input(INPUT_POST, "i3subscriber_lname"),
-    filter_input(INPUT_POST, "i3subscriber_mname"),
-    filter_input(INPUT_POST, "i3subscriber_fname"),
-    filter_input(INPUT_POST, "form_i3subscriber_relationship"),
-    filter_input(INPUT_POST, "i3subscriber_ss"),
-    $i3dob,
-    filter_input(INPUT_POST, "i3subscriber_street"),
-    filter_input(INPUT_POST, "i3subscriber_postal_code"),
-    filter_input(INPUT_POST, "i3subscriber_city"),
-    filter_input(INPUT_POST, "form_i3subscriber_state"),
-    filter_input(INPUT_POST, "form_i3subscriber_country"),
-    filter_input(INPUT_POST, "i3subscriber_phone"),
-    filter_input(INPUT_POST, "i3subscriber_employer"),
-    filter_input(INPUT_POST, "i3subscriber_employer_street"),
-    filter_input(INPUT_POST, "i3subscriber_employer_city"),
-    filter_input(INPUT_POST, "i3subscriber_employer_postal_code"),
-    filter_input(INPUT_POST, "form_i3subscriber_employer_state"),
-    filter_input(INPUT_POST, "form_i3subscriber_employer_country"),
-    filter_input(INPUT_POST, 'i3copay'),
-    filter_input(INPUT_POST, 'form_i3subscriber_sex'),
-    $i3date,
-    filter_input(INPUT_POST, 'i3accept_assignment'),
-    filter_input(INPUT_POST, 'i3policy_type')
-);
-
+    newInsuranceData(
+        $pid,
+        "tertiary",
+        filter_input(INPUT_POST, "i3provider"),
+        filter_input(INPUT_POST, "i3policy_number"),
+        filter_input(INPUT_POST, "i3group_number"),
+        filter_input(INPUT_POST, "i3plan_name"),
+        filter_input(INPUT_POST, "i3subscriber_lname"),
+        filter_input(INPUT_POST, "i3subscriber_mname"),
+        filter_input(INPUT_POST, "i3subscriber_fname"),
+        filter_input(INPUT_POST, "form_i3subscriber_relationship"),
+        filter_input(INPUT_POST, "i3subscriber_ss"),
+        $i3dob,
+        filter_input(INPUT_POST, "i3subscriber_street"),
+        filter_input(INPUT_POST, "i3subscriber_postal_code"),
+        filter_input(INPUT_POST, "i3subscriber_city"),
+        filter_input(INPUT_POST, "form_i3subscriber_state"),
+        filter_input(INPUT_POST, "form_i3subscriber_country"),
+        filter_input(INPUT_POST, "i3subscriber_phone"),
+        filter_input(INPUT_POST, "i3subscriber_employer"),
+        filter_input(INPUT_POST, "i3subscriber_employer_street"),
+        filter_input(INPUT_POST, "i3subscriber_employer_city"),
+        filter_input(INPUT_POST, "i3subscriber_employer_postal_code"),
+        filter_input(INPUT_POST, "form_i3subscriber_employer_state"),
+        filter_input(INPUT_POST, "form_i3subscriber_employer_country"),
+        filter_input(INPUT_POST, 'i3copay'),
+        filter_input(INPUT_POST, 'form_i3subscriber_sex'),
+        $i3date,
+        filter_input(INPUT_POST, 'i3accept_assignment'),
+        filter_input(INPUT_POST, 'i3policy_type')
+    );
+}
  include_once("demographics.php");

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -1009,7 +1009,13 @@ $GLOBALS_METADATA = array(
             'bool',                           // data type
             '0',                              // default false
             xl('Open all expandable forms in expanded state')
-        )
+        ),
+        'insurance_only_one' => array(
+            xl('Allow only one insurance'),
+            'bool',                           // data type
+            '0',                              // default = false
+            xl('Allow only more than one insurance')
+        ),
     ),
     // Report Tab
     //

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -342,13 +342,6 @@ $GLOBALS_METADATA = array(
             xl('Navigation area includes encounter forms')
         ),
 
-        'simplified_demographics' => array(
-            xl('Simplified Demographics'),
-            'bool',                           // data type
-            '0',                              // default = false
-            xl('Omit insurance and some other things from the demographics form')
-        ),
-
         'simplified_prescriptions' => array(
             xl('Simplified Prescriptions'),
             'bool',                           // data type
@@ -460,21 +453,6 @@ $GLOBALS_METADATA = array(
             ),
             '0',                              // default
             xl('Special treatment for the Vitals form')
-        ),
-
-        'insurance_information' => array(
-            xl('Show Additional Insurance Information'),               // descriptive name
-            array(
-                '0' => xl('None'),
-                '1' => xl('Address Only'),
-                '2' => xl('Address and Postal Code'),
-                '3' => xl('Address and State'),
-                '4' => xl('Address, State and Postal Code'),
-                '5' => xl('Address, City, State and Postal Code'),
-                '6' => xl('Postal Code and Box Number')
-            ),
-            '5',                              // default
-            xl('Show Insurance Address Information in the Insurance Panel of Demographics.')
         ),
 
         'gb_how_sort_list' => array(
@@ -776,13 +754,6 @@ $GLOBALS_METADATA = array(
             xl('Enable follow-up encounters feature')
         ),
 
-        'disable_eligibility_log' => array(
-            xl('Disable Insurance Eligibility Reports Download'),
-            'bool',
-            '0',
-            xl('Do not allow insurance eligibility report log download')
-        ),
-
         'disable_chart_tracker' => array(
             xl('Disable Chart Tracker'),
             'bool',                           // data type
@@ -1010,12 +981,7 @@ $GLOBALS_METADATA = array(
             '0',                              // default false
             xl('Open all expandable forms in expanded state')
         ),
-        'insurance_only_one' => array(
-            xl('Allow only one insurance'),
-            'bool',                           // data type
-            '0',                              // default = false
-            xl('Allow only more than one insurance')
-        ),
+
     ),
     // Report Tab
     //
@@ -1867,7 +1833,51 @@ $GLOBALS_METADATA = array(
 
 
     ),
+    // Insurance Tab
+    'Insurance' => array(
+        'enable_oa' => array(
+            xl('Enable Office Ally Insurance Eligibility'),
+            'bool',
+            '0',
+            xl('Allow insurance eligibility checks using Office Ally')
+        ),
 
+        'simplified_demographics' => array(
+            xl('Simplified Demographics'),
+            'bool',                           // data type
+            '0',                              // default = false
+            xl('Omit insurance and some other things from the demographics form')
+        ),
+
+        'insurance_information' => array(
+            xl('Show Additional Insurance Information'),               // descriptive name
+            array(
+                '0' => xl('None'),
+                '1' => xl('Address Only'),
+                '2' => xl('Address and Postal Code'),
+                '3' => xl('Address and State'),
+                '4' => xl('Address, State and Postal Code'),
+                '5' => xl('Address, City, State and Postal Code'),
+                '6' => xl('Postal Code and Box Number')
+            ),
+            '5',                              // default
+            xl('Show Insurance Address Information in the Insurance Panel of Demographics.')
+        ),
+
+        'disable_eligibility_log' => array(
+            xl('Disable Insurance Eligibility Reports Download'),
+            'bool',
+            '0',
+            xl('Do not allow insurance eligibility report log download')
+        ),
+
+        'insurance_only_one' => array(
+            xl('Allow only one insurance'),
+            'bool',                           // data type
+            '0',                              // default = false
+            xl('Allow more than one insurance')
+        ),
+    ),
     // Security Tab
     //
     'Security' => array(
@@ -3072,13 +3082,6 @@ $GLOBALS_METADATA = array(
             'bool',
             '0',
             xl('Enable OpenEMR RESTful API. SSL Required')
-        ),
-
-        'enable_oa' => array(
-            xl('Enable Office Ally Insurance Eligibility'),
-            'bool',
-            '0',
-            xl('Allow insurance eligibility checks using Office Ally')
         ),
 
         'payment_gateway' => array(


### PR DESCRIPTION

#### Short description of what this resolves:
Not able to hide unused insurances for countries that only use one.

#### Changes proposed in this pull request:
Added the ability to only show one insurance in demographics along with new/search patient. Also moved some of the globals for insurance settings to a new insurance tap since they were scattered around.