### PR TITLE
EventDispatcher hooks for patient create, and patient update

### DIFF
--- a/interface/new/new_comprehensive_save.php
+++ b/interface/new/new_comprehensive_save.php
@@ -59,10 +59,6 @@ while ($frow = sqlFetchArray($fres)) {
   //get value only if field exist in $_POST (prevent deleting of field with disabled attribute)
     if (isset($_POST["form_$field_id"]) || $field_id == "pubpid") {
         $value = get_layout_form_value($frow);
-        if ($field_id == 'pubpid' && empty($value)) {
-            $value = $pid;
-        }
-
         $newdata[$tblname][$colname] = $value;
     }
 }

--- a/interface/patient_file/summary/demographics_save.php
+++ b/interface/patient_file/summary/demographics_save.php
@@ -20,7 +20,7 @@ use OpenEMR\Common\Csrf\CsrfUtils;
 if (!CsrfUtils::verifyCsrfToken($_POST["csrf_token_form"])) {
     CsrfUtils::csrfNotVerified();
 }
-
+global $pid;
 // Check authorization.
 if ($pid) {
     if (!AclMain::aclCheckCore('patients', 'demo', '', 'write')) {

--- a/library/patient.inc
+++ b/library/patient.inc
@@ -1044,61 +1044,38 @@ function pdValueOrNull($key, $value)
     }
 }
 
