### PR TITLE
Fix to custom filter (via module/event)

### DIFF
--- a/interface/main/finder/dynamic_finder_ajax.php
+++ b/interface/main/finder/dynamic_finder_ajax.php
@@ -185,7 +185,7 @@ $iTotal = $row['count'];
 if (empty($where)) {
     $where = $customWhere;
 } else {
-    $where = "$customWhere AND $where";
+    $where = "$customWhere AND ( $where )";
 }
 $row = sqlQuery("SELECT COUNT(id) AS count FROM patient_data WHERE $where", $srch_bind);
 $iFilteredTotal = $row['count'];


### PR DESCRIPTION
Fix to custom filter (via module/event) that allowed searches to bypass filter

<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:


#### Changes proposed in this pull request:
