### PR TITLE
using uuid in patient api endpoints

### DIFF
--- a/API_README.md
+++ b/API_README.md
@@ -199,10 +199,10 @@ Response
 }
 ```
 
-#### PUT /api/patient/:pid
+#### PUT /api/patient/:puuid
 
 ```sh
-curl -X PUT 'http://localhost:8300/apis/api/patient/1' -d \
+curl -X PUT 'http://localhost:8300/apis/api/patient/90a8923c-0b1c-4d0a-9981-994b143381a7' -d \
 '{
     "title": "Mr",
     "fname": "Baz",
@@ -294,10 +294,10 @@ Response
 ```
 
 
-#### GET /api/patient/:pid
+#### GET /api/patient/:puuid
 
 ```sh
-curl -X GET 'http://localhost:8300/apis/api/patient/1'
+curl -X GET 'http://localhost:8300/apis/api/patient/90a8923c-0b1c-4d0a-9981-994b143381a7'
 ```
 
 Response

--- a/FHIR_README.md
+++ b/FHIR_README.md
@@ -57,10 +57,10 @@ curl -X GET 'http://localhost:8300/apis/fhir/Patient' \
 curl -X GET 'http://localhost:8300/apis/fhir/Patient'
 ```
 
-#### GET /fhir/Patient/:pid
+#### GET /fhir/Patient/:puuid
 
 ```sh
-curl -X GET 'http://localhost:8300/apis/fhir/Patient/1'
+curl -X GET 'http://localhost:8300/apis/fhir/Patient/90a8923c-0b1c-4d0a-9981-994b143381a7'
 ```
 
 #### POST /fhir/Patient
@@ -79,10 +79,10 @@ curl -X POST -H 'Content-Type: application/fhir+json' 'http://localhost:8300/api
 }'
 ```
 
-#### PUT /fhir/Patient/:pid
+#### PUT /fhir/Patient/:puuid
 
 ```sh
-curl -X PUT -H 'Content-Type: application/fhir+json' 'http://localhost:8300/apis/fhir/Patient/1' -d \ 
+curl -X PUT -H 'Content-Type: application/fhir+json' 'http://localhost:8300/apis/fhir/Patient/90a8923c-0b1c-4d0a-9981-994b143381a7' -d \ 
 '{
   "resourceType": "Patient",
   "id": "1",
@@ -102,10 +102,10 @@ curl -X PUT -H 'Content-Type: application/fhir+json' 'http://localhost:8300/apis
 }'
 ```
 
-#### PATCH /fhir/Patient/:pid
+#### PATCH /fhir/Patient/:puuid
 
 ```sh
-curl -X PATCH -H 'Content-Type: application/fhir+json' 'http://localhost:8300/apis/fhir/Patient/1' -d \ 
+curl -X PATCH -H 'Content-Type: application/fhir+json' 'http://localhost:8300/apis/fhir/Patient/90a8923c-0b1c-4d0a-9981-994b143381a7' -d \ 
 '[
  { 
    "op": "replace", 

--- a/FHIR_README.md
+++ b/FHIR_README.md
@@ -57,7 +57,7 @@ curl -X GET 'http://localhost:8300/apis/fhir/Patient' \
 curl -X GET 'http://localhost:8300/apis/fhir/Patient'
 ```
 
-#### GET /fhir/Patient/:puuid
+#### GET /fhir/Patient/:id
 
 ```sh
 curl -X GET 'http://localhost:8300/apis/fhir/Patient/90a8923c-0b1c-4d0a-9981-994b143381a7'
@@ -79,7 +79,7 @@ curl -X POST -H 'Content-Type: application/fhir+json' 'http://localhost:8300/api
 }'
 ```
 
-#### PUT /fhir/Patient/:puuid
+#### PUT /fhir/Patient/:id
 
 ```sh
 curl -X PUT -H 'Content-Type: application/fhir+json' 'http://localhost:8300/apis/fhir/Patient/90a8923c-0b1c-4d0a-9981-994b143381a7' -d \ 
