### PR TITLE
Session Id

### DIFF
--- a/src/Common/Session/SessionUtil.php
+++ b/src/Common/Session/SessionUtil.php
@@ -150,6 +150,7 @@ class SessionUtil
 
     public static function oauthSessionStart(): void
     {
+        session_id('authserverOpenEMR');
         session_start([
             'cookie_samesite' => "None",
             'cookie_secure' => true,


### PR DESCRIPTION
- session id is different functioning than name

#### Short description of what this resolves:

A session id is required to recall session across requests. As we are using cookie only and secure cookie, I don't see an opportunity for fixation attacks via session id.