### PR TITLE
Refactor #3542: remove outdated javascript attribute

### DIFF
--- a/Documentation/help_files/openemr_installation_help.php
+++ b/Documentation/help_files/openemr_installation_help.php
@@ -16,11 +16,11 @@
     <head>
         <link rel=stylesheet href="../../public/themes/style_light.css">
         <link rel="stylesheet" href="../../public/assets/jquery-ui/jquery-ui.css">
-        <script type="text/javascript" src="../../public/assets/jquery/dist/jquery.min.js"></script>
-        <script type="text/javascript" src="../../public/assets/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+        <script src="../../public/assets/jquery/dist/jquery.min.js"></script>
+        <script src="../../public/assets/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
         <link rel="stylesheet" href="../../public/assets/@fortawesome/fontawesome-free/css/all.min.css">
         <link rel="shortcut icon" href="../../public/images/favicon.ico" />
-        <script type="text/javascript" src="../../public/assets/jquery-ui/jquery-ui.js"></script>
+        <script src="../../public/assets/jquery-ui/jquery-ui.js"></script>
     <title><?php echo ("OpenEMR Installation Help");?></title>
     <style>
         @media only screen and (max-width: 768px) {

--- a/Documentation/help_files/openemr_multisite_admin_help.php
+++ b/Documentation/help_files/openemr_multisite_admin_help.php
@@ -16,11 +16,11 @@
     <head>
         <link rel=stylesheet href="../../public/themes/style_light.css">
         <link rel="stylesheet" href="../../public/assets/jquery-ui/jquery-ui.css">
-        <script type="text/javascript" src="../../public/assets/jquery/dist/jquery.min.js"></script>
-        <script type="text/javascript" src="../../public/assets/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+        <script src="../../public/assets/jquery/dist/jquery.min.js"></script>
+        <script src="../../public/assets/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
         <link rel="stylesheet" href="../../public/assets/@fortawesome/fontawesome-free/css/all.min.css">
         <link rel="shortcut icon" href="../../public/images/favicon.ico" />
-        <script type="text/javascript" src="../../public/assets/jquery-ui/jquery-ui.js"></script>
+        <script src="../../public/assets/jquery-ui/jquery-ui.js"></script>
     <title><?php echo ("Multi Site Administration Help");?></title>
     <style>
         @media only screen and (max-width: 768px) {

--- a/admin.php
+++ b/admin.php
@@ -43,8 +43,8 @@ function sqlQuery($statement, $link)
 <head>
 <title>OpenEMR Site Administration</title>
 <link rel="stylesheet" href="public/assets/bootstrap/dist/css/bootstrap.min.css">
-<script type="text/javascript" src="public/assets/jquery/dist/jquery.min.js"></script>
-<script type="text/javascript" src="public/assets/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+<script src="public/assets/jquery/dist/jquery.min.js"></script>
+<script src="public/assets/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
 <link rel="stylesheet" href="public/assets/@fortawesome/fontawesome-free/css/all.min.css">
 <link rel="shortcut icon" href="public/images/favicon.ico" />
 <style>

--- a/ccr/createCCR.php
+++ b/ccr/createCCR.php
@@ -319,7 +319,7 @@ function sourceType($ccr, $uuid)
 
 function displayError($message)
 {
-    echo '<script type="text/javascript">alert("' . addslashes($message) . '");</script>';
+    echo '<script>alert("' . addslashes($message) . '");</script>';
 }
 
 

--- a/contrib/forms/evaluation/templates/evaluation/general_new.html
+++ b/contrib/forms/evaluation/templates/evaluation/general_new.html
@@ -85,7 +85,7 @@ a {
 
 {literal}
 
-<script language="javascript">
+<script>
 
 
 

--- a/contrib/forms/example2/new.php
+++ b/contrib/forms/example2/new.php
@@ -101,7 +101,7 @@ Date of signature:
 
 </body>
 
-<script language="javascript">
+<script>
 
 // jQuery stuff to make the page a little easier to use
 

--- a/contrib/forms/example2/print.php
+++ b/contrib/forms/example2/print.php
@@ -123,7 +123,7 @@ Date of signature:
 
 </body>
 
-<script language="javascript">
+<script>
 window.print();
 window.close();
 </script>

--- a/contrib/forms/example2/view.php
+++ b/contrib/forms/example2/view.php
@@ -55,7 +55,7 @@ if ($record['sig_date'] != "") {
 
 <link rel="stylesheet" href="../../forms/<?php echo $form_folder; ?>/style.css?v=<?php echo $v_js_includes; ?>">
 
-<script language="JavaScript">
+<script>
 function PrintForm() {
     newwin = window.open("<?php echo "http://" . $_SERVER['SERVER_NAME'] . $rootdir . "/forms/" . $form_folder . "/print.php?id=" ?>" + <?php echo js_url($_GET["id"]); ?>,"mywin");
 }
@@ -136,7 +136,7 @@ Date of signature:
 
 </body>
 
-<script language="javascript">
+<script>
 // jQuery stuff to make the page a little easier to use
 
 $(function () {

--- a/contrib/forms/formmaker/formscript.pl
+++ b/contrib/forms/formmaker/formscript.pl
@@ -104,7 +104,7 @@ START
 my $date_field_exists = 0;
 my $date_header =<<'START';
 
-<script language='JavaScript'>
+<script>
 $(function () {
     $('.datepicker').datetimepicker({
         <?php $datetimepicker_timepicker = false; ?>

--- a/contrib/forms/ippf_srh/new.php
+++ b/contrib/forms/ippf_srh/new.php
@@ -127,7 +127,7 @@ div.section {
 
 </style>
 
-<script language="JavaScript">
+<script>
 
 // Supports customizable forms (currently just for IPPF).
 function divclick(cb, divid) {

--- a/contrib/forms/psychiatrySet/brief_aan_verwijzer/new.php
+++ b/contrib/forms/psychiatrySet/brief_aan_verwijzer/new.php
@@ -184,7 +184,7 @@ if ($vectAutosaveBAV['id']) {
 }
 
 ?>
-<script type="text/javascript">
+<script>
 $(function () {
         autosave();
         $('.datepicker').datetimepicker({

--- a/contrib/forms/psychiatrySet/intakeverslag/new.php
+++ b/contrib/forms/psychiatrySet/intakeverslag/new.php
@@ -111,7 +111,7 @@ if ($vectAutosave['id']) {
 }
 
 ?>
-<script type="text/javascript">
+<script>
 $(function () {
         autosave();
         $('.datepicker').datetimepicker({

--- a/contrib/forms/psychiatrySet/intakeverslag/view.php
+++ b/contrib/forms/psychiatrySet/intakeverslag/view.php
@@ -119,7 +119,7 @@ if ($_GET["id"]) {
 }
 
 ?>
-<script type="text/javascript">
+<script>
 $(function () {
         autosave();
         $('.datepicker').datetimepicker({

--- a/contrib/forms/psychiatrySet/psychiatrisch_onderzoek/new.php
+++ b/contrib/forms/psychiatrySet/psychiatrisch_onderzoek/new.php
@@ -182,7 +182,7 @@ if ($vectAutosavePO['id']) {
 }
 
 ?>
-<script type="text/javascript">
+<script>
 $(function () {
         autosave();
         $('.datepicker').datetimepicker({

--- a/contrib/forms/psychiatrySet/psychiatrisch_onderzoek/view.php
+++ b/contrib/forms/psychiatrySet/psychiatrisch_onderzoek/view.php
@@ -113,7 +113,7 @@ if ($_GET["id"]) {
 }
 
 ?>
-<script type="text/javascript">
+<script>
 $(function () {
         autosave();
         $('.datepicker').datetimepicker({

--- a/contrib/forms/soccer_injury/new.php
+++ b/contrib/forms/soccer_injury/new.php
@@ -186,7 +186,7 @@ if ($formid) {
 <style>
 .billcell { font-family: sans-serif; font-size: 10pt }
 </style>
-<script language="JavaScript">
+<script>
 
 </script>
 </head>

--- a/contrib/forms/soccer_injury/view.php
+++ b/contrib/forms/soccer_injury/view.php
@@ -186,7 +186,7 @@ if ($formid) {
 <style>
 .billcell { font-family: sans-serif; font-size: 10pt }
 </style>
-<script language="JavaScript">
+<script>
 
 </script>
 </head>

--- a/contrib/forms/xmlformgen/xslt/new.php.xslt
+++ b/contrib/forms/xmlformgen/xslt/new.php.xslt
@@ -69,7 +69,7 @@ $submiturl = $GLOBALS['rootdir'].'/forms/'.$form_folder.'/save.php?mode=new&amp;
 <!-- Form Specific Stylesheet. -->
 <link rel="stylesheet" href="../../forms/<?php echo $form_folder; ?>/style.css">
 
-<script type="text/javascript">
+<script>
 // this line is to assist the calendar text boxes
 var mypcc = '<?php echo $GLOBALS['phone_country_code']; ?>';
 
@@ -140,7 +140,7 @@ require_once($GLOBALS['srcdir'].'/options_listadd.inc');
 </fieldset>
 </div><!-- end bottom_buttons -->
 </form>
-<script type="text/javascript">
+<script>
 // jQuery stuff to make the page a little easier to use
 
 $(function () {

--- a/contrib/forms/xmlformgen/xslt/print.php.xslt
+++ b/contrib/forms/xmlformgen/xslt/print.php.xslt
@@ -82,7 +82,7 @@ $returnurl = 'encounter_top.php';
 </div><!-- end print_form_container -->
 
 </form>
-<script type="text/javascript">
+<script>
 window.print();
 window.close();
 </script>

--- a/contrib/forms/xmlformgen/xslt/show.php.xslt
+++ b/contrib/forms/xmlformgen/xslt/show.php.xslt
@@ -71,7 +71,7 @@ $returnurl = "../../forms/$form_folder/view.php?mode=noencounter";
 <!-- Form Specific Stylesheet. -->
 <link rel="stylesheet" href="../../forms/<?php echo $form_folder; ?>/style.css">
 
-<script type="text/javascript">
+<script>
 
 <!-- FIXME: this needs to detect access method, and construct a URL appropriately! -->
 function PrintForm() {
@@ -118,7 +118,7 @@ function PrintForm() {
 </div><!-- end button_bar -->
 
 </form>
-<script type="text/javascript">
+<script>
 // jQuery stuff to make the page a little easier to use
 
 $(function () {

--- a/contrib/forms/xmlformgen/xslt/view.php.xslt
+++ b/contrib/forms/xmlformgen/xslt/view.php.xslt
@@ -82,7 +82,7 @@ else
 <!-- Form Specific Stylesheet. -->
 <link rel="stylesheet" href="../../forms/<?php echo $form_folder; ?>/style.css">
 
-<script type="text/javascript">
+<script>
 // this line is to assist the calendar text boxes
 var mypcc = '<?php echo $GLOBALS['phone_country_code']; ?>';
 
@@ -134,7 +134,7 @@ function PrintForm() {
 </fieldset>
 </div><!-- end bottom_buttons -->
 </form>
-<script type="text/javascript">
+<script>
 // jQuery stuff to make the page a little easier to use
 
 $(function () {

--- a/contrib/util/de_identification_upgrade.php
+++ b/contrib/util/de_identification_upgrade.php
@@ -205,7 +205,7 @@ if (!empty($_POST['form_submit'])) {
 }
 ?>
 
-<script language="JavaScript">
+<script>
 function form_validate()
 {
  if(document.forms[0].root_user_name.value == "")

--- a/contrib/util/dupecheck/index.php
+++ b/contrib/util/dupecheck/index.php
@@ -243,7 +243,7 @@ if ($parameters['go'] == "Go") {
 
 </body>
 
-<script language="javascript">
+<script>
 
 $(function () {
 

--- a/contrib/util/dupecheck/mergerecords.php
+++ b/contrib/util/dupecheck/mergerecords.php
@@ -199,7 +199,7 @@ Do you wish to commit these changes to the database?
 
 </body>
 <?php if ($commitchanges == true) : ?>
-<script language="javascript">
+<script>
 window.opener.removedupe(<?php echo js_escape($parameters['dupecount']); ?>);
 window.close();
 </script>

--- a/custom/export_qrda_xml.php
+++ b/custom/export_qrda_xml.php
@@ -1501,7 +1501,7 @@ fclose($fileQRDAOPen);
 <?php Header::setupHeader('opener'); ?>
 <title><?php echo xlt('Export QRDA Report'); ?></title>
 
-<script type="text/javascript">
+<script>
     //Close Me function
     function closeme() {
       window.close();

--- a/gacl/admin/templates/phpgacl/acl_admin.tpl
+++ b/gacl/admin/templates/phpgacl/acl_admin.tpl
@@ -1,5 +1,5 @@
-{include file="phpgacl/header.tpl"} 
-<script LANGUAGE="JavaScript">
+{include file="phpgacl/header.tpl"}
+<script>
 {$js_array}
 </script>
 {include file="phpgacl/acl_admin_js.tpl"}

--- a/gacl/admin/templates/phpgacl/acl_admin_js.tpl
+++ b/gacl/admin/templates/phpgacl/acl_admin_js.tpl
@@ -1,4 +1,4 @@
 {literal}
-<script language="JavaScript" src="admin_functions.js">
+<script src="admin_functions.js">
 </script>
 {/literal}

--- a/gacl/admin/templates/phpgacl/assign_group.tpl
+++ b/gacl/admin/templates/phpgacl/assign_group.tpl
@@ -1,11 +1,11 @@
 {include file="phpgacl/header.tpl"}
-<script LANGUAGE="JavaScript">
+<script>
 {$js_array}
 </script>
 {include file="phpgacl/acl_admin_js.tpl"}
   </head>
   <body onload="populate(document.assign_group.{$group_type}_section,document.assign_group.elements['objects[]'], '{$js_array_name}')">
-    {include file="phpgacl/navigation.tpl"}    
+    {include file="phpgacl/navigation.tpl"}
     <form method="post" name="assign_group" action="assign_group.php">
       <table cellpadding="2" cellspacing="2" border="2" width="100%">
         <tbody>

--- a/interface/billing/edi_270.php
+++ b/interface/billing/edi_270.php
@@ -236,7 +236,7 @@ if ($exclude_policy != "") {
 
         </style>
 
-        <script type="text/javascript">
+        <script>
 
             var stringDelete = <?php echo xlj('Do you want to remove this record?'); ?>;
             var stringBatch  = <?php echo xlj('Please select X12 partner, required to create the 270 batch'); ?>;

--- a/interface/billing/edi_271.php
+++ b/interface/billing/edi_271.php
@@ -105,7 +105,7 @@ if ($batch_log && !$GLOBALS['disable_eligibility_log']) {
     }
 }
 </style>
-<script type="text/javascript">
+<script>
     function edivalidation() {
         var mypcc = <?php echo xlj('Required Field Missing: Please choose the EDI-271 file to upload'); ?>;
         if (document.getElementById('uploaded').value == "") {

--- a/interface/clickmap/template/general_new.html
+++ b/interface/clickmap/template/general_new.html
@@ -3,7 +3,7 @@
     <head>
     {headerTemplate}
 {/if}
-<script type="text/javascript" src="{php}echo $GLOBALS['webroot'];{/php}/library/js/clickmap.js"></script>
+<script src="{php}echo $GLOBALS['webroot'];{/php}/library/js/clickmap.js"></script>
 <link rel="stylesheet" href="{$form->template_dir}/css/clickmap.css" />
 {if !$reportMode}
 	</head>
@@ -43,7 +43,7 @@
 	<span class='count'></span>
 </div>
 
-<script type="text/javascript">
+<script>
 {literal}
     $(function () {
 		var optionsLabel = {/literal}{$form->optionsLabel}{literal};

--- a/interface/cmsportal/insurance_form.php
+++ b/interface/cmsportal/insurance_form.php
@@ -366,7 +366,7 @@ foreach ($insurance_layout as $lorow) {
 
 </form>
 
-<script language="JavaScript">
+<script>
 
 // Fix inconsistently formatted phone numbers from the database.
 var f = document.forms[0];

--- a/interface/cmsportal/list_requests.php
+++ b/interface/cmsportal/list_requests.php
@@ -135,7 +135,7 @@ tr.detail {
 }
 </style>
 
-<script language="JavaScript">
+<script>
 
 function myRestoreSession() {
  // This works whether we are a popup or in the OpenEMR frameset.

--- a/interface/de_identification_forms/de_identification_screen1.php
+++ b/interface/de_identification_forms/de_identification_screen1.php
@@ -36,7 +36,7 @@ if (!AclMain::aclCheckCore('admin', 'super')) {
     text-align: center;
 }</style>
 
-<script language="JavaScript">
+<script>
 //get value from popup window
 function set_related(s,type) {
  var list;

--- a/interface/de_identification_forms/find_drug_popup.php
+++ b/interface/de_identification_forms/find_drug_popup.php
@@ -32,7 +32,7 @@ $form_code_type = $_POST['form_code_type'];
 td { font-size:10pt; }
 </style>
 
-<script language="JavaScript">
+<script>
 //pass value selected to the parent window
  function window_submit(chk)
  {

--- a/interface/de_identification_forms/re_identification_input_screen.php
+++ b/interface/de_identification_forms/re_identification_input_screen.php
@@ -37,7 +37,7 @@ if (!AclMain::aclCheckCore('admin', 'super')) {
     text-align: center;
 }
 </style>
-<script language="JavaScript">
+<script>
 function form_validate()
 {
 

--- a/interface/drugs/dispense_drug.php
+++ b/interface/drugs/dispense_drug.php
@@ -216,7 +216,7 @@ if (false) { // if PDF output is desired
 } else { // HTML output
     ?>
 <html>
-    <script type="text/javascript" src="<?php echo $webroot ?>/interface/main/tabs/js/include_opener.js"></script>
+    <script src="<?php echo $webroot ?>/interface/main/tabs/js/include_opener.js"></script>
 <head>
 <style>
 body {
@@ -255,7 +255,7 @@ body {
  </td></tr>
 </table>
 </center>
-<script language="JavaScript">
+<script>
  var win = top.printLogPrint ? top : opener.top;
  win.printLogPrint(window);
 </script>

--- a/interface/eRx.php
+++ b/interface/eRx.php
@@ -84,7 +84,7 @@ if (count($missingExtensions) > 0) {
         ob_end_flush();
 
         ?>
-        <script type="text/javascript">
+        <script>
             window.setTimeout(function() {
                 window.location = "<?php echo $GLOBALS['webroot']; ?>/interface/patient_file/summary/demographics_full.php";
             }, <?php echo (count($messages) * 2000) + 3000; ?>);
@@ -135,14 +135,14 @@ if (count($missingExtensions) > 0) {
             $eRxPage->updatePatientData();
 
             ?>
-        <script type="text/javascript">
+        <script>
             <?php require($GLOBALS['srcdir'] . '/restoreSession.php'); ?>
         </script>
         <form name="info" method="post" action="<?php echo $GLOBALS['erx_newcrop_path']; ?>" onsubmit="return top.restoreSession()">
             <input type="submit" style="display:none">
             <input type="hidden" id="RxInput" name="RxInput" value="<?php echo attr($xml); ?>">
         </form>
-        <script type="text/javascript">
+        <script>
             window.setTimeout(function() {
                 document.forms[0].submit();
             }, <?php echo $delay; ?>);

--- a/interface/fax/fax_dispatch.php
+++ b/interface/fax/fax_dispatch.php
@@ -486,7 +486,7 @@ div.section {
 
 </style>
 
-<script language="JavaScript">
+<script>
 
     <?php require($GLOBALS['srcdir'] . "/restoreSession.php"); ?>
 

--- a/interface/forms/CAMOS/notegen.php
+++ b/interface/forms/CAMOS/notegen.php
@@ -53,7 +53,7 @@ if (!$_POST['submit_pdf'] && !$_POST['submit_html'] && !($_GET['pid'] && $_GET['
 
     <?php Header::setupHeader('datetime-picker'); ?>
 
-<script type="text/javascript">
+<script>
 $(function () {
     $('.datepicker').datetimepicker({
         <?php $datetimepicker_timepicker = false; ?>

--- a/interface/forms/CAMOS/rx_print.php
+++ b/interface/forms/CAMOS/rx_print.php
@@ -416,7 +416,7 @@ if ($_POST['print_pdf'] || $_POST['print_html']) {
 <title>
     <?php echo xlt('CAMOS'); ?>
 </title>
-<script type="text/javascript">
+<script>
 //below init function just to demonstrate how to do it.
 //now need to create 'cycle' function triggered by button to go by fours
 //through selected types of subcategories.

--- a/interface/forms/CAMOS/view.php
+++ b/interface/forms/CAMOS/view.php
@@ -34,7 +34,7 @@ $textarea_cols = 90;
 ?>
 <html><head>
     <?php Header::setupHeader(); ?>
-<script type="text/javascript">
+<script>
 function checkall(){
   var f = document.my_form;
   var x = f.elements.length;

--- a/interface/forms/LBF/new.php
+++ b/interface/forms/LBF/new.php
@@ -368,7 +368,7 @@ if (!empty($_POST['bn_save']) || !empty($_POST['bn_save_print']) || !empty($_POS
     <?php echo lbf_canvas_head(); ?>
     <?php echo signer_head(); ?>
 
-    <script language="JavaScript">
+    <script>
 
         // Support for beforeunload handler.
         var somethingChanged = false;
@@ -1589,7 +1589,7 @@ if (!empty($_POST['bn_save']) || !empty($_POST['bn_save_print']) || !empty($_POS
     <!-- include support for the list-add selectbox feature -->
     <?php include $GLOBALS['fileroot'] . "/library/options_listadd.inc"; ?>
 
-    <script language="JavaScript">
+    <script>
 
         // Array of action conditions for the checkSkipConditions() function.
         var skipArray = [

--- a/interface/forms/aftercare_plan/new.php
+++ b/interface/forms/aftercare_plan/new.php
@@ -31,7 +31,7 @@ $obj = $formid ? formFetch("form_aftercare_plan", $formid) : array();
 
 <?php Header::setupHeader('datetime-picker'); ?>
 
-<script language="JavaScript">
+<script>
  $(function () {
   var win = top.printLogSetup ? top : opener.top;
   win.printLogSetup(document.getElementById('printbutton'));

--- a/interface/forms/ankleinjury/new.php
+++ b/interface/forms/ankleinjury/new.php
@@ -112,7 +112,7 @@ formHeader("Form: ankleinjury");
 
 </tr>
 </table>
- <script language="javascript">
+ <script>
  <!--
  function doCPT(select) {
     var numchecked = 0;

--- a/interface/forms/bronchitis/new.php
+++ b/interface/forms/bronchitis/new.php
@@ -26,7 +26,7 @@ formHeader("Form: bronchitis");
 $returnurl = 'encounter_top.php';
 ?>
 <html><head>
-<SCRIPT LANGUAGE="JavaScript">
+<script>
 <!--
 
    function onset_check (form)   {
@@ -51,7 +51,7 @@ $returnurl = 'encounter_top.php';
     alert("OK, Bye!!!");
     return;
    }
-</SCRIPT>
+</script>
 
 <?php Header::setupHeader(); ?>
 </head>

--- a/interface/forms/eye_mag/SpectacleRx.php
+++ b/interface/forms/eye_mag/SpectacleRx.php
@@ -375,7 +375,7 @@ if ($_REQUEST['dispensed']) {
                 width: 300px;
             }
         </style>
-        <script language="JavaScript">
+        <script>
         <?php
         require_once("$srcdir/restoreSession.php");  ?>
 
@@ -695,7 +695,7 @@ if ($_REQUEST['dispensed']) {
 <html>
 <head>
     <?php Header::setupHeader([ 'opener', 'jquery-ui', 'jquery-ui-redmond', 'pure', 'jscolor' ]); ?>
-    <link rel="stylesheet" href="../../forms/<?php echo $form_folder; ?>/css/style.css>
+    <link rel="stylesheet" href="../../forms/<?php echo $form_folder; ?>/css/style.css">
 
     <style>
         .title {
@@ -792,7 +792,7 @@ if ($_REQUEST['dispensed']) {
     </style>
     <!-- jQuery library -->
 
-    <script language="JavaScript">
+    <script>
         <?php require_once("$srcdir/restoreSession.php"); ?>
         function pick_rxType(rxtype, id) {
             var url = "../../forms/eye_mag/SpectacleRx.php";

--- a/interface/forms/eye_mag/a_issue.php
+++ b/interface/forms/eye_mag/a_issue.php
@@ -655,7 +655,7 @@ foreach (explode(',', $given) as $item) {
     </style>
 
     <link rel="shortcut icon" href="<?php echo $GLOBALS['images_static_relative']; ?>/favicon.ico" />
-    <script type="text/javascript" src="<?php echo $GLOBALS['webroot']; ?>/interface/forms/<?php echo $form_folder; ?>/js/eye_base.php?enc=<?php echo attr($encounter); ?>&providerID=<?php echo attr($providerID); ?>"></script>
+    <script src="<?php echo $GLOBALS['webroot']; ?>/interface/forms/<?php echo $form_folder; ?>/js/eye_base.php?enc=<?php echo attr($encounter); ?>&providerID=<?php echo attr($providerID); ?>"></script>
 </head>
 
 <body>

--- a/interface/forms/eye_mag/php/eye_mag_functions.php
+++ b/interface/forms/eye_mag/php/eye_mag_functions.php
@@ -1483,7 +1483,7 @@ margin: 2px 0 2px 2px;">
         </div>
         <input type="hidden" name="PRIOR_PREFS_ACT_SHOW"  id="PRIOR_PREFS_ACT_SHOW" value="<?php echo attr($ACT_SHOW); ?>">
 
-        <script type="text/javascript">
+        <script>
             $("#PRIOR_ACTTRIGGER").mouseover(function() {
                                                    $("#PRIOR_ACTTRIGGER").toggleClass('buttonRefraction_selected').toggleClass('underline');
                                                    });

--- a/interface/forms/eye_mag/view.php
+++ b/interface/forms/eye_mag/view.php
@@ -4048,7 +4048,7 @@ if ($refresh and $refresh != 'fullscreen') {
     <!-- Undo code -->
     <script src="<?php echo $GLOBALS['assets_static_relative']; ?>/manual-added-packages/undone.js-0-0-1/undone.js"></script>
     <script src="<?php echo $GLOBALS['assets_static_relative']; ?>/manual-added-packages/undone.js-0-0-1/jquery.undone.js"></script>
-    <script language="JavaScript">
+    <script>
         function openNewForm(sel, label) {
             top.restoreSession();
             FormNameValueArray = sel.split('formname=');
@@ -4181,10 +4181,10 @@ if ($refresh and $refresh != 'fullscreen') {
         }
         var base = '<?php echo $GLOBALS['webroot']; ?>';
     </script>
-    <script type="text/javascript" src="<?php echo $GLOBALS['webroot']; ?>/interface/forms/<?php echo $form_folder; ?>/js/shorthand_eye.js"></script>
-    <script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative'] ?>/manual-added-packages/shortcut.js-2-01-B/shortcut.js"></script>
-    <script type="text/javascript" src="<?php echo $GLOBALS['webroot']; ?>/interface/forms/<?php echo $form_folder; ?>/js/eye_base.php?enc=<?php echo attr($encounter); ?>&providerID=<?php echo attr($provider_id); ?>"></script>
-    <script type="text/javascript" src="<?php echo $GLOBALS['webroot']; ?>/interface/forms/<?php echo $form_folder; ?>/js/canvasdraw.js"></script>
+    <script src="<?php echo $GLOBALS['webroot']; ?>/interface/forms/<?php echo $form_folder; ?>/js/shorthand_eye.js"></script>
+    <script src="<?php echo $GLOBALS['assets_static_relative'] ?>/manual-added-packages/shortcut.js-2-01-B/shortcut.js"></script>
+    <script src="<?php echo $GLOBALS['webroot']; ?>/interface/forms/<?php echo $form_folder; ?>/js/eye_base.php?enc=<?php echo attr($encounter); ?>&providerID=<?php echo attr($provider_id); ?>"></script>
+    <script src="<?php echo $GLOBALS['webroot']; ?>/interface/forms/<?php echo $form_folder; ?>/js/canvasdraw.js"></script>
     <div id="right-panel" name="right-panel" class="panel_side">
       <div style="margin-top:20px;text-align:center;font-size:1.2em;">
         <span class="fa fa-file-text-o" id="PANEL_TEXT" name="PANEL_TEXT" style="margin:2px;"></span>

--- a/interface/forms/fee_sheet/code_choice/initialize_code_choice.php
+++ b/interface/forms/fee_sheet/code_choice/initialize_code_choice.php
@@ -13,5 +13,5 @@
 require_once("templates/code_choices.php");
 ?>
 
-<script type="text/javascript" src="<?php echo $web_root;?>/interface/forms/fee_sheet/code_choice/js/view_model.js"></script>
+<script src="<?php echo $web_root;?>/interface/forms/fee_sheet/code_choice/js/view_model.js"></script>
 <link rel="stylesheet" href="<?php echo $web_root;?>/interface/forms/fee_sheet/code_choice/css/code_choices.css">

--- a/interface/forms/fee_sheet/review/initialize_review.php
+++ b/interface/forms/fee_sheet/review/initialize_review.php
@@ -35,10 +35,10 @@ if (!$isBilled) {
         return this;
     }
 </script>
-<script type="text/javascript" src="<?php echo $web_root;?>/interface/forms/fee_sheet/review/initialize_review.js?v=<?php echo $GLOBALS['v_js_includes']; ?>"></script>
-<script type="text/javascript" src="<?php echo $web_root;?>/interface/forms/fee_sheet/review/js/fee_sheet_core.js?v=<?php echo $GLOBALS['v_js_includes']; ?>"></script>
-<script type="text/javascript" src="<?php echo $web_root;?>/interface/forms/fee_sheet/review/fee_sheet_review_view_model.js?v=<?php echo $GLOBALS['v_js_includes']; ?>"></script>
-<script type="text/javascript" src="<?php echo $web_root;?>/interface/forms/fee_sheet/review/fee_sheet_justify_view_model.js?v=<?php echo $GLOBALS['v_js_includes']; ?>"></script>
+<script src="<?php echo $web_root;?>/interface/forms/fee_sheet/review/initialize_review.js?v=<?php echo $GLOBALS['v_js_includes']; ?>"></script>
+<script src="<?php echo $web_root;?>/interface/forms/fee_sheet/review/js/fee_sheet_core.js?v=<?php echo $GLOBALS['v_js_includes']; ?>"></script>
+<script src="<?php echo $web_root;?>/interface/forms/fee_sheet/review/fee_sheet_review_view_model.js?v=<?php echo $GLOBALS['v_js_includes']; ?>"></script>
+<script src="<?php echo $web_root;?>/interface/forms/fee_sheet/review/fee_sheet_justify_view_model.js?v=<?php echo $GLOBALS['v_js_includes']; ?>"></script>
 
     <?php
     // knockoutjs template files

--- a/interface/forms/functional_cognitive_status/new.php
+++ b/interface/forms/functional_cognitive_status/new.php
@@ -51,7 +51,7 @@ $check_res = $formid ? $check_res : array();
             }
         </style>
 
-        <script type="text/javascript">
+        <script>
 
             function duplicateRow(e) {
                 var newRow = e.cloneNode(true);

--- a/interface/forms/misc_billing_options/new.php
+++ b/interface/forms/misc_billing_options/new.php
@@ -276,7 +276,7 @@ $obj = $formid ? formFetch("form_misc_billing_options", $formid) : array();
     </div>
 </div><!--End of container div-->
 <?php $oemr_ui->oeBelowContainerDiv();?>
-<script language="javascript">
+<script>
     // jQuery stuff to make the page a little easier to use
     $(function () {
         $(".dontsave").click(function () {

--- a/interface/forms/misc_billing_options/save.php
+++ b/interface/forms/misc_billing_options/save.php
@@ -30,7 +30,7 @@ if (!CsrfUtils::verifyCsrfToken($_POST["csrf_token_form"])) {
 if (isset($_SESSION['billencounter'])) {
     $pid = $_SESSION['billpid'];
     $encounter = $_SESSION['billencounter'];
-    echo "<script type='text/javascript' src='" . $webroot . "/interface/main/tabs/js/include_opener.js'></script>";
+    echo "<script src='" . $webroot . "/interface/main/tabs/js/include_opener.js'></script>";
 }
 if (!$encounter) { // comes from globals.php
     die(xlt("Internal error: we do not seem to be in an encounter!"));

--- a/interface/forms/newGroupEncounter/common.php
+++ b/interface/forms/newGroupEncounter/common.php
@@ -70,7 +70,7 @@ $use_validate_js = 1;
 require_once($GLOBALS['srcdir'] . "/validation/validation_script.js.php"); ?>
 
 <?php include_once("{$GLOBALS['srcdir']}/ajax/facility_ajax_jav.inc.php"); ?>
-<script language="JavaScript">
+<script>
 
 /*
  // Process click on issue title.
@@ -381,7 +381,7 @@ $help_icon = '';
 
 </body>
 
-<script language="javascript">
+<script>
 <?php
 if (!$viewmode) { ?>
  function duplicateVisit(enc, datestr) {

--- a/interface/forms/newpatient/common.php
+++ b/interface/forms/newpatient/common.php
@@ -103,7 +103,7 @@ $ires = sqlStatement("SELECT id, type, title, begdate FROM lists WHERE " .
     require_once($GLOBALS['srcdir'] . "/validation/validation_script.js.php"); ?>
 
     <?php include_once("{$GLOBALS['srcdir']}/ajax/facility_ajax_jav.inc.php"); ?>
-    <script language="JavaScript">
+    <script>
         const mypcc = '' + <?php echo js_escape($GLOBALS['phone_country_code']); ?>;
 
         // Process click on issue title.

--- a/interface/forms/note/new.php
+++ b/interface/forms/note/new.php
@@ -31,7 +31,7 @@ $form_name = "note";
 
 <?php Header::setupHeader('datetime-picker'); ?>
 
-<script language="JavaScript">
+<script>
 // required for textbox date verification
 var mypcc = <?php echo js_escape($GLOBALS['phone_country_code']); ?>;
 </script>
@@ -97,7 +97,7 @@ var mypcc = <?php echo js_escape($GLOBALS['phone_country_code']); ?>;
 
 </body>
 
-<script language="javascript">
+<script>
 
 // jQuery stuff to make the page a little easier to use
 

--- a/interface/forms/note/print.php
+++ b/interface/forms/note/print.php
@@ -76,7 +76,7 @@ if ($obj['date_of_signature'] != "") {
 
 </body>
 
-<script language="javascript">
+<script>
 // jQuery stuff to make the page a little easier to use
 
 $(function () {

--- a/interface/forms/note/view.php
+++ b/interface/forms/note/view.php
@@ -42,7 +42,7 @@ if ($obj['date_of_signature'] != "") {
 
 <?php Header::setupHeader('datetime-picker'); ?>
 
-<script language="JavaScript">
+<script>
 // required for textbox date verification
 var mypcc = <?php echo js_escape($GLOBALS['phone_country_code']); ?>;
 
@@ -101,7 +101,7 @@ function PrintForm() {
 
 </body>
 
-<script language="javascript">
+<script>
 
 // jQuery stuff to make the page a little easier to use
 

--- a/interface/forms/observation/new.php
+++ b/interface/forms/observation/new.php
@@ -53,7 +53,7 @@ $check_res = $formid ? $check_res : array();
             }
         </style>
 
-        <script type="text/javascript">
+        <script>
 
             function duplicateRow(e) {
                 var newRow = e.cloneNode(true);

--- a/interface/forms/physical_exam/new.php
+++ b/interface/forms/physical_exam/new.php
@@ -141,7 +141,7 @@ if ($formid) {
 <html>
 <head>
 <?php Header::setupHeader(); ?>
-<script language="JavaScript">
+<script>
 
  function seldiag(selobj, line_id) {
   var i = selobj.selectedIndex;

--- a/interface/forms/track_anything/history.php
+++ b/interface/forms/track_anything/history.php
@@ -73,7 +73,7 @@ echo "<html><head>";
 
 <link rel="stylesheet" href="style.css">
 
-<script type="text/javascript">
+<script>
 //-------------- checkboxes checked checker --------------------
 // Pass the checkbox name to the function
 function getCheckedBoxes(chkboxName) {
@@ -351,7 +351,7 @@ while ($myrow = sqlFetchArray($query)) {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     ?>
-<script type="text/javascript">
+<script>
 function get_my_graph<?php echo attr($track_count); ?>(where){
     top.restoreSession();
     if(where=="local"){

--- a/interface/forms/track_anything/new.php
+++ b/interface/forms/track_anything/new.php
@@ -39,7 +39,7 @@ echo "<html><head>";
 ?>
 <?php Header::setupHeader(['datetime-picker', 'track-anything']); ?>
 
-<script type="text/javascript">
+<script>
 $(function () {
     $('.datetimepicker').datetimepicker({
         <?php $datetimepicker_timepicker = true; ?>

--- a/interface/forms/transfer_summary/new.php
+++ b/interface/forms/transfer_summary/new.php
@@ -31,7 +31,7 @@ $obj = $formid ? formFetch("form_transfer_summary", $formid) : array();
 
 <?php Header::setupHeader('datetime-picker'); ?>
 
-<script language="JavaScript">
+<script>
  $(function () {
   var win = top.printLogSetup ? top : opener.top;
   win.printLogSetup(document.getElementById('printbutton'));

--- a/interface/forms/treatment_plan/new.php
+++ b/interface/forms/treatment_plan/new.php
@@ -33,7 +33,7 @@ $obj = $formid ? formFetch("form_treatment_plan", $formid) : array();
 
 <?php Header::setupHeader('datetime-picker'); ?>
 
-<script language="JavaScript">
+<script>
  $(function () {
   var win = top.printLogSetup ? top : opener.top;
   win.printLogSetup(document.getElementById('printbutton'));

--- a/interface/forms/vitals/growthchart/chart.php
+++ b/interface/forms/vitals/growthchart/chart.php
@@ -305,7 +305,7 @@ function cssHeader()
         }
     }
     </style>
-    <SCRIPT LANGUAGE="JavaScript">
+    <script>
         function FormSetup()    {
         changeStyle('page1')
     }
@@ -325,7 +325,7 @@ function cssHeader()
     var win = top.printLogPrint ? top : opener.top;
     win.printLogPrint(window);
   }
-    </SCRIPT>
+    </script>
     <title><?php echo xlt('Growth Chart'); ?></title>
     </head>
     <body Onload="FormSetup()">

--- a/interface/forms/vitals/templates/vitals/general_new.html
+++ b/interface/forms/vitals/templates/vitals/general_new.html
@@ -12,7 +12,7 @@
 {headerTemplate assets='datetime-picker'}
 
 {literal}
-<script type="text/javascript">
+<script>
 function vitalsFormSubmitted() {
     var invalid = "";
 

--- a/interface/login/login.php
+++ b/interface/login/login.php
@@ -93,7 +93,7 @@ if (count($emr_app)) {
 
     <link rel="shortcut icon" href="<?php echo $GLOBALS['images_static_relative']; ?>/favicon.ico" />
 
-    <script type="text/javascript">
+    <script>
         var registrationTranslations = <?php echo json_encode(array(
             'title' => xla('OpenEMR Product Registration'),
             'pleaseProvideValidEmail' => xla('Please provide a valid email address'),
@@ -112,10 +112,10 @@ if (count($emr_app)) {
         )); ?>;
     </script>
 
-    <script type="text/javascript" src="<?php echo $webroot ?>/interface/product_registration/product_registration_service.js?v=<?php echo $v_js_includes; ?>"></script>
-    <script type="text/javascript" src="<?php echo $webroot ?>/interface/product_registration/product_registration_controller.js?v=<?php echo $v_js_includes; ?>"></script>
+    <script src="<?php echo $webroot ?>/interface/product_registration/product_registration_service.js?v=<?php echo $v_js_includes; ?>"></script>
+    <script src="<?php echo $webroot ?>/interface/product_registration/product_registration_controller.js?v=<?php echo $v_js_includes; ?>"></script>
 
-    <script type="text/javascript">
+    <script>
         $(function () {
             init();
 

--- a/interface/login_screen.php
+++ b/interface/login_screen.php
@@ -16,7 +16,7 @@ require_once("./globals.php");
 <html>
 <body>
 
-<script LANGUAGE="JavaScript">
+<script>
  top.location.href='<?php echo "$rootdir/login/login.php?site="; ?>' + <?php echo js_url($_SESSION['site_id']); ?>;
 </script>
 

--- a/interface/main/about_page.php
+++ b/interface/main/about_page.php
@@ -58,7 +58,7 @@ use OpenEMR\Services\VersionService;
         }
     </style>
 
-    <script type="text/javascript">
+    <script>
         var registrationTranslations = <?php echo json_encode(array(
             'title' => xla('OpenEMR Product Registration'),
             'pleaseProvideValidEmail' => xla('Please provide a valid email address'),
@@ -79,10 +79,10 @@ use OpenEMR\Services\VersionService;
             ?>;
     </script>
 
-    <script type="text/javascript" src="<?php echo $webroot ?>/interface/product_registration/product_registration_service.js?v=<?php echo $v_js_includes; ?>"></script>
-    <script type="text/javascript" src="<?php echo $webroot ?>/interface/product_registration/product_registration_controller.js?v=<?php echo $v_js_includes; ?>"></script>
+    <script src="<?php echo $webroot ?>/interface/product_registration/product_registration_service.js?v=<?php echo $v_js_includes; ?>"></script>
+    <script src="<?php echo $webroot ?>/interface/product_registration/product_registration_controller.js?v=<?php echo $v_js_includes; ?>"></script>
 
-    <script type="text/javascript">
+    <script>
         $(function () {
             var productRegistrationController = new ProductRegistrationController();
             productRegistrationController.getProductRegistrationStatus(function(err, data) {

--- a/interface/main/calendar/find_group_popup.php
+++ b/interface/main/calendar/find_group_popup.php
@@ -163,7 +163,7 @@ if ($_POST['searchby'] && $_POST['searchparm']) {
         }
     </style>
 
-    <script language="JavaScript">
+    <script
 
         function selgid(gid, name, end_date) {
             if (opener.closed || !opener.setgroup)
@@ -245,7 +245,7 @@ if ($_POST['searchby'] && $_POST['searchparm']) {
     </div>
 <?php endif; ?>
 
-<script language="javascript">
+<script>
 
     // jQuery stuff to make the page a little easier to use
 

--- a/interface/main/calendar/modules/PostCalendar/common.api.php
+++ b/interface/main/calendar/modules/PostCalendar/common.api.php
@@ -287,7 +287,7 @@ function postcalendar_userapi_jsPopup()
 
     $output = <<<EOF
 
-<script language="javascript">
+<script>
 <!--
 function opencal(eid,date) {
     window.name='csCalendar';
@@ -326,7 +326,7 @@ function postcalendar_userapi_loadPopups()
 
     $output = <<<EOF
 
-<script language="JavaScript">
+<script>
 <!-- overLIB configuration -->
 ol_fgcolor = "$bgcolor1";
 ol_bgcolor = "$bgcolor2";
@@ -361,7 +361,7 @@ ol_hauto = 1;
 ol_vauto = 1;
 </script>
 <div id="overDiv" style="position:absolute; top:0px; left:0px; visibility:hidden; z-index:1000;"></div>
-<script language="JavaScript" src="modules/$pcDir/pnincludes/overlib_mini.js">
+<script src="modules/$pcDir/pnincludes/overlib_mini.js">
 <!-- overLIB (c) Erik Bosrup -->
 </script>
 

--- a/interface/main/calendar/modules/PostCalendar/pnincludes/ColorPicker2.js
+++ b/interface/main/calendar/modules/PostCalendar/pnincludes/ColorPicker2.js
@@ -17,13 +17,13 @@
 // ===================================================================
 
 
-/* 
+/*
 ColorPicker.js
 Author: Matt Kruse
 Last modified: 6/19/01
 
-DESCRIPTION: This widget is used to select a color, in hexadecimal #RRGGBB 
-form. It uses a color "swatch" to display the standard 216-color web-safe 
+DESCRIPTION: This widget is used to select a color, in hexadecimal #RRGGBB
+form. It uses a color "swatch" to display the standard 216-color web-safe
 palette. The user can then click on a color to select it.
 
 COMPATABILITY: See notes in AnchorPosition.js and PopupWindow.js.
@@ -53,18 +53,18 @@ function pickColor(color) {
 NOTES:
 1) Requires the functions in AnchorPosition.js and PopupWindow.js
 
-2) Your anchor tag MUST contain both NAME and ID attributes which are the 
+2) Your anchor tag MUST contain both NAME and ID attributes which are the
    same. For example:
    <A NAME="test" ID="test"> </A>
 
-3) There must be at least a space between <A> </A> for IE5.5 to see the 
+3) There must be at least a space between <A> </A> for IE5.5 to see the
    anchor tag correctly. Do not do <A></A> with no space.
 
 4) When a ColorPicker object is created, a handler for 'onmouseup' is
    attached to any event handler you may have already defined. Do NOT define
    an event handler for 'onmouseup' after you define a ColorPicker object or
    the color picker will not hide itself correctly.
-*/ 
+*/
 
 function ColorPicker_writeDiv() {
 	document.writeln("<DIV ID=\"colorPickerDiv\" STYLE=\"position:absolute;visibility:hidden;\"> </DIV>");
@@ -83,7 +83,7 @@ function ColorPicker_pickColor(color,obj) {
 		alert("You must define a function named 'pickColor' to receive the value clicked!");
 		}
 	}
-	
+
 // This function runs when you move your mouse over a color block, if you have a newer browser
 function ColorPicker_highlightColor(c) {
 	var thedoc = (arguments.length>1)?arguments[1]:window.document;
@@ -106,7 +106,7 @@ function ColorPicker() {
 	else {
 		var divname = arguments[0];
 		}
-	
+
 	if (divname != "") {
 		var cp = new PopupWindow(divname);
 		}
@@ -117,7 +117,7 @@ function ColorPicker() {
 
 	// Object variables
 	cp.currentValue = "#FFFFFF";
-	
+
 	// Method Mappings
 	cp.writeDiv = ColorPicker_writeDiv;
 	cp.highlightColor = ColorPicker_highlightColor;
@@ -159,7 +159,7 @@ function ColorPicker() {
 		if (use_highlight) { var mo = 'onMouseOver="'+windowRef+'ColorPicker_highlightColor(\''+colors[i]+'\',window.document)"'; }
 		else { mo = ""; }
 		cp_contents += '<TD BGCOLOR="'+colors[i]+'"><FONT SIZE="-3"><A HREF="#" onClick="'+windowRef+'ColorPicker_pickColor(\''+colors[i]+'\','+windowRef+'window.popupWindowObjects['+cp.index+']);return false;" '+mo+' STYLE="text-decoration:none;">&nbsp;&nbsp;&nbsp;</A></FONT></TD>';
-		if ( ((i+1)>=total) || (((i+1) % width) == 0)) { 
+		if ( ((i+1)>=total) || (((i+1) % width) == 0)) {
 			cp_contents += "</TR>";
 			}
 		}

--- a/interface/main/calendar/modules/PostCalendar/pntemplates/default/user/ajax_search.html
+++ b/interface/main/calendar/modules/PostCalendar/pntemplates/default/user/ajax_search.html
@@ -4,8 +4,8 @@
 [-* we want to include our stylesheet for this view*-]
 <link rel="stylesheet" href="[-php-] echo $GLOBALS['assets_static_relative'] [-/php-]/jquery-datetimepicker/build/jquery.datetimepicker.min.css">
 
-<!--<script type="text/javascript" src="[-php-] echo $GLOBALS['assets_static_relative'] [-/php-]/jquery/dist/jquery.min.js"></script>-->
-<script type="text/javascript" src="[-php-] echo $GLOBALS['assets_static_relative'] [-/php-]/jquery-datetimepicker/build/jquery.datetimepicker.full.min.js"></script>
+<!--<script src="[-php-] echo $GLOBALS['assets_static_relative'] [-/php-]/jquery/dist/jquery.min.js"></script>-->
+<script src="[-php-] echo $GLOBALS['assets_static_relative'] [-/php-]/jquery-datetimepicker/build/jquery.datetimepicker.full.min.js"></script>
 
 <!-- main navigation -->
 [-*Load the Language Definitions*-]

--- a/interface/main/calendar/modules/PostCalendar/pntemplates/default/user/ajax_search.html
+++ b/interface/main/calendar/modules/PostCalendar/pntemplates/default/user/ajax_search.html
@@ -4,7 +4,6 @@
 [-* we want to include our stylesheet for this view*-]
 <link rel="stylesheet" href="[-php-] echo $GLOBALS['assets_static_relative'] [-/php-]/jquery-datetimepicker/build/jquery.datetimepicker.min.css">
 
-<!--<script src="[-php-] echo $GLOBALS['assets_static_relative'] [-/php-]/jquery/dist/jquery.min.js"></script>-->
 <script src="[-php-] echo $GLOBALS['assets_static_relative'] [-/php-]/jquery-datetimepicker/build/jquery.datetimepicker.full.min.js"></script>
 
 <!-- main navigation -->

--- a/interface/main/calendar/modules/PostCalendar/pntemplates/default/views/header.html
+++ b/interface/main/calendar/modules/PostCalendar/pntemplates/default/views/header.html
@@ -9,7 +9,7 @@
 <![endif]-->
 
 <!-- the javascript used for the ajax_* style calendars -->
-<script type="text/javascript" src="[-php-] echo $GLOBALS['webroot'] [-/php-]/library/js/calendarDirectSelect.js"></script>
+<script src="[-php-] echo $GLOBALS['webroot'] [-/php-]/library/js/calendarDirectSelect.js"></script>
 <script>
     function event_time_click(elem) {
         EditEvent($(elem).parents("div.event_appointment").get(0));

--- a/interface/main/dated_reminders/dated_reminders_add.php
+++ b/interface/main/dated_reminders/dated_reminders_add.php
@@ -119,7 +119,7 @@ if ($_POST) {
         } else {
       // --------- echo javascript
             echo '<html><body>'
-            . "<script type=\"text/javascript\" src=\"" . $webroot . "/interface/main/tabs/js/include_opener.js\"></script>"
+            . "<script src=\"" . $webroot . "/interface/main/tabs/js/include_opener.js\"></script>"
             . '<script>';
       // ------------ 1) refresh parent window this updates if sent to self
             echo '  if (opener && !opener.closed && opener.updateme) opener.updateme("new");';

--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -171,12 +171,12 @@ $esignApi = new Api();
 
     <link rel="shortcut icon" href="<?php echo $GLOBALS['images_static_relative']; ?>/favicon.ico" />
 
-    <script type="text/javascript" src="js/custom_bindings.js?v=<?php echo $v_js_includes; ?>"></script>
-    <script type="text/javascript" src="js/user_data_view_model.js?v=<?php echo $v_js_includes; ?>"></script>
-    <script type="text/javascript" src="js/patient_data_view_model.js?v=<?php echo $v_js_includes; ?>"></script>
-    <script type="text/javascript" src="js/therapy_group_data_view_model.js?v=<?php echo $v_js_includes; ?>"></script>
+    <script src="js/custom_bindings.js?v=<?php echo $v_js_includes; ?>"></script>
+    <script src="js/user_data_view_model.js?v=<?php echo $v_js_includes; ?>"></script>
+    <script src="js/patient_data_view_model.js?v=<?php echo $v_js_includes; ?>"></script>
+    <script src="js/therapy_group_data_view_model.js?v=<?php echo $v_js_includes; ?>"></script>
 
-    <script type="text/javascript">
+    <script>
         // Set the csrf_token_js token that is used in the below js/tabs_view_model.js script
         var csrf_token_js = <?php echo js_escape(CsrfUtils::collectCsrfToken()); ?>;
         // will fullfill json and return promise if needed
@@ -241,11 +241,11 @@ $esignApi = new Api();
         });
 
     </script>
-    <script type="text/javascript" src="js/tabs_view_model.js?v=<?php echo $v_js_includes; ?>"></script>
+    <script src="js/tabs_view_model.js?v=<?php echo $v_js_includes; ?>"></script>
 
-    <script type="text/javascript" src="js/application_view_model.js?v=<?php echo $v_js_includes; ?>"></script>
-    <script type="text/javascript" src="js/frame_proxies.js?v=<?php echo $v_js_includes; ?>"></script>
-    <script type="text/javascript" src="js/dialog_utils.js?v=<?php echo $v_js_includes; ?>"></script>
+    <script src="js/application_view_model.js?v=<?php echo $v_js_includes; ?>"></script>
+    <script src="js/frame_proxies.js?v=<?php echo $v_js_includes; ?>"></script>
+    <script src="js/dialog_utils.js?v=<?php echo $v_js_includes; ?>"></script>
 
     <?php
     // Below code block is to prepare certain elements for deciding what links to show on the menu
@@ -275,7 +275,7 @@ $esignApi = new Api();
     <?php require_once("menu/menu_json.php"); ?>
     <?php $userQuery = sqlQuery("select * from users where username = ?", array($_SESSION['authUser'])); ?>
 
-    <script type="text/javascript">
+    <script>
         <?php if (!empty($_SESSION['frame1url']) && !empty($_SESSION['frame1target'])) { ?>
         // Use session variables and tabStatus object to set up initial/default first tab
         app_view_model.application_data.tabs.tabsList.push(new tabStatus(<?php echo xlj("Loading"); ?> +"...",<?php echo json_encode("../" . $_SESSION['frame1url']); ?>,<?php echo json_encode($_SESSION['frame1target']); ?>,<?php echo xlj("Loading"); ?> +" " + <?php echo json_encode($_SESSION['frame1label']); ?>, true, true, false));

--- a/interface/main/tabs/menu/menu_json.php
+++ b/interface/main/tabs/menu/menu_json.php
@@ -19,7 +19,7 @@ use OpenEMR\Menu\MainMenuRole;
 $menuMain = new MainMenuRole($GLOBALS['kernel']->getEventDispatcher());
 $menu_restrictions = $menuMain->getMenu();
 ?>
-<script type="text/javascript">
+<script>
 
     function menu_entry(object)
     {

--- a/interface/main/tabs/timeout_iframe.php
+++ b/interface/main/tabs/timeout_iframe.php
@@ -25,7 +25,7 @@ $daemon_interval = 120; // Interval in seconds between reloads.
 
 <html>
 <body>
-<script type="text/javascript">
+<script>
 
 function timerint() {
     top.restoreSession();

--- a/interface/modules/zend_modules/module/Acl/view/acl/acl/acl.phtml
+++ b/interface/modules/zend_modules/module/Acl/view/acl/acl/acl.phtml
@@ -11,7 +11,7 @@
  */
 
 ?>
-<script type="text/javascript">
+<script>
     ajax_path = "<?php echo $GLOBALS['webroot'];?>/interface/modules/zend_modules/public/acl/ajax";
     module_id = "<?php echo $this->module_id; ?>";
 </script>

--- a/interface/modules/zend_modules/module/Acl/view/acl/acl/index.phtml
+++ b/interface/modules/zend_modules/module/Acl/view/acl/acl/index.phtml
@@ -12,7 +12,7 @@
 
 $listener = $this->listenerObject;
 ?>
-<script type="text/javascript">
+<script>
     var ajax_path = "<?php echo $GLOBALS['webroot']; ?>/interface/modules/zend_modules/public/acl/ajax";
     $(function () {
         <?php if($this->component_id != ''){?>

--- a/interface/modules/zend_modules/module/Acl/view/layout/layout_tabs.phtml
+++ b/interface/modules/zend_modules/module/Acl/view/layout/layout_tabs.phtml
@@ -38,7 +38,7 @@ echo $this->doctype(); ?>
 			->prependFile($this->basePath() . '/js/lib/jquery.easyui.min.js')
 			->prependFile($this->basePath() . '/js/lib/jquery-1.8.0.min.js')
 	?>
-<script type="text/javascript">
+<script>
     var i = 0;
     $(function () {
         $('#tab').tabs({

--- a/interface/modules/zend_modules/module/Application/src/Application/Helper/Javascript.php
+++ b/interface/modules/zend_modules/module/Application/src/Application/Helper/Javascript.php
@@ -30,7 +30,7 @@ class Javascript extends AbstractHelper
         }
 
         $basePath = str_replace("/index.php", "", $_SERVER['PHP_SELF']);
-        echo '<script type="text/javascript">';
+        echo '<script>';
         echo 'var basePath    = "' . $scheme . $_SERVER['SERVER_NAME'] . $basePath . '";';
         echo 'var dateFormat = "yy-mm-dd"';
         echo '</script>';

--- a/interface/modules/zend_modules/module/Carecoordination/view/carecoordination/carecoordination/revandapprove.phtml
+++ b/interface/modules/zend_modules/module/Carecoordination/view/carecoordination/carecoordination/revandapprove.phtml
@@ -64,7 +64,7 @@ $insert = $this->listenerObject->z_xlt('Insert');
         padding: 2px 10px;
     }
 </style>
-<script type="text/javascript">
+<script>
     function submit_form(setval)
     {
         $('#setval').val(setval);

--- a/interface/modules/zend_modules/module/Carecoordination/view/carecoordination/carecoordination/upload.phtml
+++ b/interface/modules/zend_modules/module/Carecoordination/view/carecoordination/carecoordination/upload.phtml
@@ -27,7 +27,7 @@ echo $this->headScript()->prependFile($this->basePath() . '/js/autosuggest/autos
     box-shadow: 1px 4px 4px 1px #8B8B8B;
   }
 </style>
-<script type="text/javascript">
+<script>
     $(function ()
     {
         height_value = parent.window.innerHeight-100;

--- a/interface/modules/zend_modules/module/Carecoordination/view/carecoordination/ccd/upload.phtml
+++ b/interface/modules/zend_modules/module/Carecoordination/view/carecoordination/ccd/upload.phtml
@@ -10,7 +10,7 @@
  */
 
 ?>
-<script type="text/javascript">
+<script>
     $(function ()
     {
         height_value = parent.window.innerHeight-100;

--- a/interface/modules/zend_modules/module/Carecoordination/view/carecoordination/encountermanager/index.phtml
+++ b/interface/modules/zend_modules/module/Carecoordination/view/carecoordination/encountermanager/index.phtml
@@ -154,7 +154,7 @@ foreach($this->status_details as $row_status){
                         <td nowrap>
                                 <input readonly maxlength="10" style="width: 42%" type="text" name="form_date_from" id="form_date_from" class="dateClass"/>
                                 <input readonly maxlength="10" style="width: 42%" type="text" name="form_date_to" id="form_date_to" class="dateClass"/>
-                                <script type="text/javascript">
+                                <script>
                                         $(function () {
                                                 $( "#form_date_from" ).datepicker("setDate", '<?php echo $this->commonplugin->date_format($this->form_data['from_date'], $GLOBALS['date_display_format'], 'yyyy-mm-dd');?>' );
                                                 $( "#form_date_to" ).datepicker("setDate", '<?php echo $this->commonplugin->date_format($this->form_data['to_date'], $GLOBALS['date_display_format'], 'yyyy-mm-dd');?>');
@@ -222,7 +222,7 @@ foreach($this->status_details as $row_status){
                         line-height: 17px !important;
                 }
                 </style>
-                <script type="text/javascript">
+                <script>
                 $(function () {
                         $('.expand_details').click(function(){
                                 var arr = (this.id).split('_');

--- a/interface/modules/zend_modules/module/Carecoordination/view/carecoordination/setup/index.phtml
+++ b/interface/modules/zend_modules/module/Carecoordination/view/carecoordination/setup/index.phtml
@@ -9,7 +9,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 ?>
-<script type="text/javascript">
+<script>
 var save_array = new Array();
 $(function () {
     $( "ul.droptrue" ).sortable({
@@ -153,7 +153,7 @@ $(function () {
             }
             ?>
         </div>
-        <script type="text/javascript">
+        <script>
             var pagecontent = new virtualpaginate({
                 piececlass      : "virtualpage_<?php echo $this->escapeHtml($key);?>", //class of container for each piece of content
                 piececontainer  : "ul",                             //container element type (ie: "div", "p" etc)
@@ -193,7 +193,7 @@ $(function () {
                         <li class="ui-state-default ui-state-disabled sortable_li <?php echo $completed;?>" style="color: #f70428 !important;" id="ID<?php echo $this->escapeHtml($row['ccda_components_field']);?>">
                             <?php echo $this->listenerObject->z_xlt($row['ccda_components_name']);?>
                         </li>
-                        <script type="text/javascript">
+                        <script>
                             $('#ID<?php echo $this->escapeHtml($row['ccda_components_field']);?>').click(function(){
                                 $('.sub_<?php echo $this->escapeHtml($row['ccda_components_field']);?>').toggle('slow');
                             });

--- a/interface/modules/zend_modules/module/Ccr/view/ccr/ccr/index.phtml
+++ b/interface/modules/zend_modules/module/Ccr/view/ccr/ccr/index.phtml
@@ -27,7 +27,7 @@ echo $this->headScript()->prependFile($this->basePath() . '/js/autosuggest/autos
     box-shadow: 1px 4px 4px 1px #8B8B8B;
   }
 </style>
-<script type="text/javascript">
+<script>
   $(function ()
   {
     height_value = parent.window.innerHeight-100;

--- a/interface/modules/zend_modules/module/Ccr/view/ccr/ccr/revandapprove.phtml
+++ b/interface/modules/zend_modules/module/Ccr/view/ccr/ccr/revandapprove.phtml
@@ -34,7 +34,7 @@ $update = $this->listenerObject->z_xlt('Update');
         width: 100px !important;
     }
 </style>
-<script type="text/javascript">
+<script>
     function submit_form(setval){
         document.getElementById('setval').value = setval;
     }

--- a/interface/modules/zend_modules/module/Immunization/view/immunization/immunization/index.phtml
+++ b/interface/modules/zend_modules/module/Immunization/view/immunization/immunization/index.phtml
@@ -22,7 +22,7 @@ $form->setAttribute('action', $this->url('immunization', array('action' => 'inde
 $form->prepare();
 
 ?>
-    <script type="text/javascript">
+    <script>
         $(function () {
             height_value = $('.responsive tr').length * 25 + 220;
             if(height_value < 245){ height_value = 245 };
@@ -42,7 +42,7 @@ $form->prepare();
                     <td nowrap>
                             <?php echo  $this->formRow($form->get('from_date'));?>
                             <?php echo  $this->formRow($form->get('to_date'));?>
-                            <script type="text/javascript">
+                            <script>
                                 $(function () {
                                         $( "#from_date" ).datepicker("setDate", '<?php echo $this->commonplugin->date_format($this->form_data['form_from_date'], $GLOBALS['date_display_format'], 'yyyy-mm-dd');?>' );
                                         $( "#to_date" ).datepicker("setDate", '<?php echo $this->commonplugin->date_format($this->form_data['form_to_date'], $GLOBALS['date_display_format'], 'yyyy-mm-dd');?>');

--- a/interface/modules/zend_modules/module/Multipledb/view/multipledb/multipledb/index.phtml
+++ b/interface/modules/zend_modules/module/Multipledb/view/multipledb/multipledb/index.phtml
@@ -46,7 +46,7 @@
         $html .= <<<html
     <tr>
         <td><a href="{$this->basePath()}/multipledb/edit?id={$id}">{$editLang}</a> | <a href="{$this->basePath()}/multipledb/remove?id={$id}"  onclick="save($(this),'{$namespace}')">{$removeLang}</a></td>
-        <td>{$namespace}</td> 
+        <td>{$namespace}</td>
         <td>{$username}</td>
         <td>{$dbname}</td>
         <td>{$host}</td>
@@ -79,7 +79,7 @@ html;
 
 </table>
 
-<script type="text/javascript">
+<script>
     function save(box,table){
         var href = box.prop('href');
         event.preventDefault()
@@ -89,6 +89,6 @@ html;
             window.location = href;
         }
     }
-    
+
 </script>
 

--- a/interface/modules/zend_modules/module/Syndromicsurveillance/view/syndromicsurveillance/syndromicsurveillance/index.phtml
+++ b/interface/modules/zend_modules/module/Syndromicsurveillance/view/syndromicsurveillance/syndromicsurveillance/index.phtml
@@ -13,7 +13,7 @@ $code_list  = $this->code_list;
 $provider   = $this->provider;
 
 ?>
-<script type="text/javascript">
+<script>
     $(function () {
         height_value = $('.responsive tr').length * 25 + 220;
         if(height_value < 300){ height_value = 300 };
@@ -47,7 +47,7 @@ $provider   = $this->provider;
                         <td nowrap>
                             <input readonly maxlength="10" style="width: 42%" type="text" name="form_date_from" id="form_date_from" class="dateClass_syndrome"/>
                             <input readonly maxlength="10" style="width: 42%" type="text" name="form_date_to" id="form_date_to" class="dateClass_syndrome"/>
-                            <script type="text/javascript">
+                            <script>
                                 $(function () {
                                     $( "#form_date_from" ).datepicker("setDate", '<?php echo $this->commonplugin->date_format($this->form_data['form_date_from'], $GLOBALS['date_display_format'], 'yyyy-mm-dd');?>' );
                                     $( "#form_date_to" ).datepicker("setDate", '<?php echo $this->commonplugin->date_format($this->form_data['form_date_to'], $GLOBALS['date_display_format'], 'yyyy-mm-dd');?>');

--- a/interface/new/new_comprehensive_save.php
+++ b/interface/new/new_comprehensive_save.php
@@ -199,7 +199,7 @@ if (!$GLOBALS['insurance_only_one']) {
 ?>
 <html>
 <body>
-<script language="Javascript">
+<script>
 <?php
 if ($alertmsg) {
     echo "alert(" . js_escape($alertmsg) . ");\n";

--- a/interface/new/new_patient_save.php
+++ b/interface/new/new_patient_save.php
@@ -146,7 +146,7 @@ if ($_POST['form_create']) {
 ?>
 <html>
 <body>
-<script language="Javascript">
+<script>
 <?php
 if ($alertmsg) {
     echo "alert(" . js_escape($alertmsg) . ");\n";

--- a/interface/orders/find_order_popup.php
+++ b/interface/orders/find_order_popup.php
@@ -38,8 +38,8 @@ if (isset($_GET['typeid'])) {
         }
     }
     ?>
-    <script type="text/javascript" src="<?php echo $webroot ?>/interface/main/tabs/js/include_opener.js"></script>
-    <script language="JavaScript">
+    <script src="<?php echo $webroot ?>/interface/main/tabs/js/include_opener.js"></script>
+    <script>
         if (opener.closed) {
             alert(<?php echo xlj('The destination form was closed; I cannot act on your selection.'); ?>);
         }
@@ -94,7 +94,7 @@ if (isset($_GET['typeid'])) {
     <?php Header::setupHeader(['opener']); ?>
     <title><?php echo xlt('Procedure Picker'); ?></title>
 
-    <script language="JavaScript">
+    <script>
         // Reload the script with the select procedure type ID.
         function selcode(typeid) {
             location.href = 'find_order_popup.php?order=' + <?php echo js_url($order); ?> + '&labid=' + <?php echo js_url($labid);

--- a/interface/orders/patient_match_dialog.php
+++ b/interface/orders/patient_match_dialog.php
@@ -34,7 +34,7 @@ $form_DOB = $args['DOB'];
     .oneResult {
     }
 </style>
-<script language="JavaScript">
+<script>
 
     $(function () {
         $(".oneresult").mouseover(function () {

--- a/interface/orders/pending_followup.php
+++ b/interface/orders/pending_followup.php
@@ -99,7 +99,7 @@ if ($_POST['form_csvexport']) {
 
 <title><?php echo xlt('Pending Followup from Results') ?></title>
 
-<script language="JavaScript">
+<script>
     $(function () {
         var win = top.printLogSetup ? top : opener.top;
         win.printLogSetup(document.getElementById('printbutton'));

--- a/interface/orders/procedure_provider_list.php
+++ b/interface/orders/procedure_provider_list.php
@@ -36,7 +36,7 @@ $res = sqlStatement($query);
     <?php Header::setupAssets('topdialog'); ?>
 <?php } ?>
 
-<script language="JavaScript">
+<script>
 
 <?php if ($popup) {
     require($GLOBALS['srcdir'] . "/restoreSession.php");

--- a/interface/orders/single_order_results.inc.php
+++ b/interface/orders/single_order_results.inc.php
@@ -430,12 +430,12 @@ function generate_order_report($orderid, $input_form = false, $genstyles = true,
 <?php } ?>
 
     <?php if ($input_form) { ?>
-<script type="text/javascript" src="<?php echo $GLOBALS['webroot']; ?>/library/textformat.js"></script>
+<script src="<?php echo $GLOBALS['webroot']; ?>/library/textformat.js"></script>
 <?php } // end if input form
     ?>
 
     <?php if (empty($GLOBALS['PATIENT_REPORT_ACTIVE'])) { ?>
-<script language="JavaScript">
+<script>
     var mypcc = '<?php echo $GLOBALS['phone_country_code'] ?>';
     if (typeof top.webroot_url === "undefined") {
         if (typeof opener.top.webroot_url !== "undefined") {

--- a/interface/orders/single_order_results.php
+++ b/interface/orders/single_order_results.php
@@ -114,8 +114,8 @@ body {
 }
 </style>
 
-<script type="text/javascript" src="../../library/topdialog.js"></script>
-<script language="JavaScript">
+<script src="../../library/topdialog.js"></script>
+<script>
 <?php require($GLOBALS['srcdir'] . "/restoreSession.php"); ?>
 </script>
 

--- a/interface/orders/types.php
+++ b/interface/orders/types.php
@@ -33,10 +33,8 @@ if ($popup && $_POST['form_save']) {
     $ptrow = sqlQuery("SELECT name FROM procedure_type WHERE procedure_type_id = ?", [$form_order]);
     $name = $ptrow['name'];
     ?>
-    <script type="text/javascript"
-        src="<?php echo $webroot ?>/interface/main/tabs/js/include_opener.js">
-    </script>
-    <script language="JavaScript">
+    <script src="<?php echo $webroot ?>/interface/main/tabs/js/include_opener.js"></script>
+    <script>
     if (opener.closed || ! opener.set_proc_type) {
         alert(<?php echo xlj('The destination form was closed; I cannot act on your selection.'); ?>);
     } else {
@@ -132,7 +130,7 @@ if ($popup && $_POST['form_save']) {
     <?php } ?>
 
 
-    <script type="text/javascript">
+    <script>
 
     <?php
     if ($popup) {

--- a/interface/orders/types_edit.php
+++ b/interface/orders/types_edit.php
@@ -140,7 +140,7 @@ div[id$="_info"] > a {
 }
 </style>
 
-<script language="JavaScript">
+<script>
 
 <?php require($GLOBALS['srcdir'] . "/restoreSession.php"); ?>
 

--- a/interface/patient_file/ccr_review_approve.php
+++ b/interface/patient_file/ccr_review_approve.php
@@ -106,7 +106,7 @@ table table tbody tr {
 }
 
 </style>
-<script type="text/javascript" >
+<script>
 
 function submit_form(val){
     document.getElementById('setval').value = val;

--- a/interface/patient_file/deleter.php
+++ b/interface/patient_file/deleter.php
@@ -207,7 +207,7 @@ function delete_document($document)
     <?php Header::setupHeader('opener'); ?>
 <title><?php echo xlt('Delete Patient, Encounter, Form, Issue, Document, Payment, Billing or Transaction'); ?></title>
 
-<script language="javascript">
+<script>
 function submit_form()
 {
 top.restoreSession();

--- a/interface/patient_file/encounter/forms.php
+++ b/interface/patient_file/encounter/forms.php
@@ -56,10 +56,10 @@ $esignApi = new Api();
 
 <?php // if the track_anything form exists, then include the styling and js functions (and js variable) for graphing
 if (file_exists(dirname(__FILE__) . "/../../forms/track_anything/style.css")) { ?>
- <script type="text/javascript">
+ <script>
  var csrf_token_js = <?php echo js_escape(CsrfUtils::collectCsrfToken()); ?>;
  </script>
- <script type="text/javascript" src="<?php echo $GLOBALS['web_root']?>/interface/forms/track_anything/report.js"></script>
+ <script src="<?php echo $GLOBALS['web_root']?>/interface/forms/track_anything/report.js"></script>
  <link rel="stylesheet" href="<?php echo $GLOBALS['web_root']?>/interface/forms/track_anything/style.css">
 <?php } ?>
 

--- a/interface/patient_file/encounter/load_form.php
+++ b/interface/patient_file/encounter/load_form.php
@@ -29,5 +29,5 @@ if (substr($_GET["formname"], 0, 3) === 'LBF') {
 }
 
 if (!empty($GLOBALS['text_templates_enabled'])) { ?>
-    <script type="text/javascript" src="<?php echo $GLOBALS['web_root'] ?>/library/js/CustomTemplateLoader.js"></script>
+    <script src="<?php echo $GLOBALS['web_root'] ?>/library/js/CustomTemplateLoader.js"></script>
 <?php } ?>

--- a/interface/patient_file/encounter/view_form.php
+++ b/interface/patient_file/encounter/view_form.php
@@ -29,5 +29,5 @@ if (substr($_GET["formname"], 0, 3) === 'LBF') {
 $id = $clean_id;
 
 if (!empty($GLOBALS['text_templates_enabled'])) { ?>
-    <script type="text/javascript" src="<?php echo $GLOBALS['web_root'] ?>/library/js/CustomTemplateLoader.js"></script>
+    <script src="<?php echo $GLOBALS['web_root'] ?>/library/js/CustomTemplateLoader.js"></script>
 <?php } ?>

--- a/interface/patient_file/front_payment.php
+++ b/interface/patient_file/front_payment.php
@@ -419,7 +419,7 @@ if ($_POST['form_save'] || $_REQUEST['receipt']) {
 
 <title><?php echo xlt('Receipt for Payment'); ?></title>
     <?php Header::setupHeader(); ?>
-<script language="JavaScript">
+<script>
 
     <?php require($GLOBALS['srcdir'] . "/restoreSession.php"); ?>
 
@@ -582,13 +582,13 @@ function toencounter(enc, datestr, topframe) {
     var mypcc = '1';
 </script>
     <?php include_once("{$GLOBALS['srcdir']}/ajax/payment_ajax_jav.inc.php"); ?>
-<script language="javascript" type="text/javascript">
+<script>
     document.onclick=HideTheAjaxDivs;
 </script>
 
     <?php Header::setupAssets('topdialog'); ?>
 
-<script language="JavaScript">
+<script>
     <?php require($GLOBALS['srcdir'] . "/restoreSession.php"); ?>
 function closeHow(e) {
     if (opener) {
@@ -1251,7 +1251,7 @@ function make_insurance() {
                 </form>
             </div>
         </div>
-        <script language="JavaScript">
+        <script>
         calctotal();
         </script>
     </div><!--end of container div of accept payment i.e the form-->

--- a/interface/patient_file/history/encounters.php
+++ b/interface/patient_file/history/encounters.php
@@ -171,7 +171,7 @@ function generatePageElement($start, $pagesize, $billing, $issue, $text)
 <!-- Not sure why we don't want this ui to be B.S responsive. -->
 <?php Header::setupHeader(['no_textformat']); ?>
 
-<script type="text/javascript" src="<?php echo $GLOBALS['webroot'] ?>/library/js/ajtooltip.js"></script>
+<script src="<?php echo $GLOBALS['webroot'] ?>/library/js/ajtooltip.js"></script>
 
 <script>
 // open dialog to edit an invoice w/o opening encounter.

--- a/interface/patient_file/history/history_full.php
+++ b/interface/patient_file/history/history_full.php
@@ -42,7 +42,7 @@ if (!AclMain::aclCheckCore('patients', 'med', '', array('write','addonly'))) {
 <title><?php echo xlt("History & Lifestyle");?></title>
 <?php include_once("{$GLOBALS['srcdir']}/options.js.php"); ?>
 
-<script LANGUAGE="JavaScript">
+<script>
  //Added on 5-jun-2k14 (regarding 'Smoking Status - display SNOMED code description')
  var code_options_js = Array();
 
@@ -170,7 +170,7 @@ function sel_related(e) {
 
 </script>
 
-<script type="text/javascript">
+<script>
 /// todo, move this to a common library
 $(function () {
     if($("#form_tobacco").val()!=""){
@@ -284,7 +284,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
 <?php $oemr_ui->oeBelowContainerDiv();?>
 </body>
 
-<script language="JavaScript">
+<script>
 
 // Array of skip conditions for the checkSkipConditions() function.
 var skipArray = [

--- a/interface/patient_file/letter.php
+++ b/interface/patient_file/letter.php
@@ -397,7 +397,7 @@ while ($srow = sqlFetchArray($sres)) {
 <title><?php echo xlt('Letter Generator'); ?></title>
 <?php Header::setupHeader(['datetime-picker', 'topdialog']); ?>
 
-<script language="JavaScript">
+<script>
 <?php echo $ulist; ?>
 
 // React to selection of a specialty.  This rebuilds the "to" users list

--- a/interface/patient_file/pos_checkout.php
+++ b/interface/patient_file/pos_checkout.php
@@ -170,7 +170,7 @@ function generate_receipt($patient_id, $encounter = 0)
 
         <?php Header::setupHeader(['datetime-picker']);?>
         <title><?php echo xlt('Receipt for Payment'); ?></title>
-        <script language="JavaScript">
+        <script>
 
         <?php require($GLOBALS['srcdir'] . "/restoreSession.php"); ?>
 
@@ -717,7 +717,7 @@ function generate_receipt($patient_id, $encounter = 0)
 <!DOCTYPE html>
     <head>
             <?php Header::setupHeader(['datetime-picker']);?>
-            <script language="JavaScript">
+            <script>
             var mypcc = <?php echo js_escape($GLOBALS['phone_country_code']); ?>;
 
             <?php require($GLOBALS['srcdir'] . "/restoreSession.php"); ?>

--- a/interface/patient_file/problem_encounter.php
+++ b/interface/patient_file/problem_encounter.php
@@ -106,7 +106,7 @@ tr.head   { font-size:10pt; background-color:#cccccc; text-align:center; }
 tr.detail { font-size:10pt; background-color:#eeeeee; }
 </style>
 
-<script language="JavaScript">
+<script>
 
 // These are the possible colors for table rows.
 var trcolors = new Object();

--- a/interface/patient_file/report/custom_report.php
+++ b/interface/patient_file/report/custom_report.php
@@ -959,7 +959,7 @@ if ($PDF_OUTPUT) {
 } else {
     ?>
     <?php if (!$printable) { // Set up translated strings for use by interactive search ?>
-<script type="text/javascript">
+<script>
 var xl_string = <?php echo json_encode(array(
     'spcl_chars' => xla('Special characters are not allowed') . '.',
     'not_found'  => xla('No results found') . '.',
@@ -968,7 +968,7 @@ var xl_string = <?php echo json_encode(array(
 ));
                 ?>;
 </script>
-<script type="text/javascript" src="<?php echo $GLOBALS['web_root']?>/interface/patient_file/report/custom_report.js?v=<?php echo $v_js_includes; ?>"></script>
+<script src="<?php echo $GLOBALS['web_root']?>/interface/patient_file/report/custom_report.js?v=<?php echo $v_js_includes; ?>"></script>
 <?php } ?>
 </body>
 </html>

--- a/interface/patient_file/rules/patient_data.php
+++ b/interface/patient_file/rules/patient_data.php
@@ -23,7 +23,7 @@ use OpenEMR\Core\Header;
 
     <?php Header::setupHeader(['datetime-picker', 'opener', 'common']); ?>
 
-<SCRIPT LANGUAGE="JavaScript">
+<script>
 
 function validate(f) {
   var bValid = true;

--- a/interface/patient_file/summary/add_edit_amendments.php
+++ b/interface/patient_file/summary/add_edit_amendments.php
@@ -130,7 +130,7 @@ tr.selected {
 }
 </style>
 
-<script type="text/javascript">
+<script>
 
 function formValidation() {
     if ( $("#amendment_date").val() == "" ) {

--- a/interface/patient_file/summary/add_edit_issue.php
+++ b/interface/patient_file/summary/add_edit_issue.php
@@ -25,7 +25,7 @@ use OpenEMR\Core\Header;
 
 // TBD - Resolve functional issues if opener is included in Header
 ?>
-<script type="text/javascript" src="<?php echo $webroot ?>/interface/main/tabs/js/include_opener.js?v=<?php echo $v_js_includes; ?>"></script>
+<script src="<?php echo $webroot ?>/interface/main/tabs/js/include_opener.js?v=<?php echo $v_js_includes; ?>"></script>
 <script><?php require($GLOBALS['srcdir'] . '/formatting_DateToYYYYMMDD_js.js.php'); ?></script>
 <?php
 
@@ -384,7 +384,7 @@ ul.tabNav li.current a {
 }
 </style>
 
-<script language="JavaScript">
+<script>
  var aitypes = new Array(); // issue type attributes
  var aopts   = new Array(); // Option objects
 <?php

--- a/interface/patient_file/summary/advancedirectives.php
+++ b/interface/patient_file/summary/advancedirectives.php
@@ -48,7 +48,7 @@ use OpenEMR\Core\Header;
     }
     ?>
 
-    <script type="text/javascript" language="JavaScript">
+    <script>
         function validate(f) {
             if (f.form_adreviewed.value == "") {
                   alert(<?php echo xlj('Please enter a date for Last Reviewed.'); ?>);

--- a/interface/patient_file/summary/create_portallogin.php
+++ b/interface/patient_file/summary/create_portallogin.php
@@ -201,7 +201,7 @@ if (isset($_POST['form_save']) && $_POST['form_save'] == 'submit') {
         }
     }
 </style>
-<script type="text/javascript">
+<script>
 function transmit(){
     // get a public key to encrypt the password info and send
     document.getElementById('form_save').value='submit';

--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -51,7 +51,7 @@ if ($GLOBALS['enable_cdr']) {
             foreach ($new_allergy_alerts as $new_allergy_alert) {
                 $pod_warnings .= js_escape($new_allergy_alert) . ' + "\n"';
             }
-            echo '<script type="text/javascript">alert(' . xlj('WARNING - FOLLOWING ACTIVE MEDICATIONS ARE ALLERGIES') . ' + "\n" + ' . $pod_warnings . ')</script>';
+            echo '<script>alert(' . xlj('WARNING - FOLLOWING ACTIVE MEDICATIONS ARE ALLERGIES') . ' + "\n" + ' . $pod_warnings . ')</script>';
         }
     }
 

--- a/interface/patient_file/summary/demographics_full.php
+++ b/interface/patient_file/summary/demographics_full.php
@@ -91,7 +91,7 @@ $fres = sqlStatement("SELECT * FROM layout_options " .
 
 <?php include_once($GLOBALS['srcdir'] . "/options.js.php"); ?>
 
-<script type="text/javascript">
+<script>
 
 // Support for beforeunload handler.
 var somethingChanged = false;

--- a/interface/patient_file/summary/disclosure_full.php
+++ b/interface/patient_file/summary/disclosure_full.php
@@ -166,7 +166,7 @@ if ($n >= $N && $noOfRecordsLeft != $N) {
  </tr>
 </table>
 </div>
-<script type="text/javascript">
+<script>
 $(function () {
     // todo, move this to a common library
     //for row highlight.

--- a/interface/patient_file/summary/immunizations.php
+++ b/interface/patient_file/summary/immunizations.php
@@ -827,7 +827,7 @@ while ($row = sqlFetchArray($result)) {
 
   </body>
 
-<script language="javascript">
+<script>
 var tr_count = $('#tr_count').val();
 
 // jQuery stuff to make the page a little easier to use

--- a/interface/patient_file/summary/list_amendments.php
+++ b/interface/patient_file/summary/list_amendments.php
@@ -33,7 +33,7 @@ tr.selected {
 }
 </style>
 
-<script type="text/javascript">
+<script>
     function checkForAmendments() {
         var amendments = "";
         $("#list_amendments input:checkbox:checked").each(function() {

--- a/interface/patient_file/summary/pnotes.php
+++ b/interface/patient_file/summary/pnotes.php
@@ -175,7 +175,7 @@ if ($result != null) {
 
 </body>
 
-<script language="javascript">
+<script>
 // jQuery stuff to make the page a little easier to use
 
 $(function () {

--- a/interface/patient_file/summary/pnotes_fragment.php
+++ b/interface/patient_file/summary/pnotes_fragment.php
@@ -234,7 +234,7 @@ if (isset($_GET['docUpdateId'])) {
     <?php } ?>
 </div>
 
-<script language="javascript">
+<script>
 // jQuery stuff to make the page a little easier to use
 
 tabbify();

--- a/interface/patient_file/summary/pnotes_full.php
+++ b/interface/patient_file/summary/pnotes_full.php
@@ -213,7 +213,7 @@ $result_sent = getSentPnotesByDate(
 
     <?php Header::setupHeader(['common', 'opener']); ?>
 
-<script type="text/javascript">
+<script>
 /// todo, move this to a common library
 
 $(function () {
@@ -773,7 +773,7 @@ if ($noteid /* && $title == 'New Document' */) {
 
 </body>
 
-<script language="javascript">
+<script>
 
 // jQuery stuff to make the page a little easier to use
 

--- a/interface/patient_file/summary/record_disclosure.php
+++ b/interface/patient_file/summary/record_disclosure.php
@@ -28,7 +28,7 @@ if (isset($_GET['editlid'])) {
 <head>
 <?php Header::setupHeader(['datetime-picker', 'opener']); ?>
 
-<script type="text/javascript">
+<script>
 //function to validate fields in record disclosure page
 function submitform() {
     if (document.forms[0].dates.value.length <= 0) {

--- a/interface/patient_file/summary/stats.php
+++ b/interface/patient_file/summary/stats.php
@@ -24,7 +24,7 @@ if (!CsrfUtils::verifyCsrfToken($_POST["csrf_token_form"])) {
 
 <div id="patient_stats_summary">
 
-<script type='text/javascript'>
+<script>
     function load_location( location ) {
         top.restoreSession();
         if ( !top.frames["RTop"] ) {

--- a/interface/patient_file/summary/stats_full.php
+++ b/interface/patient_file/summary/stats_full.php
@@ -56,7 +56,7 @@ $language = $tmp['language'];
 
 <title><?php echo xlt('Patient Issues'); ?></title>
 
-<script language="JavaScript">
+<script>
 
 // callback from add_edit_issue.php:
 function refreshIssue(issue, title) {

--- a/interface/patient_file/transaction/add_transaction.php
+++ b/interface/patient_file/transaction/add_transaction.php
@@ -155,7 +155,7 @@ $trow = $transid ? getTransById($transid) : array();
 
 <?php include_once("{$GLOBALS['srcdir']}/options.js.php"); ?>
 
-<script type="text/javascript">
+<script>
 $(function () {
   if(window.tabbify){
     tabbify();
@@ -605,7 +605,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
     <?php $oemr_ui->oeBelowContainerDiv();?>
 </body>
 
-<script language="JavaScript">
+<script>
 
 // Array of action conditions for the checkSkipConditions() function.
 var skipArray = [

--- a/interface/patient_file/transaction/record_request.php
+++ b/interface/patient_file/transaction/record_request.php
@@ -23,7 +23,7 @@ use OpenEMR\Core\Header;
 
     <?php Header::setupHeader(); ?>
 
-    <script language="JavaScript">
+    <script>
         $(function () {
             $("#req_button").click(function() {
                 // hide the button, show the message, and send the ajax call

--- a/interface/patient_tracker/patient_tracker.php
+++ b/interface/patient_tracker/patient_tracker.php
@@ -170,12 +170,12 @@ if (!$_REQUEST['flb_table']) {
     <meta name="author" content="OpenEMR: MedExBank">
     <?php Header::setupHeader(['datetime-picker', 'opener', 'purecss']); ?>
     <title><?php echo xlt('Flow Board'); ?></title>
-    <script type="text/javascript">
+    <script>
         <?php require_once "$srcdir/restoreSession.php"; ?>
     </script>
 
     <link rel="stylesheet" href="<?php echo $GLOBALS['web_root']; ?>/library/css/bootstrap_navbar.css?v=<?php echo $v_js_includes; ?>">
-    <script type="text/javascript" src="<?php echo $GLOBALS['web_root']; ?>/interface/main/messages/js/reminder_appts.js?v=<?php echo $v_js_includes; ?>"></script>
+    <script src="<?php echo $GLOBALS['web_root']; ?>/interface/main/messages/js/reminder_appts.js?v=<?php echo $v_js_includes; ?>"></script>
 
     <link rel="shortcut icon" href="<?php echo $webroot; ?>/sites/default/favicon.ico" />
     <style>
@@ -943,7 +943,7 @@ exit;
 function myLocalJS()
 {
     ?>
-    <script type="text/javascript">
+    <script>
         var auto_refresh = null;
         //this can be refined to redact HIPAA material using @media print options.
         top.restoreSession();

--- a/interface/reports/amc_tracking.php
+++ b/interface/reports/amc_tracking.php
@@ -40,7 +40,7 @@ $provider  = trim($_POST['form_provider']);
 
 <?php Header::setupHeader('datetime-picker') ?>
 
-<script LANGUAGE="JavaScript">
+<script>
 
  $(function () {
   var win = top.printLogSetup ? top : opener.top;

--- a/interface/reports/audit_log_tamper_report.php
+++ b/interface/reports/audit_log_tamper_report.php
@@ -316,7 +316,7 @@ $check_sum = isset($_GET['check_sum']);
      </TR>
         <?php
     } else {?>
-    <script type="text/javascript">$('#display_tamper').css('display', 'block');</script>
+    <script>$('#display_tamper').css('display', 'block');</script>
         <?php
     }
 
@@ -325,7 +325,7 @@ $check_sum = isset($_GET['check_sum']);
 </div>
 <?php } ?>
 </body>
-<script language="javascript">
+<script>
 
 // jQuery stuff to make the page a little easier to use
 $(function () {

--- a/interface/reports/cdr_log.php
+++ b/interface/reports/cdr_log.php
@@ -35,7 +35,7 @@ $form_end_date = DateTimeToYYYYMMDDHHMMSS($_POST['form_end_date']);
 
     <?php Header::setupHeader('datetime-picker'); ?>
 
-    <script LANGUAGE="JavaScript">
+    <script>
         $(function () {
             $('.datepicker').datetimepicker({
                 <?php $datetimepicker_timepicker = true; ?>

--- a/interface/reports/clinical_reports.php
+++ b/interface/reports/clinical_reports.php
@@ -56,7 +56,7 @@ $communication = trim($_POST["communication"]);
 
     <?php Header::setupHeader(['datetime-picker', 'report-helper']); ?>
 
-    <script language="JavaScript">
+    <script>
         $(function () {
             var win = top.printLogSetup ? top : opener.top;
             win.printLogSetup(document.getElementById('printbutton'));
@@ -144,7 +144,7 @@ $communication = trim($_POST["communication"]);
             ?>
         }
     </style>
-    <script language="javascript" type="text/javascript">
+    <script>
         function checkType() {
             if($('#type').val() == 'Service Codes')
             {

--- a/interface/reports/collections_report.php
+++ b/interface/reports/collections_report.php
@@ -344,7 +344,7 @@ if ($_POST['form_csvexport']) {
         }
     </style>
 
-    <script language="JavaScript">
+    <script>
         function reSubmit() {
             $("#form_refresh").attr("value","true");
             $("#form_csvexport").val("");

--- a/interface/reports/daily_summary_report.php
+++ b/interface/reports/daily_summary_report.php
@@ -44,7 +44,7 @@ $selectedProvider = isset($_POST['form_provider']) ? $_POST['form_provider'] : "
 
         <?php Header::setupHeader(['datetime-picker', 'report-helper']); ?>
 
-        <script type="text/javascript">
+        <script>
             function submitForm() {
                 var fromDate = $("#form_from_date").val();
                 var toDate = $("#form_to_date").val();

--- a/interface/reports/immunization_report.php
+++ b/interface/reports/immunization_report.php
@@ -269,7 +269,7 @@ if ($_POST['form_get_hl7'] === 'true') {
 
     <?php Header::setupHeader(['datetime-picker', 'report-helper']); ?>
 
-    <script language="JavaScript">
+    <script>
         <?php require($GLOBALS['srcdir'] . "/restoreSession.php"); ?>
 
         $(function () {

--- a/interface/reports/inventory_list.php
+++ b/interface/reports/inventory_list.php
@@ -94,7 +94,7 @@ table.mymaintable td, table.mymaintable th {
 }
 </style>
 
-<script language="JavaScript">
+<script>
 
  $(function () {
   oeFixedHeaderSetup(document.getElementById('mymaintable'));

--- a/interface/reports/ippf_cyp_report.php
+++ b/interface/reports/ippf_cyp_report.php
@@ -177,7 +177,7 @@ if ($_POST['form_csvexport']) {
 
     <?php Header::setupHeader(['datetime-picker']); ?>
 
-<script language="JavaScript">
+<script>
     $(function () {
         var win = top.printLogSetup ? top : opener.top;
         win.printLogSetup(document.getElementById('printbutton'));

--- a/interface/reports/ippf_daily.php
+++ b/interface/reports/ippf_daily.php
@@ -145,7 +145,7 @@ if ($form_output == 3) {
  .detail    { color:var(--black); font-family:sans-serif; font-size:10pt; font-weight:normal }
 </style>
 
-<script language="JavaScript">
+<script>
     $(function () {
         $('.datepicker').datetimepicker({
             <?php $datetimepicker_timepicker = false; ?>

--- a/interface/reports/ippf_statistics.php
+++ b/interface/reports/ippf_statistics.php
@@ -1031,7 +1031,7 @@ body       { font-family:sans-serif; font-size:10pt; font-weight:normal }
 .detail    { color:var(--black); font-family:sans-serif; font-size:10pt; font-weight:normal }
 </style>
 
-<script language="JavaScript">
+<script>
 
 // Begin experimental code
 

--- a/interface/reports/patient_edu_web_lookup.php
+++ b/interface/reports/patient_edu_web_lookup.php
@@ -43,7 +43,7 @@ $form_diagnosis = (isset($_POST['form_diagnosis'])) ? $_POST['form_diagnosis'] :
 <head>
     <?php Header::setupHeader(); ?>
     <title><?php echo xlt('Web Search'); ?> - <?php echo xlt('Patient Education Materials'); ?></title>
-    <script type="text/javascript">
+    <script>
         function searchResultsPopup(search_term,link)
         {
             link_formatted = link.replace("[%]",encodeURIComponent(search_term));
@@ -105,7 +105,7 @@ $form_diagnosis = (isset($_POST['form_diagnosis'])) ? $_POST['form_diagnosis'] :
         </div>
     </div>
     <?php if (!empty($form_diagnosis) && !empty($form_lookup_at)) { ?>
-        <script type="text/javascript">
+        <script>
             searchResultsPopup(<?php echo js_escape($form_diagnosis); ?>,<?php echo js_escape($websites[$form_lookup_at]) ?>);
         </script>
     <?php } ?>

--- a/interface/reports/patient_flow_board_report.php
+++ b/interface/reports/patient_flow_board_report.php
@@ -80,7 +80,7 @@ if ($form_patient == '') {
 
     <?php Header::setupHeader(['datetime-picker', 'report-helper']); ?>
 
-    <script type="text/javascript">
+    <script>
         $(function () {
             var win = top.printLogSetup ? top : opener.top;
             win.printLogSetup(document.getElementById('printbutton'));

--- a/interface/reports/patient_list.php
+++ b/interface/reports/patient_list.php
@@ -55,7 +55,7 @@ if ($_POST['form_csvexport']) {
 
     <?php Header::setupHeader(['datetime-picker', 'report-helper']); ?>
 
-<script language="JavaScript">
+<script>
 
 $(function () {
     oeFixedHeaderSetup(document.getElementById('mymaintable'));

--- a/interface/reports/prescriptions_report.php
+++ b/interface/reports/prescriptions_report.php
@@ -41,7 +41,7 @@ $form_facility   = isset($_POST['form_facility']) ? $_POST['form_facility'] : ''
 
 <?php Header::setupHeader(['datetime-picker', 'report-helper']); ?>
 
-<script language="JavaScript">
+<script>
 
     $(function () {
         oeFixedHeaderSetup(document.getElementById('mymaintable'));

--- a/interface/reports/referrals_report.php
+++ b/interface/reports/referrals_report.php
@@ -37,7 +37,7 @@ $form_facility = isset($_POST['form_facility']) ? $_POST['form_facility'] : '';
 
     <?php Header::setupHeader(['datetime-picker', 'report-helper']); ?>
 
-    <script language="JavaScript">
+    <script>
         <?php require($GLOBALS['srcdir'] . "/restoreSession.php"); ?>
 
         $(function () {

--- a/interface/reports/report.script.php
+++ b/interface/reports/report.script.php
@@ -14,7 +14,7 @@
  */
 
 ?>
-<script type="text/javascript">
+<script>
     //Calendar Functions to set From and To dates
     function calendar_function(val, from, to) {
 

--- a/interface/reports/svc_code_financial_report.php
+++ b/interface/reports/svc_code_financial_report.php
@@ -91,7 +91,7 @@ if ($_POST['form_csvexport']) {
         }
     </style>
 
-    <script language="JavaScript">
+    <script>
         $(function () {
             oeFixedHeaderSetup(document.getElementById('mymaintable'));
             var win = top.printLogSetup ? top : opener.top;

--- a/interface/super/edit_globals.php
+++ b/interface/super/edit_globals.php
@@ -64,7 +64,7 @@ function checkCreateCDB()
 
         $couch = new CouchDB();
         if (!$couch->check_connection()) {
-            echo "<script type='text/javascript'>alert(" . xlj("CouchDB Connection Failed.") . ");</script>";
+            echo "<script>alert(" . xlj("CouchDB Connection Failed.") . ");</script>";
             return false;
         }
 
@@ -156,7 +156,7 @@ if (array_key_exists('form_save', $_POST) && $_POST['form_save'] && $userMode) {
         }
     }
 
-    echo "<script type='text/javascript'>";
+    echo "<script>";
     echo "if (parent.left_nav.location) {";
     echo "  parent.left_nav.location.reload();";
     echo "  parent.Title.location.reload();";

--- a/interface/super/edit_layout_props.php
+++ b/interface/super/edit_layout_props.php
@@ -39,7 +39,7 @@ $group_id  = empty($_GET['group_id' ]) ? '' : $_GET['group_id' ];
 td { font-size:10pt; }
 </style>
 
-<script language="JavaScript">
+<script>
 
 <?php require($GLOBALS['srcdir'] . "/restoreSession.php"); ?>
 

--- a/interface/super/edit_list.php
+++ b/interface/super/edit_list.php
@@ -1090,7 +1090,7 @@ function writeITLine($it_array)
                 </div>
 
                 <!--Added filter-->
-                <script type="text/javascript">
+                <script>
                     function lister() {
                         var queryParams = getQueryStringAsObject();
                         var list_from = parseInt($("#list-from").val());

--- a/interface/super/rules/base/template/redirect.php
+++ b/interface/super/rules/base/template/redirect.php
@@ -7,8 +7,8 @@
  // as published by the Free Software Foundation; either version 2
  // of the License, or (at your option) any later version.
 ?>
-<script type="text/javascript">
+<script>
   top.restoreSession();
   window.location = "<?php echo $_redirect ?>";
 </script>
- 
+

--- a/interface/super/rules/controllers/browse/view/list.php
+++ b/interface/super/rules/controllers/browse/view/list.php
@@ -14,10 +14,10 @@
 
 ?>
 
-<script language="javascript" src="<?php js_src('list.js') ?>"></script>
-<script language="javascript" src="<?php js_src('jQuery.fn.sortElements.js') ?>"></script>
+<script src="<?php js_src('list.js') ?>"></script>
+<script src="<?php js_src('jQuery.fn.sortElements.js') ?>"></script>
 
-<script type="text/javascript">
+<script>
     var list = new list_rules();
     list.init();
 </script>

--- a/interface/super/rules/controllers/browse/view/plans_config.php
+++ b/interface/super/rules/controllers/browse/view/plans_config.php
@@ -23,12 +23,12 @@
 <link rel="stylesheet" href="<?php css_src('cdr-multiselect/ui.multiselect.css') ?>" />
 <link rel="stylesheet" href="<?php css_src('cdr-multiselect/plans_config.css') ?>" />
 
-<script language="javascript" src="<?php js_src('/cdr-multiselect/jquery.min.js') ?>"></script>
-<script language="javascript" src="<?php js_src('/cdr-multiselect/jquery-ui.min.js') ?>"></script>
-<script language="javascript" src="<?php js_src('/cdr-multiselect/plugins/localisation/jquery.localisation-min.js') ?>"></script>
-<script language="javascript" src="<?php js_src('/cdr-multiselect/plugins/scrollTo/jquery.scrollTo-min.js') ?>"></script>
-<script language="javascript" src="<?php js_src('/cdr-multiselect/ui.multiselect.js') ?>"></script>
-<script type="text/javascript">
+<script src="<?php js_src('/cdr-multiselect/jquery.min.js') ?>"></script>
+<script src="<?php js_src('/cdr-multiselect/jquery-ui.min.js') ?>"></script>
+<script src="<?php js_src('/cdr-multiselect/plugins/localisation/jquery.localisation-min.js') ?>"></script>
+<script src="<?php js_src('/cdr-multiselect/plugins/scrollTo/jquery.scrollTo-min.js') ?>"></script>
+<script src="<?php js_src('/cdr-multiselect/ui.multiselect.js') ?>"></script>
+<script>
 // Below variables are to be used in the javascript for the cdr-multiselect(from cdr-multiselect/locale/ui-multiselect-cdr.js)
 $.extend($.ui.multiselect.locale, {
     addAll:<?php echo xlj('Add all rules to plan'); ?>,
@@ -37,10 +37,10 @@ $.extend($.ui.multiselect.locale, {
 });
 </script>
 
-<script language="javascript" src="<?php js_src('list.js') ?>"></script>
-<script language="javascript" src="<?php js_src('jQuery.fn.sortElements.js') ?>"></script>
+<script src="<?php js_src('list.js') ?>"></script>
+<script src="<?php js_src('jQuery.fn.sortElements.js') ?>"></script>
 
-<script type="text/javascript">
+<script>
     $(function () {
         //load plans
         $("#cdr-plans").load('<?php library_src('RulesPlanMappingEventHandlers_ajax.php') ?>');

--- a/interface/super/rules/controllers/detail/view/view.php
+++ b/interface/super/rules/controllers/detail/view/view.php
@@ -14,8 +14,8 @@
 
 $rule = $viewBean->rule ?>
 
-<script language="javascript" src="<?php js_src('detail.js') ?>"></script>
-<script type="text/javascript">
+<script src="<?php js_src('detail.js') ?>"></script>
+<script>
     var detail = new rule_detail( {editable: <?php echo $rule->isEditable() ? "true" : "false"; ?>});
     detail.init();
 </script>

--- a/interface/super/rules/controllers/edit/template/criteria.php
+++ b/interface/super/rules/controllers/edit/template/criteria.php
@@ -27,8 +27,8 @@ use OpenEMR\Core\Header;
 <?php $rule = $viewBean->rule ?>
 <?php $criteria = $viewBean->criteria ?>
 
-<script language="javascript" src="<?php js_src('edit.js') ?>"></script>
-<script type="text/javascript">
+<script src="<?php js_src('edit.js') ?>"></script>
+<script>
     var edit = new rule_edit( {});
     edit.init();
 </script>

--- a/interface/super/rules/controllers/edit/view/action.php
+++ b/interface/super/rules/controllers/edit/view/action.php
@@ -16,9 +16,9 @@
 <?php $action = $viewBean->action?>
 <?php $rule = $viewBean->rule?>
 
-<script language="javascript" src="<?php js_src('edit.js') ?>"></script>
-<script language="javascript" src="<?php js_src('bucket.js') ?>"></script>
-<script type="text/javascript">
+<script src="<?php js_src('edit.js') ?>"></script>
+<script src="<?php js_src('bucket.js') ?>"></script>
+<script>
     var edit = new rule_edit( {});
     edit.init();
 

--- a/interface/super/rules/controllers/edit/view/bucket.php
+++ b/interface/super/rules/controllers/edit/view/bucket.php
@@ -14,9 +14,9 @@
 
 ?>
 <head>
-    <script language="javascript" src="<?php js_src('bucket.js') ?>"></script>
+    <script src="<?php js_src('bucket.js') ?>"></script>
 
-    <script type="text/javascript">
+    <script>
         var bucket = new bucket( {} );
         bucket.init();
     </script>

--- a/interface/super/rules/controllers/edit/view/custom.php
+++ b/interface/super/rules/controllers/edit/view/custom.php
@@ -14,9 +14,9 @@
 
 ?>
 <head>
-    <script language="javascript" src="<?php js_src('custom.js') ?>"></script>
+    <script src="<?php js_src('custom.js') ?>"></script>
 
-    <script type="text/javascript">
+    <script>
         var custom = new custom( { selectedColumn: <?php echo js_escape($criteria->column); ?> } );
         custom.init();
     </script>

--- a/interface/super/rules/controllers/edit/view/diagnosis.php
+++ b/interface/super/rules/controllers/edit/view/diagnosis.php
@@ -16,8 +16,8 @@
 
 <head>
     <link rel="stylesheet" href="<?php css_src('rules.css') ?>">
-    <script language="javascript" src="../../../library/dialog.js?v=<?php echo $v_js_includes; ?>"></script>
-    <script type="text/javascript">
+    <script src="../../../library/dialog.js?v=<?php echo $v_js_includes; ?>"></script>
+    <script>
         // This invokes the find-code popup.
         function sel_diagnosis() {
             dlgopen('../../patient_file/encounter/find_code_popup.php', '_blank', 500, 400);

--- a/interface/super/rules/controllers/edit/view/intervals.php
+++ b/interface/super/rules/controllers/edit/view/intervals.php
@@ -16,8 +16,8 @@
 <?php require_once($GLOBALS["srcdir"] . "/../interface/super/rules/controllers/edit/helper/common.php"); ?>
 <?php $rule = $viewBean->rule ?>
 <?php $intervals = $rule->reminderIntervals ?>
-<script language="javascript" src="<?php js_src('edit.js') ?>"></script>
-<script type="text/javascript">
+<script src="<?php js_src('edit.js') ?>"></script>
+<script>
     var edit = new rule_edit( {});
     edit.init();
 </script>

--- a/interface/super/rules/controllers/edit/view/summary.php
+++ b/interface/super/rules/controllers/edit/view/summary.php
@@ -14,8 +14,8 @@
 
 $rule = $viewBean->rule ?>
 
-<script language="javascript" src="<?php js_src('edit.js') ?>"></script>
-<script type="text/javascript">
+<script src="<?php js_src('edit.js') ?>"></script>
+<script>
     var edit = new rule_edit( {});
     edit.init();
 </script>

--- a/interface/usergroup/adminacl.php
+++ b/interface/usergroup/adminacl.php
@@ -34,7 +34,7 @@ if (!AclMain::aclCheckCore('admin', 'acl')) {
 
     <?php Header::setupHeader(); ?>
 
-    <script type="text/JavaScript">
+    <script>
         $(function () {
             //Bootstrap tooltip
             var groupTitle = <?php echo xlj('This section allows you to create and remove groups and modify or grant access privileges to existing groups. Check the check box to display section'); ?>;

--- a/interface/usergroup/facilities.php
+++ b/interface/usergroup/facilities.php
@@ -123,7 +123,7 @@ if (isset($_POST["mode"]) && $_POST["mode"] == "facility" && $_POST["newmode"] =
 
     <?php Header::setupHeader(['common']); ?>
 
-<script type="text/javascript">
+<script>
 
 function refreshme() {
     top.restoreSession();

--- a/interface/usergroup/facility_admin.php
+++ b/interface/usergroup/facility_admin.php
@@ -28,9 +28,9 @@ if (isset($_GET["fid"])) {
 <head>
     <?php Header::setupHeader(['opener']); ?>
 
-    <script type="text/javascript" src="../main/calendar/modules/PostCalendar/pnincludes/AnchorPosition.js"></script>
-    <script type="text/javascript" src="../main/calendar/modules/PostCalendar/pnincludes/PopupWindow.js"></script>
-    <script type="text/javascript" src="../main/calendar/modules/PostCalendar/pnincludes/ColorPicker2.js"></script>
+    <script src="../main/calendar/modules/PostCalendar/pnincludes/AnchorPosition.js"></script>
+    <script src="../main/calendar/modules/PostCalendar/pnincludes/PopupWindow.js"></script>
+    <script src="../main/calendar/modules/PostCalendar/pnincludes/ColorPicker2.js"></script>
 
     <!-- validation library -->
     <!--//Not lbf forms use the new validation, please make sure you have the corresponding values in the list Page validation-->

--- a/interface/usergroup/facility_user.php
+++ b/interface/usergroup/facility_user.php
@@ -58,7 +58,7 @@ if (isset($_POST["mode"]) && $_POST["mode"] == "facility_user_id" && isset($_POS
 
     <?php Header::setupHeader(['common']); ?>
 
-    <script type="text/javascript">
+    <script>
         function refreshme() {
             top.restoreSession();
             document.location.reload();

--- a/interface/usergroup/facility_user_admin.php
+++ b/interface/usergroup/facility_user_admin.php
@@ -38,7 +38,7 @@ if (!isset($_GET["user_id"]) || !isset($_GET["fac_id"])) {
 
     <?php Header::setupHeader(['common','datetime-picker','opener']); ?>
 
-    <script language="JavaScript">
+    <script>
         $(function () {
             $("#form_facility_user").submit(function (event) {
                 top.restoreSession();
@@ -200,7 +200,7 @@ if (!isset($_GET["user_id"]) || !isset($_GET["fac_id"])) {
     <!-- include support for the list-add selectbox feature -->
     <?php include $GLOBALS['fileroot'] . "/library/options_listadd.inc"; ?>
 
-    <script language="JavaScript">
+    <script>
     <?php echo $date_init; ?>
     </script>
 </body>

--- a/interface/usergroup/ssl_certificates_admin.php
+++ b/interface/usergroup/ssl_certificates_admin.php
@@ -451,7 +451,7 @@ if ($_POST["mode"] == "create_client_certificate") {
 
 <html>
   <head>
-    <script language="Javascript">
+    <script>
 
 
     /* If Enable User Certificate Authentication is set to "Yes", check the following:

--- a/interface/usergroup/user_admin.php
+++ b/interface/usergroup/user_admin.php
@@ -49,7 +49,7 @@ $iter = $result[0];
 
 <?php Header::setupHeader(['common','opener']); ?>
 
-<script src="checkpwd_validation.js" type="text/javascript"></script>
+<script src="checkpwd_validation.js"></script>
 
 <!-- validation library -->
 <!--//Not lbf forms use the new validation, please make sure you have the corresponding values in the list Page validation-->
@@ -66,7 +66,7 @@ if (empty($collectthis)) {
 }
 ?>
 
-<script language="JavaScript">
+<script>
 
 /*
  * validation on the form with new client side validation (using validate.js).
@@ -498,7 +498,7 @@ Display red alert if entered password matched one of last three passwords/Displa
 
 <INPUT TYPE="HIDDEN" NAME="secure_pwd" VALUE="<?php echo attr($GLOBALS['secure_password']); ?>">
 </FORM>
-<script language="JavaScript">
+<script>
 $(function () {
     $("#cancel").click(function() {
           dlgclose();

--- a/interface/usergroup/user_info.php
+++ b/interface/usergroup/user_info.php
@@ -36,7 +36,7 @@ $user_full_name = $user_name['fname'] . " " . $user_name['lname'];
 <?php Header::setupHeader(); ?>
 <title><?php echo xlt('Change Password'); ?></title>
 
-<script src="checkpwd_validation.js" type="text/javascript"></script>
+<script src="checkpwd_validation.js"></script>
 
 <script language='JavaScript'>
 //Validating password and display message if password field is empty - starts

--- a/interface/usergroup/usergroup_admin.php
+++ b/interface/usergroup/usergroup_admin.php
@@ -423,7 +423,7 @@ $form_inactive = empty($_POST['form_inactive']) ? false : true;
 
 <?php Header::setupHeader(['common']); ?>
 
-<script type="text/javascript">
+<script>
 
 $(function () {
 
@@ -592,7 +592,7 @@ function authorized_clicked() {
         </div>
     </div>
 </div>
-<script language="JavaScript">
+<script>
 <?php
 if ($alertmsg = trim($alertmsg)) {
     echo "alert(" . js_escape($alertmsg) . ");\n";

--- a/interface/usergroup/usergroup_admin_add.php
+++ b/interface/usergroup/usergroup_admin_add.php
@@ -37,7 +37,7 @@ $alertmsg = '';
 
 <?php Header::setupHeader(['common','opener']); ?>
 
-<script src="checkpwd_validation.js" type="text/javascript"></script>
+<script src="checkpwd_validation.js"></script>
 
 <!-- validation library -->
 <!--//Not lbf forms use the new validation, please make sure you have the corresponding values in the list Page validation-->
@@ -53,7 +53,7 @@ if (empty($collectthis)) {
     $collectthis = json_sanitize($collectthis["new_user"]["rules"]);
 }
 ?>
-<script language="JavaScript">
+<script>
 
 /*
 * validation on the form with new client side validation (using validate.js).

--- a/interface/weno/confirm.php
+++ b/interface/weno/confirm.php
@@ -103,7 +103,7 @@ $mailOrder = $tData->mailOrderPharmacy();
     <div id="success"></div>
 </div>
 
-<script type="text/javascript">
+<script>
 
 
     $(function () {

--- a/library/ajax/facility_ajax_jav.inc.php
+++ b/library/ajax/facility_ajax_jav.inc.php
@@ -17,7 +17,7 @@
 use OpenEMR\Common\Csrf\CsrfUtils;
 
 ?>
-<script type="text/javascript">
+<script>
 function ajax_bill_loc(pid,date,facility){
 top.restoreSession();
 $.ajax({

--- a/library/ajax/payment_ajax_jav.inc.php
+++ b/library/ajax/payment_ajax_jav.inc.php
@@ -16,7 +16,7 @@
 use OpenEMR\Common\Csrf\CsrfUtils;
 
 ?>
-<script type="text/javascript">
+<script>
 $(function () {
   $("#type_code").keyup(function(e){
       if (e.which == 9 || e.which == 13)

--- a/library/classes/TreeMenu.php
+++ b/library/classes/TreeMenu.php
@@ -629,7 +629,7 @@ class HTML_TreeMenu_DHTML extends HTML_TreeMenu_Presentation
         $menuObj     = 'objTreeMenu_' . ++$count;
 
         $html  = "\n";
-        $html .= '<script language="javascript" type="text/javascript">' . "\n\t";
+        $html .= '<script>' . "\n\t";
         $html .= sprintf(
             '%s = new TreeMenu("%s", "%s", "%s", "%s", %s, %s);',
             $menuObj,

--- a/library/custom_template/add_context.php
+++ b/library/custom_template/add_context.php
@@ -67,7 +67,7 @@ if (trim($_POST['contextname']) != '' && $_POST['action'] == 'add') {
                 background-color: #b1c0a5;
             }
         </style>
-        <script type="text/javascript">
+        <script>
             $(function () {
             $('#contextadd').hide();
             $('#contextupdate').hide();

--- a/library/custom_template/add_template.php
+++ b/library/custom_template/add_template.php
@@ -37,7 +37,7 @@ $list_id = $_REQUEST['list_id'];
 <html>
     <head>
         <?php Header::setupHeader('opener'); ?>
-        <script type="text/javascript">
+        <script>
         function add_template(){
             top.restoreSession();
             mainform=window.opener.opener.document;

--- a/library/custom_template/custom_template.php
+++ b/library/custom_template/custom_template.php
@@ -60,7 +60,7 @@ $rowContext = sqlQuery("SELECT * FROM customlists WHERE cl_list_type=2 AND cl_li
     }
 </style>
 <?php Header::setupHeader(['common', 'opener', 'select2', 'ckeditor']); ?>
-<script type="text/javascript" src="<?php echo $GLOBALS['webroot'] ?>/library/js/ajax_functions_writer.js"></script>
+<script src="<?php echo $GLOBALS['webroot'] ?>/library/js/ajax_functions_writer.js"></script>
 
 <script>
     let allowTemplateWarning = <?php echo $allowTemplateWarning; ?>;
@@ -148,7 +148,7 @@ $rowContext = sqlQuery("SELECT * FROM customlists WHERE cl_list_type=2 AND cl_li
         });
     });
 </script>
-<script type="text/javascript">
+<script>
     $(function () {
         function sortableCallback(elem){
             let clorder  = [];

--- a/library/custom_template/delete_category.php
+++ b/library/custom_template/delete_category.php
@@ -38,9 +38,9 @@ $res = sqlStatement("SELECT * FROM customlists as cl left outer join users as u 
     <head>
         <title><!-- Insert your title here --></title>
         <?php Header::setupHeader('opener'); ?>
-        <script type="text/javascript" src="<?php echo $GLOBALS['webroot'] ?>/library/js/ajax_functions_writer.js"></script>
+        <script src="<?php echo $GLOBALS['webroot'] ?>/library/js/ajax_functions_writer.js"></script>
 
-        <script type='text/javascript'>
+        <script>
         function delete_full_category(id){
                 top.restoreSession();
                 $.ajax({

--- a/library/custom_template/personalize.php
+++ b/library/custom_template/personalize.php
@@ -73,7 +73,7 @@ if (isset($_REQUEST['submitform']) && $_REQUEST['submitform'] == 'save') {
 
     <?php Header::setupHeader(['common', 'opener']); ?>
 
-    <script type="text/javascript">
+    <script>
 
         function refreshme() {
             top.restoreSession();

--- a/library/custom_template/quest_popup.php
+++ b/library/custom_template/quest_popup.php
@@ -37,7 +37,7 @@ $content = $_REQUEST['content'];
 <html>
     <head>
         <?php Header::setupHeader('opener'); ?>
-        <script type="text/javascript">
+        <script>
     function showWhereInTextarea(){
     opener.restoreSession();
     var textarea = document.getElementById('quest');

--- a/library/custom_template/share_template.php
+++ b/library/custom_template/share_template.php
@@ -37,7 +37,7 @@ $list_id = $_REQUEST['list_id'];
 <html>
     <head>
         <?php Header::setupHeader(); ?>
-        <script type="text/javascript">
+        <script>
         function add_template(){
                 top.restoreSession();
                 len = document.getElementById('provider').options.length;

--- a/library/dicom_frame.php
+++ b/library/dicom_frame.php
@@ -37,7 +37,7 @@ $web_path = attr($web_path) . '&retrieve&patient_id=' . attr_url($patid) . '&doc
 <head>
     <?php Header::setupHeader(['dwv', 'i18next', 'i18next-xhr-backend', 'i18next-browser-languagedetector', 'jszip', 'magic-wand', 'konva']); ?>
     <!-- i18n dwv wrapper -->
-    <script type="text/javascript" src="<?php echo $GLOBALS['web_root']?>/library/js/dwv/dwv_i18n.js"></script>
+    <script src="<?php echo $GLOBALS['web_root']?>/library/js/dwv/dwv_i18n.js"></script>
 </head>
 <style>
     .warn_diagnostic {
@@ -112,8 +112,8 @@ $web_path = attr($web_path) . '&retrieve&patient_id=' . attr_url($patid) . '&doc
         <!-- /layerContainer -->
     </div><!-- /dwv -->
     <!-- Main -->
-    <script type="text/javascript" src="<?php echo $GLOBALS['web_root'] ?>/library/js/dwv/dicom_gui.js"></script>
-    <script type="text/javascript" src="<?php echo $GLOBALS['web_root'] ?>/library/js/dwv/dicom_launcher.js"></script>
+    <script src="<?php echo $GLOBALS['web_root'] ?>/library/js/dwv/dicom_gui.js"></script>
+    <script src="<?php echo $GLOBALS['web_root'] ?>/library/js/dwv/dicom_launcher.js"></script>
     <script>
         var msg = <?php echo xlj("Still Loading...") ?>;
         var canvas = document.getElementById("dwvimg");

--- a/library/erx_javascript.inc.php
+++ b/library/erx_javascript.inc.php
@@ -26,7 +26,7 @@
 //
 // +------------------------------------------------------------------------------+
 ?>
-<script type="text/javascript">
+<script>
     function checkLength(eleName, eleVal, len) {
         eleName = eleName.replace('form_', '');
         var m = '';

--- a/library/js/xl/dygraphs.js.php
+++ b/library/js/xl/dygraphs.js.php
@@ -15,7 +15,7 @@
 
 ?>
 
-<script type="text/javascript">
+<script>
     // Support for translations of months in graphing dygraphs scripts
     var SHORT_MONTH_NAMES_CUSTOM = [<?php echo xlj('Jan'); ?>, <?php echo xlj('Feb'); ?>, <?php echo xlj('Mar'); ?>, <?php echo xlj('Apr'); ?>, <?php echo xlj('May'); ?>, <?php echo xlj('Jun'); ?>, <?php echo xlj('Jul'); ?>, <?php echo xlj('Aug'); ?>, <?php echo xlj('Sep'); ?>, <?php echo xlj('Oct'); ?>, <?php echo xlj('Nov'); ?>, <?php echo xlj('Dec'); ?>];
     // Dygraph xlabel translation

--- a/library/options.js.php
+++ b/library/options.js.php
@@ -15,7 +15,7 @@
  */
 
 ?>
-<script type="text/javascript">
+<script>
 
 // JavaScript support for date types when the A or B edit option is used.
 // Called to recompute displayed age dynamically when the corresponding date is

--- a/library/options_listadd.inc
+++ b/library/options_listadd.inc
@@ -40,7 +40,7 @@ use OpenEMR\Common\Csrf\CsrfUtils;
 </div>
 
 
-<script language="javascript">
+<script>
 
     // collect the custom state widget flag
     var stateCustomFlag = <?php echo json_encode($GLOBALS['state_custom_addlist_widget']); ?>;

--- a/library/payment_jav.inc.php
+++ b/library/payment_jav.inc.php
@@ -29,7 +29,7 @@
 //This section handles payment related javascript functios.Add, Search and Edit screen uses these functions.
 //===============================================================================
 ?>
-<script type="text/javascript">
+<script>
 function CheckVisible(MakeBlank)
  {//Displays and hides the check number text box.Add and edit page uses the same function.
  //In edit its value should not be lost on just a change.It is controlled be the 'MakeBlank' argument.

--- a/library/spreadsheet.inc.php
+++ b/library/spreadsheet.inc.php
@@ -338,7 +338,7 @@ $num_virtual_cols = $num_used_cols ? $num_used_cols + 5 : 10;
 }
 </style>
 
-<script language="JavaScript">
+<script>
 
  var ssChanged = false; // if they have changed anything in the spreadsheet
  var startDate = '<?php echo $start_date ? $start_date : date('Y-m-d'); ?>';

--- a/library/validation/validate_core.php
+++ b/library/validation/validate_core.php
@@ -64,7 +64,7 @@ function validateUsingPageRules($fileNamePath)
         $use_validate_js = 1;
         require_once($GLOBALS['srcdir'] . "/validation/validation_script.js.php");
         echo("\r\n");
-        print '<script type="text/javascript">';
+        print '<script>';
         echo ("$(function () {");
         echo("\r\n");
         foreach ($collectThis as $key => $value) {

--- a/library/validation/validation_script.js.php
+++ b/library/validation/validation_script.js.php
@@ -30,9 +30,9 @@ require_once($GLOBALS['srcdir'] . "/validation/LBF_Validation.php");
 /*Other pages depend if the page in the lists options (page validation)is active and exists)*/
 if ($use_validate_js) {
     ?>
-    <script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative'] ?>/moment/moment.js"></script>
-    <script type="text/javascript" src="<?php echo $GLOBALS['rootdir'] ?>/../library/js/vendors/validate/validate_modified.js"></script>
-    <script type="text/javascript" src="<?php echo $GLOBALS['rootdir'] ?>/../library/js/vendors/validate/validate_extend.js"></script>
+    <script src="<?php echo $GLOBALS['assets_static_relative'] ?>/moment/moment.js"></script>
+    <script src="<?php echo $GLOBALS['rootdir'] ?>/../library/js/vendors/validate/validate_modified.js"></script>
+    <script src="<?php echo $GLOBALS['rootdir'] ?>/../library/js/vendors/validate/validate_extend.js"></script>
     <?php
 }
 ?>

--- a/myportal/index.php
+++ b/myportal/index.php
@@ -68,7 +68,7 @@ for ($i = 1; $i <= 5; $i++) {//some times php is continuing without getting the 
 ?>
 <html>
 <head>
-<script type="text/javascript">
+<script>
  function getshansubmit(){
     document.forms[0].submit();
  }

--- a/portal/account/index_reset.php
+++ b/portal/account/index_reset.php
@@ -96,7 +96,7 @@ if (isset($_POST['submit'])) {
         echo "<script>dlgclose();</script>\n";
     }
     ?>
-    <script type="text/javascript">
+    <script>
         function checkUserName() {
             let vacct = document.getElementById('uname').value;
             let vsuname = document.getElementById('login_uname').value;

--- a/portal/patient/templates/OnsiteActivityViewListView.tpl.php
+++ b/portal/patient/templates/OnsiteActivityViewListView.tpl.php
@@ -16,7 +16,7 @@
     $this->display('_FormsHeader.tpl.php');
     echo "<script>var cuser='" . $this->cuser . "';</script>";
 ?>
-<script type="text/javascript">
+<script>
     $LAB.script("<?php echo $GLOBALS['web_root']; ?>/portal/patient/scripts/app/onsiteactivityviews.js?v=<?php echo $GLOBALS['v_js_includes']; ?>").wait(function(){
         $(function () {
             actpage.init();

--- a/portal/patient/templates/OnsiteDocumentListView.tpl.php
+++ b/portal/patient/templates/OnsiteDocumentListView.tpl.php
@@ -77,10 +77,10 @@ $cuser = isset($_SESSION['sessionUser']) ? $_SESSION['sessionUser'] : $_SESSION[
     Header::setupHeader(['no_main-theme', 'patientportal-style']);
     ?>
     <link href="<?php echo $GLOBALS['web_root']; ?>/portal/sign/css/signer_modal.css?v=<?php echo $GLOBALS['v_js_includes']; ?>" rel="stylesheet">
-    <script src="<?php echo $GLOBALS['web_root']; ?>/portal/sign/assets/signature_pad.umd.js?v=<?php echo $GLOBALS['v_js_includes']; ?>" type="text/javascript"></script>
-    <script src="<?php echo $GLOBALS['web_root']; ?>/portal/sign/assets/signer_api.js?v=<?php echo $GLOBALS['v_js_includes']; ?>" type="text/javascript"></script>
-    <script type="text/javascript" src="<?php echo $GLOBALS['web_root']; ?>/portal/patient/scripts/libs/LAB.min.js"></script>
-    <script type="text/javascript">
+    <script src="<?php echo $GLOBALS['web_root']; ?>/portal/sign/assets/signature_pad.umd.js?v=<?php echo $GLOBALS['v_js_includes']; ?>"></script>
+    <script src="<?php echo $GLOBALS['web_root']; ?>/portal/sign/assets/signer_api.js?v=<?php echo $GLOBALS['v_js_includes']; ?>"></script>
+    <script src="<?php echo $GLOBALS['web_root']; ?>/portal/patient/scripts/libs/LAB.min.js"></script>
+    <script>
         $LAB.setGlobalDefaults({
             BasePath: "<?php $this->eprint($this->ROOT_URL); ?>"
         });

--- a/portal/patient/templates/OnsitePortalActivityListView.tpl.php
+++ b/portal/patient/templates/OnsitePortalActivityListView.tpl.php
@@ -16,7 +16,7 @@
     $this->display('_Header.tpl.php');
 ?>
 
-<script type="text/javascript">
+<script>
     $LAB.script("scripts/app/onsiteportalactivities.js?v=<?php echo $GLOBALS['v_js_includes']; ?>").wait(function(){
         $(function () {
             page.init();

--- a/portal/patient/templates/PatientListView.tpl.php
+++ b/portal/patient/templates/PatientListView.tpl.php
@@ -30,7 +30,7 @@ if ($this->trow) {
     $this->display('_modalFormHeader.tpl.php');
 ?>
 
-<script type="text/javascript">
+<script>
 
     // bring in the datepicker and datetimepicker localization and setting elements
     <?php require($GLOBALS['srcdir'] . '/js/xl/jquery-datetimepicker-2-5-4-alternate.js.php'); ?>
@@ -61,7 +61,7 @@ if ($this->trow) {
     // Fixes iFrame in Patient Registratiion
     setInterval(function() {
         window.top.postMessage(document.body.scrollHeight, "*");
-    }, 500); 
+    }, 500);
 </script>
 <?php }?>
 <body>

--- a/portal/patient/templates/_FormsHeader.tpl.php
+++ b/portal/patient/templates/_FormsHeader.tpl.php
@@ -25,8 +25,8 @@ use OpenEMR\Core\Header;
 
 <!-- Styles -->
 <?php Header::setupHeader(['no_main-theme', 'datetime-picker', 'moment', 'patientportal-style']); ?>
-<script type="text/javascript" src="<?php echo $GLOBALS['web_root']; ?>/portal/patient/scripts/libs/LAB.min.js"></script>
-<script type="text/javascript">
+<script src="<?php echo $GLOBALS['web_root']; ?>/portal/patient/scripts/libs/LAB.min.js"></script>
+<script>
     $LAB.script("<?php echo $GLOBALS['assets_static_relative']; ?>/underscore/underscore-min.js").wait()
         .script("<?php echo $GLOBALS['assets_static_relative']; ?>/backbone/backbone-min.js")
         .script("<?php echo $GLOBALS['web_root']; ?>/portal/patient/scripts/app.js?v=<?php echo $GLOBALS['v_js_includes']; ?>")

--- a/portal/patient/templates/_Header.tpl.php
+++ b/portal/patient/templates/_Header.tpl.php
@@ -26,8 +26,8 @@ use OpenEMR\Core\Header;
         <meta name="description" content="Patient Portal" />
         <meta name="author" content="Form | sjpadgett@gmail.com" />
         <?php Header::setupHeader(['no_main-theme', 'patientportal-style', 'datetime-picker']); ?>
-        <script type="text/javascript" src="<?php echo $GLOBALS['web_root']; ?>/portal/patient/scripts/libs/LAB.min.js"></script>
-        <script type="text/javascript">
+        <script src="<?php echo $GLOBALS['web_root']; ?>/portal/patient/scripts/libs/LAB.min.js"></script>
+        <script>
             $LAB.script("<?php echo $GLOBALS['assets_static_relative']; ?>/moment/moment.js")
                 .script("<?php echo $GLOBALS['assets_static_relative']; ?>/underscore/underscore-min.js").wait()
                 .script("<?php echo $GLOBALS['assets_static_relative']; ?>/backbone/backbone-min.js")

--- a/portal/patient/templates/_ProviderHeader.tpl.php
+++ b/portal/patient/templates/_ProviderHeader.tpl.php
@@ -33,13 +33,13 @@
         <link href="<?php echo $GLOBALS['assets_static_relative']; ?>/@fortawesome/fontawesome-free/css/all.min.css" rel="stylesheet" />
         <link href="<?php echo $GLOBALS['web_root']; ?>/portal/sign/css/signer_modal.css?v=<?php echo $GLOBALS['v_js_includes']; ?>" rel="stylesheet">
 
-        <script src="<?php echo $GLOBALS['assets_static_relative']; ?>/jquery/dist/jquery.min.js" type="text/javascript"></script>
-        <script src="<?php echo $GLOBALS['assets_static_relative']; ?>/bootstrap/dist/js/bootstrap.bundle.min.js" type="text/javascript"></script>
-        <script src="<?php echo $GLOBALS['web_root']; ?>/portal/sign/assets/signature_pad.umd.js?v=<?php echo $GLOBALS['v_js_includes']; ?>" type="text/javascript"></script>
-        <script src="<?php echo $GLOBALS['web_root']; ?>/portal/sign/assets/signer_api.js?v=<?php echo $GLOBALS['v_js_includes']; ?>" type="text/javascript"></script>
+        <script src="<?php echo $GLOBALS['assets_static_relative']; ?>/jquery/dist/jquery.min.js"></script>
+        <script src="<?php echo $GLOBALS['assets_static_relative']; ?>/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+        <script src="<?php echo $GLOBALS['web_root']; ?>/portal/sign/assets/signature_pad.umd.js?v=<?php echo $GLOBALS['v_js_includes']; ?>"></script>
+        <script src="<?php echo $GLOBALS['web_root']; ?>/portal/sign/assets/signer_api.js?v=<?php echo $GLOBALS['v_js_includes']; ?>"></script>
 
-        <script type="text/javascript" src="<?php echo $GLOBALS['web_root']; ?>/portal/patient/scripts/libs/LAB.min.js"></script>
-        <script type="text/javascript">
+        <script src="<?php echo $GLOBALS['web_root']; ?>/portal/patient/scripts/libs/LAB.min.js"></script>
+        <script>
             $LAB.script("<?php echo $GLOBALS['assets_static_relative']; ?>/underscore/underscore-min.js")
                 .script("<?php echo $GLOBALS['assets_static_relative']; ?>/moment/moment.js")
                 .script("<?php echo $GLOBALS['assets_static_relative']; ?>/backbone/backbone-min.js")

--- a/portal/patient/templates/_modalFormHeader.tpl.php
+++ b/portal/patient/templates/_modalFormHeader.tpl.php
@@ -24,25 +24,25 @@
 <meta name="description" content="Patient Profile" />
 <meta name="author" content="Form | sjpadgett@gmail.com" />
 
-<script src="<?php echo $GLOBALS['assets_static_relative']; ?>/jquery/dist/jquery.min.js" type="text/javascript"></script>
+<script src="<?php echo $GLOBALS['assets_static_relative']; ?>/jquery/dist/jquery.min.js"></script>
 <link href="<?php echo $GLOBALS['assets_static_relative']; ?>/@fortawesome/fontawesome-free/css/all.min.css" rel="stylesheet" />
 <link href="<?php echo $GLOBALS['assets_static_relative']; ?>/jquery-datetimepicker/build/jquery.datetimepicker.min.css" rel="stylesheet" />
 <?php if ($this->register) {?>
     <link href="<?php echo $GLOBALS['assets_static_relative']; ?>/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet">
-    <script src="<?php echo $GLOBALS['assets_static_relative']; ?>/bootstrap/dist/js/bootstrap.bundle.min.js" type="text/javascript"></script>
+    <script src="<?php echo $GLOBALS['assets_static_relative']; ?>/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
 <?php } ?>
 
 <link href="<?php echo $GLOBALS['web_root']; ?>/portal/patient/styles/style.css?v=<?php echo $GLOBALS['v_js_includes']; ?>" rel="stylesheet" />
-<script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/moment/moment.js"></script>
-<script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/jquery-datetimepicker/build/jquery.datetimepicker.full.min.js"></script>
-<script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/underscore/underscore-min.js"></script>
-<script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/backbone/backbone-min.js"></script>
-<script type="text/javascript" src="<?php echo $GLOBALS['web_root']; ?>/portal/patient/scripts/app.js?v=<?php echo $GLOBALS['v_js_includes']; ?>"></script>
-<script type="text/javascript" src="<?php echo $GLOBALS['web_root']; ?>/portal/patient/scripts/model.js?v=<?php echo $GLOBALS['v_js_includes']; ?>"></script>
-<script type="text/javascript" src="<?php echo $GLOBALS['web_root']; ?>/portal/patient/scripts/view.js?v=<?php echo $GLOBALS['v_js_includes']; ?>"></script>
+<script src="<?php echo $GLOBALS['assets_static_relative']; ?>/moment/moment.js"></script>
+<script src="<?php echo $GLOBALS['assets_static_relative']; ?>/jquery-datetimepicker/build/jquery.datetimepicker.full.min.js"></script>
+<script src="<?php echo $GLOBALS['assets_static_relative']; ?>/underscore/underscore-min.js"></script>
+<script src="<?php echo $GLOBALS['assets_static_relative']; ?>/backbone/backbone-min.js"></script>
+<script src="<?php echo $GLOBALS['web_root']; ?>/portal/patient/scripts/app.js?v=<?php echo $GLOBALS['v_js_includes']; ?>"></script>
+<script src="<?php echo $GLOBALS['web_root']; ?>/portal/patient/scripts/model.js?v=<?php echo $GLOBALS['v_js_includes']; ?>"></script>
+<script src="<?php echo $GLOBALS['web_root']; ?>/portal/patient/scripts/view.js?v=<?php echo $GLOBALS['v_js_includes']; ?>"></script>
 <base href="<?php $this->eprint($this->ROOT_URL); ?>" />
-<script type="text/javascript" src="<?php echo $GLOBALS['web_root']; ?>/portal/patient/scripts/libs/LAB.min.js"></script>
-<script type="text/javascript">
+<script src="<?php echo $GLOBALS['web_root']; ?>/portal/patient/scripts/libs/LAB.min.js"></script>
+<script>
 $LAB.setGlobalDefaults({BasePath: "<?php $this->eprint($this->ROOT_URL); ?>"});
 </script>
 </head>

--- a/portal/portal_payment.php
+++ b/portal/portal_payment.php
@@ -76,7 +76,7 @@ $invdata = array();
 if ($edata) {
     $ccdata = json_decode($cryptoGen->decryptStandard($edata['checksum']), true);
     $invdata = json_decode($edata['table_args'], true);
-    echo "<script  type='text/javascript'>var jsondata='" . $edata['table_args'] . "';var ccdata='" . $edata['checksum'] . "'</script>";
+    echo "<script>var jsondata='" . $edata['table_args'] . "';var ccdata='" . $edata['checksum'] . "'</script>";
 }
 
 function bucks($amount)
@@ -437,7 +437,7 @@ if ($_POST['form_save'] || $_REQUEST['receipt']) {
     ?>
 
     <title><?php echo xlt('Receipt for Payment'); ?></title>
-    <script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/jquery/dist/jquery.min.js"></script>
+    <script src="<?php echo $GLOBALS['assets_static_relative']; ?>/jquery/dist/jquery.min.js"></script>
     <script>
 
         function goHome() {
@@ -542,9 +542,9 @@ if ($_POST['form_save'] || $_REQUEST['receipt']) {
             font-weight: normal
         }
     </style>
-    <script type="text/javascript" src="<?php echo $GLOBALS['assets_static_relative']; ?>/jquery-creditcardvalidator/jquery.creditCardValidator.js"></script>
-    <script type="text/javascript" src="<?php echo $GLOBALS['webroot'] ?>/library/textformat.js?v=<?php echo $v_js_includes; ?>"></script>
-    <script type="text/javascript">
+    <script src="<?php echo $GLOBALS['assets_static_relative']; ?>/jquery-creditcardvalidator/jquery.creditCardValidator.js"></script>
+    <script src="<?php echo $GLOBALS['webroot'] ?>/library/textformat.js?v=<?php echo $v_js_includes; ?>"></script>
+    <script>
         var chargeMsg = <?php $amsg = xl('Payment was successfully authorized and your card is charged.') . "\n" .
                 xl("You will be notified when your payment is applied for this invoice.") . "\n" .
                 xl('Until then you will continue to see payment details here.') . "\n" . xl('Thank You.');

--- a/portal/report/portal_custom_report.php
+++ b/portal/report/portal_custom_report.php
@@ -231,7 +231,7 @@ input[type="radio"] {
 
 <?php if (!$PDF_OUTPUT) { ?>
 <link rel="stylesheet" href="<?php echo $GLOBALS['webroot'] ?>/library/ESign/css/esign_report.css?v=<?php echo $v_js_includes; ?>" />
-<script type="text/javascript" src="<?php echo $GLOBALS['web_root']?>/library/js/SearchHighlight.js?v=<?php echo $v_js_includes; ?>"></script>
+<script src="<?php echo $GLOBALS['web_root']?>/library/js/SearchHighlight.js?v=<?php echo $v_js_includes; ?>"></script>
     <!-- Unclear where a conflict occurs but if jquery is already in scope then !!!! removed noconflict sjp 12-1-2019-->
 <script>var $j = '$';</script>
 

--- a/portal/sign/assets/signit.php
+++ b/portal/sign/assets/signit.php
@@ -29,10 +29,8 @@ use OpenEMR\Core\Header;
 
     <link href="<?php echo $GLOBALS['web_root']; ?>/portal/sign/css/signer_modal.css?v=<?php echo $v_js_includes; ?>"
           rel="stylesheet">
-    <script src="<?php echo $GLOBALS['web_root']; ?>/portal/sign/assets/signature_pad.umd.js"
-            type="text/javascript"></script>
-    <script src="<?php echo $GLOBALS['web_root']; ?>/portal/sign/assets/signer_api.js?v=<?php echo $v_js_includes; ?>"
-            type="text/javascript"></script>
+    <script src="<?php echo $GLOBALS['web_root']; ?>/portal/sign/assets/signature_pad.umd.js"></script>
+    <script src="<?php echo $GLOBALS['web_root']; ?>/portal/sign/assets/signer_api.js?v=<?php echo $v_js_includes; ?>"></script>
     <script>
         const remoteDevice = '' + <?php echo js_escape($thisDevice) ?>;
         let currentAuth = '';

--- a/setup.php
+++ b/setup.php
@@ -121,10 +121,9 @@ if (!$COMMAND_LINE && empty($_REQUEST['site'])) {
     <html>
     <head>
         <title>OpenEMR Setup Tool</title>
-        <!--<link rel=stylesheet href="interface/themes/style_blue.css">-->
         <link rel="stylesheet" href="public/assets/bootstrap/dist/css/bootstrap.min.css">
-        <script type="text/javascript" src="public/assets/jquery/dist/jquery.min.js"></script>
-        <script type="text/javascript" src="public/assets/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+        <script src="public/assets/jquery/dist/jquery.min.js"></script>
+        <script src="public/assets/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
         <link rel="stylesheet" href="public/assets/@fortawesome/fontawesome-free/css/all.min.css">
         <link rel="shortcut icon" href="public/images/favicon.ico" />
         <style>
@@ -231,8 +230,8 @@ if (file_exists($OE_SITE_DIR)) {
 <title>OpenEMR Setup Tool</title>
 <!--<link rel=stylesheet href="interface/themes/style_blue.css">-->
 <link rel="stylesheet" href="public/assets/bootstrap/dist/css/bootstrap.min.css">
-<script type="text/javascript" src="public/assets/jquery/dist/jquery.min.js"></script>
-<script type="text/javascript" src="public/assets/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+<script src="public/assets/jquery/dist/jquery.min.js"></script>
+<script src="public/assets/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
 <link rel="stylesheet" href="public/assets/@fortawesome/fontawesome-free/css/all.min.css">
 <link rel="shortcut icon" href="public/images/favicon.ico" />
 
@@ -315,7 +314,7 @@ if (file_exists($OE_SITE_DIR)) {
         }
     }
 </style>
-<script language="javascript">
+<script>
 // onclick handler for "clone database" checkbox
 function cloneClicked() {
  var cb = document.forms[0].clone_database;
@@ -1591,7 +1590,7 @@ BOT;
 
         });
     </script>
-    <script type = "text/javascript" >
+    <script>
         $(function () {
             $("input[type='radio']").click(function() {
                 var radioValue = $("input[name='stylesheet']:checked").val();

--- a/sites/default/referral_template.html
+++ b/sites/default/referral_template.html
@@ -455,7 +455,7 @@
 </div></div>
 
 <!-- This should really be in the onload handler but that seems to be unreliable and can crash Firefox 3. -->
-<script type="text/javascript">
+<script>
  var win = top.printLogPrint ? top : opener.top;
  win.printLogPrint(window);
 </script>

--- a/src/Core/Header.php
+++ b/src/Core/Header.php
@@ -301,7 +301,7 @@ class Header
     private static function createElement($path, $type, $alreadyBuilt)
     {
 
-        $script = "<script type=\"text/javascript\" src=\"%path%\"></script>\n";
+        $script = "<script src=\"%path%\"></script>\n";
         $link = "<link rel=\"stylesheet\" href=\"%path%\" type=\"text/css\">\n";
 
         $template = ($type == 'script') ? $script : $link;

--- a/templates/document_categories/general_list.html
+++ b/templates/document_categories/general_list.html
@@ -13,11 +13,11 @@
 -->
 </style>
 {/literal}
-<script type="text/javascript">
+<script>
 var deleteLabel={xlj t="Delete"};
 var editLabel={xlj t="Edit"};
 </script>
-<script type="text/javascript" src="{$GLOBALS.webroot}/library/js/CategoryTreeMenu.js?v={$V_JS_INCLUDES}"></script>
+<script src="{$GLOBALS.webroot}/library/js/CategoryTreeMenu.js?v={$V_JS_INCLUDES}"></script>
 <table>
 	<tr>
 		<td height="20" valign="top">{xlt t="Document Categories"}</td>

--- a/templates/documents/general_list.html
+++ b/templates/documents/general_list.html
@@ -31,10 +31,10 @@ border-radius: 4px 0 0 4px!important;
 }
 </style>
 {/literal}
-<script type="text/javascript" src="{$GLOBALS.webroot}/library/js/DocumentTreeMenu.js"></script>
-<script type="text/javascript" src="{$GLOBALS.assets_static_relative}/dropzone/dist/dropzone.js"></script>
+<script src="{$GLOBALS.webroot}/library/js/DocumentTreeMenu.js"></script>
+<script src="{$GLOBALS.assets_static_relative}/dropzone/dist/dropzone.js"></script>
 
-<script type="text/javascript">
+<script>
 	function callTemplateModule() {literal}{{/literal}
 		top.restoreSession();
 		let tele  = document.getElementById("template_filename");
@@ -100,7 +100,7 @@ border-radius: 4px 0 0 4px!important;
 		</div>
 	</div>
 </div><!--end of container div-->
-<script type="text/javascript">
+<script>
 var curpid = {$cur_pid|js_escape};
 var newVersion= {$is_new|js_escape};
 var demoPid = {$demo_pid|js_escape};

--- a/templates/documents/general_queue.html
+++ b/templates/documents/general_queue.html
@@ -48,7 +48,7 @@
 
 {literal}
 <head>
-<script language="javascript">
+<script>
 function submit_documents()
 {
     top.restoreSession();

--- a/templates/insurance_companies/general_edit.html
+++ b/templates/insurance_companies/general_edit.html
@@ -137,7 +137,7 @@
 </form>
 
 {literal}
-<script language="javascript">
+<script>
     function submit_insurancecompany() {
         if(document.insurancecompany.name.value.length>0) {
             top.restoreSession();

--- a/templates/insurance_numbers/general_edit.html
+++ b/templates/insurance_numbers/general_edit.html
@@ -137,7 +137,7 @@
 {/if}
 
 {literal}
-<script language="javascript">
+<script>
 function submit_insurancenumbers_update() {
     top.restoreSession();
     document.provider.submit();

--- a/templates/pharmacies/general_edit.html
+++ b/templates/pharmacies/general_edit.html
@@ -99,7 +99,7 @@
 </form>
 
 {literal}
-<script language="javascript">
+<script>
 function submit_pharmacy()
 {
     if(document.pharmacy.name.value.length>0)

--- a/templates/prescription/general_lookup.html
+++ b/templates/prescription/general_lookup.html
@@ -13,7 +13,7 @@
 
 {headerTemplate}
 
-<script language="Javascript">
+<script>
 {literal}
 		function my_process () {
 			// Pass the variable

--- a/templates/x12_partners/general_edit.html
+++ b/templates/x12_partners/general_edit.html
@@ -144,7 +144,7 @@
 </form>
 
 {literal}
-<script language="javascript">
+<script>
 function add_x12()
 {
 if (document.x12_partner.name.value.length>0)

--- a/tests/api/InternalApiTest.php
+++ b/tests/api/InternalApiTest.php
@@ -25,7 +25,7 @@ use OpenEMR\Core\Header;
 <head>
     <?php Header::setupAssets('jquery'); ?>
 
-    <script language="JavaScript">
+    <script>
         function testAjaxApi() {
             $.ajax({
                 type: 'GET',


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #3542

#### Short description of what this resolves:
Remove outdated javascript attributes. e.g. `type="text/javascript"` `language="javascript"`

