### PR TITLE
Fixing import bug in backup.php.

### DIFF
--- a/interface/main/backup.php
+++ b/interface/main/backup.php
@@ -897,7 +897,7 @@ if ($form_step == 202) {
         if (move_uploaded_file($_FILES['userfile']['tmp_name'], $EXPORT_FILE)) {
             $form_status .= xla('Applying') . "...<br />";
             echo nl2br($form_status);
-            $cmd = escapeshellcmd($mysql_dump_cmd) . " -u " . escapeshellarg($sqlconf["login"]) .
+            $cmd = escapeshellcmd($mysql_cmd) . " -u " . escapeshellarg($sqlconf["login"]) .
             " -p" . escapeshellarg($sqlconf["pass"]) .
             " -h " . escapeshellarg($sqlconf["host"]) .
             " --port=" . escapeshellarg($sqlconf["port"]) .


### PR DESCRIPTION
Configuration Import was trying to use mysqldump instead of mysql, causing it to fail. This fixes that.

Should be applied to 6.0.0 as well.