### PR TITLE
fix related to google sign in

### DIFF
--- a/interface/usergroup/usergroup_admin.php
+++ b/interface/usergroup/usergroup_admin.php
@@ -249,7 +249,12 @@ if (isset($_POST["privatemode"]) && $_POST["privatemode"] == "user_admin") {
             sqlStatement("update users set supervisor_id = ? where id = ? ", array((int)$_POST["supervisor_id"], $_POST["id"]));
         }
         if (isset($_POST["google_signin_email"])) {
-            sqlStatement("update users set google_signin_email = ? where id = ? ", array($_POST["google_signin_email"], $_POST["id"]));
+            if (empty($_POST["google_signin_email"])) {
+                $googleSigninEmail = null;
+            } else {
+                $googleSigninEmail = $_POST["google_signin_email"];
+            }
+            sqlStatement("update users set google_signin_email = ? where id = ? ", array($googleSigninEmail, $_POST["id"]));
         }
 
         // Set the access control group of user


### PR DESCRIPTION
fix related to google sign in

This fixes error when trying to add a new user with a blank google sign in email address. If you already have a user with a blank google sign in email address then it will break. This fixes it by converting blank to null, which does not need to be unique in the database field.