### PR TITLE
Add events on before-patient-create and before-patient-update

### DIFF
--- a/src/Events/Patient/BeforePatientCreatedEvent.php
+++ b/src/Events/Patient/BeforePatientCreatedEvent.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * BeforePatientCreatedEvent
+ *
+ * This event is fired before a patient is created so modules can
+ * listen for creation of a patient and perform additional
+ * processing, or modify insert data.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Ken Chapple <ken@mi-squared.com>
+ * @copyright Copyright (c) 2021 Ken Chapple <ken@mi-squared.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\Patient;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class BeforePatientCreatedEvent extends Event
+{
+    /**
+     * This event is triggered before a patient has been created, and an assoc
+     * array of new patient data is passed to the event object
+     */
+    const EVENT_HANDLE = 'patient.before-created';
+
+    private $patientData;
+
+    /**
+     * BeforePatientUpdatedEvent constructor takes an array
+     * of key/value pairs that represent fields of the patient_data
+     * table
+     *
+     * @param array $patientData
+     */
+    public function __construct(array $patientData)
+    {
+        $this->patientData = $patientData;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getPatientData()
+    {
+        return $this->patientData;
+    }
+
+    /**
+     * @param mixed $patientData
+     */
+    public function setPatientData(array $patientData): void
+    {
+        $this->patientData = $patientData;
+    }
+}

--- a/src/Events/Patient/BeforePatientUpdatedEvent.php
+++ b/src/Events/Patient/BeforePatientUpdatedEvent.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * BeforePatientUpdatedEvent
+ *
+ * This event is fired before a patient is updated so modules can
+ * listen for changes in patient data and perform additional
+ * processing.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Ken Chapple <ken@mi-squared.com>
+ * @copyright Copyright (c) 2021 Ken Chapple <ken@mi-squared.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\Patient;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class BeforePatientUpdatedEvent extends Event
+{
+    /**
+     * This event is triggered before a patient has been updated, and an assoc
+     * array of new patient data is passed to the event object
+     */
+    const EVENT_HANDLE = 'patient.before-updated';
+
+    private $patientData;
+
+    /**
+     * BeforePatientUpdatedEvent constructor.
+     * @param $patientData
+     */
+    public function __construct($patientData)
+    {
+        $this->patientData = $patientData;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getPatientData()
+    {
+        return $this->patientData;
+    }
+
+    /**
+     * @param mixed $patientData
+     */
+    public function setPatientData(array $patientData): void
+    {
+        $this->patientData = $patientData;
+    }
+}


### PR DESCRIPTION
#### Short description of what this resolves:
Adds two events: before a patient is created and before a patient is updated. This is helpful to do any extra processing to DB fields before they are inserted into the database. 

We are using this to dynamically generate a PUBPID that is based on a combination of sources. We can listen to the event, and in our module, calculate the PUBPID before it is inserted into the database.