@@ -102,7 +102,7 @@ curl -X PUT -H 'Content-Type: application/fhir+json' 'http://localhost:8300/apis
 }'
 ```
 
-#### PATCH /fhir/Patient/:puuid
+#### PATCH /fhir/Patient/:id
 
 ```sh
 curl -X PATCH -H 'Content-Type: application/fhir+json' 'http://localhost:8300/apis/fhir/Patient/90a8923c-0b1c-4d0a-9981-994b143381a7' -d \ 
@@ -126,7 +126,7 @@ curl -X PATCH -H 'Content-Type: application/fhir+json' 'http://localhost:8300/ap
 curl -X GET 'http://localhost:8300/apis/fhir/Encounter'
 ```
 
-#### GET /fhir/Encounter/:eid
+#### GET /fhir/Encounter/:id
 
 ```sh
 curl -X GET 'http://localhost:8300/apis/fhir/Encounter/1'
@@ -138,7 +138,7 @@ curl -X GET 'http://localhost:8300/apis/fhir/Encounter/1'
 curl -X GET 'http://localhost:8300/apis/fhir/Organization'
 ```
 
-#### GET /fhir/Organization/:oid
+#### GET /fhir/Organization/:id
 
 ```sh
 curl -X GET 'http://localhost:8300/apis/fhir/Organization/1'

--- a/_rest_routes.inc.php
+++ b/_rest_routes.inc.php
@@ -77,14 +77,14 @@ RestConfig::$ROUTE_MAP = array(
         $data = (array)(json_decode(file_get_contents("php://input")));
         return (new PatientRestController())->post($data);
     },
