### PR TITLE
ccda import memory fix

### DIFF
--- a/contrib/util/ccda_import/import_ccda.php
+++ b/contrib/util/ccda_import/import_ccda.php
@@ -47,9 +47,6 @@ if (php_sapi_name() !== 'cli' || count($argv) != 5) {
     die;
 }
 
-// get around a large ccda data array
-ini_set("memory_limit", -1);
-
 function outputMessage($message)
 {
     echo $message;

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php
@@ -113,6 +113,9 @@ class CarecoordinationController extends AbstractActionController
 
     public function newpatientImportCommandAction()
     {
+        // get around a large ccda data array
+        ini_set("memory_limit", -1);
+
         $request = $this->getRequest();
         if (!$request instanceof ConsoleRequest) {
             throw new RuntimeException('You can only use this action from a console!');


### PR DESCRIPTION
@stephenwaite , Was still getting the memory error every several thousand patients or so with the prior fix. Think is because the main ccda import script is actually running the care coordination script from commandline for each patient import (i.e. running separate php commandline processes, so not using the php settings set in the main ccda import script). This fix is within the separate php process and so far no errors yet so far on about 30K patient imports :)
As an aside, would a script that creates thousands of active users and a large number of facilities be helpful (been starting to look into how to do this).