### PR TITLE
Move deletion of issues to the table

### DIFF
--- a/interface/patient_file/deleter.php
+++ b/interface/patient_file/deleter.php
@@ -297,8 +297,11 @@ function popup_close() {
                     die("Not authorized!");
                 }
 
-                row_delete("issue_encounter", "list_id = '" . add_escape_custom($issue) . "'");
-                row_delete("lists", "id = '" . add_escape_custom($issue) . "'");
+                $ids = explode(",", $issue);
+                foreach ($ids as $id) {
+                    row_delete("issue_encounter", "list_id = '" . add_escape_custom($id) . "'");
+                    row_delete("lists", "id = '" . add_escape_custom($id) . "'");
+                }
             } elseif ($document) {
                 if (!AclMain::aclCheckCore('patients', 'docs_rm')) {
                     die("Not authorized!");

--- a/interface/patient_file/summary/add_edit_issue.php
+++ b/interface/patient_file/summary/add_edit_issue.php
@@ -535,17 +535,6 @@ function getCodeText($code)
             }
         }
 
-        // Process click on Delete link.
-        function deleteme() {
-            dlgopen('../deleter.php?issue=' + <?php echo js_url($issue); ?> + '&csrf_token_form=' + <?php echo js_url(CsrfUtils::collectCsrfToken()); ?>, '_blank', 500, 450);
-            return false;
-        }
-
-        // Called by the deleteme.php window on a successful delete.
-        function imdeleted() {
-            closeme();
-        }
-
         function closeme() {
             dlgclose();
         }
@@ -919,11 +908,6 @@ function getCodeText($code)
                                 <div class="btn-group" role="group">
                                     <button type='submit' name='form_save' class="btn btn-primary btn-save" value='<?php echo xla('Save'); ?>'><?php echo xlt('Save'); ?></button>
                                     <button type="button" class="btn btn-secondary btn-cancel" onclick='closeme();'><?php echo xlt('Cancel'); ?></button>
-                                    <?php
-                                    if ($issue && AclMain::aclCheckCore('admin', 'super')) { ?>
-                                        <button type='submit' name='form_delete' class="btn btn-danger btn-cancel btn-delete" onclick='deleteme()' value='<?php echo xla('Delete'); ?>'><?php echo xlt('Delete'); ?></button>
-                                        <?php
-                                    } ?>
                                 </div>
                             </div>
                         </div>

--- a/interface/patient_file/summary/stats_full.php
+++ b/interface/patient_file/summary/stats_full.php
@@ -61,7 +61,7 @@ $language = $tmp['language'];
 // callback from add_edit_issue.php:
 function refreshIssue(issue, title) {
     top.restoreSession();
-    location.reload();
+    window.location=window.location;
 }
 
 function dopclick(id, category) {
@@ -239,8 +239,8 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
 
                             $canDelete = AclMain::aclCheckCore('admin', 'super');
                             if ($canDelete) {
-                                echo "<button id='" . $focustype . "-delete' disabled
-                                    class='btn btn-primary btn-sm btn-delete btn-danger mr-1'
+                                echo "<button id='" . $focustype . "-delete' disabled type='button'
+                                    class='btn btn-sm btn-delete btn-danger mr-1'
                                     onclick='deleteSelectedIssues(" . attr_js($focustype)  . ")'>" . xlt('Delete') . "</button>\n";
                             }
 


### PR DESCRIPTION
## Short description of what this resolves:

Previously, to delete an issue from the table, one opened the Add/Edit Issue dialog which contained a Delete button at the bottom. This workflow is non-standard and a bit non-intuitive.

#### Changes proposed in this pull request:

Now the issues table contains a Delete button with a checkbox column to select the issue row(s) to delete. The column header's checkbox toggles selection/de-selection of all the rows. The Delete button in the Add/Edit Issue dialog has been removed.