### PR TITLE
Upgrade laminas-db to supported php8 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "kamermans/guzzle-oauth2-subscriber": "1.0.7",
         "knplabs/knp-snappy": "1.2.1",
         "laminas/laminas-config": "3.4.0",
-        "laminas/laminas-db": "2.11.3",
+        "laminas/laminas-db": "2.12.0",
         "laminas/laminas-eventmanager": "3.3.0",
         "laminas/laminas-escaper": "2.7.0",
         "laminas/laminas-filter": "2.9.4",


### PR DESCRIPTION
Hi, the current rel 600 version contains a laminas-db version that doesn't support php8, needs an update to [2.12.0](https://github.com/laminas/laminas-db/releases/tag/2.12.0). 
(the existing version throw a fatal [error](https://github.com/laminas/laminas-db/issues/178) in several functions)

Thanks
Amiel