### PR TITLE
[SQL]: Fix #3378 fix default date issue `drug_inventory`

### DIFF
--- a/sql/5_0_2-to-5_0_3_upgrade.sql
+++ b/sql/5_0_2-to-5_0_3_upgrade.sql
@@ -455,3 +455,7 @@ ALTER TABLE `amendments_history` MODIFY `created_time` timestamp NULL COMMENT 'c
 #IfNotColumnTypeDefault batchcom msg_date_sent datetime NULL
 ALTER TABLE `batchcom` MODIFY `msg_date_sent` datetime NULL;
 #EndIf
+
+#IfNotColumnTypeDefault drug_inventory last_notify date NULL
+ALTER TABLE `drug_inventory` MODIFY `last_notify` date NULL;
+#EndIf

--- a/sql/5_0_2-to-5_0_3_upgrade.sql
+++ b/sql/5_0_2-to-5_0_3_upgrade.sql
@@ -446,16 +446,32 @@ ALTER TABLE `codes` MODIFY `code_text_short` varchar(255) NOT NULL default '';
 
 #IfNotColumnTypeDefault amendments created_time timestamp NULL
 ALTER TABLE `amendments` MODIFY `created_time` timestamp NULL COMMENT 'created time';
+SET @currentSQLMode = SELECT @@sql_mode;
+SET sql_mode = '';
+UPDATE `amendments` SET `created_time` = NULL WHERE `created_time` = '0000-00-00 00:00:00';
+SET sql_mode = @currentSQLMode;
 #EndIf
 
 #IfNotColumnTypeDefault amendments_history created_time timestamp NULL
 ALTER TABLE `amendments_history` MODIFY `created_time` timestamp NULL COMMENT 'created time';
+SET @currentSQLMode = SELECT @@sql_mode;
+SET sql_mode = '';
+UPDATE `amendments_history` SET `created_time` = NULL WHERE `created_time` = '0000-00-00 00:00:00';
+SET sql_mode = @currentSQLMode;
 #EndIf
 
 #IfNotColumnTypeDefault batchcom msg_date_sent datetime NULL
 ALTER TABLE `batchcom` MODIFY `msg_date_sent` datetime NULL;
+SET @currentSQLMode = SELECT @@sql_mode;
+SET sql_mode = '';
+UPDATE `batchcom` SET `msg_date_sent` = NULL WHERE `msg_date_sent` = '0000-00-00 00:00:00';
+SET sql_mode = @currentSQLMode;
 #EndIf
 
 #IfNotColumnTypeDefault drug_inventory last_notify date NULL
 ALTER TABLE `drug_inventory` MODIFY `last_notify` date NULL;
+SET @currentSQLMode = SELECT @@sql_mode;
+SET sql_mode = '';
+UPDATE `drug_inventory` SET `last_notify` = NULL WHERE `last_notify` = '0000-00-00';
+SET sql_mode = @currentSQLMode;
 #EndIf

--- a/sql/5_0_2-to-5_0_3_upgrade.sql
+++ b/sql/5_0_2-to-5_0_3_upgrade.sql
@@ -446,7 +446,7 @@ ALTER TABLE `codes` MODIFY `code_text_short` varchar(255) NOT NULL default '';
 
 #IfNotColumnTypeDefault amendments created_time timestamp NULL
 ALTER TABLE `amendments` MODIFY `created_time` timestamp NULL COMMENT 'created time';
-SET @currentSQLMode = SELECT @@sql_mode;
+SET @currentSQLMode = (SELECT @@sql_mode);
 SET sql_mode = '';
 UPDATE `amendments` SET `created_time` = NULL WHERE `created_time` = '0000-00-00 00:00:00';
 SET sql_mode = @currentSQLMode;
@@ -454,7 +454,7 @@ SET sql_mode = @currentSQLMode;
 
 #IfNotColumnTypeDefault amendments_history created_time timestamp NULL
 ALTER TABLE `amendments_history` MODIFY `created_time` timestamp NULL COMMENT 'created time';
-SET @currentSQLMode = SELECT @@sql_mode;
+SET @currentSQLMode = (SELECT @@sql_mode);
 SET sql_mode = '';
 UPDATE `amendments_history` SET `created_time` = NULL WHERE `created_time` = '0000-00-00 00:00:00';
 SET sql_mode = @currentSQLMode;
@@ -462,7 +462,7 @@ SET sql_mode = @currentSQLMode;
 
 #IfNotColumnTypeDefault batchcom msg_date_sent datetime NULL
 ALTER TABLE `batchcom` MODIFY `msg_date_sent` datetime NULL;
-SET @currentSQLMode = SELECT @@sql_mode;
+SET @currentSQLMode = (SELECT @@sql_mode);
 SET sql_mode = '';
 UPDATE `batchcom` SET `msg_date_sent` = NULL WHERE `msg_date_sent` = '0000-00-00 00:00:00';
 SET sql_mode = @currentSQLMode;
@@ -470,7 +470,7 @@ SET sql_mode = @currentSQLMode;
 
 #IfNotColumnTypeDefault drug_inventory last_notify date NULL
 ALTER TABLE `drug_inventory` MODIFY `last_notify` date NULL;
-SET @currentSQLMode = SELECT @@sql_mode;
+SET @currentSQLMode = (SELECT @@sql_mode);
 SET sql_mode = '';
 UPDATE `drug_inventory` SET `last_notify` = NULL WHERE `last_notify` = '0000-00-00';
 SET sql_mode = @currentSQLMode;

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -1274,7 +1274,7 @@ CREATE TABLE `drug_inventory` (
   `on_hand` int(11) NOT NULL default '0',
   `warehouse_id` varchar(31) NOT NULL DEFAULT '',
   `vendor_id` bigint(20) NOT NULL DEFAULT 0,
-  `last_notify` date NOT NULL default '0000-00-00',
+  `last_notify` date NULL,
   `destroy_date` date default NULL,
   `destroy_method` varchar(255) default NULL,
   `destroy_witness` varchar(255) default NULL,

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@ $v_realpatch = '0';
 // is a database change in the course of development.  It is used
 // internally to determine when a database upgrade is needed.
 //
-$v_database = 318;
+$v_database = 319;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #3378

#### Short description of what this resolves:
We removed the wrong default date and instead of that made the `last_notify` column of the table `drug_inventory ` nullable.

#### Changes proposed in this pull request:

- Changed in the database schema file (sql/database.sql)
- Added the upgrade script
- Added the Update SQL command to update past records (for previous ones also)