### PR TITLE
XMLFormgen Changes for PHP 7 and above

### DIFF
--- a/contrib/forms/xmlformgen/xslt/common_objects.xslt
+++ b/contrib/forms/xmlformgen/xslt/common_objects.xslt
@@ -18,7 +18,7 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 <xsl:text disable-output-escaping="yes"><![CDATA[[']]></xsl:text>
 <xsl:value-of select="@name"/>
 <xsl:text disable-output-escaping="yes"><![CDATA['] != '') {
-    $dateparts = split(' ', $]]></xsl:text>
+    $dateparts = explode(' ', $]]></xsl:text>
 <xsl:value-of select="$fetchrow"/>
 <xsl:text disable-output-escaping="yes"><![CDATA[[']]></xsl:text>
 <xsl:value-of select="@name"/>

--- a/contrib/forms/xmlformgen/xslt/report.php.xslt
+++ b/contrib/forms/xmlformgen/xslt/report.php.xslt
@@ -115,7 +115,7 @@ $lists = array(]]></xsl:text>
             /* remove the time-of-day from the 'date' fields. */
             if ($field_names[$key] == 'date')
             if ($value != '') {
-              $dateparts = split(' ', $value);
+              $dateparts = explode(' ', $value);
               $value = $dateparts[0];
             }
 


### PR DESCRIPTION
Signed-off-by: Arnab Naha <superarnab@gmail.com>

<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #4103 

#### Short description of what this resolves:
It resolves the non functioning of xml formgen created forms due to split function being removed from php 7


#### Changes proposed in this pull request:
Changed the split function to explode to make the forms work again.
