### PR TITLE
Improve API and FHIR docs

### DIFF
--- a/API_README.md
+++ b/API_README.md
@@ -1,8 +1,19 @@
-![img](./public/images/openemr-rest-api.png)
+# OpenEMR REST API Documentation
 
-### Overview
+## Overview
 
-Easy-to-use JSON-based REST API for OpenEMR. All code is done in classes and separate from the view to help with codebase modernization efforts. FHIR is also supported.
+Easy-to-use JSON-based REST API for OpenEMR. All code is done in classes and separate from the view to help with codebase modernization efforts. FHIR is also supported, see FHIR API documentation [here](FHIR_README.md)
+
+### Sections
+* [facility API](API_README.md#post-apifacility)
+* [provider API](API_README.md#get-apiprovider)
+* [patient API](API_README.md#post-apipatient)
+* [insurance API](API_README.md#get-apipatientpidinsurance)
+* [appointment API](API_README.md#get-apiappointment)
+* [document API](API_README.md#get-apipatientpiddocument)
+* [message API](API_README.md#post-apipatientpidmessage)
+* [dev notes](API_README.md#dev-notes)
+* [todos](API_README.md#project-management)
 
 ### Prerequisite
 Enable this API service in OpenEMR menu: Administration->Globals->Connectors->"Enable OpenEMR REST API"
@@ -12,13 +23,12 @@ There are several ways to make API calls from an authorized session and maintain
 * See the script at tests/api/InternalApiTest.php for examples of internal API use cases.
 
 ### Endpoints
-Note: FHIR endpoints follow normal FHIR REST endpoints. Use `http://localhost:8300/apis/fhir as base URI.`
+OpenEMR standard endpoints Use `http://localhost:8300/apis/ as base URI.`
 
-_Example:_ `http://localhost:8300/apis/fhir/Patient` returns a Patients bundle resource and etc..
+_Example:_ `http://localhost:8300/apis/api/patient` returns a resource of all Patients.
+#### POST /apis/auth
 
-#### POST /api/auth
-
-Obtain an API token with your login (returns an API token). For FHIR replace Uri component 'api' with 'fhir':
+Obtain an API token with your login (returns an API token). 
 Scope must match a site that has been setup in OpenEMR in the /sites/ directory.  If you haven't created additional sites
 then 'default' should be the scope.
 
@@ -42,12 +52,14 @@ Response:
     }
 }
 ```
-Each call must include the token:
+For ssh calls, each call must include the token:
 
 ```sh
 curl -X GET 'http://localhost:8300/apis/api/patient/1/medical_problem' \
   -H 'Authorization: Bearer eyJ0b2tlbiI6IjAwNmZ4TWpsNWhsZmNPelZicXBEdEZVUlNPQUY5KzdzR1Jjejc4WGZyeGFjUjY2QlhaaEs4eThkU3cxbTd5VXFBeTVyeEZpck9mVzBQNWc5dUlidERLZ0trUElCME5wRDVtTVk5bE9WaE5DTHF5RnRnT0Q0OHVuaHRvbXZ6OTEyNmZGUmVPUllSYVJORGoyZTkzTDA5OWZSb0ZRVGViTUtWUFd4ZW5cL1piSzhIWFpJZUxsV3VNcUdjQXR5dmlLQXRXNDAiLCJzaXRlX2lkIjoiZGVmYXVsdCIsImFwaSI6Im9lbXIifQ=='
 ```
+
+While using an API client you can include the token as part of authorization 
 
 #### POST /api/facility
 
@@ -806,9 +818,9 @@ curl -X DELETE 'http://localhost:8300/apis/api/patient/1/message/1'
 
 ### Dev Notes
 
-- For business logic, make or use the services [here](https://github.com/openemr/openemr/tree/master/services)
-- For controller logic, make or use the classes [here](https://github.com/openemr/openemr/tree/master/rest_controllers)
-- For routing declarations, use the class [here](https://github.com/openemr/openemr/blob/master/_rest_routes.inc.php).
+- For business logic, make or use the services [here](src/Services)
+- For controller logic, make or use the classes [here](src/RestControllers)
+- For routing declarations, use the class [here](_rest_routes.inc.php).
 
 
 ### Project Management
@@ -823,14 +835,4 @@ curl -X DELETE 'http://localhost:8300/apis/api/patient/1/message/1'
 - TODO(?): Drug search API
 - TODO(?): API for onotes
 
-#### FHIR
-- TODO(?): ?
 
-### What is that dog drawing?
-
-That is Peppy, an old OpenEMR mascot. Long live Peppy!
-
-
-### License
-
-[GNU GPL](../LICENSE)

--- a/FHIR_README.md
+++ b/FHIR_README.md
@@ -44,7 +44,7 @@ Response:
     }
 }
 ```
-For ssh calls each call must include the token:
+For ssh calls, each call must include the token:
 
 
 ```sh
@@ -62,9 +62,9 @@ curl -X GET 'http://localhost:8300/apis/fhir/Patient'
 
 ### Dev Notes
 
-- For business logic, make or use the services [here](https://github.com/openemr/openemr/tree/master/services)
-- For controller logic, make or use the classes [here](https://github.com/openemr/openemr/tree/master/rest_controllers)
-- For routing declarations, use the class [here](https://github.com/openemr/openemr/blob/master/_rest_routes.inc.php).
+- For business logic, make or use the services [here](src/Services/FHIR)
+- For controller logic, make or use the classes [here](src/RestControllers/FHIR)
+- For routing declarations, use the class [here](_rest_routes.inc.php).
 
 
 ### Project Management
@@ -72,6 +72,3 @@ curl -X GET 'http://localhost:8300/apis/fhir/Patient'
 #### FHIR
 - TODO(?): ?
 
-### License
-
-[GNU GPL](../LICENSE)


### PR DESCRIPTION
Remove Licence from API and FHIR docs
Fix broken services and controller links for both docs
Add sections to API docs for easy navigation
Remove FHIR docs from API docs
Add single refrence for FHIR docs in API docs

Fixes issues #3361 #3366
