### PR TITLE
Implemented duplicate patients management.

### DIFF
--- a/contrib/util/dupscore.cli.php
+++ b/contrib/util/dupscore.cli.php
@@ -54,13 +54,13 @@ if (stripos(PHP_OS, 'WIN') === 0) {
     $args['webdir'] = str_replace("\\", "/", $args['webdir']);
 }
 
-// Bring in the getDupScoreSQL() function.
-require_once($args['webdir'] . "/library/dupscore.inc.php");
-
 // Bring in some libraries and settings shared with web scripts.
 $_GET['site'] = $args['site'];
 $ignoreAuth = 1;
 require_once($args['webdir'] . "/interface/globals.php");
+
+// Bring in the getDupScoreSQL() function.
+require_once("$srcdir/dupscore.inc.php");
 
 $endtime = time() + 365 * 24 * 60 * 60; // a year from now
 if (!empty($args['maxmins'])) {
@@ -83,7 +83,7 @@ while (!$finished && time() < $endtime) {
     $query1 = "SELECT p1.pid, MAX(" . getDupScoreSQL() . ") AS dupscore" .
         " FROM patient_data AS p1, patient_data AS p2" .
         " WHERE p1.dupscore = -9 AND p2.pid < p1.pid" .
-        " GROUP BY p1.pid ORDER BY p1.pid LIMIT $querylimit";
+        " GROUP BY p1.pid ORDER BY p1.pid LIMIT " . escape_limit($querylimit);
 
     // echo "$query1\n"; // debugging
 

--- a/contrib/util/dupscore.cli.php
+++ b/contrib/util/dupscore.cli.php
@@ -1,0 +1,153 @@
+<?php
+
+/**
+ * CLI script to compute patient duplication scores in patient_data.dupscore.
+ * The score is a measure of the likelihood that the patient is a duplicate of
+ * some patient created before it. Optional arguments specifying values are:
+ *
+ * --webdir   The full path to the OpenEMR web directory. Defaults to the directory
+ *            two levels below that of this script.
+ * --site     The site ID. Defaults to "default".
+ * --maxmins  The maximum number of minutes to run. Defaults to 60. Use 0 for no limit.
+ *
+ * A "-q" argument (no value) suppresses messages on stdout.
+ * A "-c" argument (no value) clears existing scores to recompute all of them;
+ * except scores of -1 are not cleared because they are manually assigned.
+ *
+ * Because we are comparing every patient with every other patient, this script can
+ * run for a very long time with a large database. Thus we want to do it offline.
+ * If --maxmins is exceeded the script will terminate but may be run again to resume
+ * where it left off.
+ *
+ * A common usage is:
+ * php /var/www/html/openemr/contrib/util/dupscore.cli.php --maxmins=240
+ *
+ * Here is a sample crontab entry to automatically run up to 2 hours nightly:
+ * 3 1 * * * root php /var/www/html/openemr/contrib/util/dupscore.cli.php -q --maxmins=120
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Rod Roark <rod@sunsetsystems.com>
+ * @copyright Copyright (c) 2021 Rod Roark <rod@sunsetsystems.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+$querylimit = 1000;
+
+function sqlExec($link, $query)
+{
+    if (!mysqli_query($link, $query)) {
+        die("Query failed: $query\n");
+    }
+    return true;
+}
+
+function sqlSelect($link, $query)
+{
+    $res = mysqli_query($link, $query);
+    if (!$res) {
+        die("Query failed: $query\n");
+    }
+    return $res;
+}
+
+function sqlSelectOne($link, $query)
+{
+    $res = sqlSelect($link, $query);
+    $row = mysqli_fetch_assoc($res);
+    mysqli_free_result($res);
+    return $row;
+}
+
+$args = getopt('cq', array('webdir:', 'site:', 'maxmins:'));
+
+// print_r($args); // debugging
+
+$args['webdir'] = $args['webdir'] ?? dirname(dirname(dirname(__FILE__)));
+$args['site'] = $args['site'] ?? 'default';
+$args['maxmins'] = floatval($args['maxmins'] ?? 60);
+
+if (stripos(PHP_OS, 'WIN') === 0) {
+    $args['webdir'] = str_replace("\\", "/", $args['webdir']);
+}
+
+$confname = $args['webdir'] . "/sites/default/sqlconf.php";
+if (!is_file($confname)) {
+    die("File not found: " . $confname . "\n");
+}
+
+// Bring in the getDupScoreSQL() function.
+require_once($args['webdir'] . "/library/dupscore.inc.php");
+
+$link = false;
+include($confname);
+$link = mysqli_connect($host, $login, $pass, $dbase, $port);
+if (empty($link)) {
+    die("Failed to open database '$dbase'\n");
+}
+
+if (!isset($args['q'])) {
+    echo "Opened database '$dbase'.\n";
+}
+
+sqlExec($link, "SET sql_mode = ''");
+
+$endtime = time() + 365 * 24 * 60 * 60; // a year from now
+if (!empty($args['maxmins'])) {
+    $endtime = time() + $args['maxmins'] * 60;
+}
+
+if (isset($args['c'])) {
+    // Note -1 means the patient is manually flagged as not a duplicate.
+    sqlExec($link, "UPDATE patient_data SET dupscore = -9 WHERE dupscore != -1");
+    if (!isset($args['q'])) {
+        echo "All scores have been cleared.\n";
+    }
+}
+
+$count = 0;
+$finished = false;
+
+while (!$finished && time() < $endtime) {
+    $scores = array();
+    $query1 = "SELECT p1.pid, MAX(" . getDupScoreSQL() . ") AS dupscore" .
+        " FROM patient_data AS p1, patient_data AS p2" .
+        " WHERE p1.dupscore = -9 AND p2.pid < p1.pid" .
+        " GROUP BY p1.pid ORDER BY p1.pid LIMIT $querylimit";
+
+    // echo "$query1\n"; // debugging
+
+    $res1 = sqlSelect($link, $query1);
+    while ($row1 = mysqli_fetch_assoc($res1)) {
+        $scores[$row1['pid']] = $row1['dupscore'];
+    };
+
+    // print_r($scores); // debugging
+
+    mysqli_free_result($res1);
+    foreach ($scores as $pid => $score) {
+        sqlExec($link, "UPDATE patient_data SET dupscore = $score WHERE pid = $pid");
+        ++$count;
+    }
+    if (!isset($args['q']) && count($scores) > 0) {
+        echo "$count... ";
+    }
+    if (count($scores) < $querylimit) {
+        $finished = true;
+    }
+}
+
+if (!isset($args['q'])) {
+    if (!$count) {
+        echo "No patients without scores were found.";
+    }
+    if ($finished) {
+        echo "\nAll done.\n";
+    } else {
+        echo "\nThis run is incomplete due to time expiration.\n";
+    }
+}
+
+if (!$finished) {
+    exit(1);
+}

--- a/contrib/util/dupscore.cli.php
+++ b/contrib/util/dupscore.cli.php
@@ -6,13 +6,15 @@
  * some patient created before it. Optional arguments specifying values are:
  *
  * --webdir   The full path to the OpenEMR web directory. Defaults to the directory
- *            two levels below that of this script.
+ *            two levels above that of this script.
  * --site     The site ID. Defaults to "default".
  * --maxmins  The maximum number of minutes to run. Defaults to 60. Use 0 for no limit.
  *
- * A "-q" argument (no value) suppresses messages on stdout.
- * A "-c" argument (no value) clears existing scores to recompute all of them;
- * except scores of -1 are not cleared because they are manually assigned.
+ * Arguments not having a value may be:
+ * 
+ * -q         Suppresses messages on stdout.
+ * -c         Clears existing scores to recompute all of them; except scores of -1 
+ *            are not cleared because they are manually assigned.
  *
  * Because we are comparing every patient with every other patient, this script can
  * run for a very long time with a large database. Thus we want to do it offline.
@@ -32,6 +34,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+// The number of scores to compute between tests for time expiration.
 $querylimit = 1000;
 
 function sqlExec($link, $query)
@@ -71,7 +74,7 @@ if (stripos(PHP_OS, 'WIN') === 0) {
     $args['webdir'] = str_replace("\\", "/", $args['webdir']);
 }
 
-$confname = $args['webdir'] . "/sites/default/sqlconf.php";
+$confname = $args['webdir'] . "/sites/" . $args['site'] . "/sqlconf.php";
 if (!is_file($confname)) {
     die("File not found: " . $confname . "\n");
 }
@@ -121,8 +124,6 @@ while (!$finished && time() < $endtime) {
     while ($row1 = mysqli_fetch_assoc($res1)) {
         $scores[$row1['pid']] = $row1['dupscore'];
     };
-
-    // print_r($scores); // debugging
 
     mysqli_free_result($res1);
     foreach ($scores as $pid => $score) {

--- a/contrib/util/dupscore.cli.php
+++ b/contrib/util/dupscore.cli.php
@@ -1,3 +1,4 @@
+#!/usr/bin/php
 <?php
 
 /**
@@ -11,9 +12,9 @@
  * --maxmins  The maximum number of minutes to run. Defaults to 60. Use 0 for no limit.
  *
  * Arguments not having a value may be:
- * 
+ *
  * -q         Suppresses messages on stdout.
- * -c         Clears existing scores to recompute all of them; except scores of -1 
+ * -c         Clears existing scores to recompute all of them; except scores of -1
  *            are not cleared because they are manually assigned.
  *
  * Because we are comparing every patient with every other patient, this script can

--- a/interface/main/tabs/menu/menus/standard.json
+++ b/interface/main/tabs/menu/menus/standard.json
@@ -852,7 +852,7 @@
             "requirement": 0,
             "acl_req": [
               "admin",
-              "delete"
+              "super"
             ]
           },
           {
@@ -864,7 +864,7 @@
             "requirement": 0,
             "acl_req": [
               "admin",
-              "delete"
+              "super"
             ]
           }
         ],
@@ -873,10 +873,6 @@
           [
             "admin",
             "super"
-          ],
-          [
-            "admin",
-            "delete"
           ]
         ]
       },

--- a/interface/main/tabs/menu/menus/standard.json
+++ b/interface/main/tabs/menu/menus/standard.json
@@ -852,7 +852,19 @@
             "requirement": 0,
             "acl_req": [
               "admin",
-              "super"
+              "delete"
+            ]
+          },
+          {
+            "label": "Manage Duplicates",
+            "menu_id": "adm0",
+            "target": "adm",
+            "url": "/interface/patient_file/manage_dup_patients.php",
+            "children": [],
+            "requirement": 0,
+            "acl_req": [
+              "admin",
+              "delete"
             ]
           }
         ],
@@ -861,6 +873,10 @@
           [
             "admin",
             "super"
+          ],
+          [
+            "admin",
+            "delete"
           ]
         ]
       },

--- a/interface/patient_file/manage_dup_patients.php
+++ b/interface/patient_file/manage_dup_patients.php
@@ -73,15 +73,15 @@ function displayRow($row, $pid = '')
     ?>
  <tr bgcolor='<?php echo $bgcolor; ?>'>
   <td class="detail" bgcolor="#dddddd">
-   <select onchange='selchange(this, <?php echo "$pid, " . $row['pid']; ?>)' style='width:100%'>
+   <select onchange='selchange(this, <?php echo attr_js($pid); ?>, <?php echo attr_js($row['pid']); ?>)' style='width:100%'>
     <?php echo $options; // this is html and already escaped as required ?>
    </select>
   </td>
   <td class="detail" align="right">
     <?php echo text($myscore); ?>
   </td>
-  <td class="detail" align="right" onclick="openNewTopWindow(<?php echo $row['pid']; ?>)"
-    title="Click to open in a new window or tab" style="color:blue;cursor:pointer">
+  <td class="detail" align="right" onclick="openNewTopWindow(<?php echo attr_js($row['pid']); ?>)"
+    title="<?php echo xla('Click to open in a new window or tab'); ?>" style="color:blue;cursor:pointer">
     <?php echo text($row['pid']); ?>
   </td>
   <td class="detail">
@@ -91,7 +91,7 @@ function displayRow($row, $pid = '')
     <?php echo text($ptname); ?>
   </td>
   <td class="detail">
-    <?php echo oeFormatShortDate($row['DOB']); ?>
+    <?php echo text(oeFormatShortDate($row['DOB'])); ?>
   </td>
   <td class="detail">
     <?php echo text($row['ss']); ?>
@@ -103,7 +103,7 @@ function displayRow($row, $pid = '')
     <?php echo text($phones); ?>
   </td>
   <td class="detail">
-    <?php echo oeFormatShortDate($row['regdate']); ?>
+    <?php echo text(oeFormatShortDate($row['regdate'])); ?>
   </td>
   <td class="detail">
     <?php echo text($facname); ?>
@@ -121,8 +121,8 @@ if (!empty($_POST)) {
     }
 }
 
-if (!AclMain::aclCheckCore('admin', 'delete')) {
-    die(xl("Unauthorized access."));
+if (!AclMain::aclCheckCore('admin', 'super')) {
+    die(xlt("Unauthorized access."));
 }
 
 $scorecalc = getDupScoreSQL();
@@ -149,10 +149,6 @@ table.mymaintable td {
 
 </style>
 
-<script type="text/javascript" src="../../library/textformat.js?v=<?php echo $v_js_includes; ?>"></script>
-<script type="text/javascript" src="../../library/dialog.js?v=<?php echo $v_js_includes; ?>"></script>
-<script type="text/javascript" src="../../library/js/jquery-1.9.1.min.js"></script>
-
 <script>
 
 $(function () {
@@ -161,8 +157,6 @@ $(function () {
         oeFixedHeaderSetup(document.getElementById('mymaintable'));
     }
 });
-
-var mypcc = '<?php echo $GLOBALS['phone_country_code'] ?>';
 
 function openNewTopWindow(pid) {
  document.fnew.patientID.value = pid;
@@ -175,10 +169,10 @@ function selchange(sel, toppid, rowpid) {
   if (sel.value == '') return;
   top.restoreSession();
   if (sel.value == 'MK') {
-    window.location = 'merge_patients.php?pid1=' + rowpid + '&pid2=' + toppid;
+    window.location = 'merge_patients.php?pid1=' + encodeURIComponent(rowpid) + '&pid2=' + encodeURIComponent(toppid);
   }
   else if (sel.value == 'MD') {
-    window.location = 'merge_patients.php?pid1=' + toppid + '&pid2=' + rowpid;
+    window.location = 'merge_patients.php?pid1=' + encodeURIComponent(toppid) + '&pid2=' + encodeURIComponent(rowpid);
   }
   else {
     // Currently 'U' and 'R' actions are supported and rowpid is meaningless.
@@ -295,7 +289,7 @@ while ($row1 = sqlFetchArray($res1)) {
 
 <!-- form used to open a new top level window when a patient row is clicked -->
 <form name='fnew' method='post' target='_blank'
- action='../main/main_screen.php?auth=login&site=<?php echo attr($_SESSION['site_id']); ?>'>
+ action='../main/main_screen.php?auth=login&site=<?php echo attr_url($_SESSION['site_id']); ?>'>
 <input type="hidden" name="csrf_token_form" value="<?php echo attr(CsrfUtils::collectCsrfToken()); ?>" />
 <input type='hidden' name='patientID' value='0' />
 </form>

--- a/interface/patient_file/manage_dup_patients.php
+++ b/interface/patient_file/manage_dup_patients.php
@@ -12,7 +12,6 @@
 
 require_once("../globals.php");
 require_once("$srcdir/patient.inc");
-require_once("$srcdir/formatting.inc.php");
 require_once("$srcdir/options.inc.php");
 
 use OpenEMR\Common\Acl\AclMain;

--- a/interface/patient_file/manage_dup_patients.php
+++ b/interface/patient_file/manage_dup_patients.php
@@ -1,0 +1,304 @@
+<?php
+
+/*
+ * This tool helps with identifying and merging duplicate patients.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Rod Roark <rod@sunsetsystems.com>
+ * @copyright Copyright (c) 2017-2021 Rod Roark <rod@sunsetsystems.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+require_once("../globals.php");
+require_once("$srcdir/patient.inc");
+require_once("$srcdir/formatting.inc.php");
+require_once("$srcdir/options.inc.php");
+
+use OpenEMR\Common\Acl\AclMain;
+use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Core\Header;
+use OpenEMR\Services\FacilityService;
+
+$firsttime = true;
+
+function displayRow($row, $pid = '')
+{
+    global $firsttime;
+
+    $bgcolor = '#ffdddd';
+    $myscore = '';
+    $options = '';
+
+    if (empty($pid)) {
+        $pid = $row['pid'];
+    }
+
+    if (isset($row['myscore'])) {
+        $myscore = $row['myscore'];
+        $options = "<option value=''></option>" .
+        "<option value='MK'>" . xlt('Merge and Keep') . "</option>" .
+        "<option value='MD'>" . xlt('Merge and Discard') . "</option>";
+    } else {
+        $myscore = $row['dupscore'];
+        $options = "<option value=''></option>" .
+        "<option value='U'>" . xlt('Mark as Unique') . "</option>" .
+        "<option value='R'>" . xlt('Recompute Score') . "</option>";
+        if (!$firsttime) {
+            echo " <tr bgcolor='#dddddd'><td class='detail' colspan='12'>&nbsp;</td></tr>\n";
+        }
+    }
+
+    $firsttime = false;
+    $ptname = $row['lname'] . ', ' . $row['fname'] . ' ' . $row['mname'];
+    $phones = array();
+    if (trim($row['phone_home'])) {
+        $phones[] = trim($row['phone_home']);
+    }
+    if (trim($row['phone_biz' ])) {
+        $phones[] = trim($row['phone_biz' ]);
+    }
+    if (trim($row['phone_cell'])) {
+        $phones[] = trim($row['phone_cell']);
+    }
+    $phones = implode(', ', $phones);
+
+    $facname = '';
+    if ($row['home_facility']) {
+        $facrow = getFacility($row['home_facility']);
+        if (!empty($facrow['name'])) {
+            $facname = $facrow['name'];
+        }
+    }
+    ?>
+ <tr bgcolor='<?php echo $bgcolor; ?>'>
+  <td class="detail" bgcolor="#dddddd">
+   <select onchange='selchange(this, <?php echo "$pid, " . $row['pid']; ?>)' style='width:100%'>
+    <?php echo $options; // this is html and already escaped as required ?>
+   </select>
+  </td>
+  <td class="detail" align="right">
+    <?php echo text($myscore); ?>
+  </td>
+  <td class="detail" align="right" onclick="openNewTopWindow(<?php echo $row['pid']; ?>)"
+    title="Click to open in a new window or tab" style="color:blue;cursor:pointer">
+    <?php echo text($row['pid']); ?>
+  </td>
+  <td class="detail">
+    <?php echo text($row['pubpid']); ?>
+  </td>
+  <td class="detail">
+    <?php echo text($ptname); ?>
+  </td>
+  <td class="detail">
+    <?php echo oeFormatShortDate($row['DOB']); ?>
+  </td>
+  <td class="detail">
+    <?php echo text($row['ss']); ?>
+  </td>
+  <td class="detail">
+    <?php echo text($row['email']); ?>
+  </td>
+  <td class="detail">
+    <?php echo text($phones); ?>
+  </td>
+  <td class="detail">
+    <?php echo oeFormatShortDate($row['regdate']); ?>
+  </td>
+  <td class="detail">
+    <?php echo text($facname); ?>
+  </td>
+  <td class="detail">
+    <?php echo text($row['street']); ?>
+  </td>
+ </tr>
+    <?php
+}
+
+if (!empty($_POST)) {
+    if (!CsrfUtils::verifyCsrfToken($_POST["csrf_token_form"])) {
+        CsrfUtils::csrfNotVerified();
+    }
+}
+
+if (!AclMain::aclCheckCore('admin', 'delete')) {
+    die(xl("Unauthorized access."));
+}
+
+$scorecalc = getDupScoreSQL();
+?>
+<html>
+<head>
+<title><?php echo xlt('Duplicate Patient Management') ?></title>
+
+    <?php Header::setupHeader(['report-helper']); ?>
+
+<style type="text/css">
+
+ .dehead { color:#000000; font-family:sans-serif; font-size:10pt; font-weight:bold }
+ .detail { color:#000000; font-family:sans-serif; font-size:10pt; font-weight:normal }
+ .delink { color:#0000cc; font-family:sans-serif; font-size:10pt; font-weight:normal; cursor:pointer }
+
+table.mymaintable, table.mymaintable td {
+ border: 1px solid #aaaaaa;
+ border-collapse: collapse;
+}
+table.mymaintable td {
+ padding: 1pt 4pt 1pt 4pt;
+}
+
+</style>
+
+<script type="text/javascript" src="../../library/textformat.js?v=<?php echo $v_js_includes; ?>"></script>
+<script type="text/javascript" src="../../library/dialog.js?v=<?php echo $v_js_includes; ?>"></script>
+<script type="text/javascript" src="../../library/js/jquery-1.9.1.min.js"></script>
+
+<script>
+
+$(function () {
+    // Enable fixed headers when scrolling the report.
+    if (window.oeFixedHeaderSetup) {
+        oeFixedHeaderSetup(document.getElementById('mymaintable'));
+    }
+});
+
+var mypcc = '<?php echo $GLOBALS['phone_country_code'] ?>';
+
+function openNewTopWindow(pid) {
+ document.fnew.patientID.value = pid;
+ top.restoreSession();
+ document.fnew.submit();
+}
+
+function selchange(sel, toppid, rowpid) {
+  var f = document.forms[0];
+  if (sel.value == '') return;
+  top.restoreSession();
+  if (sel.value == 'MK') {
+    window.location = 'merge_patients.php?pid1=' + rowpid + '&pid2=' + toppid;
+  }
+  else if (sel.value == 'MD') {
+    window.location = 'merge_patients.php?pid1=' + toppid + '&pid2=' + rowpid;
+  }
+  else {
+    // Currently 'U' and 'R' actions are supported and rowpid is meaningless.
+    f.form_action.value = sel.value;
+    f.form_toppid.value = toppid;
+    f.form_rowpid.value = rowpid;
+    f.submit();
+  }
+}
+
+</script>
+
+</head>
+
+<body style='margin: 2em; background-color: #dddddd' >
+<center>
+
+<h2><?php echo xlt('Duplicate Patient Management')?></h2>
+
+<form method='post' action='manage_dup_patients.php'>
+<input type="hidden" name="csrf_token_form" value="<?php echo attr(CsrfUtils::collectCsrfToken()); ?>" />
+
+<table border='0' cellpadding='3'>
+ <tr>
+  <td align='center'>
+   <input type='submit' name='form_refresh' value="<?php echo xla('Refresh') ?>">
+   &nbsp;
+   <input type='button' value='<?php echo xla('Print'); ?>' onclick='window.print()' />
+  </td>
+ </tr>
+ <tr>
+  <td height="1">
+  </td>
+ </tr>
+</table>
+
+<table id='mymaintable' class='mymaintable'>
+ <thead>
+  <tr bgcolor="#dddddd">
+   <td class="dehead">
+    <?php echo xlt('Actions'); ?>
+   </td>
+   <td class="dehead" align="right">
+    <?php echo xlt('Score'); ?>
+   </td>
+   <td class="dehead" align="right">
+    <?php echo xlt('Pid'); ?>
+   </td>
+   <td class="dehead">
+    <?php echo xlt('ID'); ?>
+   </td>
+   <td class="dehead">
+    <?php echo xlt('Name'); ?>
+   </td>
+   <td class="dehead">
+    <?php echo xlt('DOB'); ?>
+   </td>
+   <td class="dehead">
+    <?php echo xlt('SSN'); ?>
+   </td>
+   <td class="dehead">
+    <?php echo xlt('Email'); ?>
+   </td>
+   <td class="dehead">
+    <?php echo xlt('Telephone'); ?>
+   </td>
+   <td class="dehead">
+    <?php echo xlt('Registered'); ?>
+   </td>
+   <td class="dehead">
+    <?php echo xlt('Home Facility'); ?>
+   </td>
+   <td class="dehead">
+    <?php echo xlt('Address'); ?>
+   </td>
+  </tr>
+ </thead>
+ <tbody>
+<?php
+
+$form_action = $_POST['form_action'] ?? '';
+
+if ($form_action == 'U') {
+    sqlStatement(
+        "UPDATE patient_data SET dupscore = -1 WHERE pid = ?",
+        array($_POST['form_toppid'])
+    );
+} else if ($form_action == 'R') {
+    updateDupScore($_POST['form_toppid']);
+}
+
+$query = "SELECT * FROM patient_data WHERE dupscore > 7 " .
+    "ORDER BY dupscore DESC, pid DESC LIMIT 100";
+$res1 = sqlStatement($query);
+while ($row1 = sqlFetchArray($res1)) {
+    displayRow($row1);
+    $query = "SELECT p2.*, ($scorecalc) AS myscore " .
+    "FROM patient_data AS p1, patient_data AS p2 WHERE " .
+    "p1.pid = ? AND p2.pid < p1.pid AND ($scorecalc) > 7 " .
+    "ORDER BY myscore DESC, p2.pid DESC";
+    $res2 = sqlStatement($query, array($row1['pid']));
+    while ($row2 = sqlFetchArray($res2)) {
+        displayRow($row2, $row1['pid']);
+    }
+}
+?>
+</tbody>
+</table>
+<input type='hidden' name='form_action' value='' />
+<input type='hidden' name='form_toppid' value='0' />
+<input type='hidden' name='form_rowpid' value='0' />
+</form>
+</center>
+
+<!-- form used to open a new top level window when a patient row is clicked -->
+<form name='fnew' method='post' target='_blank'
+ action='../main/main_screen.php?auth=login&site=<?php echo attr($_SESSION['site_id']); ?>'>
+<input type="hidden" name="csrf_token_form" value="<?php echo attr(CsrfUtils::collectCsrfToken()); ?>" />
+<input type='hidden' name='patientID' value='0' />
+</form>
+
+</body>
+</html>

--- a/interface/patient_file/merge_patients.php
+++ b/interface/patient_file/merge_patients.php
@@ -28,7 +28,7 @@ $form_pid2 = empty($_GET['pid2']) ? 0 : intval($_GET['pid2']);
 // Set this to true for production use. If false you will get a "dry run" with no updates.
 $PRODUCTION = true;
 
-if (!AclMain::aclCheckCore('admin', 'delete')) {
+if (!AclMain::aclCheckCore('admin', 'super')) {
     die(xlt('Not authorized'));
 }
 ?>
@@ -322,7 +322,7 @@ if ($form_pid2) {
 
 </p>
 
-<form method='post' action='merge_patients.php?<?php echo "pid1=$form_pid1&pid2=$form_pid2"; ?>'>
+<form method='post' action='merge_patients.php?<?php echo "pid1=" . attr_url($form_pid1) . "&pid2=" . attr_url($form_pid2); ?>'>
 <input type="hidden" name="csrf_token_form" value="<?php echo attr(CsrfUtils::collectCsrfToken()); ?>" />
 <div class="table-responsive">
 <table class="table w-100">
@@ -335,7 +335,7 @@ if ($form_pid2) {
     value=' (<?php echo attr($target_string); ?>)'
     onclick='sel_patient(this, this.form.form_target_pid)'
     title='<?php echo xla('Click to select patient'); ?>' readonly />
-   <input type='hidden' name='form_target_pid' value='<?php echo $target_pid; ?>' />
+   <input type='hidden' name='form_target_pid' value='<?php echo attr($target_pid); ?>' />
   </td>
   <td>
     <?php echo xlt('This is the main chart that is to receive the merged data.'); ?>
@@ -350,7 +350,7 @@ if ($form_pid2) {
     value='<?php echo attr($source_string); ?>'
     onclick='sel_patient(this, this.form.form_source_pid)'
     title='<?php echo xla('Click to select patient'); ?>' readonly />
-   <input type='hidden' name='form_source_pid' value='<?php echo $source_pid; ?>' />
+   <input type='hidden' name='form_source_pid' value='<?php echo attr($source_pid); ?>' />
   </td>
   <td>
     <?php echo xlt('This is the chart that is to be merged into the main chart and then deleted.'); ?>

--- a/interface/patient_file/merge_patients.php
+++ b/interface/patient_file/merge_patients.php
@@ -8,7 +8,7 @@
  * @link      http://www.open-emr.org
  * @author    Rod Roark <rod@sunsetsystems.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
- * @copyright Copyright (c) 2013 Rod Roark <rod@sunsetsystems.com>
+ * @copyright Copyright (c) 2013-2021 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2018 Brady Miller <brady.g.miller@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
@@ -16,15 +16,19 @@
 set_time_limit(0);
 
 require_once("../globals.php");
+require_once("$srcdir/patient.inc");
 
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
 
+$form_pid1 = empty($_GET['pid1']) ? 0 : intval($_GET['pid1']);
+$form_pid2 = empty($_GET['pid2']) ? 0 : intval($_GET['pid2']);
+
 // Set this to true for production use. If false you will get a "dry run" with no updates.
 $PRODUCTION = true;
 
-if (!AclMain::aclCheckCore('admin', 'super')) {
+if (!AclMain::aclCheckCore('admin', 'delete')) {
     die(xlt('Not authorized'));
 }
 ?>
@@ -160,7 +164,7 @@ if (!empty($_POST['form_submit'])) {
     $tprow = sqlQuery("SELECT * FROM patient_data WHERE pid = ?", array($target_pid));
     $sprow = sqlQuery("SELECT * FROM patient_data WHERE pid = ?", array($source_pid));
 
-  // Do some checking to make sure source and target exist and are the same person.
+    // Do some checking to make sure source and target exist and are the same person.
     if (empty($tprow['pid'])) {
         die(xlt('Target patient not found'));
     }
@@ -169,20 +173,20 @@ if (!empty($_POST['form_submit'])) {
         die(xlt('Source patient not found'));
     }
 
-    if ($tprow['ss'] != $sprow['ss']) {
-        die(xlt('Target and source SSN do not match'));
-    }
-
-    if (empty($tprow['DOB']) || $tprow['DOB'] == '0000-00-00') {
-        die(xlt('Target patient has no DOB'));
-    }
-
-    if (empty($sprow['DOB']) || $sprow['DOB'] == '0000-00-00') {
-        die(xlt('Source patient has no DOB'));
-    }
-
-    if ($tprow['DOB'] != $sprow['DOB']) {
-        die(xlt('Target and source DOB do not match'));
+    // SSN and DOB checking are skipped if we are coming from the dup manager.
+    if (!$form_pid1 || !$form_pid2) {
+        if ($tprow['ss'] != $sprow['ss']) {
+            die(xlt('Target and source SSN do not match'));
+        }
+        if (empty($tprow['DOB']) || $tprow['DOB'] == '0000-00-00') {
+            die(xlt('Target patient has no DOB'));
+        }
+        if (empty($sprow['DOB']) || $sprow['DOB'] == '0000-00-00') {
+            die(xlt('Source patient has no DOB'));
+        }
+        if ($tprow['DOB'] != $sprow['DOB']) {
+            die(xlt('Target and source DOB do not match'));
+        }
     }
 
     $tdocdir = "$OE_SITE_DIR/documents/" . check_file_dir_name($target_pid);
@@ -269,15 +273,48 @@ if (!empty($_POST['form_submit'])) {
             $crow = sqlQuery("SHOW COLUMNS FROM `" . escape_table_name($tblname) . "` WHERE " .
             "`Field` LIKE 'pid' OR `Field` LIKE 'patient_id'");
             if (!empty($crow['Field'])) {
-                  $colname = $crow['Field'];
-                  updateRows($tblname, $colname, $source_pid, $target_pid);
+                $colname = $crow['Field'];
+                updateRows($tblname, $colname, $source_pid, $target_pid);
+                // Note employer_data is included here; its rows are never deleted and the
+                // most recent row for each patient is the one that is normally relevant.
             }
         }
     }
 
+    // Recompute dupscore for target patient.
+    updateDupScore($target_pid);
+
     echo "<br />" . xlt('Merge complete.') . "</div>";
 
+    echo "<br />&nbsp;<br />\n";
+    echo "<input type='button' class='btn btn-primary' value='" . xla('Go to Duplicate Manager') .
+        "' onclick='window.location = \"manage_dup_patients.php\"' />\n";
+    echo "</body></html>";
+
     exit(0);
+}
+
+
+$target_string = xl('Click to select');
+$source_string = xl('Click to select');
+$target_pid = '0';
+$source_pid = '0';
+
+if ($form_pid1) {
+    $target_pid = $form_pid1;
+    $row = sqlQuery(
+        "SELECT lname, fname FROM patient_data WHERE pid = ?",
+        array($target_pid)
+    );
+    $target_string = $row['lname'] . ', ' . $row['fname'] . " ($target_pid)";
+}
+if ($form_pid2) {
+    $source_pid = $form_pid2;
+    $row = sqlQuery(
+        "SELECT lname, fname FROM patient_data WHERE pid = ?",
+        array($source_pid)
+    );
+    $source_string = $row['lname'] . ', ' . $row['fname'] . " ($source_pid)";
 }
 ?>
 
@@ -285,7 +322,7 @@ if (!empty($_POST['form_submit'])) {
 
 </p>
 
-<form method='post' action='merge_patients.php'>
+<form method='post' action='merge_patients.php?<?php echo "pid1=$form_pid1&pid2=$form_pid2"; ?>'>
 <input type="hidden" name="csrf_token_form" value="<?php echo attr(CsrfUtils::collectCsrfToken()); ?>" />
 <div class="table-responsive">
 <table class="table w-100">
@@ -294,8 +331,11 @@ if (!empty($_POST['form_submit'])) {
     <?php echo xlt('Target Patient') ?>
   </td>
   <td>
-   <input type='text' class="form-control" size='30' name='form_target_patient' value=' (<?php echo xla('Click to select'); ?>)' onclick='sel_patient(this, this.form.form_target_pid)' title='<?php echo xla('Click to select patient'); ?>' readonly />
-   <input type='hidden' name='form_target_pid' value='0' />
+   <input type='text' class="form-control" size='30' name='form_target_patient'
+    value=' (<?php echo attr($target_string); ?>)'
+    onclick='sel_patient(this, this.form.form_target_pid)'
+    title='<?php echo xla('Click to select patient'); ?>' readonly />
+   <input type='hidden' name='form_target_pid' value='<?php echo $target_pid; ?>' />
   </td>
   <td>
     <?php echo xlt('This is the main chart that is to receive the merged data.'); ?>
@@ -307,10 +347,10 @@ if (!empty($_POST['form_submit'])) {
   </td>
   <td>
    <input type='text' class='form-control' size='30' name='form_source_patient'
-    value=' (<?php echo xla('Click to select'); ?>)'
+    value='<?php echo attr($source_string); ?>'
     onclick='sel_patient(this, this.form.form_source_pid)'
     title='<?php echo xla('Click to select patient'); ?>' readonly />
-   <input type='hidden' name='form_source_pid' value='0' />
+   <input type='hidden' name='form_source_pid' value='<?php echo $source_pid; ?>' />
   </td>
   <td>
     <?php echo xlt('This is the chart that is to be merged into the main chart and then deleted.'); ?>
@@ -321,7 +361,7 @@ if (!empty($_POST['form_submit'])) {
 </div>
 </form>
 <div class="jumbotron">
-    <p class="font-weight-bold"><?php echo xlt('This utility is experimental. Back up your database and documents before using it!'); ?></p>
+    <p class="font-weight-bold"><?php echo xlt('Be careful with this feature. Back up your database and documents before using it!'); ?></p>
 
 <?php if (!$PRODUCTION) { ?>
 <p><?php echo xlt('This will be a "dry run" with no physical data updates.'); ?></p>
@@ -333,7 +373,9 @@ if (!empty($_POST['form_submit'])) {
 
 <p><?php echo xlt('The second ("source") chart will have its demographics, history and insurance sections discarded.  Its other data will be merged into the target chart.'); ?></p>
 
+<?php if (!$form_pid1 || !$form_pid2) { ?>
 <p><?php echo xlt('The merge will not run unless SSN and DOB for the two charts are identical. DOBs cannot be empty.'); ?></p>
+<?php } ?>
 </div>
 </div>
 </body>

--- a/library/dupscore.inc.php
+++ b/library/dupscore.inc.php
@@ -17,24 +17,28 @@ function getDupScoreSQL()
 {
     return
     //  5 First name
-    "(TRIM(p1.fname) = TRIM(p2.fname)) * 5 + " .
+    "5 * (SOUNDEX(p1.fname) = SOUNDEX(p2.fname)) + " .
     //  3 Last name
-    "(p1.lname = p2.lname) * 3 + " .
+    "3 * (SOUNDEX(p1.lname) = SOUNDEX(p2.lname)) + " .
     //  4 Any phone number
-    "((TRIM(p1.phone_home) != '' AND ( " .
-      "REPLACE(REPLACE(p1.phone_home, '-', ''), ' ', '') = REPLACE(REPLACE(p2.phone_home, '-', ''), ' ', '') OR " .
-      "REPLACE(REPLACE(p1.phone_home, '-', ''), ' ', '') = REPLACE(REPLACE(p2.phone_biz , '-', ''), ' ', '') OR " .
-      "REPLACE(REPLACE(p1.phone_home, '-', ''), ' ', '') = REPLACE(REPLACE(p2.phone_cell, '-', ''), ' ', '')))" .
+    "4 * (" .
+      "(TRIM(p1.phone_home) != '' AND ( " .
+      "REPLACE(REPLACE(p1.phone_home, '-', ''), ' ', '') IN ( " .
+      "REPLACE(REPLACE(p2.phone_home, '-', ''), ' ', ''), " .
+      "REPLACE(REPLACE(p2.phone_biz , '-', ''), ' ', ''), " .
+      "REPLACE(REPLACE(p2.phone_cell, '-', ''), ' ', '')))) " .
     "OR (TRIM(p1.phone_biz) != '' AND ( " .
-      "REPLACE(REPLACE(p1.phone_biz , '-', ''), ' ', '') = REPLACE(REPLACE(p2.phone_biz , '-', ''), ' ', '') OR " .
-      "REPLACE(REPLACE(p1.phone_biz , '-', ''), ' ', '') = REPLACE(REPLACE(p2.phone_cell, '-', ''), ' ', ''))) " .
+      "REPLACE(REPLACE(p1.phone_biz , '-', ''), ' ', '') IN ( " .
+      "REPLACE(REPLACE(p2.phone_biz , '-', ''), ' ', ''), " .
+      "REPLACE(REPLACE(p2.phone_cell, '-', ''), ' ', '')))) " .
     "OR (TRIM(p1.phone_cell) != '' AND ( " .
-      "REPLACE(REPLACE(p1.phone_cell, '-', ''), ' ', '') = REPLACE(REPLACE(p2.phone_cell, '-', ''), ' ', ''))) " .
-    ") * 4 + " .
+      "REPLACE(REPLACE(p1.phone_cell, '-', ''), ' ', '') = " .
+      "REPLACE(REPLACE(p2.phone_cell, '-', ''), ' ', ''))) " .
+    ") + " .
     //  6 Birth date
-    "(p1.DOB IS NOT NULL AND p2.DOB IS NOT NULL AND p1.DOB = p2.DOB) * 6 + " .
-    // 7 Email
-    "(TRIM(p1.email) != '' AND TRIM(p2.email) != '' AND TRIM(p1.email) = TRIM(p2.email)) * 7 + " .
+    "6 * (p1.DOB IS NOT NULL AND p2.DOB IS NOT NULL AND p1.DOB = p2.DOB) + " .
+    //  7 Email
+    "7 * (TRIM(p1.email) != '' AND TRIM(p1.email) = TRIM(p2.email)) + " .
     // 15 Government ID
-    "(TRIM(p1.ss) != '' AND TRIM(p2.ss) != '' AND TRIM(p1.ss) = TRIM(p2.ss)) * 15";
+    "15 * (TRIM(p1.ss) != '' AND TRIM(p1.ss) = TRIM(p2.ss))";
 }

--- a/library/dupscore.inc.php
+++ b/library/dupscore.inc.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Note this may be included by CLI scripts, so don't do anything web-specific here!
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Rod Roark <rod@sunsetsystems.com>
+ * @copyright Copyright (c) 2021 Rod Roark <rod@sunsetsystems.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+// The SQL returned by this function is an expression that computes the duplication
+// score between two patient_data table rows p1 and p2.
+//
+function getDupScoreSQL()
+{
+    return
+    //  5 First name
+    "(TRIM(p1.fname) = TRIM(p2.fname)) * 5 + " .
+    //  3 Last name
+    "(p1.lname = p2.lname) * 3 + " .
+    //  4 Any phone number
+    "((TRIM(p1.phone_home) != '' AND ( " .
+      "REPLACE(REPLACE(p1.phone_home, '-', ''), ' ', '') = REPLACE(REPLACE(p2.phone_home, '-', ''), ' ', '') OR " .
+      "REPLACE(REPLACE(p1.phone_home, '-', ''), ' ', '') = REPLACE(REPLACE(p2.phone_biz , '-', ''), ' ', '') OR " .
+      "REPLACE(REPLACE(p1.phone_home, '-', ''), ' ', '') = REPLACE(REPLACE(p2.phone_cell, '-', ''), ' ', '')))" .
+    "OR (TRIM(p1.phone_biz) != '' AND ( " .
+      "REPLACE(REPLACE(p1.phone_biz , '-', ''), ' ', '') = REPLACE(REPLACE(p2.phone_biz , '-', ''), ' ', '') OR " .
+      "REPLACE(REPLACE(p1.phone_biz , '-', ''), ' ', '') = REPLACE(REPLACE(p2.phone_cell, '-', ''), ' ', ''))) " .
+    "OR (TRIM(p1.phone_cell) != '' AND ( " .
+      "REPLACE(REPLACE(p1.phone_cell, '-', ''), ' ', '') = REPLACE(REPLACE(p2.phone_cell, '-', ''), ' ', ''))) " .
+    ") * 4 + " .
+    //  6 Birth date
+    "(p1.DOB IS NOT NULL AND p2.DOB IS NOT NULL AND p1.DOB = p2.DOB) * 6 + " .
+    // 7 Email
+    "(TRIM(p1.email) != '' AND TRIM(p2.email) != '' AND TRIM(p1.email) = TRIM(p2.email)) * 7 + " .
+    // 15 Government ID
+    "(TRIM(p1.ss) != '' AND TRIM(p2.ss) != '' AND TRIM(p1.ss) = TRIM(p2.ss)) * 15";
+}

--- a/library/patient.inc
+++ b/library/patient.inc
@@ -8,9 +8,10 @@
  * @author    Brady Miller <brady.g.miller@gmail.com>
  * @author    Sherwin Gaddis <sherwingaddis@gmail.com>
  * @author    Stephen Waite <stephen.waite@cmsvt.com>
+ * @author    Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2018-2019 Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2019 Sherwin Gaddis <sherwingaddis@gmail.com>
- * @copyright Copyright (c) 2018-2021 Stephen Waite <stephen.waite@cmsvt.com>
+ * @copyright Copyright (c) 2021 Rod Roark <rod@sunsetsystems.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -18,6 +19,8 @@ use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Services\FacilityService;
 use OpenEMR\Services\PatientService;
 use OpenEMR\Services\SocialHistoryService;
+
+require_once(dirname(__FILE__) . "/dupscore.inc.php");
 
 $facilityService = new FacilityService();
 
@@ -1074,6 +1077,7 @@ function updatePatientData($pid, $new, $create = false)
         $pid === null
     ) {
         $result = $patientService->databaseInsert($new);
+        updateDupScore($result['pid']);
     } else {
         $new['pid'] = $pid;
         $result = $patientService->databaseUpdate($new);
@@ -1794,4 +1798,22 @@ function is_patient_deceased($pid, $date = '')
 
         return $results;
     }
+}
+
+// This computes, sets and returns the dup score for the given patient.
+//
+function updateDupScore($pid)
+{
+    $row = sqlQuery(
+        "SELECT MAX(" . getDupScoreSQL() . ") AS dupscore " .
+        "FROM patient_data AS p1, patient_data AS p2 WHERE " .
+        "p1.pid = ? AND p2.pid < p1.pid",
+        array($pid)
+    );
+    $dupscore = empty($row['dupscore']) ? 0 : $row['dupscore'];
+    sqlStatement(
+        "UPDATE patient_data SET dupscore = ? WHERE pid = ?",
+        array($dupscore, $pid)
+    );
+    return $dupscore;
 }

--- a/library/patient.inc
+++ b/library/patient.inc
@@ -11,6 +11,7 @@
  * @author    Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2018-2019 Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2019 Sherwin Gaddis <sherwingaddis@gmail.com>
+ * @copyright Copyright (c) 2018-2021 Stephen Waite <stephen.waite@cmsvt.com>
  * @copyright Copyright (c) 2021 Rod Roark <rod@sunsetsystems.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */

--- a/sql/6_0_0-to-6_1_0_upgrade.sql
+++ b/sql/6_0_0-to-6_1_0_upgrade.sql
@@ -816,3 +816,7 @@ ALTER TABLE `form_clinical_notes` ADD COLUMN `clinical_notes_category` varchar(1
 #IfRow3D list_options list_id Clinical_Note_Type option_id consultation_note notes LOINC:11488-4
 UPDATE `list_options` SET notes="LOINC:11488-4" WHERE list_id="Clinical_Note_Type" AND option_id="consultation_note" AND notes="LOINC:81222-2";
 #EndIf
+
+#IfMissingColumn patient_data dupscore
+ALTER TABLE `patient_data` ADD COLUMN `dupscore` INT NOT NULL default -9;
+#EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -7207,6 +7207,7 @@ CREATE TABLE `patient_data` (
   `birth_fname` TEXT,
   `birth_lname` TEXT,
   `birth_mname` TEXT,
+  `dupscore` INT NOT NULL default -9,
   UNIQUE KEY `pid` (`pid`),
   UNIQUE KEY `uuid` (`uuid`),
   KEY `id` (`id`)

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@ $v_realpatch = '0';
 // is a database change in the course of development.  It is used
 // internally to determine when a database upgrade is needed.
 //
-$v_database = 400;
+$v_database = 401;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
Identification and correction of duplicate patients involves the following:

 1. Column "dupscore" in the patient_data table was created to contain a value representing
    the likelihood that the patient duplicates any of the patients created earlier (that is,
    with a lesser "pid" value). It may have any of the following values:

    o -9, initially assigned, indicating that it needs to be computed.
    o -1, indicating that the patient has been manually flagged as not duplicating a previous patient.
    o A score in the range 0-40 computed by the SQL expression found in library/dupscore.inc.php.
      A value of 12 or higher is considered to be very likely a duplicate.

 2. The script library/dupscore.inc.php which provides the SQL expression needed for scoring.

 3. The command-line tool contrib/util/dupscore.cli.php which should be run to initially
    assign all patient_data.dupscore values, and may be run from time to time to update
    or recompute them. See the source of that script for its usage syntax.

 4. The web tool Administration -> Patient -> Manage Duplicates.
    For each patient with a dupscore of 7 or higher, it shows below it all the corresponding
    matching patients. Thus you see a collection of patient groups.
    Within each group you can choose to mark the first patient as not a duplicate, or you can
    merge it with one of the other patients. You do that by choosing "Merge and Keep" or
    "Merge and Discard" for the other patient, which brings up the Merge Patients page to
    complete the merge. That page describes in more detail what it will do.

<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:


#### Changes proposed in this pull request:
