### PR TITLE
fixes to remove warnings as browsers start to crack down on missing SameSite attributes

### DIFF
--- a/interface/login/login.php
+++ b/interface/login/login.php
@@ -145,7 +145,12 @@ if (count($emr_app)) {
                 // This forces the server to create a new session ID.
                 var olddate = new Date();
                 olddate.setFullYear(olddate.getFullYear() - 1);
-                document.cookie = <?php echo json_encode(urlencode(session_name())); ?> + '=' + <?php echo json_encode(urlencode(session_id())); ?> + '; path=<?php echo($web_root ? $web_root : '/');?>; expires=' + olddate.toGMTString();
+                <?php if (version_compare(phpversion(), '7.3.0', '>=')) { ?>
+                    // Using the SameSite setting when using php version 7.3.0 or above, which avoids browser warnings when cookie is not 'secure' and SameSite is not set to anything
+                    document.cookie = <?php echo json_encode(urlencode(session_name())); ?> + '=' + <?php echo json_encode(urlencode(session_id())); ?> + '; path=<?php echo($web_root ? $web_root : '/');?>; expires=' + olddate.toGMTString() + '; SameSite=Strict';
+                <?php } else { ?>
+                    document.cookie = <?php echo json_encode(urlencode(session_name())); ?> + '=' + <?php echo json_encode(urlencode(session_id())); ?> + '; path=<?php echo($web_root ? $web_root : '/');?>; expires=' + olddate.toGMTString();
+                <?php } ?>
             <?php } ?>
             document.forms[0].submit();
         }

--- a/src/Common/Session/SessionUtil.php
+++ b/src/Common/Session/SessionUtil.php
@@ -17,8 +17,9 @@
  *        vulnerabilities.
  *  2. If using php version 7.3.0 or above, then will set the cookie_samesite to Strict in
  *     order to prevent csrf vulnerabilities. Note this setting also is set in core
- *     OpenEMR restore_session() javascript function so it is maintained when the session id
- *     is changed in the cookie.
+ *     OpenEMR restoreSession() javascript function so it is maintained when the session id
+ *     is changed in the cookie (also is used in the transmit_form() function in login.php
+ *     and standardSessionCookieDestroy() function to avoid browser warnings).
  *  3. Using use_strict_mode, use_cookies, and use_only_cookies to optimize security.
  *  4. Using sid_bits_per_character of 6 to optimize security. This does allow comma to
  *     be used in the session id, so need to ensure properly escape it when modify it in
@@ -174,15 +175,30 @@ class SessionUtil
     {
         // Destroy the cookie
         $params = session_get_cookie_params();
-        setcookie(
-            session_name(),
-            '',
-            time() - 42000,
-            $params["path"],
-            $params["domain"],
-            $params["secure"],
-            $params["httponly"]
-        );
+        if (version_compare(phpversion(), '7.3.0', '>=')) {
+            setcookie(
+                session_name(),
+                '',
+                [
+                    'expires' => time() - 42000,
+                    'path' => $params["path"],
+                    'domain' => $params["domain"],
+                    'secure' => $params["secure"],
+                    'httponly' => $params["httponly"],
+                    'samesite' => $params["samesite"]
+                ]
+            );
+        } else {
+            setcookie(
+                session_name(),
+                '',
+                time() - 42000,
+                $params["path"],
+                $params["domain"],
+                $params["secure"],
+                $params["httponly"]
+            );
+        }
 
         // Destroy the session.
         session_destroy();


### PR DESCRIPTION
Dealing with following warning that is showing up in browsers:
Cookie “OpenEMR” will be soon rejected because it has the “sameSite” attribute set to “none” or an invalid value, without the “secure” attribute. To know more about the “sameSite“ attribute, read https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie/SameSite

Note really need php 7.3 to be able to set this setting. And the issue in 7.3 is that is wasn't being set when removing cookies (ie. expiring cookies). This fix addresses that.