### PR TITLE
feat #2888: add float calendar widget

### DIFF
--- a/interface/themes/ajax_calendar_sass.scss
+++ b/interface/themes/ajax_calendar_sass.scss
@@ -6,7 +6,6 @@
 @each $breakpoint in map-keys($grid-breakpoints) {
   @include media-breakpoint-up($breakpoint) {
       $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
-      
     }
 }
 
@@ -41,11 +40,16 @@ div.tiny {
 }
 
 .page-content-wrapper {
-    width: 100%;
+    width: 85%;
+    margin-left: 15%;
 }
 
 #wrapper.toggled .sidebar-wrapper {
     margin-left: 0;
+}
+
+#wrapper.toggled .page-content-wrapper {
+    margin-left: 0%;
 }
 
 #functions {
@@ -149,6 +153,8 @@ div.tiny {
 #bottomLeft {
     width: 15%;
     min-width: 8.75rem;
+    position: fixed;
+    top: 45px;
     float: left;
     clear: left;
 }
@@ -513,6 +519,16 @@ div.tiny {
     #nextmonth {
         @include font-size("1.3rem !important");
     }
+
+    .page-content-wrapper {
+        margin-left: 0%;
+        width: 100%;
+    }
+
+    #wrapper.toggled .page-content-wrapper {
+        width: 85%;
+        margin-left: 15%;
+    }
 }
 
 @media (min-width: 768px) {
@@ -522,10 +538,16 @@ div.tiny {
 
     .page-content-wrapper {
         min-width: 0;
-        width: 100%;
+        width: 85%;
+        margin-left: 15%;
     }
 
     #wrapper.toggled .sidebar-wrapper {
         margin-left: -30rem;
+    }
+
+    #wrapper.toggled .page-content-wrapper {
+        width: 100%;
+        margin-left: 0%;
     }
 }

--- a/interface/themes/ajax_calendar_sass.scss
+++ b/interface/themes/ajax_calendar_sass.scss
@@ -62,6 +62,7 @@ div.tiny {
 
 
 #topToolbarRight {
+    position: fixed;
     float: right;
     width: 100%;
     border-bottom: 1px solid $black;
@@ -143,6 +144,7 @@ div.tiny {
     border: none;
     vertical-align: middle;
     width: 100%;
+    margin-top: 45px;
 }
 
 #bigCal td {

--- a/interface/themes/ajax_calendar_sass.scss
+++ b/interface/themes/ajax_calendar_sass.scss
@@ -63,6 +63,7 @@ div.tiny {
     width: 100%;
     border-bottom: 1px solid $black;
     padding: 0.3125rem 0 0.1875rem 0;
+    z-index: 3;
 }
 
 #dateNAV {

--- a/interface/themes/ajax_calendar_sass.scss
+++ b/interface/themes/ajax_calendar_sass.scss
@@ -39,17 +39,13 @@ div.tiny {
     transition: margin .25s ease-out;
 }
 
-.page-content-wrapper {
-    width: 85%;
-    margin-left: 15%;
-}
-
 #wrapper.toggled .sidebar-wrapper {
     margin-left: 0;
+    top: 68px;
 }
 
 #wrapper.toggled .page-content-wrapper {
-    margin-left: 0%;
+    margin-left: 8.75rem;
 }
 
 #functions {
@@ -154,7 +150,7 @@ div.tiny {
 
 #bottomLeft {
     width: 15%;
-    min-width: 8.75rem;
+    min-width: 130px;
     position: fixed;
     top: 45px;
     float: left;
@@ -528,12 +524,18 @@ div.tiny {
     }
 
     #wrapper.toggled .page-content-wrapper {
-        width: 85%;
-        margin-left: 15%;
+        width: calc(100% - 150px);
+        margin-left: 130px;
     }
 }
 
-@media (min-width: 768px) {
+@media(max-width: 665px) {
+    #bigCal > table {
+        margin-top: 68px;
+    }
+}
+
+@media (min-width: 860px) {
     .sidebar-wrapper {
         margin-left: 0;
     }


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #2888 

#### Short description of what this resolves:
Added float calendar widget on page scroll 

Testing on Edge, Chrome, and Firefox.

Edge - Default
![image](https://user-images.githubusercontent.com/22230889/78518496-3b11c500-77f3-11ea-81fc-1b2e48647dc1.png)

Edge - Page Scroll Down
![image](https://user-images.githubusercontent.com/22230889/78518534-4fee5880-77f3-11ea-9f41-4428c008da4f.png)

Chrome - Default
![image](https://user-images.githubusercontent.com/22230889/78518608-89bf5f00-77f3-11ea-9952-532732516c3f.png)

Chrome - Page Scroll Down
![image](https://user-images.githubusercontent.com/22230889/78518620-917f0380-77f3-11ea-86f7-b9bea02e6e80.png)

Firefox - Default
![image](https://user-images.githubusercontent.com/22230889/78518670-b2dfef80-77f3-11ea-8666-e74cf26eb742.png)

Firefox - Page Scroll Down
![image](https://user-images.githubusercontent.com/22230889/78518684-b7a4a380-77f3-11ea-96f6-47af27133d07.png)

