### PR TITLE
Dynamically resolve host domain Uri for API's and CCDA

### DIFF
--- a/ccdaservice/ccda_gateway.php
+++ b/ccdaservice/ccda_gateway.php
@@ -12,11 +12,11 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-//authenticate for portal or main- never know where it gets used
-
-// Will start the (patient) portal OpenEMR session/cookie.
-
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Services\CDADocumentService;
+
+// authenticate for portal or main- never know where it gets used
+// Will start the (patient) portal OpenEMR session/cookie.
 
 require_once(__DIR__ . "/../src/Common/Session/SessionUtil.php");
 OpenEMR\Common\Session\SessionUtil::portalSessionStart();
@@ -45,7 +45,6 @@ if (!CsrfUtils::verifyCsrfToken($_GET["csrf_token_form"])) {
     CsrfUtils::csrfNotVerified();
 }
 
-$dowhat = $_REQUEST['action'] ?? '';
 if ((!$GLOBALS['ccda_alt_service_enable']) > 0) {
     die("Cda generation service turned off: Verify in Administration->Globals! Click back to return home."); // Die an honorable death!!
 }
@@ -56,73 +55,27 @@ if (!isset($_SESSION['site_id'])) {
 
 session_write_close();
 
-$parameterArray = array();
-//$parameterArray['encounter'];
-$parameterArray['combination'] = $pid;
-$parameterArray['components'] = 'allergies|medications|problems|immunizations|procedures|results|plan_of_care|vitals|social_history|encounters|functional_status|referral|instructions|medical_devices|goals';
-//$parameterArray['sections'];
-$parameterArray['downloadccda'] = "download_ccda";
-$parameterArray['latestccda'] = '0';
-$parameterArray['send_to'] = 'download_all';
-$parameterArray['sent_by_app'] = 'portal';
-$parameterArray['downloadformat'] = 'ccda';
-$parameterArray['ccda_pid'][] = $pid;
-//$parameterArray['me'] = urlencode(session_id());
-$parameterArray['view'] = 0;
-$parameterArray['recipient'] = 'patient'; // emr_direct or hie
-$parameterArray['site'] = $_SESSION ['site_id']; // set to an onsite portal user
+$cdaService = new CDADocumentService();
 
-
-$server_url = $GLOBALS['qualified_site_addr'];
-// CCM returns viewable CCD html file or
-// zip containing a CCDA.xml, CCDA.html and cda.xsl
-$ccdaxml = portalccdafetching($pid, $server_url, $parameterArray, $dowhat);
-
-if ($dowhat === 'dl') {
+if ($_REQUEST['action'] === 'dl') {
+    $ccda_xml = $cdaService->portalGenerateCCDZip($pid);
+    // download zip containing CCDA.xml, CCDA.html and cda.xsl files
     header("Cache-Control: public");
     header("Content-Description: File Transfer");
     header("Content-Disposition: attachment; filename=SummaryofCare.zip");
-    header("Content-Type: application/download");
+    header("Content-Type: application/zip");
     header("Content-Transfer-Encoding: binary");
-    echo $ccdaxml;
+    echo $ccda_xml;
+
     exit;
 }
-// display to new tab opened in home
-echo($ccdaxml);
+if ($_REQUEST['action'] === 'view') {
+    $ccda_xml = $cdaService->portalGenerateCCD($pid);
+    // CCM returns viewable CCD html file
+    // that displays to new tab opened from home
+    echo $ccda_xml;
 
-exit;
-
-function portalccdafetching($pid, $server_url, $parameterArray = [], $action = 'view')
-{
-    $parameters = '';
-    $site_id = $_SESSION['site_id'];
-    $url = $server_url . "/interface/modules/zend_modules/public/encounterccdadispatch/index?site=" .
-        urlencode($site_id) . "&me=" . urlencode(session_id()) .
-        "&param=1&view=1&combination=" . urlencode($pid) . "&recipient=patient";
-    if ($action === 'dl') {
-        $parameters = http_build_query($parameterArray);
-        $url = $server_url . "/interface/modules/zend_modules/public/encounterccdadispatch/index?me=" . urlencode(session_id());
-    }
-    try {
-        $ch = curl_init();
-        curl_setopt($ch, CURLOPT_URL, $url);
-        curl_setopt($ch, CURLOPT_POST, 1);
-        curl_setopt($ch, CURLOPT_POSTFIELDS, $parameters);
-        curl_setopt($ch, CURLOPT_HEADER, 0); // set true for look see
-        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
-        curl_setopt($ch, CURLOPT_COOKIESESSION, true);
-        curl_setopt($ch, CURLOPT_COOKIEJAR, "cookie");
-        curl_setopt($ch, CURLOPT_COOKIEFILE, "cookie");
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
-        //curl_setopt($ch, CURLOPT_COOKIE, 'XDEBUG_SESSION=1'); // debug break on first line in public/index.php
-
-        $result = curl_exec($ch) or die(curl_error($ch));
-        curl_close($ch);
-    } catch (Exception $e) {
-        die($e->getMessage());
-    }
-
-    return $result;
+    exit;
 }
+
+die(xlt("Error. Nothing to do."));

--- a/ccdaservice/ccda_gateway.php
+++ b/ccdaservice/ccda_gateway.php
@@ -73,7 +73,7 @@ $parameterArray['recipient'] = 'patient'; // emr_direct or hie
 $parameterArray['site'] = $_SESSION ['site_id']; // set to an onsite portal user
 
 
-$server_url = resolveHost();
+$server_url = $GLOBALS['qualified_site_addr'];
 // CCM returns viewable CCD html file or
 // zip containing a CCDA.xml, CCDA.html and cda.xsl
 $ccdaxml = portalccdafetching($pid, $server_url, $parameterArray, $dowhat);
@@ -87,7 +87,7 @@ if ($dowhat === 'dl') {
     echo $ccdaxml;
     exit;
 }
-
+// display to new tab opened in home
 echo($ccdaxml);
 
 exit;
@@ -116,7 +116,7 @@ function portalccdafetching($pid, $server_url, $parameterArray = [], $action = '
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
-        curl_setopt($ch, CURLOPT_COOKIE, 'XDEBUG_SESSION=1'); // debug break on first line in public/index.php
+        //curl_setopt($ch, CURLOPT_COOKIE, 'XDEBUG_SESSION=1'); // debug break on first line in public/index.php
 
         $result = curl_exec($ch) or die(curl_error($ch));
         curl_close($ch);
@@ -125,37 +125,4 @@ function portalccdafetching($pid, $server_url, $parameterArray = [], $action = '
     }
 
     return $result;
-}
-
-function resolveHost(): string
-{
-    if (!empty($GLOBALS['site_addr_oath'])) {
-        $host = rtrim(trim($GLOBALS['site_addr_oath']), "/");
-        return rtrim(trim($host . $GLOBALS['webroot']), "/");
-    }
-    $scheme = $_SERVER['REQUEST_SCHEME'] . "://";
-    $possibleHostSources = array('HTTP_X_FORWARDED_HOST', 'HTTP_HOST', 'SERVER_NAME', 'SERVER_ADDR');
-    $sourceTransformations = array(
-        "HTTP_X_FORWARDED_HOST" => function ($value) {
-            $elements = explode(',', $value);
-            return trim(end($elements));
-        }
-    );
-    $host = '';
-    foreach ($possibleHostSources as $source) {
-        if (!empty($host)) {
-            break;
-        }
-        if (empty($_SERVER[$source])) {
-            continue;
-        }
-        $host = $_SERVER[$source];
-        if (array_key_exists($source, $sourceTransformations)) {
-            $host = $sourceTransformations[$source]($host);
-        }
-    }
-    // remove port
-    $host = preg_replace('/:\d+$/', '', trim($host));
-
-    return rtrim(trim($scheme . $host . $GLOBALS['webroot']), "/");
 }

--- a/ccdaservice/ccda_gateway.php
+++ b/ccdaservice/ccda_gateway.php
@@ -17,7 +17,6 @@ use OpenEMR\Services\CDADocumentService;
 
 // authenticate for portal or main- never know where it gets used
 // Will start the (patient) portal OpenEMR session/cookie.
-
 require_once(__DIR__ . "/../src/Common/Session/SessionUtil.php");
 OpenEMR\Common\Session\SessionUtil::portalSessionStart();
 
@@ -66,7 +65,6 @@ if ($_REQUEST['action'] === 'dl') {
     header("Content-Type: application/zip");
     header("Content-Transfer-Encoding: binary");
     echo $ccda_xml;
-
     exit;
 }
 if ($_REQUEST['action'] === 'view') {
@@ -74,8 +72,16 @@ if ($_REQUEST['action'] === 'view') {
     // CCM returns viewable CCD html file
     // that displays to new tab opened from home
     echo $ccda_xml;
+    exit;
+}
+if ($_REQUEST['action'] === 'report_ccd_view') {
+    $ccda_xml = $cdaService->generateCCDHtml($pid);
+    if (stripos($ccda_xml, '/interface/login_screen.php') !== false) {
+        echo(xlt("Error. Not Authorized."));
+        exit;
+    }
+    echo $ccda_xml;
 
     exit;
 }
-
 die(xlt("Error. Nothing to do."));

--- a/interface/modules/zend_modules/public/index.php
+++ b/interface/modules/zend_modules/public/index.php
@@ -18,7 +18,7 @@
 use Laminas\Console\Request as ConsoleRequest;
 
 //fetching controller name and action name from the SOAP request
-$urlArray = explode('/', $_SERVER['REQUEST_URI']);
+$urlArray = explode('/', ($_SERVER['REQUEST_URI'] ?? ''));
 $countUrlArray = count($urlArray);
 preg_match('/\/(\w*)\?/', $_SERVER['REQUEST_URI'], $matches);
 $actionName = $matches[1] ?? '';

--- a/interface/modules/zend_modules/public/index.php
+++ b/interface/modules/zend_modules/public/index.php
@@ -24,9 +24,6 @@ preg_match('/\/(\w*)\?/', $_SERVER['REQUEST_URI'], $matches);
 $actionName = $matches[1] ?? '';
 $controllerName = $urlArray[$countUrlArray - 2] ?? '';
 
-session_id($_REQUEST['me']);
-session_start();
-
 //skipping OpenEMR authentication if the controller is SOAP and action is INDEX
 //SOAP authentication is done in the controller EncounterccdadispatchController
 if (!empty($_REQUEST['recipient']) && ($_REQUEST['recipient'] === 'patient') && $_REQUEST['site'] && $controllerName) {

--- a/interface/modules/zend_modules/public/index.php
+++ b/interface/modules/zend_modules/public/index.php
@@ -24,6 +24,9 @@ preg_match('/\/(\w*)\?/', $_SERVER['REQUEST_URI'], $matches);
 $actionName = $matches[1] ?? '';
 $controllerName = $urlArray[$countUrlArray - 2] ?? '';
 
+session_id($_REQUEST['me']);
+session_start();
+
 //skipping OpenEMR authentication if the controller is SOAP and action is INDEX
 //SOAP authentication is done in the controller EncounterccdadispatchController
 if (!empty($_REQUEST['recipient']) && ($_REQUEST['recipient'] === 'patient') && $_REQUEST['site'] && $controllerName) {
@@ -32,10 +35,16 @@ if (!empty($_REQUEST['recipient']) && ($_REQUEST['recipient'] === 'patient') && 
         session_id($_REQUEST['me']);
         session_start();
     }
-    if ($_SESSION['pid'] && $_SESSION['sessionUser'] == '-patient-' && $_SESSION['portal_init']) {
+    if ($_SESSION['pid'] && $_SESSION['sessionUser'] === '-patient-' && $_SESSION['portal_init']) {
         // Onsite portal was validated and patient authorized and re-validated via forwarded session.
         $ignoreAuth_onsite_portal = true;
     }
+}
+
+if (!empty($_REQUEST['me']) && $_REQUEST['sent_by_app'] === 'core_api') {
+    // pick up already running session from api's
+    session_id($_REQUEST['me']);
+    session_start();
 }
 
 if (php_sapi_name() === 'cli' && count($argv) != 0) {
@@ -50,6 +59,7 @@ if (php_sapi_name() === 'cli' && count($argv) != 0) {
     // Since from command line, set $sessionAllowWrite since need to set site_id session and no benefit to set to false
     $sessionAllowWrite = true;
 }
+
 require_once(__DIR__ . "/../../../globals.php");
 require_once(__DIR__ . "/../../../../library/forms.inc");
 require_once(__DIR__ . "/../../../../library/options.inc.php");

--- a/interface/patient_file/report/patient_report.php
+++ b/interface/patient_file/report/patient_report.php
@@ -20,6 +20,7 @@ require_once("$srcdir/forms.inc");
 require_once("$srcdir/patient.inc");
 
 use OpenEMR\Common\Acl\AclMain;
+use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
 use OpenEMR\Events\PatientReport\PatientReportEvent;
 use OpenEMR\Menu\PatientMenuRole;
@@ -170,6 +171,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                 <br/>
                                 <br/>
                                 <button type="button" class="viewCCD btn btn-primary btn-save btn-sm" value="<?php echo xla('Generate Report'); ?>" ><?php echo xlt('Generate Report'); ?></button>
+                                <button type="button" class="viewNewCCD btn btn-primary btn-save btn-sm" value="<?php echo xla('Generate Report'); ?>" ><?php echo xlt('Generate New Report'); ?></button>
                                 <button type="button" class="viewCCD_download btn btn-primary btn-download btn-sm" value="<?php echo xla('Download'); ?>" ><?php echo xlt('Download'); ?></button>
                                 <?php
                                 if ($GLOBALS['phimail_enable'] == true && $GLOBALS['phimail_ccd_enable'] == true) { ?>
@@ -619,6 +621,23 @@ $(function () {
         raw[0].value = 'pure';
         top.restoreSession();
         $("#ccr_form").submit();
+    });
+    $(".viewNewCCD").click(function() {
+        // there's a lot of ways to do this but for now, we'll go with this!
+        top.restoreSession();
+        let url = './../../../ccdaservice/ccda_gateway.php?action=report_ccd_view&csrf_token_form=' +
+            encodeURIComponent("<?php echo CsrfUtils::collectCsrfToken() ?>");
+        fetch(url, {
+            credentials: 'same-origin',
+            method: 'GET',
+        })
+        .then(response => response.text())
+        .then(response => {
+            let view = window.open('about:blank', '_blank');
+            view.document.write(response);
+            view.document.close();
+            return false;
+        })
     });
     $(".viewCCD").click(function() {
         var ccrAction = document.getElementsByName('ccrAction');

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -2976,7 +2976,7 @@ $GLOBALS_METADATA = array(
         'site_addr_oath' => array(
             xl('Site Address (required for OAuth2, FHIR and CCDA)'),
             'text',
-            'https://' . $_SERVER['HTTP_HOST'] . $GLOBALS['webroot'],
+            $ResolveServerHost(), // anonymous function in globals.php
             xl('Site Address (required for OAuth2, FHIR and CCDA). Example is') . ' https://localhost:8300 .'
         ),
 

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -2974,10 +2974,10 @@ $GLOBALS_METADATA = array(
     'Connectors' => array(
 
         'site_addr_oath' => array(
-            xl('Site Address (required for OAuth2, FHIR and CCDA)'),
+            xl('Site Address Override (if needed for OAuth2, FHIR or CCDA)'),
             'text',
-            $ResolveServerHost(), // anonymous function in globals.php
-            xl('Site Address (required for OAuth2, FHIR and CCDA). Example is') . ' https://localhost:8300 .'
+            '',
+            xl('Only need to set this if the server is not providing the correct host for OAuth2, FHIR or CCDA. Example is') . ' https://localhost:8300 .'
         ),
 
         'rest_api' => array(

--- a/portal/patient/_machine_config.php
+++ b/portal/patient/_machine_config.php
@@ -68,7 +68,7 @@ GlobalConfig::$CONNECTION_SETTING->BootstrapSQL = "SET sql_mode = '', time_zone 
  * the root url of the application with trailing slash, for example http://localhost/patient/
  * default is relative base address
  */
-GlobalConfig::$WEB_ROOT = resolveHost();
+GlobalConfig::$WEB_ROOT = $GLOBALS['qualified_site_addr'];
 if ($GLOBALS['portal_onsite_two_basepath']) {
     GlobalConfig::$ROOT_URL = GlobalConfig::$WEB_ROOT . '/portal/patient/';
 } else {
@@ -85,37 +85,4 @@ if ($GLOBALS['portal_onsite_two_basepath']) {
 // if you receive this error then either install multibyte extensions or set Multibyte to false
 if (GlobalConfig::$CONNECTION_SETTING->Multibyte && !function_exists('mb_strlen')) {
     die('<html>Multibyte extensions are not installed but Multibyte is set to true in _machine_config.php</html>');
-}
-
-function resolveHost(): string
-{
-    if (!empty($GLOBALS['site_addr_oath'])) {
-        $host = rtrim(trim($GLOBALS['site_addr_oath']), "/");
-        return rtrim(trim($host . $GLOBALS['webroot']), "/");
-    }
-    $scheme = $_SERVER['REQUEST_SCHEME'] . "://";
-    $possibleHostSources = array('HTTP_X_FORWARDED_HOST', 'HTTP_HOST', 'SERVER_NAME', 'SERVER_ADDR');
-    $sourceTransformations = array(
-        "HTTP_X_FORWARDED_HOST" => function ($value) {
-            $elements = explode(',', $value);
-            return trim(end($elements));
-        }
-    );
-    $host = '';
-    foreach ($possibleHostSources as $source) {
-        if (!empty($host)) {
-            break;
-        }
-        if (empty($_SERVER[$source])) {
-            continue;
-        }
-        $host = $_SERVER[$source];
-        if (array_key_exists($source, $sourceTransformations)) {
-            $host = $sourceTransformations[$source]($host);
-        }
-    }
-    // remove port
-    $host = preg_replace('/:\d+$/', '', trim($host));
-
-    return rtrim(trim($scheme . $host . $GLOBALS['webroot']), "/");
 }

--- a/src/Services/CDADocumentService.php
+++ b/src/Services/CDADocumentService.php
@@ -37,7 +37,7 @@ class CDADocumentService extends BaseService
         $this->serverUrl = $GLOBALS['qualified_site_addr'];
     }
 
-    public function getLastCdaMeta($pid): bool | array | null
+    public function getLastCdaMeta($pid)
     {
         $query = "SELECT cc.uuid, cc.date, pd.fname, pd.lname, pd.pid FROM ccda AS cc
 		    LEFT JOIN patient_data AS pd ON pd.pid=cc.pid
@@ -47,11 +47,11 @@ class CDADocumentService extends BaseService
         return sqlQuery($query, array($pid));
     }
 
-    public function getFile($id): bool | string
+    public function getFile($id)
     {
         $query = "select couch_docid, couch_revid, ccda_data, encrypted from ccda where uuid=?";
         $row = sqlQuery($query, array($id));
-        $content = false;
+        $content = '';
         if (!empty($row)) {
             if (!empty($row['couch_docid'])) {
                 $couch = new CouchDB();

--- a/src/Services/CDADocumentService.php
+++ b/src/Services/CDADocumentService.php
@@ -87,11 +87,15 @@ class CDADocumentService extends BaseService
         $response = $httpClient->request('GET', $url, [
             'query' => [
                 'combination' => $pid,
-                'recipient' => 'patient',
-                'view' => '1'
+                'recipient' => 'self',
+                'view' => '1',
+                'site' => $_SESSION ['site_id'],
+                'sent_by_app' => 'core_api',
+                'me' => session_id(),
+                'XDEBUG_SESSION' => '1'
             ]
         ]);
-        $contentType = $response->getHeaders()['content-type'][0];
+
         $status = $response->getStatusCode(); // @todo validate
 
         return $response->getContent();
@@ -109,10 +113,12 @@ class CDADocumentService extends BaseService
                 'combination' => $pid,
                 'recipient' => 'patient',
                 'view' => '0',
-                'hiehook' => '1'
+                'hiehook' => '1',
+                'sent_by_app' => 'core_api',
+                'me' => session_id()
             ]
         ]);
-        $contentType = $response->getHeaders()['content-type'][0];
+
         $status = $response->getStatusCode(); // @todo validate
 
         return $response->getContent();
@@ -135,7 +141,6 @@ class CDADocumentService extends BaseService
             ]
         ]);
 
-        $contentType = $response->getHeaders()['content-type'][0];
         $status = $response->getStatusCode(); // @todo validate
 
         return $response->getContent();
@@ -165,7 +170,6 @@ class CDADocumentService extends BaseService
             'body' => $parameterArray
         ]);
 
-        $contentType = $response->getHeaders()['content-type'][0];
         $status = $response->getStatusCode(); // @todo validate
 
         return $response->getContent();

--- a/src/Services/CDADocumentService.php
+++ b/src/Services/CDADocumentService.php
@@ -1,0 +1,173 @@
+<?php
+
+/**
+ * Document Service for CCDA
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright Copyright (c) 2021 Jerry Padgett <sjpadgett@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Services;
+
+use CouchDB;
+use OpenEMR\Common\Crypto\CryptoGen;
+use OpenEMR\Common\Uuid\UuidRegistry;
+use Symfony\Component\HttpClient\HttpClient;
+
+/**
+ * Class CDADocumentService
+ *
+ * @package OpenEMR\Services
+ *
+ * See interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncounterccdadispatchController.php
+ * indexAction() and interface/modules/zend_modules/public/index.php
+ */
+class CDADocumentService extends BaseService
+{
+    const TABLE_NAME = "ccda";
+    protected $serverUrl;
+
+    public function __construct()
+    {
+        parent::__construct(self::TABLE_NAME);
+        UuidRegistry::createMissingUuidsForTables([self::TABLE_NAME]);
+        $this->serverUrl = $GLOBALS['qualified_site_addr'];
+    }
+
+    public function getLastCdaMeta($pid): bool | array | null
+    {
+        $query = "SELECT cc.uuid, cc.date, pd.fname, pd.lname, pd.pid FROM ccda AS cc
+		    LEFT JOIN patient_data AS pd ON pd.pid=cc.pid
+		    WHERE cc.pid = ?
+		    ORDER BY cc.id DESC LIMIT 1";
+
+        return sqlQuery($query, array($pid));
+    }
+
+    public function getFile($id): bool | string
+    {
+        $query = "select couch_docid, couch_revid, ccda_data, encrypted from ccda where uuid=?";
+        $row = sqlQuery($query, array($id));
+        $content = false;
+        if (!empty($row)) {
+            if (!empty($row['couch_docid'])) {
+                $couch = new CouchDB();
+                $resp = $couch->retrieve_doc($row['couch_docid']);
+                if ($row['encrypted']) {
+                    $cryptoGen = new CryptoGen();
+                    $content = $cryptoGen->decryptStandard($resp->data, null, 'database');
+                } else {
+                    $content = base64_decode($resp->data);
+                }
+            } elseif (!empty($row['ccda_data'])) {
+                $fccda = fopen($row['ccda_data'], "r");
+                if ($row['encrypted']) {
+                    $cryptoGen = new CryptoGen();
+                    $content = $cryptoGen->decryptStandard(fread($fccda, filesize($row['ccda_data'])), null, 'database');
+                } else {
+                    $content = fread($fccda, filesize($row['ccda_data']));
+                }
+                fclose($fccda);
+            }
+        }
+
+        return $content;
+    }
+
+    public function generateCCDHtml($pid): string
+    {
+        $url = $this->serverUrl . "/interface/modules/zend_modules/public/encounterccdadispatch";
+        $httpClient = HttpClient::create([
+            "verify_peer" => false,
+            "verify_host" => false
+        ]);
+        $response = $httpClient->request('GET', $url, [
+            'query' => [
+                'combination' => $pid,
+                'recipient' => 'patient',
+                'view' => '1'
+            ]
+        ]);
+        $contentType = $response->getHeaders()['content-type'][0];
+        $status = $response->getStatusCode(); // @todo validate
+
+        return $response->getContent();
+    }
+
+    public function generateCCDXml($pid): string
+    {
+        $url = $this->serverUrl . "/interface/modules/zend_modules/public/encounterccdadispatch";
+        $httpClient = HttpClient::create([
+            "verify_peer" => false,
+            "verify_host" => false
+        ]);
+        $response = $httpClient->request('GET', $url, [
+            'query' => [
+                'combination' => $pid,
+                'recipient' => 'patient',
+                'view' => '0',
+                'hiehook' => '1'
+            ]
+        ]);
+        $contentType = $response->getHeaders()['content-type'][0];
+        $status = $response->getStatusCode(); // @todo validate
+
+        return $response->getContent();
+    }
+
+    public function portalGenerateCCD($pid): string
+    {
+        $url = $this->serverUrl . "/interface/modules/zend_modules/public/encounterccdadispatch";
+        $httpClient = HttpClient::create([
+            "verify_peer" => false,
+            "verify_host" => false
+        ]);
+        $response = $httpClient->request('GET', $url, [
+            'query' => [
+                'combination' => $pid,
+                'recipient' => 'patient',
+                'view' => '1',
+                'me' => session_id(),// to authenticate in CCM. Portal only.
+                'site' => $_SESSION ['site_id']
+            ]
+        ]);
+
+        $contentType = $response->getHeaders()['content-type'][0];
+        $status = $response->getStatusCode(); // @todo validate
+
+        return $response->getContent();
+    }
+
+    public function portalGenerateCCDZip($pid): string
+    {
+        $parameterArray = array(
+            'combination' => $pid,
+            'components' => 'allergies|medications|problems|immunizations|procedures|results|plan_of_care|vitals|social_history|encounters|functional_status|referral|instructions|medical_devices|goals',
+            'downloadccda' => 'download_ccda',
+            'latestccda' => '0',
+            'send_to' => 'download_all',
+            'sent_by_app' => 'portal',
+            'ccda_pid' => [0 => $pid],
+            'view' => 0,
+            'recipient' => 'patient',
+            'site' => $_SESSION ['site_id'],
+        );
+        $url = $this->serverUrl . "/interface/modules/zend_modules/public/encounterccdadispatch";
+        $httpClient = HttpClient::create([
+            "verify_peer" => false,
+            "verify_host" => false
+        ]);
+        $response = $httpClient->request('POST', $url, [
+            'query' => ['me' => session_id()], // to authenticate in CCM. Portal only.
+            'body' => $parameterArray
+        ]);
+
+        $contentType = $response->getHeaders()['content-type'][0];
+        $status = $response->getStatusCode(); // @todo validate
+
+        return $response->getContent();
+    }
+}


### PR DESCRIPTION
- fixes for prior PR

#### Short description of what this resolves:
Having user set site host address for Api's in globals is problematic IMO. Also we need to be able to resolve domain and ports that may be behind proxies, load balancers etc to the originating requests address.
Since we can't know the many different environments we run under, this is my best attempt.

As a note: Since PHP7 and deprecated in PHP5.4 it is required to provide parentheses when using new for classes.(code sniffer: Parentheses must be used when instantiating a new class).
Patterns like `throw new \RuntimeException()` will error in code sniffer. Generally using namespace paths for new() instantiations.
Even though PHP doesn't seem to mind!

Btw: I added new $GLOBALS['qualified_site_addr'] for $GLOBALS['site_addr_oath'] + webroot eg. https://opensourcedemr.us:8300/openemr