-    "PUT /api/patient/:pid" => function ($pid) {
+    "PUT /api/patient/:puuid" => function ($puuid) {
         RestConfig::authorization_check("patients", "demo");
         $data = (array)(json_decode(file_get_contents("php://input")));
-        return (new PatientRestController())->put($pid, $data);
+        return (new PatientRestController())->put($puuid, $data);
     },
-    "GET /api/patient/:pid" => function ($pid) {
+    "GET /api/patient/:puuid" => function ($puuid) {
         RestConfig::authorization_check("patients", "demo");
-        return (new PatientRestController())->getOne($pid);
+        return (new PatientRestController())->getOne($puuid);
     },
     "GET /api/patient/:pid/encounter" => function ($pid) {
         RestConfig::authorization_check("encounters", "auth_a");
@@ -463,7 +463,7 @@ RestConfig::$PORTAL_ROUTE_MAP = array(
         return (new AuthRestController())->authenticate($data);
     },
     "GET /portal/patient" => function () {
-        return (new PatientRestController())->getOne($_SESSION['pid']);
+        return (new PatientRestController())->getOne(UuidRegistry::uuidToString($_SESSION['puuid']));
     }
 );
 

--- a/_rest_routes.inc.php
+++ b/_rest_routes.inc.php
@@ -383,15 +383,15 @@ RestConfig::$FHIR_ROUTE_MAP = array(
         RestConfig::authorization_check("encounters", "auth_a");
         return (new FhirEncounterRestController(null))->getAll($_GET);
     },
-    "GET /fhir/Encounter/:eid" => function ($eid) {
+    "GET /fhir/Encounter/:id" => function ($id) {
         RestConfig::authorization_check("encounters", "auth_a");
-        return (new FhirEncounterRestController())->getOne($eid);
+        return (new FhirEncounterRestController())->getOne($id);
     },
     "GET /fhir/Organization" => function () {
         return (new FhirOrganizationRestController(null))->getAll($_GET);
     },
-    "GET /fhir/Organization/:oid" => function ($oid) {
-        return (new FhirOrganizationRestController(null))->getOne($oid);
+    "GET /fhir/Organization/:id" => function ($id) {
+        return (new FhirOrganizationRestController(null))->getOne($id);
     },
     "GET /fhir/AllergyIntolerance" => function () {
         RestConfig::authorization_check("patients", "med");

--- a/src/RestControllers/PatientRestController.php
+++ b/src/RestControllers/PatientRestController.php
@@ -55,23 +55,23 @@ class PatientRestController
 
     /**
      * Processes a HTTP PUT request used to update an existing patient record.
-     * @param $pid - The patient identifier used to lookup the existing record.
+     * @param $puuidString - The patient uuid identifier in string format.
      * @param $data - array of patient fields (full resource).
      * @return a 200/Ok status code and the patient resource.
      */
-    function put($pid, $data)
+    function put($puuidString, $data)
     {
-        $processingResult = $this->patientService->update(intval($pid), $data);
+        $processingResult = $this->patientService->update($puuidString, $data);
         return RestControllerHelper::handleProcessingResult($processingResult, 200);
     }
 
     /**
      * Fetches a single patient resource by id.
-     * @param $pid The patient identifier to fetch.
+     * @param $puuidString - The patient uuid identifier in string format.
      */
-    function getOne($pid)
+    function getOne($puuidString)
     {
-        $processingResult = $this->patientService->getOne($pid);
+        $processingResult = $this->patientService->getOne($puuidString);
 
         if (!$processingResult->hasErrors() && count($processingResult->getData()) == 0) {
             return RestControllerHelper::handleProcessingResult($processingResult, 404);

--- a/src/RestControllers/PatientRestController.php
+++ b/src/RestControllers/PatientRestController.php
@@ -71,7 +71,7 @@ class PatientRestController
      */
     function getOne($pid)
     {
-        $processingResult = $this->patientService->getOne(intval($pid));
+        $processingResult = $this->patientService->getOne($pid);
 
         if (!$processingResult->hasErrors() && count($processingResult->getData()) == 0) {
             return RestControllerHelper::handleProcessingResult($processingResult, 404);

--- a/src/Services/BaseService.php
+++ b/src/Services/BaseService.php
@@ -111,9 +111,13 @@ class BaseService
             if ($key == 'uuid') {
                 continue;
             }
+            // exclude pid columns
+            if ($key == 'pid') {
+                continue;
+            }
             if (!in_array($key, $this->fields)) {
                 // placeholder. could be for where clauses
-                $bind[] = ($value == 'NULL') ? "" : add_escape_custom($value);
+                $bind[] = ($value == 'NULL') ? "" : $value;
                 continue;
             }
             if ($value == 'YYYY-MM-DD' || $value == 'MM/DD/YYYY') {

--- a/src/Services/FHIR/FhirPatientService.php
+++ b/src/Services/FHIR/FhirPatientService.php
@@ -341,7 +341,7 @@ class FhirPatientService extends FhirServiceBase
      */
     public function updateOpenEMRRecord($fhirResourceId, $updatedOpenEMRRecord)
     {
-        $processingResult = $this->patientService->getOne($fhirResourceId, true);
+        $processingResult = $this->patientService->getOne($fhirResourceId);
 
         if ($processingResult->hasErrors()) {
             return $processingResult;
@@ -362,7 +362,7 @@ class FhirPatientService extends FhirServiceBase
      */
     public function getOne($fhirResourceId)
     {
-        $processingResult = $this->patientService->getOne($fhirResourceId, true);
+        $processingResult = $this->patientService->getOne($fhirResourceId);
         if (!$processingResult->hasErrors()) {
             if (count($processingResult->getData()) > 0) {
                 $openEmrRecord = $processingResult->getData()[0];

--- a/src/Services/FHIR/FhirPatientService.php
+++ b/src/Services/FHIR/FhirPatientService.php
@@ -341,18 +341,7 @@ class FhirPatientService extends FhirServiceBase
      */
     public function updateOpenEMRRecord($fhirResourceId, $updatedOpenEMRRecord)
     {
-        $processingResult = $this->patientService->getOne($fhirResourceId);
-
-        if ($processingResult->hasErrors()) {
-            return $processingResult;
-        }
-
-        $existingPid = null;
-        if (isset($processingResult->getData()[0])) {
-            $existingPid = (int)$processingResult->getData()[0]['pid'];
-        }
-
-        $processingResult = $this->patientService->update($existingPid, $updatedOpenEMRRecord);
+        $processingResult = $this->patientService->update($fhirResourceId, $updatedOpenEMRRecord);
         return $processingResult;
     }
 

--- a/src/Services/PatientService.php
+++ b/src/Services/PatientService.php
@@ -145,7 +145,7 @@ class PatientService extends BaseService
      */
     public function update($puuidString, $data)
     {
-        $data["puuid"] = $puuidString;
+        $data["uuid"] = $puuidString;
         $processingResult = $this->patientValidator->validate($data, PatientValidator::DATABASE_UPDATE_CONTEXT);
         if (!$processingResult->isValid()) {
             return $processingResult;

--- a/src/Services/PatientService.php
+++ b/src/Services/PatientService.php
@@ -242,13 +242,22 @@ class PatientService extends BaseService
 
     /**
      * Returns a single patient record by patient id.
-     * @param $lookupId - The patient identifier used to lookup the patient record.
-     * @param $isUuidLookup - true for patient.uuid lookups, false for patient.pid lookups
+     * @param $lookupId - The patient identifier (either pid or uuid) used to lookup the patient record.
      * @return ProcessingResult which contains validation messages, internal error messages, and the data
      * payload.
      */
-    public function getOne($lookupId, $isUuidLookup = false)
+    public function getOne($lookupId)
     {
+        // Figure out if $lookupId is uuid or pid
+        if (strpos($lookupId, '-') === false) {
+            // use pid
+            $lookupId = intval($lookupId);
+            $isUuidLookup = false;
+        } else {
+            // use uuid
+            $isUuidLookup = true;
+        }
+
         $processingResult = new ProcessingResult();
 
         if ($isUuidLookup) {

--- a/src/Validators/PatientValidator.php
+++ b/src/Validators/PatientValidator.php
@@ -39,26 +39,6 @@ class PatientValidator extends BaseValidator
         return $existingUuid != null;
     }
 
-   /**
-     * Validates that a PID exists in the database.
-     *
-     * @param $pid The pid/patient identifier to verify
-     * @return true if the pid is a valid existing pid, otherwise false
-     */
-    public function isExistingPid($pid)
-    {
-        if (!is_int($pid)) {
-            return false;
-        }
-        $result = sqlQuery(
-            "SELECT pid AS pid FROM patient_data WHERE pid = ?",
-            array($pid)
-        );
-
-        $pidValue = $result["pid"] ?? 0;
-        return $pidValue > 0;
-    }
-
     /**
      * Configures validations for the Patient DB Insert and Update use-case.
      * The update use-case is comprised of the same fields as the insert use-case.
@@ -91,15 +71,7 @@ class PatientValidator extends BaseValidator
                         }
                     }
                 );
-                // additional pid and uuid validations
-                $context->required("pid", "pid")->callback(function ($value) {
-                    if (!$this->isExistingPid($value)) {
-                        $message = "PID " . $value . " does not exist";
-                        throw new InvalidValueException($message, $value);
-                    }
-                    return true;
-                })->integer();
-
+                // additional uuid validations
                 $context->required("uuid", "uuid")->callback(function ($value) {
                     if (!$this->isExistingUuid($value)) {
                         $message = "UUID " . $value . " does not exist";

--- a/tests/Tests/Api/PatientApiTest.php
+++ b/tests/Tests/Api/PatientApiTest.php
@@ -45,7 +45,7 @@ class PatientApiTest extends TestCase
     {
         unset($this->patientRecord["fname"]);
         $actualResponse = $this->testClient->post(self::PATIENT_API_ENDPOINT, $this->patientRecord);
-        
+
         $this->assertEquals(400, $actualResponse->getStatusCode());
         $responseBody = json_decode($actualResponse->getBody(), true);
         $this->assertEquals(1, count($responseBody["validationErrors"]));
@@ -59,7 +59,7 @@ class PatientApiTest extends TestCase
     public function testPost()
     {
         $actualResponse = $this->testClient->post(self::PATIENT_API_ENDPOINT, $this->patientRecord);
-        
+
         $this->assertEquals(201, $actualResponse->getStatusCode());
         $responseBody = json_decode($actualResponse->getBody(), true);
         $this->assertEquals(0, count($responseBody["validationErrors"]));
@@ -82,11 +82,11 @@ class PatientApiTest extends TestCase
         $this->assertEquals(201, $actualResponse->getStatusCode());
 
         $this->patientRecord["phone_home"] = "222-222-2222";
-        $actualResponse = $this->testClient->put(self::PATIENT_API_ENDPOINT, "not-a-pid", $this->patientRecord);
+        $actualResponse = $this->testClient->put(self::PATIENT_API_ENDPOINT, "not-a-uuid", $this->patientRecord);
 
         $this->assertEquals(400, $actualResponse->getStatusCode());
         $responseBody = json_decode($actualResponse->getBody(), true);
-        $this->assertEquals(2, count($responseBody["validationErrors"]));
+        $this->assertEquals(1, count($responseBody["validationErrors"]));
         $this->assertEquals(0, count($responseBody["internalErrors"]));
         $this->assertEquals(0, count($responseBody["data"]));
     }
@@ -100,12 +100,10 @@ class PatientApiTest extends TestCase
         $this->assertEquals(201, $actualResponse->getStatusCode());
         $responseBody = json_decode($actualResponse->getBody(), true);
 
-        $patientPid = $responseBody["data"]["pid"];
         $patientUuid = $responseBody["data"]["uuid"];
 
         $this->patientRecord["phone_home"] = "222-222-2222";
-        $this->patientRecord["uuid"] =  $patientUuid;
-        $actualResponse = $this->testClient->put(self::PATIENT_API_ENDPOINT, $patientPid, $this->patientRecord);
+        $actualResponse = $this->testClient->put(self::PATIENT_API_ENDPOINT, $patientUuid, $this->patientRecord);
 
         $this->assertEquals(200, $actualResponse->getStatusCode());
         $responseBody = json_decode($actualResponse->getBody(), true);
@@ -121,7 +119,7 @@ class PatientApiTest extends TestCase
      */
     public function testGetOneInvalidPid()
     {
-        $actualResponse = $this->testClient->getOne(self::PATIENT_API_ENDPOINT, "not-a-pid");
+        $actualResponse = $this->testClient->getOne(self::PATIENT_API_ENDPOINT, "not-a-uuid");
         $this->assertEquals(400, $actualResponse->getStatusCode());
 
         $responseBody = json_decode($actualResponse->getBody(), true);
@@ -139,14 +137,16 @@ class PatientApiTest extends TestCase
         $this->assertEquals(201, $actualResponse->getStatusCode());
 
         $responseBody = json_decode($actualResponse->getBody(), true);
+        $patientUuid = $responseBody["data"]["uuid"];
         $patientPid = $responseBody["data"]["pid"];
 
-        $actualResponse = $this->testClient->getOne(self::PATIENT_API_ENDPOINT, $patientPid);
+        $actualResponse = $this->testClient->getOne(self::PATIENT_API_ENDPOINT, $patientUuid);
         $this->assertEquals(200, $actualResponse->getStatusCode());
 
         $responseBody = json_decode($actualResponse->getBody(), true);
         $this->assertEquals(0, count($responseBody["validationErrors"]));
         $this->assertEquals(0, count($responseBody["internalErrors"]));
+        $this->assertEquals($patientUuid, $responseBody["data"]["uuid"]);
         $this->assertEquals($patientPid, $responseBody["data"]["pid"]);
     }
 

--- a/tests/Tests/RestControllers/PatientRestControllerTest.php
+++ b/tests/Tests/RestControllers/PatientRestControllerTest.php
@@ -106,11 +106,9 @@ class PatientRestControllerTest extends TestCase
         $this->assertEquals(201, http_response_code());
         $this->assertEquals(2, count($actualResult["data"]));
 
-        $patientPid = $actualResult["data"]["pid"];
         $patientUuid = $actualResult["data"]["uuid"];
         $this->patientData["phone_home"] = "111-111-1111";
-        $this->patientData["uuid"] = $patientUuid;
-        $actualResult = $this->patientController->put($patientPid, $this->patientData);
+        $actualResult = $this->patientController->put($patientUuid, $this->patientData);
 
         $this->assertEquals(200, http_response_code());
         $this->assertEquals(0, count($actualResult["validationErrors"]));
@@ -123,11 +121,11 @@ class PatientRestControllerTest extends TestCase
     }
 
     /**
-     * @cover ::getOne with an invalid pid
+     * @cover ::getOne with an invalid uuid
      */
-    public function testGetOneInvalidPid()
+    public function testGetOneInvalidUuid()
     {
-        $actualResult = $this->patientController->getOne("not-a-pid");
+        $actualResult = $this->patientController->getOne("not-a-uuid");
         $this->assertEquals(400, http_response_code());
         $this->assertEquals(1, count($actualResult["validationErrors"]));
         $this->assertEquals(0, count($actualResult["internalErrors"]));
@@ -135,19 +133,17 @@ class PatientRestControllerTest extends TestCase
     }
 
     /**
-     * @cover ::getOne with a valid pid
+     * @cover ::getOne with a valid uuid
      */
     public function testGetOne()
     {
         // create a record
         $postResult = $this->patientController->post($this->patientData);
-        $postedPid = $postResult["data"]["pid"];
-        $this->assertIsInt($postedPid);
-        $this->assertGreaterThan(0, $postedPid);
+        $postedUuid = $postResult["data"]["uuid"];
 
         // confirm the pid matches what was requested
-        $actualResult = $this->patientController->getOne($postedPid);
-        $this->assertEquals($postedPid, $actualResult["data"]["pid"]);
+        $actualResult = $this->patientController->getOne($postedUuid);
+        $this->assertEquals($postedUuid, $actualResult["data"]["uuid"]);
     }
 
     /**
@@ -157,7 +153,7 @@ class PatientRestControllerTest extends TestCase
     {
         $this->fixtureManager->installPatientFixtures();
         $searchResult = $this->patientController->getAll(array("state" => "CA"));
-        
+
         $this->assertEquals(200, http_response_code());
         $this->assertEquals(0, count($searchResult["validationErrors"]));
         $this->assertEquals(0, count($searchResult["internalErrors"]));

--- a/tests/Tests/Validators/PatientValidatorTest.php
+++ b/tests/Tests/Validators/PatientValidatorTest.php
@@ -78,9 +78,8 @@ class PatientValidatorTest extends TestCase
 
         $this->assertArrayHasKey("fname", $actualResult->getValidationMessages());
         $this->assertArrayHasKey("sex", $actualResult->getValidationMessages());
-        $this->assertArrayHasKey("pid", $actualResult->getValidationMessages());
         $this->assertArrayHasKey("uuid", $actualResult->getValidationMessages());
-        $this->assertEquals(4, count($actualResult->getValidationMessages()));
+        $this->assertEquals(3, count($actualResult->getValidationMessages()));
     }
 
     /**
@@ -114,33 +113,6 @@ class PatientValidatorTest extends TestCase
 
         $this->assertTrue($actualResult->isValid());
         $this->assertEquals(0, count($actualResult->getValidationMessages()));
-    }
-    
-    /**
-     * @covers ::isExistingPid for success and failure use-cases
-     */
-    public function testIsExistingPid()
-    {
-        // ensure we have an installed record/patient
-        $patientFixture = $this->fixtureManager->getSinglePatientFixture();
-        $this->fixtureManager->installSinglePatientFixture($patientFixture);
-
-        $fixturePid = sqlQuery(
-            "SELECT pid FROM patient_data WHERE pubpid = ?",
-            array($patientFixture['pubpid'])
-        )['pid'];
-        $fixturePid = intval($fixturePid);
-
-        $this->assertGreaterThan(0, $fixturePid);
-
-        $actualResult = $this->patientValidator->isExistingPid($fixturePid);
-        $this->assertTrue($actualResult);
-
-        $actualResult = $this->patientValidator->isExistingPid(0);
-        $this->assertFalse($actualResult);
-
-        $actualResult = $this->patientValidator->isExistingPid("not-a-pid");
-        $this->assertFalse($actualResult);
     }
 
     /**


### PR DESCRIPTION
@dixonwhitmire , @yashrajbothra , @sjpadgett ,
Just toying around with what we should be using for the patient ids for the api endpoints. At this point, we will be using uuid in fhir and pid on the api. Per this PR (overall strategy), it wouldn't be too tough to support both, although doing this really seems murky to me. Am thinking may make sense to use uuid (and not pid) on the api also to keep things consistent.
thoughts?