### PR TITLE
Updated Readme File - grammatical error in sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ composer dump-autoload -o
 
 ### Contributors
 
-This project exists thanks to all the people who contribute. [[Contribute]](CONTRIBUTING.md).
+This project exists thanks to all the people who have contributed. [[Contribute]](CONTRIBUTING.md).
 <a href="https://github.com/openemr/openemr/graphs/contributors"><img src="https://opencollective.com/openemr/contributors.svg?width=890" /></a>
 
 ### Backers


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves: Grammatical error in README file


#### Changes proposed in this pull request: INSTEAD OF -"This project exists thanks to all the people who contribute."
IT SHOULD BE -  "This project exists thanks to all the people who have contributed."
