### PR TITLE
Adding code , effectiveDate and valueQuantity in Observation FHIR Resource

### DIFF
--- a/src/Services/FHIR/FhirObservationService.php
+++ b/src/Services/FHIR/FhirObservationService.php
@@ -11,7 +11,6 @@ use OpenEMR\Services\FHIR\FhirServiceBase;
 use OpenEMR\Services\ObservationLabService;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRQuantity;
 
-
 /**
  * FHIR Observation Service
  *

--- a/src/Services/FHIR/FhirObservationService.php
+++ b/src/Services/FHIR/FhirObservationService.php
@@ -9,6 +9,8 @@ use OpenEMR\FHIR\R4\FHIRElement\FHIRId;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRReference;
 use OpenEMR\Services\FHIR\FhirServiceBase;
 use OpenEMR\Services\ObservationLabService;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRQuantity;
+
 
 /**
  * FHIR Observation Service
@@ -63,22 +65,20 @@ class FhirObservationService extends FhirServiceBase
 
         $categoryCoding = new FHIRCoding();
         $categoryCode = new FHIRCodeableConcept();
-        $categoryCoding->setCode('complex');
-        $categoryCoding->setSystem('http://terminology.hl7.org/CodeSystem/observation-category');
-        $categoryCoding->setDisplay('laboratory');
-        $categoryCode->addCoding($categoryCoding);
-        $observationResource->setCode($categoryCode);
-
+        if (!empty($dataRecord['procedure_code'])) {
+            $categoryCoding->setCode($dataRecord['procedure_code']);
+            $categoryCoding->setSystem('http://loinc.org');
+            $categoryCoding->setDisplay($dataRecord['procedure_name']);
+            $categoryCode->addCoding($categoryCoding);
+            $observationResource->setCode($categoryCode);
+        }
+       
         $subject = new FHIRReference();
         $subject->setReference('Patient/' . $dataRecord['puuid']);
         $observationResource->setSubject($subject);
 
-        $observationCode = new FHIRCoding();
-        $observationCode->setCode($dataRecord['result_code']);
-        $observationResource->setCode($observationCode);
-
-        if (!empty($dataRecord['date'])) {
-            $observationResource->setEffectiveDateTime($dataRecord['date']);
+        if (!empty($dataRecord['date_report'])) {
+            $observationResource->setEffectiveDateTime(gmdate('c', strtotime($dataRecord['date_report'])));
         }
 
         if (!empty($dataRecord['result_status'])) {
@@ -96,8 +96,14 @@ class FhirObservationService extends FhirServiceBase
         }
 
         if (!empty($dataRecord['result'])) {
-            $observationResource->setValueRange($dataRecord['result']);
+            $quantity = new FHIRQuantity();
+            $quantity->setValue($dataRecord['result']);
+            if (!empty($dataRecord['units'])) {
+                $quantity->setUnit($dataRecord['units']);
+            }
+            $observationResource->setValueQuantity($quantity);
         }
+        
 
         if (!empty($dataRecord['comments'])) {
             $observationResource->addNote(['text' => $dataRecord['comments']]);

--- a/src/Services/ObservationLabService.php
+++ b/src/Services/ObservationLabService.php
@@ -52,13 +52,15 @@ class ObservationLabService extends BaseService
     {
         $sqlBindArray = array();
 
-        $sql = "SELECT presult.*,
-                patient.uuid AS puuid
+        $sql = "SELECT presult.*,poc.procedure_name,poc.procedure_code ,
+                patient.uuid AS puuid,preport.date_report 
                 FROM procedure_result AS presult
                 LEFT OUTER JOIN procedure_report AS preport
                 ON preport.procedure_report_id = presult.procedure_report_id
                 LEFT OUTER JOIN procedure_order AS porder
                 ON porder.procedure_order_id = preport.procedure_order_id
+                LEFT OUTER JOIN procedure_order_code AS poc
+                ON poc.procedure_order_id = porder.procedure_order_id
                 LEFT OUTER JOIN patient_data AS patient
                 ON patient.pid = porder.patient_id";
 
@@ -94,7 +96,6 @@ class ObservationLabService extends BaseService
     public function getOne($uuid)
     {
         $processingResult = new ProcessingResult();
-
         $isValid = BaseValidator::validateId("uuid", self::PROCEDURE_RESULT_TABLE, $uuid, true);
         if ($isValid !== true) {
             $validationMessages = [
@@ -103,17 +104,18 @@ class ObservationLabService extends BaseService
             $processingResult->setValidationMessages($validationMessages);
             return $processingResult;
         }
-        $sql = "SELECT presult.*,
-                patient.uuid AS puuid
+        $sql = "SELECT presult.*,poc.procedure_name,poc.procedure_code ,
+                patient.uuid AS puuid,preport.date_report 
                 FROM procedure_result AS presult
                 LEFT OUTER JOIN procedure_report AS preport
                 ON preport.procedure_report_id = presult.procedure_report_id
                 LEFT OUTER JOIN procedure_order AS porder
                 ON porder.procedure_order_id = preport.procedure_order_id
+                LEFT OUTER JOIN procedure_order_code AS poc
+                ON poc.procedure_order_id = porder.procedure_order_id
                 LEFT OUTER JOIN patient_data AS patient
                 ON patient.pid = porder.patient_id
-                WHERE preport.uuid = ?";
-
+                WHERE presult.uuid = ?";
         $uuidBinary = UuidRegistry::uuidToBytes($uuid);
         $sqlResult = sqlQuery($sql, [$uuidBinary]);
         $sqlResult['uuid'] = UuidRegistry::uuidToString($sqlResult['uuid']);


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:

- Fields _code , effectiveDateTime_ and _valueQuantity_ will now be available in Observation FHIR resource.
- And fixed single Observation Retrieval by id.


#### Changes proposed in this pull request:

- Added '_code_' field into Observation FHIR Resource which was showing up as empty before and is a mandatory field as per FHIR standards.
- Added '_effectiveDate_' field in Observation FHIR Resource by considering Procedure order reporting date.
- Added '_valueQuantity_' field in Observation FHIR Resource by taking result and units values from Procedure Result . 
- The Observation FHIR resource's _id_ should be compared with _uuid_ in  Procedure Result table in _getOne_ function but its being compared with the _uuid_ in Procedure Report table. Fixed this . 