### PR TITLE
orthanc container files

### DIFF
--- a/contrib/util/docker/dockers/dev-orthanc-proxy/Dockerfile
+++ b/contrib/util/docker/dockers/dev-orthanc-proxy/Dockerfile
@@ -1,0 +1,8 @@
+FROM nginx:1.19.2
+
+ENV ORTHANC_HOST=orthanc \
+ORTHANC_PORT=8042 \
+ORTHANC_CREDS=b3BlbmVtcjpvcGVuZW1y \
+ORTHANC_ALLOWED_HOSTS=*
+
+COPY templates /etc/nginx/templates

--- a/contrib/util/docker/dockers/dev-orthanc-proxy/templates/default.conf.template
+++ b/contrib/util/docker/dockers/dev-orthanc-proxy/templates/default.conf.template
@@ -1,0 +1,18 @@
+server {
+   listen  8080  default_server;
+   
+   location  /orthanc/  {
+      proxy_pass http://${ORTHANC_HOST}:${ORTHANC_PORT};
+      proxy_set_header HOST $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header Authorization "Basic ${ORTHANC_CREDS}";
+      rewrite /orthanc(.*) $1 break;
+      add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+      add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+      add_header 'Access-Control-Allow-Origin' 'ORTHANC_ALLOWED_HOSTS';
+
+      limit_except GET POST OPTIONS {
+         deny all;
+      }
+   }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,7 @@ services:
       OPENEMR_SETTING_gbl_ldap_dn: 'cn={login},dc=example,dc=org'
     depends_on:
     - mysql
+    - orthanc-proxy
   phpmyadmin:
     restart: always
     image: phpmyadmin/phpmyadmin
@@ -100,6 +101,22 @@ services:
       LDAP_TLS_CA_CRT_FILENAME: ca.pem
       LDAP_TLS_CRT_FILENAME: server-cert.pem
       LDAP_TLS_KEY_FILENAME: server-key.pem
+  orthanc:
+    image: jodogne/orthanc-plugins:1.8.0
+    command: /run/secrets/
+    secrets:
+      - orthanc.json
+  orthanc-proxy:
+    image: openemr/dev-orthanc-proxy
+    links:
+      - orthanc
+    depends_on:
+      - orthanc
+    environment:
+      ORTHANC_HOST: orthanc
+      ORTHANC_PORT: 8042
+      ORTHANC_CREDS: b3BlbmVtcjpvcGVuZW1y #openemr:openemr
+      ORTHANC_ALLOWED_HOSTS: '*'
 volumes:
   databasevolume: {}
   publicvolume: {}
@@ -109,3 +126,6 @@ volumes:
   ccdamodule: {}
   logvolume: {}
   couchdbvolume: {}
+secrets:
+  orthanc.json:
+    file: orthanc.json

--- a/orthanc.json
+++ b/orthanc.json
@@ -1,0 +1,8 @@
+{
+  "Name" : "Orthanc in OpenEMR",
+  "RemoteAccessAllowed" : true,
+  "AuthenticationEnabled": true,
+  "RegisteredUsers" : {
+    "openemr" : "openemr"
+  }
+}


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #1364

I am sending this PR for some feedback:

* I added a new image in `contrib/util/docker/dockers/dev-orthanc-proxy`  - is this the correct place considering there is an `openemr-devops` repository?
* NGINX template handles basic HTTP authentication from an nginx template - is this acceptable?
* The proxy image image needs to be manually built for now (there is probably some ci configuration somewhere to enable auto image building and pushing). 

#### Short description of what this resolves:

Adds Orthanc container files for development with docker. 

#### Changes proposed in this pull request:

* Adds a new orthanc-proxy container image
* Modifies docker-compose to run both orthanc and orthanc proxy
* Orthanc runs behind a nginx proxy (user and pass are handled as container vars in the proxy)
