### PR TITLE
optimize dev bulk ccda import

### DIFF
--- a/contrib/util/ccda_import/import_ccda.php
+++ b/contrib/util/ccda_import/import_ccda.php
@@ -108,11 +108,9 @@ foreach (glob($dir) as $file) {
     $counter++;
     $incrementCounter = 50; // echo every 50 records imported
     if (($counter % $incrementCounter) == 0) {
-        if (isset($timeSec)) {
-            $lasttimeSec = $timeSec;
-        }
         $timeSec = round(((round(microtime(true) * 1000)) - $millisecondsStart) / 1000);
-        outputMessage($counter . " patients imported (" . $timeSec . " total seconds) (" . (($lasttimeSec ?? $timeSec) / $counter) . " average seconds per patient for last " . $incrementCounter . " patients)\n");
+        outputMessage($counter . " patients imported (" . $timeSec . " total seconds) (" . (($lasttimeSec ? ($timeSec - $lasttimeSec) : $timeSec) / $incrementCounter) . " average seconds per patient for last " . $incrementCounter . " patients)\n");
+        $lasttimeSec = $timeSec;
     }
 }
 $timeSec = round(((round(microtime(true) * 1000)) - $millisecondsStart) / 1000);

--- a/contrib/util/ccda_import/import_ccda.php
+++ b/contrib/util/ccda_import/import_ccda.php
@@ -13,16 +13,17 @@
  *
  * Use:
  *   1. use: php import_ccda.php <ccda-directory> <site> <openemr-directory> <development-mode>
- *   2. use example: php import_ccda.php synthea default /var/www/localhost/htdocs/openemr false
- *   3. use example: php import_ccda.php synthea default /var/www/localhost/htdocs/openemr true
- *   4. Note that development-mode will markedly improve performance by clearing the audit_master
- *      and audit_details tables after each patient insert (note this should never be done on sites
- *      that already contain real data/use) and will also turn off the audit log during the import.
+ *   2. use example: php import_ccda.php synthea default /var/www/localhost/htdocs/openemr true
+ *   3. use example: php import_ccda.php synthea default /var/www/localhost/htdocs/openemr false
+ *   4. Note that development-mode will markedly improve performance by bypassing the use of
+ *      the audit_master and audit_details tables and will directly import the new patient data
+ *      from the ccda. Note this should never be done on sites that already contain real data/use.
+ *      This will also turn off the audit log during the import.
  *   5. Note that a log.txt file is created with log/stats of the run.
  *
  * Description of what this script automates (for unlimited number of ccda documents):
  *  1. import ccda document
- *  2. import to ccda table
+ *  2. import to ccda table (bypassed in development-mode)
  *  3. import as new patient
  *  4. run function to populate all the uuids via the universal service function that already exists
  *
