### PR TITLE
Menu wordings improvements

### DIFF
--- a/interface/main/tabs/menu/menus/front_office.json
+++ b/interface/main/tabs/menu/menus/front_office.json
@@ -235,7 +235,7 @@
         "global_req": "!ippf_specific"
       },
       {
-        "label": "Appts",
+        "label": "Appointments",
         "menu_id": "Popup:Appts",
         "url": "/interface/reports/appointments_report.php?patient=",
         "target": "pop",

--- a/interface/main/tabs/menu/menus/standard.json
+++ b/interface/main/tabs/menu/menus/standard.json
@@ -1140,7 +1140,7 @@
         ]
       },
       {
-        "label": "Addr Book",
+        "label": "Address Book",
         "menu_id": "adb0",
         "target": "adm",
         "url": "/interface/usergroup/addrbook_list.php",
@@ -2010,7 +2010,7 @@
         "global_req": "!disable_chart_tracker"
       },
       {
-        "label": "Ofc Notes",
+        "label": "Office Notes",
         "menu_id": "ono0",
         "target": "msc",
         "url": "/interface/main/onotes/office_comments.php",
@@ -2022,7 +2022,7 @@
         ]
       },
       {
-        "label": "BatchCom",
+        "label": "Batch Communication Tool",
         "menu_id": "adm0",
         "target": "msc",
         "url": "/interface/batchcom/batchcom.php",
@@ -2138,7 +2138,7 @@
         "global_req": "!ippf_specific"
       },
       {
-        "label": "Appts",
+        "label": "Appointments",
         "menu_id": "Popup:Appts",
         "url": "/interface/reports/appointments_report.php?patient=",
         "target": "pop",


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #4078

#### Short description of what this resolves

Various menu wording improvements for OpenEMR Patch 5:

Miscellaneous > "Ofc Notes" would be clearer as "Office Notes"

Miscellaneous > "BatchCom" would be clearer as "Batch Communication Tool"

Administration > "Addr Book" would be clearer as "Address Book"

Popups > "Appts" would be clearer as "Appointments"


#### Changes proposed in this pull request:
Edited the menu labels to proper wordings
