### PR TITLE
issue #3659 fix

### DIFF
--- a/interface/main/tabs/js/tabs_view_model.js
+++ b/interface/main/tabs/js/tabs_view_model.js
@@ -136,6 +136,7 @@ function navigateTab(url,name,afterLoadFunction,loading_label='')
             });
         }
         openExistingTab(url,name);
+        $("iframe[name='"+name+"']").get(0).contentWindow.location=url;
     }
     else
     {
@@ -246,10 +247,6 @@ function newTherapyGroupEncounter()
     });
 }
 
-function clickEncounterList(data,evt)
-{
-    encounterList();
-}
 function encounterList()
 {
     var url=webroot_url+'/interface/patient_file/history/encounters.php';


### PR DESCRIPTION
- dup function clickEncounterList
- add iframe load

<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #3659 

#### Short description of what this resolves:
Existing tabs were not loading iframe but switching back and forth if an exiting iframe already exist.

-