### PR TITLE
for vscoders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ ccdaservice/node_modules
 
 # dev editor configs
 /.idea/*
+/.vscode/*
 /nbproject/*
 .DS_Store
 .buildpath


### PR DESCRIPTION


#### Short description of what this resolves:
excludes visual studio workspace files

#### Changes proposed in this pull request:
add to '.gitignore'
