### PR TITLE
external dataload fix for RxNorm and necessary change for ICD10

### DIFF
--- a/interface/code_systems/standard_tables_manage.php
+++ b/interface/code_systems/standard_tables_manage.php
@@ -121,5 +121,5 @@ if ($newInstall === "1") {
     <?php
 }
 
-temp_dir_cleanup($db);
+//temp_dir_cleanup($db);
 ?>

--- a/interface/code_systems/standard_tables_manage.php
+++ b/interface/code_systems/standard_tables_manage.php
@@ -121,5 +121,5 @@ if ($newInstall === "1") {
     <?php
 }
 
-//temp_dir_cleanup($db);
+temp_dir_cleanup($db);
 ?>

--- a/library/standard_tables_capture.inc
+++ b/library/standard_tables_capture.inc
@@ -48,10 +48,7 @@ function temp_unarchive($filename, $type)
         return false;
     } else {
     // let's unzip the file
-    // use checksums to determine the "version"
-    //
         $zip = new ZipArchive();
-        error_log("filename is " . $filename);
         if ($zip->open($filename) === true) {
                 if (!($zip->extractTo($GLOBALS['temporary_files_dir'] . "/" . $type))) {
                     return false;
@@ -433,9 +430,9 @@ function icd_import($type)
     // set up paths
     $dir_icd = $GLOBALS['temporary_files_dir'] . "/" . $type . "/";
     $dir = str_replace('\\', '/', $dir_icd);
+    // since CMS nested the ICD10 codes...
     if ($type == 'ICD10') {
         $dir = $dir . "/2020 Code Descriptions/";
-        error_log("dir is $dir");
     }
     $db_load = '';
     $db_update = '';

--- a/library/standard_tables_capture.inc
+++ b/library/standard_tables_capture.inc
@@ -51,18 +51,11 @@ function temp_unarchive($filename, $type)
     // use checksums to determine the "version"
     //
         $zip = new ZipArchive();
-        if ($zip->open($filename, ZipArchive::CREATE) === true) {
-            // cms.gov added a subfolder to the archive :| filed a ticket with them 8-20-19 :)
-            for ($i = 0; $i < $zip->numFiles; $i++) {
-                $full_file_name = $zip->getNameIndex($i);
-                $fileinfo = pathinfo($full_file_name);
-                if (
-                    !copy("zip://" . $filename . "#" . $full_file_name, $GLOBALS['temporary_files_dir'] . "/" .
-                    $type . "/" . $fileinfo['basename'])
-                ) {
+        error_log("filename is " . $filename);
+        if ($zip->open($filename) === true) {
+                if (!($zip->extractTo($GLOBALS['temporary_files_dir'] . "/" . $type))) {
                     return false;
-                };
-            }
+                }
             $zip->close();
             return true;
         } else {
@@ -437,10 +430,13 @@ function snomedRF2_import()
 //
 function icd_import($type)
 {
-
     // set up paths
     $dir_icd = $GLOBALS['temporary_files_dir'] . "/" . $type . "/";
     $dir = str_replace('\\', '/', $dir_icd);
+    if ($type == 'ICD10') {
+        $dir = $dir . "/2020 Code Descriptions/";
+        error_log("dir is $dir");
+    }
     $db_load = '';
     $db_update = '';
 

--- a/library/standard_tables_capture.inc
+++ b/library/standard_tables_capture.inc
@@ -50,9 +50,9 @@ function temp_unarchive($filename, $type)
     // let's unzip the file
         $zip = new ZipArchive();
         if ($zip->open($filename) === true) {
-                if (!($zip->extractTo($GLOBALS['temporary_files_dir'] . "/" . $type))) {
-                    return false;
-                }
+            if (!($zip->extractTo($GLOBALS['temporary_files_dir'] . "/" . $type))) {
+                return false;
+            }
             $zip->close();
             return true;
         } else {


### PR DESCRIPTION

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
no issue, see https://community.open-emr.org/t/does-rxnorm-work/14854/2

#### Changes proposed in this pull request:

revert unarchive to restore `RxNorm` load and add kludge for `icd10`, maybe this needs more work to determine the nested folder like when it switches to 2021 in a few months :)