### PR TITLE
add default search type to session for fee sheet search for add'l codes

### DIFF
--- a/custom/code_types.inc.php
+++ b/custom/code_types.inc.php
@@ -49,8 +49,6 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-use OpenEMR\Common\Session\SessionUtil;
-
 require_once(dirname(__FILE__) . "/../library/csv_like_join.php");
 
 $code_types = array();
@@ -81,7 +79,7 @@ while ($ctrow = sqlFetchArray($ctres)) {
         reset($code_types);
         $default_search_type = key($code_types);
     }
-    SessionUtil::setSession('default_search_type', $default_search_type);
+    $_SESSION['default_search_type'] = $default_search_type;
 }
 
 /** This array contains metadata describing the arrangement of the external data

--- a/custom/code_types.inc.php
+++ b/custom/code_types.inc.php
@@ -49,6 +49,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+use OpenEMR\Common\Session\SessionUtil;
+
 require_once(dirname(__FILE__) . "/../library/csv_like_join.php");
 
 $code_types = array();
@@ -79,6 +81,7 @@ while ($ctrow = sqlFetchArray($ctres)) {
         reset($code_types);
         $default_search_type = key($code_types);
     }
+    SessionUtil::setSession('default_search_type', $default_search_type);
 }
 
 /** This array contains metadata describing the arrangement of the external data

--- a/custom/code_types.inc.php
+++ b/custom/code_types.inc.php
@@ -73,13 +73,10 @@ while ($ctrow = sqlFetchArray($ctres)) {
     'problem' => $ctrow['ct_problem'],
     'drug' => $ctrow['ct_drug']
     );
-    if (array_key_exists($GLOBALS['default_search_code_type'], $code_types)) {
-        $default_search_type = $GLOBALS['default_search_code_type'];
-    } else {
+    if (!array_key_exists($GLOBALS['default_search_code_type'], $code_types)) {
         reset($code_types);
-        $default_search_type = key($code_types);
+        $$GLOBALS['default_search_code_type'] = key($code_types);
     }
-    $_SESSION['default_search_type'] = $default_search_type;
 }
 
 /** This array contains metadata describing the arrangement of the external data

--- a/interface/forms/eye_mag/view.php
+++ b/interface/forms/eye_mag/view.php
@@ -3596,8 +3596,8 @@ if ($refresh and $refresh != 'fullscreen') {
                                   /*
                                    *  The goal here is to auto-code the encounter and link it directly to the billing module.
                                    *  Select Visit Type from dropdown (CPT4) built from practice's fee_sheet_options table.
-                                   *  Active coding system = $default_search_type;
-                                   *  We present the $default_search_type codes found in the Imp/Plan.
+                                   *  Active coding system = $GLOBALS['default_search_code_type'];
+                                   *  We present the active coding system codes found in the Imp/Plan.
                                    *  Perhaps a minor procedure/test was performed?
                                    *  Select options drawn from Eye_todo_done_".$provider_id list with a CODE
                                    *  TODO: Finally we have the "Prior Visit" functionality of the form.
@@ -3605,7 +3605,7 @@ if ($refresh and $refresh != 'fullscreen') {
                                    */
                                 ?>
                               <script>
-                                  var default_search_type = '<?php echo text($default_search_type); ?>';
+                                  var default_search_type = '<?php echo text($GLOBALS['default_search_code_type']); ?>';
                               </script>
 
                               <dt class="borderShadow"><span><?php echo xlt('Coding Engine'); ?></span></dt>

--- a/interface/forms/fee_sheet/new.php
+++ b/interface/forms/fee_sheet/new.php
@@ -1059,7 +1059,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                 }
                             }
 
-                            $search_type = $_SESSION['default_search_type'] ?? null;
+                            $search_type = $GLOBALS['default_search_code_type'] ?? null;
                             if (!empty($_POST['search_type'])) {
                                 $search_type = $_POST['search_type'];
                             }

--- a/interface/forms/fee_sheet/new.php
+++ b/interface/forms/fee_sheet/new.php
@@ -1059,7 +1059,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                 }
                             }
 
-                            $search_type = $default_search_type ?? null;
+                            $search_type = $_SESSION['default_search_type'] ?? null;
                             if (!empty($_POST['search_type'])) {
                                 $search_type = $_POST['search_type'];
                             }


### PR DESCRIPTION
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #
https://community.open-emr.org/t/default-to-icd10-on-fee-sheet/16657/

#### Short description of what this resolves:
variable wasn't in scope so added to session

as an aside, couldn't figure out why `code_types.inc.php` was being called by the `execute_background_services.php` script so `require_once("$srcdir/options.inc.php");` in the `fee_sheet/new.php` is causing the `custom/code_types.inc.php` to be loaded twice

#### Changes proposed in this pull request:
