### PR TITLE
change received message into textarea for easier viewing in messages

### DIFF
--- a/interface/main/messages/messages.php
+++ b/interface/main/messages/messages.php
@@ -531,7 +531,8 @@ if (!empty($_REQUEST['go'])) { ?>
                                                 $body = preg_replace('/(\d{4}-\d{2}-\d{2} \d{2}:\d{2}\s\([^)(]+\s)(to)(\s[^)(]+\))/', '${1}' . xl('to{{Destination}}') . '${3}', $body);
                                                 $body = nl2br(text(oeFormatPatientNote($body)));
                                                 // echo "<div class='text oe-margin-t-3 p-2' style='border: 1px solid var(--gray);'>" . $body . "</div>";
-                                                echo "<input type='text' class='form-control text oe-margin-t-3 p-2 mb-2 w-100' value='$body'>";
+                                                // echo "<input type='text' class='form-control text oe-margin-t-3 p-2 mb-2 w-100' value='$body'>";
+                                                echo "<textarea type='text' class='form-control text oe-margin-t-3 p-2 mb-2 w-100' rows='5' readonly>" . text($body) . "</textarea>";
                                             }
 
                                             ?>

--- a/interface/main/messages/messages.php
+++ b/interface/main/messages/messages.php
@@ -529,7 +529,7 @@ if (!empty($_REQUEST['go'])) { ?>
                                             if ($noteid) {
                                                 $body = preg_replace('/(:\d{2}\s\()' . $result['pid'] . '(\sto\s)/', '${1}' . $patientname . '${2}', $body);
                                                 $body = preg_replace('/(\d{4}-\d{2}-\d{2} \d{2}:\d{2}\s\([^)(]+\s)(to)(\s[^)(]+\))/', '${1}' . xl('to{{Destination}}') . '${3}', $body);
-                                                $body = nl2br(text(oeFormatPatientNote($body)));
+                                                $body = text(oeFormatPatientNote($body));
                                                 // echo "<div class='text oe-margin-t-3 p-2' style='border: 1px solid var(--gray);'>" . $body . "</div>";
                                                 // echo "<input type='text' class='form-control text oe-margin-t-3 p-2 mb-2 w-100' value='$body'>";
                                                 echo "<textarea type='text' class='form-control text oe-margin-t-3 p-2 mb-2 w-100' rows='3' readonly>" . $body . "</textarea>";

--- a/interface/main/messages/messages.php
+++ b/interface/main/messages/messages.php
@@ -530,8 +530,6 @@ if (!empty($_REQUEST['go'])) { ?>
                                                 $body = preg_replace('/(:\d{2}\s\()' . $result['pid'] . '(\sto\s)/', '${1}' . $patientname . '${2}', $body);
                                                 $body = preg_replace('/(\d{4}-\d{2}-\d{2} \d{2}:\d{2}\s\([^)(]+\s)(to)(\s[^)(]+\))/', '${1}' . xl('to{{Destination}}') . '${3}', $body);
                                                 $body = text(oeFormatPatientNote($body));
-                                                // echo "<div class='text oe-margin-t-3 p-2' style='border: 1px solid var(--gray);'>" . $body . "</div>";
-                                                // echo "<input type='text' class='form-control text oe-margin-t-3 p-2 mb-2 w-100' value='$body'>";
                                                 echo "<textarea type='text' class='form-control text oe-margin-t-3 p-2 mb-2 w-100' rows='3' readonly>" . $body . "</textarea>";
                                             }
 

--- a/interface/main/messages/messages.php
+++ b/interface/main/messages/messages.php
@@ -532,7 +532,7 @@ if (!empty($_REQUEST['go'])) { ?>
                                                 $body = nl2br(text(oeFormatPatientNote($body)));
                                                 // echo "<div class='text oe-margin-t-3 p-2' style='border: 1px solid var(--gray);'>" . $body . "</div>";
                                                 // echo "<input type='text' class='form-control text oe-margin-t-3 p-2 mb-2 w-100' value='$body'>";
-                                                echo "<textarea type='text' class='form-control text oe-margin-t-3 p-2 mb-2 w-100' rows='3' readonly>" . text($body) . "</textarea>";
+                                                echo "<textarea type='text' class='form-control text oe-margin-t-3 p-2 mb-2 w-100' rows='3' readonly>" . $body . "</textarea>";
                                             }
 
                                             ?>

--- a/interface/main/messages/messages.php
+++ b/interface/main/messages/messages.php
@@ -532,7 +532,7 @@ if (!empty($_REQUEST['go'])) { ?>
                                                 $body = nl2br(text(oeFormatPatientNote($body)));
                                                 // echo "<div class='text oe-margin-t-3 p-2' style='border: 1px solid var(--gray);'>" . $body . "</div>";
                                                 // echo "<input type='text' class='form-control text oe-margin-t-3 p-2 mb-2 w-100' value='$body'>";
-                                                echo "<textarea type='text' class='form-control text oe-margin-t-3 p-2 mb-2 w-100' rows='5' readonly>" . text($body) . "</textarea>";
+                                                echo "<textarea type='text' class='form-control text oe-margin-t-3 p-2 mb-2 w-100' rows='3' readonly>" . text($body) . "</textarea>";
                                             }
 
                                             ?>


### PR DESCRIPTION
…center

<!--
(Thanks for sending a pull request!
-->

#### Short description of what this resolves:
currently if a sent message is more than 1 line you have to go into the pt's dashboard to view the whole message

#### Changes proposed in this pull request:
gives 5 rows like the textarea reply below
also makes the received msg readonly