### PR TITLE
Feat: add the bootstrap input style in dashboard documents.

### DIFF
--- a/templates/documents/general_list.html
+++ b/templates/documents/general_list.html
@@ -68,10 +68,10 @@ border-radius: 4px 0 0 4px!important;
                     <legend>{xlt t='Documents List'}</legend>
                     <div class="pl-3">
                         <div class="form-inline float-right" id="patientSearch">
-                            <select id="selectPatient" class="form-control" type="text" data-placeholder="{$place_hld|attr}" style="width:150px;">
+                            <select id="selectPatient" class="form-control" type="text" data-placeholder="{$place_hld|attr}">
                                 <option></option>
                             </select>
-                            <button id='pid' type="button" class='float-right btn btn-primary pBtn' style="border-radius: 0 0.25rem 0.25rem 0">0</button>
+                            <button id='pid' type="button" class='float-right btn btn-primary pBtn'>&times;</button>
                         </div>
                         <a id="list_collapse" href="#" onclick="javascript:objTreeMenu_1.collapseAll();return false;">&nbsp;({xlt t='Collapse all'})</a>
                         {$tree_html}

--- a/templates/documents/general_list.html
+++ b/templates/documents/general_list.html
@@ -49,15 +49,15 @@ border-radius: 4px 0 0 4px!important;
 </head>
 <!-- ViSolve - Call expandAll function on loading of the page if global value 'expand_document' is set -->
 {if $GLOBALS.expand_document_tree}
-  <body class="body_top" onload="javascript:objTreeMenu_1.expandAll();return false;">
+  <body onload="javascript:objTreeMenu_1.expandAll();return false;">
 {else}
-  <body class="body_top">
+  <body>
 {/if}
-<div class="container-fluid">
+<div class="container-fluid mt-3">
 	<div class="row">
 		<div class="col-sm-12">
 			<div class="title">
-					<h2>{xlt t='Documents'} <a href='interface/patient_file/summary/demographics.php' onclick='top.restoreSession()' title="{xla t='Go Back'}" ><i id='advanced-tooltip' class='fa fa-undo fa-2x small' aria-hidden='true'></i></a></h2>
+				<h2>{xlt t='Documents'} <a href='interface/patient_file/summary/demographics.php' onclick='top.restoreSession()' title="{xla t='Go Back'}" ><i id='advanced-tooltip' class='fa fa-undo fa-2x small' aria-hidden='true'></i></a></h2>
 			</div>
 		</div>
 	</div>
@@ -65,25 +65,23 @@ border-radius: 4px 0 0 4px!important;
 		<div class="col-sm-3">
 			<div id="documents_list">
 				<fieldset>
-				<legend>{xlt t='Documents List'}</legend>
-                <div style="padding: 0 10px">
-                    <div class="ui-widget form-inline" class='float-right'>
-                         <select id="selectPatient" class="form-control" type="text" data-placeholder="{$place_hld|attr}" style="width:150px;">
-                            <option></option></select>
-                        <button id='pid' class="btn btn-primary pBtn" type="button" class='float-right' style="border-radius: 0 0.25rem 0.25rem 0">0</button>
+                    <legend>{xlt t='Documents List'}</legend>
+                    <div class="pl-3">
+                        <div class="ui-widget form-inline float-right">
+                            <select id="selectPatient" class="form-control" type="text" data-placeholder="{$place_hld|attr}" style="width:150px;">
+                                <option></option>
+                            </select>
+                            <button id='pid' type="button" class='float-right btn btn-primary pBtn' style="border-radius: 0 0.25rem 0.25rem 0">0</button>
+                        </div>
+                        <a id="list_collapse" href="#" onclick="javascript:objTreeMenu_1.collapseAll();return false;">&nbsp;({xlt t='Collapse all'})</a>
+                        {$tree_html}
                     </div>
-                    <a id="list_collapse" href="#" onclick="javascript:objTreeMenu_1.collapseAll();return false;">&nbsp;({xlt t='Collapse all'})</a>
-                    {$tree_html}
-                </div>
-			</fieldset>
+			    </fieldset>
             </div>
 		</div>
-
 		<div class="col-sm-9">
 			<div id="documents_actions">
-
 				<fieldset>
-
 					<legend>{xlt t='Document Uploader/Viewer'}</legend>
                     <div style="padding: 0 10px">
 						{if $message}
@@ -95,7 +93,6 @@ border-radius: 4px 0 0 4px!important;
 						{$activity}
 					</div>
 				</fieldset>
-
 			</div>
 		</div>
 	</div>

--- a/templates/documents/general_list.html
+++ b/templates/documents/general_list.html
@@ -67,7 +67,7 @@ border-radius: 4px 0 0 4px!important;
 				<fieldset>
                     <legend>{xlt t='Documents List'}</legend>
                     <div class="pl-3">
-                        <div class="ui-widget form-inline float-right">
+                        <div class="form-inline float-right" id="patientSearch">
                             <select id="selectPatient" class="form-control" type="text" data-placeholder="{$place_hld|attr}" style="width:150px;">
                                 <option></option>
                             </select>
