### PR TITLE
Fixes #4497 - FHIR search via POST

### DIFF
--- a/src/Common/Acl/AccessDeniedException.php
+++ b/src/Common/Acl/AccessDeniedException.php
@@ -25,8 +25,10 @@ class AccessDeniedException extends \Exception
      */
     private $subCategory;
 
-    public function __construct($requiredSection, $subCategory = '', $message = "", $code = 0, Throwable $previous = null)
+    public function __construct(string $requiredSection, $subCategory = '', $message = "", $code = 0, Throwable $previous = null)
     {
+        $this->requiredSection = $requiredSection;
+        $this->subCategory = $subCategory;
         if (empty($message)) {
             $message = xlt('ACL check failed');
         }

--- a/src/Common/Http/HttpRestRouteHandler.php
+++ b/src/Common/Http/HttpRestRouteHandler.php
@@ -31,8 +31,23 @@ class HttpRestRouteHandler
                 , 'user' => $restRequest->getRequestUserUUID(), 'role' => $restRequest->getRequestUserRole()
                 , 'client' => $restRequest->getClientId(), 'apiType' => $restRequest->getApiType()
                 , 'route' => $restRequest->getRequestPath()
+                , 'queryParams' => $restRequest->getQueryParams()
             ]
         );
+
+        if ($dispatchRestRequest->isFhir() && self::isFhirSearchRequest($dispatchRestRequest)) {
+            (new SystemLogger())->debug("HttpRestRouteHandler::dispatch() FHIR POST _search request needs normalization");
+            $dispatchRestRequest = self::normalizeFhirSearchRequest($dispatchRestRequest);
+            (new SystemLogger())->debug(
+                "HttpRestRouteHandler::dispatch() request normalized",
+                ['resource' => $dispatchRestRequest->getResource(), 'method' => $dispatchRestRequest->getRequestMethod()
+                    , 'user' => $dispatchRestRequest->getRequestUserUUID(), 'role' => $dispatchRestRequest->getRequestUserRole()
+                    , 'client' => $dispatchRestRequest->getClientId(), 'apiType' => $dispatchRestRequest->getApiType()
+                    , 'route' => $dispatchRestRequest->getRequestPath()
+                    , 'queryParams' => $dispatchRestRequest->getQueryParams()
+                ]
+            );
+        }
 
         $route = $dispatchRestRequest->getRequestPath();
         $request_method = $dispatchRestRequest->getRequestMethod();
@@ -142,6 +157,47 @@ class HttpRestRouteHandler
             }
         }
         echo $response->getBody()->getContents();
+    }
+
+    private static function isFhirSearchRequest(HttpRestRequest $dispatchRestRequest): bool
+    {
+        return $dispatchRestRequest->isFhirSearchRequest();
+    }
+
+    private static function normalizeFhirSearchRequest(HttpRestRequest $dispatchRestRequest): HttpRestRequest
+    {
+
+        // in FHIR a POST request to a resource/_search is identical to the equivalent GET request with parameters.
+        // POST requests are application/x-www-form-urlencoded and parameters may appear both in the URL and the request
+        // body. The spec says that putting requests into both the body and query string is the same as repeating the
+        // parameter.  In our case we treat the parameter as a union search if it appears in both the query string and
+        // the post body.
+        $normalizedRequest = clone $dispatchRestRequest;
+        // chop off the back
+        $pos = strripos($dispatchRestRequest->getRequestPath(), "/_search");
+        if ($pos === false) {
+            throw new \BadMethodCallException("Attempted to normalize search request on a path that does not contain search");
+        }
+
+        $requestPath = substr($dispatchRestRequest->getRequestPath(), 0, $pos);
+        $normalizedRequest->setRequestPath($requestPath);
+        $queryVars = $normalizedRequest->getQueryParams();
+        $normalizedRequest->setRequestMethod("GET");
+
+        // grab any post vars and stuff them into our query vars
+        // @see https://www.hl7.org/fhir/http.html#search
+        if (!empty($_POST)) {
+            foreach ($_POST as $key => $value) {
+                if (isset($queryVars[$key])) {
+                    $queryVars[$key] = is_array($queryVars[$key]) ? $queryVars[$key] : [$queryVars[$key]];
+                    $queryVars[$key][] = $value;
+                } else {
+                    $queryVars[$key] = $value;
+                }
+            }
+        }
+        $normalizedRequest->setQueryParams($queryVars);
+        return $normalizedRequest;
     }
 
     /**


### PR DESCRIPTION
Map the get requests onto a post operation for FHIR get.  Saved us
from having to duplicate all the routes just to deal with a simple
_search parameter.

Also fixed an issue where ACL exceptions were not being logged properly.
