### PR TITLE
change flex version to 3.12

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
   openemr:
     restart: always
     # use an image if you're not changing the build steps:
-    image: openemr/openemr:flex
+    image: openemr/openemr:flex-3.12
     # if editing the Dockerfile, clone the devops repo and point to the path:
     # build: ../openemr-devops/docker/openemr/flex-edge/
     ports:


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
--> 
1.  From the docker hub, it showed flex and flex-3.12 using the same docker file.
https://hub.docker.com/r/openemr/openemr/

2.  But from the /root/devtools, it seems that there is no "-p" for the PHP command, it cannot see the progress without the "-p" option. Or there are more different, so suggest to change flex version to 3.12 or edge by default.
```
[root@easy-env openemr]# docker ps
CONTAINER ID        IMAGE                       COMMAND                  CREATED             STATUS              PORTS                                         NAMES
9c542742b66a        openemr/openemr:flex-3.12   "./run_openemr.sh"       41 minutes ago      Up 41 minutes       0.0.0.0:8300->80/tcp, 0.0.0.0:9300->443/tcp   openemr_openemr_1
0f20753258ba        phpmyadmin/phpmyadmin       "/docker-entrypoint.…"   41 minutes ago      Up 41 minutes       0.0.0.0:8310->80/tcp                          openemr_phpmyadmin_1
7cb5477673e0        mariadb:10.5                "docker-entrypoint.s…"   41 minutes ago      Up 41 minutes       0.0.0.0:8320->3306/tcp                        openemr_mysql_1
[root@easy-env openemr]# openemr-cmd -d openemr_openemr_1 e "grep memory_limit /root/devtools"
    php -d memory_limit=640M /root/.composer/vendor/squizlabs/php_codesniffer/bin/phpcs -p -n --extensions=php,inc --report-width=120 --standard=ci/phpcs.xml --report=full .
    php -d memory_limit=640M /root/.composer/vendor/squizlabs/php_codesniffer/bin/phpcs -p -n --extensions=php,inc --report-width=120 --standard=ci/phpcs_src.xml --report=full src/
    php -d memory_limit=640M /root/.composer/vendor/squizlabs/php_codesniffer/bin/phpcbf -p -n --extensions=php,inc --report-width=120 --standard=ci/phpcs.xml --report=full .
[root@easy-env openemr]# openemr-cmd s
/var/www/localhost/htdocs # /root/devtools psr12-report
Generating PSR12 code styling error report
............................................................   60 / 2818 (2%)    <<<< progress
............................................................  120 / 2818 (4%)
..........................................................^C


[root@easy-env openemr]# docker ps
CONTAINER ID        IMAGE                   COMMAND                  CREATED             STATUS              PORTS                                         NAMES
4c5c3c83fd24        openemr/openemr:flex    "./run_openemr.sh"       14 minutes ago      Up 14 minutes       0.0.0.0:8300->80/tcp, 0.0.0.0:9300->443/tcp   openemr_openemr_1
1cf07155dd38        phpmyadmin/phpmyadmin   "/docker-entrypoint.…"   14 minutes ago      Up 14 minutes       0.0.0.0:8310->80/tcp                          openemr_phpmyadmin_1
99da7c94e983        mariadb:10.5            "docker-entrypoint.s…"   14 minutes ago      Up 14 minutes       0.0.0.0:8320->3306/tcp                        openemr_mysql_1
[root@easy-env openemr]# openemr-cmd -d openemr_openemr_1 e "grep memory_limit /root/devtools"
    php -d memory_limit=640M /root/.composer/vendor/squizlabs/php_codesniffer/bin/phpcs -n --extensions=php,inc --standard=ci/phpcs.xml --report=full .     <<<<
    php -d memory_limit=640M /root/.composer/vendor/squizlabs/php_codesniffer/bin/phpcs -n --extensions=php,inc --standard=ci/phpcs_src.xml --report=full src/     <<<
    php -d memory_limit=640M /root/.composer/vendor/squizlabs/php_codesniffer/bin/phpcbf -n --extensions=php,inc --standard=ci/phpcs.xml .  <<<<
[root@easy-env openemr]# openemr-cmd s
/var/www/localhost/htdocs # /root/devtools  psr12-report
Generating PSR12 code styling error report          << without progress
```

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-