### PR TITLE
Improve code selection usability in Add/Edit Issue dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ ccdaservice/node_modules
 /.idea/*
 /nbproject/*
 .DS_Store
+.buildpath
+.project
+.settings
 
 # testing
 .phpunit.result.cache

--- a/interface/patient_file/encounter/select_codes.php
+++ b/interface/patient_file/encounter/select_codes.php
@@ -1,0 +1,183 @@
+<?php
+
+/**
+ * Code selectoor.
+ * For DataTables documentation see: http://legacy.datatables.net/
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Thomas Pantelis <tompantelis@gmail.com>
+ * @copyright Copyright (c) 2020 Thomas Pantelis <tompantelis@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+require_once('../../globals.php');
+require_once($GLOBALS['srcdir'] . '/patient.inc');
+require_once($GLOBALS['srcdir'] . '/csv_like_join.php');
+require_once($GLOBALS['fileroot'] . '/custom/code_types.inc.php');
+
+use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Core\Header;
+
+$codetype = empty($_GET['codetype']) ? '' : $_GET['codetype'];
+if (! empty($codetype)) {
+    $allowed_codes = split_csv_line($codetype);
+}
+
+?>
+<!DOCTYPE html>
+<html>
+<head>
+<title><?php echo xlt('Select Codes'); ?></title>
+
+<?php Header::setupHeader(['opener', 'datatables', 'datatables-bs', 'datatables-colreorder']); ?>
+
+<script>
+
+var oTable;
+
+// Keeps track of which items have been selected during this session.
+var oSelectedIDs = {};
+
+$(function () {
+    // Initializing the DataTable.
+    oTable = $('#my_data_table').dataTable({
+        "bProcessing": true,
+
+        // Next 2 lines invoke server side processing
+        "bServerSide": true,
+        "sAjaxSource": "find_code_dynamic_ajax.php?csrf_token_form=" + <?php echo js_url(CsrfUtils::collectCsrfToken()); ?>,
+
+        // Vertical length options and their default
+        "aLengthMenu": [ 15, 25, 50, 100 ],
+        "iDisplayLength": 15,
+
+        // Specify a width for the first column.
+        "aoColumns": [{"sWidth":"10%"}, null],
+
+        // This callback function passes some form data on each call to the ajax handler.
+        "fnServerParams": function (aoData) {
+            aoData.push({"name": "what", "value": <?php echo js_escape('codes'); ?>});
+            aoData.push({"name": "codetype", "value": document.forms[0].form_code_type.value});
+            aoData.push({"name": "inactive", "value": (document.forms[0].form_include_inactive.checked ? 1 : 0)});
+        },
+
+        // Drawing a row, apply styling if it is previously selected.
+        "fnCreatedRow": function (nRow, aData, iDataIndex) {
+            showRowSelection(nRow)
+        },
+
+        // Language strings are included so we can translate them
+        "oLanguage": {
+            "sSearch"       : <?php echo xlj('Search for'); ?> + ":",
+            "sLengthMenu"   : <?php echo xlj('Show'); ?> + " _MENU_ " + <?php echo xlj('entries'); ?>,
+            "sZeroRecords"  : <?php echo xlj('No matching records found'); ?>,
+            "sInfo"         : <?php echo xlj('Showing'); ?> + " _START_ " + <?php echo xlj('to{{range}}'); ?> + " _END_ " + <?php echo xlj('of'); ?> + " _TOTAL_ " + <?php echo xlj('entries'); ?>,
+            "sInfoEmpty"    : <?php echo xlj('Nothing to show'); ?>,
+            "sInfoFiltered" : "(" + <?php echo xlj('filtered from'); ?> + " _MAX_ " + <?php echo xlj('total entries'); ?> + ")",
+            "oPaginate"     : {
+                "sFirst"        : <?php echo xlj('First'); ?>,
+                    "sPrevious" : <?php echo xlj('Previous'); ?>,
+                    "sNext"    : <?php echo xlj('Next'); ?>,
+                    "sLast"    : <?php echo xlj('Last'); ?>
+            }
+        }
+    });
+
+    // OnClick handler for the rows
+    oTable.on('click', 'tbody tr', function () {
+        oSelectedIDs[this.id] = oSelectedIDs[this.id] ? 0 : 1;
+        showRowSelection(this)
+     });
+});
+
+function showRowSelection(row) {
+    row.style.fontWeight = oSelectedIDs[row.id] ? 'bold' : 'normal';
+    //row.style.backgroundColor = "lightblue"
+}
+
+function onOK() {
+    if (opener.closed || ! opener.OnCodeSelected) {
+        alert(<?php echo xlj('The destination form was closed.'); ?>);
+    }
+    else {
+        var ids = Object.keys(oSelectedIDs)
+        for (i = 0; i < ids.length; i++) {
+            if (!oSelectedIDs[ids[i]]) {
+                continue
+            }
+
+            // Row ids are of the form "CID|jsonstring".
+            var jobj = JSON.parse(ids[i].substring(4));
+            var code = jobj['code'].split('|');
+            var msg = opener.OnCodeSelected(jobj['codetype'], code[0], code[1], jobj['description']);
+            if (msg) {
+                alert(msg);
+            }
+        }
+
+        dlgclose()
+        return false;
+    }
+}
+
+</script>
+
+</head>
+
+<body id="codes_search">
+    <div class="container-fluid">
+        <form method='post' name='theform'>
+        <?php
+        echo "<div class='form-group row mb-3'>\n";
+        if (isset($allowed_codes)) {
+            if (count($allowed_codes) == 1) {
+                echo "<div class='col'><input type='text' name='form_code_type' value='" . attr($codetype) . "' size='5' readonly /></div>\n";
+            } else {
+                echo "<div class='col'><select name='form_code_type' onchange='oTable.fnDraw()'>\n";
+                foreach ($allowed_codes as $code) {
+                    echo " <option value='" . attr($code) . "'>" . xlt($code_types[$code]['label']) . "</option>\n";
+                }
+                echo "</select></div>\n";
+            }
+        } else {
+            echo "<div class='col'><select class='form-control' name='form_code_type' onchange='oTable.fnDraw()'>\n";
+            foreach ($code_types as $key => $value) {
+                echo " <option value='" . attr($key) . "'";
+                echo ">" . xlt($value['label']) . "</option>\n";
+            }
+            echo " <option value='PROD'";
+            echo ">" . xlt("Product") . "</option>\n";
+            echo "   </select></div>\n";
+        }
+        echo "\n";
+        echo "<div class='col'>";
+        echo "<input type='checkbox' name='form_include_inactive' value='1' onclick='oTable.fnDraw()' />" . xlt('Include Inactive') . "\n";
+        echo "\n";
+        echo "<button class='btn btn-secondary btn-sm btn-save' value='" . xla('OK') . "' onclick='onOK()'>" . xla('Ok') . "</button>\n";
+        echo "\n";
+        echo "<button class='btn btn-secondary btn-sm btn-cancel' value='" . xla('Cancel') . "' onclick='dlgclose()'>" . xla('Cancel') . "</button>\n";
+        echo "</div>";
+
+        echo "</div>\n";
+        ?>
+
+          <!-- Exception here: Do not use table-responsive as it breaks datatables !-->
+          <table id="my_data_table" class="table table-sm">
+              <thead>
+                  <tr>
+                      <th><?php echo xlt('Code'); ?></th>
+                      <th><?php echo xlt('Description'); ?></th>
+                  </tr>
+              </thead>
+              <tbody>
+                  <tr>
+                      <!-- Class "dataTables_empty" is defined in jquery.dataTables.css -->
+                      <td colspan="2" class="dataTables_empty">...</td>
+                  </tr>
+              </tbody>
+          </table>
+        </form>
+    </div>
+</body>
+</html>

--- a/interface/patient_file/summary/add_edit_issue.php
+++ b/interface/patient_file/summary/add_edit_issue.php
@@ -7,8 +7,10 @@
  * @link      http://www.open-emr.org
  * @author    Rod Roark <rod@sunsetsystems.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Thomas Pantelis <tompantelis@gmail.com>
  * @copyright Copyright (c) 2005-2016 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2017-2018 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2020 Thomas Pantelis <tompantelis@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -175,9 +177,9 @@ function ActiveIssueCodeRecycleFn($thispid2, $ISSUE_TYPES2)
         echo "listBoxOptionSets[" . attr($akey) . "] = new Array();\n";
 
         if ($displayCodeSet) {
-            foreach ($displayCodeSet as $dispCode2) {
-                $codeDesc2 = lookup_code_descriptions($dispCode2);
-                echo "listBoxOptionSets[" . attr($akey) . "][listBoxOptionSets[" . attr($akey) . "].length] = new Option(" . js_escape($dispCode2 . " (" . trim($codeDesc2) . ") ") . ", " . js_escape($dispCode2) . ", false, false);\n";
+            foreach ($displayCodeSet as $code) {
+                $text = getCodeText($code);
+                echo "listBoxOptionSets[" . attr($akey) . "][listBoxOptionSets[" . attr($akey) . "].length] = new Option(" . js_escape($text) . ", " . js_escape($code) . ", false, false);\n";
             }
         }
     }
@@ -365,6 +367,26 @@ if (!empty($irow['type'])) {
         ++$type_index;
     }
 }
+
+$code_texts = array();
+
+function getCodeText($code)
+{
+    global $code_texts;
+    if (array_key_exists($code, $code_texts)) {
+        return $code_texts[$code];
+    }
+
+    $codedesc = lookup_code_descriptions($code);
+    $text = $code;
+    if ($codedesc) {
+        $text .= " (" . $codedesc . ")";
+    }
+
+    $code_texts[$code] = $text;
+    return $text;
+}
+
 ?>
 <html>
 
@@ -388,6 +410,7 @@ if (!empty($irow['type'])) {
     <script>
         var aitypes = new Array(); // issue type attributes
         var aopts = new Array(); // Option objects
+        var codeTexts = new Map()
         <?php
         $i = 0;
         foreach ($ISSUE_TYPES as $key => $value) {
@@ -395,9 +418,15 @@ if (!empty($irow['type'])) {
             echo " aopts[" . attr($i) . "] = new Array();\n";
             $qry = sqlStatement("SELECT * FROM list_options WHERE list_id = ? AND activity = 1", array($key . "_issue_list"));
             while ($res = sqlFetchArray($qry)) {
-                echo " aopts[" . attr($i) . "][aopts[" . attr($i) . "].length] = new Option(" . js_escape(xl_list_label(trim($res['title']))) . ", " . js_escape(trim($res['option_id'])) . ", false, false);\n";
+                echo " opt = new Option(" . js_escape(xl_list_label(trim($res['title']))) . ", " . js_escape(trim($res['option_id'])) . ", false, false);\n";
+                echo " aopts[" . attr($i) . "][aopts[" . attr($i) . "].length] = opt\n";
                 if ($res['codes']) {
-                    echo " aopts[" . attr($i) . "][aopts[" . attr($i) . "].length-1].setAttribute('data-code'," . js_escape(trim($res['codes'])) . ");\n";
+                    $codes = explode(";", $res['codes']);
+                    foreach ($codes as $code) {
+                        $text = getCodeText($code);
+                        echo " codeTexts.set(" . js_escape($code) . ", " . js_escape($text) . ");\n";
+                    }
+                    echo " opt.setAttribute('codes'," . js_escape(trim($res['codes'])) . ");\n";
                 }
             }
 
@@ -412,14 +441,11 @@ if (!empty($irow['type'])) {
         <?php require $GLOBALS['srcdir'] . "/restoreSession.php"; ?>
 
         ///////////////////////////
-        function codeBoxFunction2() {
+        function onActiveCodeSelected() {
             var f = document.forms[0];
-            var x2 = f.form_codeSelect2.options[f.form_codeSelect2.selectedIndex].value;
-            f.form_codeSelect2.selectedIndex = -1;
-            var x6 = f.form_diagnosis.value;
-            if (x6.length > 0) x6 += ";";
-            x6 += x2;
-            f.form_diagnosis.value = x6;
+            var sel = f.form_active_codes.options[f.form_active_codes.selectedIndex];
+            addSelectedCode(sel.value, sel.text)
+            f.form_active_codes.selectedIndex = -1;
         }
         ///////////////////////////
         //
@@ -437,14 +463,14 @@ if (!empty($irow['type'])) {
             document.getElementById('row_titles').style.display = i ? '' : 'none';
             //
             ///////////////////////
-            var listBoxOpts2 = f.form_codeSelect2.options;
+            var listBoxOpts2 = f.form_active_codes.options;
             listBoxOpts2.length = 0;
             var ix = 0;
             for (ix = 0; ix < listBoxOptions2[index].length; ++ix) {
                 listBoxOpts2[ix] = listBoxOptions2[index][ix];
                 listBoxOpts2[ix].title = listBoxOptions2[index][ix].text;
             }
-            document.getElementById('row_codeSelect2').style.display = ix ? '' : 'none';
+            document.getElementById('row_active_codes').style.display = ix ? '' : 'none';
 
             //////////////////////
             //
@@ -465,7 +491,7 @@ if (!empty($irow['type'])) {
                 //  (which is desired functionality, since then use the end date
                 //   to inactivate the item.)
                 document.getElementById('row_active').style.display = revdisp;
-                document.getElementById('row_diagnosis').style.display = comdisp;
+                document.getElementById('row_selected_codes').style.display = comdisp;
                 document.getElementById('row_occurrence').style.display = comdisp;
                 document.getElementById('row_classification').style.display = injdisp;
                 document.getElementById('row_reinjury_id').style.display = injdisp;
@@ -494,10 +520,19 @@ if (!empty($irow['type'])) {
         // If it has a code, add that too.
         function set_text() {
             var f = document.forms[0];
-            f.form_title.value = f.form_titles.options[f.form_titles.selectedIndex].text;
-            f.form_title_id.value = f.form_titles.options[f.form_titles.selectedIndex].value;
-            f.form_diagnosis.value = f.form_titles.options[f.form_titles.selectedIndex].getAttribute('data-code');
-            f.form_titles.selectedIndex = -1;
+            var sel = f.form_titles.options[f.form_titles.selectedIndex];
+            f.form_title.value = sel.text;
+            f.form_title_id.value = sel.value;
+
+            f.form_selected_codes.options.length = 0
+
+            var str = sel.getAttribute('codes')
+            if (str) {
+                var codes = str.split(";")
+                for (i = 0; i < codes.length; i++) {
+                    addSelectedCode(codes[i], codeTexts.has(codes[i]) ? codeTexts.get(codes[i]) : codes[i])
+                }
+            }
         }
 
         // Process click on Delete link.
@@ -540,41 +575,53 @@ if (!empty($irow['type'])) {
             }
         }
 
-        // This is for callback by the find-code popup.
+        // This is for callback by the select codes popup.
         // Appends to or erases the current list of diagnoses.
-        function set_related(codetype, code, selector, codedesc) {
-            var f = document.forms[0];
-            var s = f.form_diagnosis.value;
-            var title = f.form_title.value;
-            if (code) {
-                //disabled duplicate codes
-                if (s.indexOf(codetype + ':' + code) == -1) {
-                    if (s.length > 0) s += ';';
-                    s += codetype + ':' + code;
-                }
-            } else {
-                s = '';
+        function OnCodeSelected(codetype, code, selector, codedesc) {
+            var codeKey = codetype + ':' + code
+            addSelectedCode(codeKey, codeKey + ' (' + codedesc + ')')
+
+            var f = document.forms[0]
+            if (f.form_title.value == '') {
+                f.form_title.value = codedesc;
             }
-            f.form_diagnosis.value = s;
-            if (title == '') f.form_title.value = codedesc;
         }
 
-        // This is for callback by the find-code popup.
-        // Returns the array of currently selected codes with each element in codetype:code format.
-        function get_related() {
-            return document.forms[0].form_diagnosis.value.split(';');
+        function addSelectedCode(codeKey, codeText) {
+            var f = document.forms[0]
+            var sel = f.form_selected_codes
+            for (i = 0; i < sel.options.length; i++) {
+                if (sel.options[i].value == codeKey) {
+                    return
+                }
+            }
+
+            var option = document.createElement("option");
+            option.value = codeKey
+            option.text = codeText
+            sel.add(option);
+
+            updateDiagnosisFromSelectedCodes()
         }
 
-        // This is for callback by the find-code popup.
-        // Deletes the specified codetype:code from the currently selected list.
-        function del_related(s) {
-            my_del_related(s, document.forms[0].form_diagnosis, false);
+        function updateDiagnosisFromSelectedCodes() {
+            var f = document.forms[0]
+            var diag = ''
+            options = f.form_selected_codes.options
+            if (options.length > 0) {
+                diag = options[0].value
+                for (i = 1; i < options.length; i++) {
+                    diag += ';' + options[i].value;
+                }
+            }
+
+            f.form_diagnosis.value = diag;
         }
 
         // This invokes the find-code popup.
-        function sel_diagnosis() {
+        function onAddCode() {
             <?php
-            $url = '../encounter/find_code_dynamic.php?codetype=';
+            $url = '../encounter/select_codes.php?codetype=';
             if ($irow['type'] == 'medical_problem') {
                 $url .= urlencode(collect_codetypes("medical_problem", "csv"));
             } else {
@@ -592,6 +639,23 @@ if (!empty($irow['type'])) {
             }
             ?>
             dlgopen(<?php echo js_escape($url); ?>, '_blank', 985, 800, '', <?php echo xlj("Select Codes"); ?>);
+        }
+
+        function onRemoveCode() {
+            var sel = document.forms[0].form_selected_codes
+            for (i = 0; i < sel.options.length; i++) {
+                if (sel.options[i].selected) {
+                    sel.remove(i)
+                    i--
+                }
+            }
+
+            onCodeSelectionChange()
+            updateDiagnosisFromSelectedCodes()
+        }
+
+        function onCodeSelectionChange() {
+            document.forms[0].rem_selected_code.disabled = document.forms[0].form_selected_codes.selectedIndex == -1
         }
 
         // Check for errors when the form is submitted.
@@ -724,13 +788,31 @@ if (!empty($irow['type'])) {
                             <input type='text' class="form-control" name='form_title' id='form_title' value='<?php echo attr($irow['title']) ?>'>
                             <input type='hidden' name='form_title_id' value='<?php echo attr($irow['list_option_id']) ?>'>
                         </div>
-                        <div class="form-group col-12" id='row_codeSelect2'>
-                            <label for="form_codeSelect2" class="col-form-label"><?php echo xlt('Active Issue Codes'); ?>:</label>
-                            <select name='form_codeSelect2' id='form_codeSelect2' class="form-control" multiple size='4' onchange="codeBoxFunction2()" style="width:100%;"></select>
+                        <div class="form-group col-12" id='row_active_codes'>
+                            <label for="form_active_codes" class="col-form-label"><?php echo xlt('Active Issue Codes'); ?>:</label>
+                            <select name='form_active_codes' id='form_active_codes' class= "form-control" size='4'
+                                onchange="onActiveCodeSelected()" style="width:100%;"></select>
                         </div>
-                        <div class="form-group col-12" id='row_diagnosis'>
-                            <label class="col-form-label" for="form_diagnosis"><?php echo xlt('Coding'); ?>:</label>
-                            <input type='text' class="form-control" name='form_diagnosis' id='form_diagnosis' value='<?php echo attr($irow['diagnosis']) ?>' onclick='sel_diagnosis()' title='<?php echo xla('Click to select or change coding'); ?>' readonly>
+                        <div class="form-group col-12" id='row_selected_codes'>
+                            <label for="form_selected_codes" class="col-form-label"><?php echo xlt('Coding'); ?>:</label>
+                            <select name='form_selected_codes' id='form_selected_codes' class= "form-control" multiple size='4'
+                                onchange="onCodeSelectionChange()" style="width:100%;">
+                            <?php
+                            if ($irow['diagnosis'] != "") {
+                                $codes = explode(";", $irow['diagnosis']);
+                                foreach ($codes as $code) {
+                                    echo "   <option value='" . attr($code) . "'>" . text(getCodeText($code)) . "</option>\n";
+                                }
+                            }
+                            ?>
+                            </select>
+                            <div class="btn-group" style="margin-top:3px;">
+                                <button type="button" class="btn btn-secondary btn-sm" style="margin-right:5px;" onclick='onAddCode()'><?php echo xlt('Add');?></button>
+                                <button type="button" id="rem_selected_code" class="btn btn-secondary btn-sm" onclick='onRemoveCode()'><?php echo xlt('Remove');?></button>
+                            </div>
+                            <input type='hidden' class="form-control" name='form_diagnosis' id='form_diagnosis'
+                                   value='<?php echo attr($irow['diagnosis']) ?>' onclick='onAddCode()'
+                                   title='<?php echo xla('Click to select or change coding'); ?>' readonly >
                         </div>
                         <div class="form-group col-12">
                             <label class="col-form-label" for="form_begin"><?php echo xlt('Begin Date'); ?>:</label>
@@ -871,6 +953,8 @@ if (!empty($irow['type'])) {
         $(function() {
             // Include bs3 / bs4 classes here.  Keep html tags functional.
             $('table').addClass('table table-sm');
+
+            onCodeSelectionChange()
         });
     </script>
 


### PR DESCRIPTION
Fixes #3619

#### Short description of what this resolves:

Fixes some usability issues inn the **Add/Edit Issue** dialog wrt code selection and display.

#### Changes proposed in this pull request:

- Created a new **Select Codes** dialog that works like a standard selection dialog with **OK** and **Cancel** buttons. It's patterned after _find_code_dynamic.php_ but simplified to only provide functionality for the `what == codes` case (I'm unclear as to the other cases and only saw them referenced from one other php). Other minor changes were made including toggling row selection.

- The **Add/Edit Issue** dialog was changed to utilize the new **Select Codes** dialog. The prior **Coding** text field that launched the old dialog is now a hidden field. The visible field is now a selection list with **Add** and **Remove** buttons. The **Add** button launches the new **Select Codes** dialog.  The **Remove** button removes the selected code(s) from the list. On add/remove, the hidden codes field is updated.


below added by bradymiller:
Up For Grabs demo for this PR is here: https://www.open-emr.org/wiki/index.php/Development_Demo#Eta_-_Up_For_Grabs_Demo