### PR TITLE
Confidential/SMART app reg is_enabled flag

### DIFF
--- a/sql/5_0_2-to-6_0_0_upgrade.sql
+++ b/sql/5_0_2-to-6_0_0_upgrade.sql
@@ -2423,3 +2423,7 @@ ALTER TABLE `oauth_clients` ADD `endorsements` TEXT;
 ALTER TABLE `oauth_clients` ADD `policy_uri` TEXT;
 ALTER TABLE `oauth_clients` ADD `tos_uri` TEXT;
 #EndIf
+
+#IfMissingColumn oauth_clients is_enabled
+ALTER TABLE `oauth_clients` ADD `is_enabled` tinyint(1) NOT NULL DEFAULT '0';
+#EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -12266,6 +12266,7 @@ CREATE TABLE `oauth_clients` (
 `endorsements` text,
 `policy_uri` text,
 `tos_uri` text,
+`is_enabled` tinyint(1) NOT NULL DEFAULT '0',
 PRIMARY KEY (`client_id`)
 ) ENGINE=InnoDB;
 

--- a/src/Common/Auth/OpenIDConnect/Entities/ClientEntity.php
+++ b/src/Common/Auth/OpenIDConnect/Entities/ClientEntity.php
@@ -26,6 +26,13 @@ class ClientEntity implements ClientEntityInterface
     protected $scopes;
     protected $launchUri;
 
+    /**
+     * Confidential apps or apps with a 'launch' scope must be manually authorized by an adminstrator before their
+     * client can be used.
+     * @var bool
+     */
+    protected $isEnabled;
+
     public function __construct()
     {
         $this->scopes = [];
@@ -44,6 +51,16 @@ class ClientEntity implements ClientEntityInterface
     public function setIsConfidential($set): void
     {
         $this->isConfidential = $set;
+    }
+
+    public function setIsEnabled($set): void
+    {
+        $this->isEnabled = $set === 1 || $set === true;
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->isEnabled;
     }
 
     public function setUserId($id): void

--- a/src/Common/Auth/OpenIDConnect/Repositories/ClientRepository.php
+++ b/src/Common/Auth/OpenIDConnect/Repositories/ClientRepository.php
@@ -117,6 +117,7 @@ class ClientRepository implements ClientRepositoryInterface
         // launch uri is the same as the initiate_login_uri SMART uses launchUri
         // so we will refer to it that way.
         $client->setLaunchUri($client_record['initiate_login_uri']);
+        $client->setIsEnabled($client_record['is_enabled'] === "1");
         return $client;
     }
 }

--- a/src/Common/Logging/SystemLogger.php
+++ b/src/Common/Logging/SystemLogger.php
@@ -32,7 +32,7 @@ class SystemLogger implements LoggerInterface
          * We use mono
          */
         $this->logger = new Logger('OpenEMR');
-        $logLevel = Logger::WARNING; // change this if you want to filter what logs you see.
+        $logLevel = Logger::DEBUG; // change this if you want to filter what logs you see.
 
 //        $facility = LOG_SYSLOG; // @see syslog constants https://www.php.net/manual/en/network.constants.php
 //        // Change the logger level to see what logs you want to log

--- a/src/Common/Logging/SystemLogger.php
+++ b/src/Common/Logging/SystemLogger.php
@@ -32,7 +32,7 @@ class SystemLogger implements LoggerInterface
          * We use mono
          */
         $this->logger = new Logger('OpenEMR');
-        $logLevel = Logger::DEBUG; // change this if you want to filter what logs you see.
+        $logLevel = Logger::WARNING; // change this if you want to filter what logs you see.
 
 //        $facility = LOG_SYSLOG; // @see syslog constants https://www.php.net/manual/en/network.constants.php
 //        // Change the logger level to see what logs you want to log

--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -52,6 +52,7 @@ use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Common\Utils\RandomGenUtils;
 use OpenEMR\Common\Uuid\UuidRegistry;
+use OpenEMR\FHIR\SMART\SmartLaunchController;
 use OpenIDConnectServer\ClaimExtractor;
 use OpenIDConnectServer\Entities\ClaimSetEntity;
 use Psr\Http\Message\ResponseInterface;
