### PR TITLE
Openemr fhir device, careplan, goal

### DIFF
--- a/_rest_routes.inc.php
+++ b/_rest_routes.inc.php
@@ -709,14 +709,24 @@ RestConfig::$FHIR_ROUTE_MAP = array(
         return $return;
     },
     "GET /fhir/Device" => function (HttpRestRequest $request) {
-        RestConfig::authorization_check("admin", "super");
-        $return = (new FhirDeviceRestController())->getAll($request->getQueryParams());
+        if ($request->isPatientRequest()) {
+            // only allow access to data of binded patient
+            $return = (new FhirDeviceRestController())->getAll($request->getQueryParams(), $request->getPatientUUIDString());
+        } else {
+            RestConfig::authorization_check("admin", "super");
+            $return = (new FhirEncounterRestController())->getAll($request->getQueryParams());
+        }
         RestConfig::apiLog($return);
         return $return;
     },
     "GET /fhir/Device/:uuid" => function ($uuid, HttpRestRequest $request) {
-        RestConfig::authorization_check("admin", "super");
-        $return = (new FhirDeviceRestController())->getOne($uuid);
+        if ($request->isPatientRequest()) {
+            // only allow access to data of binded patient
+            $return = (new FhirDeviceRestController())->getOne($uuid, $request->getPatientUUIDString());
+        } else {
+            RestConfig::authorization_check("admin", "super");
+            $return = (new FhirEncounterRestController())->getOne($request->getQueryParams());
+        }
         RestConfig::apiLog($return);
         return $return;
     },

--- a/library/formdata.inc.php
+++ b/library/formdata.inc.php
@@ -92,9 +92,10 @@ function process_cols_escape($s)
  * @param   string|array        $s       sql column name(s) variable to be escaped/sanitized.
  * @param   array         $tables  The table(s) that the sql columns is from (in an array).
  * @param   boolean       $long    Use long form (ie. table.colname) vs short form (ie. colname).
+ * @param   boolean       $throwException Whether to throw a SQL exception instead of dieing
  * @return  string                 Escaped table name variable.
  */
-function escape_sql_column_name($s, $tables, $long = false)
+function escape_sql_column_name($s, $tables, $long = false, $throwException = false)
 {
     // If $s is asterisk return asterisk to select all columns
     if ($s === "*") {
@@ -140,7 +141,8 @@ function escape_sql_column_name($s, $tables, $long = false)
     }
 
     // Now can escape(via whitelisting) the sql column name
-    return escape_identifier($s, $columns_options, true);
+    $dieIfNoMatch = !$throwException;
+    return escape_identifier($s, $columns_options, $dieIfNoMatch, true, $throwException);
 }
 
 /**
@@ -214,9 +216,10 @@ function mitigateSqlTableUpperCase($s)
  *                                          characters (for example 'a-zA-Z0-9_').
  * @param   boolean      $die_if_no_match  If there is no match in the whitelist, then die and echo an error to screen and log.
  * @param   boolean      $case_sens_match  Use case sensitive match (this is default).
+ * @param   boolean      $throw_exception_if_no_match If there is no match in the whitelist then throw an exception
  * @return  string                         Escaped/sanitized sql identifier variable.
  */
