### PR TITLE
automated uuid updating service

### DIFF
--- a/library/sql_upgrade_fx.php
+++ b/library/sql_upgrade_fx.php
@@ -1062,8 +1062,8 @@ function upgradeFromSqlFile($filename, $path = '')
                 $skipping = false;
                 echo "<p>Going to add UUIDs to " . $matches[1] . " table</p>\n";
                 flush_echo();
-                $uuidRegistry->createMissingUuids();
-                echo "<p class='text-success'>Successfully completed adding UUIDs to " . $matches[1] . " table</p>\n";
+                $number = $uuidRegistry->createMissingUuids();
+                echo "<p class='text-success'>Successfully completed added " . $number . " UUIDs to " . $matches[1] . " table</p>\n";
                 flush_echo();
             } else {
                 $skipping = true;
@@ -1084,8 +1084,8 @@ function upgradeFromSqlFile($filename, $path = '')
                 $skipping = false;
                 echo "<p>Going to add UUIDs to " . $matches[1] . " table</p>\n";
                 flush_echo();
-                $uuidRegistry->createMissingUuids();
-                echo "<p class='text-success'>Successfully completed adding UUIDs to " . $matches[1] . " table</p>\n";
+                $number = $uuidRegistry->createMissingUuids();
+                echo "<p class='text-success'>Successfully completed added " . $number . " UUIDs to " . $matches[1] . " table</p>\n";
                 flush_echo();
             } else {
                 $skipping = true;
@@ -1100,8 +1100,8 @@ function upgradeFromSqlFile($filename, $path = '')
                 $skipping = false;
                 echo "<p>Going to add UUIDs to " . $matches[1] . " vertical table</p>\n";
                 flush_echo();
-                $uuidRegistry->createMissingUuids();
-                echo "<p class='text-success'>Successfully completed adding UUIDs to " . $matches[1] . " vertical table</p>\n";
+                $number = $uuidRegistry->createMissingUuids();
+                echo "<p class='text-success'>Successfully completed added " . $number . " UUIDs to " . $matches[1] . " vertical table</p>\n";
                 flush_echo();
             } else {
                 $skipping = true;

--- a/library/uuid.php
+++ b/library/uuid.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * function that is used by the automated uuid creation service
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2021 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+use OpenEMR\Common\Uuid\UuidRegistry;
+
+function autoPopulateAllMissingUuids() {
+    UuidRegistry::populateAllMissingUuids();
+}

--- a/library/uuid.php
+++ b/library/uuid.php
@@ -12,6 +12,7 @@
 
 use OpenEMR\Common\Uuid\UuidRegistry;
 
-function autoPopulateAllMissingUuids() {
+function autoPopulateAllMissingUuids()
+{
     UuidRegistry::populateAllMissingUuids();
 }

--- a/sql/6_0_0-to-6_1_0_upgrade.sql
+++ b/sql/6_0_0-to-6_1_0_upgrade.sql
@@ -442,3 +442,9 @@ INSERT INTO `layout_options` (`form_id`,`field_id`,`group_id`,`title`,`seq`,`dat
 #IfMissingColumn users google_signin_email
 ALTER TABLE `users` ADD COLUMN `google_signin_email` VARCHAR(255) UNIQUE DEFAULT NULL;
 #EndIf
+
+#IfNotRow background_services name UUID_Service
+INSERT INTO `background_services` (`name`, `title`, `active`, `running`, `next_run`, `execute_interval`, `function`, `require_once`, `sort_order`) VALUES
+('UUID_Service', 'Automated UUID Creation Service', 1, 0, '2021-01-18 11:25:10', 240, 'autoPopulateAllMissingUuids', '/library/uuid.php', 100);
+#EndIf
+

--- a/sql/6_0_0-to-6_1_0_upgrade.sql
+++ b/sql/6_0_0-to-6_1_0_upgrade.sql
@@ -149,11 +149,11 @@
 ALTER TABLE `insurance_companies` ADD `uuid` binary(16) DEFAULT NULL;
 #EndIf
 
-#IfUuidNeedUpdate insurance_companies
-#EndIf
-
 #IfNotIndex insurance_companies uuid
 CREATE UNIQUE INDEX `uuid` ON `insurance_companies` (`uuid`);
+#EndIf
+
+#IfUuidNeedUpdate insurance_companies
 #EndIf
 
 #IfMissingColumn insurance_data uuid

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -188,6 +188,8 @@ INSERT INTO `background_services` (`name`, `title`, `active`, `running`, `next_r
 ('X12_SFTP', 'SFTP Claims to X12 Partner Service', 0, 0, '2021-01-18 11:25:10', 1, 'start_X12_SFTP', '/library/billing_sftp_service.php', 100);
 INSERT INTO `background_services` (`name`, `title`, `active`, `running`, `next_run`, `execute_interval`, `function`, `require_once`, `sort_order`) VALUES
 ('WenoExchange', 'Weno Log Sync', 0, 0, '2021-01-18 11:25:10', 0, 'start_weno', '/library/weno_log_sync.php', 100);
+INSERT INTO `background_services` (`name`, `title`, `active`, `running`, `next_run`, `execute_interval`, `function`, `require_once`, `sort_order`) VALUES
+('UUID_Service', 'Automated UUID Creation Service', 1, 0, '2021-01-18 11:25:10', 240, 'autoPopulateAllMissingUuids', '/library/uuid.php', 100);
 -- --------------------------------------------------------
 
 --

--- a/src/Common/Uuid/UuidRegistry.php
+++ b/src/Common/Uuid/UuidRegistry.php
@@ -154,25 +154,43 @@ class UuidRegistry
     {
         $logEntryComment = '';
 
-        // Standard updates
-        $counter = (new UuidRegistry(['table_name' => 'patient_data']))->createMissingUuids();
-        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to patient_data, ' : '';
-        $counter = (new UuidRegistry(['table_name' => 'form_encounter']))->createMissingUuids();
-        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to form_encounter, ' : '';
-        $counter = (new UuidRegistry(['table_name' => 'users']))->createMissingUuids();
-        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to users, ' : '';
-        $counter = (new UuidRegistry(['table_name' => 'facility']))->createMissingUuids();
-        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to facility, ' : '';
-        $counter = (new UuidRegistry(['table_name' => 'immunizations']))->createMissingUuids();
-        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to immunizations, ' : '';
-        $counter = (new UuidRegistry(['table_name' => 'lists']))->createMissingUuids();
-        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to lists, ' : '';
-        $counter = (new UuidRegistry(['table_name' => 'prescriptions']))->createMissingUuids();
-        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to prescriptions, ' : '';
+        // Standard update for tables (alphabetically ordered):
+        //  ccda
+        //  facility
+        //  form_encounter
+        //  immunizations
+        //  insurance_companies
+        //  insurance_data
+        //  lists
+        //  patient_data
+        //  prescriptions
+        //  users
         $counter = (new UuidRegistry(['table_name' => 'ccda']))->createMissingUuids();
         $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to ccda, ' : '';
+        $counter = (new UuidRegistry(['table_name' => 'facility']))->createMissingUuids();
+        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to facility, ' : '';
+        $counter = (new UuidRegistry(['table_name' => 'form_encounter']))->createMissingUuids();
+        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to form_encounter, ' : '';
+        $counter = (new UuidRegistry(['table_name' => 'immunizations']))->createMissingUuids();
+        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to immunizations, ' : '';
+        $counter = (new UuidRegistry(['table_name' => 'insurance_companies']))->createMissingUuids();
+        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to insurance_companies, ' : '';
+        $counter = (new UuidRegistry(['table_name' => 'insurance_data']))->createMissingUuids();
+        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to insurance_data, ' : '';
+        $counter = (new UuidRegistry(['table_name' => 'lists']))->createMissingUuids();
+        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to lists, ' : '';
+        $counter = (new UuidRegistry(['table_name' => 'patient_data']))->createMissingUuids();
+        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to patient_data, ' : '';
+        $counter = (new UuidRegistry(['table_name' => 'prescriptions']))->createMissingUuids();
+        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to prescriptions, ' : '';
+        $counter = (new UuidRegistry(['table_name' => 'users']))->createMissingUuids();
+        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to users, ' : '';
 
-        // Updates with custom id sql column
+
+        // Updates with custom id sql column (alphabetically ordered):
+        //  drugs
+        //  procedure_order
+        //  procedure_result
         $counter = (new UuidRegistry(['table_name' => 'drugs', 'table_id' => 'drug_id']))->createMissingUuids();
         $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to drugs, ' : '';
         $counter = (new UuidRegistry(['table_name' => 'procedure_order', 'table_id' => 'procedure_order_id']))->createMissingUuids();
@@ -180,7 +198,8 @@ class UuidRegistry
         $counter = (new UuidRegistry(['table_name' => 'procedure_result', 'table_id' => 'procedure_result_id']))->createMissingUuids();
         $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to procedure_results, ' : '';
 
-        // Updates on vertical tables
+        // Updates on vertical tables (alphabetically ordered):
+        //  facility_user_ids
         $counter = (new UuidRegistry(['table_name' => 'facility_user_ids', 'table_vertical' => ['uid', 'facility_id']]))->createMissingUuids();
         $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to facility_user_ids, ' : '';
 

--- a/src/Common/Uuid/UuidRegistry.php
+++ b/src/Common/Uuid/UuidRegistry.php
@@ -169,39 +169,33 @@ class UuidRegistry
         //  procedure_order (with custom id procedure_order_id)
         //  procedure_result (with custom id procedure_result_id)
         //  users
-        $counter = (new UuidRegistry(['table_name' => 'ccda']))->createMissingUuids();
-        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to ccda, ' : '';
-        $counter = (new UuidRegistry(['table_name' => 'drugs', 'table_id' => 'drug_id']))->createMissingUuids();
-        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to drugs, ' : '';
-        $counter = (new UuidRegistry(['table_name' => 'facility']))->createMissingUuids();
-        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to facility, ' : '';
-        $counter = (new UuidRegistry(['table_name' => 'facility_user_ids', 'table_vertical' => ['uid', 'facility_id']]))->createMissingUuids();
-        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to facility_user_ids, ' : '';
-        $counter = (new UuidRegistry(['table_name' => 'form_encounter']))->createMissingUuids();
-        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to form_encounter, ' : '';
-        $counter = (new UuidRegistry(['table_name' => 'immunizations']))->createMissingUuids();
-        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to immunizations, ' : '';
-        $counter = (new UuidRegistry(['table_name' => 'insurance_companies']))->createMissingUuids();
-        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to insurance_companies, ' : '';
-        $counter = (new UuidRegistry(['table_name' => 'insurance_data']))->createMissingUuids();
-        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to insurance_data, ' : '';
-        $counter = (new UuidRegistry(['table_name' => 'lists']))->createMissingUuids();
-        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to lists, ' : '';
-        $counter = (new UuidRegistry(['table_name' => 'patient_data']))->createMissingUuids();
-        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to patient_data, ' : '';
-        $counter = (new UuidRegistry(['table_name' => 'prescriptions']))->createMissingUuids();
-        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to prescriptions, ' : '';
-        $counter = (new UuidRegistry(['table_name' => 'procedure_order', 'table_id' => 'procedure_order_id']))->createMissingUuids();
-        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to procedure_order, ' : '';
-        $counter = (new UuidRegistry(['table_name' => 'procedure_result', 'table_id' => 'procedure_result_id']))->createMissingUuids();
-        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to procedure_results, ' : '';
-        $counter = (new UuidRegistry(['table_name' => 'users']))->createMissingUuids();
-        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to users, ' : '';
+        self::appendPopulateLog('ccda', (new UuidRegistry(['table_name' => 'ccda']))->createMissingUuids(), $logEntryComment);
+        self::appendPopulateLog('drugs', (new UuidRegistry(['table_name' => 'drugs', 'table_id' => 'drug_id']))->createMissingUuids(), $logEntryComment);
+        self::appendPopulateLog('facility', (new UuidRegistry(['table_name' => 'facility']))->createMissingUuids(), $logEntryComment);
+        self::appendPopulateLog('facility_user_ids', (new UuidRegistry(['table_name' => 'facility_user_ids', 'table_vertical' => ['uid', 'facility_id']]))->createMissingUuids(), $logEntryComment);
+        self::appendPopulateLog('form_encounter', (new UuidRegistry(['table_name' => 'form_encounter']))->createMissingUuids(), $logEntryComment);
+        self::appendPopulateLog('immunizations', (new UuidRegistry(['table_name' => 'immunizations']))->createMissingUuids(), $logEntryComment);
+        self::appendPopulateLog('insurance_companies', (new UuidRegistry(['table_name' => 'insurance_companies']))->createMissingUuids(), $logEntryComment);
+        self::appendPopulateLog('insurance_data', (new UuidRegistry(['table_name' => 'insurance_data']))->createMissingUuids(), $logEntryComment);
+        self::appendPopulateLog('lists', (new UuidRegistry(['table_name' => 'lists']))->createMissingUuids(), $logEntryComment);
+        self::appendPopulateLog('patient_data', (new UuidRegistry(['table_name' => 'patient_data']))->createMissingUuids(), $logEntryComment);
+        self::appendPopulateLog('prescriptions', (new UuidRegistry(['table_name' => 'prescriptions']))->createMissingUuids(), $logEntryComment);
+        self::appendPopulateLog('procedure_order', (new UuidRegistry(['table_name' => 'procedure_order', 'table_id' => 'procedure_order_id']))->createMissingUuids(), $logEntryComment);
+        self::appendPopulateLog('procedure_result', (new UuidRegistry(['table_name' => 'procedure_result', 'table_id' => 'procedure_result_id']))->createMissingUuids(), $logEntryComment);
+        self::appendPopulateLog('users', (new UuidRegistry(['table_name' => 'users']))->createMissingUuids(), $logEntryComment);
 
         // log it
         if ($log && !empty($logEntryComment)) {
-            $logEntryComment = rtrim($logEntryComment, ',');
+            $logEntryComment = rtrim($logEntryComment, ', ');
             EventAuditLogger::instance()->newEvent('uuid', '', '', 1, 'Automatic uuid service creation: ' . $logEntryComment);
+        }
+    }
+
+    // Helper function for above populateAllMissingUuids function
+    private static function appendPopulateLog($table, $count, &$logEntry)
+    {
+        if ($count > 0) {
+            $logEntry .= 'added ' . $count . ' uuids to ' . $table . ', ';
         }
     }
 

--- a/src/Common/Uuid/UuidRegistry.php
+++ b/src/Common/Uuid/UuidRegistry.php
@@ -154,9 +154,11 @@ class UuidRegistry
     {
         $logEntryComment = '';
 
-        // Standard update for tables (alphabetically ordered):
+        // Update for tables (alphabetically ordered):
         //  ccda
+        //  drugs (with custom id drug_id)
         //  facility
+        //  facility_user_ids (vertical table)
         //  form_encounter
         //  immunizations
         //  insurance_companies
@@ -164,11 +166,17 @@ class UuidRegistry
         //  lists
         //  patient_data
         //  prescriptions
+        //  procedure_order (with custom id procedure_order_id)
+        //  procedure_result (with custom id procedure_result_id)
         //  users
         $counter = (new UuidRegistry(['table_name' => 'ccda']))->createMissingUuids();
         $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to ccda, ' : '';
+        $counter = (new UuidRegistry(['table_name' => 'drugs', 'table_id' => 'drug_id']))->createMissingUuids();
+        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to drugs, ' : '';
         $counter = (new UuidRegistry(['table_name' => 'facility']))->createMissingUuids();
         $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to facility, ' : '';
+        $counter = (new UuidRegistry(['table_name' => 'facility_user_ids', 'table_vertical' => ['uid', 'facility_id']]))->createMissingUuids();
+        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to facility_user_ids, ' : '';
         $counter = (new UuidRegistry(['table_name' => 'form_encounter']))->createMissingUuids();
         $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to form_encounter, ' : '';
         $counter = (new UuidRegistry(['table_name' => 'immunizations']))->createMissingUuids();
@@ -183,25 +191,12 @@ class UuidRegistry
         $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to patient_data, ' : '';
         $counter = (new UuidRegistry(['table_name' => 'prescriptions']))->createMissingUuids();
         $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to prescriptions, ' : '';
-        $counter = (new UuidRegistry(['table_name' => 'users']))->createMissingUuids();
-        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to users, ' : '';
-
-
-        // Updates with custom id sql column (alphabetically ordered):
-        //  drugs
-        //  procedure_order
-        //  procedure_result
-        $counter = (new UuidRegistry(['table_name' => 'drugs', 'table_id' => 'drug_id']))->createMissingUuids();
-        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to drugs, ' : '';
         $counter = (new UuidRegistry(['table_name' => 'procedure_order', 'table_id' => 'procedure_order_id']))->createMissingUuids();
         $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to procedure_order, ' : '';
         $counter = (new UuidRegistry(['table_name' => 'procedure_result', 'table_id' => 'procedure_result_id']))->createMissingUuids();
         $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to procedure_results, ' : '';
-
-        // Updates on vertical tables (alphabetically ordered):
-        //  facility_user_ids
-        $counter = (new UuidRegistry(['table_name' => 'facility_user_ids', 'table_vertical' => ['uid', 'facility_id']]))->createMissingUuids();
-        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to facility_user_ids, ' : '';
+        $counter = (new UuidRegistry(['table_name' => 'users']))->createMissingUuids();
+        $logEntryComment .= ($counter > 0) ? 'added ' . $counter . ' uuids to users, ' : '';
 
         // log it
         if ($log && !empty($logEntryComment)) {

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@ $v_realpatch = '0';
 // is a database change in the course of development.  It is used
 // internally to determine when a database upgrade is needed.
 //
-$v_database = 382;
+$v_database = 383;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
Goal of this is to avoid getting in a position where a huge amount of uuids need to be created at one time for when making an api/fhir request or when upgrade. This is set to populate all uuids via a service every 4 hours.

interesting openemr factoid: if this gets into the codebase, this will be the first openemr background service that is active by default :)