@@ -360,7 +361,9 @@ class AuthorizationController
     {
         $user = $_SESSION['authUserID'] ?? null; // future use for provider client.
         $site = $this->siteId;
-        $private = empty($info['client_secret']) ? 0 : 1;
+        $is_confidential_client = empty($info['client_secret']) ? 0 : 1;
+        // we do not allow a confidential app to be enabled by default;
+        $is_client_enabled = $is_confidential_client ? 0 : 1;
         $contacts = $info['contacts'];
         $redirects = $info['redirect_uris'];
         $launch_uri = $info['launch_uri'];
@@ -373,6 +376,13 @@ class AuthorizationController
         // TODO: adunsulag do we need to reject the registration if there are certain scopes here we do not support
         // TODO: adunsulag should we check these scopes against our '$this->supportedScopes'?
         $info['scope'] = $info['scope'] ?? 'openid email phone address api:oemr api:fhir api:port api:pofh';
+
+        // if a public app requests the launch scope we also do not let them through unless they've been manually
+        // authorized by an administrator user.
+        if ($is_client_enabled) {
+            $is_client_enabled = strpos($info['scope'], SmartLaunchController::CLIENT_APP_REQUIRED_LAUNCH_SCOPE) !== false ? 0 : 1;
+        }
+
         // encrypt the client secret
         if (!empty($info['client_secret'])) {
             $info['client_secret'] = $this->cryptoGen->encryptStandard($info['client_secret']);
@@ -380,7 +390,7 @@ class AuthorizationController
 
 
         try {
-            $sql = "INSERT INTO `oauth_clients` (`client_id`, `client_role`, `client_name`, `client_secret`, `registration_token`, `registration_uri_path`, `register_date`, `revoke_date`, `contacts`, `redirect_uri`, `grant_types`, `scope`, `user_id`, `site_id`, `is_confidential`, `logout_redirect_uris`, `jwks_uri`, `jwks`, `initiate_login_uri`, `endorsements`, `policy_uri`, `tos_uri`) VALUES (?, ?, ?, ?, ?, ?, NOW(), NULL, ?, ?, 'authorization_code', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+            $sql = "INSERT INTO `oauth_clients` (`client_id`, `client_role`, `client_name`, `client_secret`, `registration_token`, `registration_uri_path`, `register_date`, `revoke_date`, `contacts`, `redirect_uri`, `grant_types`, `scope`, `user_id`, `site_id`, `is_confidential`, `logout_redirect_uris`, `jwks_uri`, `jwks`, `initiate_login_uri`, `endorsements`, `policy_uri`, `tos_uri`, `is_enabled`) VALUES (?, ?, ?, ?, ?, ?, NOW(), NULL, ?, ?, 'authorization_code', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
             $i_vals = array(
                 $clientId,
                 $info['client_role'],
@@ -393,14 +403,15 @@ class AuthorizationController
                 $info['scope'],
                 $user,
                 $site,
-                $private,
+                $is_confidential_client,
                 $logout_redirect_uris,
                 ($info['jwks_uri'] ?? null),
                 ($info['jwks'] ?? null),
                 ($info['initiate_login_uri'] ?? null),
                 ($info['endorsements'] ?? null),
                 ($info['policy_uri'] ?? null),
-                ($info['tos_uri'] ?? null)
+                ($info['tos_uri'] ?? null),
+                $is_client_enabled
             );
 
             return sqlQueryNoLog($sql, $i_vals);


### PR DESCRIPTION
Made it so that an app that displays to the user in the patient
demographics must have the is_enabled database flag set to true.  This
prepares the way for us to build an admin panel that will turn on and
off the SMART apps.  Developers can still build against the OpenEMR
install in preparation for MU3 but they have to manually switch the flag
in the database for their SMART app to show up in patient demographics.

Any confidential app or app requesting the 'launch' scope will require a
manual approval from the OpenEMR administrator.  So apps can still
dynamically register but it's a two step process.

#4091 