-function escape_identifier($s, $whitelist_items, $die_if_no_match = false, $case_sens_match = true)
+function escape_identifier($s, $whitelist_items, $die_if_no_match = false, $case_sens_match = true, $throw_exception_if_no_match = false)
 {
     if (is_array($whitelist_items)) {
         // Only return an item within the whitelist_items
@@ -237,6 +240,8 @@ function escape_identifier($s, $whitelist_items, $die_if_no_match = false, $case
                     // No match and $die_if_no_match is set, so die() and send error messages to screen and log
                     error_Log("ERROR: OpenEMR SQL Escaping ERROR of the following string: " . errorLogEscape($s), 0);
                     die("<br /><span style='color:red;font-weight:bold;'>" . xlt("There was an OpenEMR SQL Escaping ERROR of the following string") . " " . text($s) . "</span><br />");
+                } else if ($throw_exception_if_no_match) {
+                    throw new \OpenEMR\Common\Database\SqlQueryException("", "ERROR: OpenEMR SQL Escaping ERROR of the following string: " . errorLogEscape($s));
                 } else {
                     // Return first token since no match
                     $key = 0;
@@ -251,6 +256,8 @@ function escape_identifier($s, $whitelist_items, $die_if_no_match = false, $case
                 // Contains illegal character and $die_if_no_match is set, so die() and send error messages to screen and log
                 error_Log("ERROR: OpenEMR SQL Escaping ERROR of the following string: " . errorLogEscape($s), 0);
                 die("<br /><span style='color:red;font-weight:bold;'>" . xlt("There was an OpenEMR SQL Escaping ERROR of the following string") . " " . text($s) . "</span><br />");
+            } else if ($throw_exception_if_no_match) {
+                throw new \OpenEMR\Common\Database\SqlQueryException("", "ERROR: OpenEMR SQL Escaping ERROR of the following string: " . errorLogEscape($s));
             } else {
                 // Contains all legal characters, so return the legal string
                 return $s;

--- a/src/Common/Database/QueryUtils.php
+++ b/src/Common/Database/QueryUtils.php
@@ -135,7 +135,7 @@ class QueryUtils
         //   Execute function.
         $recordset = $GLOBALS['adodb']['db']->Execute($statement, $binds, true);
         if ($recordset === false) {
-            throw new SqlQueryException($statement, "Insert failed. SQL error " . getSqlLastError());
+            throw new SqlQueryException($statement, "Insert failed. SQL error " . getSqlLastError() . " Query: " . $statement);
         }
 
         // Return the correct last id generated using function

--- a/src/Common/Database/QueryUtils.php
+++ b/src/Common/Database/QueryUtils.php
@@ -180,4 +180,9 @@ class QueryUtils
 
         return $results;
     }
+
+    public static function generateId()
+    {
+        return \generate_id();
+    }
 }

--- a/src/Common/Database/QueryUtils.php
+++ b/src/Common/Database/QueryUtils.php
@@ -70,6 +70,22 @@ class QueryUtils
     }
 
     /**
+     * Returns a row (as an array) from a sql recordset.
+     *
+     * Function that will allow use of the adodb binding
+     * feature to prevent sql-injection.
+     * It will act upon the object returned from the
+     * sqlStatement() function (and sqlQ() function).
+     *
+     * @param recordset $resultSet
+     * @return array
+     */
+    public static function fetchArrayFromResultSet($resultSet)
+    {
+        return sqlFetchArray($resultSet);
+    }
+
+    /**
      * Standard sql query in OpenEMR.
      *
      * Function that will allow use of the adodb binding

--- a/src/RestControllers/FHIR/FhirDeviceRestController.php
+++ b/src/RestControllers/FHIR/FhirDeviceRestController.php
@@ -12,6 +12,7 @@
 namespace OpenEMR\RestControllers\FHIR;
 
 use OpenEMR\Services\FHIR\FhirCareTeamService;
+use OpenEMR\Services\FHIR\FhirDeviceService;
 use OpenEMR\Services\FHIR\FhirResourcesService;
 use OpenEMR\RestControllers\RestControllerHelper;
 use OpenEMR\FHIR\R4\FHIRResource\FHIRBundle\FHIRBundleEntry;
@@ -23,7 +24,9 @@ class FhirDeviceRestController
 
     public function __construct()
     {
+        $this->fhirResourceService = new FhirDeviceService();
         $this->fhirService = new FhirResourcesService();
+
     }
 
     /**
@@ -34,7 +37,7 @@ class FhirDeviceRestController
      */
     public function getOne($fhirId, $puuidBind = null)
     {
-        $processingResult = new ProcessingResult(); // return nothing for now
+        $processingResult = $this->fhirResourceService->getOne($fhirId, $puuidBind);
         return RestControllerHelper::handleFhirProcessingResult($processingResult, 200);
     }
 
@@ -45,7 +48,7 @@ class FhirDeviceRestController
      */
     public function getAll($searchParams, $puuidBind = null)
     {
-        $processingResult = new ProcessingResult(); // return nothing for now
+        $processingResult = $this->fhirResourceService->getAll($searchParams, $puuidBind);
         $bundleEntries = array();
         foreach ($processingResult->getData() as $index => $searchResult) {
             $bundleEntry = [
@@ -55,7 +58,7 @@ class FhirDeviceRestController
             $fhirBundleEntry = new FHIRBundleEntry($bundleEntry);
             array_push($bundleEntries, $fhirBundleEntry);
         }
-        $bundleSearchResult = $this->fhirService->createBundle('CarePlan', $bundleEntries, false);
+        $bundleSearchResult = $this->fhirService->createBundle('Device', $bundleEntries, false);
         $searchResponseBody = RestControllerHelper::responseHandler($bundleSearchResult, null, 200);
         return $searchResponseBody;
     }

--- a/src/RestControllers/FHIR/FhirDeviceRestController.php
+++ b/src/RestControllers/FHIR/FhirDeviceRestController.php
@@ -26,7 +26,6 @@ class FhirDeviceRestController
     {
         $this->fhirResourceService = new FhirDeviceService();
         $this->fhirService = new FhirResourcesService();
-
     }
 
     /**

--- a/src/RestControllers/FHIR/FhirGoalRestController.php
+++ b/src/RestControllers/FHIR/FhirGoalRestController.php
@@ -12,6 +12,7 @@
 namespace OpenEMR\RestControllers\FHIR;
 
 use OpenEMR\Services\FHIR\FhirCareTeamService;
+use OpenEMR\Services\FHIR\FhirGoalService;
 use OpenEMR\Services\FHIR\FhirResourcesService;
 use OpenEMR\RestControllers\RestControllerHelper;
 use OpenEMR\FHIR\R4\FHIRResource\FHIRBundle\FHIRBundleEntry;
@@ -21,9 +22,15 @@ class FhirGoalRestController
 {
     private $fhirService;
 
+    /**
+     * @var FhirGoalService
+     */
+    private $service;
+
     public function __construct()
     {
         $this->fhirService = new FhirResourcesService();
+        $this->service = new FhirGoalService();
     }
 
     /**
@@ -34,7 +41,7 @@ class FhirGoalRestController
      */
     public function getOne($fhirId, $puuidBind = null)
     {
-        $processingResult = new ProcessingResult(); // return nothing for now
+        $processingResult = $this->service->getOne($fhirId, $puuidBind);
         return RestControllerHelper::handleFhirProcessingResult($processingResult, 200);
     }
 
@@ -45,7 +52,7 @@ class FhirGoalRestController
      */
     public function getAll($searchParams, $puuidBind = null)
     {
-        $processingResult = new ProcessingResult(); // return nothing for now
+        $processingResult = $this->service->getAll($searchParams, $puuidBind);
         $bundleEntries = array();
         foreach ($processingResult->getData() as $index => $searchResult) {
             $bundleEntry = [
@@ -55,7 +62,7 @@ class FhirGoalRestController
             $fhirBundleEntry = new FHIRBundleEntry($bundleEntry);
             array_push($bundleEntries, $fhirBundleEntry);
         }
-        $bundleSearchResult = $this->fhirService->createBundle('CarePlan', $bundleEntries, false);
+        $bundleSearchResult = $this->fhirService->createBundle('Goal', $bundleEntries, false);
         $searchResponseBody = RestControllerHelper::responseHandler($bundleSearchResult, null, 200);
         return $searchResponseBody;
     }

--- a/src/Services/CarePlanService.php
+++ b/src/Services/CarePlanService.php
@@ -1,0 +1,276 @@
+<?php
+
+/**
+ * CarePlanService.php
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Services;
+
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Uuid\UuidMapping;
+use OpenEMR\Common\Uuid\UuidRegistry;
+use OpenEMR\Services\FHIR\FhirCodeSystemUris;
+use OpenEMR\Services\Search\DateSearchField;
+use OpenEMR\Services\Search\FhirSearchWhereClauseBuilder;
+use OpenEMR\Services\Search\ISearchField;
+use OpenEMR\Services\Search\ReferenceSearchField;
+use OpenEMR\Services\Search\ReferenceSearchValue;
+use OpenEMR\Services\Search\SearchModifier;
+use OpenEMR\Services\Search\StringSearchField;
+use OpenEMR\Services\Search\TokenSearchField;
+use OpenEMR\Services\Search\TokenSearchValue;
+use OpenEMR\Validators\ProcessingResult;
+use Twig\Token;
+
+class CarePlanService extends BaseService
+{
+    const SURROGATE_KEY_SEPARATOR = "_";
+    private const PATIENT_TABLE = "patient_data";
+    private const ENCOUNTER_TABLE = "form_encounter";
+    private const CARE_PLAN_TABLE = "form_care_plan";
+
+    const TYPE_PLAN_OF_CARE = 'plan_of_care';
+    const TYPE_GOAL = 'goal';
+
+    const CARE_PLAN_TYPES = [self::TYPE_PLAN_OF_CARE, self::TYPE_GOAL];
+
+    /**
+     * @var string
+     */
+    private $carePlanType;
+
+    /**
+     * @var CodeTypesService
+     */
+    private $codeTypesService;
+
+    function getUuidFields(): array
+    {
+        return ['puuid', 'euuid'];
+    }
+
+    public function __construct($carePlanType = self::TYPE_PLAN_OF_CARE)
+    {
+        if (in_array($carePlanType, self::CARE_PLAN_TYPES) !== false) {
+            $this->carePlanType = $carePlanType;
+        } else {
+            throw new \InvalidArgumentException("Invalid care plan type of " . $carePlanType);
+        }
+
+        (new UuidRegistry(['table_name' => self::PATIENT_TABLE]))->createMissingUuids();
+        (new UuidRegistry(['table_name' => self::ENCOUNTER_TABLE]))->createMissingUuids();
+
+        parent::__construct(self::CARE_PLAN_TABLE);
+        $this->codeTypesService = new CodeTypesService();
+    }
+
+    public function getOne($uuid, $puuid = null)
+    {
+        $search = [
+            'uuid' => new TokenSearchField('uuid', [new TokenSearchValue($uuid, null, false)])
+        ];
+        if (isset($puuid)) {
+            $search['puuid'] = new ReferenceSearchField('puuid', [new ReferenceSearchValue($puuid, 'Patient', true)]);
+        }
+        return $this->search($search);
+    }
+
+    /**
+     * Returns a list of all care plan resources.  Search array can be a simple key => value array which does an exact
+     * match on passed in value.  For more complicated searching @see CarePlanService::search().
+     * @param $search a key => value array
+     * @param bool $isAndCondition Whether the search should be a UNION of search values or INTERSECTION of search values
+     * @return ProcessingResult
+     */
+    public function getAll($search, $isAndCondition = true)
+    {
+        $newSearch = [];
+        foreach ($search as $key => $value) {
+            if (!$value instanceof ISearchField) {
+                $newSearch[] = new StringSearchField($key, [$value], SearchModifier::EXACT);
+            } else {
+                $newSearch[$key] = $value;
+            }
+        }
+        return $this->search($search, $isAndCondition);
+    }
+
+    public function search($search, $isAndCondition = true)
+    {
+        if (isset($search['uuid']) && $search['uuid'] instanceof ISearchField) {
+            $this->populateSurrogateSearchFieldsForUUID($search['uuid'], $search);
+        }
+        // this value is defined in code so we don't need to db escape it.
+        $carePlanType = $this->carePlanType;
+        $planCategory = "assess-plan";
+        if ($carePlanType === self::TYPE_GOAL) {
+            $planCategory = "goal";
+        }
+        $sql = "SELECT
+                patients.puuid
+                ,patients.pid
+                ,encounters.euuid
+                ,encounters.eid
+                ,fcp.form_id
+                ,fcp.code
+                ,fcp.codetext
+                ,fcp.description
+                ,fcp.date
+                ,l.`notes` AS moodCode
+                ,category.careplan_category
+                 FROM 
+                 (
+                    select 
+                        id AS form_id
+                        ,code
+                        ,codetext
+                        ,description
+                        ,`date`
+                        ,`encounter`
+                        ,`pid`
+                        ,`care_plan_type`
+                    FROM 
+                        form_care_plan
+                    WHERE
+                        `care_plan_type` = '$carePlanType'
+                 ) fcp
+                 CROSS JOIN (
+                    select '$planCategory' AS careplan_category
+                 ) category
+                 JOIN (
+                    select 
+                        encounter AS eid
+                        ,uuid AS euuid
+                    FROM
+                        form_encounter
+                 ) encounters ON fcp.encounter = encounters.eid
+                 LEFT JOIN (
+                    select 
+                        pid
+                        ,uuid AS puuid
+                    FROM
+                        patient_data
+                 ) patients ON fcp.pid = patients.pid
+                 LEFT JOIN `list_options` l ON l.`option_id` = fcp.`care_plan_type` AND l.`list_id`='Plan_of_Care_Type'";
+        $whereClause = FhirSearchWhereClauseBuilder::build($search, $isAndCondition);
+
+        $sql .= $whereClause->getFragment();
+        $sqlBindArray = $whereClause->getBoundValues();
+        $statementResults =  QueryUtils::sqlStatementThrowException($sql, $sqlBindArray);
+
+        $processingResult = new ProcessingResult();
+        // since our query can eventually be sorted we want to keep things in the order that the query processed them.
+        // we will have a hash map that uses our surrogate key (uuid) to track the individual detailed care_plan items.
+        // since form_care_plan items are NOT unique and are replaced every time the care_plan form is saved we use the
+        // encounter and the form id as a surrogate key and treat the form_care_plan items as care_plan sub-items or details.
+        // we will loop through each record and aggregate the form_care_plan items into a details array using the
+        // recordsByKey as our hash map to track our individual records. this lets us reach a runtime of O(2n) as we will
+        // do one loop to generate our aggregated data and then another loop through our ordered records to populate the
+        // processing result.
+        $orderedRecords = [];
+        $recordsByKey = [];
+        $currentIndex = 0;
+        // runtime O(2n) as we create our indexed hash
+        while ($row = sqlFetchArray($statementResults)) {
+            // grab our key for the row
+            $resultRecord = $this->createResultRecordFromDatabaseResult($row);
+            $key = $resultRecord['uuid'];
+            if (!isset($recordsByKey[$key])) {
+                $orderedRecords[$currentIndex] = $resultRecord;
+                $recordsByKey[$key] = $currentIndex++;
+            } else {
+                // now combine our child array
+                $recordIndex = $recordsByKey[$key];
+                array_push($orderedRecords[$recordIndex]['details'], $resultRecord['details'][0]);
+            }
+        }
+        foreach ($orderedRecords as $record) {
+            $processingResult->addData($record);
+        }
+        return $processingResult;
+    }
+
+    /**
+     * Take our uuid surrogate key and populate the underlying data elements representing the form_care_plan id column
+     * and the connected encounter uuid.
+     * @param TokenSearchField $fieldUUID The uuid search field with the 1..* values to search on
+     * @param $search Hashmap of search operators
+     */
+    private function populateSurrogateSearchFieldsForUUID(TokenSearchField $fieldUUID, &$search)
+    {
+        $id = $search['form_id'] ?? new TokenSearchField('form_id', []);
+        $encounter = $search['encounter'] ?? new ReferenceSearchField('euuid', [], true);
+
+        // need to deparse our uuid into something else we can use
+        foreach ($fieldUUID->getValues() as $value) {
+            if ($value instanceof TokenSearchValue) {
+                $code = $value->getCode();
+                $key = $this->splitSurrogateKeyIntoParts($code);
+                if (empty($key['euuid']) && empty($key['form_id'])) {
+                    throw new \InvalidArgumentException("uuid '" . ($code ?? "") . "' was invalid for resource");
+                }
+                if (!empty($key['euuid'])) {
+                    $values = $encounter->getValues();
+                    array_push($values, new ReferenceSearchValue($key['euuid'], "Encounter", true));
+                    $encounter->setValues($values);
+                }
+                if (!empty($key['form_id'])) {
+                    $values = $id->getValues();
+                    array_push($values, new TokenSearchValue($key['form_id'], null, false));
+                    $id->setValues($values);
+                }
+            }
+        }
+        $search['form_id'] = $id;
+        $search['encounter'] = $encounter;
+        unset($search['uuid']);
+    }
+
+    /**
+     * Given a database record representing a form_care_plan row containing a 'form_id' and 'euuid' column generate the
+     * surrogate key.  If either column is empty it uses an empty string as the value.
+     * @param array $record An array containing a 'form_id' and 'euuid' element.
+     * @return string The surrogate key.
+     */
+    public function getSurrogateKeyForRecord(array $record)
+    {
+        $form_id = $record['form_id'] ?? '';
+        $encounter = $record['euuid'] ?? '';
+        return $encounter . self::SURROGATE_KEY_SEPARATOR . $form_id;
+    }
+
+    /**
+     * Given the surrogate key representing a Care Plan, split the key into its component parts.
+     * @param $key string the key to parse
+     * @return array The broken up key parts.
+     */
+    public function splitSurrogateKeyIntoParts($key)
+    {
+        $parts = explode(self::SURROGATE_KEY_SEPARATOR, $key);
+        $key = [
+            "euuid" => $parts[0] ?? ""
+            ,"form_id" => $parts[1] ?? ""
+        ];
+        return $key;
+    }
+
+    protected function createResultRecordFromDatabaseResult($row)
+    {
+        $record = parent::createResultRecordFromDatabaseResult($row);
+        // now let's prep our details record
+        $detailKeys = ['code', 'codetext', 'description', 'date', 'moodCode'];
+        $details = [];
+        foreach ($detailKeys as $key) {
+            $details[$key] = $record[$key];
+            unset($record[$key]);
+        }
+        $record['details'] = [$details];
+        $record['uuid'] = $this->getSurrogateKeyForRecord($record);
+        return $record;
+    }
+}

--- a/src/Services/CodeTypesService.php
+++ b/src/Services/CodeTypesService.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * CodeTypesService.php
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Services;
+
+use OpenEMR\Services\FHIR\FhirCodeSystemUris;
+
+class CodeTypesService
+{
+    private $snomedInstalled;
+
+    const CODE_TYPE_SNOMED_CT = "SNOMED-CT";
+    const CODE_TYPE_CPT4 = "CPT4";
+    const CODE_TYPE_LOINC = "LOINC";
+    const CODE_TYPE_NUCC = "NUCC";
+
+    public function __construct()
+    {
+        // currently our installed code types are
+        global $code_types;
+
+        $this->snomedInstalled = isset($code_types[self::CODE_TYPE_SNOMED_CT]);
+        $this->cpt4Installed = isset($code_types[self::CODE_TYPE_CPT4]);
+    }
+
+    /**
+     * Lookup the description for a series of codes in the database.  Eventually we would want to
+     * remove the global lookup_code_descriptions and use this so we can mock these codes and improve our unit test speed.
+     * @see code_types.inc.php
+     * @param  string $codes  Is of the form "type:code;type:code; etc.".
+     * @param  string $desc_detail Can choose either the normal description('code_text') or the brief description('code_text_short').
+     * @return string         Is of the form "description;description; etc.".
+     */
+    public function lookup_code_description($codes, $desc_detail = "code_text")
+    {
+        return lookup_code_descriptions($codes, $desc_detail);
+    }
+
+    /**
+     * Returns true if the snomed-ct codes are installed
+     * @return bool
+     */
+    public function isSnomedCodesInstalled()
+    {
+        return $this->snomedInstalled;
+    }
+
+    /**
+     * Returns whether the system has the cpt4 codes installed
+     * @return bool
+     */
+    public function isCPT4Installed()
+    {
+        return $this->cpt4Installed;
+    }
+
+    public function getSystemForCode($code, $useOid = false)
+    {
+        if (strpos($code, ":") !== false) {
+            $parts = explode(":", $code);
+            return $this->getSystemForCodeType($parts[0]);
+        }
+        return null;
+    }
+
+    public function getSystemForCodeType($codeType, $useOid = false)
+    {
+        $system = null;
+        if ($useOid) {
+            if (self::CODE_TYPE_SNOMED_CT == $codeType) {
+                $system = '2.16.840.1.113883.6.96';
+            } elseif (self::CODE_TYPE_CPT4 == $codeType) {
+                $system = '2.16.840.1.113883.6.12';
+            } elseif (self::CODE_TYPE_LOINC == $codeType) {
+                $system = '2.16.840.1.113883.6.1';
+            }
+        } else {
+            if (self::CODE_TYPE_SNOMED_CT == $codeType) {
+                $system = FhirCodeSystemUris::SNOMED_CT;
+            } elseif (self::CODE_TYPE_NUCC == $codeType) {
+                $system = FhirCodeSystemUris::NUCC_PROVIDER;
+            } else if (self::CODE_TYPE_LOINC == $codeType) {
+                $system = FhirCodeSystemUris::LOINC;
+            }
+        }
+        return $system;
+    }
+}

--- a/src/Services/DeviceService.php
+++ b/src/Services/DeviceService.php
@@ -77,7 +77,7 @@ class DeviceService extends BaseService
             $record['code'] = $this->addCoding($record['diagnosis']);
             $record['code_full'] = $record['diagnosis'];
         }
-       
+
         try {
             $dataSet = json_decode($json, JSON_THROW_ON_ERROR);
             $standardElements = $dataSet['standard_elements'] ?? [];

--- a/src/Services/DeviceService.php
+++ b/src/Services/DeviceService.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * DeviceService.php
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Services;
+
+
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Common\Uuid\UuidRegistry;
+use OpenEMR\Services\Search\FhirSearchWhereClauseBuilder;
+use OpenEMR\Validators\ProcessingResult;
+
+class DeviceService extends BaseService
+{
+    private const DEVICE_TABLE = "lists";
+    private $uuidRegistry;
+
+    public function __construct()
+    {
+        parent::__construct('lists');
+        $this->uuidRegistry = new UuidRegistry(['table_name' => self::DEVICE_TABLE]);
+        $this->uuidRegistry->createMissingUuids();
+    }
+
+    public function search($search, $isAndCondition = true)
+    {
+        $sql = "
+            select l.*
+            , patients.*
+            from
+            (
+                SELECT 
+                    `udi`,
+                    `uuid`, `date`, `title`,`udi_data`, `begdate`, `diagnosis`, `user`, `pid`
+                FROM lists WHERE `type` = 'medical_device'
+            ) l
+            JOIN (
+                SELECT `pid`,`uuid` AS `puuid`
+                from patient_data
+            ) patients ON l.pid = patients.pid";
+
+        $search = is_array($search) ? $search : [];
+
+        $whereClause = FhirSearchWhereClauseBuilder::build($search, $isAndCondition);
+
+        $sql .= $whereClause->getFragment();
+        $sqlBindArray = $whereClause->getBoundValues();
+        $statementResults =  QueryUtils::sqlStatementThrowException($sql, $sqlBindArray);
+
+        $processingResult = new ProcessingResult();
+        while ($row = QueryUtils::fetchArrayFromResultSet($statementResults))
+        {
+            $record = $this->createResultRecordFromDatabaseResult($row);
+            $processingResult->addData($record);
+        }
+        return $processingResult;
+    }
+
+    public function getUuidFields(): array
+    {
+        return ['uuid', 'puuid'];
+    }
+
+    protected function createResultRecordFromDatabaseResult($row)
+    {
+        // handle any uuids
+        $record = parent::createResultRecordFromDatabaseResult($row);
+
+        $json = $record['udi_data'] ?? '{}';
+        if (!empty($record['diagnosis']))
+        {
+            $record['code'] = $this->addCoding($record['diagnosis']);
+            $record['code_full'] = $record['diagnosis'];
+        }
+        /**
+         * {"standard_elements":{"udi":"(01)00643169007222(17)160128(21)BLC200461H","di":"00643169007222","serialNumber":"BLC200461H","lotNumber":null,"donationId":null,"expirationDate":"2016-01-28","manufacturingDate":null,"deviceName":"Cardiac resynchronization therapy implantable defibrillator","deviceDescription":"CRT-D DTBA1QQ VIVA QUAD XT US IS4/DF4","brandName":"Viva™ Quad XT CRT-D","versionModelNumber":"DTBA1QQ","companyName":"MEDTRONIC, INC.","MRISafetyStatus":"Labeling does not contain MRI Safety Information","labeledContainsNRL":false,"deviceHCTP":false,"issuingAgency":"GS1"},"raw_search":{"gudid":{"device":{"publicDeviceRecordKey":"cc0840a9-fc79-4cec-8f32-d07f0a3ea294","publicVersionStatus":"Update","deviceRecordStatus":"Published","publicVersionNumber":6,"publicVersionDate":"2021-02-05T00:00:00.000Z","devicePublishDate":"2014-09-23T00:00:00.000Z","deviceCommDistributionEndDate":null,"deviceCommDistributionStatus":"In Commercial Distribution","identifiers":{"identifier":[{"deviceId":"00643169007222","deviceIdType":"Primary","deviceIdIssuingAgency":"GS1","containsDINumber":null,"pkgQuantity":null,"pkgDiscontinueDate":null,"pkgStatus":null,"pkgType":null}]},"brandName":"Viva™ Quad XT CRT-D","versionModelNumber":"DTBA1QQ","catalogNumber":null,"dunsNumber":"006261481","companyName":"MEDTRONIC, INC.","deviceCount":1,"deviceDescription":"CRT-D DTBA1QQ VIVA QUAD XT US IS4/DF4","DMExempt":false,"premarketExempt":false,"deviceHCTP":false,"deviceKit":false,"deviceCombinationProduct":false,"singleUse":true,"lotBatch":false,"serialNumber":true,"manufacturingDate":false,"expirationDate":false,"donationIdNumber":false,"labeledContainsNRL":false,"labeledNoNRL":false,"MRISafetyStatus":"Labeling does not contain MRI Safety Information","rx":true,"otc":false,"contacts":{"customerContact":[{"phone":"+1(800)633-8766","phoneExtension":null,"email":"Corporate.UDI@medtronic.com"}]},"gmdnTerms":{"gmdn":[{"gmdnPTName":"Cardiac resynchronization therapy implantable defibrillator","gmdnPTDefinition":"An implantable, battery-powered device consisting of a hermetically-sealed pacing pulse generator and an integrated defibrillation pulse generator with leads in the right ventricle, in a coronary vein over the left ventricle, and often in the right atrium (triple chamber). In addition to conventional pacing and defibrillation functions, the device is intended to provide cardiac resynchronization therapy (CRT) through biventricular electrical stimulation to synchronize right and left ventricular contractions for more effective blood pumping to treat symptoms of heart failure (e.g., shortness of breath, easy fatigue) and serious heart-rhythm problems [CRT defibrillator (CRT-D)]."}]},"productCodes":{"fdaProductCode":[{"productCode":"NIK","productCodeName":"Defibrillator, automatic implantable cardioverter, with cardiac resynchronization (CRT-D)"},{"productCode":"KRG","productCodeName":"Programmer, pacemaker"}]},"deviceSizes":null,"environmentalConditions":{"storageHandling":[{"storageHandlingType":"Handling Environment Temperature","storageHandlingHigh":{"unit":"Degrees Celsius","value":"55"},"storageHandlingLow":{"unit":"Degrees Celsius","value":"-18"},"storageHandlingSpecialConditionText":null},{"storageHandlingType":"Handling Environment Temperature","storageHandlingHigh":{"unit":"Degrees Fahrenheit","value":"131"},"storageHandlingLow":{"unit":"Degrees Fahrenheit","value":"0"},"storageHandlingSpecialConditionText":null}]},"sterilization":{"deviceSterile":true,"sterilizationPriorToUse":false,"methodTypes":null}}},"productCodes":[{"productCode":"NIK","physicalState":"These devices will be indicated for patients needing an ICD who also have moderate to severe heart failure and are indicated for cardiac resynchronization therapy.","deviceClass":"3","thirdPartyFlag":"N","definition":"These devices will be indicated for patients needing an ICD who also have moderate to severe heart failure and are indicated for cardiac resynchronization therapy.","submissionTypeID":"2","reviewPanel":"CV","gmpExemptFlag":"N","technicalMethod":"These devices will be indicated for patients needing an ICD who also have moderate to severe heart failure and are indicated for cardiac resynchronization therapy.","reviewCode":null,"lifeSustainSupportFlag":"Y","unclassifiedReason":null,"implantFlag":"Y","targetArea":"These devices will be indicated for patients needing an ICD who also have moderate to severe heart failure and are indicated for cardiac resynchronization therapy.","regulationNumber":null,"deviceName":"Defibrillator, Automatic Implantable Cardioverter, With Cardiac Resynchronization (Crt-D)","medicalSpecialty":null},{"productCode":"KRG","physicalState":null,"deviceClass":"3","thirdPartyFlag":"N","definition":null,"submissionTypeID":"2","reviewPanel":"CV","gmpExemptFlag":"N","technicalMethod":null,"reviewCode":null,"lifeSustainSupportFlag":"N","unclassifiedReason":null,"implantFlag":"N","targetArea":null,"regulationNumber":"870.3700","deviceName":"Programmer, Pacemaker","medicalSpecialty":"CV"}],"udi":{"udi":"(01)00643169007222(17)160128(21)BLC200461H","issuingAgency":"GS1","di":"00643169007222","manufacturingDateOriginal":null,"expirationDateOriginal":"160128","expirationDateOriginalFormat":"YYMMDD","expirationDate":"2016-01-28","lotNumber":null,"serialNumber":"BLC200461H"}}}
+         */
+        try
+        {
+            $dataSet = json_decode($json, JSON_THROW_ON_ERROR);
+            $standardElements = $dataSet['standard_elements'] ?? [];
+            unset($record['udi_data']); // don't send back the JSON array
+            $record['udi_di'] = $standardElements['di'] ?? null;
+            // TODO: @adunsulag check with @brady.miller should this be companyName, or issuingAgency?
+            $record['manufacturer'] = $standardElements['issuingAgency'] ?? null;
+            $record['manufactureDate'] = $standardElements['manufacturingDate'] ?? null;
+            $record['expirationDate'] = $standardElements['expirationDate'] ?? null;
+            $record['lotNumber'] = $standardElements['lotNumber'] ?? null;
+            $record['serialNumber'] = $standardElements['serialNumber'] ?? null;
+            // @see https://www.accessdata.fda.gov/scripts/cdrh/cfdocs/cfcfr/CFRSearch.cfm?fr=1271.290 which describes
+            // the distinct identification code which states this is the donor id.
+            $record['distinctIdentifier'] = $standardElements['donationId'] ?? null;
+
+        }
+        catch (\JsonException $error)
+        {
+            (new SystemLogger())->error(self::class . "->createResultRecordFromDatabaseResult() failed to decode udi_data json ", ['message' => $error->getMessage(), 'trace' => $error->getTrace()]);
+        }
+        return $record;
+    }
+}

--- a/src/Services/DeviceService.php
+++ b/src/Services/DeviceService.php
@@ -20,12 +20,14 @@ use OpenEMR\Validators\ProcessingResult;
 class DeviceService extends BaseService
 {
     private const DEVICE_TABLE = "lists";
+    private const PATIENT_TABLE = "patient_data";
     private $uuidRegistry;
 
     public function __construct()
     {
         parent::__construct('lists');
         $this->uuidRegistry = new UuidRegistry(['table_name' => self::DEVICE_TABLE]);
+        $this->uuidRegistry = new UuidRegistry(['table_name' => self::PATIENT_TABLE]);
         $this->uuidRegistry->createMissingUuids();
     }
 
@@ -83,8 +85,7 @@ class DeviceService extends BaseService
             $standardElements = $dataSet['standard_elements'] ?? [];
             unset($record['udi_data']); // don't send back the JSON array
             $record['udi_di'] = $standardElements['di'] ?? null;
-            // TODO: @adunsulag check with @brady.miller should this be companyName, or issuingAgency?
-            $record['manufacturer'] = $standardElements['issuingAgency'] ?? null;
+            $record['manufacturer'] = $standardElements['companyName'] ?? null;
             $record['manufactureDate'] = $standardElements['manufacturingDate'] ?? null;
             $record['expirationDate'] = $standardElements['expirationDate'] ?? null;
             $record['lotNumber'] = $standardElements['lotNumber'] ?? null;

--- a/src/Services/DeviceService.php
+++ b/src/Services/DeviceService.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * DeviceService.php
  * @package openemr
@@ -9,7 +10,6 @@
  */
 
 namespace OpenEMR\Services;
-
 
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Logging\SystemLogger;
@@ -55,8 +55,7 @@ class DeviceService extends BaseService
         $statementResults =  QueryUtils::sqlStatementThrowException($sql, $sqlBindArray);
 
         $processingResult = new ProcessingResult();
-        while ($row = QueryUtils::fetchArrayFromResultSet($statementResults))
-        {
+        while ($row = QueryUtils::fetchArrayFromResultSet($statementResults)) {
             $record = $this->createResultRecordFromDatabaseResult($row);
             $processingResult->addData($record);
         }
@@ -74,16 +73,12 @@ class DeviceService extends BaseService
         $record = parent::createResultRecordFromDatabaseResult($row);
 
         $json = $record['udi_data'] ?? '{}';
-        if (!empty($record['diagnosis']))
-        {
+        if (!empty($record['diagnosis'])) {
             $record['code'] = $this->addCoding($record['diagnosis']);
             $record['code_full'] = $record['diagnosis'];
         }
-        /**
-         * {"standard_elements":{"udi":"(01)00643169007222(17)160128(21)BLC200461H","di":"00643169007222","serialNumber":"BLC200461H","lotNumber":null,"donationId":null,"expirationDate":"2016-01-28","manufacturingDate":null,"deviceName":"Cardiac resynchronization therapy implantable defibrillator","deviceDescription":"CRT-D DTBA1QQ VIVA QUAD XT US IS4/DF4","brandName":"Viva™ Quad XT CRT-D","versionModelNumber":"DTBA1QQ","companyName":"MEDTRONIC, INC.","MRISafetyStatus":"Labeling does not contain MRI Safety Information","labeledContainsNRL":false,"deviceHCTP":false,"issuingAgency":"GS1"},"raw_search":{"gudid":{"device":{"publicDeviceRecordKey":"cc0840a9-fc79-4cec-8f32-d07f0a3ea294","publicVersionStatus":"Update","deviceRecordStatus":"Published","publicVersionNumber":6,"publicVersionDate":"2021-02-05T00:00:00.000Z","devicePublishDate":"2014-09-23T00:00:00.000Z","deviceCommDistributionEndDate":null,"deviceCommDistributionStatus":"In Commercial Distribution","identifiers":{"identifier":[{"deviceId":"00643169007222","deviceIdType":"Primary","deviceIdIssuingAgency":"GS1","containsDINumber":null,"pkgQuantity":null,"pkgDiscontinueDate":null,"pkgStatus":null,"pkgType":null}]},"brandName":"Viva™ Quad XT CRT-D","versionModelNumber":"DTBA1QQ","catalogNumber":null,"dunsNumber":"006261481","companyName":"MEDTRONIC, INC.","deviceCount":1,"deviceDescription":"CRT-D DTBA1QQ VIVA QUAD XT US IS4/DF4","DMExempt":false,"premarketExempt":false,"deviceHCTP":false,"deviceKit":false,"deviceCombinationProduct":false,"singleUse":true,"lotBatch":false,"serialNumber":true,"manufacturingDate":false,"expirationDate":false,"donationIdNumber":false,"labeledContainsNRL":false,"labeledNoNRL":false,"MRISafetyStatus":"Labeling does not contain MRI Safety Information","rx":true,"otc":false,"contacts":{"customerContact":[{"phone":"+1(800)633-8766","phoneExtension":null,"email":"Corporate.UDI@medtronic.com"}]},"gmdnTerms":{"gmdn":[{"gmdnPTName":"Cardiac resynchronization therapy implantable defibrillator","gmdnPTDefinition":"An implantable, battery-powered device consisting of a hermetically-sealed pacing pulse generator and an integrated defibrillation pulse generator with leads in the right ventricle, in a coronary vein over the left ventricle, and often in the right atrium (triple chamber). In addition to conventional pacing and defibrillation functions, the device is intended to provide cardiac resynchronization therapy (CRT) through biventricular electrical stimulation to synchronize right and left ventricular contractions for more effective blood pumping to treat symptoms of heart failure (e.g., shortness of breath, easy fatigue) and serious heart-rhythm problems [CRT defibrillator (CRT-D)]."}]},"productCodes":{"fdaProductCode":[{"productCode":"NIK","productCodeName":"Defibrillator, automatic implantable cardioverter, with cardiac resynchronization (CRT-D)"},{"productCode":"KRG","productCodeName":"Programmer, pacemaker"}]},"deviceSizes":null,"environmentalConditions":{"storageHandling":[{"storageHandlingType":"Handling Environment Temperature","storageHandlingHigh":{"unit":"Degrees Celsius","value":"55"},"storageHandlingLow":{"unit":"Degrees Celsius","value":"-18"},"storageHandlingSpecialConditionText":null},{"storageHandlingType":"Handling Environment Temperature","storageHandlingHigh":{"unit":"Degrees Fahrenheit","value":"131"},"storageHandlingLow":{"unit":"Degrees Fahrenheit","value":"0"},"storageHandlingSpecialConditionText":null}]},"sterilization":{"deviceSterile":true,"sterilizationPriorToUse":false,"methodTypes":null}}},"productCodes":[{"productCode":"NIK","physicalState":"These devices will be indicated for patients needing an ICD who also have moderate to severe heart failure and are indicated for cardiac resynchronization therapy.","deviceClass":"3","thirdPartyFlag":"N","definition":"These devices will be indicated for patients needing an ICD who also have moderate to severe heart failure and are indicated for cardiac resynchronization therapy.","submissionTypeID":"2","reviewPanel":"CV","gmpExemptFlag":"N","technicalMethod":"These devices will be indicated for patients needing an ICD who also have moderate to severe heart failure and are indicated for cardiac resynchronization therapy.","reviewCode":null,"lifeSustainSupportFlag":"Y","unclassifiedReason":null,"implantFlag":"Y","targetArea":"These devices will be indicated for patients needing an ICD who also have moderate to severe heart failure and are indicated for cardiac resynchronization therapy.","regulationNumber":null,"deviceName":"Defibrillator, Automatic Implantable Cardioverter, With Cardiac Resynchronization (Crt-D)","medicalSpecialty":null},{"productCode":"KRG","physicalState":null,"deviceClass":"3","thirdPartyFlag":"N","definition":null,"submissionTypeID":"2","reviewPanel":"CV","gmpExemptFlag":"N","technicalMethod":null,"reviewCode":null,"lifeSustainSupportFlag":"N","unclassifiedReason":null,"implantFlag":"N","targetArea":null,"regulationNumber":"870.3700","deviceName":"Programmer, Pacemaker","medicalSpecialty":"CV"}],"udi":{"udi":"(01)00643169007222(17)160128(21)BLC200461H","issuingAgency":"GS1","di":"00643169007222","manufacturingDateOriginal":null,"expirationDateOriginal":"160128","expirationDateOriginalFormat":"YYMMDD","expirationDate":"2016-01-28","lotNumber":null,"serialNumber":"BLC200461H"}}}
-         */
-        try
-        {
+       
+        try {
             $dataSet = json_decode($json, JSON_THROW_ON_ERROR);
             $standardElements = $dataSet['standard_elements'] ?? [];
             unset($record['udi_data']); // don't send back the JSON array
@@ -97,10 +92,7 @@ class DeviceService extends BaseService
             // @see https://www.accessdata.fda.gov/scripts/cdrh/cfdocs/cfcfr/CFRSearch.cfm?fr=1271.290 which describes
             // the distinct identification code which states this is the donor id.
             $record['distinctIdentifier'] = $standardElements['donationId'] ?? null;
-
-        }
-        catch (\JsonException $error)
-        {
+        } catch (\JsonException $error) {
             (new SystemLogger())->error(self::class . "->createResultRecordFromDatabaseResult() failed to decode udi_data json ", ['message' => $error->getMessage(), 'trace' => $error->getTrace()]);
         }
         return $record;

--- a/src/Services/EncounterService.php
+++ b/src/Services/EncounterService.php
@@ -130,8 +130,12 @@ class EncounterService extends BaseService
             $facilityuuidBytes = $this->getUuidById($sqlResult['facility_id'], self::FACILITY_TABLE, "id");
             $sqlResult['puuid'] = UuidRegistry::uuidToString($puuidBytes);
             $sqlResult['uuid'] = UuidRegistry::uuidToString($sqlResult['uuid']);
-            $sqlResult['provider_id'] = UuidRegistry::uuidToString($provideruuidBytes);
-            $sqlResult['facility_id'] = UuidRegistry::uuidToString($facilityuuidBytes);
+            if (!empty($provideruuidBytes)) {
+                $sqlResult['provider_id'] = UuidRegistry::uuidToString($provideruuidBytes);
+            }
+            if (!empty($facilityuuidBytes)) {
+                $sqlResult['facility_id'] = UuidRegistry::uuidToString($facilityuuidBytes);
+            }
             $processingResult->addData($sqlResult);
         }
 

--- a/src/Services/FHIR/FhirCodeSystemUris.php
+++ b/src/Services/FHIR/FhirCodeSystemUris.php
@@ -22,4 +22,6 @@ class FhirCodeSystemUris
 
     const IMMUNIZATION_OBJECTION_REASON = "http://terminology.hl7.org/CodeSystem/v3-ActReason";
     const IMMUNIZATION_UNIT_AMOUNT = "http://unitsofmeasure.org";
+
+    const PROVIDER_NPI = "http://hl7.org/fhir/sid/us-npi";
 }

--- a/src/Services/FHIR/FhirCodeSystemUris.php
+++ b/src/Services/FHIR/FhirCodeSystemUris.php
@@ -24,4 +24,7 @@ class FhirCodeSystemUris
     const IMMUNIZATION_UNIT_AMOUNT = "http://unitsofmeasure.org";
 
     const PROVIDER_NPI = "http://hl7.org/fhir/sid/us-npi";
+
+    public const HL7_SYSTEM_CAREPLAN_CATEGORY = "http://hl7.org/fhir/us/core/CodeSystem/careplan-category";
+    const LOINC = "http://loinc.org/";
 }

--- a/src/Services/FHIR/FhirDeviceService.php
+++ b/src/Services/FHIR/FhirDeviceService.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * FhirDeviceService.php
  * @package openemr
@@ -9,7 +10,6 @@
  */
 
 namespace OpenEMR\Services\FHIR;
-
 
 use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRDevice;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRDateTime;
@@ -45,7 +45,7 @@ class FhirDeviceService extends FhirServiceBase implements IResourceUSCIGProfile
         return [
         'patient' => $this->getPatientContextSearchField(),
         '_id' => new FhirSearchParameterDefinition('_id', SearchFieldType::TOKEN, [new ServiceField('uuid', ServiceField::TYPE_UUID)]),
-    ];
+        ];
     }
 
     /**
@@ -66,15 +66,13 @@ class FhirDeviceService extends FhirServiceBase implements IResourceUSCIGProfile
         $device->setId($id);
 
         // only required field is the type and patient
-        if (!empty($dataRecord['puuid']))
-        {
+        if (!empty($dataRecord['puuid'])) {
             $device->setPatient(UtilsService::createRelativeReference('Patient', $dataRecord['puuid']));
         } else {
             $device->setPatient(UtilsService::createDataMissingExtension());
         }
 
-        if (!empty($dataRecord['code']))
-        {
+        if (!empty($dataRecord['code'])) {
             $codeableConcept = UtilsService::createCodeableConcept($dataRecord['code'], FhirCodeSystemUris::SNOMED_CT);
             $device->setType($codeableConcept);
         } else {
@@ -85,38 +83,32 @@ class FhirDeviceService extends FhirServiceBase implements IResourceUSCIGProfile
             $udiCarrier = new FHIRDeviceUdiCarrier();
             $udiCarrier->setDeviceIdentifier($dataRecord['udi_di']);
 
-            if (!empty($dataRecord['udi']))
-            {
+            if (!empty($dataRecord['udi'])) {
                 $udiCarrier->setCarrierHRF($dataRecord['udi']);
             }
             $device->addUdiCarrier($udiCarrier);
         }
 
-        if (!empty($dataRecord['manufactureDate']))
-        {
+        if (!empty($dataRecord['manufactureDate'])) {
             $manufactureDate = new FHIRDateTime();
             $manufactureDate->setValue($dataRecord['manufactureDate']);
             $device->setManufactureDate($manufactureDate);
         }
-        if (!empty($dataRecord['expirationDate']))
-        {
+        if (!empty($dataRecord['expirationDate'])) {
             $expirationDate = new FHIRDateTime();
             $expirationDate->setValue($dataRecord['expirationDate']);
             $device->setExpirationDate($expirationDate);
         }
 
-        if (!empty($dataRecord['lotNumber']))
-        {
+        if (!empty($dataRecord['lotNumber'])) {
             $device->setLotNumber($dataRecord['lotNumber']);
         }
 
-        if (!empty($dataRecord['serialNumber']))
-        {
+        if (!empty($dataRecord['serialNumber'])) {
             $device->setSerialNumber($dataRecord['serialNumber']);
         }
 
-        if (!empty($dataRecord['distinctIdentifier']))
-        {
+        if (!empty($dataRecord['distinctIdentifier'])) {
             $device->setDistinctIdentifier($dataRecord['distinctIdentifier']);
         }
         return $device;

--- a/src/Services/FHIR/FhirDeviceService.php
+++ b/src/Services/FHIR/FhirDeviceService.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * FhirDeviceService.php
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Services\FHIR;
+
+
+use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRDevice;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRDateTime;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRId;
+use OpenEMR\FHIR\R4\FHIRResource\FHIRDevice\FHIRDeviceUdiCarrier;
+use OpenEMR\Services\DeviceService;
+use OpenEMR\Services\Search\FhirSearchParameterDefinition;
+use OpenEMR\Services\Search\SearchFieldType;
+use OpenEMR\Services\Search\ServiceField;
+
+class FhirDeviceService extends FhirServiceBase implements IResourceUSCIGProfileService
+{
+
+    /**
+     * @var DeviceService
+     */
+    private $deviceService;
+
+
+    const USCGI_PROFILE_URI = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-device';
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->deviceService = new DeviceService();
+    }
+
+    /**
+     * Returns an array mapping FHIR Resource search parameters to OpenEMR search parameters
+     */
+    protected function loadSearchParameters()
+    {
+        return [
+        'patient' => $this->getPatientContextSearchField(),
+        '_id' => new FhirSearchParameterDefinition('_id', SearchFieldType::TOKEN, [new ServiceField('uuid', ServiceField::TYPE_UUID)]),
+    ];
+    }
+
+    /**
+     * Parses an OpenEMR data record, returning the equivalent FHIR Resource
+     *
+     * @param $dataRecord The source OpenEMR data record
+     * @param $encode Indicates if the returned resource is encoded into a string. Defaults to True.
+     * @return the FHIR Resource. Returned format is defined using $encode parameter.
+     */
+    public function parseOpenEMRRecord($dataRecord = array(), $encode = false)
+    {
+        $device = new FHIRDevice();
+
+        $device->setMeta(UtilsService::createFhirMeta('1', gmdate('c')));
+
+        $id = new FHIRId();
+        $id->setValue($dataRecord['uuid']);
+        $device->setId($id);
+
+        // only required field is the type and patient
+        if (!empty($dataRecord['puuid']))
+        {
+            $device->setPatient(UtilsService::createRelativeReference('Patient', $dataRecord['puuid']));
+        } else {
+            $device->setPatient(UtilsService::createDataMissingExtension());
+        }
+
+        if (!empty($dataRecord['code']))
+        {
+            $codeableConcept = UtilsService::createCodeableConcept($dataRecord['code'], FhirCodeSystemUris::SNOMED_CT);
+            $device->setType($codeableConcept);
+        } else {
+            $device->setType(UtilsService::createDataMissingExtension());
+        }
+
+        if (!empty($dataRecord['udi_di'])) {
+            $udiCarrier = new FHIRDeviceUdiCarrier();
+            $udiCarrier->setDeviceIdentifier($dataRecord['udi_di']);
+
+            if (!empty($dataRecord['udi']))
+            {
+                $udiCarrier->setCarrierHRF($dataRecord['udi']);
+            }
+            $device->addUdiCarrier($udiCarrier);
+        }
+
+        if (!empty($dataRecord['manufactureDate']))
+        {
+            $manufactureDate = new FHIRDateTime();
+            $manufactureDate->setValue($dataRecord['manufactureDate']);
+            $device->setManufactureDate($manufactureDate);
+        }
+        if (!empty($dataRecord['expirationDate']))
+        {
+            $expirationDate = new FHIRDateTime();
+            $expirationDate->setValue($dataRecord['expirationDate']);
+            $device->setExpirationDate($expirationDate);
+        }
+
+        if (!empty($dataRecord['lotNumber']))
+        {
+            $device->setLotNumber($dataRecord['lotNumber']);
+        }
+
+        if (!empty($dataRecord['serialNumber']))
+        {
+            $device->setSerialNumber($dataRecord['serialNumber']);
+        }
+
+        if (!empty($dataRecord['distinctIdentifier']))
+        {
+            $device->setDistinctIdentifier($dataRecord['distinctIdentifier']);
+        }
+        return $device;
+    }
+
+    /**
+     * Parses a FHIR Resource, returning the equivalent OpenEMR record.
+     *
+     * @param $dataRecord The source FHIR resource
+     * @return a mapped OpenEMR data record (array)
+     */
+    public function parseFhirResource($dataRecord = array())
+    {
+        throw new \BadMethodCallException("Method not implemented");
+    }
+
+    /**
+     * Inserts an OpenEMR record into the sytem.
+     * @return The OpenEMR processing result.
+     */
+    protected function insertOpenEMRRecord($openEmrRecord)
+    {
+        throw new \BadMethodCallException("Method not implemented");
+    }
+
+    /**
+     * Updates an existing OpenEMR record.
+     * @param $fhirResourceId The OpenEMR record's FHIR Resource ID.
+     * @param $updatedOpenEMRRecord The "updated" OpenEMR record.
+     * @return The OpenEMR Service Result
+     */
+    protected function updateOpenEMRRecord($fhirResourceId, $updatedOpenEMRRecord)
+    {
+        throw new \BadMethodCallException("Method not implemented");
+    }
+
+    /**
+     * Searches for OpenEMR records using OpenEMR search parameters
+     * @param openEMRSearchParameters OpenEMR search fields
+     * @param $puuidBind - Optional variable to only allow visibility of the patient with this puuid.
+     * @return OpenEMR records
+     */
+    protected function searchForOpenEMRRecords($openEMRSearchParameters)
+    {
+        return $this->deviceService->search($openEMRSearchParameters);
+    }
+
+    /**
+     * Creates the Provenance resource  for the equivalent FHIR Resource
+     *
+     * @param $dataRecord The source OpenEMR data record
+     * @param $encode Indicates if the returned resource is encoded into a string. Defaults to True.
+     * @return the FHIR Resource. Returned format is defined using $encode parameter.
+     */
+    public function createProvenanceResource($dataRecord, $encode = false)
+    {
+        if (!($dataRecord instanceof FHIRDevice)) {
+            throw new \BadMethodCallException("Data record should be correct instance class");
+        }
+        $fhirProvenanceService = new FhirProvenanceService();
+        $fhirProvenance = $fhirProvenanceService->createProvenanceForDomainResource($dataRecord);
+        if ($encode) {
+            return json_encode($fhirProvenance);
+        } else {
+            return $fhirProvenance;
+        }
+    }
+
+    /**
+     * Returns the Canonical URIs for the FHIR resource for each of the US Core Implementation Guide Profiles that the
+     * resource implements.  Most resources have only one profile, but several like DiagnosticReport and Observation
+     * has multiple profiles that must be conformed to.
+     * @see https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html for the list of profiles
+     * @return string[]
+     */
+    function getProfileURIs(): array
+    {
+        return [self::USCGI_PROFILE_URI];
+    }
+
+    public function getPatientContextSearchField(): FhirSearchParameterDefinition
+    {
+        return new FhirSearchParameterDefinition('patient', SearchFieldType::REFERENCE, [new ServiceField('puuid', ServiceField::TYPE_UUID)]);
+    }
+}