-// Create or update patient data from an array.
-//
+/**
+ * Create or update patient data from an array.
+ *
+ * This is a wrapper function for the PatientService which is now the single point
+ * of patient creation and update.
+ *
+ * If successful, returns the pid of the patient
+ *
+ * @param $pid
+ * @param $new
+ * @param false $create
+ * @return mixed
+ */
 function updatePatientData($pid, $new, $create = false)
 {
-  /*******************************************************************
-    $real = getPatientData($pid);
-    foreach ($new as $key => $value)
-        $real[$key] = $value;
-    $real['date'] = "'+NOW()+'";
-    $real['id'] = "";
-    $sql = "insert into patient_data set ";
-    foreach ($real as $key => $value)
-        $sql .= $key." = '$value', ";
-    $sql = substr($sql, 0, -2);
-    return sqlInsert($sql);
-  *******************************************************************/
-
-  // The above was broken, though seems intent to insert a new patient_data
-  // row for each update.  A good idea, but nothing is doing that yet so
-  // the code below does not yet attempt it.
-
-    if ($create) {
-        $sql = "INSERT INTO patient_data SET pid = '" . add_escape_custom($pid) . "', date = NOW()";
-        foreach ($new as $key => $value) {
-            if ($key == 'id') {
-                continue;
-            }
-
-            $sql .= ", `$key` = " . pdValueOrNull($key, $value);
-        }
-
-        // add a uuid for the new patient
-        $sql .= ", `uuid` ='" . add_escape_custom((new UuidRegistry(['table_name' => 'patient_data']))->createUuid()) . "'";
-
-        $db_id = sqlInsert($sql);
+    // Create instance of patient service
+    $patientService = new \OpenEMR\Services\PatientService();
+    if ($create === true ||
+        $pid === null) {
+        $result = $patientService->insert($new);
     } else {
-        $db_id = $new['id'];
-        $rez = sqlQuery("SELECT pid FROM patient_data WHERE id = '" . add_escape_custom($db_id) . "'");
-        // Check for brain damage:
-        if ($pid != $rez['pid']) {
-            $errmsg = "Internal error: Attempt to change patient data with pid = '" .
-            text($rez['pid']) . "' when current pid is '" . text($pid) . "' for id '" . text($db_id) . "'";
-            die($errmsg);
-        }
-
-        $sql = "UPDATE patient_data SET date = NOW()";
-        foreach ($new as $key => $value) {
-            $sql .= ", `$key` = " . pdValueOrNull($key, $value);
-        }
-
-        $sql .= " WHERE id = '" . add_escape_custom($db_id) . "'";
-        sqlStatement($sql);
+        $uuid = $patientService->getUuid($pid);
+        $uuidString = UuidRegistry::uuidToString($uuid);
+        $result = $patientService->update($uuidString, $new);
     }
 
-    return $db_id;
+    // From the returned ProcessingResult (contains data and error messages)
+    // retrieve the data and return the pid
+    $data = $result->getData();
+    $pid = $data['pid'];
+
+    return $pid;
 }
 
 function newEmployerData(

--- a/library/patient.inc
+++ b/library/patient.inc
@@ -1063,17 +1063,15 @@ function updatePatientData($pid, $new, $create = false)
     $patientService = new \OpenEMR\Services\PatientService();
     if ($create === true ||
         $pid === null) {
-        $result = $patientService->insert($new);
+        $result = $patientService->databseInsert($new);
     } else {
-        $uuid = $patientService->getUuid($pid);
-        $uuidString = UuidRegistry::uuidToString($uuid);
-        $result = $patientService->update($uuidString, $new);
+        $new['pid'] = $pid;
+        $result = $patientService->databaseUpdate($new);
     }
 
-    // From the returned ProcessingResult (contains data and error messages)
+    // From the returned patient data array
     // retrieve the data and return the pid
-    $data = $result->getData();
-    $pid = $data['pid'];
+    $pid = $result['pid'];
 
     return $pid;
 }

--- a/library/patient.inc
+++ b/library/patient.inc
@@ -14,6 +14,7 @@
 
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Services\FacilityService;
+use OpenEMR\Services\PatientService;
 
 $facilityService = new FacilityService();
 
@@ -1060,10 +1061,10 @@ function pdValueOrNull($key, $value)
 function updatePatientData($pid, $new, $create = false)
 {
     // Create instance of patient service
-    $patientService = new \OpenEMR\Services\PatientService();
+    $patientService = new PatientService();
     if ($create === true ||
         $pid === null) {
-        $result = $patientService->databseInsert($new);
+        $result = $patientService->databaseInsert($new);
     } else {
         $new['pid'] = $pid;
         $result = $patientService->databaseUpdate($new);

--- a/src/Events/Patient/PatientCreatedEvent.php
+++ b/src/Events/Patient/PatientCreatedEvent.php
@@ -29,10 +29,13 @@ class PatientCreatedEvent extends Event
     private $patientData;
 
     /**
-     * PatientUpdatedEvent constructor.
-     * @param $patientData
+     * PatientUpdatedEvent constructor takes an array
+     * of key/value pairs that represent fields of the patient_data
+     * table
+     *
+     * @param array $patientData
      */
-    public function __construct($patientData)
+    public function __construct(array $patientData)
     {
         $this->patientData = $patientData;
     }
@@ -48,7 +51,7 @@ class PatientCreatedEvent extends Event
     /**
      * @param mixed $patientData
      */
-    public function setPatientData($patientData): void
+    public function setPatientData(array $patientData): void
     {
         $this->patientData = $patientData;
     }

--- a/src/Events/Patient/PatientCreatedEvent.php
+++ b/src/Events/Patient/PatientCreatedEvent.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * PatientCreatedEvent
+ *
+ * This event is fired when a patient is created so modules can
+ * listen for creation of a patient and perform additional
+ * processing.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Ken Chapple <ken@mi-squared.com>
+ * @copyright Copyright (c) 2021 Ken Chapple <ken@mi-squared.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\Patient;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class PatientCreatedEvent extends Event
+{
+    /**
+     * This event is triggered after a patient has been created, and an assoc
+     * array of new patient data is passed to the event object
+     */
+    const EVENT_HANDLE = 'patient.created';
+
+    private $patientData;
+
+    /**
+     * PatientUpdatedEvent constructor.
+     * @param $patientData
+     */
+    public function __construct($patientData)
+    {
+        $this->patientData = $patientData;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getPatientData()
+    {
+        return $this->patientData;
+    }
+
+    /**
+     * @param mixed $patientData
+     */
+    public function setPatientData($patientData): void
+    {
+        $this->patientData = $patientData;
+    }
+}

--- a/src/Events/Patient/PatientUpdatedEvent.php
+++ b/src/Events/Patient/PatientUpdatedEvent.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * PatientUpdatedEvent
+ *
+ * This event is fired when a patient is updated so modules can
+ * listen for changes in patient data and perform additional
+ * processing.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Ken Chapple <ken@mi-squared.com>
+ * @copyright Copyright (c) 2021 Ken Chapple <ken@mi-squared.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\Patient;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class PatientUpdatedEvent extends Event
+{
+    /**
+     * This event is triggered after a patient has been updated, and an assoc
+     * array of new patient data is passed to the event object
+     */
+    const EVENT_HANDLE = 'patient.updated';
+
+    private $dataBeforeUpdate;
+    private $newPatientData;
+
+    /**
+     * PatientUpdatedEvent constructor.
+     * @param $dataBeforeUpdate
+     * @param $newPatientData
+     */
+    public function __construct($dataBeforeUpdate, $newPatientData)
+    {
+        $this->dataBeforeUpdate = $dataBeforeUpdate;
+        $this->newPatientData = $newPatientData;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getDataBeforeUpdate()
+    {
+        return $this->dataBeforeUpdate;
+    }
+
+    /**
+     * @param mixed $dataBeforeUpdate
+     */
+    public function setDataBeforeUpdate($dataBeforeUpdate): void
+    {
+        $this->dataBeforeUpdate = $dataBeforeUpdate;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getNewPatientData()
+    {
+        return $this->newPatientData;
+    }
+
+    /**
+     * @param mixed $newPatientData
+     */
+    public function setNewPatientData($newPatientData): void
+    {
+        $this->newPatientData = $newPatientData;
+    }
+}

--- a/src/Services/BaseService.php
+++ b/src/Services/BaseService.php
@@ -283,6 +283,7 @@ class BaseService
      */
     public static function getUuidById($id, $table, $field)
     {
+        $table = escape_table_name($table);
         $sql = "SELECT uuid from $table WHERE $field = ?";
         $result = sqlQuery($sql, array($id));
         return $result['uuid'] ?? false;

--- a/src/Services/PatientService.php
+++ b/src/Services/PatientService.php
@@ -106,7 +106,7 @@ class PatientService extends BaseService
      * @param $data
      * @return false|int
      */
-    public function databseInsert($data)
+    public function databaseInsert($data)
     {
         $freshPid = $this->getFreshPid();
         $data['pid'] = $freshPid;
@@ -157,7 +157,7 @@ class PatientService extends BaseService
             return $processingResult;
         }
 
-        $data = $this->databseInsert($data);
+        $data = $this->databaseInsert($data);
 
         if (false !== $data['pid']) {
             $processingResult->addData(array(

--- a/src/Services/PatientService.php
+++ b/src/Services/PatientService.php
@@ -157,11 +157,11 @@ class PatientService extends BaseService
             return $processingResult;
         }
 
-        $pid = $this->databseInsert($data);
+        $data = $this->databseInsert($data);
 
-        if (false !== $pid) {
+        if (false !== $data['pid']) {
             $processingResult->addData(array(
-                'pid' => $pid,
+                'pid' => $data['pid'],
                 'uuid' => UuidRegistry::uuidToString($data['uuid'])
             ));
 

--- a/src/Services/PatientService.php
+++ b/src/Services/PatientService.php
@@ -98,20 +98,16 @@ class PatientService extends BaseService
     }
 
     /**
-     * Inserts a new patient record.
+     * Insert a patient record into the database
      *
-     * @param $data The patient fields (array) to insert.
-     * @return ProcessingResult which contains validation messages, internal error messages, and the data
-     * payload.
+     * returns the newly-created patient data array, or false in the case of
+     * an error with the sql insert
+     *
+     * @param $data
+     * @return false|int
      */
-    public function insert($data)
+    public function databseInsert($data)
     {
-        $processingResult = $this->patientValidator->validate($data, PatientValidator::DATABASE_INSERT_CONTEXT);
-
-        if (!$processingResult->isValid()) {
-            return $processingResult;
-        }
-
         $freshPid = $this->getFreshPid();
         $data['pid'] = $freshPid;
         $data['uuid'] = (new UuidRegistry(['table_name' => 'patient_data']))->createUuid();
@@ -133,19 +129,84 @@ class PatientService extends BaseService
             $query['bind']
         );
 
+        // Tell subscribers that a new patient has been created
+        $patientCreatedEvent = new PatientCreatedEvent($data);
+        $GLOBALS["kernel"]->getEventDispatcher()->dispatch(PatientCreatedEvent::EVENT_HANDLE, $patientCreatedEvent, 10);
+
+        // If we have a result-set from our insert, return the PID,
+        // otherwise return false
         if ($results) {
+            return $data;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Inserts a new patient record.
+     *
+     * @param $data The patient fields (array) to insert.
+     * @return ProcessingResult which contains validation messages, internal error messages, and the data
+     * payload.
+     */
+    public function insert($data)
+    {
+        $processingResult = $this->patientValidator->validate($data, PatientValidator::DATABASE_INSERT_CONTEXT);
+
+        if (!$processingResult->isValid()) {
+            return $processingResult;
+        }
+
+        $pid = $this->databseInsert($data);
+
+        if (false !== $pid) {
             $processingResult->addData(array(
-                'pid' => $freshPid,
+                'pid' => $pid,
                 'uuid' => UuidRegistry::uuidToString($data['uuid'])
             ));
-            // Tell subscribers that a new patient has been created
-            $patientCreatedEvent = new PatientCreatedEvent($processingResult->getData());
-            $GLOBALS["kernel"]->getEventDispatcher()->dispatch(PatientCreatedEvent::EVENT_HANDLE, $patientCreatedEvent, 10);
+
         } else {
             $processingResult->addInternalError("error processing SQL Insert");
         }
 
         return $processingResult;
+    }
+
+    /**
+     * Do a database update using the pid from the input
+     * array
+     *
+     * Return the data that was updated into the database,
+     * or false if there was an error with the update
+     *
+     * @param array $data
+     * @return mixed
+     */
+    public function databaseUpdate($data)
+    {
+        // Get the data before update to send to the event listener
+        $dataBeforeUpdate = $this->findByPid($data['pid']);
+
+        // The `date` column is treated as an updated_date
+        $data['date'] = date("Y-m-d H:i:s");
+        $table = PatientService::TABLE_NAME;
+        $query = $this->buildUpdateColumns($data);
+        $sql = " UPDATE $table SET ";
+        $sql .= $query['set'];
+        $sql .= " WHERE `pid` = ?";
+
+        array_push($query['bind'], $data['pid']);
+        $sqlResult = sqlStatement($sql, $query['bind']);
+
+        if ($sqlResult) {
+            // Tell subscribers that a new patient has been updated
+            $patientUpdatedEvent = new PatientUpdatedEvent($dataBeforeUpdate, $data);
+            $GLOBALS["kernel"]->getEventDispatcher()->dispatch(PatientUpdatedEvent::EVENT_HANDLE, $patientUpdatedEvent, 10);
+
+            return $data;
+        } else {
+            return false;
+        }
     }
 
     /**
@@ -184,6 +245,8 @@ class PatientService extends BaseService
         } else {
             $processingResult = $this->getOne($puuidString);
             // Tell subscribers that a new patient has been updated
+            // We have to do this here and in the databaseUpdate() because this lookup is
+            // by uuid where the databseUpdate updates by pid.
             $patientUpdatedEvent = new PatientUpdatedEvent($dataBeforeUpdate, $processingResult->getData());
             $GLOBALS["kernel"]->getEventDispatcher()->dispatch(PatientUpdatedEvent::EVENT_HANDLE, $patientUpdatedEvent, 10);
         }
@@ -323,6 +386,23 @@ class PatientService extends BaseService
         $sqlResult['uuid'] = UuidRegistry::uuidToString($sqlResult['uuid']);
         $processingResult->addData($sqlResult);
         return $processingResult;
+    }
+
+    /**
+     * Given a pid, find the patient record
+     *
+     * @param $pid
+     */
+    public function findByPid($pid)
+    {
+        $table = PatientService::TABLE_NAME;
+        $patientRow = self::selectHelper("SELECT * FROM `$table`", [
+            'where' => 'WHERE pid = ?',
+            'limit' => 1,
+            'data' => [$pid]
+        ]);
+
+        return $patientRow;
     }
 
     /**

--- a/src/Validators/ProcessingResult.php
+++ b/src/Validators/ProcessingResult.php
@@ -82,12 +82,19 @@ class ProcessingResult
     }
 
     /**
-     * Appends a new data item to the current instance.
-     * @param $newData The new data item.
+     * Appends a new data item to the current instance,
+     * or if the newData is an array, merge the new with the
+     * already existing data attribute.
+     *
+     * @param $newData The new data item or array.
      */
     public function addData($newData)
     {
-        array_push($this->data, $newData);
+        if (is_array($newData)) {
+            $this->data = array_merge($this->data, $newData);
+        } else {
+            array_push($this->data, $newData);
+        }
     }
 
     /**

--- a/src/Validators/ProcessingResult.php
+++ b/src/Validators/ProcessingResult.php
@@ -82,19 +82,12 @@ class ProcessingResult
     }
 
     /**
-     * Appends a new data item to the current instance,
-     * or if the newData is an array, merge the new with the
-     * already existing data attribute.
-     *
-     * @param $newData The new data item or array.
+     * Appends a new data item to the current instance.
+     * @param $newData The new data item.
      */
     public function addData($newData)
     {
-        if (is_array($newData)) {
-            $this->data = array_merge($this->data, $newData);
-        } else {
-            array_push($this->data, $newData);
-        }
+        array_push($this->data, $newData);
     }
 
     /**

--- a/tests/eventdispatcher/oe-patient-create-update-hooks-example/README.md
+++ b/tests/eventdispatcher/oe-patient-create-update-hooks-example/README.md
@@ -1,0 +1,7 @@
+This is an example module that allows OpenEMR module developers to listen for
+creation of new patients and update of patients.
+
+Installation:
+1. Copy the oe-patient-create-update-hooks-example directory into interface/modules/custom_modules
+2. Modify the openemr.bootstrap.php file to suit your needs
+3. Install the module using module installer Modules > Manage Modules

--- a/tests/eventdispatcher/oe-patient-create-update-hooks-example/composer.json
+++ b/tests/eventdispatcher/oe-patient-create-update-hooks-example/composer.json
@@ -1,0 +1,16 @@
+{
+    "name": "mi-squared/oe-patient-create-update-hooks-example",
+    "description": "Module that listen for patient insert and update events and perform further actions",
+    "type": "openemr-module",
+    "authors": [
+        {
+            "name": "Ken Chapple",
+            "email": "ken@mi-squared.com"
+        }
+    ],
+    "require": {
+        "openemr/oe-module-installer-plugin": "^0.1.0"
+    },
+    "autoload": {},
+    "minimum-stability": "dev"
+}

--- a/tests/eventdispatcher/oe-patient-create-update-hooks-example/openemr.bootstrap.php
+++ b/tests/eventdispatcher/oe-patient-create-update-hooks-example/openemr.bootstrap.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * Bootstrap custom Patient Update/Create Listener module
+ *
+ * This is the main file for the example module that demonstrates the ability
+ * to listen for patient-update and patient-create events and perform additional
+ * actions.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Ken Chapple <ken@mi-squared.com>
+ * @copyright Copyright (c) 2021 Ken Chapple <ken@mi-squared.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+use OpenEMR\Events\Patient\PatientCreatedEvent;
+use OpenEMR\Events\Patient\PatientUpdatedEvent;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Get new or updated patient data and do something with it
+ *
+ * @param $patientData
+ */
+function send_patient_data_to_remote_system($patientData)
+{
+    // This is just a stub for example only
+    // For example, you could write data to a file and send to a remote SFTP server
+    // or build a remote API call.
+    return;
+}
+
+/**
+* This function is called when a patient is created, so we can do
+ * any additional processing that a 3rd party may require. For example,
+ * sending data to another system like Quickbooks
+ *
+ * @param PatientCreatedEvent $patientCreatedEvent
+ * @return mixed
+ */
+function oe_module_custom_patient_created_action(PatientCreatedEvent $patientCreatedEvent)
+{
+    $patientData = $patientCreatedEvent->getPatientData();
+    send_patient_data_to_remote_system($patientData);
+    return $patientCreatedEvent;
+}
+
+/**
+ * This function is called when a patient is updated, so we can do
+ * any additional processing that a 3rd party may require. For example,
+ * sending data to another system like Quickbooks
+ *
+ * @param PatientUpdatedEvent $patientUpdatedEvent
+ * @return PatientUpdatedEvent
+ */
+function oe_module_custom_patient_update_action(PatientUpdatedEvent $patientUpdatedEvent)
+{
+    $patientData = $patientUpdatedEvent->getNewPatientData();
+    send_patient_data_to_remote_system($patientData);
+    return $patientUpdatedEvent;
+}
+
+// Listen for the patient update and create events
+$eventDispatcher = $GLOBALS['kernel']->getEventDispatcher();
+$eventDispatcher->addListener(PatientCreatedEvent::EVENT_HANDLE, 'oe_module_custom_patient_created_action');
+$eventDispatcher->addListener(PatientUpdatedEvent::EVENT_HANDLE, 'oe_module_custom_patient_update_action');


### PR DESCRIPTION
Questions:

- I didn't add this behavior to the "old style" new patient form. Should that be removed?
- (1) below may break API even though I think it's a bug. When returning the ProcessResult, the service would not append the pid, and uuid to the existing data attribute array of the Result. Instead, the [pid, uuid] array was placed in a NEW array as an element of the existing data attribute. 

In the PR:

1. Fixed issue in PatientService when passing array to addData()
2. Added escape_table to BaseService when getting uuid
3. Consolidated patient update and create to the PatientService
4. Added events so modules can subscribe to patient update and create events
5. Added example module for usage of patient update/create hooks

<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:


#### Changes proposed in this pull request:
