### PR TITLE
Added ar_activity.deleted to track voids of payments and adjustments.

### DIFF
--- a/interface/billing/billing_report.php
+++ b/interface/billing/billing_report.php
@@ -1322,7 +1322,7 @@ top.window.parent.left_nav.setPatientEncounter(EncounterIdArray[" . attr($iter['
                                 $rowcnt = 0;
                                 $resMoneyGot = sqlStatement(
                                     "SELECT pay_amount AS PatientPay,date(post_time) AS date FROM ar_activity WHERE " .
-                                    "pid = ? AND encounter = ? AND payer_type=0 AND account_code='PCP'",
+                                    "pid = ? AND encounter = ? AND deleted IS NULL AND payer_type = 0 AND account_code = 'PCP'",
                                     array(
                                         $iter['enc_pid'],
                                         $iter['enc_encounter']

--- a/interface/billing/edit_payment.php
+++ b/interface/billing/edit_payment.php
@@ -127,7 +127,7 @@ if (isset($_POST["mode"])) {
                     "' AND modifier = '" . trim(formData("HiddenModifier$CountRow")) .
                     "'";
 
-                $where = "$where1 AND pay_amount > 0");
+                $where = "$where1 AND pay_amount > 0";
                 if (isset($_POST["Payment$CountRow"]) && $_POST["Payment$CountRow"] * 1 > 0) {
                     if (trim($_POST['type_name']) == 'insurance') {
                         if (trim($_POST["HiddenIns$CountRow"]) == 1) {
@@ -174,7 +174,7 @@ if (isset($_POST["mode"])) {
 
                 //==============================================================================================================================
 
-                $where = "$where1 AND adj_amount != 0");
+                $where = "$where1 AND adj_amount != 0";
                 if (isset($_POST["AdjAmount$CountRow"]) && $_POST["AdjAmount$CountRow"] * 1 !== 0) {
                     if (trim($_POST['type_name']) == 'insurance') {
                         $AdjustString = "Ins adjust Ins" . trim($_POST["HiddenIns$CountRow"]);
@@ -213,7 +213,7 @@ if (isset($_POST["mode"])) {
 
                 //==============================================================================================================================
 
-                $where = "$where1 AND (memo LIKE 'Deductable%' OR memo LIKE 'Deductible%')");
+                $where = "$where1 AND (memo LIKE 'Deductable%' OR memo LIKE 'Deductible%')";
                 if (isset($_POST["Deductible$CountRow"]) && $_POST["Deductible$CountRow"] * 1 > 0) {
                     $resPayment = sqlStatement("SELECT  * from ar_activity $where");
                     if (sqlNumRows($resPayment) > 0) {
@@ -245,7 +245,7 @@ if (isset($_POST["mode"])) {
 
                 //==============================================================================================================================
 
-                $where = "$where1 AND pay_amount < 0");
+                $where = "$where1 AND pay_amount < 0";
                 if (isset($_POST["Takeback$CountRow"]) && $_POST["Takeback$CountRow"] * 1 > 0) {
                     $resPayment = sqlStatement("SELECT  * from ar_activity $where");
                     if (sqlNumRows($resPayment) > 0) {
@@ -276,7 +276,7 @@ if (isset($_POST["mode"])) {
 
                 //==============================================================================================================================
 
-                $where = "$where1 AND follow_up = 'y'");
+                $where = "$where1 AND follow_up = 'y'";
                 if (isset($_POST["FollowUp$CountRow"]) && $_POST["FollowUp$CountRow"] == 'y') {
                     $resPayment = sqlStatement("SELECT  * from ar_activity $where");
                     if (sqlNumRows($resPayment) > 0) {

--- a/interface/billing/edit_payment.php
+++ b/interface/billing/edit_payment.php
@@ -119,7 +119,6 @@ if (isset($_POST["mode"])) {
         //==================================================================
         for ($CountRow = 1; $CountRow <= $CountIndexAbove; $CountRow++) {
             if (isset($_POST["HiddenEncounter$CountRow"])) {
-
                 $where1 = "WHERE deleted IS NULL AND session_id = '" . add_escape_custom($payment_id) .
                     "' AND pid ='" . trim(formData("HiddenPId$CountRow")) .
                     "' AND encounter = '" . trim(formData("HiddenEncounter$CountRow")) .
@@ -144,7 +143,7 @@ if (isset($_POST["mode"])) {
                         $AccountCode = "PP";
                     }
                     $resPayment = sqlStatement("SELECT * from ar_activity $where");
-                    if(sqlNumRows($resPayment) > 0) {
+                    if (sqlNumRows($resPayment) > 0) {
                         sqlStatement("UPDATE ar_activity SET deleted = NOW() $where");
                     }
                     sqlBeginTrans();
@@ -308,7 +307,6 @@ if (isset($_POST["mode"])) {
                 }
 
                 //==============================================================================================================================
-
             } else {
                 break;
             }

--- a/interface/billing/edit_payment.php
+++ b/interface/billing/edit_payment.php
@@ -11,9 +11,11 @@
  * @author    Paul Simon K <paul@zhservices.com>
  * @author    Stephen Waite <stephen.waite@cmsvt.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2010 Z&H Consultancy Services Private Limited <sam@zhservices.com>
  * @copyright Copyright (C) 2018-2020 Stephen Waite <stephen.waite@cmsvt.com>
  * @copyright Copyright (c) 2019-2020 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2020 Rod Roark <rod@sunsetsystems.com>
  * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -42,8 +44,17 @@ if (isset($_POST["mode"])) {
         $Modifier = $DeletePaymentDistributionIdArray[4];
         $Codetype = $DeletePaymentDistributionIdArray[5];
         //delete and log that action
-        row_delete("ar_activity", "session_id ='" . add_escape_custom($payment_id) . "' and  pid ='" . add_escape_custom($PId) . "' AND " .
-            "encounter='" . add_escape_custom($Encounter) . "' and code_type='" . add_escape_custom($Codetype) . "' and code='" . add_escape_custom($Code) . "' and modifier='" . add_escape_custom($Modifier) . "'");
+        row_modify(
+            "ar_activity",
+            "deleted = NOW()",
+            "session_id = '" . add_escape_custom($payment_id) . "' AND " .
+            "pid = '" . add_escape_custom($PId) . "' AND " .
+            "deleted IS NULL AND " .
+            "encounter = '" . add_escape_custom($Encounter) . "' AND " .
+            "code_type = '" . add_escape_custom($Codetype) . "' AND " .
+            "code = '" . add_escape_custom($Code) . "' AND " .
+            "modifier='" . add_escape_custom($Modifier) . "'"
+        );
         $Message = 'Delete';
         //------------------
         $_POST["mode"] = "searchdatabase";
@@ -53,6 +64,7 @@ if (isset($_POST["mode"])) {
 //===============================================================================
 //Modify Payment Code.
 //===============================================================================
+
 if (isset($_POST["mode"])) {
     if ($_POST["mode"] == "ModifyPayments" || $_POST["mode"] == "FinishPayments") {
         $payment_id = $_REQUEST['payment_id'];
@@ -107,77 +119,63 @@ if (isset($_POST["mode"])) {
         //==================================================================
         for ($CountRow = 1; $CountRow <= $CountIndexAbove; $CountRow++) {
             if (isset($_POST["HiddenEncounter$CountRow"])) {
+
+                $where1 = "WHERE deleted IS NULL AND session_id = '" . add_escape_custom($payment_id) .
+                    "' AND pid ='" . trim(formData("HiddenPId$CountRow")) .
+                    "' AND encounter = '" . trim(formData("HiddenEncounter$CountRow")) .
+                    "' AND code_type = '" . trim(formData("HiddenCodetype$CountRow")) .
+                    "' AND code = '" . trim(formData("HiddenCode$CountRow")) .
+                    "' AND modifier = '" . trim(formData("HiddenModifier$CountRow")) .
+                    "'");
+
+                $where = "$where1 AND pay_amount > 0");
                 if (isset($_POST["Payment$CountRow"]) && $_POST["Payment$CountRow"] * 1 > 0) {
                     if (trim($_POST['type_name']) == 'insurance') {
                         if (trim($_POST["HiddenIns$CountRow"]) == 1) {
                             $AccountCode = "IPP";
                         }
-
                         if (trim($_POST["HiddenIns$CountRow"]) == 2) {
                             $AccountCode = "ISP";
                         }
-
                         if (trim($_POST["HiddenIns$CountRow"]) == 3) {
                             $AccountCode = "ITP";
                         }
                     } elseif (trim($_POST['type_name']) == 'patient') {
                         $AccountCode = "PP";
                     }
-
-                    $resPayment = sqlStatement("SELECT  * from ar_activity " .
-                        " where  session_id ='" . add_escape_custom($payment_id) . "' and pid ='" . trim(formData("HiddenPId$CountRow")) .
-                        "' and  encounter  ='" . trim(formData("HiddenEncounter$CountRow")) .
-                        "' and  code_type  ='" . trim(formData("HiddenCodetype$CountRow")) .
-                        "' and  code  ='" . trim(formData("HiddenCode$CountRow")) .
-                        "' and  modifier  ='" . trim(formData("HiddenModifier$CountRow")) .
-                        "' and pay_amount>0");
-                    if (sqlNumRows($resPayment) > 0) {
-                        sqlStatement("update ar_activity set " .
-                            "   post_user = '" . trim(add_escape_custom($user_id)) .
-                            "', modified_time = '" . trim(add_escape_custom($created_time)) .
-                            "', pay_amount = '" . trim(formData("Payment$CountRow")) .
-                            "', account_code = '" . add_escape_custom($AccountCode) .
-                            "', payer_type = '" . trim(formData("HiddenIns$CountRow")) .
-                            "', reason_code = '" . trim(formData("ReasonCode$CountRow")) .
-                            "' where  session_id ='" . add_escape_custom($payment_id) . "' and pid ='" . trim(formData("HiddenPId$CountRow")) .
-                            "' and  encounter  ='" . trim(formData("HiddenEncounter$CountRow")) .
-                            "' and  code_type  ='" . trim(formData("HiddenCodetype$CountRow")) .
-                            "' and  code  ='" . trim(formData("HiddenCode$CountRow")) .
-                            "' and  modifier  ='" . trim(formData("HiddenModifier$CountRow")) .
-                            "' and pay_amount>0");
-                    } else {
-                        sqlBeginTrans();
-                        $sequence_no = sqlQuery("SELECT IFNULL(MAX(sequence_no),0) + 1 AS increment FROM ar_activity WHERE pid = '" . trim(formData("HiddenPId$CountRow")) . "' AND encounter = '" . trim(formData("HiddenEncounter$CountRow")) . "'");
-                        sqlStatement("insert into ar_activity set " .
-                            "pid = '" . trim(formData("HiddenPId$CountRow")) .
-                            "', encounter = '" . trim(formData("HiddenEncounter$CountRow")) .
-                            "', sequence_no = '" . add_escape_custom($sequence_no['increment']) .
-                            "', code_type = '" . trim(formData("HiddenCodetype$CountRow")) .
-                            "', code = '" . trim(formData("HiddenCode$CountRow")) .
-                            "', modifier = '" . trim(formData("HiddenModifier$CountRow")) .
-                            "', payer_type = '" . trim(formData("HiddenIns$CountRow")) .
-                            "', reason_code = '" . trim(formData("ReasonCode$CountRow")) .
-                            "', post_time = '" . trim(add_escape_custom($created_time)) .
-                            "', post_user = '" . trim(add_escape_custom($user_id)) .
-                            "', session_id = '" . trim(formData('payment_id')) .
-                            "', modified_time = '" . trim(add_escape_custom($created_time)) .
-                            "', pay_amount = '" . trim(formData("Payment$CountRow")) .
-                            "', adj_amount = '" . 0 .
-                            "', account_code = '" . add_escape_custom($AccountCode) .
-                            "'");
-                        sqlCommitTrans();
+                    $resPayment = sqlStatement("SELECT * from ar_activity $where");
+                    if(sqlNumRows($resPayment) > 0) {
+                        sqlStatement("UPDATE ar_activity SET deleted = NOW() $where");
                     }
+                    sqlBeginTrans();
+                    $sequence_no = sqlQuery("SELECT IFNULL(MAX(sequence_no),0) + 1 AS increment " .
+                        "FROM ar_activity WHERE pid = '" . trim(formData("HiddenPId$CountRow")) .
+                        "' AND encounter = '" . trim(formData("HiddenEncounter$CountRow")) . "'");
+                    sqlStatement("insert into ar_activity set " .
+                        "pid = '" . trim(formData("HiddenPId$CountRow")) .
+                        "', encounter = '" . trim(formData("HiddenEncounter$CountRow")) .
+                        "', sequence_no = '" . add_escape_custom($sequence_no['increment']) .
+                        "', code_type = '" . trim(formData("HiddenCodetype$CountRow")) .
+                        "', code = '" . trim(formData("HiddenCode$CountRow")) .
+                        "', modifier = '" . trim(formData("HiddenModifier$CountRow")) .
+                        "', payer_type = '" . trim(formData("HiddenIns$CountRow")) .
+                        "', reason_code = '" . trim(formData("ReasonCode$CountRow")) .
+                        "', post_time = '" . trim(add_escape_custom($created_time)) .
+                        "', post_user = '" . trim(add_escape_custom($user_id)) .
+                        "', session_id = '" . trim(formData('payment_id')) .
+                        "', modified_time = '" . trim(add_escape_custom($created_time)) .
+                        "', pay_amount = '" . trim(formData("Payment$CountRow")) .
+                        "', adj_amount = '" . 0 .
+                        "', account_code = '" . add_escape_custom($AccountCode) .
+                        "'");
+                    sqlCommitTrans();
                 } else {
-                    sqlStatement("delete from ar_activity " .
-                        " where  session_id ='" . add_escape_custom($payment_id) . "' and pid ='" . trim(formData("HiddenPId$CountRow")) .
-                        "' and  encounter  ='" . trim(formData("HiddenEncounter$CountRow")) .
-                        "' and  code_type  ='" . trim(formData("HiddenCodetype$CountRow")) .
-                        "' and  code  ='" . trim(formData("HiddenCode$CountRow")) .
-                        "' and  modifier  ='" . trim(formData("HiddenModifier$CountRow")) .
-                        "' and pay_amount>0");
+                    sqlStatement("UPDATE ar_activity SET deleted = NOW() $where");
                 }
 
                 //==============================================================================================================================
+
+                $where = "$where1 AND adj_amount != 0");
                 if (isset($_POST["AdjAmount$CountRow"]) && $_POST["AdjAmount$CountRow"] * 1 !== 0) {
                     if (trim($_POST['type_name']) == 'insurance') {
                         $AdjustString = "Ins adjust Ins" . trim($_POST["HiddenIns$CountRow"]);
@@ -186,222 +184,131 @@ if (isset($_POST["mode"])) {
                         $AdjustString = "Pt adjust";
                         $AccountCode = "PA";
                     }
-
-                    $resPayment = sqlStatement("SELECT  * from ar_activity " .
-                        " where  session_id ='" . add_escape_custom($payment_id) . "' and pid ='" . trim(formData("HiddenPId$CountRow")) .
-                        "' and  encounter  ='" . trim(formData("HiddenEncounter$CountRow")) .
-                        "' and  code_type  ='" . trim(formData("HiddenCodetype$CountRow")) .
-                        "' and  code  ='" . trim(formData("HiddenCode$CountRow")) .
-                        "' and  modifier  ='" . trim(formData("HiddenModifier$CountRow")) .
-                        "' and adj_amount!=0");
+                    $resPayment = sqlStatement("SELECT  * from ar_activity $where");
                     if (sqlNumRows($resPayment) > 0) {
-                        sqlStatement("update ar_activity set " .
-                            "   post_user = '" . trim(add_escape_custom($user_id)) .
-                            "', modified_time = '" . trim(add_escape_custom($created_time)) .
-                            "', adj_amount = '" . trim(formData("AdjAmount$CountRow")) .
-                            "', memo = '" . add_escape_custom($AdjustString) .
-                            "', account_code = '" . add_escape_custom($AccountCode) .
-                            "', payer_type = '" . trim(formData("HiddenIns$CountRow")) .
-                            "' where  session_id ='" . add_escape_custom($payment_id) . "' and pid ='" . trim(formData("HiddenPId$CountRow")) .
-                            "' and  encounter  ='" . trim(formData("HiddenEncounter$CountRow")) .
-                            "' and  code_type  ='" . trim(formData("HiddenCodetype$CountRow")) .
-                            "' and  code  ='" . trim(formData("HiddenCode$CountRow")) .
-                            "' and  modifier  ='" . trim(formData("HiddenModifier$CountRow")) .
-                            "' and adj_amount!=0");
-                    } else {
-                        sqlBeginTrans();
-                        $sequence_no = sqlQuery("SELECT IFNULL(MAX(sequence_no),0) + 1 AS increment FROM ar_activity WHERE pid = '" . trim(formData("HiddenPId$CountRow")) . "' AND encounter = '" . trim(formData("HiddenEncounter$CountRow")) . "'");
-                        sqlStatement("insert into ar_activity set " .
-                            "pid = '" . trim(formData("HiddenPId$CountRow")) .
-                            "', encounter = '" . trim(formData("HiddenEncounter$CountRow")) .
-                            "', sequence_no = '" . add_escape_custom($sequence_no['increment']) .
-                            "', code_type = '" . trim(formData("HiddenCodetype$CountRow")) .
-                            "', code = '" . trim(formData("HiddenCode$CountRow")) .
-                            "', modifier = '" . trim(formData("HiddenModifier$CountRow")) .
-                            "', payer_type = '" . trim(formData("HiddenIns$CountRow")) .
-                            "', post_time = '" . trim(add_escape_custom($created_time)) .
-                            "', post_user = '" . trim(add_escape_custom($user_id)) .
-                            "', session_id = '" . trim(formData('payment_id')) .
-                            "', modified_time = '" . trim(add_escape_custom($created_time)) .
-                            "', pay_amount = '" . 0 .
-                            "', adj_amount = '" . trim(formData("AdjAmount$CountRow")) .
-                            "', memo = '" . add_escape_custom($AdjustString) .
-                            "', account_code = '" . add_escape_custom($AccountCode) .
-                            "'");
-                        sqlCommitTrans();
+                        sqlStatement("update ar_activity set deleted = NOW() $where");
                     }
+                    sqlBeginTrans();
+                    $sequence_no = sqlQuery("SELECT IFNULL(MAX(sequence_no),0) + 1 AS increment FROM ar_activity WHERE pid = '" . trim(formData("HiddenPId$CountRow")) . "' AND encounter = '" . trim(formData("HiddenEncounter$CountRow")) . "'");
+                    sqlStatement("insert into ar_activity set " .
+                        "pid = '" . trim(formData("HiddenPId$CountRow")) .
+                        "', encounter = '" . trim(formData("HiddenEncounter$CountRow")) .
+                        "', sequence_no = '" . add_escape_custom($sequence_no['increment']) .
+                        "', code_type = '" . trim(formData("HiddenCodetype$CountRow")) .
+                        "', code = '" . trim(formData("HiddenCode$CountRow")) .
+                        "', modifier = '" . trim(formData("HiddenModifier$CountRow")) .
+                        "', payer_type = '" . trim(formData("HiddenIns$CountRow")) .
+                        "', post_time = '" . trim(add_escape_custom($created_time)) .
+                        "', post_user = '" . trim(add_escape_custom($user_id)) .
+                        "', session_id = '" . trim(formData('payment_id')) .
+                        "', modified_time = '" . trim(add_escape_custom($created_time)) .
+                        "', pay_amount = '" . 0 .
+                        "', adj_amount = '" . trim(formData("AdjAmount$CountRow")) .
+                        "', memo = '" . add_escape_custom($AdjustString) .
+                        "', account_code = '" . add_escape_custom($AccountCode) .
+                        "'");
+                    sqlCommitTrans();
                 } else {
-                    sqlStatement("delete from ar_activity " .
-                        " where  session_id ='" . add_escape_custom($payment_id) . "' and pid ='" . trim(formData("HiddenPId$CountRow")) .
-                        "' and  encounter  ='" . trim(formData("HiddenEncounter$CountRow")) .
-                        "' and  code_type  ='" . trim(formData("HiddenCodetype$CountRow")) .
-                        "' and  code  ='" . trim(formData("HiddenCode$CountRow")) .
-                        "' and  modifier  ='" . trim(formData("HiddenModifier$CountRow")) .
-                        "' and adj_amount!=0");
+                    sqlStatement("update ar_activity set deleted = NOW() $where");
                 }
 
                 //==============================================================================================================================
+
+                $where = "$where1 AND (memo LIKE 'Deductable%' OR memo LIKE 'Deductible%')");
                 if (isset($_POST["Deductible$CountRow"]) && $_POST["Deductible$CountRow"] * 1 > 0) {
-                    $resPayment = sqlStatement("SELECT  * from ar_activity " .
-                        " where  session_id ='" . add_escape_custom($payment_id) . "' and pid ='" . trim(formData("HiddenPId$CountRow")) .
-                        "' and  encounter  ='" . trim(formData("HiddenEncounter$CountRow")) .
-                        "' and  code_type  ='" . trim(formData("HiddenCodetype$CountRow")) .
-                        "' and  code  ='" . trim(formData("HiddenCode$CountRow")) .
-                        "' and  modifier  ='" . trim(formData("HiddenModifier$CountRow")) .
-                        "' and (memo like 'Deductable%' OR memo like 'Deductible%')");
+                    $resPayment = sqlStatement("SELECT  * from ar_activity $where");
                     if (sqlNumRows($resPayment) > 0) {
-                        sqlStatement("update ar_activity set " .
-                            "   post_user = '" . trim(add_escape_custom($user_id)) .
-                            "', modified_time = '" . trim(add_escape_custom($created_time)) .
-                            "', memo = '" . "Deductible $" . trim(formData("Deductible$CountRow")) .
-                            "', account_code = '" . "Deduct" .
-                            "', payer_type = '" . trim(formData("HiddenIns$CountRow")) .
-                            "' where  session_id ='" . add_escape_custom($payment_id) . "' and pid ='" . trim(formData("HiddenPId$CountRow")) .
-                            "' and  encounter  ='" . trim(formData("HiddenEncounter$CountRow")) .
-                            "' and  code_type  ='" . trim(formData("HiddenCodetype$CountRow")) .
-                            "' and  code  ='" . trim(formData("HiddenCode$CountRow")) .
-                            "' and  modifier  ='" . trim(formData("HiddenModifier$CountRow")) .
-                            "' and (memo like 'Deductable%' OR memo like 'Deductible%')");
-                    } else {
-                        sqlBeginTrans();
-                        $sequence_no = sqlQuery("SELECT IFNULL(MAX(sequence_no),0) + 1 AS increment FROM ar_activity WHERE pid = '" . trim(formData("HiddenPId$CountRow")) . "' AND encounter = '" . trim(formData("HiddenEncounter$CountRow")) . "'");
-                        sqlStatement("insert into ar_activity set " .
-                            "pid = '" . trim(formData("HiddenPId$CountRow")) .
-                            "', encounter = '" . trim(formData("HiddenEncounter$CountRow")) .
-                            "', sequence_no = '" . add_escape_custom($sequence_no['increment']) .
-                            "', code_type = '" . trim(formData("HiddenCodetype$CountRow")) .
-                            "', code = '" . trim(formData("HiddenCode$CountRow")) .
-                            "', modifier = '" . trim(formData("HiddenModifier$CountRow")) .
-                            "', payer_type = '" . trim(formData("HiddenIns$CountRow")) .
-                            "', post_time = '" . trim(add_escape_custom($created_time)) .
-                            "', post_user = '" . trim(add_escape_custom($user_id)) .
-                            "', session_id = '" . trim(formData('payment_id')) .
-                            "', modified_time = '" . trim(add_escape_custom($created_time)) .
-                            "', pay_amount = '" . 0 .
-                            "', adj_amount = '" . 0 .
-                            "', memo = '" . "Deductible $" . trim(formData("Deductible$CountRow")) .
-                            "', account_code = '" . "Deduct" .
-                            "'");
-                        sqlCommitTrans();
+                        sqlStatement("update ar_activity set deleted = NOW() $where");
                     }
+                    sqlBeginTrans();
+                    $sequence_no = sqlQuery("SELECT IFNULL(MAX(sequence_no),0) + 1 AS increment FROM ar_activity WHERE pid = '" . trim(formData("HiddenPId$CountRow")) . "' AND encounter = '" . trim(formData("HiddenEncounter$CountRow")) . "'");
+                    sqlStatement("insert into ar_activity set " .
+                        "pid = '" . trim(formData("HiddenPId$CountRow")) .
+                        "', encounter = '" . trim(formData("HiddenEncounter$CountRow")) .
+                        "', sequence_no = '" . add_escape_custom($sequence_no['increment']) .
+                        "', code_type = '" . trim(formData("HiddenCodetype$CountRow")) .
+                        "', code = '" . trim(formData("HiddenCode$CountRow")) .
+                        "', modifier = '" . trim(formData("HiddenModifier$CountRow")) .
+                        "', payer_type = '" . trim(formData("HiddenIns$CountRow")) .
+                        "', post_time = '" . trim(add_escape_custom($created_time)) .
+                        "', post_user = '" . trim(add_escape_custom($user_id)) .
+                        "', session_id = '" . trim(formData('payment_id')) .
+                        "', modified_time = '" . trim(add_escape_custom($created_time)) .
+                        "', pay_amount = '" . 0 .
+                        "', adj_amount = '" . 0 .
+                        "', memo = '" . "Deductible $" . trim(formData("Deductible$CountRow")) .
+                        "', account_code = '" . "Deduct" .
+                        "'");
+                    sqlCommitTrans();
                 } else {
-                    sqlStatement("delete from ar_activity " .
-                        " where  session_id ='" . add_escape_custom($payment_id) . "' and pid ='" . trim(formData("HiddenPId$CountRow")) .
-                        "' and  encounter  ='" . trim(formData("HiddenEncounter$CountRow")) .
-                        "' and  code_type  ='" . trim(formData("HiddenCodetype$CountRow")) .
-                        "' and  code  ='" . trim(formData("HiddenCode$CountRow")) .
-                        "' and  modifier  ='" . trim(formData("HiddenModifier$CountRow")) .
-                        "' and (memo like 'Deductable%' OR memo like 'Deductible%')");
+                    sqlStatement("delete from ar_activity $where");
                 }
 
                 //==============================================================================================================================
+
+                $where = "$where1 AND pay_amount < 0");
                 if (isset($_POST["Takeback$CountRow"]) && $_POST["Takeback$CountRow"] * 1 > 0) {
-                    $resPayment = sqlStatement("SELECT  * from ar_activity " .
-                        " where  session_id ='" . add_escape_custom($payment_id) . "' and pid ='" . trim(formData("HiddenPId$CountRow")) .
-                        "' and  encounter  ='" . trim(formData("HiddenEncounter$CountRow")) .
-                        "' and  code_type  ='" . trim(formData("HiddenCodetype$CountRow")) .
-                        "' and  code  ='" . trim(formData("HiddenCode$CountRow")) .
-                        "' and  modifier  ='" . trim(formData("HiddenModifier$CountRow")) .
-                        "' and pay_amount < 0");
+                    $resPayment = sqlStatement("SELECT  * from ar_activity $where");
                     if (sqlNumRows($resPayment) > 0) {
-                        sqlStatement("update ar_activity set " .
-                            "   post_user = '" . trim(add_escape_custom($user_id)) .
-                            "', modified_time = '" . trim(add_escape_custom($created_time)) .
-                            "', pay_amount = '" . trim(formData("Takeback$CountRow")) * -1 .
-                            "', account_code = '" . "Takeback" .
-                            "', payer_type = '" . trim(formData("HiddenIns$CountRow")) .
-                            "' where  session_id ='" . add_escape_custom($payment_id) . "' and pid ='" . trim(formData("HiddenPId$CountRow")) .
-                            "' and  encounter  ='" . trim(formData("HiddenEncounter$CountRow")) .
-                            "' and  code_type  ='" . trim(formData("HiddenCodetype$CountRow")) .
-                            "' and  code  ='" . trim(formData("HiddenCode$CountRow")) .
-                            "' and  modifier  ='" . trim(formData("HiddenModifier$CountRow")) .
-                            "' and pay_amount < 0");
-                    } else {
-                        sqlBeginTrans();
-                        $sequence_no = sqlQuery("SELECT IFNULL(MAX(sequence_no),0) + 1 AS increment FROM ar_activity WHERE pid = '" . trim(formData("HiddenPId$CountRow")) . "' AND encounter = '" . trim(formData("HiddenEncounter$CountRow")) . "'");
-                        sqlStatement("insert into ar_activity set " .
-                            "pid = '" . trim(formData("HiddenPId$CountRow")) .
-                            "', encounter = '" . trim(formData("HiddenEncounter$CountRow")) .
-                            "', sequence_no = '" . add_escape_custom($sequence_no['increment']) .
-                            "', code_type = '" . trim(formData("HiddenCodetype$CountRow")) .
-                            "', code = '" . trim(formData("HiddenCode$CountRow")) .
-                            "', modifier = '" . trim(formData("HiddenModifier$CountRow")) .
-                            "', payer_type = '" . trim(formData("HiddenIns$CountRow")) .
-                            "', post_time = '" . trim(add_escape_custom($created_time)) .
-                            "', post_user = '" . trim(add_escape_custom($user_id)) .
-                            "', session_id = '" . trim(formData('payment_id')) .
-                            "', modified_time = '" . trim(add_escape_custom($created_time)) .
-                            "', pay_amount = '" . trim(formData("Takeback$CountRow")) * -1 .
-                            "', adj_amount = '" . 0 .
-                            "', account_code = '" . "Takeback" .
-                            "'");
-                        sqlCommitTrans();
+                        sqlStatement("update ar_activity set deleted = NOW() $where");
                     }
+                    sqlBeginTrans();
+                    $sequence_no = sqlQuery("SELECT IFNULL(MAX(sequence_no),0) + 1 AS increment FROM ar_activity WHERE pid = '" . trim(formData("HiddenPId$CountRow")) . "' AND encounter = '" . trim(formData("HiddenEncounter$CountRow")) . "'");
+                    sqlStatement("insert into ar_activity set " .
+                        "pid = '" . trim(formData("HiddenPId$CountRow")) .
+                        "', encounter = '" . trim(formData("HiddenEncounter$CountRow")) .
+                        "', sequence_no = '" . add_escape_custom($sequence_no['increment']) .
+                        "', code_type = '" . trim(formData("HiddenCodetype$CountRow")) .
+                        "', code = '" . trim(formData("HiddenCode$CountRow")) .
+                        "', modifier = '" . trim(formData("HiddenModifier$CountRow")) .
+                        "', payer_type = '" . trim(formData("HiddenIns$CountRow")) .
+                        "', post_time = '" . trim(add_escape_custom($created_time)) .
+                        "', post_user = '" . trim(add_escape_custom($user_id)) .
+                        "', session_id = '" . trim(formData('payment_id')) .
+                        "', modified_time = '" . trim(add_escape_custom($created_time)) .
+                        "', pay_amount = '" . trim(formData("Takeback$CountRow")) * -1 .
+                        "', adj_amount = '" . 0 .
+                        "', account_code = '" . "Takeback" .
+                        "'");
+                    sqlCommitTrans();
                 } else {
-                    sqlStatement("delete from ar_activity " .
-                        " where  session_id ='" . add_escape_custom($payment_id) . "' and pid ='" . trim(formData("HiddenPId$CountRow")) .
-                        "' and  encounter  ='" . trim(formData("HiddenEncounter$CountRow")) .
-                        "' and  code_type  ='" . trim(formData("HiddenCodetype$CountRow")) .
-                        "' and  code  ='" . trim(formData("HiddenCode$CountRow")) .
-                        "' and  modifier  ='" . trim(formData("HiddenModifier$CountRow")) .
-                        "' and pay_amount < 0");
+                    sqlStatement("delete from ar_activity $where");
                 }
 
                 //==============================================================================================================================
+
+                $where = "$where1 AND follow_up = 'y'");
                 if (isset($_POST["FollowUp$CountRow"]) && $_POST["FollowUp$CountRow"] == 'y') {
-                    $resPayment = sqlStatement("SELECT  * from ar_activity " .
-                        " where  session_id ='" . add_escape_custom($payment_id) . "' and pid ='" . trim(formData("HiddenPId$CountRow")) .
-                        "' and  encounter  ='" . trim(formData("HiddenEncounter$CountRow")) .
-                        "' and  code_type  ='" . trim(formData("HiddenCodetype$CountRow")) .
-                        "' and  code  ='" . trim(formData("HiddenCode$CountRow")) .
-                        "' and  modifier  ='" . trim(formData("HiddenModifier$CountRow")) .
-                        "' and follow_up ='y'");
+                    $resPayment = sqlStatement("SELECT  * from ar_activity $where");
                     if (sqlNumRows($resPayment) > 0) {
-                        sqlStatement("update ar_activity set " .
-                            "   post_user = '" . trim(add_escape_custom($user_id)) .
-                            "', modified_time = '" . trim(add_escape_custom($created_time)) .
-                            "', follow_up = '" . "y" .
-                            "', follow_up_note = '" . trim(formData("FollowUpReason$CountRow")) .
-                            "', payer_type = '" . trim(formData("HiddenIns$CountRow")) .
-                            "' where  session_id ='" . add_escape_custom($payment_id) . "' and pid ='" . trim(formData("HiddenPId$CountRow")) .
-                            "' and  encounter  ='" . trim(formData("HiddenEncounter$CountRow")) .
-                            "' and  code_type  ='" . trim(formData("HiddenCodetype$CountRow")) .
-                            "' and  code  ='" . trim(formData("HiddenCode$CountRow")) .
-                            "' and  modifier  ='" . trim(formData("HiddenModifier$CountRow")) .
-                            "' and follow_up ='y'");
-                    } else {
-                        sqlBeginTrans();
-                        $sequence_no = sqlQuery("SELECT IFNULL(MAX(sequence_no),0) + 1 AS increment FROM ar_activity WHERE pid = '" . trim(formData("HiddenPId$CountRow")) . "' AND encounter = '" . trim(formData("HiddenEncounter$CountRow")) . "'");
-                        sqlStatement("insert into ar_activity set " .
-                            "pid = '" . trim(formData("HiddenPId$CountRow")) .
-                            "', encounter = '" . trim(formData("HiddenEncounter$CountRow")) .
-                            "', sequence_no = '" . add_escape_custom($sequence_no['increment']) .
-                            "', code_type = '" . trim(formData("HiddenCodetype$CountRow")) .
-                            "', code = '" . trim(formData("HiddenCode$CountRow")) .
-                            "', modifier = '" . trim(formData("HiddenModifier$CountRow")) .
-                            "', payer_type = '" . trim(formData("HiddenIns$CountRow")) .
-                            "', post_time = '" . trim(add_escape_custom($created_time)) .
-                            "', post_user = '" . trim(add_escape_custom($user_id)) .
-                            "', session_id = '" . trim(formData('payment_id')) .
-                            "', modified_time = '" . trim(add_escape_custom($created_time)) .
-                            "', pay_amount = '" . 0 .
-                            "', adj_amount = '" . 0 .
-                            "', follow_up = '" . "y" .
-                            "', follow_up_note = '" . trim(formData("FollowUpReason$CountRow")) .
-                            "'");
-                        sqlCommitTrans();
+                        sqlStatement("update ar_activity set deleted = NOW() $where");
                     }
+                    sqlBeginTrans();
+                    $sequence_no = sqlQuery("SELECT IFNULL(MAX(sequence_no),0) + 1 AS increment FROM ar_activity WHERE pid = '" . trim(formData("HiddenPId$CountRow")) . "' AND encounter = '" . trim(formData("HiddenEncounter$CountRow")) . "'");
+                    sqlStatement("insert into ar_activity set " .
+                        "pid = '" . trim(formData("HiddenPId$CountRow")) .
+                        "', encounter = '" . trim(formData("HiddenEncounter$CountRow")) .
+                        "', sequence_no = '" . add_escape_custom($sequence_no['increment']) .
+                        "', code_type = '" . trim(formData("HiddenCodetype$CountRow")) .
+                        "', code = '" . trim(formData("HiddenCode$CountRow")) .
+                        "', modifier = '" . trim(formData("HiddenModifier$CountRow")) .
+                        "', payer_type = '" . trim(formData("HiddenIns$CountRow")) .
+                        "', post_time = '" . trim(add_escape_custom($created_time)) .
+                        "', post_user = '" . trim(add_escape_custom($user_id)) .
+                        "', session_id = '" . trim(formData('payment_id')) .
+                        "', modified_time = '" . trim(add_escape_custom($created_time)) .
+                        "', pay_amount = '" . 0 .
+                        "', adj_amount = '" . 0 .
+                        "', follow_up = '" . "y" .
+                        "', follow_up_note = '" . trim(formData("FollowUpReason$CountRow")) .
+                        "'");
+                    sqlCommitTrans();
                 } else {
-                    sqlStatement("delete from ar_activity " .
-                        " where  session_id ='" . add_escape_custom($payment_id) . "' and pid ='" . trim(formData("HiddenPId$CountRow")) .
-                        "' and  encounter  ='" . trim(formData("HiddenEncounter$CountRow")) .
-                        "' and  code_type  ='" . trim(formData("HiddenCodetype$CountRow")) .
-                        "' and  code  ='" . trim(formData("HiddenCode$CountRow")) .
-                        "' and  modifier  ='" . trim(formData("HiddenModifier$CountRow")) .
-                        "' and follow_up ='y'");
+                    sqlStatement("delete from ar_activity $where");
                 }
 
                 //==============================================================================================================================
+
             } else {
                 break;
             }
@@ -435,7 +342,13 @@ if (isset($_POST["mode"])) {
 //Search Code
 //===============================================================================
 $payment_id = $payment_id * 1 > 0 ? $payment_id : $_REQUEST['payment_id'];
-$ResultSearchSub = sqlStatement("SELECT  distinct encounter,code_type,code,modifier, pid from ar_activity where session_id =? order by pid,encounter,code,modifier", [$payment_id]);
+$ResultSearchSub = sqlStatement(
+    "SELECT DISTINCT encounter, code_type, code, modifier, pid " .
+    "FROM ar_activity WHERE deleted IS NULL AND session_id = ? " .
+    "ORDER BY pid, encounter, code, modifier",
+    [$payment_id]
+);
+
 //==============================================================================
 
 //==============================================================================
@@ -714,7 +627,11 @@ $ResultSearchSub = sqlStatement("SELECT  distinct encounter,code_type,code,modif
                 if ($payment_id * 1 > 0) {//Distribution rows already in the database are displayed.
                     ?>
                     <?php //
-                    $resCount = sqlStatement("SELECT distinct encounter,code_type,code,modifier from ar_activity where  session_id =?", [$payment_id]);
+                    $resCount = sqlStatement(
+                        "SELECT DISTINCT encounter, code_type, code, modifier FROM ar_activity " .
+                        "WHERE deleted IS NULL AND session_id = ?",
+                        [$payment_id]
+                    );
                     $TotalRows = sqlNumRows($resCount);
                     $CountPatient = 0;
                     $CountIndex = 0;
@@ -802,8 +719,12 @@ $ResultSearchSub = sqlStatement("SELECT  distinct encounter,code_type,code,modif
                                     $Fee = $RowSearch['fee'];
                                     $Encounter = $RowSearch['encounter'];
 
-                                    $resPayer = sqlStatement("SELECT payer_type from ar_activity where session_id =? and
-                                    pid=? and encounter=? and code_type=? and code=? and modifier=?", [$payment_id, $PId, $Encounter, $Codetype, $Code, $Modifier]);
+                                    $resPayer = sqlStatement(
+                                        "SELECT payer_type FROM ar_activity WHERE " .
+                                        "deleted IS NULL AND session_id = ? AND pid = ? AND encounter = ? " .
+                                        "AND code_type = ? AND code = ? AND modifier = ?",
+                                        [$payment_id, $PId, $Encounter, $Codetype, $Code, $Modifier]
+                                    );
                                     $rowPayer = sqlFetchArray($resPayer);
                                     $Ins = $rowPayer['payer_type'];
 
@@ -822,8 +743,12 @@ $ResultSearchSub = sqlStatement("SELECT  distinct encounter,code_type,code,modif
                                         $rowCopay = sqlFetchArray($resCopay);
                                         $Copay = $rowCopay['copay'] * -1;
 
-                                        $resMoneyGot = sqlStatement("SELECT sum(pay_amount) as PatientPay FROM ar_activity where
-                                    pid =? and  encounter =? and payer_type=0 and account_code='PCP'", [$PId, $Encounter]);//new fees screen copay gives account_code='PCP'
+                                        $resMoneyGot = sqlStatement(
+                                            "SELECT sum(pay_amount) AS PatientPay FROM ar_activity WHERE " .
+                                            "deleted IS NULL AND pid = ? and encounter = ? AND " .
+                                            "payer_type = 0 AND account_code = 'PCP'",
+                                            [$PId, $Encounter]
+                                        ); //new fees screen copay gives account_code='PCP'
                                         $rowMoneyGot = sqlFetchArray($resMoneyGot);
                                         $PatientPay = $rowMoneyGot['PatientPay'];
 
@@ -832,15 +757,23 @@ $ResultSearchSub = sqlStatement("SELECT  distinct encounter,code_type,code,modif
 
                                     //For calculating Remainder
                                     if ($Ins == 0) {//Fetch all values
-                                        $resMoneyGot = sqlStatement("SELECT sum(pay_amount) as MoneyGot FROM ar_activity where
-                                    pid=? and code_type=? and code=? and modifier=? and encounter=? and !(payer_type=0 and
-                                    account_code='PCP')", [$PId, $Codetype, $Code, $Modifier, $Encounter]);
+                                        $resMoneyGot = sqlStatement(
+                                            "SELECT sum(pay_amount) as MoneyGot FROM ar_activity WHERE " .
+                                            "deleted IS NULL AND pid = ? and code_type = ? AND code = ? AND " .
+                                            "modifier = ? AND encounter = ? AND " .
+                                            "!(payer_type = 0 AND account_code = 'PCP')",
+                                            [$PId, $Codetype, $Code, $Modifier, $Encounter]
+                                        );
                                         //new fees screen copay gives account_code='PCP'
                                         $rowMoneyGot = sqlFetchArray($resMoneyGot);
                                         $MoneyGot = $rowMoneyGot['MoneyGot'];
 
-                                        $resMoneyAdjusted = sqlStatement("SELECT sum(adj_amount) as MoneyAdjusted FROM ar_activity where
-                                    pid=? and code_type=? and code=? and modifier=? and encounter=?", [$PId, $Codetype, $Code, $Modifier, $Encounter]);
+                                        $resMoneyAdjusted = sqlStatement(
+                                            "SELECT sum(adj_amount) AS MoneyAdjusted FROM ar_activity WHERE " .
+                                            "deleted IS NULL AND pid = ? and code_type = ? and code = ? AND " .
+                                            "modifier = ? AND encounter = ?",
+                                            [$PId, $Codetype, $Code, $Modifier, $Encounter]
+                                        );
                                         $rowMoneyAdjusted = sqlFetchArray($resMoneyAdjusted);
                                         $MoneyAdjusted = $rowMoneyAdjusted['MoneyAdjusted'];
                                     } else {
@@ -852,85 +785,139 @@ $ResultSearchSub = sqlStatement("SELECT  distinct encounter,code_type,code,modif
                                         $rowSequence = sqlFetchArray($resSequence);
                                         $Sequence = $rowSequence['sequence_no'];
 
-                                        $resMoneyGot = sqlStatement("SELECT sum(pay_amount) as MoneyGot FROM ar_activity where
-                                    pid=? and code_type=? and code=? and modifier=? and encounter=? and
-                                    payer_type > 0 and payer_type <=? and sequence_no<=?", [$PId, $Codetype, $Code, $Modifier, $Encounter, $Ins, $Sequence]);
+                                        $resMoneyGot = sqlStatement(
+                                            "SELECT sum(pay_amount) as MoneyGot FROM ar_activity WHERE " .
+                                            "deleted IS NULL AND pid = ? and code_type = ? AND code = ? AND " .
+                                            "modifier = ? and encounter = ? AND " .
+                                            "payer_type > 0 and payer_type <= ? and sequence_no <= ?",
+                                            [$PId, $Codetype, $Code, $Modifier, $Encounter, $Ins, $Sequence]
+                                        );
                                         $rowMoneyGot = sqlFetchArray($resMoneyGot);
                                         $MoneyGot = $rowMoneyGot['MoneyGot'];
 
-                                        $resMoneyAdjusted = sqlStatement("SELECT sum(adj_amount) as MoneyAdjusted FROM ar_activity where pid =? and code_type=? and code=? and modifier=? and encounter =? and payer_type > 0 and payer_type <=? and sequence_no <=?", [$PId, $Codetype, $Code, $Modifier, $Encounter, $Ins, $Sequence]);
+                                        $resMoneyAdjusted = sqlStatement(
+                                            "SELECT sum(adj_amount) AS MoneyAdjusted FROM ar_activity WHERE " .
+                                            "deleted IS NULL AND pid = ? and code_type = ? and code = ? AND " .
+                                            "modifier = ? AND encounter = ? AND payer_type > 0 AND " .
+                                            "payer_type <= ? and sequence_no <= ?",
+                                            [$PId, $Codetype, $Code, $Modifier, $Encounter, $Ins, $Sequence]
+                                        );
                                         $rowMoneyAdjusted = sqlFetchArray($resMoneyAdjusted);
                                         $MoneyAdjusted = $rowMoneyAdjusted['MoneyAdjusted'];
                                     }
                                     $Remainder = $Fee - $Copay - $MoneyGot - $MoneyAdjusted;
                                     //For calculating RemainderJS.Used while restoring back the values.
                                     if ($Ins == 0) {//Got just before Patient
-                                        $resMoneyGot = sqlStatement("SELECT sum(pay_amount) as MoneyGot FROM ar_activity where
-                                    pid=? and code_type=? and code=? and modifier=? and encounter=? and  payer_type !=0", [$PId, $Codetype, $Code, $Modifier, $Encounter]);
+                                        $resMoneyGot = sqlStatement(
+                                            "SELECT sum(pay_amount) AS MoneyGot FROM ar_activity WHERE " .
+                                            "deleted IS NULL AND pid = ? AND code_type = ? AND code = ? AND " .
+                                            "modifier = ? AND encounter = ? and payer_type != 0",
+                                            [$PId, $Codetype, $Code, $Modifier, $Encounter]
+                                        );
                                         $rowMoneyGot = sqlFetchArray($resMoneyGot);
                                         $MoneyGot = $rowMoneyGot['MoneyGot'];
 
-                                        $resMoneyAdjusted = sqlStatement("SELECT sum(adj_amount) as MoneyAdjusted FROM ar_activity where
-                                    pid=? and code_type=? and code=? and modifier=? and encounter=? and payer_type !=0", [$PId, $Codetype, $Code, $Modifier, $Encounter]);
+                                        $resMoneyAdjusted = sqlStatement(
+                                            "SELECT sum(adj_amount) AS MoneyAdjusted FROM ar_activity WHERE " .
+                                            "deleted IS NULL AND pid = ? AND code_type = ? AND code = ? AND " .
+                                            "modifier = ? and encounter = ? and payer_type != 0",
+                                            [$PId, $Codetype, $Code, $Modifier, $Encounter]
+                                        );
                                         $rowMoneyAdjusted = sqlFetchArray($resMoneyAdjusted);
                                         $MoneyAdjusted = $rowMoneyAdjusted['MoneyAdjusted'];
                                     } else {
                                         //Got just before the previous
                                         //Fetch the LOWEST sequence_no till this session.
                                         //Used maily in  the case if primary/others pays once more.
-                                        $resSequence = sqlStatement("SELECT  sequence_no from ar_activity where session_id =? and
-                                    pid=? and encounter=? order by sequence_no", [$payment_id, $PId, $Encounter]);
+                                        $resSequence = sqlStatement(
+                                            "SELECT sequence_no FROM ar_activity WHERE " .
+                                            "session_id = ? AND deleted IS NULL AND pid = ? AND encounter = ? " .
+                                            "order by sequence_no",
+                                            [$payment_id, $PId, $Encounter]
+                                        );
                                         $rowSequence = sqlFetchArray($resSequence);
                                         $Sequence = $rowSequence['sequence_no'];
 
-                                        $resMoneyGot = sqlStatement("SELECT sum(pay_amount) as MoneyGot FROM ar_activity where
-                                    pid=? and code_type=? and code=? and modifier=? and encounter=?
-                                    and payer_type > 0  and payer_type <=? and sequence_no<?", [$PId, $Codetype, $Code, $Modifier, $Encounter, $Ins, $Sequence]);
+                                        $resMoneyGot = sqlStatement(
+                                            "SELECT sum(pay_amount) as MoneyGot FROM ar_activity WHERE " .
+                                            "deleted IS NULL AND pid = ? AND code_type = ? AND code = ? " .
+                                            "AND modifier = ? AND encounter = ? AND payer_type > 0 AND " .
+                                            "payer_type <= ? AND sequence_no < ?",
+                                            [$PId, $Codetype, $Code, $Modifier, $Encounter, $Ins, $Sequence]
+                                        );
                                         $rowMoneyGot = sqlFetchArray($resMoneyGot);
                                         $MoneyGot = $rowMoneyGot['MoneyGot'];
 
-                                        $resMoneyAdjusted = sqlStatement("SELECT sum(adj_amount) as MoneyAdjusted FROM ar_activity where pid=? and code_type=? and code=? and modifier=? and encounter=? and payer_type <=? and sequence_no < ?", [$PId, $Codetype, $Code, $Modifier, $Encounter, $Ins, $Sequence]);
+                                        $resMoneyAdjusted = sqlStatement(
+                                            "SELECT sum(adj_amount) as MoneyAdjusted FROM ar_activity WHERE " .
+                                            "deleted IS NULL AND pid = ? and code_type = ? and code = ? AND " .
+                                            "modifier = ? AND encounter = ? AND payer_type <= ? AND sequence_no < ?",
+                                            [$PId, $Codetype, $Code, $Modifier, $Encounter, $Ins, $Sequence]
+                                        );
                                         $rowMoneyAdjusted = sqlFetchArray($resMoneyAdjusted);
                                         $MoneyAdjusted = $rowMoneyAdjusted['MoneyAdjusted'];
                                     }
                                     //Stored in hidden so that can be used while restoring back the values.
                                     $RemainderJS = $Fee - $Copay - $MoneyGot - $MoneyAdjusted;
 
-                                    $resPayment = sqlStatement("SELECT  pay_amount from ar_activity where session_id=? and
-                                pid=? and  encounter=? and code_type=? and code=? and modifier=? and pay_amount>0", [$payment_id, $PId, $Encounter, $Codetype, $Code, $Modifier]);
+                                    $resPayment = sqlStatement(
+                                        "SELECT pay_amount FROM ar_activity WHERE " .
+                                        "deleted IS NULL AND session_id=? AND pid = ? AND encounter = ? AND " .
+                                        "code_type = ? AND code = ? AND modifier = ? AND pay_amount > 0",
+                                        [$payment_id, $PId, $Encounter, $Codetype, $Code, $Modifier]
+                                    );
                                     $rowPayment = sqlFetchArray($resPayment);
                                     $PaymentDB = $rowPayment['pay_amount'] * 1;
                                     $PaymentDB = $PaymentDB == 0 ? '' : $PaymentDB;
 
-                                    $resPayment = sqlStatement("SELECT  pay_amount from ar_activity where session_id =? and
-                                pid=? and  encounter=? and code_type=? and code=? and modifier=? and pay_amount<0", [$payment_id, $PId, $Encounter, $Codetype, $Code, $Modifier]);
+                                    $resPayment = sqlStatement(
+                                        "SELECT pay_amount FROM ar_activity WHERE " .
+                                        "deleted IS NULL AND session_id = ? AND pid = ? AND encounter = ? AND " .
+                                        "code_type = ? AND code = ? AND modifier = ? AND pay_amount < 0",
+                                        [$payment_id, $PId, $Encounter, $Codetype, $Code, $Modifier]
+                                    );
                                     $rowPayment = sqlFetchArray($resPayment);
                                     $TakebackDB = $rowPayment['pay_amount'] * -1;
                                     $TakebackDB = $TakebackDB == 0 ? '' : $TakebackDB;
 
-                                    $resPayment = sqlStatement("SELECT  adj_amount from ar_activity where session_id=? and
-                                pid=? and  encounter=? and code_type=? and code=? and modifier=? and adj_amount!=0", [$payment_id, $PId, $Encounter, $Codetype, $Code, $Modifier]);
+                                    $resPayment = sqlStatement(
+                                        "SELECT adj_amount FROM ar_activity WHERE " .
+                                        "deleted IS NULL AND session_id = ? AND pid = ? AND encounter = ? AND " .
+                                        "code_type = ? AND code = ? AND modifier = ? AND adj_amount != 0",
+                                        [$payment_id, $PId, $Encounter, $Codetype, $Code, $Modifier]
+                                    );
                                     $rowPayment = sqlFetchArray($resPayment);
                                     $AdjAmountDB = $rowPayment['adj_amount'] * 1;
                                     $AdjAmountDB = $AdjAmountDB == 0 ? '' : $AdjAmountDB;
 
-                                    $resPayment = sqlStatement("SELECT  memo from ar_activity where session_id=? and
-                                pid=? and encounter=? and code_type=? and code=? and modifier=? and
-                                (memo like 'Deductable%' OR memo like 'Deductible%')", [$payment_id, $PId, $Encounter, $Codetype, $Code, $Modifier]);
+                                    $resPayment = sqlStatement(
+                                        "SELECT memo FROM ar_activity WHERE " .
+                                        "deleted IS NULL AND session_id = ? AND pid = ? AND encounter = ? AND " .
+                                        "code_type = ? AND code = ? AND modifier = ? AND " .
+                                        "(memo LIKE 'Deductable%' OR memo LIKE 'Deductible%')",
+                                        [$payment_id, $PId, $Encounter, $Codetype, $Code, $Modifier]
+                                    );
                                     $rowPayment = sqlFetchArray($resPayment);
                                     $DeductibleDB = $rowPayment['memo'];
                                     $DeductibleDB = str_replace('Deductable $', '', $DeductibleDB);
                                     $DeductibleDB = str_replace('Deductible $', '', $DeductibleDB);
 
-                                    $resPayment = sqlStatement("SELECT  follow_up,follow_up_note from ar_activity where session_id=? and
-                                pid=? and encounter=? and code_type=? and code=? and modifier=? and
-                                follow_up = 'y'", [$payment_id, $PId, $Encounter, $Codetype, $Code, $Modifier]);
+                                    $resPayment = sqlStatement(
+                                        "SELECT follow_up, follow_up_note FROM ar_activity WHERE " .
+                                        "deleted IS NULL AND session_id = ? AND pid = ? AND encounter = ? AND " .
+                                        "code_type = ? AND code = ? AND modifier = ? AND follow_up = 'y'",
+                                        [$payment_id, $PId, $Encounter, $Codetype, $Code, $Modifier]
+                                    );
                                     $rowPayment = sqlFetchArray($resPayment);
                                     $FollowUpDB = $rowPayment['follow_up'];
                                     $FollowUpReasonDB = $rowPayment['follow_up_note'];
 
-                                    $resPayment = sqlStatement("SELECT reason_code from ar_activity where session_id =? and
-                                pid=? and encounter=? and code_type=? and code=? and modifier=?", [$payment_id, $PId, $Encounter, $Codetype, $Code, $Modifier]);
+                                    $resPayment = sqlStatement(
+                                        "SELECT reason_code FROM ar_activity WHERE " .
+                                        "deleted IS NULL AND session_id = ? AND pid = ? AND encounter = ? AND " .
+                                        "code_type = ? AND code = ? AND modifier = ?",
+                                        [$payment_id, $PId, $Encounter, $Codetype, $Code, $Modifier]
+                                    );
                                     $rowPayment = sqlFetchArray($resPayment);
                                     $ReasonCodeDB = $rowPayment['reason_code'];
 

--- a/interface/billing/edit_payment.php
+++ b/interface/billing/edit_payment.php
@@ -125,7 +125,7 @@ if (isset($_POST["mode"])) {
                     "' AND code_type = '" . trim(formData("HiddenCodetype$CountRow")) .
                     "' AND code = '" . trim(formData("HiddenCode$CountRow")) .
                     "' AND modifier = '" . trim(formData("HiddenModifier$CountRow")) .
-                    "'");
+                    "'";
 
                 $where = "$where1 AND pay_amount > 0");
                 if (isset($_POST["Payment$CountRow"]) && $_POST["Payment$CountRow"] * 1 > 0) {

--- a/interface/billing/indigent_patients_report.php
+++ b/interface/billing/indigent_patients_report.php
@@ -9,7 +9,7 @@
  * @link      http://www.open-emr.org
  * @author    Rod Roark <rod@sunsetsystems.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
- * @copyright Copyright (c) 2005-2015 Rod Roark <rod@sunsetsystems.com>
+ * @copyright Copyright (c) 2005-2015, 2020 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2017-2020 Brady Miller <brady.g.miller@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
@@ -223,9 +223,11 @@ if ($_POST['form_refresh']) {
           "pid = ? AND encounter = ? AND " .
           "activity = 1 AND code_type = 'COPAY'", array($patient_id, $encounter_id));
         $inv_paid = 0 - $arow['amount'];
-        $arow = sqlQuery("SELECT SUM(pay_amount) AS pay, " .
-          "sum(adj_amount) AS adj FROM ar_activity WHERE " .
-          "pid = ? AND encounter = ?", array($patient_id, $encounter_id));
+        $arow = sqlQuery(
+            "SELECT SUM(pay_amount) AS pay, sum(adj_amount) AS adj " .
+            "FROM ar_activity WHERE pid = ? AND encounter = ? AND deleted IS NULL",
+            array($patient_id, $encounter_id)
+        );
         $inv_paid   += floatval($arow['pay']);
         $inv_amount -= floatval($arow['adj']);
         $total_amount += $inv_amount;

--- a/interface/billing/payment_master.inc.php
+++ b/interface/billing/payment_master.inc.php
@@ -8,6 +8,7 @@
  * @link      http://www.open-emr.org
  * @author    Eldho Chacko <eldho@zhservices.com>
  * @author    Paul Simon K <paul@zhservices.com>
+ * @author    Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2010 Z&H Consultancy Services Private Limited <sam@zhservices.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
@@ -71,7 +72,10 @@ if ($payment_id > 0) {
     $row = sqlFetchArray($rs);
     $pay_total = $row['pay_total'];
     $global_amount = $row['global_amount'];
-    $rs = sqlStatement("select sum(pay_amount) sum_pay_amount from ar_activity where session_id=?", array($payment_id));
+    $rs = sqlStatement(
+        "SELECT sum(pay_amount) sum_pay_amount FROM ar_activity WHERE session_id = ? AND deleted IS NULL",
+        array($payment_id)
+    );
     $row = sqlFetchArray($rs);
     $pay_amount = $row['sum_pay_amount'];
     $UndistributedAmount = $pay_total - $pay_amount - $global_amount;

--- a/interface/billing/payment_pat_sel.inc.php
+++ b/interface/billing/payment_pat_sel.inc.php
@@ -9,9 +9,11 @@
  * @author    Paul Simon K <paul@zhservices.com>
  * @author    Stephen Waite <stephen.waite@cmsvt.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2010 Z&H Consultancy Services Private Limited <sam@zhservices.com>
  * @copyright Copyright (c) 2018 Stephen Waite <stephen.waite@cmsvt.com>
  * @copyright Copyright (c) 2019-2020 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2020 Rod Roark <rod@sunsetsystems.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -165,23 +167,34 @@ if (isset($_POST["mode"])) {
                             $rowCopay = sqlFetchArray($resCopay);
                             $Copay = $rowCopay['copay'] * -1;
 
-                            $resMoneyGot = sqlStatement("SELECT sum(pay_amount) as PatientPay FROM ar_activity where
-                            pid =?  and  encounter =? and  payer_type=0 and
-                            account_code='PCP'", array($hidden_patient_code, $Encounter));//new fees screen copay gives account_code='PCP'
+                            $resMoneyGot = sqlStatement(
+                                "SELECT sum(pay_amount) as PatientPay FROM ar_activity where " .
+                                "deleted IS NULL AND pid = ? and encounter = ? and payer_type = 0 and " .
+                                "account_code = 'PCP'",
+                                array($hidden_patient_code, $Encounter)
+                            );//new fees screen copay gives account_code='PCP'
                             $rowMoneyGot = sqlFetchArray($resMoneyGot);
                             $PatientPay = $rowMoneyGot['PatientPay'];
 
                             $Copay = $Copay + $PatientPay;
                         }
                         //payer_type!=0, supports both mapped and unmapped code_type in ar_activity
-                        $resMoneyGot = sqlStatement("SELECT sum(pay_amount) as MoneyGot FROM ar_activity where
-                        pid =? and (code_type=? or code_type='') and code=? and modifier=?  and  encounter  =? and  !(payer_type=0 and
-                        account_code='PCP')", array($hidden_patient_code, $Codetype, $Code, $Modifier, $Encounter));//new fees screen copay gives account_code='PCP'
+                        $resMoneyGot = sqlStatement(
+                            "SELECT sum(pay_amount) as MoneyGot FROM ar_activity where " .
+                            "deleted IS NULL AND pid = ? and (code_type = ? or code_type = '') and " .
+                            "code = ? and modifier = ? and encounter = ? and ! (payer_type = 0 and " .
+                            "account_code = 'PCP')",
+                            array($hidden_patient_code, $Codetype, $Code, $Modifier, $Encounter)
+                        );//new fees screen copay gives account_code='PCP'
                         $rowMoneyGot = sqlFetchArray($resMoneyGot);
                         $MoneyGot = $rowMoneyGot['MoneyGot'];
-                                                //supports both mapped and unmapped code_type in ar_activity
-                        $resMoneyAdjusted = sqlStatement("SELECT sum(adj_amount) as MoneyAdjusted FROM ar_activity where
-                        pid =? and (code_type=? or code_type='') and code=? and modifier=? and encounter =?", array($hidden_patient_code, $Codetype, $Code, $Modifier, $Encounter));
+                        //supports both mapped and unmapped code_type in ar_activity
+                        $resMoneyAdjusted = sqlStatement(
+                            "SELECT sum(adj_amount) as MoneyAdjusted FROM ar_activity where " .
+                            "deleted IS NULL AND pid = ? and (code_type = ? or code_type = '') and " .
+                            "code = ? and modifier = ? and encounter = ?",
+                            array($hidden_patient_code, $Codetype, $Code, $Modifier, $Encounter)
+                        );
                         $rowMoneyAdjusted = sqlFetchArray($resMoneyAdjusted);
                         $MoneyAdjusted = $rowMoneyAdjusted['MoneyAdjusted'];
 

--- a/interface/billing/search_payments.php
+++ b/interface/billing/search_payments.php
@@ -47,7 +47,7 @@ if (isset($_POST["mode"])) {
 
     //delete and log that action
         row_delete("ar_session", "session_id ='" . add_escape_custom($DeletePaymentId) . "'");
-        row_modify("ar_activity", "deleted = NOW()", "deleted IS NULL AND session_id ='$DeletePaymentId'");
+        row_modify("ar_activity", "deleted = NOW()", "deleted IS NULL AND session_id = '" . add_escape_custom($DeletePaymentId) . "'");
         $Message = 'Delete';
     //------------------
         $_POST["mode"] = "SearchPayment";

--- a/interface/billing/search_payments.php
+++ b/interface/billing/search_payments.php
@@ -10,8 +10,10 @@
 * @author    Eldho Chacko <eldho@zhservices.com>
 * @author    Paul Simon K <paul@zhservices.com>
 * @author    Brady Miller <brady.g.miller@gmail.com>
+* @author    Rod Roark <rod@sunsetsystems.com>
 * @copyright Copyright (c) 2010 Z&H Consultancy Services Private Limited <sam@zhservices.com>
 * @copyright Copyright (c) 2019-2020 Brady Miller <brady.g.miller@gmail.com>
+* @copyright Copyright (c) 2020 Rod Roark <rod@sunsetsystems.com>
 * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
 */
 
@@ -31,7 +33,10 @@ set_time_limit(0);
 if (isset($_POST["mode"])) {
     if ($_POST["mode"] == "DeletePayments") {
         $DeletePaymentId = isset($_POST['DeletePaymentId']) ? trim($_POST['DeletePaymentId']) : '';
-        $ResultSearch = sqlStatement("SELECT distinct encounter,pid from ar_activity where  session_id =?", [$DeletePaymentId]);
+        $ResultSearch = sqlStatement(
+            "SELECT distinct encounter, pid from ar_activity where deleted IS NULL AND session_id = ?",
+            [$DeletePaymentId]
+        );
         if (sqlNumRows($ResultSearch) > 0) {
             while ($RowSearch = sqlFetchArray($ResultSearch)) {
                 $Encounter = $RowSearch['encounter'];
@@ -42,7 +47,7 @@ if (isset($_POST["mode"])) {
 
     //delete and log that action
         row_delete("ar_session", "session_id ='" . add_escape_custom($DeletePaymentId) . "'");
-        row_delete("ar_activity", "session_id ='" . add_escape_custom($DeletePaymentId) . "'");
+        row_modify("ar_activity", "deleted = NOW()", "deleted IS NULL AND session_id ='$DeletePaymentId'");
         $Message = 'Delete';
     //------------------
         $_POST["mode"] = "SearchPayment";
@@ -156,9 +161,11 @@ if (isset($_POST["mode"])) {
         }
 
         if ($PaymentStatus != '') {
-            $QsString = "select ar_session.session_id,pay_total,global_amount,sum(pay_amount) sum_pay_amount from ar_session,ar_activity
-        where ar_session.session_id=ar_activity.session_id group by ar_activity.session_id,ar_session.session_id
-        having pay_total-global_amount-sum_pay_amount=0 or pay_total=0";
+            $QsString = "select ar_session.session_id, pay_total, global_amount, sum(pay_amount) sum_pay_amount " .
+                "from ar_session,ar_activity WHERE " .
+                "ar_activity.deleted IS NULL AND ar_session.session_id = ar_activity.session_id " .
+                "group by ar_activity.session_id, ar_session.session_id " .
+                "having pay_total - global_amount - sum_pay_amount = 0 or pay_total = 0";
             $rs = sqlStatement($QsString);
             while ($rowrs = sqlFetchArray($rs)) {
                 $StringSessionId .= $rowrs['session_id'] . ',';
@@ -566,7 +573,11 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                         $row = sqlFetchArray($rs);
                                         $pay_total = $row['pay_total'];
                                         $global_amount = $row['global_amount'];
-                                        $rs = sqlStatement("select sum(pay_amount) sum_pay_amount from ar_activity where session_id=?", [$RowSearch['session_id']]);
+                                        $rs = sqlStatement(
+                                            "select sum(pay_amount) sum_pay_amount from ar_activity where " .
+                                            "deleted IS NULL AND session_id = ?",
+                                            [$RowSearch['session_id']]
+                                        );
                                         $row = sqlFetchArray($rs);
                                         $pay_amount = $row['sum_pay_amount'];
                                         $UndistributedAmount = $pay_total - $pay_amount - $global_amount;

--- a/interface/billing/search_payments.php
+++ b/interface/billing/search_payments.php
@@ -568,7 +568,8 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                         <a class="medium_modal" href='edit_payment.php?payment_id=<?php echo attr_url($RowSearch['session_id']); ?>'"><?php echo $RowSearch['reference'] == '' ? '&nbsp;' : text($RowSearch['reference']); ?></a>
                                     </td>
                                     <td align="left">
-                                        <a class="medium_modal" href='edit_payment.php?payment_id=<?php echo attr_url($RowSearch['session_id']); ?>'"><?php
+                                        <a class="medium_modal" href='edit_payment.php?payment_id=<?php echo attr_url($RowSearch['session_id']); ?>'">
+                                <?php
                                         $rs = sqlStatement("select pay_total,global_amount from ar_session where session_id=?", [$RowSearch['session_id']]);
                                         $row = sqlFetchArray($rs);
                                         $pay_total = $row['pay_total'];

--- a/interface/billing/sl_eob_invoice.php
+++ b/interface/billing/sl_eob_invoice.php
@@ -13,7 +13,7 @@
  * @author    Jerry Padgett <sjpadgett@gmail.com>
  * @author    Stephen Waite <stephen.waite@cmsvt.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
- * @copyright Copyright (c) 2005-2016 Rod Roark <rod@sunsetsystems.com>
+ * @copyright Copyright (c) 2005-2020 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2018-2020 Stephen Waite <stephen.waite@cmsvt.com>
  * @copyright Copyright (c) 2019-2020 Brady Miller <brady.g.miller@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
@@ -24,6 +24,7 @@ require_once("$srcdir/patient.inc");
 require_once("$srcdir/forms.inc");
 require_once("../../custom/code_types.inc.php");
 require_once "$srcdir/user.inc";
+require_once("$srcdir/payment.inc.php");
 
 use OpenEMR\Billing\InvoiceSummary;
 use OpenEMR\Billing\SLEOB;
@@ -52,37 +53,6 @@ function bucks($amount)
 {
     if ($amount) {
         return sprintf("%.2f", $amount);
-    }
-}
-
-// Delete rows, with logging, for the specified table using the
-// specified WHERE clause.  Borrowed from deleter.php.
-//
-function row_delete($table, $where)
-{
-    $tres = sqlStatement("SELECT * FROM " . escape_table_name($table) . " WHERE $where");
-    $count = 0;
-    while ($trow = sqlFetchArray($tres)) {
-        $logstring = "";
-        foreach ($trow as $key => $value) {
-            if (!$value || $value == '0000-00-00 00:00:00') {
-                continue;
-            }
-
-            if ($logstring) {
-                $logstring .= " ";
-            }
-
-            $logstring .= $key . "='" . addslashes($value) . "'";
-        }
-
-        EventAuditLogger::instance()->newEvent("delete", $_SESSION['authUser'], $_SESSION['authProvider'], 1, "$table: $logstring");
-        ++$count;
-    }
-
-    if ($count) { // Lets not echo the query for stay and save
-        $query = "DELETE FROM " . escape_table_name($table) . " WHERE $where";
-        sqlStatement($query);
     }
 }
 
@@ -348,7 +318,13 @@ if (($_POST['form_save'] || $_POST['form_cancel'])) {
         if ($ALLOW_DELETE && !$debug) {
             if (is_array($_POST['form_del'])) {
                 foreach ($_POST['form_del'] as $arseq => $dummy) {
-                    row_delete("ar_activity", "pid = '" . add_escape_custom($patient_id) . "' AND " . "encounter = '" . add_escape_custom($encounter_id) . "' AND sequence_no = '" . add_escape_custom($arseq) . "'");
+                    row_modify(
+                        "ar_activity",
+                        "deleted = NOW()",
+                        "pid = '" . add_escape_custom($patient_id) .
+                        "' AND encounter = '" . add_escape_custom($encounter_id) .
+                        "' AND sequence_no = '" . add_escape_custom($arseq) .
+                        "' AND deleted IS NULL");
                 }
             }
         }

--- a/interface/billing/sl_eob_invoice.php
+++ b/interface/billing/sl_eob_invoice.php
@@ -324,7 +324,8 @@ if (($_POST['form_save'] || $_POST['form_cancel'])) {
                         "pid = '" . add_escape_custom($patient_id) .
                         "' AND encounter = '" . add_escape_custom($encounter_id) .
                         "' AND sequence_no = '" . add_escape_custom($arseq) .
-                        "' AND deleted IS NULL");
+                        "' AND deleted IS NULL"
+                    );
                 }
             }
         }

--- a/interface/billing/sl_eob_process.php
+++ b/interface/billing/sl_eob_process.php
@@ -8,7 +8,7 @@
  * @author    Rod Roark <rod@sunsetsystems.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
  * @author    Stephen Waite <stephen.waite@cmsvt.com>
- * @copyright Copyright (c) 2006-2010 Rod Roark <rod@sunsetsystems.com>
+ * @copyright Copyright (c) 2006-2020 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2018 Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2019-2020 Stephen Waite <stephen.waite@cmsvt.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
@@ -779,7 +779,10 @@ if ($_GET['original'] == 'original') {
             $rs = sqlQ("select pay_total from ar_session where session_id=?", array($value));
             $row = sqlFetchArray($rs);
             $pay_total = $row['pay_total'];
-            $rs = sqlQ("select sum(pay_amount) sum_pay_amount from ar_activity where session_id=?", array($value));
+            $rs = sqlQ(
+                "select sum(pay_amount) sum_pay_amount from ar_activity where deleted IS NULL AND session_id = ?",
+                array($value)
+            );
             $row = sqlFetchArray($rs);
             $pay_amount = $row['sum_pay_amount'];
 

--- a/interface/billing/sl_eob_search.php
+++ b/interface/billing/sl_eob_search.php
@@ -12,7 +12,7 @@
  * @author    Roberto Vasquez <robertogagliotta@gmail.com>
  * @author    Jerry Padgett <sjpadgett@gmail.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
- * @copyright Copyright (c) 2005-2010 Rod Roark <rod@sunsetsystems.com>
+ * @copyright Copyright (c) 2005-2020 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2018-2020 Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2018-2020 Jerry Padgett <sjpadgett@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
@@ -972,11 +972,11 @@ if (($_REQUEST['form_print'] || $_REQUEST['form_download'] || $_REQUEST['form_em
                             "b.pid = f.pid AND b.encounter = f.encounter AND " .
                             "b.activity = 1 AND b.code_type != 'COPAY' ) AS charges, " .
                             "( SELECT SUM(a.pay_amount) FROM ar_activity AS a WHERE " .
-                            "a.pid = f.pid AND a.encounter = f.encounter AND a.payer_type = 0 AND a.account_code = 'PCP')*-1 AS copays, " .
+                            "a.pid = f.pid AND a.encounter = f.encounter AND a.deleted IS NULL AND a.payer_type = 0 AND a.account_code = 'PCP')*-1 AS copays, " .
                             "( SELECT SUM(a.pay_amount) FROM ar_activity AS a WHERE " .
-                            "a.pid = f.pid AND a.encounter = f.encounter AND a.account_code != 'PCP') AS payments, " .
+                            "a.pid = f.pid AND a.encounter = f.encounter AND a.deleted IS NULL AND a.account_code != 'PCP') AS payments, " .
                             "( SELECT SUM(a.adj_amount) FROM ar_activity AS a WHERE " .
-                            "a.pid = f.pid AND a.encounter = f.encounter ) AS adjustments " .
+                            "a.pid = f.pid AND a.encounter = f.encounter AND a.deleted IS NULL ) AS adjustments " .
                             "FROM form_encounter AS f " .
                             "JOIN patient_data AS p ON p.pid = f.pid " .
                             "WHERE $where " .

--- a/interface/billing/sl_receipts_report.php
+++ b/interface/billing/sl_receipts_report.php
@@ -13,7 +13,7 @@
  * @author    Rod Roark <rod@sunsetsystems.com>
  * @author    Terry Hill <terry@lillysystems.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
- * @copyright Copyright (c) 2006-2016 Rod Roark <rod@sunsetsystems.com>
+ * @copyright Copyright (c) 2006-2020 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2016 Terry Hill <terry@lillysystems.com>
  * @copyright Copyright (c) 2017-2019 Brady Miller <brady.g.miller@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
@@ -500,7 +500,7 @@ $form_facility   = $_POST['form_facility'];
                         "LEFT OUTER JOIN billing AS b ON b.pid = a.pid AND b.encounter = a.encounter AND " .
                         "b.code = a.code AND b.modifier = a.modifier AND b.activity = 1 AND " .
                         "b.code_type != 'COPAY' AND b.code_type != 'TAX' " .
-                        "WHERE a.pay_amount != 0 AND ( " .
+                        "WHERE a.deleted IS NULL AND a.pay_amount != 0 AND ( " .
                         "a.post_time >= ? AND a.post_time <= ? " .
                         "OR fe.date >= ? AND fe.date <= ? " .
                         "OR s.deposit_date >= ? AND s.deposit_date <= ? )";

--- a/interface/forms/fee_sheet/new.php
+++ b/interface/forms/fee_sheet/new.php
@@ -8,7 +8,7 @@
  * @author    Rod Roark <rod@sunsetsystems.com>
  * @author    Terry Hill <terry@lillysystems.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
- * @copyright Copyright (c) 2005-2016 Rod Roark <rod@sunsetsystems.com>
+ * @copyright Copyright (c) 2005-2020 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2018-2019 Brady Miller <brady.g.miller@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
@@ -1203,8 +1203,9 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                 }
 
                                     $resMoneyGot = sqlStatement(
-                                        "SELECT pay_amount as PatientPay,session_id as id,date(post_time) as date " .
-                                        "FROM ar_activity where pid =? and encounter =? and payer_type=0 and account_code='PCP'",
+                                        "SELECT pay_amount as PatientPay,session_id as id, date(post_time) as date " .
+                                        "FROM ar_activity where deleted IS NULL AND pid = ? and encounter = ? and " .
+                                        "payer_type = 0 and account_code = 'PCP'",
                                         array($fs->pid, $fs->encounter)
                                     ); //new fees screen copay gives account_code='PCP'
                                     while ($rowMoneyGot = sqlFetchArray($resMoneyGot)) {

--- a/interface/patient_file/deleter.php
+++ b/interface/patient_file/deleter.php
@@ -352,14 +352,17 @@ if ($_POST['form_submit']) {
                 }
 
                 // Delete the payment.
-                row_modify("ar_activity", "deleted = NOW()",
+                row_modify(
+                    "ar_activity",
+                    "deleted = NOW()",
                     "pid = '" . add_escape_custom($patient_id) . "' AND " .
                     "encounter = '" . add_escape_custom($payrow['encounter']) . "' AND " .
                     "deleted IS NULL AND " .
                     "payer_type = 0 AND " .
                     "pay_amount != 0.00 AND " .
                     "adj_amount = 0.00 AND " .
-                    "session_id = '" . add_escape_custom($ref_id) . "'");
+                    "session_id = '" . add_escape_custom($ref_id) . "'"
+                );
                 if ($ref_id) {
                     row_delete(
                         "ar_session",
@@ -367,7 +370,6 @@ if ($_POST['form_submit']) {
                         "session_id = '" . add_escape_custom($ref_id) . "'"
                     );
                 }
-
             } else {
                 // Encounter is 0! Seems this happens for pre-payments.
                 $tpmt = sprintf("%01.2f", $payrow['amount1'] + $payrow['amount2']);

--- a/interface/patient_file/deleter.php
+++ b/interface/patient_file/deleter.php
@@ -10,7 +10,7 @@
  * @author    Rod Roark <rod@sunsetsystems.com>
  * @author    Roberto Vasquez <robertogagliotta@gmail.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
- * @copyright Copyright (c) 2005-2016 Rod Roark <rod@sunsetsystems.com>
+ * @copyright Copyright (c) 2005-2020 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2015 Roberto Vasquez <robertogagliotta@gmail.com>
  * @copyright Copyright (c) 2018 Brady Miller <brady.g.miller@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
@@ -241,7 +241,7 @@ if ($_POST['form_submit']) {
         row_delete("claims", "patient_id = '" . add_escape_custom($patient) . "'");
         delete_drug_sales($patient);
         row_delete("payments", "pid = '" . add_escape_custom($patient) . "'");
-        row_delete("ar_activity", "pid = '" . add_escape_custom($patient) . "'");
+        row_modify("ar_activity", "deleted = NOW()", "pid = '" . add_escape_custom($patient) . "' AND deleted IS NULL");
         row_delete("openemr_postcalendar_events", "pc_pid = '" . add_escape_custom($patient) . "'");
         row_delete("immunizations", "patient_id = '" . add_escape_custom($patient) . "'");
         row_delete("issue_encounter", "pid = '" . add_escape_custom($patient) . "'");
@@ -272,7 +272,7 @@ if ($_POST['form_submit']) {
 
         row_modify("billing", "activity = 0", "encounter = '" . add_escape_custom($encounterid) . "'");
         delete_drug_sales(0, $encounterid);
-        row_delete("ar_activity", "encounter = '" . add_escape_custom($encounterid) . "'");
+        row_modify("ar_activity", "deleted = NOW()", "encounter = '" . add_escape_custom($encounterid) . "' AND deleted IS NULL");
         row_delete("claims", "encounter_id = '" . add_escape_custom($encounterid) . "'");
         row_delete("issue_encounter", "encounter = '" . add_escape_custom($encounterid) . "'");
         $res = sqlStatement("SELECT * FROM forms WHERE encounter = ?", array($encounterid));
@@ -332,6 +332,7 @@ if ($_POST['form_submit']) {
                 "FROM ar_activity WHERE " .
                 "pid = ? AND " .
                 "encounter = ? AND " .
+                "deleted IS NULL AND " .
                 "payer_type = 0 AND " .
                 "adj_amount = 0.00 " .
                 "GROUP BY session_id ORDER BY session_id DESC", array($patient_id, $payrow['encounter']));
@@ -351,22 +352,22 @@ if ($_POST['form_submit']) {
                 }
 
                 // Delete the payment.
-                row_delete(
-                    "ar_activity",
+                row_modify("ar_activity", "deleted = NOW()",
                     "pid = '" . add_escape_custom($patient_id) . "' AND " .
                     "encounter = '" . add_escape_custom($payrow['encounter']) . "' AND " .
+                    "deleted IS NULL AND " .
                     "payer_type = 0 AND " .
                     "pay_amount != 0.00 AND " .
                     "adj_amount = 0.00 AND " .
-                    "session_id = '" . add_escape_custom($ref_id) . "'"
-                );
+                    "session_id = '" . add_escape_custom($ref_id) . "'");
                 if ($ref_id) {
-                        row_delete(
-                            "ar_session",
-                            "patient_id = '" . add_escape_custom($patient_id) . "' AND " .
-                            "session_id = '" . add_escape_custom($ref_id) . "'"
-                        );
+                    row_delete(
+                        "ar_session",
+                        "patient_id = '" . add_escape_custom($patient_id) . "' AND " .
+                        "session_id = '" . add_escape_custom($ref_id) . "'"
+                    );
                 }
+
             } else {
                 // Encounter is 0! Seems this happens for pre-payments.
                 $tpmt = sprintf("%01.2f", $payrow['amount1'] + $payrow['amount2']);
@@ -393,11 +394,21 @@ if ($_POST['form_submit']) {
         }
 
         list($patient_id, $encounter_id) = explode(".", $billing);
-        sqlStatement("DELETE FROM ar_activity WHERE " .
-        "pid = ? AND encounter = ? ", array($patient_id, $encounter_id));
-        sqlStatement("DELETE ar_session FROM ar_session LEFT JOIN " .
-        "ar_activity ON ar_session.session_id = ar_activity.session_id " .
-        "WHERE ar_activity.session_id IS NULL");
+
+        row_modify(
+            "ar_activity",
+            "deleted = NOW()",
+            "pid = '" . add_escape_custom($patient_id) . "' AND encounter = '" .
+            add_escape_custom($encounter_id) . "' AND deleted IS NULL"
+        );
+
+        // Looks like this deletes all ar_session rows that have no matching ar_activity rows.
+        sqlStatement(
+            "DELETE ar_session FROM ar_session LEFT JOIN " .
+            "ar_activity ON ar_session.session_id = ar_activity.session_id AND ar_activity.deleted IS NULL " .
+            "WHERE ar_activity.session_id IS NULL"
+        );
+
         row_modify(
             "billing",
             "activity = 0",

--- a/interface/patient_file/front_payment.php
+++ b/interface/patient_file/front_payment.php
@@ -7,7 +7,7 @@
  * @link      http://www.open-emr.org
  * @author    Rod Roark <rod@sunsetsystems.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
- * @copyright Copyright (c) 2006-2016 Rod Roark <rod@sunsetsystems.com>
+ * @copyright Copyright (c) 2006-2020 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2017-2018 Brady Miller <brady.g.miller@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
@@ -276,7 +276,7 @@ if ($_POST['form_save']) {
 
                             $resMoneyGot = sqlStatement(
                                 "SELECT sum(pay_amount) as PatientPay FROM ar_activity where pid =? and " .
-                                "encounter =? and payer_type=0 and account_code='PCP'",
+                                "encounter = ? and payer_type = 0 and account_code = 'PCP' AND deleted IS NULL",
                                 array($form_pid, $enc)
                             );//new fees screen copay gives account_code='PCP'
                             $rowMoneyGot = sqlFetchArray($resMoneyGot);
@@ -297,7 +297,7 @@ if ($_POST['form_save']) {
                         $Fee = $RowSearch['fee'];
 
                         $resMoneyGot = sqlStatement(
-                            "SELECT sum(pay_amount) as MoneyGot FROM ar_activity where pid =? " .
+                            "SELECT sum(pay_amount) as MoneyGot FROM ar_activity where pid = ? AND deleted IS NULL " .
                             "and code_type=? and code=? and modifier=? and encounter =? and !(payer_type=0 and account_code='PCP')",
                             array($form_pid, $Codetype, $Code, $Modifier, $enc)
                         );
@@ -307,7 +307,7 @@ if ($_POST['form_save']) {
 
                         $resMoneyAdjusted = sqlStatement(
                             "SELECT sum(adj_amount) as MoneyAdjusted FROM ar_activity where " .
-                            "pid =? and code_type=? and code=? and modifier=? and encounter =?",
+                            "pid = ? and code_type = ? and code = ? and modifier = ? and encounter = ? AND deleted IS NULL",
                             array($form_pid, $Codetype, $Code, $Modifier, $enc)
                         );
                         $rowMoneyAdjusted = sqlFetchArray($resMoneyAdjusted);
@@ -1169,7 +1169,7 @@ function make_insurance() {
                                     $drow = sqlQuery(
                                         "SELECT  SUM(pay_amount) AS payments, " .
                                         "SUM(adj_amount) AS adjustments  FROM ar_activity WHERE " .
-                                        "pid = ? and encounter = ? and " .
+                                        "deleted IS NULL AND pid = ? and encounter = ? and " .
                                         "payer_type != 0 and account_code!='PCP' ",
                                         array($pid, $enc)
                                     );
@@ -1180,7 +1180,7 @@ function make_insurance() {
                                     $drow = sqlQuery(
                                         "SELECT  SUM(pay_amount) AS payments, " .
                                         "SUM(adj_amount) AS adjustments  FROM ar_activity WHERE " .
-                                        "pid = ? and encounter = ? and " .
+                                        "deleted IS NULL AND pid = ? and encounter = ? and " .
                                         "payer_type = 0 and account_code!='PCP' ",
                                         array($pid, $enc)
                                     );
@@ -1201,7 +1201,7 @@ function make_insurance() {
                                             "pid = ? and encounter = ? ", array($pid, $enc));
                                         $drow = sqlQuery("SELECT SUM(pay_amount) AS payments, " .
                                             "SUM(adj_amount) AS adjustments FROM ar_activity WHERE " .
-                                            "pid = ? and encounter = ? ", array($pid, $enc));
+                                            "deleted IS NULL AND pid = ? and encounter = ? ", array($pid, $enc));
                                         $duept = $brow['amount'] + $srow['amount'] - $drow['payments'] - $drow['adjustments'];
                                     }
 

--- a/interface/patient_file/pos_checkout.php
+++ b/interface/patient_file/pos_checkout.php
@@ -40,7 +40,7 @@
  * @author    Ranganath Pathak <pathak@scrs1.org>
  * @author    Jerry Padgett <sjpadgett@gmail.com>
  * @author    Stephen Waite <stephen.waite@cmsvt.com>
- * @copyright Copyright (c) 2006-2017 Rod Roark <rod@sunsetsystems.com>
+ * @copyright Copyright (c) 2006-2020 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2017-2019 Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2018 Ranganath Pathak <pathak@scrs1.org>
  * @copyright Copyright (c) 2019 Jerry Padgett <sjpadgett@gmail.com>
@@ -66,6 +66,9 @@ $currdecimals = $GLOBALS['currency_decimals'];
 $details = empty($_GET['details']) ? 0 : 1;
 
 $patient_id = empty($_GET['ptid']) ? $pid : 0 + $_GET['ptid'];
+
+// This will be used for SQL timestamps that we write.
+$this_bill_date = date('Y-m-d H:i:s');
 
 // Get the patient's name and chart number.
 $patdata = getPatientData($patient_id, 'fname,mname,lname,pubpid,street,city,state,postal_code');
@@ -292,7 +295,7 @@ function generate_receipt($patient_id, $encounter = 0)
                               "s.payer_id, s.reference, s.check_date, s.deposit_date " .
                               "FROM ar_activity AS a " .
                               "LEFT JOIN ar_session AS s ON s.session_id = a.session_id WHERE " .
-                              "a.pid = ? AND a.encounter = ? AND " .
+                              "a.pid = ? AND a.encounter = ? AND a.deleted IS NULL AND " .
                               "a.adj_amount != 0 " .
                               "ORDER BY s.check_date, a.sequence_no", array($patient_id,$encounter));
                         while ($inrow = sqlFetchArray($inres)) {
@@ -335,7 +338,7 @@ function generate_receipt($patient_id, $encounter = 0)
                         "s.payer_id, s.reference, s.check_date, s.deposit_date " .
                         "FROM ar_activity AS a " .
                         "LEFT JOIN ar_session AS s ON s.session_id = a.session_id WHERE " .
-                        "a.pid = ? AND a.encounter = ? AND " .
+                        "a.pid = ? AND a.encounter = ? AND a.deleted IS NULL AND " .
                         "a.pay_amount != 0 " .
                         "ORDER BY s.check_date, a.sequence_no", array($patient_id,$encounter));
                         while ($inrow = sqlFetchArray($inres)) {
@@ -507,7 +510,7 @@ function generate_receipt($patient_id, $encounter = 0)
         $form_encounter = $_POST['form_encounter'];
 
       // Get the posting date from the form as yyyy-mm-dd.
-        $dosdate = date("Y-m-d");
+        $dosdate = substr($this_bill_date, 0, 10);
         if (preg_match("/(\d\d\d\d)\D*(\d\d)\D*(\d\d)/", $_POST['form_date'], $matches)) {
             $dosdate = $matches[1] . '-' . $matches[2] . '-' . $matches[3];
         }
@@ -577,8 +580,8 @@ function generate_receipt($patient_id, $encounter = 0)
                 // table entry and so we do not call updateClaim().  Note we should not
                 // eliminate billed and bill_date from the billing table!
                 $query = "UPDATE billing SET fee = ?, billed = 1, " .
-                "bill_date = NOW() WHERE id = ?";
-                sqlQuery($query, array($amount,$id));
+                "bill_date = ? WHERE id = ?";
+                sqlQuery($query, array($amount, $this_bill_date, $id));
             }
         }
 
@@ -590,7 +593,6 @@ function generate_receipt($patient_id, $encounter = 0)
                 $amount  = sprintf('%01.2f', trim($_POST['form_discount']) * $form_amount / 100);
             }
             $memo = xl('Discount');
-            $time = date('Y-m-d H:i:s');
             sqlBeginTrans();
             $sequence_no = sqlQuery("SELECT IFNULL(MAX(sequence_no),0) + 1 AS increment FROM ar_activity WHERE pid = ? AND encounter = ?", array($form_pid, $form_encounter));
             $query = "INSERT INTO ar_activity ( " .
@@ -609,7 +611,10 @@ function generate_receipt($patient_id, $encounter = 0)
             "?, " .
             "? " .
             ")";
-            sqlStatement($query, array($form_pid,$form_encounter,$sequence_no['increment'],$_SESSION['authUserID'],$time,$memo,$amount));
+            sqlStatement(
+                $query,
+                array($form_pid, $form_encounter, $sequence_no['increment'], $_SESSION['authUserID'], $this_bill_date, $memo, $amount)
+            );
             sqlCommitTrans();
         }
 
@@ -645,7 +650,7 @@ function generate_receipt($patient_id, $encounter = 0)
               $insrt_id = sqlInsert(
                   "INSERT INTO ar_activity (pid,encounter,sequence_no,code_type,code,modifier,payer_type,post_time,post_user,session_id,pay_amount,account_code)" .
                   " VALUES (?,?,?,?,?,?,0,?,?,?,?,'PCP')",
-                  array($form_pid,$form_encounter,$sequence_no['increment'],$Codetype,$Code,$Modifier,$dosdate,$_SESSION['authUserID'],$session_id,$amount)
+                  array($form_pid,$form_encounter,$sequence_no['increment'],$Codetype,$Code,$Modifier,$this_bill_date,$_SESSION['authUserID'],$session_id,$amount)
               );
               sqlCommitTrans();
         }

--- a/interface/reports/collections_report.php
+++ b/interface/reports/collections_report.php
@@ -13,7 +13,7 @@
  * @author    Brady Miller <brady.g.miller@gmail.com>
  * @author    Stephen Waite <stephen.waite@cmsvt.com>
  * @author    Sherwin Gaddis <sherwingaddis@gmail.com>
- * @copyright Copyright (c) 2006-2016 Rod Roark <rod@sunsetsystems.com>
+ * @copyright Copyright (c) 2006-2020 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2015 Terry Hill <terry@lillysystems.com>
  * @copyright Copyright (c) 2017-2018 Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2019 Stephen Waite <stephen.waite@cmsvt.com>
@@ -716,9 +716,9 @@ if ($_POST['form_refresh'] || $_POST['form_export'] || $_POST['form_csvexport'])
       "( SELECT SUM(s.fee) FROM drug_sales AS s WHERE " .
       "s.pid = f.pid AND s.encounter = f.encounter ) AS sales, " .
       "( SELECT SUM(a.pay_amount) FROM ar_activity AS a WHERE " .
-      "a.pid = f.pid AND a.encounter = f.encounter ) AS payments, " .
+      "a.pid = f.pid AND a.encounter = f.encounter AND a.deleted IS NULL) AS payments, " .
       "( SELECT SUM(a.adj_amount) FROM ar_activity AS a WHERE " .
-      "a.pid = f.pid AND a.encounter = f.encounter ) AS adjustments " .
+      "a.pid = f.pid AND a.encounter = f.encounter AND a.deleted IS NULL) AS adjustments " .
       "FROM form_encounter AS f " .
       "JOIN patient_data AS p ON p.pid = f.pid " .
       "LEFT OUTER JOIN users AS u ON u.id = p.ref_providerID " .

--- a/interface/reports/pat_ledger.php
+++ b/interface/reports/pat_ledger.php
@@ -59,7 +59,7 @@ function GetAllUnapplied($pat = '', $from_dt = '', $to_dt = '')
     $sql = "SELECT ar_session.*, ins.name, " .
       "pat.lname, pat.fname, pat.mname, " .
       "(SELECT SUM(ar_activity.pay_amount) FROM ar_activity WHERE " .
-      "ar_activity.session_id = ar_session.session_id) AS applied " .
+      "ar_activity.session_id = ar_session.session_id AND ar_activity.deleted IS NULL) AS applied " .
       "FROM ar_session " .
       "LEFT JOIN insurance_companies AS ins on ar_session.payer_id = ins.id " .
       "LEFT JOIN patient_data AS pat on ar_session.patient_id = pat.pid " .
@@ -129,7 +129,7 @@ function GetAllCredits($enc = '', $pat = '')
     $sql = "SELECT activity.*, session.*, ins.name FROM ar_activity AS " .
     "activity LEFT JOIN ar_session AS session USING (session_id) " .
     "LEFT JOIN insurance_companies AS ins ON session.payer_id = " .
-    "ins.id WHERE encounter=? AND pid=? " .
+    "ins.id WHERE encounter = ? AND pid = ? AND activity.deleted IS NULL" .
     "ORDER BY sequence_no";
     $result = sqlStatement($sql, array($enc, $pat));
     $iter = 0;

--- a/interface/reports/receipts_by_method_report.php
+++ b/interface/reports/receipts_by_method_report.php
@@ -15,7 +15,7 @@
  * @author    Rod Roark <rod@sunsetsystems.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
  * @author    Stephen Waite <stephen.waite@cmsvt.com>
- * @copyright Copyright (c) 2006-2016 Rod Roark <rod@sunsetsystems.com>
+ * @copyright Copyright (c) 2006-2020 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2017-2018 Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2019 Stephen Waite <stephen.waite@cmsvt.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
@@ -528,7 +528,7 @@ if ($_POST['form_refresh']) {
           "JOIN forms AS f ON f.pid = a.pid AND f.encounter = a.encounter AND f.formdir = 'newpatient' " .
           "LEFT JOIN ar_session AS s ON s.session_id = a.session_id " .
           "LEFT JOIN insurance_companies AS i ON i.id = s.payer_id " .
-          "WHERE ( a.pay_amount != 0 OR a.adj_amount != 0 )";
+          "WHERE a.deleted IS NULL AND (a.pay_amount != 0 OR a.adj_amount != 0)";
         //
         if ($form_use_edate) {
             $query .= " AND fe.date >= ? AND fe.date <= ?";

--- a/interface/reports/svc_code_financial_report.php
+++ b/interface/reports/svc_code_financial_report.php
@@ -14,7 +14,7 @@
  * @author    Rod Roark <rod@sunsetsystems.com>
  * @author    Visolve
  * @author    Brady Miller <brady.g.miller@gmail.com>
- * @copyright Copyright (C) 2006-2016 Rod Roark <rod@sunsetsystems.com>
+ * @copyright Copyright (C) 2006-2020 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2017-2018 Brady Miller <brady.g.miller@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
@@ -217,7 +217,8 @@ if ($_POST['form_refresh'] || $_POST['form_csvexport']) {
     "c.financial_reporting " .
     "FROM form_encounter as fe " .
     "JOIN billing as b on b.pid=fe.pid and b.encounter=fe.encounter " .
-    "JOIN (select pid,encounter,code,sum(pay_amount) as paid,sum(adj_amount) as adjust from ar_activity group by pid,encounter,code) as ar_act " .
+    "JOIN (select pid, encounter, code, sum(pay_amount) as paid, sum(adj_amount) as adjust " .
+    "from ar_activity WHERE deleted IS NULL group by pid, encounter, code) as ar_act " .
     "ON ar_act.pid=b.pid and ar_act.encounter=b.encounter and ar_act.code=b.code " .
     "LEFT OUTER JOIN codes AS c ON c.code = b.code " .
     "INNER JOIN code_types AS ct ON ct.ct_key = b.code_type AND ct.ct_fee = '1' " .

--- a/library/daysheet.inc.php
+++ b/library/daysheet.inc.php
@@ -188,7 +188,7 @@ function getBillsBetweendayReport(
     "ar_activity.session_id AS sesid, ar_activity.account_code AS paytype, ar_activity.post_user AS user, ar_activity.memo AS reason," .
     "ar_activity.adj_amount AS pat_adjust_dollar, providerid as 'provider_id' " .
     "FROM ar_activity LEFT OUTER JOIN patient_data ON patient_data.pid = ar_activity.pid " .
-    "where 1=1 $query_part_day AND payer_type=0 ORDER BY fulname ASC, date ASC, pid");
+    "WHERE ar_activity.deleted IS NULL $query_part_day AND payer_type = 0 ORDER BY fulname ASC, date ASC, pid");
 
     for ($iter; $row = sqlFetchArray($query); $iter++) {
         $all[$iter] = $row;
@@ -199,7 +199,7 @@ function getBillsBetweendayReport(
     "ar_activity.session_id AS sesid, ar_activity.account_code AS paytype, ar_activity.post_user AS user, ar_activity.memo AS reason," .
     "ar_activity.adj_amount AS ins_adjust_dollar, providerid as 'provider_id' " .
     "FROM ar_activity LEFT OUTER JOIN patient_data ON patient_data.pid = ar_activity.pid " .
-    "where 1=1 $query_part_day AND payer_type!=0 ORDER BY  fulname ASC, date ASC, pid");
+    "WHERE ar_activity.deleted IS NULL $query_part_day AND payer_type != 0 ORDER BY fulname ASC, date ASC, pid");
 
     for ($iter; $row = sqlFetchArray($query); $iter++) {
         $all[$iter] = $row;

--- a/library/patient.inc
+++ b/library/patient.inc
@@ -1721,7 +1721,7 @@ function get_patient_balance($pid, $with_insurance = false, $eid = false)
             $drow = sqlQuery(
                 "SELECT SUM(pay_amount) AS payments " .
                 "FROM ar_activity WHERE " .
-                "pid = ? AND encounter = ? AND payer_type = 0",
+                "deleted IS NULL AND pid = ? AND encounter = ? AND payer_type = 0",
                 array($pid, $encounter)
             );
             $copay = !empty($insarr[0]['copay']) ? $insarr[0]['copay'] * 1 : 0;
@@ -1738,7 +1738,7 @@ function get_patient_balance($pid, $with_insurance = false, $eid = false)
             "activity = 1", array($pid, $encounter));
             $drow = sqlQuery("SELECT SUM(pay_amount) AS payments, " .
               "SUM(adj_amount) AS adjustments FROM ar_activity WHERE " .
-              "pid = ? AND encounter = ?", array($pid, $encounter));
+              "deleted IS NULL AND pid = ? AND encounter = ?", array($pid, $encounter));
             $srow = sqlQuery("SELECT SUM(fee) AS amount FROM drug_sales WHERE " .
               "pid = ? AND encounter = ?", array($pid, $encounter));
             $balance += $brow['amount'] + $srow['amount']

--- a/library/payment.inc.php
+++ b/library/payment.inc.php
@@ -268,7 +268,8 @@ function row_delete($table, $where)
 // Deactivate rows, with logging, for the specified table using the
 // specified SET and WHERE clauses.  Borrowed from deleter.php.
 //
-function row_modify($table, $set, $where) {
+function row_modify($table, $set, $where)
+{
     if (sqlQuery("SELECT * FROM " . escape_table_name($table) . " WHERE $where")) {
         EventAuditLogger::instance()->newEvent(
             "deactivate",

--- a/library/payment.inc.php
+++ b/library/payment.inc.php
@@ -6,8 +6,10 @@
  * @author Eldho Chacko <eldho@zhservices.com>
  * @author Paul Simon K <paul@zhservices.com>
  * @author Stephen Waite <stephen.waite@cmsvt.com>
+ * @author Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2010 Z&H Consultancy Services Private Limited <sam@zhservices.com>
  * @copyright Copyright (c) 2018 Stephen Waite <stephen.waite@cmsvt.com>
+ * @copyright Copyright (c) 2020 Rod Roark <rod@sunsetsystems.com>
  * @link https://www.open-emr.org
  * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
@@ -262,4 +264,22 @@ function row_delete($table, $where)
         sqlStatement($query);
     }
 }
+
+// Deactivate rows, with logging, for the specified table using the
+// specified SET and WHERE clauses.  Borrowed from deleter.php.
+//
+function row_modify($table, $set, $where) {
+    if (sqlQuery("SELECT * FROM " . escape_table_name($table) . " WHERE $where")) {
+        EventAuditLogger::instance()->newEvent(
+            "deactivate",
+            $_SESSION['authUser'],
+            $_SESSION['authProvider'],
+            1,
+            "$table: $where"
+        );
+        $query = "UPDATE $table SET $set WHERE $where";
+        sqlStatement($query);
+    }
+}
+
 //===============================================================================

--- a/portal/report/pat_ledger.php
+++ b/portal/report/pat_ledger.php
@@ -44,7 +44,7 @@ function GetAllUnapplied($pat = '', $from_dt = '', $to_dt = '')
     $sql = "SELECT ar_session.*, ins.name, " .
       "pat.lname, pat.fname, pat.mname, " .
       "(SELECT SUM(ar_activity.pay_amount) FROM ar_activity WHERE " .
-      "ar_activity.session_id = ar_session.session_id) AS applied " .
+      "ar_activity.deleted IS NULL AND ar_activity.session_id = ar_session.session_id) AS applied " .
       "FROM ar_session " .
       "LEFT JOIN insurance_companies AS ins on ar_session.payer_id = ins.id " .
       "LEFT JOIN patient_data AS pat on ar_session.patient_id = pat.pid " .
@@ -114,7 +114,7 @@ function GetAllCredits($enc = '', $pat = '')
     $sql = "SELECT activity.*, session.*, ins.name FROM ar_activity AS " .
     "activity LEFT JOIN ar_session AS session USING (session_id) " .
     "LEFT JOIN insurance_companies AS ins ON session.payer_id = " .
-    "ins.id WHERE encounter=? AND pid=? " .
+    "ins.id WHERE deleted IS NULL AND encounter = ? AND pid = ? " .
     "ORDER BY sequence_no";
     $result = sqlStatement($sql, array($enc, $pat));
     $iter = 0;

--- a/sql/5_0_2-to-6_0_0_upgrade.sql
+++ b/sql/5_0_2-to-6_0_0_upgrade.sql
@@ -1962,3 +1962,6 @@ ALTER TABLE `immunizations` ADD `uuid` binary(16) DEFAULT NULL;
 CREATE UNIQUE INDEX `uuid` ON `immunizations` (`uuid`);
 #EndIf
 
+#IfMissingColumn ar_activity deleted
+ALTER TABLE `ar_activity` ADD COLUMN `deleted` datetime DEFAULT NULL COMMENT 'NULL if active, otherwise when voided';
+#EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -8559,6 +8559,7 @@ CREATE TABLE ar_activity (
   follow_up_note text,
   account_code varchar(15) NOT NULL,
   reason_code varchar(255) DEFAULT NULL COMMENT 'Use as needed to show the primary payer adjustment reason code',
+  deleted        datetime DEFAULT NULL COMMENT 'NULL if active, otherwise when voided',
   PRIMARY KEY (pid, encounter, sequence_no),
   KEY session_id (session_id)
 ) ENGINE=InnoDB;

--- a/src/Billing/BillingReport.php
+++ b/src/Billing/BillingReport.php
@@ -9,9 +9,11 @@
  * @author    Paul Simon K <paul@zhservices.com>
  * @author    Stephen Waite <stephen.waite@cmsvt.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2010 Z&H Consultancy Services Private Limited <sam@zhservices.com>
  * @copyright Copyright (c) 2018-2019 Stephen Waite <stephen.waite@cmsvt.com>
  * @copyright Copyright (c) 2019 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2020 Rod Roark <rod@sunsetsystems.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -133,7 +135,7 @@ class BillingReport
         }
 
         $query = sqlStatement("SELECT pid, 'COPAY' AS code_type, pay_amount AS code, date(post_time) AS date " .
-            "FROM ar_activity where 1=1 $query_part2 and payer_type=0 and account_code='PCP'");
+            "FROM ar_activity where deleted IS NULL $query_part2 and payer_type=0 and account_code='PCP'");
         //new fees screen copay gives account_code='PCP' openemr payment screen copay gives code='CO-PAY'
         for ($iter; $row = sqlFetchArray($query); $iter++) {
             $all[$iter] = $row;

--- a/src/Billing/BillingUtilities.php
+++ b/src/Billing/BillingUtilities.php
@@ -6,7 +6,7 @@
  * @package OpenEMR
  * @author Rod Roark <rod@sunsetsystems.com>
  * @author Stephen Waite <stephen.waite@cmsvt.com>
- * @copyright Copyright (c) 2011-2019 Rod Roark <rod@sunsetsystems.com>
+ * @copyright Copyright (c) 2011-2020 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2019 Stephen Waite <stephen.waite@cmsvt.com>
  * @link https://www.open-emr.org
  * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
@@ -1685,7 +1685,7 @@ class BillingUtilities
     {
         $resMoneyGot = sqlStatement(
             "SELECT sum(pay_amount) as PatientPay FROM ar_activity where " .
-            "pid = ? and encounter = ? and payer_type=0 and account_code='PCP'",
+            "deleted IS NULL AND pid = ? AND encounter = ? AND payer_type = 0 AND account_code = 'PCP'",
             array($patient_id, $encounter)
         );
         //new fees screen copay gives account_code='PCP'
@@ -1759,7 +1759,7 @@ class BillingUtilities
             $row = sqlQuery(
                 "SELECT SUM(pay_amount) AS payments, " .
                 "SUM(adj_amount) AS adjustments FROM ar_activity WHERE " .
-                "pid = ? AND encounter = ?",
+                "deleted IS NULL AND pid = ? AND encounter = ?",
                 array($patient_id, $encounter_id)
             );
             $adjustments = empty($row['adjustments']) ? 0 : $row['adjustments'];
@@ -1773,7 +1773,7 @@ class BillingUtilities
             $row = sqlQuery(
                 "SELECT SUM(pay_amount) AS payments, " .
                 "SUM(adj_amount) AS adjustments FROM ar_activity WHERE " .
-                "pid = ? AND encounter = ? AND post_time = ?",
+                "deleted IS NULL AND pid = ? AND encounter = ? AND post_time = ?",
                 array($patient_id, $encounter_id, $date_original)
             );
             $adjustments = empty($row['adjustments']) ? 0 : $row['adjustments'];
@@ -1815,8 +1815,8 @@ class BillingUtilities
             // and re-open the visit.
             if ($date_original) {
                 sqlStatement(
-                    "DELETE FROM ar_activity WHERE " .
-                    "pid = ? AND encounter = ? AND post_time = ?",
+                    "UPDATE ar_activity SET deleted = NOW() WHERE " .
+                    "deleted IS NULL AND pid = ? AND encounter = ? AND post_time = ?",
                     array($patient_id, $encounter_id, $date_original)
                 );
                 sqlStatement(
@@ -1834,8 +1834,8 @@ class BillingUtilities
             } else {
                 if ($time == 'all') {
                     sqlStatement(
-                        "DELETE FROM ar_activity WHERE " .
-                        "pid = ? AND encounter = ?",
+                        "UPDATE ar_activity SET deleted = NOW() WHERE " .
+                        "deleted IS NULL AND pid = ? AND encounter = ?",
                         array($patient_id, $encounter_id)
                     );
                 }

--- a/src/Billing/Claim.php
+++ b/src/Billing/Claim.php
@@ -5,7 +5,7 @@
  * @package OpenEMR
  * @author Rod Roark <rod@sunsetsystems.com>
  * @author Stephen Waite <stephen.waite@cmsvt.com>
- * @copyright Copyright (c) 2009 Rod Roark <rod@sunsetsystems.com>
+ * @copyright Copyright (c) 2009-2020 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2017 Stephen Waite <stephen.waite@cmsvt.com>
  * @link https://github.com/openemr/openemr/tree/master
  * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
@@ -212,9 +212,12 @@ class Claim
             $this->procs[] = $row;
         }
 
-        $resMoneyGot = sqlStatement("SELECT pay_amount as PatientPay,session_id as id," .
-        "date(post_time) as date FROM ar_activity WHERE pid = ? AND encounter = ? AND " .
-        "payer_type=0 AND account_code='PCP'", array($this->pid, $this->encounter_id));
+        $resMoneyGot = sqlStatement(
+            "SELECT pay_amount as PatientPay, session_id as id, " .
+            "date(post_time) as date FROM ar_activity WHERE pid = ? AND encounter = ? AND " .
+            "deleted IS NULL AND payer_type = 0 AND account_code = 'PCP'",
+            array($this->pid, $this->encounter_id)
+        );
           //new fees screen copay gives account_code='PCP'
         while ($rowMoneyGot = sqlFetchArray($resMoneyGot)) {
               $PatientPay = $rowMoneyGot['PatientPay'] * -1;

--- a/src/Billing/InvoiceSummary.php
+++ b/src/Billing/InvoiceSummary.php
@@ -4,7 +4,7 @@
  * @package OpenEMR
  * @author Rod Roark <rod@sunsetsystems.com>
  * @author Stephen Waite <stephen.waite@cmsvt.com>
- * @copyright Copyright (c) 2005-2010 Rod Roark <rod@sunsetsystems.com>
+ * @copyright Copyright (c) 2005-2020 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2018-2019 Stephen Waite <stephen.waite@cmsvt.com>
  * @link https://www.open-emr.org
  * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
@@ -133,7 +133,7 @@ class InvoiceSummary
             "FROM ar_activity AS a " .
             "LEFT OUTER JOIN ar_session AS s ON s.session_id = a.session_id " .
             "LEFT OUTER JOIN insurance_companies AS i ON i.id = s.payer_id " .
-            "WHERE a.pid = ? AND a.encounter = ? " .
+            "WHERE a.deleted IS NULL AND a.pid = ? AND a.encounter = ? " .
             "ORDER BY s.check_date, a.sequence_no", array($patient_id, $encounter_id));
         while ($row = sqlFetchArray($res)) {
             $code = $row['code'];

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@ $v_realpatch = '0';
 // is a database change in the course of development.  It is used
 // internally to determine when a database upgrade is needed.
 //
-$v_database = 339;
+$v_database = 340;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
This is an infrastructure update, in preparation for reporting on deleted/voided payments and adjustments.

It adds a new column "deleted" to the ar_activity table, which when not null is the timestamp of when the entry was deleted. Thus physical deletes of these rows do not happen any more.

Also fixed a bug where voiding the last checkout from the Fee Sheet did not work.

I've done basic testing, though more eyeballs on this would be good.