### PR TITLE
write to billing log, even if there is not an onLogComplete callback set

### DIFF
--- a/src/Billing/BillingProcessor/BillingLogger.php
+++ b/src/Billing/BillingProcessor/BillingLogger.php
@@ -89,17 +89,17 @@ class BillingLogger
      */
     public function onLogComplete()
     {
-        // If the generator set a callback function for when the log completes, call it here
-        if (isset($this->onLogCompleteCallback)) {
-            call_user_func($this->onLogCompleteCallback);
-        }
-
         // If the hlog isn't empty, write the log to disk
         if (!empty($this->hlog)) {
             if ($GLOBALS['drive_encryption']) {
                 $this->hlog = $this->cryptoGen->encryptStandard($this->hlog, null, 'database');
             }
             file_put_contents($GLOBALS['OE_SITE_DIR'] . "/documents/edi/process_bills.log", $this->hlog);
+        }
+
+        // If the generator set a callback function for when the log completes, call it here
+        if (isset($this->onLogCompleteCallback)) {
+            return call_user_func($this->onLogCompleteCallback);
         }
 
         return false;

--- a/src/Billing/BillingProcessor/BillingLogger.php
+++ b/src/Billing/BillingProcessor/BillingLogger.php
@@ -89,14 +89,17 @@ class BillingLogger
      */
     public function onLogComplete()
     {
+        // If the generator set a callback function for when the log completes, call it here
         if (isset($this->onLogCompleteCallback)) {
             call_user_func($this->onLogCompleteCallback);
-            if (!empty($this->hlog)) {
-                if ($GLOBALS['drive_encryption']) {
-                    $this->hlog = $this->cryptoGen->encryptStandard($this->hlog, null, 'database');
-                }
-                file_put_contents($GLOBALS['OE_SITE_DIR'] . "/documents/edi/process_bills.log", $this->hlog);
+        }
+
+        // If the hlog isn't empty, write the log to disk
+        if (!empty($this->hlog)) {
+            if ($GLOBALS['drive_encryption']) {
+                $this->hlog = $this->cryptoGen->encryptStandard($this->hlog, null, 'database');
             }
+            file_put_contents($GLOBALS['OE_SITE_DIR'] . "/documents/edi/process_bills.log", $this->hlog);
         }
 
         return false;

--- a/src/Billing/BillingProcessor/Tasks/GeneratorX12.php
+++ b/src/Billing/BillingProcessor/Tasks/GeneratorX12.php
@@ -175,7 +175,6 @@ class GeneratorX12 extends AbstractGenerator implements GeneratorInterface, Gene
         $format_bat = str_replace('~', PHP_EOL, $this->batch->getBatContent());
         $wrap = "<!DOCTYPE html><html><head></head><body><div style='overflow: hidden;'><pre>" . text($format_bat) . "</pre></div></body></html>";
         echo $wrap;
-        exit();
     }
 
     /**

--- a/src/Billing/BillingProcessor/Tasks/GeneratorX12Direct.php
+++ b/src/Billing/BillingProcessor/Tasks/GeneratorX12Direct.php
@@ -282,7 +282,6 @@ class GeneratorX12Direct extends AbstractGenerator implements GeneratorInterface
             // if validating (sending to screen for user)
             $wrap = "<!DOCTYPE html><html><head></head><body><div style='overflow: hidden;'><pre>" . text($format_bat) . "</pre></div></body></html>";
             echo $wrap;
-            exit();
         });
     }
 


### PR DESCRIPTION
#### Short description of what this resolves:

The billing log was only being written to disk if the generator task set an onLogCompleteCallback. In the case of the X12Direct generator, it doesn't set a callback, so the log is never written. This change writes the process_bills.log to disk every time.



