### PR TITLE
added uuid mapping mechanism

### DIFF
--- a/sql/5_0_2-to-6_0_0_upgrade.sql
+++ b/sql/5_0_2-to-6_0_0_upgrade.sql
@@ -560,6 +560,10 @@ ALTER TABLE `uuid_registry` ADD `table_id` varchar(255) NOT NULL DEFAULT '';
 ALTER TABLE `uuid_registry` ADD `couchdb` varchar(255) NOT NULL DEFAULT '';
 #EndIf
 
+#IfMissingColumn uuid_registry mapped
+ALTER TABLE `uuid_registry` ADD `mapped` tinyint(4) NOT NULL DEFAULT '0';
+#EndIf
+
 #IfMissingColumn patient_data uuid
 ALTER TABLE `patient_data` ADD `uuid` binary(16) DEFAULT NULL;
 #EndIf
@@ -1991,4 +1995,20 @@ CREATE UNIQUE INDEX `uuid` ON `drugs` (`uuid`);
 
 #IfMissingColumn ccda encrypted
 ALTER TABLE `ccda` ADD `encrypted` TINYINT(4) NOT NULL DEFAULT '0' COMMENT '0->No,1->Yes';
+#EndIf
+
+#IfNotTable uuid_mapping
+CREATE TABLE `uuid_mapping` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `uuid` binary(16) NOT NULL DEFAULT '',
+  `resource` varchar(255) NOT NULL DEFAULT '',
+  `table` varchar(255) NOT NULL DEFAULT '',
+  `target_uuid` binary(16) NOT NULL DEFAULT '',
+  `created` timestamp NULL,
+  PRIMARY KEY (`id`),
+  KEY `uuid` (`uuid`),
+  KEY `resource` (`resource`),
+  KEY `table` (`table`),
+  KEY `target_uuid` (`target_uuid`)
+) ENGINE=InnoDB AUTO_INCREMENT=1;
 #EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -8360,6 +8360,27 @@ INSERT INTO user_settings ( setting_user, setting_label, setting_value ) VALUES 
 -- --------------------------------------------------------
 
 --
+-- Table structure for table `uuid_mapping`
+--
+
+DROP TABLE IF EXISTS `uuid_mapping`;
+CREATE TABLE `uuid_mapping` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `uuid` binary(16) NOT NULL DEFAULT '',
+  `resource` varchar(255) NOT NULL DEFAULT '',
+  `table` varchar(255) NOT NULL DEFAULT '',
+  `target_uuid` binary(16) NOT NULL DEFAULT '',
+  `created` timestamp NULL,
+  PRIMARY KEY (`id`),
+  KEY `uuid` (`uuid`),
+  KEY `resource` (`resource`),
+  KEY `table` (`table`),
+  KEY `target_uuid` (`target_uuid`)
+) ENGINE=InnoDB AUTO_INCREMENT=1;
+
+-- --------------------------------------------------------
+
+--
 -- Table structure for table `uuid_registry`
 --
 
@@ -8370,6 +8391,7 @@ CREATE TABLE `uuid_registry` (
   `table_id` varchar(255) NOT NULL DEFAULT '',
   `table_vertical` varchar(255) NOT NULL DEFAULT '',
   `couchdb` varchar(255) NOT NULL DEFAULT '',
+  `mapped` tinyint(4) NOT NULL DEFAULT '0',
   `created` timestamp NULL,
   PRIMARY KEY (`uuid`)
 ) ENGINE=InnoDB;

--- a/src/Common/Uuid/UuidMapping.php
+++ b/src/Common/Uuid/UuidMapping.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * UuidMapping class
+ *
+ *    Generic support for UUID mapping. Goal is to support:
+ *     1. uuid for fhir that can not be supported via the standard mechanism (the standard mechanism is when there
+ *        is a uuid representing the data within the sql row).
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2020 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Common\Uuid;
+
+use OpenEMR\Common\Uuid\UuidRegistry;
+
+class UuidMapping
+{
+    // For now, support one to one uuid to target table, but will plan to add one uuid to many targets tables in future
+    //   when presented with that use case (this is why the uuid column in uuid_mapping is not unique btw).
+    public static function createMissingResourceUuids($resource, $table) {
+        // find the missing mapped uuids
+        $resultSet = sqlStatementNoLog(
+            "SELECT `" . $table . "`.`uuid`
+                       FROM `" . $table . "`
+                       LEFT OUTER JOIN `uuid_mapping` ON `" . $table . "`.`uuid` = `uuid_mapping`.`target_uuid`
+                       WHERE (`uuid_mapping`.`uuid` IS NULL OR `uuid_mapping`.`uuid` = '' OR `uuid_mapping`.`uuid` = '\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0')
+                       AND (`" . $table . "`.`uuid` IS NOT NULL AND `" . $table . "`.`uuid` != '' AND `" . $table . "`.`uuid` != '\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0')"
+        );
+        while ($row = sqlFetchArray($resultSet)) {
+            // populate the missing mapped uuids
+            sqlQueryNoLog("INSERT INTO `uuid_mapping` (`uuid`, `resource`, `table`, `target_uuid`, `created`) VALUES (?, ?, ?, ?, NOW())", [(new UuidRegistry(['table_name' => 'uuid_mapping', 'mapped' => true]))->createUuid(), $resource, $table, $row['uuid']]);
+        }
+    }
+}

--- a/src/Common/Uuid/UuidMapping.php
+++ b/src/Common/Uuid/UuidMapping.php
@@ -22,7 +22,8 @@ class UuidMapping
 {
     // For now, support one to one uuid to target table, but will plan to add one uuid to many targets tables in future
     //   when presented with that use case (this is why the uuid column in uuid_mapping is not unique btw).
-    public static function createMissingResourceUuids($resource, $table) {
+    public static function createMissingResourceUuids($resource, $table)
+    {
         // find the missing mapped uuids
         $resultSet = sqlStatementNoLog(
             "SELECT `" . $table . "`.`uuid`

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@ $v_realpatch = '0';
 // is a database change in the course of development.  It is used
 // internally to determine when a database upgrade is needed.
 //
-$v_database = 349;
+$v_database = 350;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
@yashrajbothra  , here's the uuid mapping mechanism. Can ensure all needed stuff is populated with:
```
use OpenEMR\Common\Uuid\UuidMapping;

UuidMapping::createMissingResourceUuids('Location', 'patient_data');
UuidMapping::createMissingResourceUuids('Location', 'users');
UuidMapping::createMissingResourceUuids('Location', 'facility');
```
The uuid in the mapping table is the resource uuid. the target_uuid is for mapping to the item in the table. Note still need to populate the anchor tables with the `->createMissingUuids` which need to be done prior to the above calls.
This is working well for me, so plan to bring in soon; which you can then integrate into your Location resource PR