### PR TITLE
Modernize 'Site ID Missing' (#284)

### DIFF
--- a/interface/globals.php
+++ b/interface/globals.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Default values for optional variables that are allowed to be set by callers.
  *
@@ -131,7 +130,10 @@ if (empty($_SESSION['site_id']) || !empty($_GET['site'])) {
                 $srcdir = "../library";
                 require_once("$srcdir/auth.inc");
             }
-            die("Site ID is missing from session data!");
+            // Site ID missing from session data
+            require_once("session_expired.php");
+            sessionExpired($web_root);
+            exit();
         }
 
         $tmp = $_SERVER['HTTP_HOST'];

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Default values for optional variables that are allowed to be set by callers.
  *

--- a/interface/session_expired.php
+++ b/interface/session_expired.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Runs when site ID is missing from session data
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Tyler Wrenn <tyler@tylerwrenn.com>
+ * @copyright Copyright (c) 2020 Tyler Wrenn <tyler@tylerwrenn.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+function sessionExpired($web_root) { ?>
+  <!DOCTYPE HTML>
+  <html>
+  <head>
+    <script src="main/tabs/js/include_opener.js"></script>
+    <script>
+      // Equivalent to jQuery ready function
+      window.onload = function() {
+        // Call that session timed out using opener
+        top.timed_out = true;
+        // Get main frame and redirect to login page
+        top.location.href = "<?php echo $web_root; ?>/interface/login/login.php";
+      };
+    </script>
+    <style>
+      body {
+        font-family: 'Arial', sans-serif;
+        text-align: center;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>Invalid Session</h2>
+    <p>Please logout of OpenEMR and log back in again if you are not redirected.</p>
+  </body>
+  </html>
+<?php } ?>

--- a/interface/session_expired.php
+++ b/interface/session_expired.php
@@ -9,7 +9,9 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-function sessionExpired($web_root) { ?>
+function sessionExpired($web_root)
+{
+    ?>
   <!DOCTYPE HTML>
   <html>
   <head>


### PR DESCRIPTION
Fixes #284

#### Short description of what this resolves:
Revamps 'Site ID is missing from session data' prompt

This is still ongoing. Any further suggestions of how to improve this would be awesome.

A big issue here is getting xl translations working in such an early area of globals which @bradymiller needs to help me with.