### PR TITLE
Refactor: remove unnecessary oe classes.

### DIFF
--- a/interface/README.md
+++ b/interface/README.md
@@ -22,10 +22,6 @@ Files specific to different themes are named with the following conventions:
 ### Special Classes
 
 * `position-override` gives a hook for style to change placement of buttons. In light/manila style this is ignored and buttons go to left positioned under data entry field. Whereas in the other styles this is used to center the buttons.
-* `oe-opt-btn-group-pinch` gives a hook for style to pinch the buttons (i think make them more rounded). Not used in light/manila, but used in other styles.
-* `oe-opt-btn-separate-left` gives a hook to place a space between the buttons. Not used in light/manila, but used in other styles.
-* `oe-text-to-right` does as it says (and then does the opposite for RTL languages).
-* `oe-text-to-left` does as it says (and then does the opposite for RTL languages).
 
 ## Getting Started
 

--- a/interface/billing/billing_report.php
+++ b/interface/billing/billing_report.php
@@ -116,11 +116,6 @@ $partners = $x->_utility_array($x->x12_partner_factory());
 
     <?php Header::setupHeader(['datetime-picker', 'common']); ?>
     <style>
-        .btn-group-pinch > .btn:nth-last-child(4):not(.dropdown-toggle) {
-            border-top-right-radius: 3px !important;
-            border-bottom-right-radius: 3px !important;
-        }
-
         .modal {
             overflow-y: auto;
         }

--- a/interface/billing/new_payment.php
+++ b/interface/billing/new_payment.php
@@ -367,7 +367,7 @@ $payment_id = $payment_id * 1 > 0 ? $payment_id + 0 : $request_payment_id + 0;
                             <div class="form-group clearfix">
                             <div class="col-sm-12 text-left position-override">
                                 <br />
-                                <div class="btn-group btn-group-pinch" role="group">
+                                <div class="btn-group" role="group">
                                     <button class="btn btn-secondary btn-save" href="#" onclick="return PostPayments();"><?php echo xlt('Post Payments');?></button>
                                     <button class="btn btn-secondary btn-save" href="#" onclick="return FinishPayments();"><?php echo xlt('Finish Payments');?></button>
                                     <button class="btn btn-link btn-cancel btn-separate-left" href="#" onclick="CancelDistribute()"><?php echo xlt('Cancel');?></button>

--- a/interface/billing/new_payment.php
+++ b/interface/billing/new_payment.php
@@ -370,7 +370,7 @@ $payment_id = $payment_id * 1 > 0 ? $payment_id + 0 : $request_payment_id + 0;
                                 <div class="btn-group" role="group">
                                     <button class="btn btn-secondary btn-save" href="#" onclick="return PostPayments();"><?php echo xlt('Post Payments');?></button>
                                     <button class="btn btn-secondary btn-save" href="#" onclick="return FinishPayments();"><?php echo xlt('Finish Payments');?></button>
-                                    <button class="btn btn-link btn-cancel btn-separate-left" href="#" onclick="CancelDistribute()"><?php echo xlt('Cancel');?></button>
+                                    <button class="btn btn-link btn-cancel" href="#" onclick="CancelDistribute()"><?php echo xlt('Cancel');?></button>
                                 </div>
                             </div>
                             </div>

