### PR TITLE
using getAllServiceLocations in user_admin.php to retrieve facility list

### DIFF
--- a/interface/usergroup/user_admin.php
+++ b/interface/usergroup/user_admin.php
@@ -315,7 +315,7 @@ if ($iter["portal_user"]) {
 <td><span class=text><?php echo xlt('Last Name'); ?>: </span></td><td><input type="text" name=lname id=lname style="width:150px;"  class="form-control" value="<?php echo attr($iter["lname"]); ?>"><span class="mandatory"></span></td>
 <td><span class=text><?php echo xlt('Default Facility'); ?>: </span></td><td><select name=facility_id style="width:150px;" class="form-control">
 <?php
-$fres = $facilityService->getAllBillingLocations();
+$fres = $facilityService->getAllServiceLocations();
 if ($fres) {
     for ($iter2 = 0; $iter2 < sizeof($fres); $iter2++) {
                 $result[$iter2] = $fres[$iter2];


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #1541 

#### Short description of what this resolves:

* Lists a collection of facilities in the user "default facility" field as long as it is flagged as a "service location"


#### Changes proposed in this pull request:

- uses `getAllServiceLocations` instead of `getPrimaryBillingLocation` to load available facilities
