### PR TITLE
Bug/typo in FacilityService class

### DIFF
--- a/src/Services/FacilityService.php
+++ b/src/Services/FacilityService.php
@@ -198,7 +198,7 @@ class FacilityService extends BaseService
         $query = $this->buildInsertColumns($data);
         $sql = " INSERT INTO facility SET ";
         $sql .= $query['set'];
-        return sqlStatement(
+        return sqlInsert(
             $sql,
             $query['bind']
         );


### PR DESCRIPTION


<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:

Corrected issue where insert function in facility service was using sqlStatement not sqlInsert and resulted in insert ID not being returned. The previous behavior was that the id of the inserted record was returned.


#### Changes proposed in this pull request:

insert method in FacilityService returns ID of inserted record.
-
-
-