### PR TITLE
store Rxnorm in prescription table from nlm lookup api

### DIFF
--- a/controllers/C_Prescription.class.php
+++ b/controllers/C_Prescription.class.php
@@ -713,10 +713,9 @@ class C_Prescription extends Controller
 
         $this->multiprint_footer($pdf);
 
-            $pFirstName = $p->patient->fname; //modified by epsdky for prescription title change to include patient name and ID
-            $pFName = convert_safe_file_dir_name($pFirstName);
-            $modedFileName = "Rx_{$pFName}_{$p->patient->id}.pdf";
-
+        $pFirstName = $p->patient->fname; //modified by epsdky for prescription filename change to include patient name and ID
+        $pFName = convert_safe_file_dir_name($pFirstName);
+        $modedFileName = "Rx_{$pFName}_{$p->patient->id}.pdf";
         $pdf->ezStream(array('Content-Disposition' => $modedFileName));
         return;
     }
@@ -920,7 +919,7 @@ class C_Prescription extends Controller
                     return;
         }
 
-                // process the lookup
+        // process the lookup
         $this->assign("drug", $_POST['drug']);
         $list = array();
         if (!empty($_POST['drug'])) {

--- a/controllers/C_Prescription.class.php
+++ b/controllers/C_Prescription.class.php
@@ -33,7 +33,6 @@ class C_Prescription extends Controller
     function __construct($template_mod = "general")
     {
         parent::__construct();
-
         $this->template_mod = $template_mod;
         $this->assign("FORM_ACTION", $GLOBALS['webroot'] . "/controller.php?" . attr($_SERVER['QUERY_STRING']));
         $this->assign("TOP_ACTION", $GLOBALS['webroot'] . "/controller.php?" . "prescription" . "&");

--- a/controllers/C_Prescription.class.php
+++ b/controllers/C_Prescription.class.php
@@ -19,6 +19,7 @@ require_once($GLOBALS['fileroot'] . "/library/amc.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Http\oeHttp;
+use OpenEMR\Rx\RxList;
 use PHPMailer\PHPMailer\PHPMailer;
 
 class C_Prescription extends Controller
@@ -922,7 +923,7 @@ class C_Prescription extends Controller
         $this->assign("drug", $_POST['drug']);
         $list = array();
         if (!empty($_POST['drug'])) {
-            $list = $this->RxList->get_list($_POST['drug']);
+            $list = $this->RxList->getList($_POST['drug']);
         }
 
         if (is_array($list)) {

--- a/interface/patient_file/summary/add_edit_issue.php
+++ b/interface/patient_file/summary/add_edit_issue.php
@@ -264,7 +264,7 @@ if (!empty($_POST['form_save'])) {
             "modifydate = NOW() " .
             "WHERE id = '" . add_escape_custom($issue) . "'";
         sqlStatement($query);
-        if ($text_type == "medication" && enddate != '') {
+        if ($text_type == "medication" && $form_end != '') {
             sqlStatement(
                 'UPDATE prescriptions SET '
                 . 'medication = 0 where patient_id = ? '

--- a/library/ajax/prescription_drugname_lookup.php
+++ b/library/ajax/prescription_drugname_lookup.php
@@ -1,9 +1,9 @@
 <?php
 
 /**
- * This file use is used specifically to look up drug names when
+ * This file is used specifically to look up drug names when
  * writing a prescription. See the file:
- *    templates/prescriptions/general_edit.html
+ * templates/prescription/general_edit.html
  * for additional information
  *
  * @package   OpenEMR

--- a/library/classes/RXList.class.php
+++ b/library/classes/RXList.class.php
@@ -67,7 +67,7 @@ class RxList
         $response = oeHttp::get($url, ['name' => $query]);
         $buffer = $response->body();
         return $buffer ? $buffer : false;
-    } // end function RxList::getPage
+    }
 
     function get_list($query)
     {
@@ -75,30 +75,29 @@ class RxList
         $tokens = RxList::parse2tokens($page);
         $hash = RxList::tokens2hash($tokens);
         if (!empty($hash)) {
-        foreach ($hash as $index => $data) {
-            unset($my_data);
-            foreach ($data as $k => $v) {
-                $my_data[$k] = $v;
+            foreach ($hash as $index => $data) {
+                unset($my_data);
+                foreach ($data as $k => $v) {
+                    $my_data[$k] = $v;
+                }
+
+                $rxcui = '';
+
+                if (trim($my_data['rxcui']) !== '') {
+                    $rxcui = " RXCUI:" . trim($my_data['rxcui']);
+                }
+
+                $synonym = '';
+                if (trim($my_data['synonym']) !== '') {
+                    $synonym = " | (" . trim($my_data['synonym']) . ")";
+                }
+
+                $list[trim($my_data['name'] . $rxcui) . $synonym] =
+                    trim($my_data['name']);
             }
-
-            $rxcui = '';
-
-            if (trim($my_data['rxcui']) !== '') {
-                $rxcui = " / " . trim($my_data['rxcui']);
-            }
-
-            $synonym = '';
-            if (trim($my_data['synonym']) !== '') {
-                $synonym = " == (" . trim($my_data['synonym']) . $rxcui . ")";
-            }
-
-            $list[trim($my_data['name']) . $synonym] =
-                trim($my_data['name']);
         }
-    }
-
         return $list;
-    } // end function RxList::get_list
+    }
 
     /* break the web page into a collection of TAGS
      * such as <input ..> or <img ... >

--- a/library/classes/RXList.class.php
+++ b/library/classes/RXList.class.php
@@ -74,6 +74,7 @@ class RxList
         $page = RxList::getPage($query);
         $tokens = RxList::parse2tokens($page);
         $hash = RxList::tokens2hash($tokens);
+        if (!empty($hash)) {
         foreach ($hash as $index => $data) {
             unset($my_data);
             foreach ($data as $k => $v) {
@@ -94,6 +95,7 @@ class RxList
             $list[trim($my_data['name']) . $synonym] =
                 trim($my_data['name']);
         }
+    }
 
         return $list;
     } // end function RxList::get_list

--- a/src/Rx/RxList.php
+++ b/src/Rx/RxList.php
@@ -44,24 +44,28 @@
  * @author    avanss llc
  * @author    Brady Miller <brady.g.miller@gmail.com>
  * @author    Jerry Padgett <sjpadgett@gmail.com>
- * @author    Copyright (c) 2002 rufustfirefly
- * @author    Copyright (c) 2005 wpennington
- * @author    Copyright (c) 2005 drbowen
- * @author    Copyright (c) 2005-2007 sunsetsystems
- * @author    Copyright (c) 2008 cfapress
- * @author    Copyright (c) 2016 sherwin gaddis
- * @author    Copyright (c) 2019 avanss llc
- * @author    Copyright (c) 2019 Brady Miller <brady.g.miller@gmail.com>
- * @author    Copyright (c) 2019 Jerry Padgett <sjpadgett@gmail.com>
+ * @author    Stephen Waite <stephen.waite@cmsvt.com>
+ * @copyright Copyright (c) 2002 rufustfirefly
+ * @copyright Copyright (c) 2005 wpennington
+ * @copyright Copyright (c) 2005 drbowen
+ * @copyright Copyright (c) 2005-2007 sunsetsystems
+ * @copyright Copyright (c) 2008 cfapress
+ * @copyright Copyright (c) 2016 sherwin gaddis
+ * @copyright Copyright (c) 2019 avanss llc
+ * @copyright Copyright (c) 2019 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2019-2021 Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright Copyright (c) 2021 Stephen Waite <stephen.waite@cmsvt.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
+
+namespace OpenEMR\Rx;
 
 use OpenEMR\Common\Http\oeHttp;
 
 class RxList
 {
 
-    function getPage($query)
+    public function getPage($query)
     {
         $url = "https://rxnav.nlm.nih.gov/REST/Prescribe/drugs";
         $response = oeHttp::get($url, ['name' => $query]);
@@ -69,11 +73,11 @@ class RxList
         return $buffer ? $buffer : false;
     }
 
-    function get_list($query)
+    public function getList($query)
     {
-        $page = RxList::getPage($query);
-        $tokens = RxList::parse2tokens($page);
-        $hash = RxList::tokens2hash($tokens);
+        $page = $this->getPage($query);
+        $tokens = $this->parse2tokens($page);
+        $hash = $this->tokens2hash($tokens);
         if (!empty($hash)) {
             foreach ($hash as $index => $data) {
                 unset($my_data);
@@ -102,7 +106,7 @@ class RxList
     /* break the web page into a collection of TAGS
      * such as <input ..> or <img ... >
      */
-    function parse2tokens($page)
+    public function parse2tokens($page)
     {
         $pos = 0;
         $token = 0;
@@ -130,13 +134,13 @@ class RxList
                     $tokens[$token] .= substr($page, $pos, 1);
                     $in_token = false;
                     break;
-            } // end decide what to do
+            }
             $pos++;
-        } // end looping through string
+        }
         return $tokens;
-    } // end function RxList::parse2tokens
+    }
 
-    function tokens2hash($tokens)
+    public function tokens2hash($tokens)
     {
         $record = false;
         $current = 0;
@@ -185,7 +189,7 @@ class RxList
                 $type = "";
                 $ending = "";
             }
-        } // end looping
+        }
         return $all;
-    } // end function RxList::tokens2hash
-} // end class RxList
+    }
+}

