### PR TITLE
Fix #3842: fix the recall board disappear when click the arrow button.

### DIFF
--- a/library/MedEx/API.php
+++ b/library/MedEx/API.php
@@ -1868,7 +1868,7 @@ class Display extends base
                                         }
                                         ?>  onchange="show_this();">
                                         <option value=""><?php echo xlt('All Facilities'); ?></option>
-                                            <?php echo $select_facs; ?>
+                                        <?php echo $select_facs; ?>
                                     </select>
                                 </div>
                                 <div class="form-group row mx-sm-1">
@@ -1971,11 +1971,11 @@ class Display extends base
                                         <?php echo $current_events; ?>
                                     </span>
                                 </a>
+                                <?php } ?>
                             </div>
                         </div>
-                        <?php } ?>
-
-                        <div name="message" id="message" class="warning"></div>
+                        <div name="message" id="message" class="warning">
+                        </div>
                     </form>
                 </div>
             </div>
@@ -2456,7 +2456,7 @@ class Display extends base
         ?>
         <div class="table-responsive">
             <table class="table table-bordered">
-                <thead>
+                <thead class="table-primary">
                     <tr>
                         <th>
                             <?php echo xlt('Name'); ?>


### PR DESCRIPTION
Fix the recall board disappears when clicking the arrow button.
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #3842

#### Short description of what this resolves:
- Adjust the PHP curly braces to fix the recall board disappears.
- Adjust the table thead style.


![image](https://user-images.githubusercontent.com/22230889/90190147-0e009f00-ddf1-11ea-811f-8e2f2f88f1e4.png)

![image](https://user-images.githubusercontent.com/22230889/90190168-178a0700-ddf1-11ea-89a2-9c6479bfe2b2.png)