@@ -104,7 +104,7 @@ var demoPid = {$demo_pid|js_escape};
 var inUseMsg = {$used_msg|js_escape};
 {literal}
 if(curpid == demoPid && !newVersion){
-    $(".ui-widget").hide();
+    $("#patientSearch").hide();
 }
 else{
     $("#pid").text(curpid);

--- a/templates/documents/general_upload.html
+++ b/templates/documents/general_upload.html
@@ -26,7 +26,7 @@
         <br/>
         <br/>
     </div>
-    <div class="text bold">
+    <div class="text font-weight-bold">
         {xlt t="Upload Document"} {if $category_name} {xlt t="to category"} '{$category_name|text}'{/if}
     </div>
     <div class="text">

--- a/templates/documents/general_upload.html
+++ b/templates/documents/general_upload.html
@@ -11,70 +11,82 @@
 *}
 
 <form method="post" enctype="multipart/form-data" action="{$FORM_ACTION}" onsubmit="return top.restoreSession()">
-<input type="hidden" name="MAX_FILE_SIZE" value="64000000" />
-<h3>{$error}</h3>
-{if (!($patient_id > 0)) }
-  <div class="text text-danger">
-    {xlt t="IMPORTANT: This upload tool is only for uploading documents on patients that are not yet entered into the system. To upload files for patients whom already have been entered into the system, please use the upload tool linked within the Patient Summary screen."}
-    <br/>
-    <br/>
-  </div>
-{/if}
-
-<div class="text">
-    {xlt t="NOTE: Uploading files with duplicate names will cause the files to be automatically renamed (for example, file.jpg will become file.1.jpg). Filenames are considered unique per patient, not per category."}
-    <br/>
-    <br/>
-</div>
-<div class="text bold">
-    {xlt t="Upload Document"} {if $category_name} {xlt t="to category"} '{$category_name|text}'{/if}
-</div>
-<div class="text">
-    <div class="form-group">
-        <p>(<small>{xlt t="Multiple files can be uploaded at one time by selecting them using CTRL+Click or SHIFT+Click."}</small>)</p>
-        <span>{xlt t="Source File Path"}:</span> <input type="file" name="file[]" id="source-name" multiple="true" />
+    <input type="hidden" name="MAX_FILE_SIZE" value="64000000" />
+    <h3>{$error}</h3>
+    {if (!($patient_id > 0)) }
+    <div class="text text-danger">
+        {xlt t="IMPORTANT: This upload tool is only for uploading documents on patients that are not yet entered into the system. To upload files for patients whom already have been entered into the system, please use the upload tool linked within the Patient Summary screen."}
+        <br/>
+        <br/>
     </div>
-    <div class="form-group">
-        <p>(<small>{xlt t="Select below to Zip Directory of image slices."}</small>)</p>
-        <input type="file" name="dicom_folder[]" id="dicom_folder" multiple directory=""  webkitdirectory="" moxdirectory="" />
-    </div>
-    <p><span title="{xla t='Leave Blank To Keep Original Filename'}">{xlt t="Optional Destination or Dicom Study Name"}:</span> <input type="text" name="destination" title="{xla t='Leave Blank To Keep Original Filename'}" id="destination-name" /></p>
-    {if !$hide_encryption}
-	<br />
-	<p><span title="{xla t='Check the box if this is an encrypted file'}">{xlt t="Is The File Encrypted?"}:</span> <input type="checkbox" name="encrypted" title="{xla t='Check the box if this is an encrypted file'}" id="encrypted" /></p>
-	<p><span title="{xla t='Pass phrase to decrypt document'}">{xlt t="Pass Phrase"}:</span> <input type="text" class="form-control" name="passphrase" title="{xla t='Pass phrase to decrypt document'}" id="passphrase" /></p>
-	<p><i>{xlt t='Supports AES-256-CBC encryption/decryption only.'}</i></p>
     {/if}
-</div>
-<p><input type="submit" class="btn btn-primary" value="{xl t='Upload'|attr}" /></p>
 
