### PR TITLE
Esign Bug

### DIFF
--- a/library/ESign/Form/Signable.php
+++ b/library/ESign/Form/Signable.php
@@ -118,6 +118,11 @@ class Form_Signable extends DbRow_Signable implements SignableIF
         }
 
         $tbl = (isset($excp->tbl) ? $excp->tbl : "form_" . $this->_formDir);
+        // Either change here or revise eye form code to use
+        // table form_eye_mag instead of form_eye_base
+        // Could be as simple as a sed function but for now, do this:
+        if ($tbl =='form_eye_mag') { $tbl = 'form_eye_base'; }
+        
         $id = (isset($excp->id) ? $excp->id : 'id');
         $limit = (isset($excp->limit) ? $excp->limit : 1);
 


### PR DESCRIPTION
Esign failed when eye forms were used during an encounter.  The structure of OpenEMR requires the name of the form to be the samepart of the table name (form_eye_mag).  For the Eye Form the name of the form is eye_mag but the name of the table is form_eye_base.

<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:


#### Changes proposed in this pull request:
