### PR TITLE
fix broken search icon; TypeError: event.stopImmediatePropagation is not a function

### DIFF
--- a/interface/main/tabs/js/user_data_view_model.js
+++ b/interface/main/tabs/js/user_data_view_model.js
@@ -33,10 +33,10 @@ function user_data_view_model(username,fname,lname,authGrp)
 
 }
 
-function viewPtFinder(myMessage, searchAnyType, event)
+function viewPtFinder(myMessage, searchAnyType, data, event)
 {
-    event.stopImmediatePropagation;
-    event.preventDefault;
+    event.stopImmediatePropagation();
+    event.preventDefault();
     let srchBox = document.getElementById("anySearchBox");
     srchBox.focus();
 

--- a/interface/main/tabs/js/user_data_view_model.js
+++ b/interface/main/tabs/js/user_data_view_model.js
@@ -35,8 +35,8 @@ function user_data_view_model(username,fname,lname,authGrp)
 
 function viewPtFinder(myMessage, searchAnyType, event)
 {
-    event.stopImmediatePropagation();
-    event.preventDefault();
+    event.stopImmediatePropagation;
+    event.preventDefault;
     let srchBox = document.getElementById("anySearchBox");
     srchBox.focus();
 


### PR DESCRIPTION
@tywrenn , the parenthesis at end of this were breaking the search icon at top right. So, I added them back. Let me know if better way.
(these parenthesis were add in this PR: https://github.com/openemr/openemr/pull/3636)