### PR TITLE
fixtures cleanup

### DIFF
--- a/tests/Tests/Fixtures/FHIR/facility.json
+++ b/tests/Tests/Fixtures/FHIR/facility.json
@@ -9,7 +9,7 @@
             "system": "http://hl7.org/fhir/sid/us-npi",
             "value": "1063494177"
         }],
-        "name": "Saint Luke's Hospital of Kansas City",
+        "name": "test-fixture-Saint Luke's Hospital of Kansas City",
         "telecom": [{
             "system": "phone",
             "value": "(816)932-2000",
@@ -27,7 +27,7 @@
     {
         "resourceType": "Organization",
         "id": "42fe3345-76cc-4fb7-9750-734b759c872e",
-        "name": "Health Level Seven International",
+        "name": "test-fixture-Health Level Seven International",
         "telecom": [{
                 "system": "phone",
                 "value": "(+1) 734-677-7777",
@@ -59,7 +59,7 @@
             "system": "http://hl7.org/fhir/sid/us-npi",
             "value": "1939403029"
         }],
-        "name": "Gastroenterology",
+        "name": "test-fixture-Gastroenterology",
         "telecom": [{
             "system": "email",
             "value": "gastro@acme.org",
@@ -73,7 +73,7 @@
             "system": "http://hl7.org/fhir/sid/us-npi",
             "value": "1927402830"
         }],
-        "name": "Clinical Lab",
+        "name": "test-fixture-Clinical Lab",
         "telecom": [{
                 "system": "phone",
                 "value": "+1 555 234 1234",

--- a/tests/Tests/Fixtures/FHIR/practitioners.json
+++ b/tests/Tests/Fixtures/FHIR/practitioners.json
@@ -18,7 +18,7 @@
             "use": "official",
             "family": "Perez",
             "given": [
-                "Eduardo",
+                "test-fixture-Eduardo",
                 "Kathy"
             ],
             "prefix": [
@@ -71,7 +71,7 @@
             "use": "official",
             "family": "Careful",
             "given": [
-                "Adam"
+                "test-fixture-Adam"
             ],
             "prefix": [
                 "Dr"
@@ -101,7 +101,7 @@
             "use": "official",
             "family": "Hippocrates",
             "given": [
-                "Harold"
+                "test-fixture-Harold"
             ],
             "suffix": [
                 "MD"
@@ -122,7 +122,7 @@
             "use": "official",
             "family": "Beverly",
             "given": [
-                "Crusher"
+                "test-fixture-Crusher"
             ],
             "prefix": [
                 "Dr"
@@ -147,7 +147,7 @@
             "use": "official",
             "family": "Seven",
             "given": [
-                "Henry"
+                "test-fixture-Henry"
             ]
         }],
         "telecom": [{
@@ -179,7 +179,7 @@
             "use": "official",
             "family": "Assigned",
             "given": [
-                "Amanda"
+                "test-fixture-Amanda"
             ]
         }],
         "telecom": [{

--- a/tests/Tests/Fixtures/PractitionerFixtureManager.php
+++ b/tests/Tests/Fixtures/PractitionerFixtureManager.php
@@ -23,7 +23,7 @@ use Ramsey\Uuid\Uuid;
 class PractitionerFixtureManager
 {
     // use a prefix so we can easily remove fixtures
-    const FIXTURE_PREFIX = "-";
+    const FIXTURE_PREFIX = "test-fixture";
 
     private $practitionerFixtures;
     private $fhirPractitionerFixtures;
@@ -172,14 +172,14 @@ class PractitionerFixtureManager
         $bindVariable = self::FIXTURE_PREFIX . "%";
 
         // remove the related uuids from uuid_registry
-        $select = "SELECT `uuid` FROM `users` WHERE `id` LIKE ?";
+        $select = "SELECT `uuid` FROM `users` WHERE `fname` LIKE ?";
         $sel = sqlStatement($select, [$bindVariable]);
         while ($row = sqlFetchArray($sel)) {
             sqlQuery("DELETE FROM `uuid_registry` WHERE `table_name` = 'users' AND `uuid` = ?", [$row['uuid']]);
         }
 
         // remove the practitioners
-        $delete = "DELETE FROM users WHERE id LIKE ?";
+        $delete = "DELETE FROM users WHERE fname LIKE ?";
         sqlStatement($delete, array($bindVariable));
     }
 

--- a/tests/Tests/Fixtures/practitioners.json
+++ b/tests/Tests/Fixtures/practitioners.json
@@ -1,7 +1,7 @@
 [{
     "id": "-1",
     "title": "Mrs.",
-    "fname": "Eduardo",
+    "fname": "test-fixture-Eduardo",
     "mname": "Kathy",
     "lname": "Perez",
     "federaltaxid": "91-897-4899",
@@ -31,7 +31,7 @@
 }, {
     "id": "-2",
     "title": "Mrs.",
-    "fname": "Nora",
+    "fname": "test-fixture-Nora",
     "mname": "Lisa",
     "lname": "Cohen",
     "federaltaxid": "98-597-5540",
@@ -61,7 +61,7 @@
 }, {
     "id": "-3",
     "title": "Mr.",
-    "fname": "Jim",
+    "fname": "test-fixture-Jim",
     "mname": "Jeffrey",
     "lname": "Moses",
     "federaltaxid": "91-897-8763",
@@ -91,7 +91,7 @@
 }, {
     "id": "-4",
     "title": "Mr.",
-    "fname": "Richard",
+    "fname": "test-fixture-Richard",
     "mname": "Cortez",
     "lname": "Jones",
     "federaltaxid": "94-773-9022",
@@ -121,7 +121,7 @@
 }, {
     "id": "-5",
     "title": "Mr.",
-    "fname": "Ilias",
+    "fname": "test-fixture-Ilias",
     "mname": "Alexis",
     "lname": "Jenane",
     "federaltaxid": "91-920-1232",

--- a/tests/Tests/RestControllers/FHIR/FhirOrganizationRestControllerTest.php
+++ b/tests/Tests/RestControllers/FHIR/FhirOrganizationRestControllerTest.php
@@ -71,7 +71,7 @@ class FhirOrganizationRestControllerTest extends TestCase
         $actualResult = $this->fhirOrganizationController->post($this->fhirFixture);
         $fhirId = $actualResult['data']['uuid'];
 
-        $this->fhirFixture['name'] = 'Glenmark Clinic';
+        $this->fhirFixture['name'] = 'test-fixture-Glenmark Clinic';
         $actualResult = $this->fhirOrganizationController->patch($fhirId, $this->fhirFixture);
 
         $this->assertEquals(200, http_response_code());

--- a/tests/Tests/RestControllers/FacilityRestControllerTest.php
+++ b/tests/Tests/RestControllers/FacilityRestControllerTest.php
@@ -26,7 +26,7 @@ class FacilityRestControllerTest extends TestCase
     protected function setUp(): void
     {
         $this->facilityData = array(
-            'name' => 'Your Clinic Name Here',
+            'name' => 'test-fixture-Your Clinic Name Here',
             'phone' => '(619) 555-4859',
             'fax' => '(619) 555-7822',
             'street' => '789 Third Avenue',

--- a/tests/Tests/RestControllers/PractitionerRestControllerTest.php
+++ b/tests/Tests/RestControllers/PractitionerRestControllerTest.php
@@ -29,7 +29,7 @@ class PractitionerRestControllerTest extends TestCase
             "id" => "test-fixture-789456",
             "uuid" => "90cde167-7b9b-4ed1-bd55-533925cb2605",
             "title" => "Mrs.",
-            "fname" => "Eduardo",
+            "fname" => "test-fixture-Eduardo",
             "mname" => "Kathy",
             "lname" => "Perez",
             "federaltaxid" => "",

--- a/tests/Tests/Services/FHIR/FhirOrganizationServiceCrudTest.php
+++ b/tests/Tests/Services/FHIR/FhirOrganizationServiceCrudTest.php
@@ -79,14 +79,14 @@ class FhirOrganizationServiceCrudTest extends TestCase
         $fhirId = $dataResult['uuid'];
         $this->assertIsString($fhirId);
 
-        $this->fhirOrganizationFixture['name'] = 'Glenmark Clinic';
+        $this->fhirOrganizationFixture['name'] = 'test-fixture-Glenmark Clinic';
         $this->fhirOrganizationFixture['id'] = $fhirId;
         $actualResult = $this->fhirOrganizationService->update($fhirId, $this->fhirOrganizationFixture);
         $this->assertTrue($actualResult->isValid());
 
         $actualFhirRecord = $actualResult->getData()[0];
         $actualName = $actualFhirRecord->getName();
-        $this->assertEquals('Glenmark Clinic', $actualName);
+        $this->assertEquals('test-fixture-Glenmark Clinic', $actualName);
 
         $this->assertEquals($fhirId, $actualFhirRecord->getId());
     }

--- a/tests/Tests/Services/FHIR/FhirPatientServiceQueryTest.php
+++ b/tests/Tests/Services/FHIR/FhirPatientServiceQueryTest.php
@@ -106,7 +106,7 @@ class FhirPatientServiceQueryTest extends TestCase
         $this->assertGreaterThan(0, $actualResult->getData());
 
         $expectedId = $actualResult->getData()[0]->getId();
-        
+
         $actualResult = $this->fhirPatientService->getOne($expectedId);
         $this->assertGreaterThan(0, $actualResult->getData());
         $actualId = $actualResult->getData()[0]->getId();


### PR DESCRIPTION
@yashrajbothra , Noted lots of lingering users/facilities in database after running automated testing. These changes wipe them out. Note can't used negative id's for fhir fixtures, so just used the first name :)
The negative id's are good, though, for the main fixtures, since it avoids clashing with any current users.