### PR TITLE
fix #3309: duplicate summary tabs and background color

### DIFF
--- a/interface/clickmap/template/css/clickmap.css
+++ b/interface/clickmap/template/css/clickmap.css
@@ -1,25 +1,21 @@
-body {
-	background-color: lightblue;		
-}
-
 .outer-container {
 	margin: 20px;
 }
 
 #container {
 	position: relative;
-	margin: 20px;	
+	margin: 20px;
 	border: 2px dashed;
 }
 
 .marker {
 	position: absolute;
-	border: 1px solid; 
+	border: 1px solid;
 	background-color: red;
-	min-width:12px; 
+	min-width:12px;
 	min-height: 12px;
 	text-align:center;
-}	
+}
 
 .count {
 	font-size: 12px;

--- a/interface/clickmap/template/general_new.html
+++ b/interface/clickmap/template/general_new.html
@@ -24,9 +24,11 @@
             </div>
         </div>
         <div class="col-12">
-            <button class="btn btn-primary btn-save" id="btn_save">{xl t="Save"}</button>
-            <button class="btn btn-secondary btn-delete" id="btn_clear">{xl t="Clear"}</button>
-            <button class="btn btn-secondary btn-cancel" id="cancel">{xl t="Cancel"}</button>
+            <div class="btn-group">
+                <button class="btn btn-primary btn-save" id="btn_save">{xl t="Save"}</button>
+                <button class="btn btn-secondary btn-delete" id="btn_clear">{xl t="Clear"}</button>
+                <button class="btn btn-secondary btn-cancel" onclick="top.restoreSession(); location.href='javascript:parent.closeTab(window.name, false)'">{xl t="Cancel"}</button>
+            </div>
             <p>
                 {xl t="Click a spot on the graphic to add a new annotation, click it again to remove it"} <br/>
                 {xl t="The 'Clear' button will remove all annotations."}
@@ -40,12 +42,8 @@
 </div>
 
 <script type="text/javascript">
-var cancellink = '{$DONT_SAVE_LINK}';
 {literal}
     $(function () {
-        $("#cancel").click(function() {
-            location.href = cancellink;
-        });
 		var optionsLabel = {/literal}{$form->optionsLabel}{literal};
 		var options = {/literal}{$form->optionList}{literal};
 		var data = {/literal}{$form->data}{literal};


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #3309 

#### Short description of what this resolves:
Fixed duplicate summary tabs.
Removed `clickmap.css` body background color.

![image](https://user-images.githubusercontent.com/22230889/78423679-aa27d600-769a-11ea-8ea2-2c60dc008696.png)
