### PR TITLE
Add cli commands for installing Laminas modules

### DIFF
--- a/interface/modules/zend_modules/module/Installer/Module.php
+++ b/interface/modules/zend_modules/module/Installer/Module.php
@@ -48,7 +48,7 @@ class Module
         return [
             ['zfc-module', 'Part of route for console call'],
             ['--site=<site_name>', 'Name of site, by default: "default" '],
-            ['--modaction=<action_name>', 'Available actions: install_sql, install_acl, upgrade_acl, upgrade_sql,install,enable,disable,unregister'],
+            ['--modaction=<action_name>', 'Available actions: install_sql, install_acl, upgrade_acl, upgrade_sql, install, enable, disable, unregister'],
             ['--modname=<module_name>', 'Name of module'],
         ];
     }

--- a/interface/modules/zend_modules/module/Installer/Module.php
+++ b/interface/modules/zend_modules/module/Installer/Module.php
@@ -48,7 +48,7 @@ class Module
         return [
             ['zfc-module', 'Part of route for console call'],
             ['--site=<site_name>', 'Name of site, by default: "default" '],
-            ['--modaction=<action_name>', 'Available actions: install_sql, install_acl, upgrade_acl, upgrade_sql'],
+            ['--modaction=<action_name>', 'Available actions: install_sql, install_acl, upgrade_acl, upgrade_sql,install,enable,disable,unregister'],
             ['--modname=<module_name>', 'Name of module'],
         ];
     }

--- a/interface/modules/zend_modules/module/Installer/Module.php
+++ b/interface/modules/zend_modules/module/Installer/Module.php
@@ -50,6 +50,9 @@ class Module
             ['--site=<site_name>', 'Name of site, by default: "default" '],
             ['--modaction=<action_name>', 'Available actions: install_sql, install_acl, upgrade_acl, upgrade_sql, install, enable, disable, unregister'],
             ['--modname=<module_name>', 'Name of module'],
+            ['register', 'Part of route for console call'],
+            ['--mtype=<module_type>', 'module'],
+            ['--modname=<module_name>', 'Name of module'],
         ];
     }
 }

--- a/interface/modules/zend_modules/module/Installer/config/module.config.php
+++ b/interface/modules/zend_modules/module/Installer/config/module.config.php
@@ -54,6 +54,7 @@ return array(
     'console' => array(
         'router' => array(
             'routes' => array(
+
                 'zfc-module' => array(
                     'options' => array(
                         'route' => 'zfc-module --site= --modaction= --modname= ',
@@ -63,6 +64,17 @@ return array(
                         ),
                     )
                 ),
+
+                'register' => array(
+                    'options' => array(
+                        'route'    => 'register --mtype= --modname=',
+                        'defaults' => array(
+                            'controller' => Installer\Controller\InstallerController::class,
+                            'action'     => 'register',
+                        ),
+                    ),
+                ),
+
             )
         )
     ),

--- a/interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php
+++ b/interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php
@@ -109,16 +109,11 @@ class InstallerController extends AbstractActionController
                     $status = true;
                 }
             }
-
             die($status ? $this->listenerObject->z_xlt("Success") : $this->listenerObject->z_xlt("Failure"));
-
         } else {
-
             $moduleType = $request->getParam('mtype');
             $moduleName = $request->getParam('modname');
-
             if ($moduleType == 'zend') {
-
                 $rel_path = "public/" . $moduleName . "/";
                 // registering the table inserts the module record into the database.
                 // it's always loaded regardless, but it inserts it in the database as not activated
@@ -146,7 +141,6 @@ class InstallerController extends AbstractActionController
                 $modId = $request->getPost('modId');
                 $mod_enc_menu = $request->getPost('mod_enc_menu');
                 $mod_nick_name = $request->getPost('mod_nick_name');
-
                 $status = $this->InstallModule($modId, $mod_enc_menu, $mod_nick_name);
             } elseif ($request->getPost('modAction') == 'install_sql') {
                 if ($this->InstallModuleSQL($request->getPost('modId'))) {
@@ -174,13 +168,11 @@ class InstallerController extends AbstractActionController
                 $status = $this->UnregisterModule($request->getPost('modId'));
             }
         }
-
         $output = "";
         if (is_array($div)) {
             $output = implode("<br />\n", $div);
         }
         echo json_encode(["status" => $status, "output" => $output]);
-
         exit(0);
     }
 

