### PR TITLE
fixed .interval span select width

### DIFF
--- a/interface/super/rules/www/css/rules.css
+++ b/interface/super/rules/www/css/rules.css
@@ -102,10 +102,6 @@ root {
   display: block;
 }
 
-.rule_detail p {
-  margin-bottom: -10px;
-}
-
 .action_link {
   font-size: small;
 }
@@ -156,4 +152,8 @@ root {
 
 input[type='text'].short {
   width: 80px;
+}
+
+.intervals span select {
+  width: inherit;
 }


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #3728 

#### Short description of what this resolves:

Fixes the rule config row so it won't break the line width.

#### Changes proposed in this pull request:

- removes negative margin of `.rule_detail p` in `rules.css`
- sets the `width` of `.intervals span select` to `inherit`

**Google Chrome:**
![Screenshot from 2020-07-16 16-01-56](https://user-images.githubusercontent.com/2183506/87711539-c3eab600-c77d-11ea-9c41-0987e98fbc2e.png)

**Mozilla Firefox:**
![Screenshot from 2020-07-16 16-04-28](https://user-images.githubusercontent.com/2183506/87711830-3491d280-c77e-11ea-9c58-1073a3db38bb.png)


