### PR TITLE
Update Bootstrap to 4.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1449,9 +1449,9 @@
       }
     },
     "bootstrap": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.4.1.tgz",
-      "integrity": "sha512-tbx5cHubwE6e2ZG7nqM3g/FZ5PQEDMWmMGNrCUBVRPHXTJaH7CBDdsLeu3eCh3B1tzAxTnAbtmrzvWEvT2NNEA=="
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.5.0.tgz",
+      "integrity": "sha512-Z93QoXvodoVslA+PWNdk23Hze4RBYIkpb5h8I2HY2Tu2h7A0LpAgLcyrhrSUyo2/Oxm2l1fRZPs1e5hnxnliXA=="
     },
     "bootswatch": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "angular-sanitize": "1.7.9",
     "angular-summernote": "0.8.1",
     "backbone": "1.4.0",
-    "bootstrap": "4.4.1",
+    "bootstrap": "^4.5.0",
     "bootswatch": "4.4.1",
     "chart.js": "2.9.3",
     "checklist-model": "1.0.0",


### PR DESCRIPTION
Fixes #3508 

This updates Bootstrap to 4.5.0.

Note that this does not update RTL to 4.5.0 as they haven't updated that part yet. There should be no real difference between the two as this is a very minor update.