### PR TITLE
Patient menu hook

### DIFF
--- a/src/Menu/PatientMenuEvent.php
+++ b/src/Menu/PatientMenuEvent.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * PatientMenuEvent class. This class enables 3rd party developers to modify the tabs
+ * at the top of the patient's medical record, which by default are Dashboard, History, Report,
+ * Documents, etc. New items can be added, existing items can be redirected, etc.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Ken Chapple <ken@mi-squared.com>
+ * @copyright Copyright (c) 2021 Ken Chapple <ken@mi-squared.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Menu;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class PatientMenuEvent extends Event
+{
+
+     /**
+     * The UPDATE event occurs once the patient tabbed menu is created, so
+      * that modifications can be made to the tabs at the top of the patient menu
+     *
+     */
+    const MENU_UPDATE = 'patient.menu.update';
+
+    /**
+     * The RESTRICT event occurs once a menu has been created, updated, and now is applying security ACLs or
+     * filters against the menu to decide if the menu should be shown or not.
+     */
+    const MENU_RESTRICT = 'patient.menu.restrict';
+
+
+
+    /** @var array The menu list */
+    private $menu;
+
+    public function __construct($menu = [])
+    {
+        $this->menu = $menu;
+    }
+
+    /**
+     * Get a list of menu items
+     *
+     * @return array Array of menu items
+     */
+    public function getMenu()
+    {
+        return $this->menu;
+    }
+
+    public function setMenu(array $menu)
+    {
+        $this->menu = $menu;
+    }
+}

--- a/tests/eventdispatcher/oe-modify-patient-menu-example/README.md
+++ b/tests/eventdispatcher/oe-modify-patient-menu-example/README.md
@@ -1,0 +1,4 @@
+
+1. Copy the oe-modify-patient-menu-example directory into interface/modules/custom_modules
+2. Modify the custom_patient_menu.json file to suit your needs
+3. Install the module using module installer Modules > Manage Modules

--- a/tests/eventdispatcher/oe-modify-patient-menu-example/composer.json
+++ b/tests/eventdispatcher/oe-modify-patient-menu-example/composer.json
@@ -1,0 +1,16 @@
+{
+    "name": "mi-squared/oe-custom-patient-menu",
+    "description": "Module that can modify the patient menu on dashboard.",
+    "type": "openemr-module",
+    "authors": [
+        {
+            "name": "Ken Chapple",
+            "email": "ken@mi-squared.com"
+        }
+    ],
+    "require": {
+        "openemr/oe-module-installer-plugin": "^0.1.0"
+    },
+    "autoload": {},
+    "minimum-stability": "dev"
+}

--- a/tests/eventdispatcher/oe-modify-patient-menu-example/custom_patient_menu.json
+++ b/tests/eventdispatcher/oe-modify-patient-menu-example/custom_patient_menu.json
@@ -1,0 +1,117 @@
+[
+    {
+        "label": "Rename to Home",
+        "menu_id": "dashboard",
+        "target": "main",
+        "on_click": "top.restoreSession()",
+        "url": "interface/patient_file/summary/demographics.php",
+        "pid": "false",
+        "children": [],
+        "requirement": 0
+    },
+    {
+        "label": "History",
+        "menu_id": "history",
+        "target": "main",
+        "on_click": "top.restoreSession()",
+        "url": "interface/patient_file/history/history.php",
+        "pid": "false",
+        "children": [],
+        "requirement": 0
+    },
+    {
+        "label": "Report",
+        "menu_id": "report",
+        "target": "main",
+        "on_click": "top.restoreSession()",
+        "url": "interface/patient_file/report/patient_report.php",
+        "pid": "false",
+        "children": [],
+        "requirement": 0,
+        "acl_req": [
+            "patients",
+            "pat_rep"
+        ]
+    },
+    {
+        "label": "Documents",
+        "menu_id": "documents",
+        "target": "main",
+        "on_click": "top.restoreSession()",
+        "url": "controller.php?document&list&patient_id=",
+        "pid": "true",
+        "children": [],
+        "requirement": 0
+    },
+    {
+        "label": "Transactions",
+        "menu_id": "transactions",
+        "target": "main",
+        "on_click": "top.restoreSession()",
+        "url": "interface/patient_file/transaction/transactions.php",
+        "pid": "false",
+        "children": [],
+        "requirement": 0
+    },
+    {
+        "label": "Issues",
+        "menu_id": "issues",
+        "target": "main",
+        "on_click": "top.restoreSession()",
+        "url": "interface/patient_file/summary/stats_full.php?active=all",
+        "pid": "false",
+        "children": [],
+        "requirement": 0
+    },
+    {
+        "label": "Ledger",
+        "menu_id": "ledger",
+        "target": "main",
+        "on_click": "top.restoreSession()",
+        "url": "interface/reports/pat_ledger.php?form=1&patient_id=",
+        "pid": "true",
+        "children": [],
+        "requirement": 0
+    },
+    {
+        "label": "External Data",
+        "menu_id": "external_data",
+        "target": "main",
+        "on_click": "top.restoreSession()",
+        "url": "interface/reports/external_data.php",
+        "pid": "false",
+        "children": [],
+        "requirement": 0
+    },
+    {
+        "label": "PRO{{Patient Reported Outcomes}}",
+        "menu_id": "patient_reported_outcomes",
+        "target": "main",
+        "on_click": "top.restoreSession()",
+        "url": "interface/easipro/pro.php",
+        "pid": "false",
+        "children": [],
+        "requirement": 0,
+        "global_req_strict": [
+            "easipro_enable",
+            "easipro_server",
+            "easipro_name"
+        ]
+    },
+    {
+        "label": "Publish",
+        "menu_id": "publish",
+        "target": "main",
+        "on_click": "doPublish();return false;",
+        "url": "",
+        "pid": "false",
+        "children": [],
+        "requirement": 0,
+        "global_req": "fhir_enable"
+    },
+    {
+        "label": "Modules",
+        "children": [],
+        "requirement": 0
+    }
+]

