### PR TITLE
Fix sql error with MySQL 8 when viewing event log.

### DIFF
--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -280,7 +280,10 @@ MSG;
         } else {
             // do the query
             $sqlBindArray = array();
-            $sql = "SELECT $cols FROM `log_comment_encrypt` as el LEFT OUTER JOIN `log` as l ON el.`log_id` = l.`id` LEFT OUTER JOIN `api_log` as al ON el.`log_id` = al.`log_id` WHERE ((l.`date` >= ? AND l.`date` <= ?) OR (l.`date` IS NULL OR l.`date` = ''))";
+            $sql = "SELECT $cols FROM `log_comment_encrypt` as el " .
+                "LEFT OUTER JOIN `log` as l ON el.`log_id` = l.`id` " .
+                "LEFT OUTER JOIN `api_log` as al ON el.`log_id` = al.`log_id` " .
+                "WHERE (l.`date` IS NULL OR (l.`date` >= ? AND l.`date` <= ?))";
             array_push($sqlBindArray, $date1, $date2);
 
             if ($user != "") {


### PR DESCRIPTION
#### Short description of what this resolves:

Fixes SQL error "Incorrect DATETIME value: ''" when viewing the event log using MySQL 8 (and perhaps other versions).
