### PR TITLE
Update jQuery to 3.5.1 (#3425)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6179,9 +6179,9 @@
       "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo="
     },
     "jquery": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
+      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
     },
     "jquery-datetimepicker": {
       "version": "2.5.21",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "i18next-browser-languagedetector": "4.1.1",
     "i18next-xhr-backend": "3.2.2",
     "interactjs": "1.9.9",
-    "jquery": "3.4.1",
+    "jquery": "3.5.1",
     "jquery-datetimepicker": "2.5.21",
     "jquery-validation": "1.19.1",
     "jscolor": "github:EastDesire/jscolor",


### PR DESCRIPTION
Fixes #3425

#### Short description of what this resolves:

Updates jQuery to 3.5.1