--- a/interface/billing/payment_master.inc.php
+++ b/interface/billing/payment_master.inc.php
@@ -267,7 +267,7 @@ if (($screen == 'new_payment' && $payment_id * 1 == 0) || ($screen == 'edit_paym
         <div class="form-group">
             <div class="row">
                 <div class="col-sm-12 text-left position-override">
-                    <div class="btn-group btn-group-pinch" role="group">
+                    <div class="btn-group" role="group">
                         <button onClick="return SavePayment();" class="btn btn-primary btn-save"><?php echo xlt('Save Changes'); ?></button>
                         <button class="btn btn-secondary btn-save" onClick="OpenEOBEntry();"><?php echo xlt('Allocate'); ?></button>
                         <button onclick="ResetForm(); return false;" class="btn btn-link btn-cancel btn-separate-left"><?php echo xlt('Cancel Changes'); ?></button>

--- a/interface/billing/payment_master.inc.php
+++ b/interface/billing/payment_master.inc.php
@@ -270,7 +270,7 @@ if (($screen == 'new_payment' && $payment_id * 1 == 0) || ($screen == 'edit_paym
                     <div class="btn-group" role="group">
                         <button onClick="return SavePayment();" class="btn btn-primary btn-save"><?php echo xlt('Save Changes'); ?></button>
                         <button class="btn btn-secondary btn-save" onClick="OpenEOBEntry();"><?php echo xlt('Allocate'); ?></button>
-                        <button onclick="ResetForm(); return false;" class="btn btn-link btn-cancel btn-separate-left"><?php echo xlt('Cancel Changes'); ?></button>
+                        <button onclick="ResetForm(); return false;" class="btn btn-link btn-cancel"><?php echo xlt('Cancel Changes'); ?></button>
                         <br />
                     </div>
                 </div>

--- a/interface/billing/sl_eob_invoice.php
+++ b/interface/billing/sl_eob_invoice.php
@@ -739,7 +739,7 @@ $pdrow = sqlQuery("select billing_note from patient_data where pid = ? limit 1",
                             onclick="this.value='1';"><?php echo xlt("Save Current"); ?></button>
                         <button type='submit' class="btn btn-primary btn-save" name='form_save' id="btn-save"
                             onclick="this.value='2';"><?php echo xlt("Save & Exit"); ?></button>
-                        <button type='button' class="btn btn-secondary btn-cancel btn-separate-left" name='form_cancel'
+                        <button type='button' class="btn btn-secondary btn-cancel" name='form_cancel'
                             id="btn-cancel" onclick='doClose()'><?php echo xlt("Close"); ?></button>
                     </div>
                     <?php if ($from_posting) { ?>

--- a/interface/billing/sl_eob_patient_note.php
+++ b/interface/billing/sl_eob_patient_note.php
@@ -78,7 +78,7 @@ $info_msg = "";
                         <div class="col-sm-12 text-left position-override" id="search-btn">
                             <div class="btn-group" role="group">
                                 <button type='submit' class="btn btn-secondary btn-save" name='form_save' id="btn-save"><?php echo xlt("Save"); ?></button>
-                                <button type='submit' class="btn btn-link btn-cancel btn-separate-left" name='form_cancel' id="btn-cancel" onclick='dlgclose();'><?php echo xlt("Cancel"); ?></button>
+                                <button type='submit' class="btn btn-link btn-cancel" name='form_cancel' id="btn-cancel" onclick='dlgclose();'><?php echo xlt("Cancel"); ?></button>
                             </div>
                         </div>
                     </div>

--- a/interface/forms/care_plan/new.php
+++ b/interface/forms/care_plan/new.php
@@ -217,7 +217,7 @@ endforeach;
                 </fieldset>
                  <div class="form-group clearfix">
                     <div class="col-sm-12 position-override">
-                        <div class="btn-group oe-opt-btn-group-pinch" role="group">
+                        <div class="btn-group" role="group">
                             <button type="submit" onclick="top.restoreSession()" class="btn btn-default btn-save"><?php echo xlt('Save'); ?></button>
                             <button type="button" class="btn btn-link btn-cancel" onclick="top.restoreSession(); parent.closeTab(window.name, false);"><?php echo xlt('Cancel');?></button>
                             <input type="hidden" id="clickId" value="" />

--- a/interface/forms/care_plan/new.php
+++ b/interface/forms/care_plan/new.php
@@ -219,7 +219,7 @@ endforeach;
                     <div class="col-sm-12 position-override">
                         <div class="btn-group oe-opt-btn-group-pinch" role="group">
                             <button type="submit" onclick="top.restoreSession()" class="btn btn-default btn-save"><?php echo xlt('Save'); ?></button>
-                            <button type="button" class="btn btn-link btn-cancel oe-opt-btn-separate-left" onclick="top.restoreSession(); parent.closeTab(window.name, false);"><?php echo xlt('Cancel');?></button>
+                            <button type="button" class="btn btn-link btn-cancel" onclick="top.restoreSession(); parent.closeTab(window.name, false);"><?php echo xlt('Cancel');?></button>
                             <input type="hidden" id="clickId" value="" />
                         </div>
                     </div>

--- a/interface/forms/clinical_instructions/new.php
+++ b/interface/forms/clinical_instructions/new.php
@@ -48,7 +48,7 @@ $check_res = $formid ? formFetch("form_clinical_instructions", $formid) : array(
                     </fieldset>
                     <div class="form-group clearfix">
                         <div class="col-sm-12 offset-sm-1 position-override">
-                            <div class="btn-group oe-opt-btn-group-pinch" role="group">
+                            <div class="btn-group" role="group">
                                 <button type='submit' onclick='top.restoreSession()' class="btn btn-secondary btn-save"><?php echo xlt('Save'); ?></button>
                                 <button type="button" class="btn btn-link btn-cancel" onclick="top.restoreSession(); parent.closeTab(window.name, false);"><?php echo xlt('Cancel');?></button>
                             </div>

--- a/interface/forms/clinical_instructions/new.php
+++ b/interface/forms/clinical_instructions/new.php
@@ -50,7 +50,7 @@ $check_res = $formid ? formFetch("form_clinical_instructions", $formid) : array(
                         <div class="col-sm-12 offset-sm-1 position-override">
                             <div class="btn-group oe-opt-btn-group-pinch" role="group">
                                 <button type='submit' onclick='top.restoreSession()' class="btn btn-secondary btn-save"><?php echo xlt('Save'); ?></button>
-                                <button type="button" class="btn btn-link btn-cancel oe-opt-btn-separate-left" onclick="top.restoreSession(); parent.closeTab(window.name, false);"><?php echo xlt('Cancel');?></button>
+                                <button type="button" class="btn btn-link btn-cancel" onclick="top.restoreSession(); parent.closeTab(window.name, false);"><?php echo xlt('Cancel');?></button>
                             </div>
                         </div>
                     </div>

--- a/interface/forms/dictation/new.php
+++ b/interface/forms/dictation/new.php
@@ -59,7 +59,7 @@ $returnurl = 'encounter_top.php';
                         <div class="col-sm-12 offset-sm-1 position-override">
                             <div class="btn-group oe-opt-btn-group-pinch" role="group">
                                 <button type='submit' onclick='top.restoreSession()' class="btn btn-secondary btn-save"><?php echo xlt('Save'); ?></button>
-                                <button type="button" class="btn btn-link btn-cancel oe-opt-btn-separate-left" onclick="top.restoreSession(); parent.closeTab(window.name, false);"><?php echo xlt('Cancel');?></button>
+                                <button type="button" class="btn btn-link btn-cancel" onclick="top.restoreSession(); parent.closeTab(window.name, false);"><?php echo xlt('Cancel');?></button>
                             </div>
                         </div>
                     </div>

--- a/interface/forms/dictation/new.php
+++ b/interface/forms/dictation/new.php
@@ -57,7 +57,7 @@ $returnurl = 'encounter_top.php';
                     </fieldset>
                     <div class="form-group clearfix">
                         <div class="col-sm-12 offset-sm-1 position-override">
-                            <div class="btn-group oe-opt-btn-group-pinch" role="group">
+                            <div class="btn-group" role="group">
                                 <button type='submit' onclick='top.restoreSession()' class="btn btn-secondary btn-save"><?php echo xlt('Save'); ?></button>
                                 <button type="button" class="btn btn-link btn-cancel" onclick="top.restoreSession(); parent.closeTab(window.name, false);"><?php echo xlt('Cancel');?></button>
                             </div>

--- a/interface/forms/dictation/view.php
+++ b/interface/forms/dictation/view.php
@@ -60,7 +60,7 @@ $obj = formFetch("form_dictation", $_GET["id"]);
                 </fieldset>
                 <div class="form-group clearfix">
                     <div class="col-sm-12 offset-sm-1 position-override">
-                        <div class="btn-group oe-opt-btn-group-pinch" role="group">
+                        <div class="btn-group" role="group">
                             <button type='submit' onclick='top.restoreSession()' class="btn btn-secondary btn-save"><?php echo xlt('Save'); ?></button>
                             <button type="button" class="btn btn-link btn-cancel" onclick="top.restoreSession(); parent.closeTab(window.name, false);"><?php echo xlt('Cancel');?></button>
                         </div>

--- a/interface/forms/dictation/view.php
+++ b/interface/forms/dictation/view.php
@@ -62,7 +62,7 @@ $obj = formFetch("form_dictation", $_GET["id"]);
                     <div class="col-sm-12 offset-sm-1 position-override">
                         <div class="btn-group oe-opt-btn-group-pinch" role="group">
                             <button type='submit' onclick='top.restoreSession()' class="btn btn-secondary btn-save"><?php echo xlt('Save'); ?></button>
-                            <button type="button" class="btn btn-link btn-cancel oe-opt-btn-separate-left" onclick="top.restoreSession(); parent.closeTab(window.name, false);"><?php echo xlt('Cancel');?></button>
+                            <button type="button" class="btn btn-link btn-cancel" onclick="top.restoreSession(); parent.closeTab(window.name, false);"><?php echo xlt('Cancel');?></button>
                         </div>
                     </div>
                 </div>

--- a/interface/forms/fee_sheet/new.php
+++ b/interface/forms/fee_sheet/new.php
@@ -1475,7 +1475,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                     <!--&nbsp; &nbsp; &nbsp;-->
                     <div class="form-group">
                         <div class="col-sm-12 position-override">
-                            <div class="btn-group oe-opt-btn-group-pinch" role="group">
+                            <div class="btn-group" role="group">
                                 <button type='button' class='btn btn-secondary btn-calendar' onclick='newEvt()'><?php echo xlt('New Appointment');?></button>
                                 <?php if (!$isBilled) { // visit is not yet billed ?>
                                     <button type='submit' name='bn_refresh' class='btn btn-secondary btn-refresh' value='<?php echo xla('Refresh');?>' onclick='return this.clicked = true;'><?php echo xlt('Refresh');?></button>
@@ -1504,7 +1504,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                     <button type='submit' class='btn btn-secondary btn-add' name='bn_addmore' onclick='return this.clicked = true;' value='<?php echo xla('Add More Items'); ?>'>
                                         <?php echo xlt('Add More Items'); ?></button>
                                 <?php } // end billed ?>
-                                    <button type='button' class='btn btn-link btn-cancel btn-separate-left' onclick="top.restoreSession();location='<?php echo $GLOBALS['form_exit_url']; ?>'">
+                                    <button type='button' class='btn btn-link btn-cancel' onclick="top.restoreSession();location='<?php echo $GLOBALS['form_exit_url']; ?>'">
                                     <?php echo xlt('Cancel');?></button>
                                     <input type='hidden' name='form_has_charges' value='<?php echo $fs->hasCharges ? 1 : 0; ?>' />
                                     <input type='hidden' name='form_checksum' value='<?php echo attr($current_checksum); ?>' />

--- a/interface/forms/functional_cognitive_status/new.php
+++ b/interface/forms/functional_cognitive_status/new.php
@@ -227,7 +227,7 @@ $check_res = $formid ? $check_res : array();
                         <div class="col-sm-12 position-override">
                             <div class="btn-group oe-opt-btn-group-pinch" role="group">
                                 <button type="submit" onclick="top.restoreSession()" class="btn btn-secondary btn-save"><?php echo xlt('Save'); ?></button>
-                                <button type="button" class="btn btn-link btn-cancel oe-opt-btn-separate-left" onclick="top.restoreSession(); parent.closeTab(window.name, false)"><?php echo xlt('Cancel');?></button>
+                                <button type="button" class="btn btn-link btn-cancel" onclick="top.restoreSession(); parent.closeTab(window.name, false)"><?php echo xlt('Cancel');?></button>
                                 <input type="hidden" id="clickId" value="" />
                             </div>
                         </div>

--- a/interface/forms/functional_cognitive_status/new.php
+++ b/interface/forms/functional_cognitive_status/new.php
@@ -225,7 +225,7 @@ $check_res = $formid ? $check_res : array();
                     </fieldset>
                     <div class="form-group clearfix">
                         <div class="col-sm-12 position-override">
-                            <div class="btn-group oe-opt-btn-group-pinch" role="group">
+                            <div class="btn-group" role="group">
                                 <button type="submit" onclick="top.restoreSession()" class="btn btn-secondary btn-save"><?php echo xlt('Save'); ?></button>
                                 <button type="button" class="btn btn-link btn-cancel" onclick="top.restoreSession(); parent.closeTab(window.name, false)"><?php echo xlt('Cancel');?></button>
                                 <input type="hidden" id="clickId" value="" />

--- a/interface/forms/misc_billing_options/new.php
+++ b/interface/forms/misc_billing_options/new.php
@@ -263,7 +263,7 @@ $obj = $formid ? formFetch("form_misc_billing_options", $formid) : array();
                             <!-- Save/Cancel buttons -->
                             <button type="submit" class="btn btn-secondary btn-save save"><?php echo xlt('Save'); ?></button>
                             <button type="button"
-                                    class="dontsave btn btn-link btn-cancel btn-separate-left"><?php echo xlt('Cancel'); ?></button>
+                                    class="dontsave btn btn-link btn-cancel"><?php echo xlt('Cancel'); ?></button>
                         </div>
                     </div>
                 </div>

--- a/interface/forms/newGroupEncounter/common.php
+++ b/interface/forms/newGroupEncounter/common.php
@@ -354,9 +354,9 @@ $help_icon = '';
                 <div class="col-md-12 form-group clearfix">
                       <button type="button" class="btn btn-secondary btn-save" onclick="top.restoreSession(); saveClicked(undefined);"><?php echo xlt('Save');?></button>
                       <?php if ($viewmode || empty($_GET["autoloaded"])) { // not creating new encounter ?>
-                          <button type="button" class="btn btn-link btn-cancel btn-separate-left" onClick="return cancelClickedOld()"><?php echo xlt('Cancel');?></button>
+                          <button type="button" class="btn btn-link btn-cancel" onClick="return cancelClickedOld()"><?php echo xlt('Cancel');?></button>
                       <?php } else { // not $viewmode ?>
-                          <button class="btn btn-link btn-cancel btn-separate-left link_submit" onClick="return cancelClickedNew()">
+                          <button class="btn btn-link btn-cancel link_submit" onClick="return cancelClickedNew()">
                               <?php echo xlt('Cancel'); ?></button>
                       <?php } // end not $viewmode ?>
                 </div>

--- a/interface/forms/newpatient/common.php
+++ b/interface/forms/newpatient/common.php
@@ -323,7 +323,7 @@ $ires = sqlStatement("SELECT id, type, title, begdate FROM lists WHERE " .
                 <div id="visit-details" class="px-5">
                     <div class="form-row align-items-center">
                         <div class="col-sm-2">
-                            <label for="pc_catid" class="oe-text-to-right"><?php echo xlt('Visit Category:'); ?></label>
+                            <label for="pc_catid" class="text-right"><?php echo xlt('Visit Category:'); ?></label>
                         </div>
                         <div class="col-sm">
                             <select name='pc_catid' id='pc_catid' class='form-control' <?php echo ($mode === "followup") ? 'disabled' : ''; ?>>
@@ -391,7 +391,7 @@ $ires = sqlStatement("SELECT id, type, title, begdate FROM lists WHERE " .
                             usort($sensitivities, "sensitivity_compare");
                             ?>
                         <div class="col-sm-2">
-                            <label for="pc_catid" class="oe-text-to-right"><?php echo xlt('Sensitivity:'); ?> <i id='sensitivity-tooltip' class="fa fa-info-circle text-primary" aria-hidden="true"></i></label>
+                            <label for="pc_catid" class="text-right"><?php echo xlt('Sensitivity:'); ?> <i id='sensitivity-tooltip' class="fa fa-info-circle text-primary" aria-hidden="true"></i></label>
                         </div>
                         <div class="col-sm">
                             <select name='form_sensitivity' id='form_sensitivity' class='form-control'>
@@ -419,7 +419,7 @@ $ires = sqlStatement("SELECT id, type, title, begdate FROM lists WHERE " .
                     </div>
                     <div class="form-row align-items-center mt-2">
                         <div class="col-sm-2">
-                            <label for='form_date' class="oe-text-to-right"><?php echo xlt('Date of Service:'); ?></label>
+                            <label for='form_date' class="text-right"><?php echo xlt('Date of Service:'); ?></label>
                         </div>
                         <div class="col-sm">
                             <input type='text' class='form-control datepicker' name='form_date' id='form_date' <?php echo $disabled ?> value='<?php echo $viewmode ? attr(oeFormatShortDate(substr($result['date'], 0, 10))) : attr(oeFormatShortDate(date('Y-m-d'))); ?>' title='<?php echo xla('Date of service'); ?>' />
@@ -427,7 +427,7 @@ $ires = sqlStatement("SELECT id, type, title, begdate FROM lists WHERE " .
                         <div class="col-sm-2" <?php if ($GLOBALS['ippf_specific']) {
                             echo " style='visibility:hidden;'";
                                               } ?>>
-                            <label for='form_onset_date' class="oe-text-to-right"><?php echo xlt('Onset/hosp. date:'); ?> &nbsp;<i id='onset-tooltip' class="fa fa-info-circle text-primary" aria-hidden="true"></i></label>
+                            <label for='form_onset_date' class="text-right"><?php echo xlt('Onset/hosp. date:'); ?> &nbsp;<i id='onset-tooltip' class="fa fa-info-circle text-primary" aria-hidden="true"></i></label>
                         </div>
                         <div class="col-sm">
                             <input type='text' class='form-control datepicker' name='form_onset_date' id='form_onset_date' value='<?php echo $viewmode && $result['onset_date'] !== '0000-00-00 00:00:00' ? attr(oeFormatShortDate(substr($result['onset_date'], 0, 10))) : ''; ?>' title='<?php echo xla('Date of onset or hospitalization'); ?>' />
@@ -440,7 +440,7 @@ $ires = sqlStatement("SELECT id, type, title, begdate FROM lists WHERE " .
                         } ?>
                     >
                         <div class="col-sm-2">
-                            <label for="form_referral_source" class="oe-text-to-right"><?php echo xlt('Referral Source'); ?>:</label>
+                            <label for="form_referral_source" class="text-right"><?php echo xlt('Referral Source'); ?>:</label>
                         </div>
                         <div class="col-sm">
                             <?php echo generate_select_list('form_referral_source', 'refsource', $viewmode ? $result['referral_source'] : '', ''); ?>
@@ -449,7 +449,7 @@ $ires = sqlStatement("SELECT id, type, title, begdate FROM lists WHERE " .
                     <?php if ($GLOBALS['enable_group_therapy']) { ?>
                     <div class="form-group mx-auto mt-2" id="therapy_group_name" style="display: none">
                         <div class="col-sm-2">
-                            <label for="form_group" class="col-sm-2 oe-text-to-right"><?php echo xlt('Group name'); ?>:</label>
+                            <label for="form_group" class="col-sm-2 text-right"><?php echo xlt('Group name'); ?>:</label>
                         </div>
                         <div class="col-sm">
                             <input type='text' name='form_group' class='form-control' id="form_group" placeholder='<?php echo xla('Click to select'); ?>' value='<?php echo $viewmode && in_array($result['pc_catid'], $therapyGroupCategories) ? attr(getGroup($result['external_id'])['group_name']) : ''; ?>' onclick='sel_group()' title='<?php echo xla('Click to select group'); ?>' readonly />
@@ -459,7 +459,7 @@ $ires = sqlStatement("SELECT id, type, title, begdate FROM lists WHERE " .
                     <?php } ?>
                     <div class="form-row align-items-center mt-2">
                         <div class="col-sm-2">
-                            <label for='provider_id' class="oe-text-to-right"><?php echo xlt('Encounter Provider'); ?>:</label>
+                            <label for='provider_id' class="text-right"><?php echo xlt('Encounter Provider'); ?>:</label>
                         </div>
                         <div class="col-sm">
                             <select name='provider_id' id='provider_id' class='form-control' onChange="newUserSelected()">
@@ -492,7 +492,7 @@ $ires = sqlStatement("SELECT id, type, title, begdate FROM lists WHERE " .
                             </select>
                         </div>
                         <div class="col-sm-2">
-                            <label for='class' class="oe-text-to-right"><?php echo xlt('Class'); ?>:</label>
+                            <label for='class' class="text-right"><?php echo xlt('Class'); ?>:</label>
                         </div>
                         <div class="col-sm">
                             <?php echo generate_select_list('class_code', '_ActEncounterCode', $viewmode ? $result['class_code'] : '', '', ''); ?>
@@ -501,7 +501,7 @@ $ires = sqlStatement("SELECT id, type, title, begdate FROM lists WHERE " .
                     </div>
                     <div class="form-row align-items-center mt-2">
                         <div class="col-sm-2">
-                            <label for='facility_id' class="oe-text-to-right"><?php echo xlt('Facility'); ?>:</label>
+                            <label for='facility_id' class="text-right"><?php echo xlt('Facility'); ?>:</label>
                         </div>
                         <div class="col-sm">
                             <select name='facility_id' id='facility_id' class='form-control' onChange="getPOS()" <?php echo ($mode === "followup") ? 'disabled' : ''; ?> >
@@ -531,7 +531,7 @@ $ires = sqlStatement("SELECT id, type, title, begdate FROM lists WHERE " .
                             <input type="hidden" name="facility_id" value="<?php echo attr($result['facility_id']); ?>" />
                         <?php } ?>
                         <div class="col-sm-2">
-                            <label for='billing_facility' class="oe-text-to-right"><?php echo xlt('Billing Facility'); ?>:</label>
+                            <label for='billing_facility' class="text-right"><?php echo xlt('Billing Facility'); ?>:</label>
                         </div>
                         <div id="ajaxdiv" class="col-sm">
                             <?php
@@ -551,7 +551,7 @@ $ires = sqlStatement("SELECT id, type, title, begdate FROM lists WHERE " .
                     <?php if ($GLOBALS['set_pos_code_encounter']) { ?>
                     <div class="form-row mt-2">
                         <div class="col-sm-2">
-                            <label for='pos_code' class="oe-text-to-right"><?php echo xlt('POS Code'); ?>:</label>
+                            <label for='pos_code' class="text-right"><?php echo xlt('POS Code'); ?>:</label>
                         </div>
                         <div class="col-sm-8">
                             <select name="pos_code" id="pos_code" class='form-control'>

--- a/interface/forms/newpatient/common.php
+++ b/interface/forms/newpatient/common.php
@@ -641,9 +641,9 @@ $ires = sqlStatement("SELECT id, type, title, begdate FROM lists WHERE " .
                     <div class="btn-group" role="group">
                         <button type="button" class="btn btn-primary btn-save" onclick="top.restoreSession(); saveClicked(undefined);"><?php echo xlt('Save'); ?></button>
                         <?php if ($viewmode || empty($_GET["autoloaded"])) { // not creating new encounter ?>
-                            <button type="button" class="btn btn-secondary btn-cancel btn-separate-left" onClick="return cancelClickedOld()"><?php echo xlt('Cancel'); ?></button>
+                            <button type="button" class="btn btn-secondary btn-cancel" onClick="return cancelClickedOld()"><?php echo xlt('Cancel'); ?></button>
                         <?php } else { // not $viewmode ?>
-                            <button class="btn btn-secondary btn-cancel btn-separate-left link_submit" onClick="return cancelClickedNew()"><?php echo xlt('Cancel'); ?></button>
+                            <button class="btn btn-secondary btn-cancel link_submit" onClick="return cancelClickedNew()"><?php echo xlt('Cancel'); ?></button>
                         <?php } // end not $viewmode ?>
                     </div>
                 </div>

--- a/interface/forms/observation/new.php
+++ b/interface/forms/observation/new.php
@@ -336,7 +336,7 @@ $check_res = $formid ? $check_res : array();
                         <div class="col-sm-12 position-override">
                             <div class="btn-group oe-opt-btn-group-pinch" role="group">
                                 <button type="submit" onclick='top.restoreSession()' class="btn btn-secondary btn-save"><?php echo xlt('Save'); ?></button>
-                                <button type="button" class="btn btn-link btn-cancel oe-opt-btn-separate-left" onclick="top.restoreSession(); parent.closeTab(window.name, false);"><?php echo xlt('Cancel');?></button>
+                                <button type="button" class="btn btn-link btn-cancel" onclick="top.restoreSession(); parent.closeTab(window.name, false);"><?php echo xlt('Cancel');?></button>
                                 <input type="hidden" id="clickId" value="">
                             </div>
                         </div>

--- a/interface/forms/observation/new.php
+++ b/interface/forms/observation/new.php
@@ -334,7 +334,7 @@ $check_res = $formid ? $check_res : array();
                     </fieldset>
                      <div class="form-group clearfix">
                         <div class="col-sm-12 position-override">
-                            <div class="btn-group oe-opt-btn-group-pinch" role="group">
+                            <div class="btn-group" role="group">
                                 <button type="submit" onclick='top.restoreSession()' class="btn btn-secondary btn-save"><?php echo xlt('Save'); ?></button>
                                 <button type="button" class="btn btn-link btn-cancel" onclick="top.restoreSession(); parent.closeTab(window.name, false);"><?php echo xlt('Cancel');?></button>
                                 <input type="hidden" id="clickId" value="">

--- a/interface/forms/procedure_order/new.php
+++ b/interface/forms/procedure_order/new.php
@@ -752,7 +752,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                             <button type="button" class="btn btn-secondary btn-add" onclick="addProcLine()"><?php echo xlt('Add Procedure'); ?></button>
                             <button type="submit" class="btn btn-secondary btn-save" name='bn_save' value="save" onclick='transmitting = false;'><?php echo xlt('Save'); ?></button>
                             <button type="submit" class="btn btn-secondary btn-transmit" name='bn_xmit' value="transmit" onclick='transmitting = true;'><?php echo xlt('Save and Transmit'); ?></button>
-                            <button type="button" class="btn btn-link btn-cancel btn-separate-left" onclick="top.restoreSession();location='<?php echo $GLOBALS['form_exit_url']; ?>'"><?php echo xlt('Cancel'); ?></button>
+                            <button type="button" class="btn btn-link btn-cancel" onclick="top.restoreSession();location='<?php echo $GLOBALS['form_exit_url']; ?>'"><?php echo xlt('Cancel'); ?></button>
                         </div>
                     </div>
                 </div>

--- a/interface/forms/procedure_order/new.php
+++ b/interface/forms/procedure_order/new.php
@@ -553,11 +553,11 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                     <legend><?php echo xlt('Select Options for Current Procedure Order Id ') . (($formid) ? text($formid) : 'New Order')?></legend>
                     <div class="col-12">
                         <div class="form-row">
-                            <label for="provider_id" class="col-form-label col-sm-3 oe-text-to-right"><?php echo xlt('Ordering Provider'); ?></label>
+                            <label for="provider_id" class="col-form-label col-sm-3 text-right"><?php echo xlt('Ordering Provider'); ?></label>
                             <div class="col-sm-2">
                                 <?php generate_form_field(array('data_type' => 10, 'field_id' => 'provider_id'), $row['provider_id']); ?>
                             </div>
-                            <label for="lab_id" class="col-form-label col-sm-3 oe-text-to-right"><?php echo xlt('Sending To'); ?></label>
+                            <label for="lab_id" class="col-form-label col-sm-3 text-right"><?php echo xlt('Sending To'); ?></label>
                             <div class="col-sm-2">
                                 <select name='form_lab_id' onchange='lab_id_changed()' class='form-control'>
                                     <?php
@@ -576,18 +576,18 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                             <div class="clearfix"></div>
                         </div>
                         <div class="form-row">
-                            <label for="form_data_ordered" class="col-form-label col-sm-3 oe-text-to-right"><?php echo xlt('Order Date'); ?></label>
+                            <label for="form_data_ordered" class="col-form-label col-sm-3 text-right"><?php echo xlt('Order Date'); ?></label>
                             <div class="col-sm-2">
                                 <input type='text' class='datepicker form-control' name='form_date_ordered' id='form_date_ordered' value="<?php echo attr($row['date_ordered']); ?>" title="<?php echo xla('Date of this order'); ?>"/>
                             </div>
-                            <label for="form_data_ordered" class="col-form-label col-sm-3 oe-text-to-right"><?php echo xlt('Internal Time Collected'); ?></label>
+                            <label for="form_data_ordered" class="col-form-label col-sm-3 text-right"><?php echo xlt('Internal Time Collected'); ?></label>
                             <div class="col-sm-2">
                                 <input class='datetimepicker form-control' type='text' name='form_date_collected' id='form_date_collected' value="<?php echo attr(substr($row['date_collected'], 0, 16)); ?>" title="<?php echo xla('Date and time that the sample was collected'); ?>"/>
                             </div>
                             <div class="clearfix"></div>
                         </div>
                         <div class="form-row">
-                            <label for="form_data_ordered" class="col-form-label col-sm-3 oe-text-to-right"><?php echo xlt('Priority'); ?></label>
+                            <label for="form_data_ordered" class="col-form-label col-sm-3 text-right"><?php echo xlt('Priority'); ?></label>
                             <div class="col-sm-2">
                                 <?php
                                 generate_form_field(array('data_type' => 1, 'field_id' => 'order_priority',
@@ -595,7 +595,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                 ?>
                             </div>
 
-                            <label for="form_data_ordered" class="col-form-label col-sm-3 oe-text-to-right"><?php echo xlt('Status'); ?></label>
+                            <label for="form_data_ordered" class="col-form-label col-sm-3 text-right"><?php echo xlt('Status'); ?></label>
                             <div class="col-sm-2">
                                 <?php
                                 generate_form_field(array('data_type' => 1, 'field_id' => 'order_status',
@@ -605,7 +605,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                             <div class="clearfix"></div>
                         </div>
                         <div class="form-row">
-                            <label for="form_data_ordered" class="col-form-label col-sm-3 oe-text-to-right"><?php echo xlt('History Order'); ?></label>
+                            <label for="form_data_ordered" class="col-form-label col-sm-3 text-right"><?php echo xlt('History Order'); ?></label>
                             <div class="col-sm-2">
                                 <?php
                                 $historyOrderOpts = array(
@@ -625,7 +625,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                         </div>
                         <?php // Hide this for now with a hidden class as it does not yet do anything ?>
                         <div class="form-row hidden">
-                            <label for="form_data_ordered" class="col-form-label col-sm-3 oe-text-to-right"><?php echo xlt('Patient Instructions'); ?></label>
+                            <label for="form_data_ordered" class="col-form-label col-sm-3 text-right"><?php echo xlt('Patient Instructions'); ?></label>
                             <div class="col-sm-7">
                                 <textarea rows='3' cols='35' name='form_patient_instructions' class='form-control inputtext'><?php echo text($row['patient_instructions']); ?></textarea>
                             </div>
@@ -748,7 +748,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                 <?php //can change position of buttons by creating a class 'position-override' and adding rule text-alig:center or right as the case may be in individual stylesheets ?>
                 <div class="form-group clearfix">
                     <div class="col-sm-12 text-left position-override">
-                        <div class="btn-group btn-group-pinch" role="group">
+                        <div class="btn-group" role="group">
                             <button type="button" class="btn btn-secondary btn-add" onclick="addProcLine()"><?php echo xlt('Add Procedure'); ?></button>
                             <button type="submit" class="btn btn-secondary btn-save" name='bn_save' value="save" onclick='transmitting = false;'><?php echo xlt('Save'); ?></button>
                             <button type="submit" class="btn btn-secondary btn-transmit" name='bn_xmit' value="transmit" onclick='transmitting = true;'><?php echo xlt('Save and Transmit'); ?></button>

--- a/interface/forms/reviewofs/new.php
+++ b/interface/forms/reviewofs/new.php
@@ -803,7 +803,7 @@ $returnurl = 'encounter_top.php';
                     <div class="col-sm-12 offset-sm-1 position-override">
                         <div class="btn-group oe-opt-btn-group-pinch" role="group">
                         <button type="submit" onclick="top.restoreSession()" class="btn btn-secondary btn-save"><?php echo xlt('Save'); ?></button>
-                        <button type="button" class="btn btn-link btn-cancel oe-opt-btn-separate-left" onclick="top.restoreSession(); parent.closeTab(window.name, false);"><?php echo xlt('Cancel');?></button>
+                        <button type="button" class="btn btn-link btn-cancel" onclick="top.restoreSession(); parent.closeTab(window.name, false);"><?php echo xlt('Cancel');?></button>
                     </div>
                 </div>
             </div>

--- a/interface/forms/reviewofs/new.php
+++ b/interface/forms/reviewofs/new.php
@@ -801,7 +801,7 @@ $returnurl = 'encounter_top.php';
             </fieldset>
                 <div class="form-group clearfix">
                     <div class="col-sm-12 offset-sm-1 position-override">
-                        <div class="btn-group oe-opt-btn-group-pinch" role="group">
+                        <div class="btn-group" role="group">
                         <button type="submit" onclick="top.restoreSession()" class="btn btn-secondary btn-save"><?php echo xlt('Save'); ?></button>
                         <button type="button" class="btn btn-link btn-cancel" onclick="top.restoreSession(); parent.closeTab(window.name, false);"><?php echo xlt('Cancel');?></button>
                     </div>

--- a/interface/forms/reviewofs/view.php
+++ b/interface/forms/reviewofs/view.php
@@ -793,7 +793,7 @@ $obj = formFetch("form_reviewofs", $_GET["id"]);
                 </fieldset>
                     <div class="form-group clearfix">
                         <div class="col-sm-12 offset-sm-1 position-override">
-                            <div class="btn-group oe-opt-btn-group-pinch" role="group">
+                            <div class="btn-group" role="group">
                             <button type="submit" onclick="top.restoreSession()" class="btn btn-secondary btn-save"><?php echo xlt('Save'); ?></button>
                             <button type="button" class="btn btn-link btn-cancel" onclick="top.restoreSession(); parent.closeTab(window.name, false);"><?php echo xlt('Cancel');?></button>
                         </div>

--- a/interface/forms/reviewofs/view.php
+++ b/interface/forms/reviewofs/view.php
@@ -795,7 +795,7 @@ $obj = formFetch("form_reviewofs", $_GET["id"]);
                         <div class="col-sm-12 offset-sm-1 position-override">
                             <div class="btn-group oe-opt-btn-group-pinch" role="group">
                             <button type="submit" onclick="top.restoreSession()" class="btn btn-secondary btn-save"><?php echo xlt('Save'); ?></button>
-                            <button type="button" class="btn btn-link btn-cancel oe-opt-btn-separate-left" onclick="top.restoreSession(); parent.closeTab(window.name, false);"><?php echo xlt('Cancel');?></button>
+                            <button type="button" class="btn btn-link btn-cancel" onclick="top.restoreSession(); parent.closeTab(window.name, false);"><?php echo xlt('Cancel');?></button>
                         </div>
                     </div>
                 </div>

--- a/interface/forms/ros/templates/ros/general_new.html
+++ b/interface/forms/ros/templates/ros/general_new.html
@@ -741,7 +741,7 @@
                         <div class="col-sm-12 offset-sm-2 position-override">
                             <div class="btn-group oe-opt-btn-group-pinch" role="group">
                                 <button type="submit" class="btn btn-secondary btn-save" onclick="top.restoreSession();" name="Submit">{xlt t='Save'}</button>
-                                <button type="button" class="btn btn-link btn-cancel oe-opt-btn-separate-left" onclick="top.restoreSession(); location.href='{$DONT_SAVE_LINK}';">{xlt t='Cancel'}</button>
+                                <button type="button" class="btn btn-link btn-cancel" onclick="top.restoreSession(); location.href='{$DONT_SAVE_LINK}';">{xlt t='Cancel'}</button>
                             </div>
                             <input type="hidden" name="id" value="{$form->get_id()|attr}" />
                             <input type="hidden" name="pid" value="{$form->get_pid()|attr}">

--- a/interface/forms/ros/templates/ros/general_new.html
+++ b/interface/forms/ros/templates/ros/general_new.html
@@ -739,7 +739,7 @@
                     </fieldset>
                     <div class="form-group clearfix">
                         <div class="col-sm-12 offset-sm-2 position-override">
-                            <div class="btn-group oe-opt-btn-group-pinch" role="group">
+                            <div class="btn-group" role="group">
                                 <button type="submit" class="btn btn-secondary btn-save" onclick="top.restoreSession();" name="Submit">{xlt t='Save'}</button>
                                 <button type="button" class="btn btn-link btn-cancel" onclick="top.restoreSession(); location.href='{$DONT_SAVE_LINK}';">{xlt t='Cancel'}</button>
                             </div>

--- a/interface/forms/soap/templates/general_new.html
+++ b/interface/forms/soap/templates/general_new.html
@@ -48,7 +48,7 @@
                     </fieldset>
                     <div class="form-group clearfix">
                         <div class="col-sm-10 offset-sm-1 position-override">
-                            <div class="btn-group oe-opt-btn-group-pinch" role="group">
+                            <div class="btn-group" role="group">
                                 <button type="submit" class="btn btn-secondary btn-save" name="Submit">{xlt t='Save'}</button>
                                 <button type="button" class="btn btn-link btn-cancel" id="btnClose">{xlt t='Cancel'}</button>
                             </div>

--- a/interface/forms/soap/templates/general_new.html
+++ b/interface/forms/soap/templates/general_new.html
@@ -50,7 +50,7 @@
                         <div class="col-sm-10 offset-sm-1 position-override">
                             <div class="btn-group oe-opt-btn-group-pinch" role="group">
                                 <button type="submit" class="btn btn-secondary btn-save" name="Submit">{xlt t='Save'}</button>
-                                <button type="button" class="btn btn-link btn-cancel oe-opt-btn-separate-left" id="btnClose">{xlt t='Cancel'}</button>
+                                <button type="button" class="btn btn-link btn-cancel" id="btnClose">{xlt t='Cancel'}</button>
                             </div>
                             <input type="hidden" name="id" value="{$data->get_id()|attr}" />
                             <input type="hidden" name="activity" value="{$data->get_activity()|attr}">

--- a/interface/forms/vitals/templates/vitals/general_new.html
+++ b/interface/forms/vitals/templates/vitals/general_new.html
@@ -360,7 +360,7 @@ function vitalsFormSubmitted() {
                     <div class="text-left position-override">
                         <div class="btn-group" role="group">
                             <button type="submit" class="btn btn-secondary btn-save editonly" name="Submit" value=''>{xlt t="Save"}</button>
-                            <button type="button" class="btn btn-link btn-cancel btn-separate-left editonly" id="cancel" value=''>{xlt t="Cancel"}</button>
+                            <button type="button" class="btn btn-link btn-cancel editonly" id="cancel" value=''>{xlt t="Cancel"}</button>
                         </div>
                     </div>
                 </div>

--- a/interface/main/dated_reminders/dated_reminders_add.php
+++ b/interface/main/dated_reminders/dated_reminders_add.php
@@ -388,7 +388,7 @@ if (isset($this_message['pid'])) {
 
             <div class="form-group mt-3">
                 <label class="text-right" for="message"><?php echo xlt('Type Your message here');?>:</label>
-                <textarea onKeyDown="limitText(this.form.message,this.form.countdown,<?php echo attr(addslashes($max_reminder_words)); ?>);" onKeyUp="limitText(this.form.message,this.form.countdown,<?php echo attr(addslashes($max_reminder_words)); ?>);" class="form-control oe-text-to-left" rows="5" name="message" id="message" placeholder="<?php echo xla('Maximum characters') ?> : <?php echo attr($max_reminder_words); ?>"><?php echo text($this_message['dr_message_text']);?></textarea>
+                <textarea onKeyDown="limitText(this.form.message,this.form.countdown,<?php echo attr(addslashes($max_reminder_words)); ?>);" onKeyUp="limitText(this.form.message,this.form.countdown,<?php echo attr(addslashes($max_reminder_words)); ?>);" class="form-control text-left" rows="5" name="message" id="message" placeholder="<?php echo xla('Maximum characters') ?> : <?php echo attr($max_reminder_words); ?>"><?php echo text($this_message['dr_message_text']);?></textarea>
             </div>
 
             <div class="form-row mt-3">

--- a/interface/main/dated_reminders/dated_reminders_log.php
+++ b/interface/main/dated_reminders/dated_reminders_log.php
@@ -189,7 +189,7 @@ if ($_GET) {
                     </fieldset>
                     <div class="form-group row">
                         <div class="col-sm-12 position-override">
-                            <div class="btn-group oe-opt-btn-group-pinch form-group" role="group">
+                            <div class="btn-group form-group" role="group">
                                 <button type="button" value="Refresh" id="submitForm" class="btn btn-secondary btn-refresh" ><?php echo xlt('Refresh') ?></button>
                             </div>
                         </div>

--- a/interface/main/messages/messages.php
+++ b/interface/main/messages/messages.php
@@ -544,11 +544,11 @@ if (!empty($_REQUEST['go'])) { ?>
                                                 <!-- This is for displaying an existing note. -->
                                                 <button type="button" class="btn btn-primary btn-send-msg" id="newnote" value="<?php echo xla('Send message'); ?>"><?php echo xlt('Send message'); ?></button>
                                                 <button type="button" class="btn btn-primary btn-print" id="printnote" value="<?php echo xla('Print message'); ?>"><?php echo xlt('Print message'); ?></button>
-                                                <button type="button" class="btn btn-secondary btn-cancel oe-opt-btn-separate-left" id="cancel" value="<?php echo xla('Cancel'); ?>"><?php echo xlt('Cancel'); ?></button>
+                                                <button type="button" class="btn btn-secondary btn-cancel" id="cancel" value="<?php echo xla('Cancel'); ?>"><?php echo xlt('Cancel'); ?></button>
                                             <?php } else { ?>
                                                 <!-- This is for displaying a new note. -->
                                                 <button type="button" class="btn btn-primary btn-send-msg" id="newnote" value="<?php echo xla('Send message'); ?>"><?php echo xlt('Send message'); ?></button>
-                                                <button type="button" class="btn btn-cancel btn-secondary oe-opt-btn-separate-left" id="cancel" value="<?php echo xla('Cancel'); ?>"><?php echo xlt('Cancel'); ?></button>
+                                                <button type="button" class="btn btn-cancel btn-secondary" id="cancel" value="<?php echo xla('Cancel'); ?>"><?php echo xlt('Cancel'); ?></button>
                                             <?php }
                                             ?>
                                         </div>

--- a/interface/orders/procedure_provider_edit.php
+++ b/interface/orders/procedure_provider_edit.php
@@ -442,9 +442,9 @@ function invalue($name)
                         <div class="col-sm-12 text-left position-override">
                             <div class="btn-group" role="group">
                                 <button type='submit' name='form_save'  class="btn btn-primary btn-save"  value='<?php echo xla('Save'); ?>'><?php echo xlt('Save'); ?></button>
-                                <button type="button" class="btn btn-secondary btn-cancel btn-separate-left" onclick='window.close()';><?php echo xlt('Cancel');?></button>
+                                <button type="button" class="btn btn-secondary btn-cancel" onclick='window.close()';><?php echo xlt('Cancel');?></button>
                                 <?php if ($ppid) { ?>
-                                    <button type='submit' name='form_delete' class="btn btn-danger btn-cancel btn-delete btn-separate-left" value='<?php echo xla('Delete'); ?>'><?php echo xlt('Delete'); ?></button>
+                                    <button type='submit' name='form_delete' class="btn btn-danger btn-cancel btn-delete" value='<?php echo xla('Delete'); ?>'><?php echo xlt('Delete'); ?></button>
                                 <?php } ?>
                             </div>
                         </div>

--- a/interface/orders/procedure_provider_edit.php
+++ b/interface/orders/procedure_provider_edit.php
@@ -440,7 +440,7 @@ function invalue($name)
                    <div class="mt-3">
                     <div class="form-group clearfix" id="button-container">
                         <div class="col-sm-12 text-left position-override">
-                            <div class="btn-group btn-group-pinch" role="group">
+                            <div class="btn-group" role="group">
                                 <button type='submit' name='form_save'  class="btn btn-primary btn-save"  value='<?php echo xla('Save'); ?>'><?php echo xlt('Save'); ?></button>
                                 <button type="button" class="btn btn-secondary btn-cancel btn-separate-left" onclick='window.close()';><?php echo xlt('Cancel');?></button>
                                 <?php if ($ppid) { ?>

--- a/interface/orders/types.php
+++ b/interface/orders/types.php
@@ -327,7 +327,7 @@ if ($popup && $_POST['form_save']) {
                     <?php //can change position of buttons by creating a class 'position-override' and adding rule text-align:center or right as the case may be in individual stylesheets ?>
                     <div class="form-group clearfix">
                         <div class="col-sm-12 text-left position-override">
-                            <div class="btn-group btn-group-pinch" role="group">
+                            <div class="btn-group" role="group">
                                 <?php if ($popup) { ?>
                                     <button type="submit" class="btn btn-secondary btn-save" name='form_save' value='<?php echo xla('Save'); ?>'><?php echo xlt('Save');?></button>
                                     <button class="btn btn-link btn-cancel btn-separate-left" onclick="CancelDistribute()"><?php echo xlt('Cancel');?></button>

--- a/interface/orders/types.php
+++ b/interface/orders/types.php
@@ -330,7 +330,7 @@ if ($popup && $_POST['form_save']) {
                             <div class="btn-group" role="group">
                                 <?php if ($popup) { ?>
                                     <button type="submit" class="btn btn-secondary btn-save" name='form_save' value='<?php echo xla('Save'); ?>'><?php echo xlt('Save');?></button>
-                                    <button class="btn btn-link btn-cancel btn-separate-left" onclick="CancelDistribute()"><?php echo xlt('Cancel');?></button>
+                                    <button class="btn btn-link btn-cancel" onclick="CancelDistribute()"><?php echo xlt('Cancel');?></button>
                                 <?php } ?>
                             </div>
                         </div>

--- a/interface/orders/types_edit.php
+++ b/interface/orders/types_edit.php
@@ -712,7 +712,7 @@ function proc_type_changed() {
                         <?php //can change position of buttons by creating a class 'position-override' and adding rule text-alig:center or right as the case may be in individual stylesheets ?>
                         <div class="form-group clearfix" id="button-container">
                             <div class="col-sm-12 text-left position-override">
-                                <div class="btn-group btn-group-pinch" role="group">
+                                <div class="btn-group" role="group">
                                     <button type='submit' name='form_save'  class="btn btn-secondary btn-save"  value='<?php echo xla('Save'); ?>'><?php echo xlt('Save'); ?></button>
                                     <button type="button" class="btn btn-link btn-cancel btn-separate-left" onclick='window.close()';><?php echo xlt('Cancel');?></button>
                                     <?php if ($typeid) { ?>

--- a/interface/orders/types_edit.php
+++ b/interface/orders/types_edit.php
@@ -714,9 +714,9 @@ function proc_type_changed() {
                             <div class="col-sm-12 text-left position-override">
                                 <div class="btn-group" role="group">
                                     <button type='submit' name='form_save'  class="btn btn-secondary btn-save"  value='<?php echo xla('Save'); ?>'><?php echo xlt('Save'); ?></button>
-                                    <button type="button" class="btn btn-link btn-cancel btn-separate-left" onclick='window.close()';><?php echo xlt('Cancel');?></button>
+                                    <button type="button" class="btn btn-link btn-cancel" onclick='window.close()';><?php echo xlt('Cancel');?></button>
                                     <?php if ($typeid) { ?>
-                                        <button type='submit' name='form_delete'  class="btn btn-secondary btn-cancel btn-delete btn-separate-left" value='<?php echo xla('Delete'); ?>'><?php echo xlt('Delete'); ?></button>
+                                        <button type='submit' name='form_delete'  class="btn btn-secondary btn-cancel btn-delete" value='<?php echo xla('Delete'); ?>'><?php echo xlt('Delete'); ?></button>
                                     <?php } ?>
                                 </div>
                             </div>

--- a/interface/patient_file/front_payment.php
+++ b/interface/patient_file/front_payment.php
@@ -1237,7 +1237,7 @@ function make_insurance() {
                     </fieldset>
                     <div class="form-group">
                         <div class="col-sm-12 text-left position-override">
-                            <div class="btn-group btn-group-pinch" role="group">
+                            <div class="btn-group" role="group">
                                 <button type='submit' class="btn btn-secondary btn-save" name='form_save' value='<?php echo xla('Generate Invoice');?>'><?php echo xlt('Generate Invoice');?></button>
                                 <button type='button' class="btn btn-link btn-cancel btn-separate-left"  value='<?php echo xla('Cancel'); ?>' onclick='closeHow(event)'><?php echo xlt('Cancel'); ?></button>
                                 <input type="hidden" name="hidden_patient_code" id="hidden_patient_code" value="<?php echo attr($pid);?>"/>

--- a/interface/patient_file/front_payment.php
+++ b/interface/patient_file/front_payment.php
@@ -1239,7 +1239,7 @@ function make_insurance() {
                         <div class="col-sm-12 text-left position-override">
                             <div class="btn-group" role="group">
                                 <button type='submit' class="btn btn-secondary btn-save" name='form_save' value='<?php echo xla('Generate Invoice');?>'><?php echo xlt('Generate Invoice');?></button>
-                                <button type='button' class="btn btn-link btn-cancel btn-separate-left"  value='<?php echo xla('Cancel'); ?>' onclick='closeHow(event)'><?php echo xlt('Cancel'); ?></button>
+                                <button type='button' class="btn btn-link btn-cancel"  value='<?php echo xla('Cancel'); ?>' onclick='closeHow(event)'><?php echo xlt('Cancel'); ?></button>
                                 <input type="hidden" name="hidden_patient_code" id="hidden_patient_code" value="<?php echo attr($pid);?>"/>
                                 <input type='hidden' name='ajax_mode' id='ajax_mode' value='' />
                                 <input type='hidden' name='mode' id='mode' value='' />

--- a/interface/patient_file/pos_checkout.php
+++ b/interface/patient_file/pos_checkout.php
@@ -1107,7 +1107,7 @@ function generate_receipt($patient_id, $encounter = 0)
                                 <div class="btn-group" role="group">
                                     <button type='submit' class="btn btn-secondary btn-save"  name='form_save' id='form_save' value='save'><?php echo xlt('Save');?></button>
                                     <?php if (empty($_GET['framed'])) { ?>
-                                    <button type='button' class="btn btn-link btn-cancel btn-separate-left" onclick='window.close()'><?php echo xlt('Cancel'); ?></button>
+                                    <button type='button' class="btn btn-link btn-cancel" onclick='window.close()'><?php echo xlt('Cancel'); ?></button>
                                     <?php } ?>
                                     <input type='hidden' name='form_provider'  value='<?php echo attr($inv_provider)  ?>' />
                                     <input type='hidden' name='form_payer'     value='<?php echo attr($inv_payer)     ?>' />

--- a/interface/patient_file/pos_checkout.php
+++ b/interface/patient_file/pos_checkout.php
@@ -1104,7 +1104,7 @@ function generate_receipt($patient_id, $encounter = 0)
                         </fieldset>
                         <div class="form-group">
                             <div class="col-sm-12 text-left position-override">
-                                <div class="btn-group btn-group-pinch" role="group">
+                                <div class="btn-group" role="group">
                                     <button type='submit' class="btn btn-secondary btn-save"  name='form_save' id='form_save' value='save'><?php echo xlt('Save');?></button>
                                     <?php if (empty($_GET['framed'])) { ?>
                                     <button type='button' class="btn btn-link btn-cancel btn-separate-left" onclick='window.close()'><?php echo xlt('Cancel'); ?></button>

--- a/interface/patient_file/summary/add_edit_issue.php
+++ b/interface/patient_file/summary/add_edit_issue.php
@@ -834,7 +834,7 @@ if (!empty($irow['type'])) {
                         ?>
                         <div class="form-group clearfix" id="button-container">
                             <div class="col-sm-12 text-left position-override">
-                                <div class="btn-group btn-group-pinch" role="group">
+                                <div class="btn-group" role="group">
                                     <button type='submit' name='form_save' class="btn btn-secondary btn-save" value='<?php echo xla('Save'); ?>'><?php echo xlt('Save'); ?></button>
                                     <button type="button" class="btn btn-link btn-cancel btn-separate-left" onclick='closeme();'><?php echo xlt('Cancel'); ?></button>
                                     <?php

--- a/interface/patient_file/summary/add_edit_issue.php
+++ b/interface/patient_file/summary/add_edit_issue.php
@@ -836,10 +836,10 @@ if (!empty($irow['type'])) {
                             <div class="col-sm-12 text-left position-override">
                                 <div class="btn-group" role="group">
                                     <button type='submit' name='form_save' class="btn btn-secondary btn-save" value='<?php echo xla('Save'); ?>'><?php echo xlt('Save'); ?></button>
-                                    <button type="button" class="btn btn-link btn-cancel btn-separate-left" onclick='closeme();'><?php echo xlt('Cancel'); ?></button>
+                                    <button type="button" class="btn btn-link btn-cancel" onclick='closeme();'><?php echo xlt('Cancel'); ?></button>
                                     <?php
                                     if ($issue && AclMain::aclCheckCore('admin', 'super')) { ?>
-                                        <button type='submit' name='form_delete' class="btn btn-secondary btn-cancel btn-delete btn-separate-left" onclick='deleteme()' value='<?php echo xla('Delete'); ?>'><?php echo xlt('Delete'); ?></button>
+                                        <button type='submit' name='form_delete' class="btn btn-secondary btn-cancel btn-delete" onclick='deleteme()' value='<?php echo xla('Delete'); ?>'><?php echo xlt('Delete'); ?></button>
                                         <?php
                                     } ?>
                                 </div>

--- a/interface/patient_file/summary/dashboard_header.php
+++ b/interface/patient_file/summary/dashboard_header.php
@@ -57,7 +57,7 @@ if ($days_deceased) { ?>
 } ?>
     <div class="form-group">
 
-            <div class="btn-group oe-opt-btn-group-pinch" role="group">
+            <div class="btn-group" role="group">
 
             <?php
             if (AclMain::aclCheckCore('admin', 'super') && $GLOBALS['allow_pat_delete']) { ?>

--- a/interface/patient_tracker/patient_tracker_status.php
+++ b/interface/patient_tracker/patient_tracker_status.php
@@ -115,7 +115,7 @@ $row = sqlQuery("select fname, lname " .
                 <?php echo generate_select_list('roomnum', 'patient_flow_board_rooms', $trow['lastroom'], xl('Exam Room Number')); ?>
             </div>
             <div class="position-override">
-                <div class="btn-group oe-opt-btn-group-pinch" role="group">
+                <div class="btn-group" role="group">
                     <button type="button" class='btn btn-primary btn-save btn-sm' onclick='document.getElementById("form_note").submit();'><?php echo xlt('Save')?></button>
                     <button type="button" class='btn btn-secondary btn-cancel btn-sm' onclick="dlgclose();" ><?php echo xlt('Cancel'); ?></button>
                 </div>

--- a/interface/patient_tracker/patient_tracker_status.php
+++ b/interface/patient_tracker/patient_tracker_status.php
@@ -117,7 +117,7 @@ $row = sqlQuery("select fname, lname " .
             <div class="position-override">
                 <div class="btn-group oe-opt-btn-group-pinch" role="group">
                     <button type="button" class='btn btn-primary btn-save btn-sm' onclick='document.getElementById("form_note").submit();'><?php echo xlt('Save')?></button>
-                    <button type="button" class='btn btn-secondary btn-cancel btn-sm oe-opt-btn-separate-left' onclick="dlgclose();" ><?php echo xlt('Cancel'); ?></button>
+                    <button type="button" class='btn btn-secondary btn-cancel btn-sm' onclick="dlgclose();" ><?php echo xlt('Cancel'); ?></button>
                 </div>
             </div>
         </form>

--- a/interface/themes/colors/utilities/bootstrap.scss
+++ b/interface/themes/colors/utilities/bootstrap.scss
@@ -74,11 +74,6 @@ textarea.form-control {
   transition: border-color ease-in-out 0.3s, box-shadow ease-in-out 0.3s;
 }
 
-.btn-separate-left,
-.oe-opt-btn-separate-left {
-  margin-left: 20px !important;
-}
-
 .btn-group .btn {
   margin-right: 2px !important;
 }
@@ -88,12 +83,6 @@ textarea.form-control {
   border-bottom-right-radius: 0 !important;
   border-top-left-radius: 3px !important;
   border-top-right-radius: 0 !important;
-}
-
-.btn-group-pinch > .btn:nth-last-child(2):not(.dropdown-toggle),
-.oe-opt-btn-group-pinch > .btn:nth-last-child(2):not(.dropdown-toggle) {
-  border-bottom-right-radius: 3px !important;
-  border-top-right-radius: 3px !important;
 }
 
 .btn-sm {

--- a/interface/themes/core/text.scss
+++ b/interface/themes/core/text.scss
@@ -111,10 +111,3 @@ body.admin-layout input[type="button"] {
   width: 44px;
 }
 
-.oe-text-to-right {
-  text-align: $right;
-}
-
-.oe-text-to-left {
-  text-align: $left;
-}

--- a/interface/themes/rtl_style_pdf.css
+++ b/interface/themes/rtl_style_pdf.css
@@ -1322,14 +1322,6 @@ body {
   padding: 0;
 }
 
-.oe-text-to-right {
-  text-align: left;
-}
-
-.oe-text-to-left {
-  text-align: right;
-}
-
 .oe-pull-toward {
   float: right !important;
 }

--- a/interface/usergroup/adminacl.php
+++ b/interface/usergroup/adminacl.php
@@ -585,7 +585,7 @@ if (!AclMain::aclCheckCore('admin', 'acl')) {
                                     <div class="col-12" style="padding: 15px 18px">
                                         <button type="submit" class="button_acl_add btn btn-secondary" id="button_acl_add_submit" title='<?php echo xla('Add Group'); ?>'><?php echo xlt('Add Group'); ?></button>
                                         <button type="reset" class="button_acl_add btn btn-link" id="button_acl_add_clear" title='<?php echo xla('Clear'); ?>'><?php echo xlt('Clear'); ?></button>
-                                        <button type="reset" class="button_acl_add btn btn-link btn-cancel oe-opt-btn-separate-left" id="button_acl_add_cancel" title='<?php echo xla('Cancel'); ?>'><?php echo xlt('Cancel'); ?></button>
+                                        <button type="reset" class="button_acl_add btn btn-link btn-cancel" id="button_acl_add_cancel" title='<?php echo xla('Cancel'); ?>'><?php echo xlt('Cancel'); ?></button>
                                     </div>
                                 </div>
                             </div>
@@ -627,7 +627,7 @@ if (!AclMain::aclCheckCore('admin', 'acl')) {
                                 <div class="row">
                                     <div class="col-12" style="padding:15px 18px">
                                         <button type="submit" class="button_acl_remove btn btn-secondary" id="button_acl_remove_delete" title='<?php echo xla('Delete Group'); ?>'><?php echo xlt('Delete Group'); ?></button>
-                                        <button type="reset" class="button_acl_remove btn btn-link btn-cancel oe-opt-btn-separate-left" id="button_acl_remove_cancel" title='<?php echo xla('Cancel'); ?>'><?php echo xlt('Cancel'); ?></button>
+                                        <button type="reset" class="button_acl_remove btn btn-link btn-cancel" id="button_acl_remove_cancel" title='<?php echo xla('Cancel'); ?>'><?php echo xlt('Cancel'); ?></button>
                                     </div>
                                 </div>
                             </div>

--- a/interface/usergroup/facility_user_admin.php
+++ b/interface/usergroup/facility_user_admin.php
@@ -206,7 +206,7 @@ if (!isset($_GET["user_id"]) || !isset($_GET["fac_id"])) {
                             <button type="submit" class="btn btn-secondary btn-save" name='form_save' id='form_save' href='#'>
                                 <?php echo xlt('Save'); ?>
                             </button>
-                            <a class="btn btn-link btn-cancel oe-opt-btn-separate-left" id='cancel' href='#'>
+                            <a class="btn btn-link btn-cancel" id='cancel' href='#'>
                                 <?php echo xlt('Cancel'); ?>
                             </a>
                         </td>

--- a/interface/usergroup/mfa_totp.php
+++ b/interface/usergroup/mfa_totp.php
@@ -127,7 +127,7 @@ $user_full_name = $user_name['fname'] . " " . $user_name['lname'];
                                 <div class="form-group clearfix">
                                 <div class="col-sm-12 text-left position-override">
                                         <button type="button" class="btn btn-secondary btn-save" value="<?php echo xla('Submit'); ?>" onclick="doregister('reg2')"><?php echo xlt('Submit'); ?></button>
-                                        <button type="button" class="btn btn-link btn-cancel btn-separate-left" value="<?php echo xla('Cancel'); ?>" onclick="docancel()" ><?php echo xlt('Cancel'); ?></button>
+                                        <button type="button" class="btn btn-link btn-cancel" value="<?php echo xla('Cancel'); ?>" onclick="docancel()" ><?php echo xlt('Cancel'); ?></button>
                                     </div>
                                 </div>
                             </div>
@@ -206,9 +206,9 @@ $user_full_name = $user_name['fname'] . " " . $user_name['lname'];
                                 <div class="col-sm-12 text-left position-override">
                                     <?php if (!$doesExist) { ?>
                                         <button type="button" class="btn btn-secondary btn-save" value="<?php echo xla('Register'); ?>" onclick="doregister('reg3')"><?php echo xlt('Register'); ?></button>
-                                        <button type="button" class="btn btn-link btn-cancel btn-separate-left" value="<?php echo xla('Cancel'); ?>" onclick="docancel()" ><?php echo xlt('Cancel'); ?></button>
+                                        <button type="button" class="btn btn-link btn-cancel" value="<?php echo xla('Cancel'); ?>" onclick="docancel()" ><?php echo xlt('Cancel'); ?></button>
                                     <?php } else { // $doesExist ?>
-                                        <button type="button" class="btn btn-link btn-back btn-separate-left" value="<?php echo xla('Back'); ?>" onclick="docancel()" ><?php echo xlt('Back'); ?></button>
+                                        <button type="button" class="btn btn-link btn-back" value="<?php echo xla('Back'); ?>" onclick="docancel()" ><?php echo xlt('Back'); ?></button>
                                     <?php } ?>
                                     </div>
                                 </div>

--- a/interface/usergroup/mfa_u2f.php
+++ b/interface/usergroup/mfa_u2f.php
@@ -135,7 +135,7 @@ function docancel() {
                 <div class="form-group clearfix">
                 <div class="col-sm-12 text-left position-override">
                         <button type="button" class="btn btn-secondary btn-save" value='<?php echo xla('Register'); ?>' onclick='doregister()'><?php echo xlt('Register'); ?></button>
-                        <button type="button" class="btn btn-link btn-cancel btn-separate-left" value="<?php echo xla('Cancel'); ?>" onclick="docancel()" ><?php echo xlt('Cancel'); ?></button>
+                        <button type="button" class="btn btn-link btn-cancel" value="<?php echo xla('Cancel'); ?>" onclick="docancel()" ><?php echo xlt('Cancel'); ?></button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->
Remove unnecessary `oe` classes.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

#### Short description of what this resolves:
In this PR,  remove the 
- oe-opt-btn-separate-left
- oe-opt-btn-group-pinch
- btn-group-pinch
- btn-separate-left

And convert the `oe-text-to-right`, `oe-text-to-left` to Bootstrap classes
- text-left
- text-right



