### PR TITLE
Fix: remove report.css a tag style.

### DIFF
--- a/interface/forms/eye_mag/css/report.css
+++ b/interface/forms/eye_mag/css/report.css
@@ -47,25 +47,6 @@
 #sddm {
     z-index:31;
 }
-a:link {
-    color: black;
-}
-
-/* visited link */
-a:visited {
-    color: #000000;
-}
-
-/* mouse over link */
-a:hover {
-    color: black;
-    text-decoration: underline;
-}
-
-/* selected link */
-a:active {
-    color: black;
-}
 .fa {
     cursor: pointer;
 }


### PR DESCRIPTION
#### Short description of what this resolves:
When we have the Eye Exam, The report.css a style will affect the button font colors are incorrect.
https://github.com/openemr/openemr/pull/3323#issuecomment-609164229

![image](https://user-images.githubusercontent.com/22230889/78466232-6633e000-7731-11ea-9a01-2821fd798b9b.png)