--- a/templates/insurance_companies/general_edit.html
+++ b/templates/insurance_companies/general_edit.html
@@ -2,11 +2,12 @@
  * Insurance company edit
  *
  * @package   OpenEMR
- * @link      http://www.open-emr.org
+ * @link      https://www.open-emr.org
  * @author    Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2017 Brady Miller <brady.g.miller@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  *}
+
 <form name="insurancecompany" method="post" action="{$FORM_ACTION}" class='form-horizontal' onsubmit="return top.restoreSession()">
     <!-- it is important that the hidden form_id field be listed first, when it is called it populates any old information attached with the id, this allows for partial edits
     if it were called last, the settings from the form would be overwritten with the old information-->

--- a/templates/prescription/general_edit.html
+++ b/templates/prescription/general_edit.html
@@ -16,9 +16,10 @@
 <script>
 
 {literal}
-    function my_process_lookup(drug) {
+    function my_process_lookup(drug, rxcode = '') {
       // Pass the variable
-      var newOption = new Option(drug, drug, true, true);
+      let newOption = new Option(drug, drug, true, true);
+      $("#rxnorm_drugcode").val(rxcode);
       $('#drug').append(newOption).trigger('change');
       $('#hiddendiv').hide();
       $("#hiddendiv").html( "&nbsp;" );
@@ -260,6 +261,7 @@
 
         <input type="hidden" name="id" value="{$prescription->id|attr}" />
         <input type="hidden" name="process" value="{$PROCESS|attr}" />
+        <input type="hidden" id="rxnorm_drugcode" name="rxnorm_drugcode" value="{$prescription->rxnorm_drugcode|attr}" />
 
         <script>
             {if !empty($ENDING_JAVASCRIPT)}{$ENDING_JAVASCRIPT}{/if}

--- a/templates/prescription/general_lookup.html
+++ b/templates/prescription/general_lookup.html
@@ -18,7 +18,9 @@
 		function my_process () {
 			// Pass the variable
 {/literal}
-			parent.my_process_lookup(document.lookup.drug.value, document.lookup.drug.value.substring(document.lookup.drug.value.length -7));
+			let rxText = document.lookup.drug[document.lookup.drug.selectedIndex].text;
+			let rxcode = (rxText.split('RXCUI:').pop().split('|')[0]).trim();
+			parent.my_process_lookup(document.lookup.drug.value, rxcode);
 {literal}
 		}
 {/literal}

--- a/templates/prescription/general_lookup.html
+++ b/templates/prescription/general_lookup.html
@@ -18,7 +18,7 @@
 		function my_process () {
 			// Pass the variable
 {/literal}
-			parent.my_process_lookup(document.lookup.drug.value);
+			parent.my_process_lookup(document.lookup.drug.value, document.lookup.drug.value.substring(document.lookup.drug.value.length -7));
 {literal}
 		}
 {/literal}


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
ultimately trying to fix #4373 

#### Short description of what this resolves:
the way we grab the `rxnorm` code isn't working; think it's since the array flip doesn't store the code in a hidden post variable or in the array for smarty

#### Changes proposed in this pull request:
some minor edits with a couple php warnings but nothing significant yet