### PR TITLE
Show prior authorization number in the billing manager

### DIFF
--- a/interface/billing/billing_report.php
+++ b/interface/billing/billing_report.php
@@ -1087,7 +1087,7 @@ $partners = $x->_utility_array($x->x12_partner_factory());
                                 }
                                 $prior_auth = getPriorAuth($iter['enc_pid']);
                                 if ($prior_auth !== 'None') {
-                                    $lhtml .= "<span>&nbsp;&nbsp; " . xlt('Authorization') ."#: " . text($prior_auth) . "</span>";
+                                    $lhtml .= "<span>&nbsp;&nbsp; " . xlt('Authorization') . "#: " . text($prior_auth) . "</span>";
                                 }
                                 if ($iter['id']) {
                                     $lcount += 2;

--- a/interface/billing/billing_report.php
+++ b/interface/billing/billing_report.php
@@ -1087,7 +1087,7 @@ $partners = $x->_utility_array($x->x12_partner_factory());
                                 }
                                 $prior_auth = getPriorAuth($iter['enc_pid']);
                                 if ($prior_auth !== 'None') {
-                                    $lhtml .= "<span>&nbsp;&nbsp; xlt('Authorization')#: " . text($prior_auth) . "</span>";
+                                    $lhtml .= "<span>&nbsp;&nbsp; " . xlt('Authorization') ."#: " . text($prior_auth) . "</span>";
                                 }
                                 if ($iter['id']) {
                                     $lcount += 2;

--- a/interface/billing/billing_report.php
+++ b/interface/billing/billing_report.php
@@ -1085,7 +1085,10 @@ $partners = $x->_utility_array($x->x12_partner_factory());
                                 if ($GLOBALS['notes_to_display_in_Billing'] == 2 || $GLOBALS['notes_to_display_in_Billing'] == 3) {
                                     $lhtml .= '<span class="font-weight-bold text-danger" style="margin-left: 20px;">' . text($billing_note) . '</span>';
                                 }
-
+                                $prior_auth = getPriorAuth($iter['enc_pid']);
+                                if ($prior_auth !== 'None') {
+                                    $lhtml .= "<span>&nbsp;&nbsp; Authorization#: " . $prior_auth . "</span>";
+                                }
                                 if ($iter['id']) {
                                     $lcount += 2;
                                     $lhtml .= "<br />\n";

--- a/interface/billing/billing_report.php
+++ b/interface/billing/billing_report.php
@@ -1087,7 +1087,7 @@ $partners = $x->_utility_array($x->x12_partner_factory());
                                 }
                                 $prior_auth = getPriorAuth($iter['enc_pid']);
                                 if ($prior_auth !== 'None') {
-                                    $lhtml .= "<span>&nbsp;&nbsp; Authorization#: " . $prior_auth . "</span>";
+                                    $lhtml .= "<span>&nbsp;&nbsp; xlt('Authorization')#: " . text($prior_auth) . "</span>";
                                 }
                                 if ($iter['id']) {
                                     $lcount += 2;

--- a/library/patient.inc
+++ b/library/patient.inc
@@ -109,7 +109,7 @@ function getInsuranceProvidersExtra()
     $returnval = array();
     // add a global and if for where to allow inactive inscompanies
 
-    $sql = "SELECT insurance_companies.name, insurance_companies.id, insurance_companies.cms_id, 
+    $sql = "SELECT insurance_companies.name, insurance_companies.id, insurance_companies.cms_id,
             addresses.line1, addresses.line2, addresses.city, addresses.state, addresses.zip
             FROM insurance_companies, addresses
             WHERE addresses.foreign_id = insurance_companies.id
@@ -1811,5 +1811,16 @@ function is_patient_deceased($pid, $date = '')
         }
 
         return $results;
+    }
+}
+
+function getPriorAuth($pid)
+{
+    $sql = "select prior_auth_number from form_prior_auth where pid = ?";
+    $auth_num = sqlQuery($sql, [$pid]);
+    if (!empty($auth_num['prior_auth_number'])) {
+        return $auth_num['prior_auth_number'];
+    } else {
+        return "None";
     }
 }


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:


#### Changes proposed in this pull request:

I was asked to show the prior authorization number in the billing manager display. This is kind of a first step because there is more to this than just a single number. However, here is the infant stage of this request. The number only shows if there is a number in the prior auth table. If there is not prior auth nothing changes in the billing manager.  
