### PR TITLE
Updating Email Address Listed In Copyright Notice

### DIFF
--- a/src/Validators/BaseValidator.php
+++ b/src/Validators/BaseValidator.php
@@ -10,9 +10,9 @@ use OpenEMR\Validators\ProcessingResult;
  * Validation processes are implemented using Particle (https://github.com/particle-php/Validator)
  * @package   OpenEMR
  * @link      http://www.open-emr.org
- * @author    Dixon Whitmire <dixon.whitmire@ibm.com>
+ * @author    Dixon Whitmire <dixonwh@gmail.com>
  * @copyright Copyright (c) 2020 Jerry Padgett <sjpadgett@gmail.com>
- * @copyright Copyright (c) 2020 Dixon Whitmire <dixon.whitmire@ibm.com>
+ * @copyright Copyright (c) 2020 Dixon Whitmire <dixonwh@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 abstract class BaseValidator

--- a/src/Validators/PatientValidator.php
+++ b/src/Validators/PatientValidator.php
@@ -10,9 +10,9 @@ use Particle\Validator\Exception\InvalidValueException;
  *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
- * @author    Dixon Whitmire <dixon.whitmire@ibm.com>
+ * @author    Dixon Whitmire <dixonwh@gmail.com>
  * @copyright Copyright (c) 2020 Jerry Padgett <sjpadgett@gmail.com>
- * @copyright Copyright (c) 2020 Dixon Whitmire <dixon.whitmire@ibm.com>
+ * @copyright Copyright (c) 2020 Dixon Whitmire <dixonwh@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 class PatientValidator extends BaseValidator

--- a/src/Validators/ProcessingResult.php
+++ b/src/Validators/ProcessingResult.php
@@ -13,8 +13,8 @@ namespace OpenEMR\Validators;
  *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
- * @author    Dixon Whitmire <dixon.whitmire@ibm.com>
- * @copyright Copyright (c) 2020 Dixon Whitmire <dixon.whitmire@ibm.com>
+ * @author    Dixon Whitmire <dixonwh@gmail.com>
+ * @copyright Copyright (c) 2020 Dixon Whitmire <dixonwh@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 

--- a/tests/Tests/Fixtures/FixtureManager.php
+++ b/tests/Tests/Fixtures/FixtureManager.php
@@ -12,8 +12,8 @@ namespace OpenEMR\Tests\Fixtures;
  *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
- * @author    Dixon Whitmire <dixon.whitmire@ibm.com>
- * @copyright Copyright (c) 2020 Dixon Whitmire <dixon.whitmire@ibm.com>
+ * @author    Dixon Whitmire <dixonwh@gmail.com>
+ * @copyright Copyright (c) 2020 Dixon Whitmire <dixonwh@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 class FixtureManager

--- a/tests/Tests/Fixtures/FixtureManagerTest.php
+++ b/tests/Tests/Fixtures/FixtureManagerTest.php
@@ -10,8 +10,8 @@ use OpenEMR\Tests\Fixtures\FixtureManager;
  *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
- * @author    Dixon Whitmire <dixon.whitmire@ibm.com>
- * @copyright Copyright (c) 2020 Dixon Whitmire <dixon.whitmire@ibm.com>
+ * @author    Dixon Whitmire <dixonwh@gmail.com>
+ * @copyright Copyright (c) 2020 Dixon Whitmire <dixonwh@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 class FixtureManagerTest extends TestCase

--- a/tests/Tests/Services/PatientServiceTest.php
+++ b/tests/Tests/Services/PatientServiceTest.php
@@ -11,8 +11,8 @@ use OpenEMR\Tests\Fixtures\FixtureManager;
  * @coversDefaultClass OpenEMR\Services\PatientService
  * @package   OpenEMR
  * @link      http://www.open-emr.org
- * @author    Dixon Whitmire <dixon.whitmire@ibm.com>
- * @copyright Copyright (c) 2020 Dixon Whitmire <dixon.whitmire@ibm.com>
+ * @author    Dixon Whitmire <dixonwh@gmail.com>
+ * @copyright Copyright (c) 2020 Dixon Whitmire <dixonwh@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  *
  */

--- a/tests/Tests/Validators/ProcessingResultTest.php
+++ b/tests/Tests/Validators/ProcessingResultTest.php
@@ -11,8 +11,8 @@ use OpenEMR\Validators\ProcessingResult;
  * @coversDefaultClass OpenEMR\Services\ServiceResult
  * @package   OpenEMR
  * @link      http://www.open-emr.org
- * @author    Dixon Whitmire <dixon.whitmire@ibm.com>
- * @copyright Copyright (c) 2020 Dixon Whitmire <dixon.whitmire@ibm.com>
+ * @author    Dixon Whitmire <dixonwh@gmail.com>
+ * @copyright Copyright (c) 2020 Dixon Whitmire <dixonwh@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  *
  */


### PR DESCRIPTION
Fixes #3353 (sort of :) 

#### Short description of what this resolves:
This PR simply updates the email address I'm listing in OpenEMR's copyright notices.

Hi @bradymiller - I'm still on-board to enhance/update OpenEMR's API and FHIR publishing features. I just need to update the email address I'm using. Thanks!