### PR TITLE
using same port used in docs: 8330 for docker compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,8 +16,8 @@ services:
     restart: always
     image: openemr/openemr:latest
     ports:
-    - 80:80
-    - 443:443
+    - 8300:80
+    - 8443:443
     volumes:
     - logvolume01:/var/log
     - sitevolume:/var/www/localhost/htdocs/openemr/sites


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
~~Fixes #~~

#### Short description of what this resolves:

Using `8330` port in `docker-compose.yml` file to match what is being used in the contribution docs.

I also changed the https port to `8443` to avoid local conflicts.


#### Changes proposed in this pull request:

- Changes http port in docker-compose to `8330`
- Changes docker-compose https port to `8443`