### PR TITLE
Issue #4316: Minor amendment to FHIR API docs

### DIFF
--- a/FHIR_README.md
+++ b/FHIR_README.md
@@ -156,6 +156,7 @@ curl -X POST -H 'Content-Type: application/fhir+json' 'http://localhost:8300/api
   "resourceType": "Patient",
   "identifier": [ { "system": "urn:oid:1.2.36.146.595.217.0.1", "value": "12345" } ],
   "name": [ {
+      "use": "official",
       "family": "Chalmers",
       "given": [ "Peter", "James" ]
   } ],


### PR DESCRIPTION
Fixes #4316

#### Short description of what this resolves:

As per Issue #4316; when creating a Patient entity via the FHIR API endpoint it's expected that one of the provided names has the `use` attribute set to `official`. The FHIR specification actually states that this property should be mandatory.

- [`HumanName`](http://hl7.org/fhir/stu3/datatypes.html#HumanName) FHIR resource documentation
- [`Patient`](http://hl7.org/fhir/stu3/patient.html) FHIR resource documentation

#### Changes proposed in this pull request:

- One line change to documentation showing the presence of the above attribute.