--- a/tests/eventdispatcher/oe-modify-patient-menu-example/custom_patient_menu.json
+++ b/tests/eventdispatcher/oe-modify-patient-menu-example/custom_patient_menu.json
@@ -4,7 +4,7 @@
         "menu_id": "dashboard",
         "target": "main",
         "on_click": "top.restoreSession()",
-        "url": "interface/patient_file/summary/demographics.php",
+        "url": "/interface/patient_file/summary/demographics.php",
         "pid": "false",
         "children": [],
         "requirement": 0
@@ -14,7 +14,7 @@
         "menu_id": "history",
         "target": "main",
         "on_click": "top.restoreSession()",
-        "url": "interface/patient_file/history/history.php",
+        "url": "/interface/patient_file/history/history.php",
         "pid": "false",
         "children": [],
         "requirement": 0
@@ -24,7 +24,7 @@
         "menu_id": "report",
         "target": "main",
         "on_click": "top.restoreSession()",
-        "url": "interface/patient_file/report/patient_report.php",
+        "url": "/interface/patient_file/report/patient_report.php",
         "pid": "false",
         "children": [],
         "requirement": 0,
@@ -38,7 +38,7 @@
         "menu_id": "documents",
         "target": "main",
         "on_click": "top.restoreSession()",
-        "url": "controller.php?document&list&patient_id=",
+        "url": "/controller.php?document&list&patient_id=",
         "pid": "true",
         "children": [],
         "requirement": 0
@@ -48,7 +48,7 @@
         "menu_id": "transactions",
         "target": "main",
         "on_click": "top.restoreSession()",
-        "url": "interface/patient_file/transaction/transactions.php",
+        "url": "/interface/patient_file/transaction/transactions.php",
         "pid": "false",
         "children": [],
         "requirement": 0
@@ -58,7 +58,7 @@
         "menu_id": "issues",
         "target": "main",
         "on_click": "top.restoreSession()",
-        "url": "interface/patient_file/summary/stats_full.php?active=all",
+        "url": "/interface/patient_file/summary/stats_full.php?active=all",
         "pid": "false",
         "children": [],
         "requirement": 0
@@ -78,7 +78,7 @@
         "menu_id": "external_data",
         "target": "main",
         "on_click": "top.restoreSession()",
-        "url": "interface/reports/external_data.php",
+        "url": "/interface/reports/external_data.php",
         "pid": "false",
         "children": [],
         "requirement": 0
@@ -88,7 +88,7 @@
         "menu_id": "patient_reported_outcomes",
         "target": "main",
         "on_click": "top.restoreSession()",
-        "url": "interface/easipro/pro.php",
+        "url": "/interface/easipro/pro.php",
         "pid": "false",
         "children": [],
         "requirement": 0,

--- a/tests/eventdispatcher/oe-modify-patient-menu-example/openemr.bootstrap.php
+++ b/tests/eventdispatcher/oe-modify-patient-menu-example/openemr.bootstrap.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Bootstrap custom Patient Privacy module.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Ken Chapple <ken@mi-squared.com>
+ * @copyright Copyright (c) 2020 Ken Chapple <ken@mi-squared.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+use OpenEMR\Menu\PatientMenuEvent;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @param PatientMenuEvent $menuEvent
+ *
+ * Load our custom patient menu JSON
+ */
+function oe_module_custom_patient_menu(PatientMenuEvent $menuEvent)
+{
+    $menu = file_get_contents(__DIR__.'/custom_patient_menu.json');
+    $menu_parsed = json_decode($menu);
+    $menuEvent->setMenu($menu_parsed);
+    return $menuEvent;
+}
+
+// Listen for the menu update event so we can dynamically add our patient privacy menu item
+$eventDispatcher = $GLOBALS['kernel']->getEventDispatcher();
+$eventDispatcher->addListener(PatientMenuEvent::MENU_UPDATE, 'oe_module_custom_patient_menu');
+
+

--- a/tests/eventdispatcher/oe-modify-patient-menu-example/openemr.bootstrap.php
+++ b/tests/eventdispatcher/oe-modify-patient-menu-example/openemr.bootstrap.php
@@ -1,6 +1,11 @@
 <?php
+
 /**
- * Bootstrap custom Patient Privacy module.
+ * Bootstrap custom Patient Menu Module
+ *
+ * This is the main file for the example module that demonstrates the ability
+ * to modify the patient menu tabs on the demographics dashboard using a
+ * module and the EventDispatcher.
  *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
@@ -20,7 +25,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 function oe_module_custom_patient_menu(PatientMenuEvent $menuEvent)
 {
-    $menu = file_get_contents(__DIR__.'/custom_patient_menu.json');
+    $menu = file_get_contents(__DIR__ . '/custom_patient_menu.json');
     $menu_parsed = json_decode($menu);
     $menuEvent->setMenu($menu_parsed);
     return $menuEvent;
@@ -29,5 +34,3 @@ function oe_module_custom_patient_menu(PatientMenuEvent $menuEvent)
 // Listen for the menu update event so we can dynamically add our patient privacy menu item
 $eventDispatcher = $GLOBALS['kernel']->getEventDispatcher();
 $eventDispatcher->addListener(PatientMenuEvent::MENU_UPDATE, 'oe_module_custom_patient_menu');
-
-


### PR DESCRIPTION
Added event and hook to allow 3rd party modules to modify the tab navigation in the patient dashboard, similar to the main menu

<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:


#### Changes proposed in this pull request:
