### PR TITLE
The error message was miss leading.

### DIFF
--- a/src/Billing/EDI270.php
+++ b/src/Billing/EDI270.php
@@ -452,7 +452,7 @@ class EDI270
                 $X12info = self::getX12Partner($row['partner']);
             }
             if ($row['providerID'] === 0 || !$row['provider_npi']) {
-                $error_accum .= xlt("Error") . ": " . xlt("Provider Missing Add one in Choices") . "\n";
+                $error_accum .= xlt("Error") . ": " . xlt("Provider Missing NPI") . "\n";
             }
             if (!$row['eligibility_id']) {
                 $error_accum .= xlt("Error") . ": " . xlt("Missing Insurance Payer Id") . "\n";

--- a/src/Billing/EDI270.php
+++ b/src/Billing/EDI270.php
@@ -452,7 +452,7 @@ class EDI270
                 $X12info = self::getX12Partner($row['partner']);
             }
             if ($row['providerID'] === 0 || !$row['provider_npi']) {
-                $error_accum .= xlt("Error") . ": " . xlt("Provider Missing NPI") . "\n";
+                $error_accum .= xlt("Error") . ": " . xlt("Provider Missing NPI or Provider not selected in choices") . "\n";
             }
             if (!$row['eligibility_id']) {
                 $error_accum .= xlt("Error") . ": " . xlt("Missing Insurance Payer Id") . "\n";


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes # The error message received during the eligibility process

#### Short description of what this resolves:
It said that the provider was missing and when a provider is entered is says the provider is missing when in fact. It is the NPI that is missing not the provider in choices. 
 

#### Changes proposed in this pull request:
