### PR TITLE
[SQL]: Fix #3378 fix default datetime issue `batchcom`

### DIFF
--- a/sql/5_0_2-to-5_0_3_upgrade.sql
+++ b/sql/5_0_2-to-5_0_3_upgrade.sql
@@ -451,3 +451,7 @@ ALTER TABLE `amendments` MODIFY `created_time` timestamp NULL COMMENT 'created t
 #IfNotColumnTypeDefault amendments_history created_time timestamp NULL
 ALTER TABLE `amendments_history` MODIFY `created_time` timestamp NULL COMMENT 'created time';
 #EndIf
+
+#IfNotColumnTypeDefault batchcom msg_date_sent datetime NULL
+ALTER TABLE `batchcom` MODIFY `msg_date_sent` datetime NULL;
+#EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -161,7 +161,7 @@ CREATE TABLE `batchcom` (
   `msg_type` varchar(60) default NULL,
   `msg_subject` varchar(255) default NULL,
   `msg_text` mediumtext,
-  `msg_date_sent` datetime NOT NULL default '0000-00-00 00:00:00',
+  `msg_date_sent` datetime NULL,
   PRIMARY KEY  (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 ;
 

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@ $v_realpatch = '0';
 // is a database change in the course of development.  It is used
 // internally to determine when a database upgrade is needed.
 //
-$v_database = 317;
+$v_database = 318;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #3378

#### Short description of what this resolves:
We removed the wrong default timestamp and instead of that made the `msg_date_sent` column of the table `batchcom ` nullable.

#### Changes proposed in this pull request:

- Changed in the database schema file (sql/database.sql)
- Added the upgrade script
-