### PR TITLE
Implemented CSV loader for language translations.

### DIFF
--- a/interface/language/csv/commit_csv.php
+++ b/interface/language/csv/commit_csv.php
@@ -12,6 +12,7 @@
 
 // This script is ajax-loaded into a div by validate_csv.php, so much of
 // the normal framework does not apply.
+header('Content-Type: application/json');
 
 require_once("../../globals.php");
 require_once("translation_utilities.php");
@@ -54,14 +55,14 @@ if (!$errmsg) {
             false,
             $preview
         );
-        if (strpos($result, xl('Definition Exists') . ':') !== 0) {
-            if (strpos($result, xl('Empty Definition')) !== 0) {
+        if (strpos($result, '[2]') !== 0) { // Definition Exists
+            if (strpos($result, '[1]') !== 0) { // Empty Definition
                 if ($result) {
                     array_push($changed, $result);
-                    if (strpos($result, xl('Update From') . ':') === 0) {
-                        array_push($updated, $result);
-                    } else if (strpos($result, xl('Create') . ':') === 0) {
-                        array_push($created, $result);
+                    if (strpos($result, '[3]') === 0) {
+                        array_push($updated, substr($result, 3));
+                    } else if (strpos($result, '[5]') === 0) {
+                        array_push($created, substr($result, 3));
                     }
                 }
             } else {

--- a/interface/language/csv/commit_csv.php
+++ b/interface/language/csv/commit_csv.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * @package OpenEMR
+ * @link    http://www.open-emr.org
+ * @author  Kevin Yeh <kevin.y@integralemr.com>
+ * @author  Rod Roark <rod@sunsetsystems.com>
+ * @copyright Copyright (c) 2014 Kevin Yeh <kevin.y@integralemr.com>
+ * @copyright Copyright (c) 2021 Rod Roark <rod@sunsetsystems.com>
+ * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+// This script is ajax-loaded into a div by validate_csv.php, so much of
+// the normal framework does not apply.
+
+require_once("../../globals.php");
+require_once("translation_utilities.php");
+
+$errmsg = '';
+
+if (!$errmsg && !isset($_REQUEST['translations'])) {
+    $errmsg = xlt("No translations!");
+}
+
+if (!$errmsg && !isset($_REQUEST['lang_id'])) {
+    $errmsg = xlt("No Language ID specified!");
+}
+
+if (!isset($_REQUEST['preview'])) {
+    $preview = true;
+} else {
+    $preview = $_REQUEST['preview'];
+    if ($preview === "false") {
+        $preview = false;
+    }
+}
+
+$unchanged = 0;
+$empty = 0;
+$changed = array();
+$created = array();
+$updated = array();
+
+if (!$errmsg) {
+    $lang_id = $_REQUEST['lang_id'];
+    $translations = json_decode($_REQUEST['translations']);
+    foreach ($translations as $translation) {
+        $result = verify_translation(
+            str_replace("\r\n", "\n", $translation[0]),
+            str_replace("\r\n", "\n", $translation[1]),
+            $lang_id,
+            true,
+            "",
+            false,
+            $preview
+        );
+        if (strpos($result, xl('Definition Exists') . ':') !== 0) {
+            if (strpos($result, xl('Empty Definition')) !== 0) {
+                if ($result) {
+                    array_push($changed, $result);
+                    if (strpos($result, xl('Update From') . ':') === 0) {
+                        array_push($updated, $result);
+                    } else if (strpos($result, xl('Create') . ':') === 0) {
+                        array_push($created, $result);
+                    }
+                }
+            } else {
+                $empty++;
+            }
+        } else {
+            $unchanged++;
+        }
+    }
+}
+
+if ($errmsg) {
+    $created[] = xl('ERROR') . ': ' . $errmsg;
+}
+
+$retval = array();
+$retval['changed'] = $changed;
+$retval['unchanged'] = $unchanged;
+$retval['empty'] = $empty;
+$retval['updated'] = $updated;
+$retval['created'] = $created;
+$changes_html = "";
+foreach ($changed as $change) {
+    $changes_html .= $change . "<br>";
+}
+$retval['html_changes'] = $changes_html;
+echo json_encode($retval);

--- a/interface/language/csv/commit_csv.php
+++ b/interface/language/csv/commit_csv.php
@@ -52,7 +52,6 @@ if (!$errmsg) {
             $lang_id,
             true,
             "",
-            false,
             $preview
         );
         if (strpos($result, '[2]') !== 0) { // Definition Exists

--- a/interface/language/csv/load_csv_file.php
+++ b/interface/language/csv/load_csv_file.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * @package OpenEMR
+ * @link    http://www.open-emr.org
+ * @author  Kevin Yeh <kevin.y@integralemr.com>
+ * @author  Rod Roark <rod@sunsetsystems.com>
+ * @copyright Copyright (c) 2014 Kevin Yeh <kevin.y@integralemr.com>
+ * @copyright Copyright (c) 2021 Rod Roark <rod@sunsetsystems.com>
+ * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+use OpenEMR\Common\Acl\AclMain;
+use OpenEMR\Common\Csrf\CsrfUtils;
+
+// Ensure this script is not called separately
+if ($langModuleFlag !== true) {
+    die(function_exists('xlt') ? xlt('Authentication Error') : 'Authentication Error');
+}
+
+// gacl control
+$thisauth = AclMain::aclCheckCore('admin', 'language');
+if (!$thisauth) {
+    echo "<html>\n<body>\n";
+    echo "<p>" . xlt('You are not authorized for this.') . "</p>\n";
+    echo "</body>\n</html>\n";
+    exit();
+}
+
+//default to language ID 3 (should be spanish)
+$defaultLangID = 3;
+
+$sqlLanguages = "SELECT *, lang_description as trans_lang_description FROM lang_languages ORDER BY lang_id";
+$resLanguages = SqlStatement($sqlLanguages);
+$languages = array();
+while ($row = sqlFetchArray($resLanguages)) {
+    array_push($languages, $row);
+}
+
+?>
+<form name="process_csv" method="post" enctype="multipart/form-data"
+    action="?m=csvval&csrf_token_form=<?php echo attr_url(CsrfUtils::collectCsrfToken()); ?>"
+    onsubmit="return top.restoreSession()">
+
+    <!-- Select Language. Cloned from lang_definition.php. -->
+    <div class="form-group">
+        <label for="selectLanguage"><?php echo xlt('Select Language') . ":"; ?></label>
+        <select class="form-control" name='language_id' id="selectLanguage">
+            <?php
+            // sorting order of language titles depends on language translation options.
+            $mainLangID = empty($_SESSION['language_choice']) ? '1' : $_SESSION['language_choice'];
+            // Use and sort by the translated language name.
+            $sql = "SELECT ll.lang_id, " .
+                "IF(LENGTH(ld.definition),ld.definition,ll.lang_description) AS lang_description " .
+                "FROM lang_languages AS ll " .
+                "LEFT JOIN lang_constants AS lc ON lc.constant_name = ll.lang_description " .
+                "LEFT JOIN lang_definitions AS ld ON ld.cons_id = lc.cons_id AND " .
+                "ld.lang_id = ? " .
+                "ORDER BY IF(LENGTH(ld.definition),ld.definition,ll.lang_description), ll.lang_id";
+            $res = SqlStatement($sql, array($mainLangID));
+            // collect the default selected language id, and then display list
+            $tempLangID = isset($_POST['language_id']) ? $_POST['language_id'] : $mainLangID;
+            while ($row = SqlFetchArray($res)) {
+                if ($tempLangID == $row['lang_id']) {
+                    echo "<option value='" . attr($row['lang_id']) . "' selected>" .
+                        text($row['lang_description']) . "</option>";
+                } else {
+                      echo "<option value='" . attr($row['lang_id']) . "'>" .
+                          text($row['lang_description']) . "</option>";
+                }
+            }
+            ?>
+        </select>
+    </div>
+
+    <!-- File Upload Control -->
+    <div class="form-group">
+        <p><?php echo xlt('Select a CSV file with translation information to review.'); ?>
+        <?php echo xlt('It should be UTF-8 encoded with comma separated values.'); ?></p>
+        <input type="file" name="language_file" id="language_file"></input>
+    </div>
+
+    <!-- Submit Button -->
+    <div class="form-group">
+        <input type="submit" class="btn btn-primary" name="submit" value="<?php echo xla('Submit'); ?>">
+    </div>
+
+</form>
+
+<?php echo activate_lang_tab('csv-link'); ?>

--- a/interface/language/csv/translation_utilities.php
+++ b/interface/language/csv/translation_utilities.php
@@ -1,0 +1,165 @@
+<?php
+
+/* Copyright (C) 2014 Kevin Yeh <kevin.y@integralemr.com>
+ *
+ * LICENSE: This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://opensource.org/licenses/gpl-license.php>;.
+ *
+ * @package OpenEMR
+ * @author  Kevin Yeh <kevin.y@integralemr.com>
+ * @link    http://www.open-emr.org
+ */
+
+function find_or_create_constant($constant)
+{
+    $sqlFind = " SELECT cons_id , constant_name FROM lang_constants where BINARY constant_name = ?";
+    $result = sqlStatement($sqlFind, array($constant));
+    if ($result) {
+        $row_count = sqlNumRows($result);
+        if ($row_count == 1) {
+            $row = sqlFetchArray($result);
+            return $row['cons_id'];
+        }
+        if ($row_count > 1) {
+            error_log("Duplicate Entries for language constant:" . $constant);
+            $row = sqlFetchArray($result);
+            $retval = $row['cons_id'];
+            while ($row = sqlFetchArray($result)) {
+                $sqlDelete = " DELETE FROM lang_constants where cons_id = ? ";
+                sqlStatement($sqlDelete, array($row['cons_id']));
+                $sqlDelete = " DELETE FROM lang_definitions where cons_id = ? ";
+                sqlStatement($sqlDelete, array($row['cons_id']));
+                error_log("DELETED Definitions for duplicate constant:" . $constant . "|" . $row['cons_id']);
+            }
+            return $retval;
+        }
+        if ($row_count == 0) {
+            $sqlInsert = " INSERT INTO lang_constants (constant_name) VALUES (?)";
+            $new_index = sqlInsert($sqlInsert, array($constant));
+            return $new_index;
+        }
+    }
+}
+
+function update_metainfo($constant, $definition, $source, $set_source = false)
+{
+    if ($source != "") {
+        $sqlUpdate = " UPDATE ippf_lang_definitions set " . $source . "= ? where BINARY constant_name = ?";
+        $parameters = array($definition, $constant);
+        sqlStatement($sqlUpdate, $parameters);
+        if ($set_source) {
+            $sqlUpdate = " UPDATE ippf_lang_definitions set source = ? where BINARY constant_name = ?";
+            $parameters = array($source, $constant);
+            sqlStatement($sqlUpdate, $parameters);
+        }
+    }
+}
+
+function verify_translation($constant, $definition, $language, $replace = true, $source = "", $set_metainfo = false, $preview = false)
+{
+    if (empty($constant) || empty($definition)) {
+        return xl("Empty Definition");
+    }
+    $cons_id = find_or_create_constant($constant);
+    $whereClause = " lang_id = ? and cons_id = ? ";
+    $sqlFind = " SELECT def_id, definition FROM lang_definitions WHERE " . $whereClause;
+    $result = sqlStatement($sqlFind, array($language, $cons_id));
+    $infoText = $constant . "|" . $definition;
+    if ($result) {
+        $row_count = sqlNumRows($result);
+        if ($row_count == 1) {
+            $row = sqlFetchArray($result);
+            $row['definition'] = iconv('utf-8', 'utf-8', $row['definition']);
+            if ($row['definition'] === $definition) {
+                return xl('Definition Exists') . ':' . $infoText;
+            } else {
+                if ($replace) {
+                    $sqlUpdate = " UPDATE lang_definitions SET definition=? WHERE def_id=?";
+                    if (!$preview) {
+                        $result = sqlStatement($sqlUpdate, array($definition,$row['def_id']));
+                        if ($set_metainfo) {
+                            update_metainfo($constant, $definition, $source, true);}
+                    }
+                    return xl('Update From') . ':' . $row['definition'] . ' => ' . $definition . ' (' . xl('for') . ': ' . $constant . ')';
+                } else {
+                    if (!$preview) {
+                        if ($set_metainfo) {
+                            update_metainfo($constant, $definition, $source, false);
+                        }
+                    }
+                    return xl('Definition Not Updated') . ': ' . xl('Current') . $row['definition'] . '|' . $infoText;
+                }
+            }
+        }
+        if ($row_count > 1) {
+            // Too many definitions, delete then recreate.
+            if (!$preview) {
+                $sqlDelete = " DELETE FROM lang_definitions WHERE " . $whereClause;
+                $sqlStatement($sqlDelete, array($language, $cons_id));
+            }
+            $create = true;
+        }
+        if ($row_count == 0) {
+            $create = true;
+        }
+        if ($create) {
+            $sqlInsert = " INSERT INTO lang_definitions (cons_id,lang_id,definition) VALUES (?,?,?) ";
+            if (!$preview) {
+                $id = sqlInsert($sqlInsert, array($cons_id, $language, $definition));
+                if ($set_metainfo) {
+                    update_metainfo($constant, $definition, $source, true);
+                }
+            }
+            return xl('Create') . ':' . $constant . ' => ' . $definition;
+        }
+    }
+}
+
+function verify_translations($definitions, $language, $replace = true)
+{
+    foreach ($definitions as $constant => $definition) {
+        verify_translation($constant, $definition, $language, $replace);
+    }
+}
+
+function utf8_fopen_read($fileName)
+{
+    $fc = iconv('UTF-8', 'UTF-8', file_get_contents($fileName));
+    if (empty($fc)) {
+        return false;
+    }
+    $handle = fopen("php://memory", "rw");
+    fwrite($handle, $fc);
+    fseek($handle, 0);
+    return $handle;
+}
+
+function verify_file($filename, $language, $replace = true, $source_name = '', $constant_colummn = 0, $definition_column = 1)
+{
+    if (($handle = utf8_fopen_read("$filename")) !== false) {
+        $first = true;
+        while (($data = fgetcsv($handle, 1000, ",")) !== false) {
+            $num = count($data);
+            if ($num >= 2) {
+                $constant   = str_replace("\r\n", "\n", $data[$constant_colummn]);
+                $definition = str_replace("\r\n", "\n", $data[$definition_column]);
+                if (!$first || $constant != 'constant_name') {
+                    $result = verify_translation($constant, $definition, $language, $replace, $source_name);
+                    if ((strpos($result, xl('Definition Exists') . ':') !== 0) && (strpos($result, xl('Empty Definition')) !== 0)) {
+                        echo  text($result) . "<br>";
+                    }
+                }
+                $first = false;
+            }
+        }
+        fclose($handle);
+    }
+}

--- a/interface/language/csv/translation_utilities.php
+++ b/interface/language/csv/translation_utilities.php
@@ -49,21 +49,7 @@ function find_or_create_constant($constant)
     }
 }
 
-function update_metainfo($constant, $definition, $source, $set_source = false)
-{
-    if ($source != "") {
-        $sqlUpdate = " UPDATE ippf_lang_definitions set " . $source . "= ? where BINARY constant_name = ?";
-        $parameters = array($definition, $constant);
-        sqlStatement($sqlUpdate, $parameters);
-        if ($set_source) {
-            $sqlUpdate = " UPDATE ippf_lang_definitions set source = ? where BINARY constant_name = ?";
-            $parameters = array($source, $constant);
-            sqlStatement($sqlUpdate, $parameters);
-        }
-    }
-}
-
-function verify_translation($constant, $definition, $language, $replace = true, $source = "", $set_metainfo = false, $preview = false)
+function verify_translation($constant, $definition, $language, $replace = true, $source = "", $preview = false)
 {
     if (empty($constant) || empty($definition)) {
         return '[1]' . xl("Empty Definition");
@@ -85,16 +71,9 @@ function verify_translation($constant, $definition, $language, $replace = true, 
                     $sqlUpdate = " UPDATE lang_definitions SET definition=? WHERE def_id=?";
                     if (!$preview) {
                         $result = sqlStatement($sqlUpdate, array($definition,$row['def_id']));
-                        if ($set_metainfo) {
-                            update_metainfo($constant, $definition, $source, true);}
                     }
                     return '[3]' . xl('Update From') . ':' . $row['definition'] . ' => ' . $definition . ' (' . xl('for') . ': ' . $constant . ')';
                 } else {
-                    if (!$preview) {
-                        if ($set_metainfo) {
-                            update_metainfo($constant, $definition, $source, false);
-                        }
-                    }
                     return '[4]' . xl('Definition Not Updated') . ': ' . xl('Current') . $row['definition'] . '|' . $infoText;
                 }
             }
@@ -114,9 +93,6 @@ function verify_translation($constant, $definition, $language, $replace = true, 
             $sqlInsert = " INSERT INTO lang_definitions (cons_id,lang_id,definition) VALUES (?,?,?) ";
             if (!$preview) {
                 $id = sqlInsert($sqlInsert, array($cons_id, $language, $definition));
-                if ($set_metainfo) {
-                    update_metainfo($constant, $definition, $source, true);
-                }
             }
             return '[5]' . xl('Create') . ':' . $constant . ' => ' . $definition;
         }

--- a/interface/language/csv/translation_utilities.php
+++ b/interface/language/csv/translation_utilities.php
@@ -66,7 +66,7 @@ function update_metainfo($constant, $definition, $source, $set_source = false)
 function verify_translation($constant, $definition, $language, $replace = true, $source = "", $set_metainfo = false, $preview = false)
 {
     if (empty($constant) || empty($definition)) {
-        return xl("Empty Definition");
+        return '[1]' . xl("Empty Definition");
     }
     $cons_id = find_or_create_constant($constant);
     $whereClause = " lang_id = ? and cons_id = ? ";
@@ -79,7 +79,7 @@ function verify_translation($constant, $definition, $language, $replace = true, 
             $row = sqlFetchArray($result);
             $row['definition'] = iconv('utf-8', 'utf-8', $row['definition']);
             if ($row['definition'] === $definition) {
-                return xl('Definition Exists') . ':' . $infoText;
+                return '[2]' . xl('Definition Exists') . ':' . $infoText;
             } else {
                 if ($replace) {
                     $sqlUpdate = " UPDATE lang_definitions SET definition=? WHERE def_id=?";
@@ -88,14 +88,14 @@ function verify_translation($constant, $definition, $language, $replace = true, 
                         if ($set_metainfo) {
                             update_metainfo($constant, $definition, $source, true);}
                     }
-                    return xl('Update From') . ':' . $row['definition'] . ' => ' . $definition . ' (' . xl('for') . ': ' . $constant . ')';
+                    return '[3]' . xl('Update From') . ':' . $row['definition'] . ' => ' . $definition . ' (' . xl('for') . ': ' . $constant . ')';
                 } else {
                     if (!$preview) {
                         if ($set_metainfo) {
                             update_metainfo($constant, $definition, $source, false);
                         }
                     }
-                    return xl('Definition Not Updated') . ': ' . xl('Current') . $row['definition'] . '|' . $infoText;
+                    return '[4]' . xl('Definition Not Updated') . ': ' . xl('Current') . $row['definition'] . '|' . $infoText;
                 }
             }
         }
@@ -118,7 +118,7 @@ function verify_translation($constant, $definition, $language, $replace = true, 
                     update_metainfo($constant, $definition, $source, true);
                 }
             }
-            return xl('Create') . ':' . $constant . ' => ' . $definition;
+            return '[5]' . xl('Create') . ':' . $constant . ' => ' . $definition;
         }
     }
 }
@@ -153,8 +153,8 @@ function verify_file($filename, $language, $replace = true, $source_name = '', $
                 $definition = str_replace("\r\n", "\n", $data[$definition_column]);
                 if (!$first || $constant != 'constant_name') {
                     $result = verify_translation($constant, $definition, $language, $replace, $source_name);
-                    if ((strpos($result, xl('Definition Exists') . ':') !== 0) && (strpos($result, xl('Empty Definition')) !== 0)) {
-                        echo  text($result) . "<br>";
+                    if ((strpos($result, '[2]') !== 0) && (strpos($result, '[1]') !== 0)) {
+                        echo text(substr($result, 3)) . "<br>";
                     }
                 }
                 $first = false;

--- a/interface/language/csv/validate_csv.php
+++ b/interface/language/csv/validate_csv.php
@@ -1,0 +1,284 @@
+<?php
+
+/*
+ * @package OpenEMR
+ * @link    http://www.open-emr.org
+ * @author  Kevin Yeh <kevin.y@integralemr.com>
+ * @author  Rod Roark <rod@sunsetsystems.com>
+ * @copyright Copyright (c) 2014 Kevin Yeh <kevin.y@integralemr.com>
+ * @copyright Copyright (c) 2021 Rod Roark <rod@sunsetsystems.com>
+ * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+use OpenEMR\Common\Acl\AclMain;
+use OpenEMR\Common\Csrf\CsrfUtils;
+
+// Ensure this script is not called separately
+if ($langModuleFlag !== true) {
+    die(function_exists('xlt') ? xlt('Authentication Error') : 'Authentication Error');
+}
+
+// gacl control
+$thisauth = AclMain::aclCheckCore('admin', 'language');
+if (!$thisauth) {
+    echo "<html>\n<body>\n";
+    echo "<p>" . xlt('You are not authorized for this.') . "</p>\n";
+    echo "</body>\n</html>\n";
+    exit();
+}
+
+require_once("translation_utilities.php");
+
+if (!isset($_FILES['language_file'])) {
+    die(xlt('No file specified'));
+}
+
+if (!isset($_REQUEST['language_id'])) {
+    die(xlt('No Language ID specified'));
+}
+
+$lang_id = $_REQUEST['language_id'];
+$resLanguage = sqlStatement("select * from lang_languages where  lang_id = ?", array($lang_id));
+$rowLanguage = sqlFetchArray($resLanguage);
+$lang_description = $rowLanguage['lang_description'];
+
+$handle = utf8_fopen_read($_FILES["language_file"]["tmp_name"]);
+$file_contents = array();
+if ($handle) {
+    while (($data = fgetcsv($handle, 1000, ",")) !== false) {
+        $file_contents[] = $data;
+    }
+}
+
+if (count($file_contents) === 0) {
+    die(xlt('Unable to Parse file! Verify File encoding'));
+}
+
+?>
+
+<div id="status"></div>
+<div id="information"></div>
+<div id="file-display" data-bind="template:{name: 'file-info', data: filedata}" ></div>
+
+<script type="text/html" id="file-info">
+
+    <div id="verify" data-bind="visible: mode()=='verify' ">
+        <h1>
+            <?php echo xlt('Verify Contents to apply to') . ' ' . $lang_description; ?>
+        </h1>
+        <span><?php echo xlt('Choose constant column'); ?></span> <select data-bind="options: header,optionsText: 'text', value: constant_choice" ></select><br>
+
+        <span><?php echo xlt('Choose definition column'); ?></span> <select data-bind="options: header,optionsText: 'text', value: definition_choice" ></select><br>
+
+        <input type="button" id="preview" value="<?php echo xla('Preview Changes'); ?>" data-bind="click: previewChanges"></input>
+
+        <table>
+            <thead>
+                <tr data-bind="foreach: header">
+                        <th data-bind="text:$data.text, attr: { index: $index}"></th>                
+                </tr>
+            </thead>
+            <tbody>
+                <?php
+                for ($idx = 1; $idx < count($file_contents); $idx++) {
+                    $row = $file_contents[$idx];
+                    echo "<tr>";
+                    foreach ($row as $cell) {
+                        echo "<td>" . $cell . "</td>";
+                    }
+                    echo "</tr>";
+                }
+                ?>
+            </tbody>
+        </table>
+    </div>
+    
+    <!-- ko if: mode()=='preview' -->
+    <div id="preview" data-bind="with: preview_data">
+        <h1><?php echo xlt('Preview Changes'); ?></h1>
+        <input type="button" id="preview" value="<?php echo xla('Commit Changes'); ?>" data-bind="click: commitChanges"></input>        
+        <div>
+            <span><?php echo xlt('Unchanged Entries verified'); ?>:</span><span data-bind="text:unchanged()"></span>
+        </div>
+        <div>
+            <span><?php echo xlt('Empty Definitions'); ?>:</span><span data-bind="text:empty()"></span>
+        </div>
+        <div>
+            <div><?php echo xlt('Created Definitions'); ?>:</span><span data-bind="text:created().length"></div>
+            <div><?php echo xlt('Updated Definitions'); ?>:</span><span data-bind="text:updated().length"></div>
+            <h3><?php echo xlt('Created Definitions List'); ?></h3>
+            <div data-bind="foreach: created">
+                <div data-bind="text:$data"></div>
+            </div>
+            <h3><?php echo xlt('Updated Definitions List'); ?></h3>
+            <div data-bind="foreach: updated">
+                <div data-bind="text:$data"></div>
+            </div>
+        </div>
+    </div>
+    <!-- /ko -->
+
+    <!-- ko if: mode()=='committed' -->
+    <div id="committed" data-bind="with: review_data">
+        <h1><?php echo xlt('Committed Changes'); ?></h1>
+        <div>
+            <span><?php echo xlt('Unchanged Entries verified'); ?>:</span><span data-bind="text:unchanged()"></span>
+        </div>
+        <div>
+            <span><?php echo xlt('Empty Definitions'); ?>:</span><span data-bind="text:empty()"></span>
+        </div>
+        <div>
+            <div><?php echo xlt('Created Definitions'); ?>:</span><span data-bind="text:created().length"></div>
+            <div><?php echo xlt('Updated Definitions'); ?>:</span><span data-bind="text:updated().length"></div>
+            <h3><?php echo xlt('Created Definitions List'); ?></h3>
+            <div data-bind="foreach: created">
+                <div data-bind="text:$data"></div>
+            </div>
+            <h3><?php echo xlt('Updated Definitions List'); ?></h3>
+            <div data-bind="foreach: updated">
+                <div data-bind="text:$data"></div>
+            </div>
+        </div>
+    </div>
+    <!-- /ko -->
+
+    <!-- ko if:loading() -->
+        <span data-bind="text:processingStatus"></span><img src='<?php echo $webroot . "/interface/pic/ajax-loader.gif"; ?>'/>
+    <!-- /ko -->
+</script>
+
+<script>
+    var file_contents = <?php echo json_encode($file_contents); ?>;
+    var header_data = ko.observableArray();
+    for(var h_index = 0; h_index < file_contents[0].length; h_index++)
+    {
+        var entry = {
+            idx: h_index,
+            text: file_contents[0][h_index]
+        }
+        header_data.push(entry);
+    }
+
+    var vm_file_display = {
+        filedata: {
+            start: ko.observable(1),
+            end: ko.observable(20),
+            total:ko.observable(file_contents.length),
+            header: header_data,            
+            constant_choice: ko.observable(),
+            definition_choice: ko.observable(),            
+            mode: ko.observable("verify"),
+            preview_data: {
+                changed: ko.observableArray(),
+                unchanged: ko.observable(0),
+                empty: ko.observable(0),
+                changed_html:ko.observable(),
+                updated: ko.observableArray(),
+                created: ko.observableArray()
+            },
+            loading: ko.observable(false),
+            display_contents: ko.observableArray(),
+            review_data: {
+                changed: ko.observableArray(),
+                unchanged: ko.observable(0),
+                empty: ko.observable(0),
+                changed_html:ko.observable(),
+                updated: ko.observableArray(),
+                created: ko.observableArray()
+            },
+            processingStatus: ko.observable(<?php echo xlj('Please wait'); ?>)
+        },
+        select_display_contents: function()
+        {
+            this.filedata.display_contents.removeAll();
+            if (this.filedata.end() >= file_contents.length)
+            {
+                this.filedata.end(file_contents.length);
+            }
+            for (var idx=this.filedata.start(); (idx <= this.filedata.end()); idx++)
+            {
+                this.filedata.display_contents.push(file_contents[idx]);
+            }
+        }
+    };
+
+    vm_file_display.filedata.constant_choice(vm_file_display.filedata.header()[1]);
+    vm_file_display.filedata.definition_choice(vm_file_display.filedata.header()[3]);
+    vm_file_display.select_display_contents(1,20);
+    ko.applyBindings(vm_file_display);
+    var translations = [];    
+    function previewChanges()
+    {
+        translations = [];
+        var constant_index = vm_file_display.filedata.constant_choice().idx;
+        var definition_index = vm_file_display.filedata.definition_choice().idx;
+
+        for (var idx=1; idx < file_contents.length; idx++)
+        {
+            var entry = file_contents[idx];
+            var translation = [];
+            translation[0] = entry[constant_index];
+            translation[1] = entry[definition_index];
+            translations[idx-1] = translation;
+        }
+        vm_file_display.filedata.mode("processing");
+        vm_file_display.filedata.processingStatus(<?php echo xlj('Generating preview data. Please Wait'); ?>);
+        vm_file_display.filedata.loading(true);
+        
+        $.post("csv/commit_csv.php",
+            {
+                lang_id: <?php echo json_encode($lang_id);?>
+                ,translations:JSON.stringify(translations)
+                ,preview: true
+            },
+            function(data)
+            {
+                vm_file_display.filedata.mode("preview");
+                vm_file_display.filedata.loading(false);
+                vm_file_display.filedata.preview_data.unchanged(data.unchanged);
+                vm_file_display.filedata.preview_data.empty(data.empty);
+                vm_file_display.filedata.preview_data.changed.removeAll();
+                vm_file_display.filedata.preview_data.changed(data.changed);
+                vm_file_display.filedata.preview_data.changed_html(data.html_changes);   
+                vm_file_display.filedata.preview_data.updated.removeAll();
+                vm_file_display.filedata.preview_data.updated(data.updated);
+                vm_file_display.filedata.preview_data.created.removeAll();
+                vm_file_display.filedata.preview_data.created(data.created);
+            }
+            ,"json"
+        );
+    }
+
+    function commitChanges()
+    {
+        vm_file_display.filedata.mode("processing");
+        vm_file_display.filedata.processingStatus(<?php echo xlj('Committing changes. Please Wait'); ?>);
+        vm_file_display.filedata.loading(true);    
+        $.post("csv/commit_csv.php",
+            {
+                lang_id: <?php echo json_encode($lang_id);?>
+                ,translations:JSON.stringify(translations)
+                ,preview: false
+            },
+            function(data)
+            {
+                vm_file_display.filedata.mode("committed");
+                vm_file_display.filedata.loading(false);
+                vm_file_display.filedata.review_data.unchanged(data.unchanged);
+                vm_file_display.filedata.review_data.empty(data.empty);
+                vm_file_display.filedata.review_data.changed.removeAll();
+                vm_file_display.filedata.review_data.changed(data.changed);                
+                vm_file_display.filedata.review_data.changed_html(data.html_changes);                
+                vm_file_display.filedata.review_data.updated.removeAll();
+                vm_file_display.filedata.review_data.updated(data.updated);
+                vm_file_display.filedata.review_data.created.removeAll();
+                vm_file_display.filedata.review_data.created(data.created);
+                
+            }
+            ,"json"
+        );
+}    
+</script>
+
+
+<?php echo activate_lang_tab('csv-link'); ?>

--- a/interface/language/csv/validate_csv.php
+++ b/interface/language/csv/validate_csv.php
@@ -64,7 +64,7 @@ if (count($file_contents) === 0) {
 
     <div id="verify" data-bind="visible: mode()=='verify' ">
         <h1>
-            <?php echo xlt('Verify Contents to apply to') . ' ' . $lang_description; ?>
+            <?php echo xlt('Verify Contents to apply to') . ' ' . text($lang_description); ?>
         </h1>
         <span><?php echo xlt('Choose constant column'); ?></span> <select data-bind="options: header,optionsText: 'text', value: constant_choice" ></select><br>
 
@@ -84,7 +84,7 @@ if (count($file_contents) === 0) {
                     $row = $file_contents[$idx];
                     echo "<tr>";
                     foreach ($row as $cell) {
-                        echo "<td>" . $cell . "</td>";
+                        echo "<td>" . text($cell) . "</td>";
                     }
                     echo "</tr>";
                 }
@@ -143,7 +143,7 @@ if (count($file_contents) === 0) {
     <!-- /ko -->
 
     <!-- ko if:loading() -->
-        <span data-bind="text:processingStatus"></span><img src='<?php echo $webroot . "/interface/pic/ajax-loader.gif"; ?>'/>
+        <span data-bind="text:processingStatus"></span><i class="fa fa-spinner fa-spin"></i>
     <!-- /ko -->
 </script>
 

--- a/interface/language/lang_constant.php
+++ b/interface/language/lang_constant.php
@@ -81,9 +81,5 @@ if (!empty($_POST['add'])) {
 </form>
 
 <span class="text"><?php echo xlt('Please Note: constants are case sensitive and any string is allowed.'); ?></span>
-<script>
-    $("#constant-link").addClass("active");
-    $("#definition-link").removeClass("active");
-    $("#language-link").removeClass("active");
-    $("#manage-link").removeClass("active");
-</script>
+
+<?php echo activate_lang_tab('constant-link'); ?>

--- a/interface/language/lang_definition.php
+++ b/interface/language/lang_definition.php
@@ -315,9 +315,5 @@ if (!empty($_POST['edit'])) {
 }
 
 ?>
-<script>
-    $("#definition-link").addClass("active");
-    $("#language-link").removeClass("active");
-    $("#constant-link").removeClass("active");
-    $("#manage-link").removeClass("active");
-</script>
+
+<?php echo activate_lang_tab('definition-link'); ?>

--- a/interface/language/lang_language.php
+++ b/interface/language/lang_language.php
@@ -81,9 +81,4 @@ if (!empty($_POST['add'])) {
     </div>
 </form>
 
-<script>
-    $("#language-link").addClass("active");
-    $("#definition-link").removeClass("active");
-    $("#constant-link").removeClass("active");
-    $("#manage-link").removeClass("active");
-</script>
+<?php echo activate_lang_tab('language-link'); ?>

--- a/interface/language/lang_manage.php
+++ b/interface/language/lang_manage.php
@@ -216,9 +216,4 @@ if (!empty($_POST['check']) || !empty($_POST['synchronize'])) {
     </div>
 </form>
 
-<script>
-    $("#manage-link").addClass("active");
-    $("#definition-link").removeClass("active");
-    $("#language-link").removeClass("active");
-    $("#constant-link").removeClass("active");
-</script>
+<?php echo activate_lang_tab('manage-link'); ?>

--- a/interface/language/language.php
+++ b/interface/language/language.php
@@ -17,11 +17,28 @@ require_once("language.inc.php");
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
 
+// Generates a Javascript section to activate the specified tab.
+function activate_lang_tab($linkid)
+{
+    $s = "<script>\n";
+    foreach (array(
+        'language-link',
+        'definition-link',
+        'constant-link',
+        'manage-link',
+        'csv-link',
+    ) as $id) {
+        $s .= "\$('#$id')." . ($id == $linkid ? 'addClass' : 'removeClass') . "('active');\n";
+    }
+    $s .= "</script>\n";
+    return $s;
+}
+
 //START OUT OUR PAGE....
 ?>
 <html>
 <head>
-<?php Header::setupHeader(); ?>
+<?php Header::setupHeader(['knockout']); ?>
 </head>
 
 <body class="body_top">
@@ -52,6 +69,9 @@ use OpenEMR\Core\Header;
                     <li class="nav-item" id="li-manage">
                         <a href="?m=manage&csrf_token_form=<?php echo attr_url(CsrfUtils::collectCsrfToken()); ?>" onclick="top.restoreSession()" class="nav-link font-weight-bold" id="manage-link"><?php echo xlt('Manage Translations'); ?></a>
                     </li>
+                    <li class="nav-item" id="li-csv">
+                        <a href="?m=csv&csrf_token_form=<?php echo attr_url(CsrfUtils::collectCsrfToken()); ?>" onclick="top.restoreSession()" class="nav-link font-weight-bold" id="csv-link"><?php echo xlt('Load from CSV'); ?></a>
+                    </li>
                 </ui>
             </form>
         </div><!--end of nav-pills div-->
@@ -81,6 +101,12 @@ use OpenEMR\Core\Header;
                                     break;
                                 case 'manage':
                                     require_once('lang_manage.php');
+                                    break;
+                                case 'csv':
+                                    require_once('csv/load_csv_file.php');
+                                    break;
+                                case 'csvval':
+                                    require_once('csv/validate_csv.php');
                                     break;
                             endswitch;
                         } else {

--- a/interface/language/language.php
+++ b/interface/language/language.php
@@ -21,13 +21,15 @@ use OpenEMR\Core\Header;
 function activate_lang_tab($linkid)
 {
     $s = "<script>\n";
-    foreach (array(
+    foreach (
+        array(
         'language-link',
         'definition-link',
         'constant-link',
         'manage-link',
         'csv-link',
-    ) as $id) {
+        ) as $id
+    ) {
         $s .= "\$('#$id')." . ($id == $linkid ? 'addClass' : 'removeClass') . "('active');\n";
     }
     $s .= "</script>\n";


### PR DESCRIPTION
This is based on old work from Kevin Yeh for IPPF. I adapted it as an enhancement to the existing Multi Language Tool.

The idea is that you can easily upload and process a CSV spreadsheet that has language constants in one column, and the desired translations in some other column.