### PR TITLE
[SQL]: Fix #3378 fix default date issue `drug`

### DIFF
--- a/sql/5_0_2-to-5_0_3_upgrade.sql
+++ b/sql/5_0_2-to-5_0_3_upgrade.sql
@@ -475,3 +475,11 @@ SET sql_mode = '';
 UPDATE `drug_inventory` SET `last_notify` = NULL WHERE `last_notify` = '0000-00-00';
 SET sql_mode = @currentSQLMode;
 #EndIf
+
+#IfNotColumnTypeDefault drug last_notify date NULL
+ALTER TABLE `drug` MODIFY `last_notify` date NULL;
+SET @currentSQLMode = (SELECT @@sql_mode);
+SET sql_mode = '';
+UPDATE `drug` SET `last_notify` = NULL WHERE `last_notify` = '0000-00-00';
+SET sql_mode = @currentSQLMode;
+#EndIf

--- a/sql/5_0_2-to-5_0_3_upgrade.sql
+++ b/sql/5_0_2-to-5_0_3_upgrade.sql
@@ -476,10 +476,10 @@ UPDATE `drug_inventory` SET `last_notify` = NULL WHERE `last_notify` = '0000-00-
 SET sql_mode = @currentSQLMode;
 #EndIf
 
-#IfNotColumnTypeDefault drug last_notify date NULL
-ALTER TABLE `drug` MODIFY `last_notify` date NULL;
+#IfNotColumnTypeDefault drugs last_notify date NULL
+ALTER TABLE `drugs` MODIFY `last_notify` date NULL;
 SET @currentSQLMode = (SELECT @@sql_mode);
 SET sql_mode = '';
-UPDATE `drug` SET `last_notify` = NULL WHERE `last_notify` = '0000-00-00';
+UPDATE `drugs` SET `last_notify` = NULL WHERE `last_notify` = '0000-00-00';
 SET sql_mode = @currentSQLMode;
 #EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -1342,7 +1342,7 @@ CREATE TABLE `drugs` (
   `on_order` int(11) NOT NULL default '0',
   `reorder_point` float NOT NULL DEFAULT 0.0,
   `max_level` float NOT NULL DEFAULT 0.0,
-  `last_notify` date NOT NULL default '0000-00-00',
+  `last_notify` date NULL,
   `reactions` text,
   `form` int(3) NOT NULL default '0',
   `size` varchar(25) NOT NULL default '',

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@ $v_realpatch = '0';
 // is a database change in the course of development.  It is used
 // internally to determine when a database upgrade is needed.
 //
-$v_database = 319;
+$v_database = 320;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #3378

#### Short description of what this resolves:
We removed the wrong default date and instead of that made the `last_notify` column of the table `drug` nullable.

#### Changes proposed in this pull request:

- Changed in the database schema file (sql/database.sql)
- Added the upgrade script