### PR TITLE
Fixed a MySQL Innodb table lock bug

### DIFF
--- a/src/Common/Uuid/UuidRegistry.php
+++ b/src/Common/Uuid/UuidRegistry.php
@@ -25,6 +25,7 @@
 
 namespace OpenEMR\Common\Uuid;
 
+use Exception;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Logging\EventAuditLogger;
 use Ramsey\Uuid\Codec\TimestampFirstCombCodec;


### PR DESCRIPTION
If an exception is thrown in generating the UUIDs the tables were being
locked through an open transaction.  PHP did not have the Exception
class imported so SqlQueryException was not being caught, fatal error
occurred and the transaction was left open.

Fixing the import now lets the transaction be caught and then roll backed.  It looks like there is also a timing element involved as I had difficulty reproducing the bug. Regardless we need to catch the exception and roll back the uuid transactions if a sql query exception is thrown.
