### PR TITLE
Add turn API on variable to docker environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       EASY_DEV_MODE: "yes"
       EASY_DEV_MODE_NEW: "yes"
       DEVELOPER_TOOLS: "yes"
+      ACTIVATE_API: "yes"
       GITHUB_COMPOSER_TOKEN: c313de1ed5a00eb6ff9309559ec9ad01fcc553f0
     depends_on:
     - mysql


### PR DESCRIPTION
Fixes #3320



#### Short description of what this resolves:
Add Turn_API_ON environment variable to docker
this environment variable will be used to turn the OpenEMR API on from
within a docker install

