### PR TITLE
removed strtoupper conversion for result status

### DIFF
--- a/src/Services/FHIR/FhirObservationService.php
+++ b/src/Services/FHIR/FhirObservationService.php
@@ -82,7 +82,7 @@ class FhirObservationService extends FhirServiceBase
         }
 
         if (!empty($dataRecord['result_status'])) {
-            $observationResource->setStatus(strtoupper($dataRecord['result_status']));
+            $observationResource->setStatus(($dataRecord['result_status']));
         } else {
             $observationResource->setStatus("unknown");
         }


### PR DESCRIPTION
strtoupper is not required as 'final' is the valid observation Code whereas 'FINAL' is not a valid Code in FHIR

<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:
For FHIR Observation resource 'status' has the following valid codes :
registered | preliminary | final | amended
Currently the FHIR Observation resource is sending status with capitalised codes  due to strtoupper usage
#### Changes proposed in this pull request:

-Removed the conversion of status from smallcase to capitalcase
-
-