### PR TITLE
This stops the double display of each entry.

### DIFF
--- a/interface/patient_file/encounter/superbill_custom_full.php
+++ b/interface/patient_file/encounter/superbill_custom_full.php
@@ -714,12 +714,15 @@ if ($fend > $count) {
     for ($i = 0; $row = sqlFetchArray($res); $i++) {
         $all[$i] = $row;
     }
-
+    $previous = '';
     if (!empty($all)) {
         $count = 0;
         foreach ($all as $iter) {
             $count++;
 
+            if ($previous == $iter['code_text']) {
+                continue;
+            }
             $has_fees = false;
             foreach ($code_types as $key => $value) {
                 if ($value['id'] == $iter['code_type']) {
@@ -787,6 +790,7 @@ if ($fend > $count) {
             }
 
             echo " </tr>\n";
+            $previous = $iter['code_text'];
         }
     }
 


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes # #3655

#### Short description of what this resolves:

This stops the double display of each entry.

#### Changes proposed in this pull request:

-  After all my troubleshooting. It comes down to something inside the PHP while command that is causing the display issue.
-  I have tested all the data returned from the database right up to the while loop and the problem for us is inside the while loop 
-  So, all we can do is set the previous variable and check to see if the text is the same. If it is, skip the loop. This does not interfere with the normal operation. I have tested this on all of our systems and it is a fix across all OS ubuntu and CentOS. 
We are using PHP 7.2.30. 