### PR TITLE
support item d12 for onc 2015

### DIFF
--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -2068,10 +2068,10 @@ $GLOBALS_METADATA = array(
             xl('Hash Algorithm for Authentication'),
             array(
                 'DEFAULT' => xl('PHP Default'),
-                'BCRYPT' => xl('Bcrypt'),
-                'ARGON2I' => xl('Argon2I') . ' (PHP 7.3 or greater)',
-                'ARGON2ID' => xl('Argon2ID') . ' (PHP 7.3 or greater)',
-                'SHA512HASH' => xl('SHA512') . ' (ONC 2015)',
+                'BCRYPT' => 'Bcrypt',
+                'ARGON2I' => 'Argon2I',
+                'ARGON2ID' => 'Argon2ID',
+                'SHA512HASH' => 'SHA512 (ONC 2015)',
             ),
             'DEFAULT',                // default
             xl('Hashing algorithm for authentication. Suggest PHP Default unless you know what you are doing.')
@@ -2218,10 +2218,10 @@ $GLOBALS_METADATA = array(
             xl('Hash Algorithm for Token'),
             array(
                 'DEFAULT' => xl('PHP Default'),
-                'BCRYPT' => xl('Bcrypt'),
-                'ARGON2I' => xl('Argon2I') . ' (PHP 7.3 or greater)',
-                'ARGON2ID' => xl('Argon2ID') . ' (PHP 7.3 or greater)',
-                'SHA512HASH' => xl('SHA512') . ' (ONC 2015)',
+                'BCRYPT' => 'Bcrypt',
+                'ARGON2I' => 'Argon2I',
+                'ARGON2ID' => 'Argon2ID',
+                'SHA512HASH' => 'SHA512 (ONC 2015)',
             ),
             'DEFAULT',                // default
             xl('Hashing algorithm for token. Suggest PHP Default unless you know what you are doing.')

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -2071,6 +2071,7 @@ $GLOBALS_METADATA = array(
                 'BCRYPT' => xl('Bcrypt'),
                 'ARGON2I' => xl('Argon2I') . ' (PHP 7.3 or greater)',
                 'ARGON2ID' => xl('Argon2ID') . ' (PHP 7.3 or greater)',
+                'SHA512HASH' => xl('SHA512') . ' (ONC 2015)',
             ),
             'DEFAULT',                // default
             xl('Hashing algorithm for authentication. Suggest PHP Default unless you know what you are doing.')
@@ -2181,6 +2182,38 @@ $GLOBALS_METADATA = array(
             xl('Authentication argon hash thread number. Suggest PHP Default unless you know what you are doing.')
         ),
 
+        'gbl_auth_sha512_rounds' => array(
+            xl('Authentication SHA512 Hash Rounds Number'),
+            array(
+                '1000' => '1000',
+                '5000' => '5000',
+                '10000' => '10000',
+                '15000' => '15000',
+                '20000' => '20000',
+                '30000' => '30000',
+                '40000' => '40000',
+                '50000' => '50000',
+                '75000' => '75000',
+                '100000' => '100000',
+                '200000' => '200000',
+                '300000' => '300000',
+                '400000' => '400000',
+                '500000' => '500000',
+                '750000' => '750000',
+                '1000000' => '1000000',
+                '2000000' => '2000000',
+                '3000000' => '3000000',
+                '4000000' => '4000000',
+                '5000000' => '5000000',
+                '6000000' => '6000000',
+                '7000000' => '7000000',
+                '8000000' => '8000000',
+                '9000000' => '9000000',
+            ),
+            '100000',                // default
+            xl('Authentication SHA512 hash rounds number.')
+        ),
+
         'gbl_token_hash_algo' => array(
             xl('Hash Algorithm for Token'),
             array(
@@ -2188,6 +2221,7 @@ $GLOBALS_METADATA = array(
                 'BCRYPT' => xl('Bcrypt'),
                 'ARGON2I' => xl('Argon2I') . ' (PHP 7.3 or greater)',
                 'ARGON2ID' => xl('Argon2ID') . ' (PHP 7.3 or greater)',
+                'SHA512HASH' => xl('SHA512') . ' (ONC 2015)',
             ),
             'DEFAULT',                // default
             xl('Hashing algorithm for token. Suggest PHP Default unless you know what you are doing.')
@@ -2296,6 +2330,38 @@ $GLOBALS_METADATA = array(
             ),
             'DEFAULT',                // default
             xl('Token argon hash thread number. Suggest PHP Default unless you know what you are doing.')
+        ),
+
+        'gbl_token_sha512_rounds' => array(
+            xl('Token SHA512 Hash Rounds Number'),
+            array(
+                '1000' => '1000',
+                '5000' => '5000',
+                '10000' => '10000',
+                '15000' => '15000',
+                '20000' => '20000',
+                '30000' => '30000',
+                '40000' => '40000',
+                '50000' => '50000',
+                '75000' => '75000',
+                '100000' => '100000',
+                '200000' => '200000',
+                '300000' => '300000',
+                '400000' => '400000',
+                '500000' => '500000',
+                '750000' => '750000',
+                '1000000' => '1000000',
+                '2000000' => '2000000',
+                '3000000' => '3000000',
+                '4000000' => '4000000',
+                '5000000' => '5000000',
+                '6000000' => '6000000',
+                '7000000' => '7000000',
+                '8000000' => '8000000',
+                '9000000' => '9000000',
+            ),
+            '100000',                // default
+            xl('Token SHA512 hash rounds number.')
         ),
     ),
 

--- a/src/Common/Auth/AuthHash.php
+++ b/src/Common/Auth/AuthHash.php
@@ -170,7 +170,7 @@ class AuthHash
     public function passwordNeedsRehash($hash)
     {
         if ($this->algo == "SHA512HASH") {
-            // Process SHA512HASH algo separately, since uses crypt
+            // Process when going to SHA512HASH algo separately, since not supported by standard password_needs_rehash
             if (empty(preg_match('/^\$6\$rounds=/', $hash))) {
                 // algo does not match, so needs rehash
                 return true;
@@ -181,8 +181,12 @@ class AuthHash
                 // number of rounds does not match, so needs rehash
                 return true;
             }
+        } elseif (!empty(preg_match('/^\$6\$rounds=/', $hash))) {
+            // Process when going from SHA512HASH algo separately, since not supported by standard password_needs_rehash
+            // Note we already know that $this->algo != "SHA512HASH", so we return true
+            return true;
         } else {
-            // Process algos supported by standard password_needs_rehash
+            // Process when going to and from algos supported by standard password_needs_rehash
             if (empty($this->options)) {
                 return password_needs_rehash($hash, $this->algo_constant);
             } else {

--- a/src/Common/Auth/AuthHash.php
+++ b/src/Common/Auth/AuthHash.php
@@ -28,11 +28,13 @@
  * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @author    Brady Miller <brady.g.miller@gmail.com>
- * @copyright Copyright (c) 2019 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2019-2020 Brady Miller <brady.g.miller@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
 namespace OpenEMR\Common\Auth;
+
+use OpenEMR\Common\Utils\RandomGenUtils;
 
 class AuthHash
 {
@@ -56,6 +58,14 @@ class AuthHash
             $this->mode = 'auth';
         }
         $this->algo = $GLOBALS['gbl_' . $this->mode . '_hash_algo'];
+
+        // If SHA512HASH is selected, then ensure CRYPT_SHA512 is supported
+        if ($this->algo == "SHA512HASH") {
+            if (CRYPT_SHA512 != 1) {
+                $this->algo == "DEFAULT";
+                error_log("OpenEMR WARNING: SHA512HASH not supported, so using DEFAULT instead");
+            }
+        }
 
         // If set to php default algorithm, then figure out what it is.
         //  This basically resolves what PHP is using as PASSWORD_DEFAULT,
@@ -120,6 +130,14 @@ class AuthHash
             if (($GLOBALS['gbl_' . $this->mode . '_bcrypt_hash_cost'] != "DEFAULT") && (check_integer($GLOBALS['gbl_' . $this->mode . '_bcrypt_hash_cost']))) {
                 $this->options = ['cost' => $GLOBALS['gbl_' . $this->mode . '_bcrypt_hash_cost']];
             }
+        } elseif ($this->algo == "SHA512HASH") {
+            // SHA512HASH - Using crypt and set up crypt option for this algo
+            $this->algo_constant = $this->algo;
+            if (check_integer($GLOBALS['gbl_' . $this->mode . '_sha512_rounds'])) {
+                $this->options = ['rounds' => $GLOBALS['gbl_' . $this->mode . '_sha512_rounds']];
+            } else {
+                $this->options = ['rounds' => 10000];
+            }
         } else {
             // This should never happen.
             //  Will only happen if unable to map the DEFAULT setting above or if using a invalid setting other than
@@ -132,6 +150,16 @@ class AuthHash
 
     public function passwordHash(&$password)
     {
+        // Process SHA512HASH algo separately, since uses crypt
+        if ($this->algo == "SHA512HASH") {
+            // Create salt
+            $salt = RandomGenUtils::produceRandomString(16, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
+
+            // Create hash
+            return crypt($password, '$6$rounds=' . $this->options['rounds'] . '$' . $salt . '$');
+        }
+
+        // Process algos supported by standard password_hash
         if (empty($this->options)) {
             return password_hash($password, $this->algo_constant);
         } else {
@@ -141,10 +169,25 @@ class AuthHash
 
     public function passwordNeedsRehash($hash)
     {
-        if (empty($this->options)) {
-            return password_needs_rehash($hash, $this->algo_constant);
+        if ($this->algo == "SHA512HASH") {
+            // Process SHA512HASH algo separately, since uses crypt
+            if (empty(preg_match('/^\$6\$rounds=/', $hash))) {
+                // algo does not match, so needs rehash
+                return true;
+            }
+            preg_match('/^\$6\$rounds=([0-9]*)\$/', $hash, $matches);
+            $rounds = $matches[1];
+            if ($rounds != $this->options['rounds']) {
+                // number of rounds does not match, so needs rehash
+                return true;
+            }
         } else {
-            return password_needs_rehash($hash, $this->algo_constant, $this->options);
+            // Process algos supported by standard password_needs_rehash
+            if (empty($this->options)) {
+                return password_needs_rehash($hash, $this->algo_constant);
+            } else {
+                return password_needs_rehash($hash, $this->algo_constant, $this->options);
+            }
         }
     }
 
@@ -160,7 +203,13 @@ class AuthHash
             $millisecondsStart = round(microtime(true) * 1000);
         }
 
-        $valid = password_verify($password, $hash);
+        if (!empty(preg_match('/^\$6\$rounds=/', $hash))) {
+            // Process SHA512HASH algo separately, since uses crypt
+            $valid = hash_equals($hash, crypt($password, $hash));
+        } else {
+            // Process algos supported by standard password_verify
+            $valid = password_verify($password, $hash);
+        }
 
         if ($GLOBALS['gbl_debug_hash_verify_execution_time']) {
             // Reporting collection time to allow fine tuning of hashing algorithm
@@ -169,5 +218,22 @@ class AuthHash
         }
 
         return $valid;
+    }
+
+    // To improve performance, this function is run as static since
+    //  requires no defines from the class
+    public static function hashValid($hash)
+    {
+        //  (note need to preg_match for \$2a\$05\$ for backward compatibility since
+        //   password_get_info() call can not identify older bcrypt hashes)
+        //  (note also need to preg_match for /^\$6\$rounds=/ to support the SHA512HASH hashing option)
+        $hash_info = password_get_info($hash);
+        if (empty($hash_info['algo']) && empty(preg_match('/^\$2a\$05\$/', $hash)) && empty(preg_match('/^\$6\$rounds=/', $hash))) {
+            // Invalid hash
+            return false;
+        } else {
+            // Valid hash
+            return true;
+        }
     }
 }

--- a/src/Common/Auth/AuthHash.php
+++ b/src/Common/Auth/AuthHash.php
@@ -42,7 +42,7 @@ class AuthHash
                             //  Note this is used to collect the mode specific algorithm options from globals
 
     private $algo;          // Algorithm setting from globals
-    private $algo_constant; // Standard algorithm constant
+    private $algo_constant; // Standard algorithm constant, if exists
 
     private $options;       // Standardized array of options
 
@@ -136,7 +136,7 @@ class AuthHash
             if (check_integer($GLOBALS['gbl_' . $this->mode . '_sha512_rounds'])) {
                 $this->options = ['rounds' => $GLOBALS['gbl_' . $this->mode . '_sha512_rounds']];
             } else {
-                $this->options = ['rounds' => 10000];
+                $this->options = ['rounds' => 100000];
             }
         } else {
             // This should never happen.

--- a/src/Common/Auth/AuthUtils.php
+++ b/src/Common/Auth/AuthUtils.php
@@ -27,7 +27,7 @@
  * @author    Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2013 Kevin Yeh <kevin.y@integralemr.com>
  * @copyright Copyright (c) 2013 OEMR <www.oemr.org>
- * @copyright Copyright (c) 2018-2019 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2018-2020 Brady Miller <brady.g.miller@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -216,10 +216,7 @@ class AuthUtils
 
         // Authentication
         // First, ensure the user hash is a valid hash
-        //  (note need to preg_match for \$2a\$05\$ for backward compatibility since
-        //   password_get_info() call can not identify older bcrypt hashes)
-        $hash_info = password_get_info($patientInfo['portal_pwd']);
-        if (empty($hash_info['algo']) && empty(preg_match('/^\$2a\$05\$/', $patientInfo['portal_pwd']))) {
+        if (!AuthHash::hashValid($patientInfo['portal_pwd'])) {
             EventAuditLogger::instance()->newEvent($event, $username, '', 0, $beginLog . ": " . $ip['ip_string'] . ". patient stored password hash is invalid", $patientDataInfo['pid']);
             $this->clearFromMemory($password);
             $this->preventTimingAttack();
@@ -333,10 +330,7 @@ class AuthUtils
         } else {
             // standard authentication
             // First, ensure the user hash is a valid hash
-            //  (note need to preg_match for \$2a\$05\$ for backward compatibility since
-            //   password_get_info() call can not identify older bcrypt hashes)
-            $hash_info = password_get_info($userSecure['password']);
-            if (empty($hash_info['algo']) && empty(preg_match('/^\$2a\$05\$/', $userSecure['password']))) {
+            if (!AuthHash::hashValid($userSecure['password'])) {
                 EventAuditLogger::instance()->newEvent($event, $username, $authGroup['name'], 0, $beginLog . ": " . $ip['ip_string'] . ". user stored password hash is invalid");
                 $this->clearFromMemory($password);
                 $this->preventTimingAttack();

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@ $v_realpatch = '0';
 // is a database change in the course of development.  It is used
 // internally to determine when a database upgrade is needed.
 //
-$v_database = 358;
+$v_database = 359;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
Added support for ONC 2015 item d12:
Encrypt authentication credentials certification criterion

The gist of this is that the hashing needs to be listed by NIST document ("Yes – the Health IT Module encrypts stored authentication credentials in accordance with standards adopted in § 170.210(a)(2)", which is the document linked below):
http://csrc.nist.gov/publications/fips/fips140-2/fips1402annexa.pdf

The current hash schemes (blowfish and argon2/blake2b) are not listed.
So added support for hashing by SHA-512.
(as an aside, blowfish is better and argon2/blake2b is way better than SHA-512 for hashing passwords, but that is the US government for you :) )