### PR TITLE
Adding new get api endpoint for Insurance Company by Id

### DIFF
--- a/_rest_routes.inc.php
+++ b/_rest_routes.inc.php
@@ -450,6 +450,11 @@ RestConfig::$ROUTE_MAP = array(
         RestConfig::apiLog($return);
         return $return;
     },
+    "GET /api/insurance_company/:iid" => function ($iid) {
+        $return = (new InsuranceCompanyRestController())->getOne($iid);
+        RestConfig::apiLog($return);
+        return $return;
+    },
     "GET /api/insurance_type" => function () {
         $return = (new InsuranceCompanyRestController())->getInsuranceTypes();
         RestConfig::apiLog($return);

--- a/src/RestControllers/InsuranceCompanyRestController.php
+++ b/src/RestControllers/InsuranceCompanyRestController.php
@@ -33,6 +33,12 @@ class InsuranceCompanyRestController
         return RestControllerHelper::responseHandler($serviceResult, null, 200);
     }
 
+    public function getOne($iid)
+    {
+        $serviceResult = $this->insuranceCompanyService->getOne($iid);
+        return RestControllerHelper::responseHandler($serviceResult, null, 200);
+    }
+
     public function getInsuranceTypes()
     {
         $serviceResult = $this->insuranceCompanyService->getInsuranceTypes();

--- a/src/Services/FHIR/FhirProcedureService.php
+++ b/src/Services/FHIR/FhirProcedureService.php
@@ -97,7 +97,7 @@ class FhirProcedureService extends FhirServiceBase
         }
 
         if (!empty($dataRecord['date_collected'])) {
-            $procedureResource->setPerformedDateTime($dataRecord['date_collected']);
+            $procedureResource->setPerformedDateTime(gmdate('c', strtotime($dataRecord['date_collected'])));
         }
 
         if (!empty($dataRecord['notes'])) {


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:
The functionality for getting the insurance company details by id has been written but the API end point was not created.
function getOne($id) in the InsuranceCompanyService.php

#### Changes proposed in this pull request:
Created a new GET api endpoint for the same by
adding the endpoint in the route map (_rest_routes.inc.php)
adding the function for this in the appropriate restcontroller (InsuranceCompanyRestController.php)
-
-
-