### PR TITLE
Patient Results correct units type fix

### DIFF
--- a/interface/orders/orders_results.php
+++ b/interface/orders/orders_results.php
@@ -464,7 +464,7 @@ if (!empty($_POST['form_submit']) && !empty($_POST['form_line'])) {
                         continue;
                     }
 
-                    $selects = "pt2.procedure_type, pt2.procedure_code, pt2.units AS pt2_units, " .
+                    $selects = "pt2.procedure_type, pt2.procedure_code, ll.title AS pt2_units, " .
                         "pt2.range AS pt2_range, pt2.procedure_type_id AS procedure_type_id, " .
                         "pt2.name AS name, pt2.description, pt2.seq AS seq, " .
                         "ps.procedure_result_id, ps.result_code AS result_code, ps.result_text, ps.abnormal, ps.result, " .
@@ -484,10 +484,12 @@ if (!empty($_POST['form_submit']) && !empty($_POST['form_line'])) {
                     // results that do not have a matching result type.
                     $query = "(SELECT $selects FROM procedure_type AS pt2 " .
                         "LEFT JOIN procedure_result AS ps ON $pscond AND $joincond " .
+                        "LEFT JOIN list_options AS ll ON ll.list_id = 'proc_unit' AND ll.option_id = pt2.units " .
                         "WHERE $pt2cond" .
                         ") UNION (" .
                         "SELECT $selects FROM procedure_result AS ps " .
                         "LEFT JOIN procedure_type AS pt2 ON $pt2cond AND $joincond " .
+                        "LEFT JOIN list_options AS ll ON ll.list_id = 'proc_unit' AND ll.option_id = pt2.units " .
                         "WHERE $pscond) " .
                         "ORDER BY seq, name, procedure_type_id, result_code";
 


### PR DESCRIPTION
Modify query to select unit title instead of id.

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:
Forum issue:
https://community.open-emr.org/t/results-unit-id-shows-instead-of-text-value/16930
