### PR TITLE
missing require, missing close tag

### DIFF
--- a/ccr/stylesheet/ccr.xsl
+++ b/ccr/stylesheet/ccr.xsl
@@ -51,7 +51,7 @@ this XSLT back to the community.
         <!-- Load in the CSS file -->
         <xsl:choose>
           <xsl:when test="$stylesheet!=''">
-            <link href="{$stylesheet}" rel="stylesheet">
+            <link href="{$stylesheet}" rel="stylesheet"/>
           </xsl:when>
           <xsl:otherwise>
             <xsl:call-template name="defaultCCS"/>

--- a/interface/patient_file/encounter/diagnosis.php
+++ b/interface/patient_file/encounter/diagnosis.php
@@ -11,6 +11,7 @@
  */
 
 require_once("../../globals.php");
+require_once("$srcdir/patient.inc");
 
 use OpenEMR\Billing\BillingUtilities;
 use OpenEMR\Common\Acl\AclMain;


### PR DESCRIPTION
#### Short description of what this resolves:
missing `patient.inc` require for charges panel

[bug report via forum](https://community.open-emr.org/t/openemr-ccr-stylesheet-ccr-xsl-error/16770?u=stephenwaite)