--- a/src/Services/FHIR/FhirPatientService.php
+++ b/src/Services/FHIR/FhirPatientService.php
@@ -221,38 +221,9 @@ class FhirPatientService extends FhirServiceBase implements IFhirExportableResou
 
     private function parseOpenEMRPatientAddress(FHIRPatient $patientResource, $dataRecord)
     {
-        $address = new FHIRAddress();
-        // TODO: we don't track start and end periods for dates so what value should go here...?
-        $addressPeriod = new FHIRPeriod();
-        $start = new \DateTime();
-        $start->sub(new \DateInterval('P1Y')); // subtract one year
-        $end = new \DateTime();
-        $addressPeriod->setStart(new FHIRDateTime($start->format(\DateTime::RFC3339_EXTENDED)));
-        // if there's an end date we provide one here, but for now we just go back one year
-//        $addressPeriod->setEnd(new FHIRDateTime($end->format(\DateTime::RFC3339_EXTENDED)));
-        $address->setPeriod($addressPeriod);
-        $hasAddress = false;
-        if (!empty($dataRecord['street'])) {
-            $address->addLine($dataRecord['street']);
-            $hasAddress = true;
-        }
-        if (!empty($dataRecord['city'])) {
-            $address->setCity($dataRecord['city']);
-            $hasAddress = true;
-        }
-        if (!empty($dataRecord['state'])) {
-            $address->setState($dataRecord['state']);
-            $hasAddress = true;
-        }
-        if (!empty($dataRecord['postal_code'])) {
-            $address->setPostalCode($dataRecord['postal_code']);
-            $hasAddress = true;
-        }
-        if (!empty($dataRecord['country_code'])) {
-            $address->setCountry($dataRecord['country_code']);
-            $hasAddress = true;
-        }
-        if ($hasAddress) {
+        $address = UtilsService::createAddressFromRecord($dataRecord);
+        if ($address !== null)
+        {
             $patientResource->addAddress($address);
         }
     }

--- a/src/Services/FHIR/FhirPatientService.php
+++ b/src/Services/FHIR/FhirPatientService.php
@@ -222,8 +222,7 @@ class FhirPatientService extends FhirServiceBase implements IFhirExportableResou
     private function parseOpenEMRPatientAddress(FHIRPatient $patientResource, $dataRecord)
     {
         $address = UtilsService::createAddressFromRecord($dataRecord);
-        if ($address !== null)
-        {
+        if ($address !== null) {
             $patientResource->addAddress($address);
         }
     }

--- a/src/Services/FHIR/FhirPersonService.php
+++ b/src/Services/FHIR/FhirPersonService.php
@@ -97,46 +97,8 @@ class FhirPersonService extends FhirServiceBase
         $id->setValue($dataRecord['uuid']);
         $person->setId($id);
 
-        $name = new FHIRHumanName();
-        $name->setUse('official');
-
-        if (isset($dataRecord['title'])) {
-            $name->addPrefix($dataRecord['title']);
-        }
-        if (isset($dataRecord['lname'])) {
-            $name->setFamily($dataRecord['lname']);
-        }
-
-        $givenName = array();
-        if (isset($dataRecord['fname'])) {
-            array_push($givenName, $dataRecord['fname']);
-        }
-
-        if (isset($dataRecord['mname'])) {
-            array_push($givenName, $dataRecord['mname']);
-        }
-
-        if (count($givenName) > 0) {
-            $name->given = $givenName;
-        }
-
-        $person->addName($name);
-
-        $address = new FHIRAddress();
-        if (!empty($dataRecord['street'])) {
-            $address->addLine($dataRecord['street']);
-        }
-        if (!empty($dataRecord['city'])) {
-            $address->setCity($dataRecord['city']);
-        }
-        if (!empty($dataRecord['state'])) {
-            $address->setState($dataRecord['state']);
-        }
-        if (!empty($dataRecord['zip'])) {
-            $address->setPostalCode($dataRecord['zip']);
-        }
-
-        $person->addAddress($address);
+        $person->addName(UtilsService::createHumanNameFromRecord($dataRecord));
+        $person->addAddress(UtilsService::createAddressFromRecord($dataRecord));
 
         if (!empty($dataRecord['phone'])) {
             $person->addTelecom(array(

--- a/src/Services/FHIR/FhirPractitionerService.php
+++ b/src/Services/FHIR/FhirPractitionerService.php
@@ -2,6 +2,8 @@
 
 namespace OpenEMR\Services\FHIR;
 
+use OpenEMR\FHIR\R4\FHIRElement\FHIRIdentifier;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRMeta;
 use OpenEMR\Services\FHIR\FhirServiceBase;
 use OpenEMR\Services\PractitionerService;
 use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRPractitioner;
@@ -71,7 +73,9 @@ class FhirPractitionerService extends FhirServiceBase
     {
         $practitionerResource = new FHIRPractitioner();
 
-        $meta = array('versionId' => '1', 'lastUpdated' => gmdate('c'));
+        $meta = new FHIRMeta();
+        $meta->setVersionId('1');
+        $meta->setLastUpdated(gmdate('c'));
         $practitionerResource->setMeta($meta);
 
         $practitionerResource->setActive($dataRecord['active'] == "1" ? true : false);
@@ -93,46 +97,11 @@ class FhirPractitionerService extends FhirServiceBase
         $id->setValue($dataRecord['uuid']);
         $practitionerResource->setId($id);
 
-        $name = new FHIRHumanName();
-        $name->setUse('official');
-
-        if (isset($dataRecord['title'])) {
-            $name->addPrefix($dataRecord['title']);
+        $practitionerResource->addName(UtilsService::createHumanNameFromRecord($dataRecord));
+        $address = UtilsService::createAddressFromRecord($dataRecord);
+        if (isset($address)) {
+            $practitionerResource->addAddress($address);
         }
-        if (isset($dataRecord['lname'])) {
-            $name->setFamily($dataRecord['lname']);
-        }
-
-        $givenName = array();
-        if (isset($dataRecord['fname'])) {
-            array_push($givenName, $dataRecord['fname']);
-        }
-
-        if (isset($dataRecord['mname'])) {
-            array_push($givenName, $dataRecord['mname']);
-        }
-
-        if (count($givenName) > 0) {
-            $name->given = $givenName;
-        }
-
-        $practitionerResource->addName($name);
-
-        $address = new FHIRAddress();
-        if (!empty($dataRecord['street'])) {
-            $address->addLine($dataRecord['street']);
-        }
-        if (!empty($dataRecord['city'])) {
-            $address->setCity($dataRecord['city']);
-        }
-        if (!empty($dataRecord['state'])) {
-            $address->setState($dataRecord['state']);
-        }
-        if (!empty($dataRecord['zip'])) {
-            $address->setPostalCode($dataRecord['zip']);
-        }
-
-        $practitionerResource->addAddress($address);
 
         if (!empty($dataRecord['phone'])) {
             $practitionerResource->addTelecom(array(
@@ -158,7 +127,7 @@ class FhirPractitionerService extends FhirServiceBase
             ));
         }
 
-        if (isset($dataRecord['email'])) {
+        if (!empty($dataRecord['email'])) {
             $practitionerResource->addTelecom(array(
                 'system' => 'email',
                 'value' => $dataRecord['email'],
@@ -166,12 +135,13 @@ class FhirPractitionerService extends FhirServiceBase
             ));
         }
 
-        if (isset($dataRecord['npi'])) {
-            $fhirIdentifier = [
-                'system' => "http://hl7.org/fhir/sid/us-npi",
-                'value' => $dataRecord['npi']
-            ];
-            $practitionerResource->addIdentifier($fhirIdentifier);
+        if (!empty($dataRecord['npi'])) {
+            $identifier = new FHIRIdentifier();
+            $identifier->setSystem(FhirCodeSystemUris::PROVIDER_NPI);
+            $identifier->setValue($dataRecord['npi']);
+            $practitionerResource->addIdentifier($identifier);
+        } else {
+            $practitionerResource->addIdentifier(UtilsService::createDataMissingExtension());
         }
 
         if ($encode) {
@@ -301,7 +271,7 @@ class FhirPractitionerService extends FhirServiceBase
      */
     public function searchForOpenEMRRecords($openEMRSearchParameters, $puuidBind = null)
     {
-        return $this->practitionerService->getAll($openEMRSearchParameters, false);
+        return $this->practitionerService->getAll($openEMRSearchParameters, true);
     }
     public function createProvenanceResource($dataRecord = array(), $encode = false)
     {

--- a/src/Services/FHIR/UtilsService.php
+++ b/src/Services/FHIR/UtilsService.php
@@ -32,7 +32,7 @@ class UtilsService
         return $reference;
     }
 
-    public static function createCodeableConcept(array $diagnosisCodes, $codeSystem) : FHIRCodeableConcept
+    public static function createCodeableConcept(array $diagnosisCodes, $codeSystem): FHIRCodeableConcept
     {
         $diagnosisCoding = new FHIRCoding();
         $diagnosisCode = new FHIRCodeableConcept();
@@ -61,7 +61,7 @@ class UtilsService
         return $outerExtension;
     }
 
-    public static function createAddressFromRecord($dataRecord) : ?FHIRAddress
+    public static function createAddressFromRecord($dataRecord): ?FHIRAddress
     {
         $address = new FHIRAddress();
         // TODO: we don't track start and end periods for dates so what value should go here...?
@@ -77,8 +77,7 @@ class UtilsService
         if (!empty($dataRecord['line1'])) {
             $address->addLine($dataRecord['line1']);
             $hasAddress = true;
-        } else if (!empty($dataRecord['street']))
-        {
+        } else if (!empty($dataRecord['street'])) {
             $address->addLine($dataRecord['street']);
             $hasAddress = true;
         }
@@ -99,14 +98,13 @@ class UtilsService
             $hasAddress = true;
         }
 
-        if ($hasAddress)
-        {
+        if ($hasAddress) {
             return $address;
         }
         return null;
     }
 
-    public static function createFhirMeta($version, $date) :FHIRMeta
+    public static function createFhirMeta($version, $date): FHIRMeta
     {
         $meta = new FHIRMeta();
         $meta->setVersionId($version);
@@ -114,7 +112,7 @@ class UtilsService
         return $meta;
     }
 
-    public static function createHumanNameFromRecord($dataRecord) : FHIRHumanName
+    public static function createHumanNameFromRecord($dataRecord): FHIRHumanName
     {
         $name = new FHIRHumanName();
         $name->setUse('official');

--- a/src/Services/FHIR/UtilsService.php
+++ b/src/Services/FHIR/UtilsService.php
@@ -11,8 +11,15 @@
 
 namespace OpenEMR\Services\FHIR;
 
+use OpenEMR\FHIR\R4\FHIRElement\FHIRAddress;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRCode;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRCoding;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRDateTime;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRExtension;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRHumanName;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRMeta;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRPeriod;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRReference;
 
 class UtilsService
@@ -23,6 +30,22 @@ class UtilsService
         $reference->setType($type);
         $reference->setReference($type . "/" . $uuid);
         return $reference;
+    }
+
+    public static function createCodeableConcept(array $diagnosisCodes, $codeSystem) : FHIRCodeableConcept
+    {
+        $diagnosisCoding = new FHIRCoding();
+        $diagnosisCode = new FHIRCodeableConcept();
+        foreach ($diagnosisCodes as $code => $display) {
+            if (!is_string($code)) {
+                $code = "$code"; // FHIR expects a string
+            }
+            $diagnosisCoding->setCode($code);
+            $diagnosisCoding->setDisplay($display);
+            $diagnosisCoding->setSystem($codeSystem);
+            $diagnosisCode->addCoding($diagnosisCoding);
+        }
+        return $diagnosisCode;
     }
 
     public static function createDataMissingExtension()
@@ -36,5 +59,80 @@ class UtilsService
         $outerExtension = new FHIRExtension();
         $outerExtension->addExtension($extension);
         return $outerExtension;
+    }
+
+    public static function createAddressFromRecord($dataRecord) : ?FHIRAddress
+    {
+        $address = new FHIRAddress();
+        // TODO: we don't track start and end periods for dates so what value should go here...?
+        $addressPeriod = new FHIRPeriod();
+        $start = new \DateTime();
+        $start->sub(new \DateInterval('P1Y')); // subtract one year
+        $end = new \DateTime();
+        $addressPeriod->setStart(new FHIRDateTime($start->format(\DateTime::RFC3339_EXTENDED)));
+        // if there's an end date we provide one here, but for now we just go back one year
+//        $addressPeriod->setEnd(new FHIRDateTime($end->format(\DateTime::RFC3339_EXTENDED)));
+        $address->setPeriod($addressPeriod);
+        $hasAddress = false;
+        if (!empty($dataRecord['line1'])) {
+            $address->addLine($dataRecord['line1']);
+            $hasAddress = true;
+        } else if (!empty($dataRecord['street']))
+        {
+            $address->addLine($dataRecord['street']);
+            $hasAddress = true;
+        }
+        if (!empty($dataRecord['city'])) {
+            $address->setCity($dataRecord['city']);
+            $hasAddress = true;
+        }
+        if (!empty($dataRecord['state'])) {
+            $address->setState($dataRecord['state']);
+            $hasAddress = true;
+        }
+        if (!empty($dataRecord['postal_code'])) {
+            $address->setPostalCode($dataRecord['postal_code']);
+            $hasAddress = true;
+        }
+        if (!empty($dataRecord['country_code'])) {
+            $address->setCountry($dataRecord['country_code']);
+            $hasAddress = true;
+        }
+
+        if ($hasAddress)
+        {
+            return $address;
+        }
+        return null;
+    }
+
+    public static function createFhirMeta($version, $date) :FHIRMeta
+    {
+        $meta = new FHIRMeta();
+        $meta->setVersionId($version);
+        $meta->setLastUpdated($date);
+        return $meta;
+    }
+
+    public static function createHumanNameFromRecord($dataRecord) : FHIRHumanName
+    {
+        $name = new FHIRHumanName();
+        $name->setUse('official');
+
+        if (!empty($dataRecord['title'])) {
+            $name->addPrefix($dataRecord['title']);
+        }
+        if (!empty($dataRecord['lname'])) {
+            $name->setFamily($dataRecord['lname']);
+        }
+
+        if (!empty($dataRecord['fname'])) {
+            $name->addGiven($dataRecord['fname']);
+        }
+
+        if (!empty($dataRecord['mname'])) {
+            $name->addGiven($dataRecord['mname']);
+        }
+        return $name;
     }
 }

--- a/src/Services/PatientService.php
+++ b/src/Services/PatientService.php
@@ -335,43 +335,7 @@ class PatientService extends BaseService
             return $processingResult;
         }
 
-        $sql = "SELECT  id,
-                        pid,
-                        uuid,
-                        pubpid,
-                        title,
-                        fname,
-                        mname,
-                        lname,
-                        ss,
-                        street,
-                        postal_code,
-                        city,
-                        state,
-                        county,
-                        country_code,
-                        drivers_license,
-                        contact_relationship,
-                        phone_contact,
-                        phone_home,
-                        phone_biz,
-                        phone_cell,
-                        email,
-                        DOB,
-                        sex,
-                        race,
-                        ethnicity,
-                        status,
-                        `language`
-                FROM patient_data
-                WHERE uuid = ?";
-
-        $puuidBinary = UuidRegistry::uuidToBytes($puuidString);
-        $sqlResult = sqlQuery($sql, [$puuidBinary]);
-
-        $sqlResult['uuid'] = UuidRegistry::uuidToString($sqlResult['uuid']);
-        $processingResult->addData($sqlResult);
-        return $processingResult;
+        return $this->search(['uuid' => new TokenSearchField('uuid', [$puuidString], true)]);
     }
 
     /**

--- a/src/Services/PractitionerService.php
+++ b/src/Services/PractitionerService.php
@@ -68,25 +68,12 @@ class PractitionerService extends BaseService
     {
         return ['uuid'];
     }
-
-    public function selectHelper($sqlUpToFromStatement, $map)
-    {
-        // TODO: adunsulag we only are putting this in here until we can get the npi:missing modifier to work properly
-        // and then we will remove this stuff.
-        if (!empty($map['where'])) {
-            $map['where'] .= " AND NPI IS NOT null";
-        } else {
-            $map['where'] = "WHERE npi IS NOT null";
-        }
-        return parent::selectHelper($sqlUpToFromStatement, $map);
-    }
-
+    
     public function search($search, $isAndCondition = true)
     {
-        // we make sure we only get NPI values
-        // TODO: adunsulag when we can get the Missing modifier working we can do that here...
-//        $search['npi'] = new TokenSearchField('npi');
-//        $search['npi']->setModifier(SearchModifier::MISSING);
+        // we only retrieve from our database when our practitioners are not null
+        $search['npi'] = new TokenSearchField('npi', [new TokenSearchValue(false)]);
+        $search['npi']->setModifier(SearchModifier::MISSING);
         return parent::search($search, $isAndCondition);
     }
 

--- a/src/Services/PractitionerService.php
+++ b/src/Services/PractitionerService.php
@@ -68,12 +68,22 @@ class PractitionerService extends BaseService
     {
         return ['uuid'];
     }
-    
+
     public function search($search, $isAndCondition = true)
     {
         // we only retrieve from our database when our practitioners are not null
-        $search['npi'] = new TokenSearchField('npi', [new TokenSearchValue(false)]);
-        $search['npi']->setModifier(SearchModifier::MISSING);
+        if (!empty($search['npi'])) {
+            if (!$search['npi'] instanceof ISearchField) {
+                throw new \BadMethodCallException("npi search must be instance of " . ISearchField::class);
+            }
+            if ($search['npi']->getModifier() === SearchModifier::MISSING) {
+                // force our value to be false as the only thing that differentiates users as practitioners is our npi number
+                $search['npi'] = new TokenSearchField('npi', [new TokenSearchValue(false)]);
+            }
+        } else {
+            $search['npi'] = new TokenSearchField('npi', [new TokenSearchValue(false)]);
+            $search['npi']->setModifier(SearchModifier::MISSING);
+        }
         return parent::search($search, $isAndCondition);
     }
 

--- a/src/Services/Search/FHIRSearchFieldFactory.php
+++ b/src/Services/Search/FHIRSearchFieldFactory.php
@@ -143,7 +143,7 @@ class FHIRSearchFieldFactory
         }
 
         if ($type == SearchFieldType::TOKEN) {
-            return new TokenSearchField($fieldName, $fhirSearchValues, $isUUID);
+            return $this->createTokenSearchField($fieldName, $fhirSearchValues, $modifier, $isUUID);
         } else if ($type == SearchFieldType::URI) {
             throw new \BadMethodCallException("URI Search Parameter not implemented yet");
         } else if ($type == SearchFieldType::DATE) {
@@ -153,11 +153,19 @@ class FHIRSearchFieldFactory
         } else if ($type == SearchFieldType::NUMBER) {
             throw new \BadMethodCallException("Number search parameter not implemented yet");
         } else if ($type == SearchFieldType::REFERENCE) {
-            return $this->createReferenceFieldType($fieldName, $fhirSearchValues, $modifiers, $isUUID);
+            return $this->createReferenceFieldType($fieldName, $fhirSearchValues, $modifier, $isUUID);
         } else {
             // default is a string token
             return new StringSearchField($fieldName, $fhirSearchValues, $modifier);
         }
+    }
+    private function createTokenSearchField($fieldName, $fhirSearchValues, $modifier, $isUUID)
+    {
+        $token = new TokenSearchField($fieldName, $fhirSearchValues, $isUUID);
+        if (!empty($modifier)) {
+            $token->setModifier($modifier);
+        }
+        return $token;
     }
 
     private function createReferenceFieldType($fieldName, $fhirSearchValues, $modifiers, $isUUID)

--- a/src/Services/Search/SearchFieldStatementResolver.php
+++ b/src/Services/Search/SearchFieldStatementResolver.php
@@ -216,7 +216,7 @@ class SearchFieldStatementResolver
             /** @var TokenSearchValue $value  */
 
             if ($modifier === SearchModifier::MISSING) {
-                if ($value === false) {
+                if ($value->getCode() === false) {
                     // often our tokens get treated as string values so we will do this here also
                     $clauses[] = $searchField->getField() . " IS NOT NULL AND " . $searchField->getField() . " != '' ";
                 } else {

--- a/src/Services/Search/TokenSearchValue.php
+++ b/src/Services/Search/TokenSearchValue.php
@@ -16,7 +16,7 @@ use OpenEMR\Common\Uuid\UuidRegistry;
 class TokenSearchValue
 {
     /**
-     * @var string|int|float
+     * @var string|int|float|boolean
      */
     private $code;
 

--- a/tests/Tests/Api/FacilityApiTest.php
+++ b/tests/Tests/Api/FacilityApiTest.php
@@ -20,6 +20,10 @@ class FacilityApiTest extends TestCase
 {
     const FACILITY_API_ENDPOINT = "/apis/default/api/facility";
     private $testClient;
+
+    /**
+     * @var FacilityFixtureManager
+     */
     private $fixtureManager;
 
     protected function setUp(): void
@@ -34,7 +38,7 @@ class FacilityApiTest extends TestCase
 
     protected function tearDown(): void
     {
-        $this->fixtureManager->removeFacilityFixtures();
+        $this->fixtureManager->removeFixtures();
         $this->testClient->cleanupRevokeAuth();
         $this->testClient->cleanupClient();
     }

--- a/tests/Tests/Fixtures/BaseFixtureManager.php
+++ b/tests/Tests/Fixtures/BaseFixtureManager.php
@@ -195,10 +195,10 @@ abstract class BaseFixtureManager
         // these values come from flat files in the unit tests, I'm torn on whether we should escape these or not
         // TODO: @adunsulag check with @brady.miller on whether we should escape these or not
         $table_name = escape_table_name($reference['table']);
-        $column = $reference['columnSearch'];
-        $referenceColumn = $reference['columnReference'];
+        $column = escape_sql_column_name($reference['columnSearch'], [$reference['table_name']]);
+        $referenceColumn = escape_sql_column_name($reference['columnReference'], [$reference['table_name']]);
         $searchValue = $reference['columnSearchValue'];
-        $sql = "( SELECT `$referenceColumn` FROM $table_name WHERE `$column` = ? )";
+        $sql = "( SELECT $referenceColumn FROM $table_name WHERE $column = ? )";
         return new SearchQueryFragment($sql, [$reference['columnSearchValue']]);
     }
 

--- a/tests/Tests/Fixtures/BaseFixtureManager.php
+++ b/tests/Tests/Fixtures/BaseFixtureManager.php
@@ -200,9 +200,7 @@ abstract class BaseFixtureManager
             $referenceColumn = escape_sql_column_name($reference['columnReference'], [$reference['table']], false, true);
             $searchValue = $reference['columnSearchValue'];
             $sql = "( SELECT $referenceColumn FROM $table_name WHERE $column = ? )";
-        }
-        catch (SqlQueryException $exception)
-        {
+        } catch (SqlQueryException $exception) {
             (new SystemLogger())->error("Failed to escape column for foreign key reference ", ['reference' => $reference]);
             throw $exception;
         }

--- a/tests/Tests/Fixtures/BaseFixtureManager.php
+++ b/tests/Tests/Fixtures/BaseFixtureManager.php
@@ -2,7 +2,9 @@
 
 namespace OpenEMR\Tests\Fixtures;
 
+use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Uuid\UuidRegistry;
+use OpenEMR\Services\Search\SearchQueryFragment;
 use Ramsey\Uuid\Uuid;
 
 /**
@@ -14,10 +16,30 @@ use Ramsey\Uuid\Uuid;
  * @copyright Copyright (c) 2020 Yash Bothra <yashrajbothra786gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
-class BaseFixtureManager
+abstract class BaseFixtureManager
 {
     // use a prefix so we can easily remove fixtures
     const FIXTURE_PREFIX = "test-fixture";
+
+    private $fileName;
+    private $tableName;
+    private $hasInstalledFixtured;
+    private $fixtures;
+
+    public function __construct($fileName = "", $tableName = "")
+    {
+        $this->fileName = $fileName;
+        $this->tableName = $tableName;
+        $this->hasInstalledFixtured = false;
+    }
+
+    protected function getFixturesFromFile()
+    {
+        if (empty($this->fixtures)) {
+            $this->fixtures = $this->loadJsonFile($this->fileName);
+        }
+        return $this->fixtures;
+    }
 
     /**
      * Loads a JSON fixture from a file within the Fixture namespace, returning the data as an array of records.
@@ -62,5 +84,133 @@ class BaseFixtureManager
     public function getUnregisteredUuid()
     {
         return UuidRegistry::uuidToString((new UuidRegistry(['disable_tracker' => true]))->createUuid());
+    }
+
+    /**
+     * Installs fixtures into the OpenEMR DB.
+     *
+     * @param $tableName The target OpenEMR DB table name.
+     * @param $fixtures Array of fixture objects to install.
+     * @return the number of fixtures installed.
+     */
+    protected function installFixturesForTable($tableName, $fixtures)
+    {
+        $insertCount = 0;
+        $sqlInsert = "INSERT INTO " . escape_table_name($tableName) . " SET ";
+
+        foreach ($fixtures as $index => $fixture) {
+            $sqlColumnValues = "";
+            $sqlBinds = array();
+
+            foreach ($fixture as $field => $fieldValue) {
+                if (is_array($fieldValue) && $this->isForeignReference($fieldValue)) {
+                    $fragment = $this->getQueryForForeignReference($fieldValue);
+                    $sqlColumnValues .= $field . " = " . $fragment->getFragment() . ", ";
+                    $sqlBinds = array_merge($sqlBinds, $fragment->getBoundValues());
+                } else if ($this->isFunctionCall($fieldValue)) {
+                    $sqlColumnValues .= $field . " = ?, ";
+                    $fieldValue = $this->getValueFromFunction($fieldValue);
+                    array_push($sqlBinds, $fieldValue);
+                } else {
+                    $sqlColumnValues .= $field . " = ?, ";
+                    array_push($sqlBinds, $fieldValue);
+                }
+            }
+            $sqlColumnValues = rtrim($sqlColumnValues, " ,");
+            $isInserted = QueryUtils::sqlInsert($sqlInsert . $sqlColumnValues, $sqlBinds);
+            if ($isInserted) {
+                $insertCount += 1;
+            }
+        }
+        return $insertCount;
+    }
+
+    public function installFixtures()
+    {
+        $fixtures = $this->getFixturesFromFile();
+        $insertCount = $this->installFixturesForTable($this->tableName, $fixtures);
+        $this->hasInstalledFixtured = true;
+        return $insertCount;
+    }
+
+    // we don't have a good way to solve this so we will force all sub classes to implement.
+    public function removeFixtures()
+    {
+        // we have no generic way of signifying what the primary key of the table is so we force sub classes
+        // to implement the remove fixture method
+        $this->removeInstalledFixtures();
+        $this->hasInstalledFixtured = false;
+    }
+
+    public function hasInstalledFixtures()
+    {
+        return $this->hasInstalledFixtured;
+    }
+
+    /**
+     * @return a random fixture.
+     */
+    public function getSingleFixture()
+    {
+        $fixtures = $this->getFixturesFromFile();
+        return $this->getSingleEntry($fixtures);
+    }
+
+    abstract protected function removeInstalledFixtures();
+
+    private function getValueFromFunction($value)
+    {
+        $functionName = strtok($value, "()");
+
+        // white list our functions here
+        if ($functionName === "uuid") {
+            $table = strtok("(,)");
+            if ($table !== false) {
+                // trim spaces, and quotes
+                $table = trim($table, "'\" \t\n\r\0\x0B");
+                return $this->getUuid($table);
+            } else {
+                throw new \BadMethodCallException("uuid(table_name) function is missing table name");
+            }
+        } else if ($functionName === "generateId") {
+            return QueryUtils::generateId();
+        } else {
+            throw new \BadMethodCallException("Function could not be interpreted from fixture: " . $value);
+        }
+        return ""; // return empty string
+    }
+
+    private function isFunctionCall($value)
+    {
+        return preg_match("/[a-zA-Z]+\(['a-zA-Z_0-9\-]*\)/", $value) === 1;
+    }
+
+    private function isForeignReference(array $reference)
+    {
+        return isset($reference['table']) && isset($reference['columnSearch']) && isset($reference['columnSearchValue']) && isset($reference['columnReference']);
+    }
+
+    private function getQueryForForeignReference(array $reference): SearchQueryFragment
+    {
+        // these values come from flat files in the unit tests, I'm torn on whether we should escape these or not
+        // TODO: @adunsulag check with @brady.miller on whether we should escape these or not
+        $table_name = escape_table_name($reference['table']);
+        $column = $reference['columnSearch'];
+        $referenceColumn = $reference['columnReference'];
+        $searchValue = $reference['columnSearchValue'];
+        $sql = "( SELECT `$referenceColumn` FROM $table_name WHERE `$column` = ? )";
+        return new SearchQueryFragment($sql, [$reference['columnSearchValue']]);
+    }
+
+    /**
+     * @return random single entry from an array.
+     */
+    protected function getSingleEntry($array)
+    {
+        if (empty($array)) {
+            throw new \InvalidArgumentException("cannot get single entry from empty array");
+        }
+        $randomIndex = array_rand($array, 1);
+        return $array[$randomIndex];
     }
 }

--- a/tests/Tests/Fixtures/CarePlanFixtureManager.php
+++ b/tests/Tests/Fixtures/CarePlanFixtureManager.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * CarePlanFixtureManager.php
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Fixtures;
+
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Database\SqlQueryException;
+use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Common\Uuid\UuidRegistry;
+use Ramsey\Uuid\Uuid;
+
+class CarePlanFixtureManager extends BaseFixtureManager
+{
+    // use a prefix so we can easily remove fixtures
+    const FIXTURE_PREFIX = "test-fixture";
+
+    private $encounterFixtureManager;
+
+    public function __construct()
+    {
+        $patientFixtureManager = new FixtureManager();
+        $this->encounterFixtureManager = new EncounterFixtureManager(null, $patientFixtureManager);
+        parent::__construct("care-plan.json", "form_care_plan");
+    }
+
+    public function installFixtures()
+    {
+        // if we fail, attempt to remove everything
+        try {
+            $this->encounterFixtureManager->installFixtures();
+            parent::installFixtures();
+        } catch (SqlQueryException $exception) {
+            $this->removeInstalledFixtures();
+            throw $exception;
+        }
+    }
+
+    protected function removeInstalledFixtures()
+    {
+        $sql = "DELETE FROM form_care_plan WHERE description LIKE '" . self::FIXTURE_PREFIX . "%'";
+        try {
+            QueryUtils::sqlStatementThrowException($sql, []);
+        } catch (SqlQueryException $exception) {
+            (new SystemLogger())->error("Failed to delete form_care_plan data ", ['message' => $exception, 'trace' => $exception->getTraceAsString()]);
+            throw $exception;
+        } finally {
+            $this->encounterFixtureManager->removeFixtures();
+        }
+    }
+}

--- a/tests/Tests/Fixtures/EncounterFixtureManager.php
+++ b/tests/Tests/Fixtures/EncounterFixtureManager.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * EncounterFixtureManager.php
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Fixtures;
+
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Database\SqlQueryException;
+use OpenEMR\Common\Logging\SystemLogger;
+
+class EncounterFixtureManager extends BaseFixtureManager
+{
+    private $facilityFixture;
+    private $patientFixtureManager;
+
+    public function __construct(FacilityFixtureManager $facilityFixtureManager = null, FixtureManager $patientFixtureManager = null)
+    {
+        parent::__construct("encounters.json", "form_encounter");
+        if (isset($facilityFixtureManager)) {
+            $this->facilityFixture = $facilityFixtureManager;
+        } else {
+            $this->facilityFixture = new FacilityFixtureManager();
+        }
+        if (isset($patientFixtureManager)) {
+            $this->patientFixtureManager = $patientFixtureManager;
+        } else {
+            $this->patientFixtureManager = new FixtureManager();
+        }
+    }
+
+    public function installFixtures()
+    {
+        $this->patientFixtureManager->installPatientFixtures();
+        $this->facilityFixture->installFacilityFixtures();
+        return parent::installFixtures();
+    }
+
+    protected function removeInstalledFixtures()
+    {
+        $sql = "DELETE FROM form_encounter WHERE reason LIKE 'test-fixture-%'";
+        try {
+            QueryUtils::sqlStatementThrowException($sql, []);
+        } catch (SqlQueryException $exception) {
+            (new SystemLogger())->error("Failed to delete form_encounter data ", ['message' => $exception, 'trace' => $exception->getTraceAsString()]);
+            throw $exception;
+        } finally {
+            $this->patientFixtureManager->removePatientFixtures();
+            $this->facilityFixture->removeFixtures();
+        }
+    }
+}

--- a/tests/Tests/Fixtures/FacilityFixtureManager.php
+++ b/tests/Tests/Fixtures/FacilityFixtureManager.php
@@ -22,48 +22,12 @@ use Ramsey\Uuid\Uuid;
  */
 class FacilityFixtureManager extends BaseFixtureManager
 {
-    private $facilityFixtures;
     private $fhirFacilityFixtures;
 
     public function __construct()
     {
-        $this->facilityFixtures = $this->loadJsonFile("facility.json");
+        parent::__construct("facility.json", "facility");
         $this->fhirFacilityFixtures = $this->loadJsonFile("FHIR/facility.json");
-    }
-
-    /**
-     * Installs fixtures into the OpenEMR DB.
-     *
-     * @param $tableName The target OpenEMR DB table name.
-     * @param $fixtures Array of fixture objects to install.
-     * @return the number of fixtures installed.
-     */
-    private function installFixtures($tableName, $fixtures)
-    {
-        $insertCount = 0;
-        $sqlInsert = "INSERT INTO " . escape_table_name($tableName) . " SET ";
-
-        foreach ($fixtures as $index => $fixture) {
-            $sqlColumnValues = "";
-            $sqlBinds = array();
-
-            foreach ($fixture as $field => $fieldValue) {
-                $sqlColumnValues .= $field . " = ?, ";
-                array_push($sqlBinds, $fieldValue);
-            }
-
-            // add uuid
-            $sqlColumnValues .= '`uuid` = ?';
-            $uuidFacility = $this->getUuid("facility");
-            array_push($sqlBinds, $uuidFacility);
-
-            $sqlColumnValues = rtrim($sqlColumnValues, " ,");
-            $isInserted = sqlInsert($sqlInsert . $sqlColumnValues, $sqlBinds);
-            if ($isInserted) {
-                $insertCount += 1;
-            }
-        }
-        return $insertCount;
     }
 
     /**
@@ -87,24 +51,16 @@ class FacilityFixtureManager extends BaseFixtureManager
      */
     public function getFacilityFixtures()
     {
-        return $this->facilityFixtures;
+        return $this->getFixturesFromFile();
     }
 
-    /**
-     * @return random single entry from an array.
-     */
-    private function getSingleEntry($array)
-    {
-        $randomIndex = array_rand($array, 1);
-        return $array[$randomIndex];
-    }
 
     /**
      * @return a random facility fixture.
      */
     public function getSingleFacilityFixture()
     {
-        return $this->getSingleEntry($this->facilityFixtures);
+        return $this->getSingleEntry($this->getFixturesFromFile());
     }
 
     /**
@@ -128,7 +84,7 @@ class FacilityFixtureManager extends BaseFixtureManager
     /**
      * Removes Facility Fixtures from the OpenEMR DB.
      */
-    public function removeFacilityFixtures()
+    public function removeInstalledFixtures()
     {
         $bindVariable = self::FIXTURE_PREFIX . "%";
 

--- a/tests/Tests/Fixtures/care-plan.json
+++ b/tests/Tests/Fixtures/care-plan.json
@@ -18,6 +18,7 @@
 			"columnSearchValue": "1",
 			"columnReference": "username"
 		},
+		"id": "generateId()",
 		"groupname": "Default",
 		"authorized": 1,
 		"activity": 1,

--- a/tests/Tests/Fixtures/care-plan.json
+++ b/tests/Tests/Fixtures/care-plan.json
@@ -1,0 +1,29 @@
+[
+	{
+		"pid" : {
+			"table": "patient_data",
+			"columnSearch": "pubpid",
+			"columnSearchValue": "test-fixture-789456",
+			"columnReference": "pid"
+		},
+		"encounter": {
+			"table": "form_encounter",
+			"columnSearch": "reason",
+			"columnSearchValue": "test-fixture-Complains of nausea, loose stools and weakness.",
+			"columnReference": "encounter"
+		},
+		"user": {
+			"table": "users",
+			"columnSearch": "id",
+			"columnSearchValue": "1",
+			"columnReference": "username"
+		},
+		"groupname": "Default",
+		"authorized": 1,
+		"activity": 1,
+		"code": "SNOMED-CT:168731009",
+		"codetext": "Standard chest x-ray",
+		"description": "test-fixture-xray",
+		"care_plan_type": "plan_of_care"
+	}
+]

--- a/tests/Tests/Fixtures/encounters.json
+++ b/tests/Tests/Fixtures/encounters.json
@@ -23,7 +23,7 @@
 			"table": "openemr_postcalendar_categories",
 			"columnSearch": "pc_constant_id",
 			"columnSearchValue": "office_visit",
-			"columnReference": "id"
+			"columnReference": "pc_catid"
 		},
 		"uuid": "uuid('form_encounter')",
 		"encounter": "generateId()",

--- a/tests/Tests/Fixtures/encounters.json
+++ b/tests/Tests/Fixtures/encounters.json
@@ -1,0 +1,42 @@
+[
+	{
+		"pid" : {
+			"table": "patient_data",
+			"columnSearch": "pubpid",
+			"columnSearchValue": "test-fixture-789456",
+			"columnReference": "pid"
+		},
+		"facility_id": {
+			"table": "facility",
+			"columnSearch": "name",
+			"columnSearchValue": "test-fixture-Your Clinic Name Here",
+			"columnReference": "id"
+		},
+		"facility":"test-fixture-Your Clinic Name Here",
+		"billing_facility": {
+			"table": "facility",
+			"columnSearch": "name",
+			"columnSearchValue": "test-fixture-Your Clinic Name Here",
+			"columnReference": "id"
+		},
+		"pc_catid": {
+			"table": "openemr_postcalendar_categories",
+			"columnSearch": "pc_constant_id",
+			"columnSearchValue": "office_visit",
+			"columnReference": "id"
+		},
+		"uuid": "uuid('form_encounter')",
+		"encounter": "generateId()",
+		"sensitivity": "normal",
+		"reason": "test-fixture-Complains of nausea, loose stools and weakness.",
+		"last_level_billed":  0,
+		"last_level_closed": 0,
+		"stmt_count": 0,
+		"invoice_refno": "",
+		"referral_source": "",
+		"billing_facility": "",
+		"class_code": "AMB",
+		"shift": "",
+		"voucher_number": ""
+	}
+]

--- a/tests/Tests/Fixtures/facility.json
+++ b/tests/Tests/Fixtures/facility.json
@@ -31,7 +31,8 @@
     "mail_zip": "",
     "oid": "",
     "iban": "",
-    "info": ""
+    "info": "",
+    "uuid": "uuid('facility')"
 }, {
     "name": "test-fixture-Saint Luke's Hospital of Kansas City",
     "phone": "(816)932-2000",
@@ -65,7 +66,8 @@
     "mail_zip": "",
     "oid": "",
     "iban": "",
-    "info": ""
+    "info": "",
+    "uuid": "uuid('facility')"
 }, {
     "name": "test-fixture-Health Level Seven International",
     "phone": "(+1) 734-677-7777",
@@ -99,5 +101,6 @@
     "mail_zip": "",
     "oid": "",
     "iban": "",
-    "info": ""
+    "info": "",
+    "uuid": "uuid('facility')"
 }]

--- a/tests/Tests/RestControllers/FHIR/FhirOrganizationRestControllerTest.php
+++ b/tests/Tests/RestControllers/FHIR/FhirOrganizationRestControllerTest.php
@@ -23,7 +23,11 @@ class FhirOrganizationRestControllerTest extends TestCase
      */
     private $fhirOrganizationController;
 
+    /*
+     * FacilityFixtureManager
+     */
     private $fixtureManager;
+
     private $fhirFixture;
 
     protected function setUp(): void
@@ -38,7 +42,7 @@ class FhirOrganizationRestControllerTest extends TestCase
 
     protected function tearDown(): void
     {
-        $this->fixtureManager->removeFacilityFixtures();
+        $this->fixtureManager->removeFixtures();
     }
 
     /**

--- a/tests/Tests/RestControllers/FacilityRestControllerTest.php
+++ b/tests/Tests/RestControllers/FacilityRestControllerTest.php
@@ -21,6 +21,10 @@ class FacilityRestControllerTest extends TestCase
 
     private $facilityData;
     private $facilityController;
+
+    /**
+     * @var FacilityFixtureManager
+     */
     private $fixtureManager;
 
     protected function setUp(): void
@@ -67,7 +71,7 @@ class FacilityRestControllerTest extends TestCase
 
     protected function tearDown(): void
     {
-        $this->fixtureManager->removeFacilityFixtures();
+        $this->fixtureManager->removeFixtures();
     }
 
     /**

--- a/tests/Tests/Services/CarePlanServiceTest.php
+++ b/tests/Tests/Services/CarePlanServiceTest.php
@@ -35,6 +35,9 @@ class CarePlanServiceTest extends TestCase
      */
     private $service;
 
+    /**
+     * @var CarePlanFixtureManager
+     */
     private $fixtureManager;
 
     protected function setUp(): void

--- a/tests/Tests/Services/CarePlanServiceTest.php
+++ b/tests/Tests/Services/CarePlanServiceTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * CarePlanServiceTest.php
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Services;
+
+use OpenEMR\Services\CarePlanService;
+use OpenEMR\Tests\Fixtures\CarePlanFixtureManager;
+use PHPUnit\Framework\TestCase;
+use OpenEMR\Common\Uuid\UuidRegistry;
+use OpenEMR\Services\PractitionerService;
+use OpenEMR\Tests\Fixtures\PractitionerFixtureManager;
+
+/**
+ * Practitioner Service Tests
+ * @coversDefaultClass OpenEMR\Services\PractitionerService
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Yash Bothra <yashrajbothra786gmail.com>
+ * @copyright Copyright (c) 2020 Yash Bothra <yashrajbothra786gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+class CarePlanServiceTest extends TestCase
+{
+    /**
+     * @var CarePlanService
+     */
+    private $service;
+
+    private $fixtureManager;
+
+    protected function setUp(): void
+    {
+        $this->service = new CarePlanService();
+        $this->fixtureManager = new CarePlanFixtureManager();
+        $this->fixture = (array) $this->fixtureManager->getSingleFixture();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->fixtureManager->removeFixtures();
+    }
+
+    /**
+     * @cover ::getOne
+     */
+    public function testGetOne()
+    {
+        $this->fixtureManager->installFixtures();
+
+        // attempt to verify the uuid surrogate key is working correctly
+        $expectedResult = sqlQuery("SELECT `fcp`.`id` AS `form_id`,`fe`.`uuid` AS `euuid`, `fcp`.`encounter` FROM `form_care_plan` fcp "
+        . " JOIN `form_encounter` fe ON `fcp`.`encounter` = `fe`.`encounter` LIMIT 1");
+        $expectedResult['euuid'] = UuidRegistry::uuidToString($expectedResult['euuid']);
+        $uuid = $this->service->getSurrogateKeyForRecord($expectedResult);
+
+        // getOne
+        $actualResult = $this->service->getOne($uuid);
+        $resultData = $actualResult->getData()[0];
+        $this->assertNotNull($resultData);
+        foreach (['euuid','form_id'] as $check) {
+            $this->assertEquals($expectedResult[$check], $resultData[$check]);
+        }
+    }
+}

--- a/tests/Tests/Services/EncounterServiceTest.php
+++ b/tests/Tests/Services/EncounterServiceTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * EncounterServiceTest.php
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+/**
+ * CarePlanServiceTest.php
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Services;
+
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Database\SqlQueryException;
+use OpenEMR\Services\EncounterService;
+use OpenEMR\Tests\Fixtures\EncounterFixtureManager;
+use PHPUnit\Framework\TestCase;
+use OpenEMR\Common\Uuid\UuidRegistry;
+
+class EncounterServiceTest extends TestCase
+{
+    /**
+     * @var EncounterService
+     */
+    private $service;
+
+    /**
+     * @var EncounterFixtureManager
+     */
+    private $fixtureManager;
+
+    protected function setUp(): void
+    {
+        $this->service = new EncounterService();
+        $this->fixtureManager = new EncounterFixtureManager();
+        $this->fixture = (array) $this->fixtureManager->getSingleFixture();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->fixtureManager->removeFixtures();
+    }
+
+    /**
+     * @cover ::getOne
+     */
+    public function testGetOne()
+    {
+        $this->fixtureManager->installFixtures();
+
+        // attempt to verify the uuid surrogate key is working correctly
+        $uuid = QueryUtils::fetchSingleValue("SELECT `uuid`,`encounter` FROM `form_encounter`", "uuid");
+        $uuidString = UuidRegistry::uuidToString($uuid);
+        // getOne
+        $actualResult = $this->service->getEncounter($uuidString);
+        $resultData = $actualResult->getData()[0];
+        $this->assertNotNull($resultData);
+    }
+}

--- a/tests/Tests/Services/EncounterServiceTest.php
+++ b/tests/Tests/Services/EncounterServiceTest.php
@@ -9,15 +9,6 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-/**
- * CarePlanServiceTest.php
- * @package openemr
- * @link      http://www.open-emr.org
- * @author    Stephen Nielson <stephen@nielson.org>
- * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
- * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
- */
-
 namespace OpenEMR\Tests\Services;
 
 use OpenEMR\Common\Database\QueryUtils;

--- a/tests/Tests/Services/FHIR/FhirOrganizationServiceCrudTest.php
+++ b/tests/Tests/Services/FHIR/FhirOrganizationServiceCrudTest.php
@@ -2,6 +2,7 @@
 
 namespace OpenEMR\Tests\Services\FHIR;
 
+use OpenEMR\Tests\Fixtures\FixtureManager;
 use PHPUnit\Framework\TestCase;
 use OpenEMR\Tests\Fixtures\FacilityFixtureManager;
 use OpenEMR\Services\FHIR\FhirOrganizationService;
@@ -18,6 +19,9 @@ use OpenEMR\Services\FHIR\FhirOrganizationService;
  */
 class FhirOrganizationServiceCrudTest extends TestCase
 {
+    /**
+     * @var FacilityFixtureManager
+     */
     private $fixtureManager;
     private $fhirOrganizationFixture;
     private $fhirOrganizationService;
@@ -31,7 +35,7 @@ class FhirOrganizationServiceCrudTest extends TestCase
 
     protected function tearDown(): void
     {
-        $this->fixtureManager->removeFacilityFixtures();
+        $this->fixtureManager->removeFixtures();
     }
 
     /**

--- a/tests/Tests/Services/FacilityServiceTest.php
+++ b/tests/Tests/Services/FacilityServiceTest.php
@@ -31,7 +31,7 @@ class FacilityServiceTest extends TestCase
 
     protected function tearDown(): void
     {
-        $this->fixtureManager->removeFacilityFixtures();
+        $this->fixtureManager->removeFixtures();
     }
 
     /**

--- a/tests/Tests/Services/PatientServiceTest.php
+++ b/tests/Tests/Services/PatientServiceTest.php
@@ -19,6 +19,9 @@ use OpenEMR\Tests\Fixtures\FixtureManager;
  */
 class PatientServiceTest extends TestCase
 {
+    /**
+     * @var PatientService
+     */
     private $patientService;
     private $fixtureManager;
 


### PR DESCRIPTION
This PR implements and passes ONC Inferno requirements for Device, Careplan and Goal (See #4205). I also improved Test Fixtures by allowing us to grab foreign key data and generate uuids and database ids as part of the json definition.

Created a CarePlan service that handles the care plan form where goals and care plans are stored.  Since care plans do not have a unique id we had to implement a surrogate key using the encounter and the form_id of the care plan form.

Implemented the CodeTypesService that wraps around some of the global lookup code functions and provides additional helper method functions for grabbing the OID or system URI for a specific code.

Fixed some style issues in various classes.

Updated PatientService's getOne function to remove duplicate code.

Added some protection on npi number in the PractitionerService class to deal with the 'missing' modifier.

Heavily modified the test fixtures to be able to pull in referenced column data points for the fixture.  Wrote a small DSL to allow whitelisted function calls inside the JSON to do things like generate ids, and uuids.  Wrote a fixture manager for Encounters and care plan.  