### PR TITLE
fix layout export for windows

### DIFF
--- a/interface/main/backup.php
+++ b/interface/main/backup.php
@@ -502,7 +502,7 @@ if ($form_step == 102) {
                     $cmd .= "echo 'DELETE FROM layout_group_properties WHERE grp_form_id = \"" . add_escape_custom($layoutid) . "\";' >> " . escapeshellarg($EXPORT_FILE) . ";";
                 }
                 $cmd .= $dumppfx .
-                    " --where='grp_form_id = \"" . add_escape_custom($layoutid) . "\"' " .
+                    ' --where="grp_form_id = \'' . add_escape_custom($layoutid) . "'\" " .
                     escapeshellarg($sqlconf["dbase"]) . " layout_group_properties";
                 if (IS_WINDOWS) {
                     # windows uses the & to join statements.
@@ -511,7 +511,7 @@ if ($form_step == 102) {
                     $cmd .= " >> " . escapeshellarg($EXPORT_FILE) . ";";
                 }
                 $cmd .= $dumppfx .
-                " --where='form_id = \"" . add_escape_custom($layoutid) . "\" ORDER BY group_id, seq, title' " .
+                ' --where="form_id = \'' . add_escape_custom($layoutid) . '\' ORDER BY group_id, seq, title" '  .
                 escapeshellarg($sqlconf["dbase"]) . " layout_options" ;
                 if (IS_WINDOWS) {
                     # windows uses the & to join statements.


### PR DESCRIPTION
- refactored command escaping to work on window and linux

<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #4158 

#### Short description of what this resolves:
Backups LBF export dump command was breaking due to escaping on windows.