### PR TITLE
fix for install/upgrade external data load deets

### DIFF
--- a/interface/code_systems/dataloads_ajax.php
+++ b/interface/code_systems/dataloads_ajax.php
@@ -251,7 +251,7 @@ $activeAccordionSection = isset($_GET['aas']) ? $_GET['aas'] : '0';
                         const stg_load_id = `#${dbName}_stg_loading`;
                         $(stg_load_id).show();
                         let thisInterval;
-                        const parm = `db=${dbName}&newInstall=` + (($(this).val() === 'INSTALL') ? 1 : 0) + '&file_checksum=' + $(this).prop('file_checksum') + '&file_revision_date=' + $(this).prop('file_revision_date') + '&version=' + $(this).prop('version') + '&rf=' + $(this).prop('rf');
+                        const parm = `db=${dbName}&newInstall=` + (($(this).val() === 'INSTALL') ? 1 : 0) + '&file_checksum=' + $(this).attr('file_checksum') + '&file_revision_date=' + $(this).attr('file_revision_date') + '&version=' + $(this).attr('version') + '&rf=' + $(this).attr('rf');
                         const stg_dets_id = `#${dbName}_stage_details`;
 
                         $.ajax({


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

#### Short description of what this resolves:
external dataload wasn't setting updated values in `standardized_tables_track` which resulted in misleading info after install

#### Changes proposed in this pull request:
change `.prop()` to `.attr()`