### PR TITLE
After megration hashed salted passwords from 4.2.0 couldn't login due…

### DIFF
--- a/src/Common/Auth/AuthHash.php
+++ b/src/Common/Auth/AuthHash.php
@@ -192,7 +192,7 @@ class AuthHash
         if (!empty(preg_match('/^\$6\$rounds=/', $hash))) {
             // Process SHA512HASH algo separately, since uses crypt
             $valid = hash_equals($hash, crypt($password, $hash));
-        }  else {
+        } else {
             // Process algos supported by standard password_verify
             $valid = password_verify($password, $hash);
             if (!$valid) {

--- a/src/Common/Auth/AuthHash.php
+++ b/src/Common/Auth/AuthHash.php
@@ -199,6 +199,19 @@ class AuthHash
         } else {
             // Process algos supported by standard password_verify
             $valid = password_verify($password, $hash);
+            if (!$valid) {
+                // Ensure do not need to process legacy hash (pre 5.0.0), which will get converted to standard hash
+                //  after a successful auth. The legacy hash has a malformed salt/hash combination which needs to
+                //  be adjusted and then run via crypt.
+                if (!empty(preg_match('/^\$2a\$05\$/', $hash)) && (substr($hash, 28, 1) === '.')) {
+                    $fixedSalt = substr($hash, 0, 28) . "$";
+                    if (strlen($fixedSalt) !== 29) {
+                        $valid = false;
+                    } else {
+                        $valid = hash_equals($hash, crypt($password, $fixedSalt));
+                    }
+                }
+            }
         }
 
         if ($GLOBALS['gbl_debug_hash_verify_execution_time']) {

--- a/src/Common/Auth/AuthHash.php
+++ b/src/Common/Auth/AuthHash.php
@@ -192,7 +192,12 @@ class AuthHash
         if (!empty(preg_match('/^\$6\$rounds=/', $hash))) {
             // Process SHA512HASH algo separately, since uses crypt
             $valid = hash_equals($hash, crypt($password, $hash));
-        } else {
+        } else if(preg_match('/^\$2a\$05\$/', $hash)){ 
+            $salt = explode("$",$hash);
+            $salt = "$2a$05$".substr($salt[3],0, 21)."$";
+            $valid = hash_equals($hash, crypt($password, $salt));
+        }
+        else {
             // Process algos supported by standard password_verify
             $valid = password_verify($password, $hash);
         }

--- a/src/Common/Auth/AuthHash.php
+++ b/src/Common/Auth/AuthHash.php
@@ -192,12 +192,11 @@ class AuthHash
         if (!empty(preg_match('/^\$6\$rounds=/', $hash))) {
             // Process SHA512HASH algo separately, since uses crypt
             $valid = hash_equals($hash, crypt($password, $hash));
-        } else if(preg_match('/^\$2a\$05\$/', $hash)){ 
-            $salt = explode("$",$hash);
-            $salt = "$2a$05$".substr($salt[3],0, 21)."$";
+        } else if (preg_match('/^\$2a\$05\$/', $hash)) {
+            $salt = explode("$", $hash);
+            $salt = "$2a$05$".substr($salt[3],0, 21) . "$";
             $valid = hash_equals($hash, crypt($password, $salt));
-        }
-        else {
+        } else {
             // Process algos supported by standard password_verify
             $valid = password_verify($password, $hash);
         }

--- a/src/Common/Auth/AuthHash.php
+++ b/src/Common/Auth/AuthHash.php
@@ -194,7 +194,7 @@ class AuthHash
             $valid = hash_equals($hash, crypt($password, $hash));
         } else if (preg_match('/^\$2a\$05\$/', $hash)) {
             $salt = explode("$", $hash);
-            $salt = "$2a$05$".substr($salt[3],0, 21) . "$";
+
             $valid = hash_equals($hash, crypt($password, $salt));
         } else {
             // Process algos supported by standard password_verify

--- a/src/Common/Auth/AuthHash.php
+++ b/src/Common/Auth/AuthHash.php
@@ -192,11 +192,7 @@ class AuthHash
         if (!empty(preg_match('/^\$6\$rounds=/', $hash))) {
             // Process SHA512HASH algo separately, since uses crypt
             $valid = hash_equals($hash, crypt($password, $hash));
-        } else if (preg_match('/^\$2a\$05\$/', $hash)) {
-            $salt = explode("$", $hash);
-
-            $valid = hash_equals($hash, crypt($password, $salt));
-        } else {
+        }  else {
             // Process algos supported by standard password_verify
             $valid = password_verify($password, $hash);
             if (!$valid) {


### PR DESCRIPTION

[test_passwords.txt](https://github.com/openemr/openemr/files/5716804/test_passwords.txt)

Diogo Vidigal 4 minutes ago
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:

After megration hashed salted passwords from 4.2.0 couldn't login due to the drop of the salt. 
This will fix that migration and it should happen only one time. After the first successful login, the hash password will be updated 

#### Changes proposed in this pull request:
Alter the passwordVerify function to validate legacy passwords

The file in the attachment could help test the legacy passwords