### PR TITLE
declare ct_external_options global for edit list

### DIFF
--- a/custom/code_types.inc.php
+++ b/custom/code_types.inc.php
@@ -172,7 +172,8 @@ define_external_table($code_external_tables, 6, 'icd10_pcs_order_code', 'pcs_cod
  * 'external' attribute  for explanation of the option listings.
  * @var array
  */
-$cd_external_options = array(
+global $ct_external_options;
+$ct_external_options = array(
   '0' => xl('No'),
   '4' => xl('ICD9 Diagnosis'),
   '5' => xl('ICD9 Procedure/Service'),

--- a/interface/super/edit_list.php
+++ b/interface/super/edit_list.php
@@ -580,7 +580,7 @@ function ctSelector($opt_line_no, $data_array, $name, $option_array, $title = ''
 //
 function writeCTLine($ct_array)
 {
-    global $opt_line_no, $cd_external_options;
+    global $opt_line_no, $ct_external_options;
 
     ++$opt_line_no;
     $bgcolor = "#" . (($opt_line_no & 1) ? "ddddff" : "ffdddd");
@@ -711,7 +711,7 @@ function writeCTLine($ct_array)
         $opt_line_no,
         $ct_array,
         'ct_external',
-        $cd_external_options,
+        $ct_external_options,
         xl('Is this using external sql tables? If it is, then choose the format.')
     );
     echo " </tr>\n";


### PR DESCRIPTION
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #3967 

#### Short description of what this resolves:
restores code type edit

#### Changes proposed in this pull request:
declare global
change var name (minor)