### PR TITLE
move label to avoid calling multi_patient_finder; prettify dated_remi…

### DIFF
--- a/interface/main/dated_reminders/dated_reminders.php
+++ b/interface/main/dated_reminders/dated_reminders.php
@@ -4,7 +4,7 @@
  * Used for displaying dated reminders.
  *
  * @package   OpenEMR
- * @link      http://www.open-emr.org
+ * @link      https://www.open-emr.org
  * @author    Craig Bezuidenhout <http://www.tajemo.co.za/>
  * @author    Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2012 tajemo.co.za <http://www.tajemo.co.za/>
@@ -18,22 +18,22 @@ require_once("$srcdir/dated_reminder_functions.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 
-        $days_to_show = 30;
-        $alerts_to_show = $GLOBALS['dated_reminders_max_alerts_to_show'];
-        $updateDelay = 60; // time is seconds
+$days_to_show = 30;
+$alerts_to_show = $GLOBALS['dated_reminders_max_alerts_to_show'];
+$updateDelay = 60; // time is seconds
 
 
 // ----- get time stamp for start of today, this is used to check for due and overdue reminders
-        $today = strtotime(date('Y/m/d'));
+$today = strtotime(date('Y/m/d'));
 
- // ----- set $hasAlerts to false, this is used for auto-hiding reminders if there are no due or overdue reminders
-        $hasAlerts = false;
+// ----- set $hasAlerts to false, this is used for auto-hiding reminders if there are no due or overdue reminders
+$hasAlerts = false;
 
 // mulitply $updateDelay by 1000 to get miliseconds
-        $updateDelay = $updateDelay * 1000;
+$updateDelay = $updateDelay * 1000;
 
 //-----------------------------------------------------------------------------
-// HANDEL AJAX TO MARK REMINDERS AS READ
+// HANDLE AJAX TO MARK REMINDERS AS READ
 // Javascript will send a post
 // ----------------------------------------------------------------------------
 if (isset($_POST['drR'])) {
@@ -52,125 +52,129 @@ if (isset($_POST['drR'])) {
 }
 
 //-----------------------------------------------------------------------------
-// END HANDEL AJAX TO MARK REMINDERS AS READ
+// END HANDLE AJAX TO MARK REMINDERS AS READ
 // ----------------------------------------------------------------------------
 
-      $reminders = RemindersArray($days_to_show, $today, $alerts_to_show);
+$reminders = RemindersArray($days_to_show, $today, $alerts_to_show);
 
 ?>
 
-      <style>
-         div.dr {
-           margin: 0;
-           font-size: 0.6rem;
-         }
-         .dr_container a {
-           font-size: 0.8rem;
-         }
-         .dr_container {
-           padding:5px 5px 8px 5px;
-         }
-         .dr_container p {
-           margin: 6px 0 0 0;
-         }
-         .patLink {
-           font-weight: bolder;
-           cursor: pointer;
-           text-decoration: none;
-         }
-         .patLink:hover{
-           font-weight: bolder;
-           cursor: pointer;
-           text-decoration: underline;
-         }
-      </style>
-      <script>
-         $(function () {
-            $(".hideDR").click(function(){
-              if($(this).html() == "<span><?php echo xla('Hide Reminders') ?></span>"){
-                $(this).html("<span><?php echo xla('Show Reminders') ?></span>");
-                $(".drHide").slideUp("slow");
-              }
-              else{
-                $(this).html("<span><?php echo xla('Hide Reminders') ?></span>");
-                $(".drHide").slideDown("slow");
-              }
-            });
-           // run updater after 30 seconds
-           var updater = setTimeout("updateme(0)", 1);
-         });
+<style>
+  div.dr {
+    margin: 0;
+    font-size: 0.6rem;
+  }
+  .dr_container a {
+    font-size: 0.8rem;
+  }
+  .dr_container {
+    padding:5px 5px 8px 5px;
+  }
+  .dr_container p {
+    margin: 6px 0 0 0;
+  }
+  .patLink {
+    font-weight: bolder;
+    cursor: pointer;
+    text-decoration: none;
+  }
+  .patLink:hover{
+    font-weight: bolder;
+    cursor: pointer;
+    text-decoration: underline;
+  }
+</style>
 
-           function openAddScreen(id){
-             if(id == 0){
-               top.restoreSession();
-               dlgopen('<?php echo $GLOBALS['webroot']; ?>/interface/main/dated_reminders/dated_reminders_add.php', '_drAdd', 700, 500);
-             }else{
-               top.restoreSession();
-               dlgopen('<?php echo $GLOBALS['webroot']; ?>/interface/main/dated_reminders/dated_reminders_add.php?mID='+encodeURIComponent(id)+'&csrf_token_form=<?php echo attr_url(CsrfUtils::collectCsrfToken()); ?>', '_drAdd', 700, 500);
-             }
-           }
+<script>
+$(function () {
+  $(".hideDR").click(function(){
+    if($(this).html() == "<span><?php echo xla('Hide Reminders') ?></span>"){
+      $(this).html("<span><?php echo xla('Show Reminders') ?></span>");
+      $(".drHide").slideUp("slow");
+    }
+    else{
+      $(this).html("<span><?php echo xla('Hide Reminders') ?></span>");
+      $(".drHide").slideDown("slow");
+    }
+  });
 
-           function updateme(id){
-             refreshInterval = <?php echo attr($updateDelay); ?>;
-             if(id > 0){
-              $(".drTD").html('<p class="text-body font-weight-bold" style="font-size: 3rem; margin-left: 200px;"><?php echo xla("Processing") ?>...</p>');
-             }
-             if(id == 'new'){
-              $(".drTD").html('<p class="text-body font-weight-bold" style="font-size: 3rem; margin-left: 200px;"><?php echo xla("Processing") ?>...</p>');
-             }
-             top.restoreSession();
-             // Send the skip_timeout_reset parameter to not count this as a manual entry in the
-             //  timing out mechanism in OpenEMR.
-             $.post("<?php echo $GLOBALS['webroot']; ?>/interface/main/dated_reminders/dated_reminders.php",
-               {
-                drR: id,
-                skip_timeout_reset: "1",
-                csrf_token_form: "<?php echo attr(CsrfUtils::collectCsrfToken()); ?>"
-               },
-               function(data) {
-                if(data == 'error'){
-                  alert("<?php echo xls('Error Removing Message') ?>");
-                }else{
-                  if(id > 0){
-                    $(".drTD").html('<p class="text-body font-weight-bold" style="font-size: 3rem; margin-left: 200px;"><?php echo xla("Refreshing Reminders") ?> ...</p>');
-                  }
-                  $(".drTD").html(data);
-                }
-              // run updater every refreshInterval seconds
-              var repeater = setTimeout("updateme(0)", refreshInterval);
-             });
-           }
+  // run updater after 30 seconds
+  var updater = setTimeout("updateme(0)", 1);
+});
 
-            function openLogScreen(){
-               top.restoreSession();
-               dlgopen('<?php echo $GLOBALS['webroot']; ?>/interface/main/dated_reminders/dated_reminders_log.php', '_drLog', 'modal-mlg', 850);
-            }
-
-
-            function goPid(pid) {
-              top.restoreSession();
-                <?php
-                  echo "  top.RTop.location = '../../patient_file/summary/demographics.php' " .
-                  "+ '?set_pid=' + pid;\n";
-                ?>
+function openAddScreen(id){
+  if (id == 0){
+    top.restoreSession();
+    dlgopen('<?php echo $GLOBALS['webroot']; ?>/interface/main/dated_reminders/dated_reminders_add.php', '_drAdd', 700, 500);
+  } else {
+    top.restoreSession();
+    dlgopen('<?php echo $GLOBALS['webroot']; ?>/interface/main/dated_reminders/dated_reminders_add.php?mID='+encodeURIComponent(id)+'&csrf_token_form=<?php echo attr_url(CsrfUtils::collectCsrfToken()); ?>', '_drAdd', 700, 500);
+  }
 }
-      </script>
 
-        <?php
-          // initialize html string
-          $pdHTML = '<div class="container">
-                            <div class="drHide col-12">' .
-                                '<a title="' . xla('View Past and Future Reminders') . '" onclick="openLogScreen()" class="btn btn-secondary  btn-sm btn-show" href="#">' . xlt('View Log') . '</a>&nbsp;' . '<a onclick="openAddScreen(0)" class="btn btn-primary btn-sm btn-add" href="#">' . xlt('Create A Dated Reminder') . '</a>
-                            </div>
-                            <div class="col-12 pre-scrollable oe-margin-t-10">
-                            <fieldset>
-                            <legend>' . xla('Dated Reminders') . '</legend>
-                           <table class="table-sm">
-                            </tr>
-                                <td class="drHide drTD">';
+function updateme(id){
+  refreshInterval = <?php echo attr($updateDelay); ?>;
+  if (id > 0) {
+    $(".drTD").html('<p class="text-body font-weight-bold" style="font-size: 3rem; margin-left: 200px;"><?php echo xla("Processing") ?>...</p>');
+  }
 
-          $pdHTML .= getRemindersHTML($today, $reminders);
-          $pdHTML .= '</td></tr></table></fieldset></div></div>';
-          // print output
-          echo $pdHTML;
-        ?>
+  if (id == 'new') {
+    $(".drTD").html('<p class="text-body font-weight-bold" style="font-size: 3rem; margin-left: 200px;"><?php echo xla("Processing") ?>...</p>');
+  }
+  
+  top.restoreSession();
+  
+  // Send the skip_timeout_reset parameter to not count this as a manual entry in the
+  // timing out mechanism in OpenEMR.
+  $.post("<?php echo $GLOBALS['webroot']; ?>/interface/main/dated_reminders/dated_reminders.php",
+    {
+      drR: id,
+      skip_timeout_reset: "1",
+      csrf_token_form: "<?php echo attr(CsrfUtils::collectCsrfToken()); ?>"
+    },
+    function(data) {
+    if (data == 'error') {
+      alert("<?php echo xls('Error Removing Message') ?>");
+    } else {
+      if (id > 0) {
+        $(".drTD").html('<p class="text-body font-weight-bold" style="font-size: 3rem; margin-left: 200px;"><?php echo xla("Refreshing Reminders") ?> ...</p>');
+      }
+      $(".drTD").html(data);
+    }
+    
+    // run updater every refreshInterval seconds
+    var repeater = setTimeout("updateme(0)", refreshInterval);
+  });
+}
+
+function openLogScreen(){
+  top.restoreSession();
+    dlgopen('<?php echo $GLOBALS['webroot']; ?>/interface/main/dated_reminders/dated_reminders_log.php', '_drLog', 'modal-mlg', 850);
+}
+
+function goPid(pid) {
+  top.restoreSession();
+  <?php echo "  top.RTop.location = '../../patient_file/summary/demographics.php' " .
+      "+ '?set_pid=' + pid;\n"; ?>
+}
+
+</script>
+
+<?php
+    // initialize html string
+    $pdHTML = '<div class="container">
+                      <div class="drHide col-12">' .
+                          '<a title="' . xla('View Past and Future Reminders') . '" onclick="openLogScreen()" class="btn btn-secondary  btn-sm btn-show" href="#">' . xlt('View Log') . '</a>&nbsp;' . '<a onclick="openAddScreen(0)" class="btn btn-primary btn-sm btn-add" href="#">' . xlt('Create A Dated Reminder') . '</a>
+                      </div>
+                      <div class="col-12 pre-scrollable oe-margin-t-10">
+                      <fieldset>
+                      <legend>' . xla('Dated Reminders') . '</legend>
+                      <table class="table-sm">
+                      </tr>
+                          <td class="drHide drTD">';
+
+    $pdHTML .= getRemindersHTML($today, $reminders);
+    $pdHTML .= '</td></tr></table></fieldset></div></div>';
+    // print output
+    echo $pdHTML;
+?>

--- a/interface/main/messages/messages.php
+++ b/interface/main/messages/messages.php
@@ -393,17 +393,15 @@ if (!empty($_REQUEST['go'])) { ?>
                                                     generate_form_field(array('data_type' => 1, 'field_id' => 'message_status', 'list_id' => 'message_status', 'empty_title' => 'SKIP', 'order_by' => 'title', 'class' => 'form-control'), $form_message_status); ?>
                                                 </div>
                                                 <div class="col-6 col-md-4">
-                                                    <label for="form_patient">
                                                         <?php
                                                         if ($task != "addnew" && $result['pid'] != 0) { ?>
-                                                            <a class="patLink" onclick="goPid('<?php echo attr(addslashes($result['pid'])); ?>')"><?php echo xlt('Patient'); ?>:</a>
+                                                            <a class="patLink" onclick="goPid('<?php echo attr(addslashes($result['pid'])); ?>')" title='<?php echo attr(xlt('Click me to Open Patient Dashboard')) ?>'><?php echo xlt('Patient'); ?>:</a><label for="form_patient">&nbsp</label>
                                                             <?php
                                                         } else { ?>
-                                                            <span class='font-weight-bold <?php echo($task == "addnew" ? "text-danger" : "") ?>'><?php echo xlt('Patient'); ?>:</span>
+                                                            <span class='font-weight-bold <?php echo($task == "addnew" ? "text-danger" : "") ?>'><?php echo xlt('Patient'); ?>:</span></a><label for="form_patient"></label>
                                                             <?php
                                                         }
                                                         ?>
-                                                    </label>
                                                     <?php
                                                     if ($reply_to) {
                                                         $prow = sqlQuery("SELECT lname, fname,pid, pubpid, DOB  " .

--- a/interface/main/messages/messages.php
+++ b/interface/main/messages/messages.php
@@ -394,26 +394,26 @@ if (!empty($_REQUEST['go'])) { ?>
                                                 </div>
                                                 <div class="col-6 col-md-4">
                                                     <?php
-                                                        if ($task != "addnew" && $result['pid'] != 0) { ?>
-                                                            <a class="patLink" onclick="goPid('<?php echo attr(addslashes($result['pid'])); ?>')" title='<?php echo xla('Click me to Open Patient Dashboard') ?>'><?php echo xlt('Patient'); ?>:</a><label for="form_patient">&nbsp</label>
-                                                            <?php
-                                                        } else { ?>
-                                                            <span class='font-weight-bold <?php echo($task == "addnew" ? "text-danger" : "") ?>'><?php echo xlt('Patient'); ?>:</span></a><label for="form_patient"></label>
-                                                            <?php
-                                                        }
-                                                    
-                                                        if ($reply_to) {
-                                                            $prow = sqlQuery("SELECT lname, fname,pid, pubpid, DOB  " .
-                                                                "FROM patient_data WHERE pid = ?", array($reply_to));
-                                                            $patientname = $prow['lname'] . ", " . $prow['fname'];
-                                                        }
-                                                        if ($task == "addnew" || $result['pid'] == 0) {
-                                                            $cursor = "oe-cursor-add";
-                                                            $background = "oe-patient-background";
-                                                        } elseif ($task == "edit") {
-                                                            $cursor = "oe-cursor-stop";
-                                                            $background = '';
-                                                        }
+                                                    if ($task != "addnew" && $result['pid'] != 0) { ?>
+                                                        <a class="patLink" onclick="goPid('<?php echo attr(addslashes($result['pid'])); ?>')" title='<?php echo xla('Click me to Open Patient Dashboard') ?>'><?php echo xlt('Patient'); ?>:</a><label for="form_patient">&nbsp</label>
+                                                        <?php
+                                                    } else { ?>
+                                                        <span class='font-weight-bold <?php echo($task == "addnew" ? "text-danger" : "") ?>'><?php echo xlt('Patient'); ?>:</span></a><label for="form_patient"></label>
+                                                        <?php
+                                                    }
+
+                                                    if ($reply_to) {
+                                                        $prow = sqlQuery("SELECT lname, fname,pid, pubpid, DOB  " .
+                                                            "FROM patient_data WHERE pid = ?", array($reply_to));
+                                                        $patientname = $prow['lname'] . ", " . $prow['fname'];
+                                                    }
+                                                    if ($task == "addnew" || $result['pid'] == 0) {
+                                                        $cursor = "oe-cursor-add";
+                                                        $background = "oe-patient-background";
+                                                    } elseif ($task == "edit") {
+                                                        $cursor = "oe-cursor-stop";
+                                                        $background = '';
+                                                    }
                                                     ?>
                                                     <input type='text' id='form_patient' name='form_patient' class='form-control <?php echo $cursor . " " . $background;?>' onclick="multi_sel_patient()" placeholder='<?php echo xla("Click to add patient"); ?>' value='<?php echo attr($patientname); ?>' readonly />
                                                     <input type='hidden' class="form-control" name='reply_to' id='reply_to' value='<?php echo attr($reply_to); ?>'/>

--- a/interface/main/messages/messages.php
+++ b/interface/main/messages/messages.php
@@ -395,7 +395,7 @@ if (!empty($_REQUEST['go'])) { ?>
                                                 <div class="col-6 col-md-4">
                                                     <?php
                                                         if ($task != "addnew" && $result['pid'] != 0) { ?>
-                                                            <a class="patLink" onclick="goPid('<?php echo attr(addslashes($result['pid'])); ?>')" title='<?php echo attr(xlt('Click me to Open Patient Dashboard')) ?>'><?php echo xlt('Patient'); ?>:</a><label for="form_patient">&nbsp</label>
+                                                            <a class="patLink" onclick="goPid('<?php echo attr(addslashes($result['pid'])); ?>')" title='<?php echo xla('Click me to Open Patient Dashboard') ?>'><?php echo xlt('Patient'); ?>:</a><label for="form_patient">&nbsp</label>
                                                             <?php
                                                         } else { ?>
                                                             <span class='font-weight-bold <?php echo($task == "addnew" ? "text-danger" : "") ?>'><?php echo xlt('Patient'); ?>:</span></a><label for="form_patient"></label>

--- a/interface/main/messages/messages.php
+++ b/interface/main/messages/messages.php
@@ -393,16 +393,15 @@ if (!empty($_REQUEST['go'])) { ?>
                                                     generate_form_field(array('data_type' => 1, 'field_id' => 'message_status', 'list_id' => 'message_status', 'empty_title' => 'SKIP', 'order_by' => 'title', 'class' => 'form-control'), $form_message_status); ?>
                                                 </div>
                                                 <div class="col-6 col-md-4">
-                                                        <?php
-                                                        if ($task != "addnew" && $result['pid'] != 0) { ?>
-                                                            <a class="patLink" onclick="goPid('<?php echo attr(addslashes($result['pid'])); ?>')" title='<?php echo attr(xlt('Click me to Open Patient Dashboard')) ?>'><?php echo xlt('Patient'); ?>:</a><label for="form_patient">&nbsp</label>
-                                                            <?php
-                                                        } else { ?>
-                                                            <span class='font-weight-bold <?php echo($task == "addnew" ? "text-danger" : "") ?>'><?php echo xlt('Patient'); ?>:</span></a><label for="form_patient"></label>
-                                                            <?php
-                                                        }
-                                                        ?>
                                                     <?php
+                                                    if ($task != "addnew" && $result['pid'] != 0) { ?>
+                                                        <a class="patLink" onclick="goPid('<?php echo attr(addslashes($result['pid'])); ?>')" title='<?php echo attr(xlt('Click me to Open Patient Dashboard')) ?>'><?php echo xlt('Patient'); ?>:</a><label for="form_patient">&nbsp</label>
+                                                        <?php
+                                                    } else { ?>
+                                                        <span class='font-weight-bold <?php echo($task == "addnew" ? "text-danger" : "") ?>'><?php echo xlt('Patient'); ?>:</span></a><label for="form_patient"></label>
+                                                        <?php
+                                                    }
+                                                    
                                                     if ($reply_to) {
                                                         $prow = sqlQuery("SELECT lname, fname,pid, pubpid, DOB  " .
                                                             "FROM patient_data WHERE pid = ?", array($reply_to));

--- a/interface/main/messages/messages.php
+++ b/interface/main/messages/messages.php
@@ -394,26 +394,26 @@ if (!empty($_REQUEST['go'])) { ?>
                                                 </div>
                                                 <div class="col-6 col-md-4">
                                                     <?php
-                                                    if ($task != "addnew" && $result['pid'] != 0) { ?>
-                                                        <a class="patLink" onclick="goPid('<?php echo attr(addslashes($result['pid'])); ?>')" title='<?php echo attr(xlt('Click me to Open Patient Dashboard')) ?>'><?php echo xlt('Patient'); ?>:</a><label for="form_patient">&nbsp</label>
-                                                        <?php
-                                                    } else { ?>
-                                                        <span class='font-weight-bold <?php echo($task == "addnew" ? "text-danger" : "") ?>'><?php echo xlt('Patient'); ?>:</span></a><label for="form_patient"></label>
-                                                        <?php
-                                                    }
+                                                        if ($task != "addnew" && $result['pid'] != 0) { ?>
+                                                            <a class="patLink" onclick="goPid('<?php echo attr(addslashes($result['pid'])); ?>')" title='<?php echo attr(xlt('Click me to Open Patient Dashboard')) ?>'><?php echo xlt('Patient'); ?>:</a><label for="form_patient">&nbsp</label>
+                                                            <?php
+                                                        } else { ?>
+                                                            <span class='font-weight-bold <?php echo($task == "addnew" ? "text-danger" : "") ?>'><?php echo xlt('Patient'); ?>:</span></a><label for="form_patient"></label>
+                                                            <?php
+                                                        }
                                                     
-                                                    if ($reply_to) {
-                                                        $prow = sqlQuery("SELECT lname, fname,pid, pubpid, DOB  " .
-                                                            "FROM patient_data WHERE pid = ?", array($reply_to));
-                                                        $patientname = $prow['lname'] . ", " . $prow['fname'];
-                                                    }
-                                                    if ($task == "addnew" || $result['pid'] == 0) {
-                                                        $cursor = "oe-cursor-add";
-                                                        $background = "oe-patient-background";
-                                                    } elseif ($task == "edit") {
-                                                        $cursor = "oe-cursor-stop";
-                                                        $background = '';
-                                                    }
+                                                        if ($reply_to) {
+                                                            $prow = sqlQuery("SELECT lname, fname,pid, pubpid, DOB  " .
+                                                                "FROM patient_data WHERE pid = ?", array($reply_to));
+                                                            $patientname = $prow['lname'] . ", " . $prow['fname'];
+                                                        }
+                                                        if ($task == "addnew" || $result['pid'] == 0) {
+                                                            $cursor = "oe-cursor-add";
+                                                            $background = "oe-patient-background";
+                                                        } elseif ($task == "edit") {
+                                                            $cursor = "oe-cursor-stop";
+                                                            $background = '';
+                                                        }
                                                     ?>
                                                     <input type='text' id='form_patient' name='form_patient' class='form-control <?php echo $cursor . " " . $background;?>' onclick="multi_sel_patient()" placeholder='<?php echo xla("Click to add patient"); ?>' value='<?php echo attr($patientname); ?>' readonly />
                                                     <input type='hidden' class="form-control" name='reply_to' id='reply_to' value='<?php echo attr($reply_to); ?>'/>


### PR DESCRIPTION
…nders.php

<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #4105 

#### Short description of what this resolves:
stops `a` tag inside label from firing `multi_patient_finder()` when trying to navigate to pt dashboard

#### Changes proposed in this pull request:
moved `label`, quasi psr 12 styling to `dated_reminders.php`
