### PR TITLE
Refactor: remove oudated javascript attribute

### DIFF
--- a/contrib/forms/specialist_notes/new.php
+++ b/contrib/forms/specialist_notes/new.php
@@ -65,9 +65,9 @@ if ($_POST['bn_save']) {
  //
     if ($formid) {
         $query = "UPDATE form_specialist_notes SET
-          notes = ?      
+          notes = ?
           followup_required = ?
-          followup_timing = ?                  
+          followup_timing = ?
           followup_location = ?
           WHERE id = ?";
         sqlStatement($query, array($_POST['form_notes'], cbvalue('fu_required'), $fu_timing, $fu_location, $formid));
@@ -93,7 +93,7 @@ if ($formid) {
 <html>
 <head>
     <?php Header::setupHeader(); ?>
-<script language='JavaScript'>
+<script>
  function newEvt() {
   dlgopen('../../main/calendar/add_edit_event.php?patientid=' + <?php echo js_url($pid); ?>,
    '_blank', 775, 500);

--- a/contrib/forms/specialist_notes/view.php
+++ b/contrib/forms/specialist_notes/view.php
@@ -93,7 +93,7 @@ if ($formid) {
 <html>
 <head>
     <?php Header::setupHeader(); ?>
-<script language='JavaScript'>
+<script>
  function newEvt() {
   dlgopen('../../main/calendar/add_edit_event.php?patientid=' + <?php echo js_url($pid); ?>,
    '_blank', 775, 500);

--- a/controllers/C_Prescription.class.php
+++ b/controllers/C_Prescription.class.php
@@ -586,7 +586,7 @@ class C_Prescription extends Controller
 
     function multiprintcss_postfooter()
     {
-        echo("<script language='JavaScript'>\n");
+        echo("<script>\n");
         echo("opener.top.printLogPrint(window);\n");
         echo("</script>\n");
         echo("</body>\n");

--- a/custom/import_xml.php
+++ b/custom/import_xml.php
@@ -189,7 +189,7 @@ if ($_POST['form_import']) {
     setInsurance($pid, $ainsurance, $asubscriber, '2');
     setInsurance($pid, $ainsurance, $asubscriber, '3');
 
-    echo "<html>\n<body>\n<script language='JavaScript'>\n";
+    echo "<html>\n<body>\n<script>\n";
     if ($alertmsg) {
         echo " alert('" . addslashes($alertmsg) . "');\n";
     }

--- a/gacl/admin/templates/phpgacl/debug.tpl
+++ b/gacl/admin/templates/phpgacl/debug.tpl
@@ -4,7 +4,7 @@
 
 {assign_debug_info}
 
-<SCRIPT language=javascript>
+<SCRIPT>
 	if( self.name == '' ) {ldelim}
 	   var title = 'Console';
 	{rdelim}
@@ -19,19 +19,19 @@
 	{section name=templates loop=$_debug_tpls}
 		_smarty_console.document.write("<tr bgcolor={if %templates.index% is even}#eeeeee{else}#fafafa{/if}><td colspan=2><tt>{section name=indent loop=$_debug_tpls[templates].depth}&nbsp;&nbsp;&nbsp;{/section}<font color={if $_debug_tpls[templates].type eq "template"}brown{elseif $_debug_tpls[templates].type eq "insert"}black{else}green{/if}>{$_debug_tpls[templates].filename}</font> <font size=-1><i>({$_debug_tpls[templates].exec_time|string_format:"%.5f"}){if %templates.index% eq 0} (total){/if}</i></font></tt></td></tr>");
 	{sectionelse}
-		_smarty_console.document.write("<tr bgcolor=#eeeeee><td colspan=2><tt><i>no templates included</i></tt></td></tr>");	
+		_smarty_console.document.write("<tr bgcolor=#eeeeee><td colspan=2><tt><i>no templates included</i></tt></td></tr>");
 	{/section}
 	_smarty_console.document.write("<tr bgcolor=#cccccc><td colspan=2><b>assigned template variables:</b></td></tr>");
 	{section name=vars loop=$_debug_keys}
 		_smarty_console.document.write("<tr bgcolor={if %vars.index% is even}#eeeeee{else}#fafafa{/if}><td valign=top><tt><font color=blue>{ldelim}${$_debug_keys[vars]}{rdelim}</font></tt></td><td nowrap><tt><font color=green>{$_debug_vals[vars]|@debug_print_var}</font></tt></td></tr>");
 	{sectionelse}
-		_smarty_console.document.write("<tr bgcolor=#eeeeee><td colspan=2><tt><i>no template variables assigned</i></tt></td></tr>");	
+		_smarty_console.document.write("<tr bgcolor=#eeeeee><td colspan=2><tt><i>no template variables assigned</i></tt></td></tr>");
 	{/section}
 	_smarty_console.document.write("<tr bgcolor=#cccccc><td colspan=2><b>assigned config file variables (outter template scope):</b></td></tr>");
 	{section name=config_vars loop=$_debug_config_keys}
 		_smarty_console.document.write("<tr bgcolor={if %config_vars.index% is even}#eeeeee{else}#fafafa{/if}><td valign=top><tt><font color=maroon>{ldelim}#{$_debug_config_keys[config_vars]}#{rdelim}</font></tt></td><td><tt><font color=green>{$_debug_config_vals[config_vars]|@debug_print_var}</font></tt></td></tr>");
 	{sectionelse}
-		_smarty_console.document.write("<tr bgcolor=#eeeeee><td colspan=2><tt><i>no config vars assigned</i></tt></td></tr>");	
+		_smarty_console.document.write("<tr bgcolor=#eeeeee><td colspan=2><tt><i>no config vars assigned</i></tt></td></tr>");
 	{/section}
 	_smarty_console.document.write("</table>");
 	_smarty_console.document.write("</BODY></HTML>");

--- a/interface/de_identification_forms/find_drug_popup.php
+++ b/interface/de_identification_forms/find_drug_popup.php
@@ -161,7 +161,7 @@ function check_search_str()
         $no_of_items = $row['count'];
         if ($no_of_items < 1) {
             ?>
-        <script language='JavaScript'>
+        <script>
             alert(<?php echo xlj('Search string does not match with list in database'); ?> + '\n' + <?php echo xlj('Please enter new search string'); ?>);
         document.theform.search_term.value=" ";
         document.theform.search_term.focus();

--- a/interface/fax/fax_dispatch.php
+++ b/interface/fax/fax_dispatch.php
@@ -396,7 +396,7 @@ if ($_POST['form_save']) {
 
     if ($info_msg || $form_cb_delete != '1') {
         // Close this window and refresh the fax list.
-        echo "<html>\n<body>\n<script language='JavaScript'>\n";
+        echo "<html>\n<body>\n<script>\n";
         if ($info_msg) {
             echo " alert('" . addslashes($info_msg) . "');\n";
         }

--- a/interface/forms/CAMOS/notegen.php
+++ b/interface/forms/CAMOS/notegen.php
@@ -255,7 +255,7 @@ if ($_POST['submit_pdf'] || $_POST['submit_html'] || ($_GET['pid'] && $_GET['enc
             }
         }
         ?>
-        <script language='JavaScript'>
+        <script>
         var win = top.printLogPrint ? top : opener.top;
         win.printLogPrint(window);
         </script>

--- a/interface/forms/CAMOS/rx_print.php
+++ b/interface/forms/CAMOS/rx_print.php
@@ -370,7 +370,7 @@ if ($_POST['print_pdf'] || $_POST['print_html']) {
 
             print "</div>";
             ?>
-        <script language='JavaScript'>
+        <script>
         var win = top.printLogPrint ? top : opener.top;
         win.printLogPrint(window);
         </script>

--- a/interface/forms/LBF/new.php
+++ b/interface/forms/LBF/new.php
@@ -299,7 +299,7 @@ if (!empty($_POST['bn_save']) || !empty($_POST['bn_save_print']) || !empty($_POS
         formHeader("Redirecting....");
         // If Save and Print, write the JavaScript to open a window for printing.
         if (!empty($_POST['bn_save_print'])) {
-            echo "<script language='Javascript'>\n" .
+            echo "<script>\n" .
                 "top.restoreSession();\n" .
                 "window.open('$rootdir/forms/LBF/printable.php?" .
                 "formname=" . attr_url($formname) .

--- a/interface/forms/LBF/printable.php
+++ b/interface/forms/LBF/printable.php
@@ -624,7 +624,7 @@ if ($PDF_OUTPUT) {
     $pdf->Output('form.pdf', 'I'); // D = Download, I = Inline
 } else {
     ?>
-<script language='JavaScript'>
+<script>
  var win = top.printLogPrint ? top : opener.top;
  win.printLogPrint(window);
 </script>

--- a/interface/forms/newGroupEncounter/save.php
+++ b/interface/forms/newGroupEncounter/save.php
@@ -58,7 +58,7 @@ if ($mode == 'new') {
         "New Therapy Group Encounter",
         sqlInsert(
             "INSERT INTO form_groups_encounter SET
-                date = ?,      
+                date = ?,
                 onset_date = ?,
                 reason = ?,
                 facility = ?,
@@ -164,7 +164,7 @@ $result4 = sqlStatement("SELECT fe.encounter,fe.date,openemr_postcalendar_catego
 ?>
 <html>
 <body>
-<script language='JavaScript'>
+<script>
     EncounterDateArray=new Array;
     CalendarCategoryArray=new Array;
     EncounterIdArray=new Array;

--- a/interface/forms/physical_exam/edit_diagnoses.php
+++ b/interface/forms/physical_exam/edit_diagnoses.php
@@ -61,7 +61,7 @@ if ($_POST['form_save']) {
 
   // Close this window and redisplay the updated encounter form.
   //
-    echo "<script language='JavaScript'>\n";
+    echo "<script>\n";
     if ($info_msg) {
         echo " alert(" . js_escape($info_msg) . ");\n";
     }

--- a/interface/forms/procedure_order/new.php
+++ b/interface/forms/procedure_order/new.php
@@ -248,7 +248,7 @@ if ($_POST['bn_save'] || $_POST['bn_xmit']) {
 
     formHeader("Redirecting....");
     if ($alertmsg) {
-        echo "\n<script language='Javascript'>alert(";
+        echo "\n<script>alert(";
         echo js_escape(xl('Transmit failed') . ': ' . $alertmsg);
         echo ")</script>\n";
     }
@@ -731,7 +731,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                         $qoe_init_javascript = '';
                                         echo generate_qoe_html($ptid, $formid, $oprow['procedure_order_seq'], $i);
                                         if ($qoe_init_javascript) {
-                                            echo "<script language='JavaScript'>$qoe_init_javascript</script>";
+                                            echo "<script>$qoe_init_javascript</script>";
                                         }
                                         ?>
                                     </div>

--- a/interface/main/calendar/modules/PostCalendar/pntemplates/default/views/month_print/outlook_ajax_template.html
+++ b/interface/main/calendar/modules/PostCalendar/pntemplates/default/views/month_print/outlook_ajax_template.html
@@ -518,7 +518,7 @@ function PrintDatePicker($caldate, $DOWlist, $daynames) {
 
 </body>
 
-<script language='JavaScript'>
+<script>
 $(function () {
     var win = top.printLogPrint ? top : opener.top;
     win.printLogPrint(window);

--- a/interface/orders/procedure_provider_edit.php
+++ b/interface/orders/procedure_provider_edit.php
@@ -111,7 +111,7 @@ function invalue($name)
 
         if ($_POST['form_save'] || $_POST['form_delete']) {
           // Close this window and redisplay the updated list.
-            echo "<script language='JavaScript'>\n";
+            echo "<script>\n";
             if ($info_msg) {
                 echo " alert(" . js_escape($info_msg) . ");\n";
             }

--- a/interface/orders/single_order_results.php
+++ b/interface/orders/single_order_results.php
@@ -126,7 +126,7 @@ if (empty($_POST['form_sign'])) {
     generate_order_report($orderid, true, true, $finals_only);
 } else {
     ?>
-<script language='JavaScript'>
+<script>
  if (opener.document.forms && opener.document.forms[0]) {
   // Opener should be list_reports.php. Make it refresh.
   var f = opener.document.forms[0];

--- a/interface/orders/types_edit.php
+++ b/interface/orders/types_edit.php
@@ -309,7 +309,7 @@ function proc_type_changed() {
                 // Find out if this parent still has any children.
                 $trow = sqlQuery("SELECT procedure_type_id FROM procedure_type WHERE parent = ? LIMIT 1", [$parent]);
                 // Close this window and redisplay the updated list.
-                echo "<script language='JavaScript'>\n";
+                echo "<script>\n";
                 if ($info_msg) {
                     echo " alert(" . js_escape($info_msg) . ");\n";
                 }

--- a/interface/patient_file/deleter.php
+++ b/interface/patient_file/deleter.php
@@ -428,7 +428,7 @@ if ($_POST['form_submit']) {
 
   // Close this window and tell our opener that it's done.
   // Not sure yet if the callback can be used universally.
-    echo "<script language='JavaScript'>\n";
+    echo "<script>\n";
     if (!$encounterid) {
         if ($info_msg) {
             echo " alert(" . json_encode($info_msg) . ");\n";

--- a/interface/patient_file/education.php
+++ b/interface/patient_file/education.php
@@ -69,7 +69,7 @@ if ($_POST['bn_submit']) {
         } else { // Removed opener because this is not a dialog. sjp 12/14/17
             echo "<html><body>"
             //."<script type=\"text/javascript\" src=\"". $webroot ."/interface/main/tabs/js/include_opener.js\"></script>"
-            . "<script language='JavaScript'>\n";
+            . "<script>\n";
             echo "document.location.href = " . js_escape($url) . ";\n";
             echo "</script></body></html>\n";
         }

--- a/interface/patient_file/front_payment.php
+++ b/interface/patient_file/front_payment.php
@@ -578,7 +578,7 @@ function toencounter(enc, datestr, topframe) {
 
 
 <!-- supporting javascript code -->
-<script language='JavaScript'>
+<script>
     var mypcc = '1';
 </script>
     <?php include_once("{$GLOBALS['srcdir']}/ajax/payment_ajax_jav.inc.php"); ?>

--- a/interface/patient_file/history/edit_billnote.php
+++ b/interface/patient_file/history/edit_billnote.php
@@ -60,7 +60,7 @@ if ($_POST['form_submit'] || $_POST['form_cancel']) {
         $fenote = '[' . xl('Add') . ']';
     }
 
-    echo "<script language='JavaScript'>\n";
+    echo "<script>\n";
     echo " parent.closeNote(" . js_escape($feid) . ", " . js_escape($fenote) . ")\n";
     echo "</script></body></html>\n";
     exit();

--- a/interface/patient_file/history/history_full.php
+++ b/interface/patient_file/history/history_full.php
@@ -305,7 +305,7 @@ var skipArray = [
 
 </script>
 
-<script language='JavaScript'>
+<script>
     // Array of skip conditions for the checkSkipConditions() function.
     var skipArray = [
         <?php echo $condition_str; ?>

--- a/interface/patient_file/letter.php
+++ b/interface/patient_file/letter.php
@@ -216,7 +216,7 @@ if ($_POST['formaction'] == "generate") {
         <div class="navigate">
     <a href='<?php echo $GLOBALS['rootdir'] . '/patient_file/letter.php?template=autosaved&csrf_token_form=' . attr_url(CsrfUtils::collectCsrfToken()); ?>' onclick='top.restoreSession()'>(<?php echo xlt('Back'); ?>)</a>
     </div>
-    <script language='JavaScript'>
+    <script>
     window.print();
     </script>
     </body>
@@ -685,7 +685,7 @@ closedir($dh);
 </form>
 </body>
 
-<script language='JavaScript'>
+<script>
 
 // jQuery stuff to make the page a little easier to use
 

--- a/interface/patient_file/pos_checkout.php
+++ b/interface/patient_file/pos_checkout.php
@@ -1117,7 +1117,7 @@ function generate_receipt($patient_id, $encounter = 0)
             </div>
         </div><!-- end of div container-->
         <?php $oemr_ui->oeBelowContainerDiv();?>
-        <script language='JavaScript'>
+        <script>
             computeTotals();
                 <?php
                 if ($gcac_related_visit && !$gcac_service_provided) {

--- a/interface/patient_file/printed_fee_sheet.php
+++ b/interface/patient_file/printed_fee_sheet.php
@@ -315,7 +315,7 @@ height: " . attr($page_height) . "pt;
 
 $html .= "<title>" . text($frow['name']) . "</title>" .
     Header::setupHeader(['opener', 'topdialog'], false) .
-    "<script language=\"JavaScript\">";
+    "<script>";
 
 $html .= "
 $(function () {

--- a/interface/patient_file/problem_encounter.php
+++ b/interface/patient_file/problem_encounter.php
@@ -71,7 +71,7 @@ if ($_POST['form_save']) {
 
     echo "<html><body>"
     . "<script type=\"text/javascript\" src=\"" . $webroot . "/interface/main/tabs/js/include_opener.js\"></script>"
-    . "<script language='JavaScript'>\n";
+    . "<script>\n";
     if ($alertmsg) {
         echo " alert(" . js_escape($alertmsg) . ");\n";
     }

--- a/interface/patient_file/rules/patient_data.php
+++ b/interface/patient_file/rules/patient_data.php
@@ -117,7 +117,7 @@ if ($_POST['form_complete']) {
     }
 
     // Close this window and refresh the patient summary display.
-    echo "<html>\n<body>\n<script language='JavaScript'>\n";
+    echo "<html>\n<body>\n<script>\n";
     echo " dlgclose();\n";
     echo " top.restoreSession();\n";
     // refreshed by dialog callback- if issue with refresh try to do elsewhere as here is an IE11 issue.

--- a/interface/patient_file/summary/advancedirectives.php
+++ b/interface/patient_file/summary/advancedirectives.php
@@ -33,7 +33,7 @@ use OpenEMR\Core\Header;
         $form_adreviewed = DateToYYYYMMDD(filter_input(INPUT_POST, 'form_adreviewed'));
         sqlQuery("UPDATE patient_data SET completed_ad = ?, ad_reviewed = ? where pid = ?", array($form_yesno,$form_adreviewed,$pid));
         // Close this window and refresh the calendar display.
-        echo "</head><body>\n<script language='JavaScript'>\n";
+        echo "</head><body>\n<script>\n";
         echo " if (!opener.closed && opener.refreshme) opener.refreshme();\n";
         echo " dlgclose();\n";
         echo "</script>\n</body>\n</html>\n";

--- a/interface/patient_file/summary/demographics_print.php
+++ b/interface/patient_file/summary/demographics_print.php
@@ -405,7 +405,7 @@ if ($PDF_OUTPUT) {
 } else {
     ?>
 <!-- This should really be in the onload handler but that seems to be unreliable and can crash Firefox 3. -->
-<script language='JavaScript'>
+<script>
 opener.top.printLogPrint(window);
 </script>
 </body>

--- a/interface/patient_file/summary/pnotes_full.php
+++ b/interface/patient_file/summary/pnotes_full.php
@@ -737,7 +737,7 @@ if ($result_sent_count == $M) {
 
   </div>
 </div>
-<script language='JavaScript'>
+<script>
 
 <?php
 if ($_GET['set_pid']) {

--- a/interface/patient_file/summary/pnotes_print.php
+++ b/interface/patient_file/summary/pnotes_print.php
@@ -65,7 +65,7 @@ if ($noteid) {
 
 <p><?php echo nl2br(text($body)); ?></p>
 
-<script language='JavaScript'>
+<script>
 opener.top.printLogPrint(window);
 </script>
 

--- a/interface/patient_file/summary/print_amendments.php
+++ b/interface/patient_file/summary/print_amendments.php
@@ -95,7 +95,7 @@ function printAmendment($amendmentID, $lastAmendment)
     }
     ?>
 
-<script language='JavaScript'>
+<script>
     opener.top.printLogPrint(window);
 </script>
 

--- a/interface/patient_file/summary/shot_record.php
+++ b/interface/patient_file/summary/shot_record.php
@@ -282,7 +282,7 @@ function printHTML($res, $res2, $data)
 
     ?>
 
-  <script language='JavaScript'>
+  <script>
     opener.top.printLogPrint(window);
   </script>
   </body>

--- a/interface/patient_tracker/patient_tracker_status.php
+++ b/interface/patient_tracker/patient_tracker_status.php
@@ -85,7 +85,7 @@ if ($_POST['statustype'] != '') {
         }
     }
 
-    echo "<body>\n<script language='JavaScript'>\n";
+    echo "<body>\n<script>\n";
     echo " window.opener.document.flb.submit();\n";
     echo " dlgclose();\n";
     echo "</script></body></html>\n";

--- a/interface/reports/inventory_activity.php
+++ b/interface/reports/inventory_activity.php
@@ -420,7 +420,7 @@ table.mymaintable td, table.mymaintable th {
 }
 </style>
 
-<script language='JavaScript'>
+<script>
 
     $(function () {
         oeFixedHeaderSetup(document.getElementById('mymaintable'));

--- a/interface/reports/ippf_daily.php
+++ b/interface/reports/ippf_daily.php
@@ -415,7 +415,7 @@ if ($form_output != 3) {
 </form>
 </center>
 
-<script language='JavaScript'>
+<script>
     <?php if ($form_output == 2) { ?>
  var win = top.printLogPrint ? top : opener.top;
  win.printLogPrint(window);

--- a/interface/reports/ippf_statistics.php
+++ b/interface/reports/ippf_statistics.php
@@ -1687,7 +1687,7 @@ if ($form_output != 3) {
 </form>
 </center>
 
-<script language='JavaScript'>
+<script>
 selreport();
     <?php if ($form_output == 2) { ?>
  var win = top.printLogPrint ? top : opener.top;

--- a/interface/super/edit_layout_props.php
+++ b/interface/super/edit_layout_props.php
@@ -188,7 +188,7 @@ if ($_POST['form_submit'] && !$alertmsg) {
 
     // Close this window and redisplay the layout editor.
     //
-    echo "<script language='JavaScript'>\n";
+    echo "<script>\n";
     if ($alertmsg) {
         echo " alert(" . js_escape($alertmsg) . ");\n";
     }

--- a/interface/usergroup/user_info.php
+++ b/interface/usergroup/user_info.php
@@ -38,7 +38,7 @@ $user_full_name = $user_name['fname'] . " " . $user_name['lname'];
 
 <script src="checkpwd_validation.js"></script>
 
-<script language='JavaScript'>
+<script>
 //Validating password and display message if password field is empty - starts
 var webroot=<?php echo js_escape($webroot); ?>;
 function update_password()

--- a/library/spreadsheet.inc.php
+++ b/library/spreadsheet.inc.php
@@ -717,7 +717,7 @@ for ($i = 0; $i < $num_virtual_rows; ++$i) {
         echo "<input type='hidden' name='cell[$i][$j]' value='" . attr($celltype) . attr($cellvalue) . "' />";
         if ($celltype == '1') {
             // So we don't have to write a PHP version of genStatic():
-            echo "<script language='JavaScript'>document.write(genStatic('$cellstatic'));</script>";
+            echo "<script>document.write(genStatic('$cellstatic'));</script>";
         } elseif ($celltype == '2') {
             echo "<input type='checkbox' value='1' onclick='cbClick(this,$i,$j)'";
             if ($cellvalue) {
@@ -762,7 +762,7 @@ for ($i = 0; $i < $num_virtual_rows; ++$i) {
 
 </center>
 </form>
-<script language='JavaScript'>
+<script>
 <?php
 if ($alertmsg) {
     echo " alert(" . js_escape($alertmsg) . ");\n";


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #3542

#### Short description of what this resolves:
Remove outdated javascript attributes. e.g. `language='JavaScript'`
