### PR TITLE
Make Title column a hyperlink

### DIFF
--- a/interface/patient_file/summary/stats_full.php
+++ b/interface/patient_file/summary/stats_full.php
@@ -268,7 +268,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                     }
 
                     echo " <tr class='" . attr($bgclass) . " detail' $colorstyle>\n";
-                    echo "  <td class='text-left " . attr($click_class) . "' id='" . attr($rowid) . "'>" . text($disptitle) . "</td>\n";
+                    echo "  <td class='text-left " . attr($click_class) . "' style='text-decoration: underline' id='" . attr($rowid) . "'>" . text($disptitle) . "</td>\n";
                     echo "  <td>" . text(oeFormatShortDate($row['begdate'])) . "&nbsp;</td>\n";
                     echo "  <td>" . text(oeFormatShortDate($row['enddate'])) . "&nbsp;</td>\n";
                     // both codetext and statusCompute have already been escaped above with htmlspecialchars)


### PR DESCRIPTION
#### Short description of what this resolves:

In the issues (ie Medical Problem, Allergies etc) tables, clicking the **Title** column launches the edit dialog. However this is not intuitive - it took a bit of time for me to realize it.

#### Changes proposed in this pull request:

The text in the **Title** column now displays as a hyperlink (ie underlined) to make it clear it is clickable. 