### PR TITLE
fix: firefox vertical align center

### DIFF
--- a/interface/themes/login_page.scss
+++ b/interface/themes/login_page.scss
@@ -25,10 +25,10 @@ $login-form-bg-color: $white !default;
 $login-button-primary: false !default;
 
 body.login {
-  height: 100%;
   align-items: center;
   background: $light;
   display: flex;
+  height: 100%;
   justify-content: center;
   resize: both;
 }

--- a/interface/themes/login_page.scss
+++ b/interface/themes/login_page.scss
@@ -25,11 +25,11 @@ $login-form-bg-color: $white !default;
 $login-button-primary: false !default;
 
 body.login {
+  height: 100%;
   align-items: center;
   background: $light;
   display: flex;
   justify-content: center;
-  height: 100%;
   resize: both;
 }
 

--- a/interface/themes/login_page.scss
+++ b/interface/themes/login_page.scss
@@ -29,8 +29,8 @@ body.login {
   background: $light;
   display: flex;
   justify-content: center;
-  resize: both;
   height: 100%;
+  resize: both;
 }
 
 .login-failure {

--- a/interface/themes/login_page.scss
+++ b/interface/themes/login_page.scss
@@ -30,6 +30,7 @@ body.login {
   display: flex;
   justify-content: center;
   resize: both;
+  height: 100%;
 }
 
 .login-failure {


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:
In the Firefox browser, The login form didn't vertical-align center.

Before:
![image](https://user-images.githubusercontent.com/22230889/85630555-6dbab380-b6a6-11ea-83eb-14ff3535b904.png)

After:
![image](https://user-images.githubusercontent.com/22230889/85630580-7b703900-b6a6-11ea-9142-968ffc96158d.png)
