### PR TITLE
converted to FHIR Datetime format

### DIFF
--- a/src/Services/FHIR/FhirProcedureService.php
+++ b/src/Services/FHIR/FhirProcedureService.php
@@ -97,7 +97,7 @@ class FhirProcedureService extends FhirServiceBase
         }
 
         if (!empty($dataRecord['date_collected'])) {
-            $procedureResource->setPerformedDateTime($dataRecord['date_collected']);
+            $procedureResource->setPerformedDateTime(gmdate('c', strtotime($dataRecord['date_collected'])));
         }
 
         if (!empty($dataRecord['notes'])) {


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:
For Procedure FHIR Resource, the performedDateTime is not being populated with valid FHIRDatetime format
 Example : The current value being populated is 2020-09-10 12:03:00 
It should be in the format  as given here (https://www.hl7.org/fhir/datatypes.html#dateTime)

#### Changes proposed in this pull request:

-  converted the datetime to a valid FHIR DateTime format using gmdate
-
-