### PR TITLE
miss the git and compose installation link in md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ You will need a "local" version of OpenEMR to make changes to the source code. T
     - It's best to also add an `upstream` origin to keep your local fork up to date. [Check out this guide](https://oneemptymind.wordpress.com/2018/07/11/keeping-a-fork-up-to-date/) for more info.
 	- If you haven't already, [install git](https://git-scm.com/downloads) for your system
 2. `cd openemr` (the directory you cloned the code into)
-    - If you haven't already, install [Docker](https://docs.docker.com/install/) and compose(https://docs.docker.com/compose/install/) for your system
+    - If you haven't already, [install Docker](https://docs.docker.com/install/) and [install compose](https://docs.docker.com/compose/install/) for your system
 3. Run `docker-compose up` from your command line
     - When the build is done, you'll see the following message:
     ```sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,9 @@ You will need a "local" version of OpenEMR to make changes to the source code. T
 
 1. [Create your own fork of OpenEMR](https://github.com/openemr/openemr/fork) (you will need a GitHub account) and `git clone` it to your local machine.
     - It's best to also add an `upstream` origin to keep your local fork up to date. [Check out this guide](https://oneemptymind.wordpress.com/2018/07/11/keeping-a-fork-up-to-date/) for more info.
+	- If you haven't already, [install git](https://git-scm.com/downloads) for your system
 2. `cd openemr` (the directory you cloned the code into)
-    - If you haven't already, [install Docker](https://docs.docker.com/install/) for your system
+    - If you haven't already, install [Docker](https://docs.docker.com/install/) and compose(https://docs.docker.com/compose/install/) for your system
 3. Run `docker-compose up` from your command line
     - When the build is done, you'll see the following message:
     ```sh


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #  The git and compose installation link in Easy Development Docker Environment.

#### Short description of what this resolves:
Before:  It didn't mention the git and compose link in the doc
After: added the git and compose link in the doc
```
If you haven't already, [install git](https://git-scm.com/downloads) for your system

If you haven't already, install [Docker](https://docs.docker.com/install/) and compose(https://docs.docker.com/compose/install/) for your system
```


#### Changes proposed in this pull request:

-  Especially compose, you can not run step 3 `docker-compose up`, there is no `docker-compose` command