-<input type="hidden" name="patient_id" value="{$patient_id|attr}" />
-<input type="hidden" name="category_id" value="{$category_id|attr}" />
-<input type="hidden" name="process" value="{$PROCESS|attr}" />
+    <div class="text">
+        {xlt t="NOTE: Uploading files with duplicate names will cause the files to be automatically renamed (for example, file.jpg will become file.1.jpg). Filenames are considered unique per patient, not per category."}
+        <br/>
+        <br/>
+    </div>
+    <div class="text bold">
+        {xlt t="Upload Document"} {if $category_name} {xlt t="to category"} '{$category_name|text}'{/if}
+    </div>
+    <div class="text">
+        <div class="form-group">
+            <p>(<small>{xlt t="Multiple files can be uploaded at one time by selecting them using CTRL+Click or SHIFT+Click."}</small>)</p>
+            <span>{xlt t="Source File Path"}:</span>
+            <input type="file" class="form-control-file" name="file[]" id="source-name" multiple="true" />
+        </div>
+        <div class="form-group">
+            <p>(<small>{xlt t="Select below to Zip Directory of image slices."}</small>)</p>
+            <input type="file" class="form-control-file" name="dicom_folder[]" id="dicom_folder" multiple directory=""  webkitdirectory="" moxdirectory="" />
+        </div>
+        <p>
+            <span title="{xla t='Leave Blank To Keep Original Filename'}">{xlt t="Optional Destination or Dicom Study Name"}:</span>
+            <input type="text" class="form-control" name="destination" title="{xla t='Leave Blank To Keep Original Filename'}" id="destination-name" />
+        </p>
+        {if !$hide_encryption}
+        <br />
+        <p>
+            <span title="{xla t='Check the box if this is an encrypted file'}">{xlt t="Is The File Encrypted?"}:</span>
+            <input type="checkbox" name="encrypted" title="{xla t='Check the box if this is an encrypted file'}" id="encrypted" />
+        </p>
+        <p>
+            <span title="{xla t='Pass phrase to decrypt document'}">{xlt t="Pass Phrase"}:</span>
+            <input type="text" class="form-control" name="passphrase" title="{xla t='Pass phrase to decrypt document'}" id="passphrase" />
+        </p>
+        <p><i>{xlt t='Supports AES-256-CBC encryption/decryption only.'}</i></p>
+        {/if}
+    </div>
+    <p>
+        <input type="submit" class="btn btn-primary" value="{xl t='Upload'|attr}" />
+    </p>
+
+    <input type="hidden" name="patient_id" value="{$patient_id|attr}" />
+    <input type="hidden" name="category_id" value="{$category_id|attr}" />
+    <input type="hidden" name="process" value="{$PROCESS|attr}" />
 </form>
 
 <br /><br />
 
 <!-- Drag and drop uploader -->
 <div id="autouploader">
-<form method="post" enctype="multipart/form-data" action="{$GLOBALS.webroot}/library/ajax/upload.php?patient_id={$patient_id|attr_url}&parent_id={$category_id|attr_url}&csrf_token_form={$CSRF_TOKEN_FORM|attr_url}" class="dropzone">
-<input type="hidden" name="MAX_FILE_SIZE" value="64000000" />
-</form>
+    <form method="post" enctype="multipart/form-data" action="{$GLOBALS.webroot}/library/ajax/upload.php?patient_id={$patient_id|attr_url}&parent_id={$category_id|attr_url}&csrf_token_form={$CSRF_TOKEN_FORM|attr_url}" class="dropzone">
+        <input type="hidden" name="MAX_FILE_SIZE" value="64000000" />
+    </form>
 </div>
 
 <!-- Section for document template download -->
 <form method='post' action='interface/patient_file/download_template.php' onsubmit='return top.restoreSession()'>
-<input type="hidden" name="csrf_token_form" value="{$CSRF_TOKEN_FORM|attr}">
-<input type='hidden' name='patient_id' value='{$patient_id|attr}' />
-<div class='col-sm-6'>
-	<p class='text font-weight-bold'>{xlt t="Download document template for this patient and visit"}</p>
-	<div class="input-group">
-		<span class="input-group-prepend">
-        	<button type="submit" class="btn btn-download">{xlt t="Fetch"}</button>
-        </span>
-		<select class="form-control" name='form_filename'>{$TEMPLATES_LIST}</select>
-	</div>
-</div>
+    <input type="hidden" name="csrf_token_form" value="{$CSRF_TOKEN_FORM|attr}" />
+    <input type='hidden' name='patient_id' value='{$patient_id|attr}' />
+    <div class='col-sm-6'>
+        <p class='text font-weight-bold'>{xlt t="Download document template for this patient and visit"}</p>
+        <div class="input-group">
+            <span class="input-group-prepend">
+                <button type="submit" class="btn btn-download">{xlt t="Fetch"}</button>
+            </span>
+            <select class="form-control" name='form_filename'>{$TEMPLATES_LIST}</select>
+        </div>
+    </div>
 </form>
 <!-- End document template download section -->
 

--- a/templates/documents/general_upload.html
+++ b/templates/documents/general_upload.html
@@ -20,7 +20,6 @@
         <br/>
     </div>
     {/if}
-
     <div class="text">
         {xlt t="NOTE: Uploading files with duplicate names will cause the files to be automatically renamed (for example, file.jpg will become file.1.jpg). Filenames are considered unique per patient, not per category."}
         <br/>
@@ -82,7 +81,7 @@
         <p class='text font-weight-bold'>{xlt t="Download document template for this patient and visit"}</p>
         <div class="input-group">
             <span class="input-group-prepend">
-                <button type="submit" class="btn btn-download">{xlt t="Fetch"}</button>
+                <button type="submit" class="btn btn-primary btn-download">{xlt t="Fetch"}</button>
             </span>
             <select class="form-control" name='form_filename'>{$TEMPLATES_LIST}</select>
         </div>


### PR DESCRIPTION
Add the bootstrap input style in dashboard documents.

<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

#### Short description of what this resolves:
- Remove outdated code and inline-style.
- Add the bootstrap input style.