@@ -73,8 +74,6 @@ outputMessage("openemr path: " . $openemrPath . "\n");
 
 if ($seriousOptimize) {
     outputMessage("development mode is on\n");
-    // temporarily remove audit_master_id index from audit_details
-    sqlStatementNoLog("DROP INDEX `audit_master_id` ON `audit_details`");
     // temporarily disable the audit log
     $auditLogSetting = sqlQueryNoLog("SELECT `gl_value` FROM `globals` WHERE `gl_name` = 'enable_auditlog'")['gl_value'] ?? 0;
     sqlStatementNoLog("UPDATE `globals` SET `gl_value` = 0 WHERE `gl_name` = 'enable_auditlog'");
@@ -94,16 +93,18 @@ foreach (glob($dir) as $file) {
     // TODO: collect CCDA category id instead of hardcoding 13
     $document->createDocument('00', 13, basename($file), 'text/xml', $fileContents);
     $documentId = $document->get_id();
-    //  2. import to ccda table
     if ($seriousOptimize) {
-        // truncate (ie. clear) the audit_master and audit_details tables
-        sqlStatementNoLog("TRUNCATE `audit_master`");
-        sqlStatementNoLog("TRUNCATE `audit_details`");
+        // development-mode is on (note step 2 is bypassed)
+        // 3. import as new patient
+        exec("php " . $openemrPath . "/interface/modules/zend_modules/public/index.php ccda-newpatient-import --site=" . $_SESSION['site_id'] . " --document_id=" . $documentId);
+    } else {
+        // development mode is off
+        //  2. import to ccda table
+        exec("php " . $openemrPath . "/interface/modules/zend_modules/public/index.php ccda-import --site=" . $_SESSION['site_id'] . " --document_id=" . $documentId);
+        $auditId = sqlQueryNoLog("SELECT max(`id`) as `maxid` FROM `audit_master`")['maxid'];
+        //  3. import as new patient
+        exec("php " . $openemrPath . "/interface/modules/zend_modules/public/index.php ccda-newpatient --site=" . $_SESSION['site_id'] . " --am_id=" . $auditId . " --document_id=" . $documentId);
     }
-    exec("php " . $openemrPath . "/interface/modules/zend_modules/public/index.php ccda-import --site=" . $_SESSION['site_id'] . " --document_id=" . $documentId);
-    $auditId = sqlQueryNoLog("SELECT max(`id`) as `maxid` FROM `audit_master`")['maxid'];
-    //  3. import as new patient
-    exec("php " . $openemrPath . "/interface/modules/zend_modules/public/index.php ccda-newpatient --site=" . $_SESSION['site_id'] . " --am_id=" . $auditId . " --document_id=" . $documentId);
     $counter++;
     $incrementCounter = 50; // echo every 50 records imported
     if (($counter % $incrementCounter) == 0) {
@@ -111,11 +112,11 @@ foreach (glob($dir) as $file) {
             $lasttimeSec = $timeSec;
         }
         $timeSec = round(((round(microtime(true) * 1000)) - $millisecondsStart) / 1000);
-        outputMessage($counter . " patients imported (" . $timeSec . " total seconds) (" . round(($lasttimeSec ?? $timeSec) / $counter) . " average seconds per patient for last " . $incrementCounter . " patients)\n");
+        outputMessage($counter . " patients imported (" . $timeSec . " total seconds) (" . (($lasttimeSec ?? $timeSec) / $counter) . " average seconds per patient for last " . $incrementCounter . " patients)\n");
     }
 }
 $timeSec = round(((round(microtime(true) * 1000)) - $millisecondsStart) / 1000);
-echo outputMessage("Completed patients import (" . $counter . " patients) (" . $timeSec . " total seconds) (" . round(($timeSec) / $counter) . " average seconds per patient)\n");
+echo outputMessage("Completed patients import (" . $counter . " patients) (" . $timeSec . " total seconds) (" . (($timeSec) / $counter) . " average seconds per patient)\n");
 //  4. run function to populate all the uuids via the universal service function that already exists
 echo outputMessage("Started uuid creation\n");
 autoPopulateAllMissingUuids();
@@ -123,8 +124,6 @@ $timeSec = round(((round(microtime(true) * 1000)) - $millisecondsStart) / 1000);
 echo outputMessage("Completed uuid creation (" . $timeSec . " total seconds; " . $timeSec / 3600 . " total hours)\n");
 
 if ($seriousOptimize) {
-    // add back audit_master_id index to audit_details
-    sqlStatementNoLog("CREATE INDEX `audit_master_id` ON `audit_details` (`audit_master_id`)");
     // reset the audit log to the original value
     sqlStatementNoLog("UPDATE `globals` SET `gl_value` = ? WHERE `gl_name` = 'enable_auditlog'", [$auditLogSetting]);
     sqlStatementNoLog("UPDATE `globals` SET `gl_value` = ? WHERE `gl_name` = 'gbl_force_log_breakglass'", [$auditLogBreakglassSetting]);

--- a/contrib/util/ccda_import/import_ccda.php
+++ b/contrib/util/ccda_import/import_ccda.php
@@ -13,16 +13,17 @@
  *
  * Use:
  *   1. use: php import_ccda.php <ccda-directory> <site> <openemr-directory> <development-mode>
- *   2. use example: php import_ccda.php synthea default /var/www/localhost/htdocs/openemr true
- *   3. use example: php import_ccda.php synthea default /var/www/localhost/htdocs/openemr false
- *   4. Note that development-mode will markedly improve performance by bypassing the use of
- *      the audit_master and audit_details tables and will directly import the new patient data
- *      from the ccda. Note this should never be done on sites that already contain real data/use.
- *      This will also turn off the audit log during the import.
+ *   2. use example: php import_ccda.php /var/www/localhost/htdocs/openemr/synthea default /var/www/localhost/htdocs/openemr true
+ *   3. use example: php import_ccda.php /var/www/localhost/htdocs/openemr/synthea default /var/www/localhost/htdocs/openemr false
+ *   4. Note that development-mode will markedly improve performance by bypassing the import of
+ *      the ccda document and bypassing the use of the audit_master and audit_details tables and
+ *      will directly import the new patient data from the ccda. Note this should never be done
+ *      on sites that already contain real data/use. This will also turn off the audit log during
+ *      the import.
  *   5. Note that a log.txt file is created with log/stats of the run.
  *
  * Description of what this script automates (for unlimited number of ccda documents):
- *  1. import ccda document
+ *  1. import ccda document (bypassed in development-mode)
  *  2. import to ccda table (bypassed in development-mode)
  *  3. import as new patient
  *  4. run function to populate all the uuids via the universal service function that already exists
@@ -41,8 +42,8 @@ exit;
 if (php_sapi_name() !== 'cli' || count($argv) != 5) {
     echo "Only php cli can execute a command\n";
     echo "use: php import_ccda.php <ccda-directory> <site> <openemr-directory> <development-mode>\n";
-    echo "example use: php import_ccda.php synthea default /var/www/localhost/htdocs/openemr false\n";
-    echo "example use: php import_ccda.php synthea default /var/www/localhost/htdocs/openemr true\n";
+    echo "example use: php import_ccda.php /var/www/localhost/htdocs/openemr/synthea default /var/www/localhost/htdocs/openemr true\n";
+    echo "example use: php import_ccda.php /var/www/localhost/htdocs/openemr/synthea default /var/www/localhost/htdocs/openemr false\n";
     die;
 }
 
@@ -65,7 +66,8 @@ if ($seriousOptimizeFlag == "true") {
 
 $ignoreAuth = 1;
 require_once($openemrPath . "/interface/globals.php");
-require_once($openemrPath . "/library/uuid.php");
+
+use OpenEMR\Common\Uuid\UuidRegistry;
 
 // show parameters (need to do after globals)
 outputMessage("ccda directory: " . $argv[1] . "\n");
@@ -87,18 +89,18 @@ outputMessage("Starting patients import\n");
 $counter = 0;
 $millisecondsStart = round(microtime(true) * 1000);
 foreach (glob($dir) as $file) {
-    //  1. import ccda document
-    $fileContents = file_get_contents($file);
-    $document = new Document();
-    // TODO: collect CCDA category id instead of hardcoding 13
-    $document->createDocument('00', 13, basename($file), 'text/xml', $fileContents);
-    $documentId = $document->get_id();
     if ($seriousOptimize) {
-        // development-mode is on (note step 2 is bypassed)
+        // development-mode is on (note step 1 and step 2 are bypassed)
         // 3. import as new patient
-        exec("php " . $openemrPath . "/interface/modules/zend_modules/public/index.php ccda-newpatient-import --site=" . $_SESSION['site_id'] . " --document_id=" . $documentId);
+        exec("php " . $openemrPath . "/interface/modules/zend_modules/public/index.php ccda-newpatient-import --site=" . $_SESSION['site_id'] . " --document=" . $file);
     } else {
         // development mode is off
+        //  1. import ccda document
+        $fileContents = file_get_contents($file);
+        $document = new Document();
+        // TODO: collect CCDA category id instead of hardcoding 13
+        $document->createDocument('00', 13, basename($file), 'text/xml', $fileContents);
+        $documentId = $document->get_id();
         //  2. import to ccda table
         exec("php " . $openemrPath . "/interface/modules/zend_modules/public/index.php ccda-import --site=" . $_SESSION['site_id'] . " --document_id=" . $documentId);
         $auditId = sqlQueryNoLog("SELECT max(`id`) as `maxid` FROM `audit_master`")['maxid'];
@@ -117,7 +119,7 @@ $timeSec = round(((round(microtime(true) * 1000)) - $millisecondsStart) / 1000);
 echo outputMessage("Completed patients import (" . $counter . " patients) (" . $timeSec . " total seconds) (" . (($timeSec) / $counter) . " average seconds per patient)\n");
 //  4. run function to populate all the uuids via the universal service function that already exists
 echo outputMessage("Started uuid creation\n");
-autoPopulateAllMissingUuids();
+UuidRegistry::populateAllMissingUuids(false);
 $timeSec = round(((round(microtime(true) * 1000)) - $millisecondsStart) / 1000);
 echo outputMessage("Completed uuid creation (" . $timeSec . " total seconds; " . $timeSec / 3600 . " total hours)\n");
 

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php
@@ -117,8 +117,8 @@ class CarecoordinationController extends AbstractActionController
         if (!$request instanceof ConsoleRequest) {
             throw new RuntimeException('You can only use this action from a console!');
         }
-        $document_id = $request->getParam('document_id');
-        $this->getCarecoordinationTable()->importNewpatient($document_id);
+        $document = $request->getParam('document');
+        $this->getCarecoordinationTable()->importNewpatient($document);
         exit;
     }
 

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php
@@ -111,6 +111,17 @@ class CarecoordinationController extends AbstractActionController
         return $view;
     }
 
+    public function newpatientImportCommandAction()
+    {
+        $request = $this->getRequest();
+        if (!$request instanceof ConsoleRequest) {
+            throw new RuntimeException('You can only use this action from a console!');
+        }
+        $document_id = $request->getParam('document_id');
+        $this->getCarecoordinationTable()->importNewpatient($document_id);
+        exit;
+    }
+
     public function newpatientCommandAction()
     {
         $request = $this->getRequest();

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php
@@ -184,6 +184,15 @@ class CarecoordinationTable extends AbstractTableGateway
         $patient_lname = $patient_role['patient']['name']['given'][1];
         $patient_family_name = $patient_role['patient']['name']['family'];
         $patient_gender_code = $patient_role['patient']['administrativeGenderCode']['code'];
+        if (empty($patient_role['patient']['administrativeGenderCode']['displayName'])) {
+            if ($patient_role['patient']['administrativeGenderCode']['code'] == 'F') {
+                $patient_role['patient']['administrativeGenderCode']['displayName'] = 'Female';
+                $xml['recordTarget']['patientRole']['patient']['administrativeGenderCode']['displayName'] = 'Female';
+            } elseif ($patient_role['patient']['administrativeGenderCode']['code'] == 'M') {
+                $patient_role['patient']['administrativeGenderCode']['displayName'] = 'Male';
+                $xml['recordTarget']['patientRole']['patient']['administrativeGenderCode']['displayName'] = 'Male';
+            }
+        }
         $patient_gender_name = $patient_role['patient']['administrativeGenderCode']['displayName'];
         $patient_dob = $patient_role['patient']['birthTime']['value'];
         $patient_marital_status = $patient_role['patient']['religiousAffiliationCode']['code'];

--- a/interface/modules/zend_modules/module/Installer/Module.php
+++ b/interface/modules/zend_modules/module/Installer/Module.php
@@ -61,6 +61,9 @@ class Module
             ['--site=<site_name>', 'Name of site, by default: "default" '],
             ['--am_id=<am_id>', 'The master audit table id of patient that will be imported as a new patient'],
             ['--document_id=<document_id>', 'The ccda document id that was previously imported into the audit table'],
+            ['ccda-newpatient-import', 'Part of route for console call'],
+            ['--site=<site_name>', 'Name of site, by default: "default" '],
+            ['--document_id=<document_id>', 'The ccda document id that will be imported to create the new patient'],
         ];
     }
 }

--- a/interface/modules/zend_modules/module/Installer/Module.php
+++ b/interface/modules/zend_modules/module/Installer/Module.php
@@ -63,7 +63,7 @@ class Module
             ['--document_id=<document_id>', 'The ccda document id that was previously imported into the audit table'],
             ['ccda-newpatient-import', 'Part of route for console call'],
             ['--site=<site_name>', 'Name of site, by default: "default" '],
-            ['--document_id=<document_id>', 'The ccda document id that will be imported to create the new patient'],
+            ['--document=<document>', 'File (path) that will be imported to create the new patient'],
         ];
     }
 }

