### PR TITLE
Change from 'like' to '=' in rxcui query 'where' clauses

### DIFF
--- a/library/classes/Prescription.class.php
+++ b/library/classes/Prescription.class.php
@@ -603,8 +603,8 @@ class Prescription extends ORDataObject
         $this->drug = $drug;
 
         if ($GLOBALS['weno_rx_enable']) {
-            $sql = "SELECT rxcui_drug_coded FROM erx_weno_drugs WHERE full_name LIKE ? ";
-            $val = array('%'.$drug.'%');
+            $sql = "SELECT rxcui_drug_coded FROM erx_weno_drugs WHERE full_name = ? ";
+            $val = array($drug);
             $ndc = sqlQuery($sql, $val);
             $drug_id = $ndc['rxcui_drug_coded'];
             //Save this drug id
@@ -615,8 +615,8 @@ class Prescription extends ORDataObject
     {
         if ($GLOBALS['weno_rx_enable']) {
             $drug = trim($this->drug);
-            $sql = "SELECT rxcui_drug_coded FROM erx_weno_drugs WHERE full_name  LIKE ? ";
-            $val = array('%'.$drug.'%');
+            $sql = "SELECT rxcui_drug_coded FROM erx_weno_drugs WHERE full_name = ? ";
+            $val = array($drug);
             $ndc = sqlQuery($sql, $val);
             $drug_id = $ndc['rxcui_drug_coded'];
             //Save this drug id
@@ -624,6 +624,7 @@ class Prescription extends ORDataObject
         }
         return $this->drug;
     }
+
     function set_ntx($ntx)
     {
         $this->ntx = $ntx;


### PR DESCRIPTION
There probably should be some refactoring of the entire drug selection process, but for now this fixes the error where the wrong rxcui code was sometimes selected and stored for a prescription.  That obviously is a potentially serious patient safety issue, as if this is not caught before the prescription is transmitted by the e-prescribing gateway then potentially the wrong drug could inadvertently be prescribed and dispensed.  To avoid this issue the 'where' clause in the set_drug() and get_drug() functions was changed from 'like' to '=' on the drug 'full_name'.

<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-