### PR TITLE
[SQL]: Fix #3378 fix default date issue `insurance_data`

### DIFF
--- a/sql/5_0_2-to-5_0_3_upgrade.sql
+++ b/sql/5_0_2-to-5_0_3_upgrade.sql
@@ -483,3 +483,11 @@ SET sql_mode = '';
 UPDATE `drugs` SET `last_notify` = NULL WHERE `last_notify` = '0000-00-00';
 SET sql_mode = @currentSQLMode;
 #EndIf
+
+#IfNotColumnTypeDefault insurance_data date NULL
+ALTER TABLE `insurance_data` MODIFY `date` date NULL;
+SET @currentSQLMode = (SELECT @@sql_mode);
+SET sql_mode = '';
+UPDATE `insurance_data` SET `date` = NULL WHERE `date` = '0000-00-00';
+SET sql_mode = @currentSQLMode;
+#EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -2547,7 +2547,7 @@ CREATE TABLE `insurance_data` (
   `subscriber_employer_country` varchar(255) default NULL,
   `subscriber_employer_city` varchar(255) default NULL,
   `copay` varchar(255) default NULL,
-  `date` date NOT NULL default '0000-00-00',
+  `date` date NULL,
   `pid` bigint(20) NOT NULL default '0',
   `subscriber_sex` varchar(25) default NULL,
   `accept_assignment` varchar(5) NOT NULL DEFAULT 'TRUE',

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@ $v_realpatch = '0';
 // is a database change in the course of development.  It is used
 // internally to determine when a database upgrade is needed.
 //
-$v_database = 320;
+$v_database = 321;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #3378

#### Short description of what this resolves:
We removed the wrong default date and instead of that made the `date` column of the table `insurance_data ` nullable.

#### Changes proposed in this pull request:

- Changed in the database schema file (sql/database.sql)
- Added the upgrade script