### PR TITLE
Refactor portal base controller scope

### DIFF
--- a/portal/patient/_global_config.php
+++ b/portal/patient/_global_config.php
@@ -97,9 +97,9 @@ class GlobalConfig
             require_once 'verysimple/HTTP/RequestUtil.php';
             RequestUtil::NormalizeUrlRewrite();
 
-            require_once 'verysimple/Phreeze/Controller.php';
-            Controller::$SmartyViewPrefix = '';
-            Controller::$DefaultRedirectMode = 'header';
+            require_once 'verysimple/Phreeze/PortalController.php';
+            PortalController::$SmartyViewPrefix = '';
+            PortalController::$DefaultRedirectMode = 'header';
 
             self::$IS_INITIALIZED = true;
         }

--- a/portal/patient/fwk/libs/verysimple/Phreeze/PortalController.php
+++ b/portal/patient/fwk/libs/verysimple/Phreeze/PortalController.php
@@ -25,7 +25,7 @@ require_once("verysimple/Authentication/IAuthenticatable.php");
  * @license http://www.gnu.org/licenses/lgpl.html LGPL
  * @version 3.1
  */
-abstract class Controller
+abstract class PortalController
 {
     protected $Phreezer;
     protected $RenderEngine;

--- a/portal/patient/libs/Controller/AppBasePortalController.php
+++ b/portal/patient/libs/Controller/AppBasePortalController.php
@@ -3,7 +3,7 @@
 /** @package    Patient Portal::Controller */
 
 /** import supporting libraries */
-require_once("verysimple/Phreeze/Controller.php");
+require_once("verysimple/Phreeze/PortalController.php");
 require_once(dirname(__FILE__) . "/../../../lib/appsql.class.php");
 /**
  * AppBaseController is a base class Controller class from which
@@ -18,7 +18,7 @@ require_once(dirname(__FILE__) . "/../../../lib/appsql.class.php");
  * @author ClassBuilder
  * @version 1.0
  */
-class AppBaseController extends Controller
+class AppBasePortalController extends PortalController
 {
 
     static $DEFAULT_PAGE_SIZE = 20;

--- a/portal/patient/libs/Controller/DefaultController.php
+++ b/portal/patient/libs/Controller/DefaultController.php
@@ -3,7 +3,7 @@
 /** @package Openemr::Controller */
 
 /** import supporting libraries */
-require_once("AppBaseController.php");
+require_once("AppBasePortalController.php");
 
 /**
  * DefaultController is the entry point to the application
@@ -15,7 +15,7 @@ require_once("AppBaseController.php");
  * @author ClassBuilder
  * @version 1.0
  */
-class DefaultController extends AppBaseController
+class DefaultController extends AppBasePortalController
 {
 
     /**

--- a/portal/patient/libs/Controller/OnsiteActivityViewController.php
+++ b/portal/patient/libs/Controller/OnsiteActivityViewController.php
@@ -13,7 +13,7 @@
 /**
  * import supporting libraries
  */
-require_once("AppBaseController.php");
+require_once("AppBasePortalController.php");
 require_once("Model/OnsiteActivityView.php");
 
 /**
@@ -26,7 +26,7 @@ require_once("Model/OnsiteActivityView.php");
  * @author  ClassBuilder
  * @version 1.0
  */
-class OnsiteActivityViewController extends AppBaseController
+class OnsiteActivityViewController extends AppBasePortalController
 {
 
     /**

--- a/portal/patient/libs/Controller/OnsiteDocumentController.php
+++ b/portal/patient/libs/Controller/OnsiteDocumentController.php
@@ -11,7 +11,7 @@
  */
 
 /** import supporting libraries */
-require_once("AppBaseController.php");
+require_once("AppBasePortalController.php");
 require_once("Model/OnsiteDocument.php");
 
 /**
@@ -23,7 +23,7 @@ require_once("Model/OnsiteDocument.php");
  * @author ClassBuilder
  * @version 1.0
  */
-class OnsiteDocumentController extends AppBaseController
+class OnsiteDocumentController extends AppBasePortalController
 {
 
     /**

--- a/portal/patient/libs/Controller/OnsitePortalActivityController.php
+++ b/portal/patient/libs/Controller/OnsitePortalActivityController.php
@@ -11,7 +11,7 @@
  */
 
 /** import supporting libraries */
-require_once("AppBaseController.php");
+require_once("AppBasePortalController.php");
 require_once("Model/OnsitePortalActivity.php");
 
 /**
@@ -23,7 +23,7 @@ require_once("Model/OnsitePortalActivity.php");
  * @author ClassBuilder
  * @version 1.0
  */
-class OnsitePortalActivityController extends AppBaseController
+class OnsitePortalActivityController extends AppBasePortalController
 {
 
     /**

--- a/portal/patient/libs/Controller/PatientController.php
+++ b/portal/patient/libs/Controller/PatientController.php
@@ -13,7 +13,7 @@
 /**
  * import supporting libraries
  */
-require_once("AppBaseController.php");
+require_once("AppBasePortalController.php");
 require_once("Model/Patient.php");
 /**
  * PatientController is the controller class for the Patient object.
@@ -25,7 +25,7 @@ require_once("Model/Patient.php");
  * @author ClassBuilder
  * @version 1.0
  */
-class PatientController extends AppBaseController
+class PatientController extends AppBasePortalController
 {
 
     /**

--- a/portal/patient/libs/Controller/PortalPatientController.php
+++ b/portal/patient/libs/Controller/PortalPatientController.php
@@ -13,7 +13,7 @@
 /**
  * import supporting libraries
  */
-require_once("AppBaseController.php");
+require_once("AppBasePortalController.php");
 require_once("Model/Patient.php");
 
 /**
@@ -26,7 +26,7 @@ require_once("Model/Patient.php");
  * @author ClassBuilder
  * @version 1.0
  */
-class PortalPatientController extends AppBaseController
+class PortalPatientController extends AppBasePortalController
 {
 
     /**

--- a/portal/patient/libs/Controller/ProviderController.php
+++ b/portal/patient/libs/Controller/ProviderController.php
@@ -11,7 +11,7 @@
  */
 
 /** import supporting libraries */
-require_once("AppBaseController.php");
+require_once("AppBasePortalController.php");
 
 /**
  * DefaultController is the entry point to the application
@@ -20,7 +20,7 @@ require_once("AppBaseController.php");
  * @author ClassBuilder
  * @version 1.0
  */
-class ProviderController extends AppBaseController
+class ProviderController extends AppBasePortalController
 {
     /**
      * Override here for any controller-specific functionality


### PR DESCRIPTION
- rename controller

#### Short description of what this resolves:
There is, and has been, a class naming conflict between cores smarty 'Controller' and the patient portal application api 'Controller'.
Because they both live in the PHPs default namespace ie. no namespace, the possibility for contention exists, especially since the portal controller is an abstract class so, whose final!

It's unknown if this resolve any outstanding issues but my guess is that it may explain some unexplainable issues in the past.