### PR TITLE
Add issue relations to clinical notes

### DIFF
--- a/interface/forms/care_plan/new.php
+++ b/interface/forms/care_plan/new.php
@@ -70,6 +70,11 @@ endforeach;
                 document.getElementById("displaytext_" + rowid1[1]).innerHTML = '';
                 document.getElementById("care_plan_type_" + rowid1[1]).value = '';
                 document.getElementById("user_" + rowid1[1]).value = '';
+                if (typeof doTemplateEditor !== 'undefined') {
+                    document.getElementById("description_" + rowid1[1]).addEventListener('dblclick', event => {
+                        doTemplateEditor(this, event, event.target.dataset.textcontext);
+                    })
+                }
             }
 
             function changeIds(class_val) {
@@ -133,6 +138,7 @@ endforeach;
                                 <?php
                                 if (!empty($check_res)) {
                                     foreach ($check_res as $key => $obj) {
+                                        $context = "";
                                         ?>
                                     <div class="tb_row" id="tb_row_<?php echo attr($key) + 1; ?>">
                                         <div class="form-row">
@@ -153,25 +159,31 @@ endforeach;
                                                     <option value=""></option>
                                                     <?php foreach ($care_plan_type as $value) :
                                                         $selected = ($value['value'] == $obj["care_plan_type"]) ? 'selected="selected"' : '';
+                                                        if (!empty($selected)) {
+                                                            $context = $value['title'];
+                                                        }
                                                         ?>
                                                         <option value="<?php echo attr($value['value']);?>" <?php echo $selected;?>><?php echo text($value['title']);?></option>
                                                     <?php endforeach;?>
                                                     </select>
                                             </div>
-                                            <div class="forms col-md-4">
+                                            <div class="forms col-md-6">
                                                 <label for="description_<?php echo attr($key) + 1; ?>" class="h5"><?php echo xlt('Description'); ?>:</label>
-                                                <textarea name="description[]"  id="description_<?php echo attr($key) + 1; ?>" class="form-control description" rows="3" ><?php echo text($obj["description"]); ?></textarea>
+                                                <textarea name="description[]"  id="description_<?php echo attr($key) + 1; ?>" data-textcontext="<?php echo text($context); ?>" class="form-control description" rows="6" ><?php echo text($obj["description"]); ?></textarea>
                                             </div>
-                                            <div class="forms col-md-2">
-                                                <button type="button" class="btn btn-primary btn-add btn-sm" onclick="duplicateRow(this.parentElement.parentElement.parentElement);" title='<?php echo xla('Click here to duplicate the row'); ?>'>
-                                                    <?php echo xlt('Add'); ?>
-                                                </button>
-                                                <button class="btn btn-danger btn-sm" onclick="deleteRow(this.parentElement.parentElement.parentElement.id);" title='<?php echo xla('Click here to delete the row'); ?>'>
-                                                    <?php echo xlt('Delete'); ?>
-                                                </button>
+                                            <div class="form-row w-100 mt-2 text-center">
+                                                <div class="forms col-md-12">
+                                                    <button type="button" class="btn btn-primary btn-add btn-sm" onclick="duplicateRow(this.parentElement.parentElement.parentElement.parentElement);" title='<?php echo xla('Click here to duplicate the row'); ?>'>
+                                                        <?php echo xlt('Add'); ?>
+                                                    </button>
+                                                    <button class="btn btn-danger btn-sm" onclick="deleteRow(this.parentElement.parentElement.parentElement.parentElement.id);" title='<?php echo xla('Click here to delete the row'); ?>'>
+                                                        <?php echo xlt('Delete'); ?>
+                                                    </button>
+                                                </div>
+                                                <input type="hidden" name="count[]" id="count_<?php echo attr($key) + 1; ?>" class="count" value="<?php echo attr($key) + 1;?>" />
                                             </div>
-                                            <input type="hidden" name="count[]" id="count_<?php echo attr($key) + 1; ?>" class="count" value="<?php echo attr($key) + 1;?>" />
                                         </div>
+                                        <hr />
                                     </div>
                                 <?php }
                                 } else {  ?>
@@ -179,7 +191,7 @@ endforeach;
                                         <div class="form-row">
                                             <div class="forms col-md-2">
                                                 <label for="code_1" class="h5"><?php echo xlt('Code'); ?>:</label>
-                                                <input type="text" id="code_1"  name="code[]" class="form-control code" value="<?php echo attr($obj["code"] ?? ''); ?>"  onclick='sel_code(this.parentElement.parentElement.parentElement.id);'>
+                                                <input type="text" id="code_1"  name="code[]" class="form-control code" value="<?php echo attr($obj["code"] ?? ''); ?>"  onclick='sel_code(this.parentElement.parentElement.parentElement.parentElement.id);'>
                                                 <input type="hidden" id="user_1" name="user[]" class="user" value="<?php echo attr($obj["user"] ?? $_SESSION["authUser"]); ?>" />
                                                 <span id="displaytext_1"  class="displaytext help-block"></span>
                                                 <input type="hidden" id="codetext_1" name="codetext[]" class="codetext" value="<?php echo attr($obj["codetext"] ?? ''); ?>">
@@ -199,19 +211,22 @@ endforeach;
                                                     <?php endforeach;?>
                                                 </select>
                                             </div>
-                                            <div class="forms col-md-4">
+                                            <div class="forms col-md-6">
                                                 <label for="description_1" class="h5"><?php echo xlt('Description'); ?>:</label>
-                                                <textarea name="description[]"  id="description_1" class="form-control description" rows="3" ><?php echo text($obj["description"] ?? ''); ?></textarea>
+                                                <textarea name="description[]"  id="description_1" data-textcontext="" class="form-control description" rows="6" ><?php echo text($obj["description"] ?? ''); ?></textarea>
                                             </div>
-                                            <div class="forms col-md-2">
-                                                <button type="button" class="btn btn-primary btn-add btn-sm" onclick="duplicateRow(this.parentElement.parentElement.parentElement);" title='<?php echo xla('Click here to duplicate the row'); ?>'>
-                                                    <?php echo xlt('Add'); ?>
-                                                </button>
-                                                <button type="button" class="btn btn-danger btn-delete btn-sm" onclick="deleteRow(this.parentElement.parentElement.parentElement.id);" title='<?php echo xla('Click here to delete the row'); ?>'>
-                                                    <?php echo xlt('Delete'); ?>
-                                                </button>
+                                            <div class="form-row w-100 mt-2 text-center">
+                                                <div class="forms col-md-12">
+                                                    <button type="button" class="btn btn-primary btn-add btn-sm" onclick="duplicateRow(this.parentElement.parentElement.parentElement.parentElement);" title='<?php echo xla('Click here to duplicate the row'); ?>'>
+                                                        <?php echo xlt('Add'); ?>
+                                                    </button>
+                                                    <button type="button" class="btn btn-danger btn-delete btn-sm" onclick="deleteRow(this.parentElement.parentElement.parentElement.parentElement.id);" title='<?php echo xla('Click here to delete the row'); ?>'>
+                                                        <?php echo xlt('Delete'); ?>
+                                                    </button>
+                                                </div>
+                                                <input type="hidden" name="count[]" id="count_1" class="count" value="1" />
                                             </div>
-                                            <input type="hidden" name="count[]" id="count_1" class="count" value="1" />
+                                            <hr />
                                         </div>
                                     </div>
                                 <?php } ?>

--- a/interface/forms/care_plan/save.php
+++ b/interface/forms/care_plan/save.php
@@ -35,6 +35,7 @@ $code_des = $_POST["description"];
 $count = $_POST["count"];
 $care_plan_type = $_POST['care_plan_type'];
 $care_plan_user = $_POST["user"];
+$note_relations = "";
 
 if ($id && $id != 0) {
     sqlStatement("DELETE FROM `form_care_plan` WHERE id=? AND pid = ? AND encounter = ?", array($id, $_SESSION["pid"], $_SESSION["encounter"]));
@@ -59,6 +60,7 @@ if (!empty($count)) {
         $description_val = $code_des[$key] ? $code_des[$key] : 'NULL';
         $care_plan_type_val = $care_plan_type[$key] ? $care_plan_type[$key] : 'NULL';
         $care_user_val = $care_plan_user[$key] ?: $_SESSION["authUser"];
+        $note_relations = parse_note($description_val);
         $sets = "id = ?,
             pid = ?,
             groupname = ?,
@@ -70,7 +72,8 @@ if (!empty($count)) {
             codetext = ?,
             description = ?,
             date =  ?,
-            care_plan_type = ?";
+            care_plan_type = ?,
+            note_related_to = ?";
         sqlStatement(
             "INSERT INTO form_care_plan SET " . $sets,
             [
@@ -84,7 +87,8 @@ if (!empty($count)) {
                 $codetext_val,
                 $description_val,
                 $code_date[$key],
-                $care_plan_type_val
+                $care_plan_type_val,
+                $note_relations
             ]
         );
     endforeach;
@@ -93,3 +97,9 @@ if (!empty($count)) {
 formHeader("Redirecting....");
 formJump();
 formFooter();
+
+function parse_note($note)
+{
+    $result = preg_match_all("/\{\|([^\]]*)\|}/", $note, $matches);
+    return json_encode($matches[1]);
+}

--- a/interface/forms/care_plan/table.sql
+++ b/interface/forms/care_plan/table.sql
@@ -15,6 +15,7 @@ CREATE TABLE IF NOT EXISTS `form_care_plan` (
   `codetext` text,
   `description` text,
   `external_id` VARCHAR(30) DEFAULT NULL,
-  `care_plan_type` varchar(30) DEFAULT NULL
+  `care_plan_type` varchar(30) DEFAULT NULL,
+  `note_related_to` TEXT
 ) ENGINE=InnoDB;
 

--- a/interface/forms/clinical_notes/new.php
+++ b/interface/forms/clinical_notes/new.php
@@ -70,6 +70,11 @@ foreach ($result as $value) {
             document.getElementById("code_date_" + rowid1[1]).value = '';
             document.getElementById("clinical_notes_type_" + rowid1[1]).value = '';
             document.getElementById("user_" + rowid1[1]).value = '';
+            if (typeof doTemplateEditor !== 'undefined') {
+                document.getElementById("description_" + rowid1[1]).addEventListener('dblclick', event => {
+                    doTemplateEditor(this, event, event.target.dataset.textcontext);
+                })
+            }
         }
 
         function changeIds(class_val) {
@@ -175,8 +180,8 @@ foreach ($result as $value) {
                                         </div>
                                         <input type="hidden" name="count[]" id="count_<?php echo attr($key) + 1; ?>" class="count" value="<?php echo attr($key) + 1; ?>" />
                                     </div>
-                        </div>
-                            </fieldset>
+                            </div>
+                        </fieldset>
                     </div>
                     <hr />
                         <?php }

--- a/interface/forms/clinical_notes/table.sql
+++ b/interface/forms/clinical_notes/table.sql
@@ -15,6 +15,7 @@ CREATE TABLE IF NOT EXISTS `form_clinical_notes` (
   `codetext` text,
   `description` text,
   `external_id` VARCHAR(30) DEFAULT NULL,
-  `clinical_notes_type` varchar(100) DEFAULT NULL
+  `clinical_notes_type` varchar(100) DEFAULT NULL,
+  `note_related_to` TEXT
 ) ENGINE=InnoDB;
 

--- a/library/custom_template/custom_template.php
+++ b/library/custom_template/custom_template.php
@@ -35,11 +35,15 @@ use OpenEMR\Core\Header;
 use OpenEMR\Common\Csrf\CsrfUtils;
 
 // mdsupport : li code
-function listitemCode($strDisp, $strInsert)
+function listitemCode($strDisp, $strInsert, $ref = '')
 {
     if ($strInsert) {
+        if (!empty($ref)) {
+            $id = text($ref);
+            $ref = " {|$id|}";
+        }
         echo '<li><a href="#" onclick="top.restoreSession();CKEDITOR.instances.textarea1.insertText(' .
-             "'" . htmlspecialchars($strInsert, ENT_QUOTES) . "'" . ');">' . htmlspecialchars($strDisp, ENT_QUOTES) . '</a></li>';
+             "'" . text($strInsert) . $ref . "'" . ');">' . text($strDisp) . '</a></li>';
     }
 }
 
@@ -258,14 +262,17 @@ if (empty($isNN) && empty($rowContext)) {
                                 </li>
                                 <?php
                                 foreach ($ISSUE_TYPES as $issType => $issTypeDesc) {
-                                    $res = sqlStatement('SELECT title, IF(diagnosis="","",CONCAT(" [",diagnosis,"]")) codes FROM lists WHERE pid=? AND type=? AND enddate IS NULL ORDER BY title', array($pid, $issType));
+                                    $res = sqlStatement('SELECT title, id, IF(diagnosis="","",CONCAT(" [",diagnosis,"]")) codes FROM lists WHERE pid=? AND type=? AND enddate IS NULL ORDER BY title', array($pid, $issType));
                                     if (sqlNumRows($res)) { ?>
                                     <li>
                                         <a class="collapsed"><?php echo htmlspecialchars(xl($issTypeDesc[0]), ENT_QUOTES); ?></a>
                                         <ul>
                                             <?php
                                             while ($row = sqlFetchArray($res)) {
-                                                listitemCode((strlen($row['title']) > 20) ? (substr($row['title'], 0, 18) . '..') : $row['title'], ($row['title'] . $row['codes']));
+                                                if (!empty($isNN)) {
+                                                    $row['id'] = "";
+                                                }
+                                                listitemCode((strlen($row['title']) > 20) ? (substr($row['title'], 0, 18) . '..') : $row['title'], ($row['title'] . $row['codes']), $row['id']);
                                             }
                                             ?>
                                         </ul>

--- a/sql/6_0_0-to-6_1_0_upgrade.sql
+++ b/sql/6_0_0-to-6_1_0_upgrade.sql
@@ -681,6 +681,6 @@ ALTER TABLE `form_vitals` ADD `oxygen_flow_rate` FLOAT(5,2) NULL DEFAULT '0.00';
 #EndIf
 
 #IfMissingColumn form_clinical_notes note_related_to
-ALTER TABLE `form_clinical_notes` ADD `note_related_to` TEXT NULL COMMENT 'Reference to lists id for note relationships(json)';
-ALTER TABLE `form_care_plan` ADD `note_related_to` TEXT NULL COMMENT 'Reference to lists id for note relationships(json)';
+ALTER TABLE `form_clinical_notes` ADD `note_related_to` TEXT COMMENT 'Reference to lists id for note relationships(json)';
+ALTER TABLE `form_care_plan` ADD `note_related_to` TEXT COMMENT 'Reference to lists id for note relationships(json)';
 #EndIf

--- a/sql/6_0_0-to-6_1_0_upgrade.sql
+++ b/sql/6_0_0-to-6_1_0_upgrade.sql
@@ -679,3 +679,8 @@ INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`
 #IfMissingColumn form_vitals oxygen_flow_rate
 ALTER TABLE `form_vitals` ADD `oxygen_flow_rate` FLOAT(5,2) NULL DEFAULT '0.00';
 #EndIf
+
+#IfMissingColumn form_clinical_notes note_related_to
+ALTER TABLE `form_clinical_notes` ADD `note_related_to` TEXT NULL COMMENT 'Reference to lists id for note relationships(json)';
+ALTER TABLE `form_care_plan` ADD `note_related_to` TEXT NULL COMMENT 'Reference to lists id for note relationships(json)';
+#EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -1747,7 +1747,8 @@ CREATE TABLE `form_clinical_notes` (
     `codetext` text,
     `description` text,
     `external_id` VARCHAR(30) DEFAULT NULL,
-    `clinical_notes_type` varchar(100) DEFAULT NULL
+    `clinical_notes_type` varchar(100) DEFAULT NULL,
+    `note_related_to` text
 ) ENGINE=InnoDB;
 
 -- --------------------------------------------------------
@@ -11150,7 +11151,8 @@ CREATE TABLE `form_care_plan` (
   `codetext` text,
   `description` text,
   `external_id` varchar(30) DEFAULT NULL,
-  `care_plan_type` varchar(30) DEFAULT NULL
+  `care_plan_type` varchar(30) DEFAULT NULL,
+  `note_related_to` text
 ) ENGINE=InnoDB;
 
 -- --------------------------------------------------------

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@ $v_realpatch = '0';
 // is a database change in the course of development.  It is used
 // internally to determine when a database upgrade is needed.
 //
-$v_database = 396;
+$v_database = 397;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
- from Text Templating feature

- Ensure Administration->Globals->Features `Enable Text Templates in Encounter Forms` is enabled.
- Double click in note narrative.
- Add from templating dialog.
![image](https://user-images.githubusercontent.com/1859985/121819797-1ae25f00-cc5d-11eb-9d0d-f2d65bb6970b.png)

Now `form_clinical_notes` has the ref mapping to lists table id in `note_related_to` column as json array.
![image](https://user-images.githubusercontent.com/1859985/121819916-c2f82800-cc5d-11eb-95a0-2204591ee3c8.png)

See issue #4462