### PR TITLE
frames left nav messages

### DIFF
--- a/interface/main/left_nav.php
+++ b/interface/main/left_nav.php
@@ -229,7 +229,7 @@ function genTreeLink($frame, $name, $title, $mono = false)
         }
 
         echo "return loadFrame2(" . attr_js($id) . "," . attr_js($frame) . "," .
-            attr_js($primary_docs[$name][2]) . ")\">" . text($title) . ($name == 'msg' ? ' <span id="reminderCountSpan" class="bold"></span>' : '')."</a></li>";
+            attr_js($primary_docs[$name][2]) . ") \">" . text($title) . ($name == 'msg' ? ' <span id="reminderCountSpan" class="bold"></span>' : '')."</a></li>";
     }
 }
 
@@ -529,7 +529,8 @@ function genModuleMenuFromMenuItems($navMenuItems, $disallowed)
        csrf_token_form: "<?php echo attr(CsrfUtils::collectCsrfToken()); ?>"
      },
      function(data) {
-       $("#reminderCountSpan").html(data);
+       data = JSON.parse(data);
+       $("#reminderCountSpan").html(data.reminderText);
     // run updater every 60 seconds
      var repeater = setTimeout("getReminderCount()", 60000);
    });


### PR DESCRIPTION
- fix for frames left nav messages reminder showing object instead of text

<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:
Forum issue https://community.open-emr.org/t/new-artifact-shows-after-upgrade-5-0-0-patch-7-to-5-0-2-patch-4/15004