--- a/interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php
+++ b/interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php
@@ -121,13 +121,17 @@ class InstallerController extends AbstractActionController
         $status = $this->listenerObject->z_xlt("Failure");
         if ($request->isPost()) {
             if ($request->getPost('modAction') == "enable") {
-                $status =$this->InstallModuleSQL($request->getPost('modId'));
+                $status =$this->EnableModule($request->getPost('modId'));
             }
             elseif ($request->getPost('modAction') == "disable") {
                 $status =$this->DisableModule($request->getPost('modId'));
             }
             elseif ($request->getPost('modAction') == "install") {
-                $status =$this->InstallModule($request);
+                $modId = $request->getPost('modId');
+                $mod_enc_menu=$request->getPost('mod_enc_menu');
+                $mod_nick_name=$request->getPost('mod_nick_name');
+
+                $status =$this->InstallModule($modId,$mod_enc_menu,$mod_nick_name);
             }
             elseif ($request->getPost('modAction') == 'install_sql') {
                 if ($this->InstallModuleSQL($request->getPost('modId'))) {
@@ -596,7 +600,6 @@ class InstallerController extends AbstractActionController
         } else {
             $status = $this->listenerObject->z_xlt("Success");
         }
-
         return $status;
     }
 
@@ -630,17 +633,16 @@ class InstallerController extends AbstractActionController
      * @param string $dir Location of the php file which calling functions to add sections,aco etc.
      * @return boolean
      */
-    public function InstallModule($request)
+    public function InstallModule($modId = '',$mod_enc_menu='',$mod_nick_name='')
     {
-        $dirModule = $this->getInstallerTable()->getRegistryEntry($request->getPost('modId'), "mod_directory");
-        $mod_enc_menu = $request->getPost('mod_enc_menu');
-        $mod_nick_name = $request->getPost('mod_nick_name');
+        $dirModule = $this->getInstallerTable()->getRegistryEntry($modId, "mod_directory");
+
         if ($this->getInstallerTable()->installSQL($GLOBALS['srcdir'] . "/../" . $GLOBALS['baseModDir'] . $GLOBALS['customModDir'] . "/" . $dirModule->modDirectory)) {
             $values = array($mod_nick_name, $mod_enc_menu);
             //Run custom sql's in folder sql of module
             if ($this->getInstallerTable()->installSQL($GLOBALS['srcdir'] . "/../" . $GLOBALS['baseModDir'] . "zend_modules/module/" . $dirModule->modDirectory . "/sql")) {
-                $values[2] = $this->getModuleVersionFromFile($request->getPost('modId'));
-                $this->getInstallerTable()->updateRegistered($request->getPost('modId'), '', $values);
+                $values[2] = $this->getModuleVersionFromFile($modId);
+                $this->getInstallerTable()->updateRegistered($modId, '', $values);
                 $status = $this->listenerObject->z_xlt("Success");
             } else {
                 $status = $this->listenerObject->z_xlt("ERROR") . ':' . $this->listenerObject->z_xlt("could not run sql query");

--- a/interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php
+++ b/interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php
@@ -88,7 +88,7 @@ class InstallerController extends AbstractActionController
     {
         $status = false;
         $request = $this->getRequest();
-        if ($request->isPost()) {
+        if (method_exists($request,'isPost')) {
             if ($request->getPost('mtype') == 'zend') {
                 // TODO: We want to be able to load the modules
                 // from the database.. however, this can be fairly slow so we might want to do some kind of APC caching of the module
@@ -111,6 +111,25 @@ class InstallerController extends AbstractActionController
             }
 
             die($status ? $this->listenerObject->z_xlt("Success") : $this->listenerObject->z_xlt("Failure"));
+
+        }else{
+
+            $moduleType = $request->getParam('mtype');
+            $moduleName = $request->getParam('modname');
+
+            if ($moduleType == 'zend') {
+
+                $rel_path = "public/" . $moduleName . "/";
+                // registering the table inserts the module record into the database.
+                // it's always loaded regardless, but it inserts it in the database as not activated
+                if ($this->getInstallerTable()->register($moduleName, $rel_path, 0, $GLOBALS['zendModDir'])) {
+                    $status = true;
+                }
+                die($status ? $this->listenerObject->z_xlt("Success") : $this->listenerObject->z_xlt("Failure"));
+            }
+            else{
+                die("not supported");
+            }
         }
     }
 

--- a/interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php
+++ b/interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php
@@ -164,7 +164,6 @@ class InstallerController extends AbstractActionController
                     $status = $this->listenerObject->z_xlt("ERROR") . ':' . $this->listenerObject->z_xlt("could not install ACL ");
                 }
             } elseif ($request->getPost('modAction') == "unregister") {
-
                 $status = $this->UnregisterModule($request->getPost('modId'));
             }
         }

--- a/interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php
+++ b/interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php
@@ -88,7 +88,7 @@ class InstallerController extends AbstractActionController
     {
         $status = false;
         $request = $this->getRequest();
-        if (method_exists($request,'isPost')) {
+        if (method_exists($request, 'isPost')) {
             if ($request->getPost('mtype') == 'zend') {
                 // TODO: We want to be able to load the modules
                 // from the database.. however, this can be fairly slow so we might want to do some kind of APC caching of the module
@@ -112,7 +112,7 @@ class InstallerController extends AbstractActionController
 
             die($status ? $this->listenerObject->z_xlt("Success") : $this->listenerObject->z_xlt("Failure"));
 
-        }else{
+        } else {
 
             $moduleType = $request->getParam('mtype');
             $moduleName = $request->getParam('modname');
@@ -126,8 +126,7 @@ class InstallerController extends AbstractActionController
                     $status = true;
                 }
                 die($status ? $this->listenerObject->z_xlt("Success") : $this->listenerObject->z_xlt("Failure"));
-            }
-            else{
+            } else {
                 die("not supported");
             }
         }
@@ -140,52 +139,45 @@ class InstallerController extends AbstractActionController
         $status = $this->listenerObject->z_xlt("Failure");
         if ($request->isPost()) {
             if ($request->getPost('modAction') == "enable") {
-                $status =$this->EnableModule($request->getPost('modId'));
-            }
-            elseif ($request->getPost('modAction') == "disable") {
-                $status =$this->DisableModule($request->getPost('modId'));
-            }
-            elseif ($request->getPost('modAction') == "install") {
+                $status = $this->EnableModule($request->getPost('modId'));
+            } elseif ($request->getPost('modAction') == "disable") {
+                $status = $this->DisableModule($request->getPost('modId'));
+            } elseif ($request->getPost('modAction') == "install") {
                 $modId = $request->getPost('modId');
-                $mod_enc_menu=$request->getPost('mod_enc_menu');
-                $mod_nick_name=$request->getPost('mod_nick_name');
+                $mod_enc_menu = $request->getPost('mod_enc_menu');
+                $mod_nick_name = $request->getPost('mod_nick_name');
 
-                $status =$this->InstallModule($modId,$mod_enc_menu,$mod_nick_name);
-            }
-            elseif ($request->getPost('modAction') == 'install_sql') {
+                $status = $this->InstallModule($modId, $mod_enc_menu, $mod_nick_name);
+            } elseif ($request->getPost('modAction') == 'install_sql') {
                 if ($this->InstallModuleSQL($request->getPost('modId'))) {
                     $status = $this->listenerObject->z_xlt("Success");
                 } else {
                     $status = $this->listenerObject->z_xlt("ERROR") . ':' . $this->listenerObject->z_xlt("could not open table") . '.' . $this->listenerObject->z_xlt("sql") . ', ' . $this->listenerObject->z_xlt("broken form") . "?";
                 }
-            }
-            elseif ($request->getPost('modAction') == 'upgrade_sql') {
+            } elseif ($request->getPost('modAction') == 'upgrade_sql') {
                 $div = $this->UpgradeModuleSQL($request->getPost('modId'));
                 $status = $this->listenerObject->z_xlt("Success");
-            }
-            elseif ($request->getPost('modAction') == 'install_acl') {
+            } elseif ($request->getPost('modAction') == 'install_acl') {
                 if ($div = $this->InstallModuleACL($request->getPost('modId'))) {
                     $status = $this->listenerObject->z_xlt("Success");
                 } else {
                     $status = $this->listenerObject->z_xlt("ERROR") . ':' . $this->listenerObject->z_xlt("could not install ACL ");
                 }
-            }
-            elseif ($request->getPost('modAction') == 'upgrade_acl') {
+            } elseif ($request->getPost('modAction') == 'upgrade_acl') {
                 if ($div = $this->UpgradeModuleACL($request->getPost('modId'))) {
                     $status = $this->listenerObject->z_xlt("Success");
                 } else {
                     $status = $this->listenerObject->z_xlt("ERROR") . ':' . $this->listenerObject->z_xlt("could not install ACL ");
                 }
-            }
-            elseif ($request->getPost('modAction') == "unregister") {
+            } elseif ($request->getPost('modAction') == "unregister") {
 
                 $status = $this->UnregisterModule($request->getPost('modId'));
             }
         }
 
-        $output="";
-        if(is_array($div)){
-            $output=implode("<br />\n", $div);
+        $output = "";
+        if (is_array($div)) {
+            $output = implode("<br />\n", $div);
         }
         echo json_encode(["status" => $status, "output" => $output]);
 
@@ -652,7 +644,7 @@ class InstallerController extends AbstractActionController
      * @param string $dir Location of the php file which calling functions to add sections,aco etc.
      * @return boolean
      */
-    public function InstallModule($modId = '',$mod_enc_menu='',$mod_nick_name='')
+    public function InstallModule($modId = '', $mod_enc_menu = '', $mod_nick_name = '')
     {
         $dirModule = $this->getInstallerTable()->getRegistryEntry($modId, "mod_directory");
 
@@ -745,63 +737,46 @@ class InstallerController extends AbstractActionController
         echo PHP_EOL . '--- Run command [' . $moduleAction . '] in module:  ' . $moduleName . '---' . PHP_EOL;
         echo 'start process - ' . date('Y-m-d H:i:s') . PHP_EOL;
 
-
         if (!empty($moduleAction) && !empty($moduleName) && $moduleName != "all") {
             $moduleId = $this->getModuleId($moduleName);
         }
 
-
-        $msg="";
-
         if ($moduleId !== null) {
             echo 'module [' . $moduleName . '] was find' . PHP_EOL;
 
-            $msg="command completed successfully";
+            $msg = "command completed successfully";
 
             if ($moduleAction === "install_sql") {
                 $this->InstallModuleSQL($moduleId);
-            }
-
-            elseif ($moduleAction === "upgrade_sql") {
+            } elseif ($moduleAction === "upgrade_sql") {
                 $div = $this->UpgradeModuleSQL($moduleId);
-            }
-
-            elseif ($moduleAction === "install_acl") {
+            } elseif ($moduleAction === "install_acl") {
                 $div = $this->InstallModuleACL($moduleId);
-            }
-
-            elseif ($moduleAction === "upgrade_acl") {
+            } elseif ($moduleAction === "upgrade_acl") {
                 $div = $this->UpgradeModuleACL($moduleId);
-            }
-            elseif ($moduleAction === "enable") {
+            } elseif ($moduleAction === "enable") {
                 $div = $this->EnableModule($moduleId);
-            }
-            elseif ($moduleAction === "disable") {
+            } elseif ($moduleAction === "disable") {
                 $div = $this->DisableModule($moduleId);
-            }
-            elseif ($moduleAction === "install") {
+            } elseif ($moduleAction === "install") {
                 $div = $this->InstallModule($moduleId);
-            }
-            elseif ($moduleAction === "unregister") {
+            } elseif ($moduleAction === "unregister") {
                 $div = $this->UnregisterModule($moduleId);
+            } else {
+                $msg = 'Unsupported command';
             }
-            else{
-                $msg='Unsupported command';
-            }
-        }else{
-            $msg="module Id is null";
+        } else {
+            $msg = "module Id is null";
         }
 
 
-        $output="";
+        $output = "";
 
-        if(is_array($div)){
-            $output= implode("<br />\n", $div) . PHP_EOL;
+        if (is_array($div)) {
+            $output = implode("<br />\n", $div) . PHP_EOL;
         }
         echo $output;
 
         exit($msg . PHP_EOL);
-
-
     }
 }


### PR DESCRIPTION
Add functionality  (register,unregister,disable,enable,install) to cli 
in order to enable the following commands : 

php openemr/interface/modules/zend_modules/public/index.php 

and 

1. register --mtype=zend --modname=Imaging
2. zfc-module --site=default --modaction=disable --modname=Documents
3. zfc-module --site=default --modaction=enable --modname=Documents
4. zfc-module --site=default --modaction=install --modname=Documents
5. zfc-module --site=default --modaction=unregister --modname=Documents

The commands, along with the existing commands, allows to write script to manually install 
zend (Laminas) modules from bash script

related pull request 
https://github.com/openemr/openemr/pull/2922

