### PR TITLE
Fix broken forms, malformed html, db errors in batchcom

### DIFF
--- a/interface/batchcom/batchcom.inc.php
+++ b/interface/batchcom/batchcom.inc.php
@@ -15,8 +15,11 @@
 //validation functions
 function check_date_format($date)
 {
-    $pat = "/^(19[0-9]{2}|20[0-1]{1}[0-9]{1})-(0[1-9]|1[0-2])-(0[1-9]{1}|1[0-9]{1}|2[0-9]{1}|3[0-1]{1})$/";
-    return preg_match($pat, $date) or $date == '' or $date == '0000-00-00';
+    if (($date == '') || ($date == '0000-00-00')) {
+        return true;
+    }
+    $ymd = explode('-', $date);
+    return (count($ymd) == 3) && ($ymd[0] > 1900) && checkdate($ymd[1], $ymd[2], $ymd[0]);
 }
 
 function check_age($age)


### PR DESCRIPTION
The SMS and Email configuration in batchcom expected form arguments that
never get sent.  These values were not needed, but having null values
for them caused a database error.  These are now defaulted.

The select box for SMS gateway type was broken due to a missing ">".

All form arguments now get basic validation.  Validation for dates was
rewritten to use checkdate, because the existing regex validation
rejected years after 2019.

<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-