--- a/interface/modules/zend_modules/module/Installer/config/module.config.php
+++ b/interface/modules/zend_modules/module/Installer/config/module.config.php
@@ -96,6 +96,16 @@ return array(
                         ),
                     ),
                 ),
+
+                'ccda-newpatient-import' => array(
+                    'options' => array(
+                        'route'    => 'ccda-newpatient-import --site= --document_id=',
+                        'defaults' => array(
+                            'controller' => Carecoordination\Controller\CarecoordinationController::class,
+                            'action'     => 'newpatient-import-command',
+                        ),
+                    ),
+                ),
             )
         )
     ),

--- a/interface/modules/zend_modules/module/Installer/config/module.config.php
+++ b/interface/modules/zend_modules/module/Installer/config/module.config.php
@@ -99,7 +99,7 @@ return array(
 
                 'ccda-newpatient-import' => array(
                     'options' => array(
-                        'route'    => 'ccda-newpatient-import --site= --document_id=',
+                        'route'    => 'ccda-newpatient-import --site= --document=',
                         'defaults' => array(
                             'controller' => Carecoordination\Controller\CarecoordinationController::class,
                             'action'     => 'newpatient-import-command',


### PR DESCRIPTION
- optimize dev bulk ccda import (by bypassing use of the audit_* tables)
```
Completed patients import (1000 patients) (2545 total seconds) (2.545 average seconds per patient)
Started uuid creation
Completed uuid creation (2805 total seconds; 0.77916666666667 total hours)
```
- gender fix for synthea ccda import
