### PR TITLE
[SQL]: Fix #3378 fix default timestamp issue `amendments_history`

### DIFF
--- a/sql/5_0_2-to-5_0_3_upgrade.sql
+++ b/sql/5_0_2-to-5_0_3_upgrade.sql
@@ -447,3 +447,7 @@ ALTER TABLE `codes` MODIFY `code_text_short` varchar(255) NOT NULL default '';
 #IfNotColumnTypeDefault amendments created_time timestamp NULL
 ALTER TABLE `amendments` MODIFY `created_time` timestamp NULL COMMENT 'created time';
 #EndIf
+
+#IfNotColumnTypeDefault amendments_history created_time timestamp NULL
+ALTER TABLE `amendments_history` MODIFY `created_time` timestamp NULL COMMENT 'created time';
+#EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -75,7 +75,7 @@ CREATE TABLE `amendments_history` (
   `amendment_note` text COMMENT 'Amendment requested from',
   `amendment_status` VARCHAR(50) NULL COMMENT 'Amendment Request Status',
   `created_by` int(11) NOT NULL COMMENT 'references users.id for session owner',
-  `created_time` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00' COMMENT 'created time',
+  `created_time` timestamp NULL COMMENT 'created time',
 KEY amendment_history_id(`amendment_id`)
 ) ENGINE = InnoDB;
 

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@ $v_realpatch = '0';
 // is a database change in the course of development.  It is used
 // internally to determine when a database upgrade is needed.
 //
-$v_database = 316;
+$v_database = 317;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #3378

#### Short description of what this resolves:
We removed the wrong default timestamp and instead of that made the `created_time` column of the table `amendments_history ` nullable.

#### Changes proposed in this pull request:

- Changed in the database schema file (sql/database.sql)
- Added the upgrade script
-