### PR TITLE
[SQL]: Converting tinyint to smallint to store large values

### DIFF
--- a/sql/4_2_2-to-5_0_0_upgrade.sql
+++ b/sql/4_2_2-to-5_0_0_upgrade.sql
@@ -1252,7 +1252,7 @@ CREATE TABLE `form_eye_mag_prefs` (
   `selection` varchar(255) DEFAULT NULL,
   `ZONE_ORDER` int(11) DEFAULT NULL,
   `GOVALUE` varchar(10) DEFAULT '0',
-  `ordering` tinyint(4) DEFAULT NULL,
+  `ordering` smallint(6) DEFAULT NULL,
   `FILL_ACTION` varchar(10) NOT NULL DEFAULT 'ADD',
   `GORIGHT` varchar(50) NOT NULL,
   `GOLEFT` varchar(50) NOT NULL,

--- a/sql/4_2_2-to-5_0_0_upgrade.sql
+++ b/sql/4_2_2-to-5_0_0_upgrade.sql
@@ -1252,7 +1252,7 @@ CREATE TABLE `form_eye_mag_prefs` (
   `selection` varchar(255) DEFAULT NULL,
   `ZONE_ORDER` int(11) DEFAULT NULL,
   `GOVALUE` varchar(10) DEFAULT '0',
-  `ordering` smallint(6) DEFAULT NULL,
+  `ordering` tinyint(4) DEFAULT NULL,
   `FILL_ACTION` varchar(10) NOT NULL DEFAULT 'ADD',
   `GORIGHT` varchar(50) NOT NULL,
   `GOLEFT` varchar(50) NOT NULL,

--- a/sql/5_0_2-to-5_0_3_upgrade.sql
+++ b/sql/5_0_2-to-5_0_3_upgrade.sql
@@ -432,6 +432,6 @@ INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`
 INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `activity`) VALUES ('Sort_Direction', '1', 'desc', 20, 0, 1);
 #EndIf
 
-#IfNotColumnType form_eye_mag_prefs ordering smallint(6) NULL
-ALTER TABLE `form_eye_mag_prefs` MODIFY `ordering` smallint(6) NULL;
+#IfNotColumnType form_eye_mag_prefs ordering smallint(6)
+ALTER TABLE `form_eye_mag_prefs` MODIFY `ordering` smallint(6) DEFAULT NULL;
 #EndIf

--- a/sql/5_0_2-to-5_0_3_upgrade.sql
+++ b/sql/5_0_2-to-5_0_3_upgrade.sql
@@ -431,3 +431,7 @@ INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`
 #IfNotRow2D list_options list_id Sort_Direction option_id 1
 INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `activity`) VALUES ('Sort_Direction', '1', 'desc', 20, 0, 1);
 #EndIf
+
+#IfNotColumnType form_eye_mag_prefs ordering smallint(6) NULL
+ALTER TABLE `form_eye_mag_prefs` MODIFY `ordering` smallint(6) NULL;
+#EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -9529,7 +9529,7 @@ CREATE TABLE `form_eye_mag_prefs` (
   `selection` varchar(255) DEFAULT NULL,
   `ZONE_ORDER` int(11) DEFAULT NULL,
   `GOVALUE` varchar(10) DEFAULT '0',
-  `ordering` tinyint(4) DEFAULT NULL,
+  `ordering` smallint(4) DEFAULT NULL,
   `FILL_ACTION` varchar(10) NOT NULL DEFAULT 'ADD',
   `GORIGHT` varchar(50) NOT NULL,
   `GOLEFT` varchar(50) NOT NULL,

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -9529,7 +9529,7 @@ CREATE TABLE `form_eye_mag_prefs` (
   `selection` varchar(255) DEFAULT NULL,
   `ZONE_ORDER` int(11) DEFAULT NULL,
   `GOVALUE` varchar(10) DEFAULT '0',
-  `ordering` smallint(4) DEFAULT NULL,
+  `ordering` smallint(6) DEFAULT NULL,
   `FILL_ACTION` varchar(10) NOT NULL DEFAULT 'ADD',
   `GORIGHT` varchar(50) NOT NULL,
   `GOLEFT` varchar(50) NOT NULL,

--- a/version.php
+++ b/version.php
@@ -27,7 +27,7 @@ $v_realpatch = '0';
 // is a database change in the course of development.  It is used
 // internally to determine when a database upgrade is needed.
 //
-$v_database = 312;
+$v_database = 314;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
Github Issue:
https://github.com/openemr/openemr/issues/3239

<!--
(Thanks for sending a pull request!
-->

#### Short description of what this resolves:
In the table `form_eye_mag_prefs1` the type of `ordering` column is changed from `tinyint` to smallint to store larger values as one of the insert statement is having the value `2048`
Initially without `SQL_MODE` it's stores the max value in the tinyint ie. 127 but with `SQL_MODE` it throws error

#### Changes proposed in this pull request:

- Changed the type of ordering column from `tinyint` to `smallint`
-
-
Note:
- Thinking of using [SQL] in the SQL_MODE related PRs, what are your thoughts on the same?  