### PR TITLE
Openemr fhir encounters

### DIFF
--- a/_rest_routes.inc.php
+++ b/_rest_routes.inc.php
@@ -873,13 +873,11 @@ RestConfig::$FHIR_ROUTE_MAP = array(
         return $return;
     },
     "GET /fhir/Location" => function (HttpRestRequest $request) {
-        RestConfig::authorization_check("patients", "med");
         $return = (new FhirLocationRestController())->getAll($request->getQueryParams());
         RestConfig::apiLog($return);
         return $return;
     },
     "GET /fhir/Location/:uuid" => function ($uuid, HttpRestRequest $request) {
-        RestConfig::authorization_check("patients", "med");
         $return = (new FhirLocationRestController())->getOne($uuid);
         RestConfig::apiLog($return);
         return $return;

--- a/_rest_routes.inc.php
+++ b/_rest_routes.inc.php
@@ -873,12 +873,12 @@ RestConfig::$FHIR_ROUTE_MAP = array(
         return $return;
     },
     "GET /fhir/Location" => function (HttpRestRequest $request) {
-        $return = (new FhirLocationRestController())->getAll($request->getQueryParams());
+        $return = (new FhirLocationRestController())->getAll($request->getQueryParams(), $request->getPatientUUIDString());
         RestConfig::apiLog($return);
         return $return;
     },
     "GET /fhir/Location/:uuid" => function ($uuid, HttpRestRequest $request) {
-        $return = (new FhirLocationRestController())->getOne($uuid);
+        $return = (new FhirLocationRestController())->getOne($uuid, $request->getPatientUUIDString());
         RestConfig::apiLog($return);
         return $return;
     },

--- a/interface/forms/newpatient/common.php
+++ b/interface/forms/newpatient/common.php
@@ -554,7 +554,7 @@ $ires = sqlStatement("SELECT id, type, title, begdate FROM lists WHERE " .
                                 $dischargeDisposiitons = $dischargeListDisposition->getOptionsByListName('discharge-disposition') ?? [];
                                 foreach ($dischargeDisposiitons as $dispositon) {
                                     $selected = $result['discharge_disposition'] == $dispositon['option_id'] ? "selected='selected'" : "";
-                                ?>
+                                    ?>
                                 <option value="<?php echo $dispositon['option_id']; ?>" <?php echo $selected; ?> ><?php echo $dispositon['title']; ?></option>
                                 <?php } ?>
                             </select>

--- a/interface/forms/newpatient/common.php
+++ b/interface/forms/newpatient/common.php
@@ -20,8 +20,9 @@ use OpenEMR\Common\Acl\AclExtended;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
-use OpenEMR\Services\UserService;
 use OpenEMR\Services\FacilityService;
+use OpenEMR\Services\ListService;
+use OpenEMR\Services\UserService;
 use OpenEMR\OeUI\OemrUI;
 
 $facilityService = new FacilityService();
@@ -550,12 +551,12 @@ $ires = sqlStatement("SELECT id, type, title, begdate FROM lists WHERE " .
                         <div class="col-sm">
                             <select name='discharge_disposition' id='discharge_disposition' class='form-control'>
                                 <?php
-                                $dischargeListDisposition = new \OpenEMR\Services\ListService();
+                                $dischargeListDisposition = new ListService();
                                 $dischargeDisposiitons = $dischargeListDisposition->getOptionsByListName('discharge-disposition') ?? [];
                                 foreach ($dischargeDisposiitons as $dispositon) {
                                     $selected = $result['discharge_disposition'] == $dispositon['option_id'] ? "selected='selected'" : "";
                                     ?>
-                                <option value="<?php echo $dispositon['option_id']; ?>" <?php echo $selected; ?> ><?php echo $dispositon['title']; ?></option>
+                                <option value="<?php echo attr($dispositon['option_id']); ?>" <?php echo $selected; ?> ><?php echo text($dispositon['title']); ?></option>
                                 <?php } ?>
                             </select>
                         </div>

--- a/interface/forms/newpatient/common.php
+++ b/interface/forms/newpatient/common.php
@@ -542,6 +542,26 @@ $ires = sqlStatement("SELECT id, type, title, begdate FROM lists WHERE " .
                             ?>
                         </div>
                     </div>
+                    <!-- Discharge Disposition -->
+                    <div class="form-row align-items-center mt-2">
+                        <div class="col-sm-2">
+                            <label for='facility_id' class="text-right"><?php echo xlt('Discharge Disposition'); ?>:</label>
+                        </div>
+                        <div class="col-sm">
+                            <select name='discharge_disposition' id='discharge_disposition' class='form-control'>
+                                <?php
+                                $dischargeListDisposition = new \OpenEMR\Services\ListService();
+                                $dischargeDisposiitons = $dischargeListDisposition->getOptionsByListName('discharge-disposition') ?? [];
+                                foreach ($dischargeDisposiitons as $dispositon) {
+                                    $selected = $result['discharge_disposition'] == $dispositon['option_id'] ? "selected='selected'" : "";
+                                ?>
+                                <option value="<?php echo $dispositon['option_id']; ?>" <?php echo $selected; ?> ><?php echo $dispositon['title']; ?></option>
+                                <?php } ?>
+                            </select>
+                        </div>
+                        <div class="col-sm-2"></div>
+                        <div class="col-sm"></div>
+                    </div>
                     <?php if ($GLOBALS['set_pos_code_encounter']) { ?>
                     <div class="form-row mt-2">
                         <div class="col-sm-2">

--- a/interface/forms/newpatient/new.php
+++ b/interface/forms/newpatient/new.php
@@ -22,6 +22,7 @@ if (
     ($tmp['squad'] && ! AclMain::aclCheckCore('squads', $tmp['squad'])) ||
     !AclMain::aclCheckForm('newpatient', '', array('write', 'addonly'))
 ) {
+    // TODO: why is this reversed?
     echo "<body>\n<html>\n";
     echo "<p>(" . xlt('New encounters not authorized') . ")</p>\n";
     echo "</body>\n</html>\n";

--- a/interface/forms/newpatient/save.php
+++ b/interface/forms/newpatient/save.php
@@ -42,6 +42,8 @@ $encounter_provider = $_POST['provider_id'] ?? null;
 //save therapy group if exist in external_id column
 $external_id = isset($_POST['form_gid']) ? $_POST['form_gid'] : '';
 
+$discharge_disposition = $_POST['discharge_disposition'] ?? null;
+
 $facilityresult = $facilityService->getById($facility_id);
 $facility = $facilityresult['name'];
 
@@ -74,7 +76,8 @@ if ($mode == 'new') {
                 class_code = ?,
                 external_id = ?,
                 parent_encounter_id = ?,
-                provider_id = ?",
+                provider_id = ?,
+                discharge_disposition = ?",
             [
                 $date,
                 $onset_date,
@@ -92,6 +95,7 @@ if ($mode == 'new') {
                 $external_id,
                 $parent_enc_id,
                 $provider_id,
+                $discharge_disposition,
             ]
         ),
         "newpatient",
@@ -127,6 +131,7 @@ if ($mode == 'new') {
         $referral_source,
         $class_code,
         $pos_code,
+        $discharge_disposition,
         $id
     );
     sqlStatement(
@@ -142,7 +147,8 @@ if ($mode == 'new') {
             sensitivity = ?,
             referral_source = ?,
             class_code = ?,
-            pos_code = ? WHERE id = ?",
+            pos_code = ?,
+            discharge_disposition = ? WHERE id = ?",
         $sqlBindArray
     );
 } else {

--- a/sql/6_0_0-to-6_1_0_upgrade.sql
+++ b/sql/6_0_0-to-6_1_0_upgrade.sql
@@ -827,6 +827,24 @@ INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUE
 UPDATE `list_options` SET `notes` = '{"form_datetime":{"futureDate":{"message": "Must be future date"}}, "reply_to":{"presence": {"message": "Please choose a patient"}}, "note":{"presence": {"message": "Please enter a note"}}}' where option_id = 'messages#new_note';
 #EndIf
 
+#IfNotRow2D list_options list_id lists option_id discharge-disposition
+INSERT INTO list_options (list_id,option_id,title, seq, is_default, option_value) VALUES ('lists','discharge-disposition','Discharge Disposition',0, 1, 0);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','home','Home',10,1,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','alt-home','Alternative Home',20,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','other-hcf','Other healthcare facility',30,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','hosp','Hospice',40,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','long','Long-term care',50,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','aadvice','Left against advice',60,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','exp','Expired',70,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','psy','Psychiatric hospital',80,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','rehab','Rehabilitation',90,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','snf','Skilled nursing facility',100,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','oth','Other',110,0,1);
+#EndIf
+
+#IfMissingColumn form_encounter discharge_disposition
+ALTER TABLE `form_encounter` ADD COLUMN `discharge_disposition` varchar(100) NULL DEFAULT NULL;
+#EndIf
 #IfMissingColumn form_vitals inhaled_oxygen_concentration
 ALTER TABLE `form_vitals` ADD `inhaled_oxygen_concentration` float(4,1) DEFAULT '0.00';
 #EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -1813,7 +1813,7 @@ CREATE TABLE `form_encounter` (
   `class_code` VARCHAR(10) NOT NULL DEFAULT "AMB",
   `shift` varchar(31) NOT NULL DEFAULT '',
   `voucher_number` varchar(255) NOT NULL DEFAULT '' COMMENT 'also called referral number',
-  `discharge_disposition` varchar(100) NULL DEFAULT NULL
+  `discharge_disposition` varchar(100) NULL DEFAULT NULL,
   PRIMARY KEY  (`id`),
   UNIQUE KEY `uuid` (`uuid`),
   KEY `pid_encounter` (`pid`, `encounter`),

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -6503,6 +6503,20 @@ INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUE
 INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('vitals-interpretation','LL','Critical low',70,0,1);
 INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('vitals-interpretation','HU','Significantly high',80,0,1);
 INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('vitals-interpretation','LU','Significantly low',90,0,1);
+
+-- Discharge Disposition (for encounters and eventually appointments)
+INSERT INTO list_options (list_id,option_id,title, seq, is_default, option_value) VALUES ('lists','discharge-disposition','Discharge Disposition',0, 1, 0);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','home','Home',10,1,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','alt-home','Alternative Home',20,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','other-hcf','Other healthcare facility',30,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','hosp','Hospice',40,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','long','Long-term care',50,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','aadvice','Left against advice',60,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','exp','Expired',70,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','psy','Psychiatric hospital',80,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','rehab','Rehabilitation',90,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','snf','Skilled nursing facility',100,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','oth','Other',110,0,1);
 -- --------------------------------------------------------
 
 --

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -1813,6 +1813,7 @@ CREATE TABLE `form_encounter` (
   `class_code` VARCHAR(10) NOT NULL DEFAULT "AMB",
   `shift` varchar(31) NOT NULL DEFAULT '',
   `voucher_number` varchar(255) NOT NULL DEFAULT '' COMMENT 'also called referral number',
+  `discharge_disposition` varchar(100) NULL DEFAULT NULL
   PRIMARY KEY  (`id`),
   UNIQUE KEY `uuid` (`uuid`),
   KEY `pid_encounter` (`pid`, `encounter`),

--- a/src/RestControllers/FHIR/FhirLocationRestController.php
+++ b/src/RestControllers/FHIR/FhirLocationRestController.php
@@ -40,9 +40,9 @@ class FhirLocationRestController
      * @param $fhirId The FHIR location resource id (uuid)
      * @returns 200 if the operation completes successfully
      */
-    public function getOne($fhirId)
+    public function getOne($fhirId, $patientUuid)
     {
-        $processingResult = $this->fhirLocationService->getOne($fhirId);
+        $processingResult = $this->fhirLocationService->getOne($fhirId, $patientUuid);
         return RestControllerHelper::handleFhirProcessingResult($processingResult, 200);
     }
 
@@ -50,9 +50,9 @@ class FhirLocationRestController
      * Queries for FHIR location resources using various search parameters.
      * @return FHIR bundle with query results, if found
      */
-    public function getAll($searchParams)
+    public function getAll($searchParams, $patientUuid)
     {
-        $processingResult = $this->fhirLocationService->getAll($searchParams);
+        $processingResult = $this->fhirLocationService->getAll($searchParams, $patientUuid);
         $bundleEntries = array();
         foreach ($processingResult->getData() as $index => $searchResult) {
             $bundleEntry = [

--- a/src/RestControllers/FHIR/FhirLocationRestController.php
+++ b/src/RestControllers/FHIR/FhirLocationRestController.php
@@ -19,6 +19,9 @@ use OpenEMR\FHIR\R4\FHIRResource\FHIRBundle\FHIRBundleEntry;
 
 class FhirLocationRestController
 {
+    /**
+     * @var FhirLocationService
+     */
     private $fhirLocationService;
     private $fhirService;
 
@@ -35,8 +38,7 @@ class FhirLocationRestController
      */
     public function getOne($fhirId)
     {
-        $processingResult = $this->fhirLocationService->getOne($fhirId);
-        return RestControllerHelper::handleFhirProcessingResult($processingResult, 200);
+        return $this->getAll(['_id' => $fhirId]);
     }
 
     /**

--- a/src/RestControllers/FHIR/FhirLocationRestController.php
+++ b/src/RestControllers/FHIR/FhirLocationRestController.php
@@ -23,6 +23,10 @@ class FhirLocationRestController
      * @var FhirLocationService
      */
     private $fhirLocationService;
+
+    /**
+     * @var FhirResourcesService
+     */
     private $fhirService;
 
     public function __construct()
@@ -38,7 +42,8 @@ class FhirLocationRestController
      */
     public function getOne($fhirId)
     {
-        return $this->getAll(['_id' => $fhirId]);
+        $processingResult = $this->fhirLocationService->getOne($fhirId);
+        return RestControllerHelper::handleFhirProcessingResult($processingResult, 200);
     }
 
     /**

--- a/src/Services/EncounterService.php
+++ b/src/Services/EncounterService.php
@@ -128,7 +128,6 @@ class EncounterService extends BaseService
                        fe.last_level_closed,
                        fe.last_stmt_date,
                        fe.stmt_count,
-                       fe.provider_id,
                        fe.supervisor_id,
                        fe.invoice_refno,
                        fe.referral_source,
@@ -147,7 +146,12 @@ class EncounterService extends BaseService
 
                        fa.billing_facility_id,
                        fa.billing_facility_uuid,
-                       fa.billing_facility_name
+                       fa.billing_facility_name,
+                
+                       fe.provider_id,
+                       providers.provider_uuid,
+                       providers.provider_username
+                       
 
                        FROM (
                            select
@@ -193,13 +197,13 @@ class EncounterService extends BaseService
                        ) patient ON fe.pid = patient.pid
                        LEFT JOIN (
                            select
-                                id AS provider_id
+                                id AS provider_provider_id
                                 ,uuid AS provider_uuid
-                                ,`username` AS provider_name
+                                ,`username` AS provider_username
                             FROM users
                             WHERE
                                 npi IS NOT NULL and npi != ''
-                       ) providers ON fe.provider_id = providers.provider_id
+                       ) providers ON fe.provider_id = providers.provider_provider_id
                        LEFT JOIN (
                            select
                                 id AS facility_id
@@ -231,6 +235,16 @@ class EncounterService extends BaseService
         }
 
         return $processingResult;
+    }
+
+    protected function createResultRecordFromDatabaseResult($row)
+    {
+        $record = parent::createResultRecordFromDatabaseResult($row);
+        // TODO: @adunsulag how are we supporting the different discharge dispositions as seen here:
+        // http://hl7.org/fhir/R4/valueset-encounter-discharge-disposition.html
+        $record['discharge_disposition'] = "home";
+        $record['discharge_disposition_text'] = "Home";
+        return $record;
     }
 
     /**

--- a/src/Services/EncounterService.php
+++ b/src/Services/EncounterService.php
@@ -69,7 +69,8 @@ class EncounterService extends BaseService
 
     public function getUuidFields(): array
     {
-        return ['provider_uuid', 'facility_uuid', 'euuid', 'puuid', 'billing_facility_uuid'];
+        return ['provider_uuid', 'facility_uuid', 'euuid', 'puuid', 'billing_facility_uuid'
+            , 'facility_location_uuid', 'billing_location_uuid'];
     }
 
     /**
@@ -143,10 +144,12 @@ class EncounterService extends BaseService
                        facilities.facility_id,
                        facilities.facility_uuid,
                        facilities.facility_name,
+                       facilities.facility_location_uuid,
 
                        fa.billing_facility_id,
                        fa.billing_facility_uuid,
                        fa.billing_facility_name,
+                       fa.billing_location_uuid,
                 
                        fe.provider_id,
                        providers.provider_uuid,
@@ -184,10 +187,13 @@ class EncounterService extends BaseService
                        LEFT JOIN list_options as class ON class.option_id = fe.class_code
                        LEFT JOIN (
                            select
-                                id AS billing_facility_id
-                                ,uuid AS billing_facility_uuid
-                                ,`name` AS billing_facility_name
+                                facility.id AS billing_facility_id
+                                ,facility.uuid AS billing_facility_uuid
+                                ,facility.`name` AS billing_facility_name
+                                ,locations.uuid AS billing_location_uuid
                            from facility
+                           LEFT JOIN uuid_mapping AS locations 
+                               ON locations.target_uuid = facility.uuid AND locations.resource='Location'
                        ) fa ON fa.billing_facility_id = fe.billing_facility
                        LEFT JOIN (
                            select
@@ -206,10 +212,13 @@ class EncounterService extends BaseService
                        ) providers ON fe.provider_id = providers.provider_provider_id
                        LEFT JOIN (
                            select
-                                id AS facility_id
-                                ,uuid AS facility_uuid
-                                ,`name` AS facility_name
+                                facility.id AS facility_id
+                                ,facility.uuid AS facility_uuid
+                                ,facility.`name` AS facility_name
+                                ,`locations`.`uuid` AS facility_location_uuid
                            from facility
+                           LEFT JOIN uuid_mapping AS locations 
+                               ON locations.target_uuid = facility.uuid AND locations.resource='Location'
                        ) facilities ON facilities.facility_id = fe.facility_id";
 
         try {

--- a/src/Services/FHIR/FhirCodeSystemConstants.php
+++ b/src/Services/FHIR/FhirCodeSystemConstants.php
@@ -55,4 +55,11 @@ class FhirCodeSystemConstants
     const HL7_V3_OBSERVATION_INTERPRETATION = "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation";
 
     const HL7_ICD10 = "http://hl7.org/fhir/sid/icd-10";
+    public const HL7_V3_ACT_CODE = "http://terminology.hl7.org/CodeSystem/v3-ActCode";
+
+    public const HL7_PARTICIPATION_TYPE = "http://terminology.hl7.org/CodeSystem/v3-ParticipationType";
+
+    public const RFC_3986 = "urn:ietf:rfc:3986";
+
+    const HL7_DISCHARGE_DISPOSITION = "http://terminology.hl7.org/CodeSystem/discharge-disposition";
 }

--- a/src/Services/FHIR/FhirEncounterService.php
+++ b/src/Services/FHIR/FhirEncounterService.php
@@ -104,23 +104,21 @@ class FhirEncounterService extends FhirServiceBase implements IFhirExportableRes
             $class->setCode($dataRecord['class_code']);
             $class->setDisplay($dataRecord['class_title']);
             $encounterResource->setClass($class);
-        }
-        else
-        {
+        } else {
             $encounterResource->setClass(UtilsService::createDataAbsentUnknownCodeableConcept());
         }
 
         // TODO: @adunsulag check with @brady.miller and find out if this really is the only possible encounter type...  it was here originally
-        $type = UtilsService::createCodeableConcept([self::ENCOUNTER_TYPE_CHECK_UP => self::ENCOUNTER_TYPE_CHECK_UP_DESCRIPTION]
-            , FhirCodeSystemConstants::SNOMED_CT);
+        $type = UtilsService::createCodeableConcept(
+            [self::ENCOUNTER_TYPE_CHECK_UP => self::ENCOUNTER_TYPE_CHECK_UP_DESCRIPTION],
+            FhirCodeSystemConstants::SNOMED_CT
+        );
         $encounterResource->addType($type);
 
         // subject - required
         if (!empty($dataRecord['puuid'])) {
             $encounterResource->setSubject(UtilsService::createRelativeReference('Patient', $dataRecord['puuid']));
-        }
-        else
-        {
+        } else {
             $encounterResource->setSubject(UtilsService::createDataMissingExtension());
         }
 
@@ -163,8 +161,10 @@ class FhirEncounterService extends FhirServiceBase implements IFhirExportableRes
             $text = $dataRecord['discharge_disposition_text'];
 
             $hospitalization = new FHIREncounterHospitalization();
-            $hospitalization->setDischargeDisposition(UtilsService::createCodeableConcept([$code => $text],
-                FhirCodeSystemConstants::HL7_DISCHARGE_DISPOSITION));
+            $hospitalization->setDischargeDisposition(UtilsService::createCodeableConcept(
+                [$code => $text],
+                FhirCodeSystemConstants::HL7_DISCHARGE_DISPOSITION
+            ));
             $encounterResource->setHospitalization($hospitalization);
         }
 
@@ -176,8 +176,7 @@ class FhirEncounterService extends FhirServiceBase implements IFhirExportableRes
             $encounterResource->setServiceProvider(UtilsService::createRelativeReference('Organization', $dataRecord['facility_uuid']));
 
             // grab the facility location address
-            if (!empty($dataRecord['facility_location_uuid']))
-            {
+            if (!empty($dataRecord['facility_location_uuid'])) {
                 $location = new FHIREncounterLocation();
                 $location->setLocation(UtilsService::createRelativeReference("Location", $dataRecord['facility_location_uuid']));
                 $encounterResource->addLocation($location);

--- a/src/Services/FHIR/FhirEncounterService.php
+++ b/src/Services/FHIR/FhirEncounterService.php
@@ -7,6 +7,9 @@ use OpenEMR\FHIR\Export\ExportException;
 use OpenEMR\FHIR\Export\ExportJob;
 use OpenEMR\FHIR\Export\ExportStreamWriter;
 use OpenEMR\FHIR\Export\ExportWillShutdownException;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRIdentifier;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRMeta;
+use OpenEMR\FHIR\R4\FHIRResource\FHIREncounter\FHIREncounterHospitalization;
 use OpenEMR\Services\EncounterService;
 use OpenEMR\Services\FHIR\FhirServiceBase;
 use OpenEMR\FHIR\R4\FHIRDomainResource\FHIREncounter;
@@ -28,6 +31,15 @@ class FhirEncounterService extends FhirServiceBase implements IFhirExportableRes
 {
     use PatientSearchTrait;
     use FhirServiceBaseEmptyTrait;
+
+    const ENCOUNTER_STATUS_FINISHED = "finished";
+
+    const ENCOUNTER_TYPE_CHECK_UP = "185349003";
+    const ENCOUNTER_TYPE_CHECK_UP_DESCRIPTION = "Encounter for check up (procedure)";
+
+    const ENCOUNTER_PARTICIPANT_TYPE_PRIMARY_PERFORMER = "PPRF";
+    const ENCOUNTER_PARTICIPANT_TYPE_PRIMARY_PERFORMER_TEXT = "Primary Performer";
+
 
     /**
      * @var EncounterService
@@ -65,70 +77,105 @@ class FhirEncounterService extends FhirServiceBase implements IFhirExportableRes
     {
         $encounterResource = new FHIREncounter();
 
-        $meta = array('versionId' => '1', 'lastUpdated' => gmdate('c'));
+        $meta = new FHIRMeta();
+        $meta->setVersionId('1');
+        $meta->setLastUpdated(gmdate('c'));
         $encounterResource->setMeta($meta);
 
         $id = new FhirId();
         $id->setValue($dataRecord['euuid']);
         $encounterResource->setId($id);
 
-        $status = new FHIRCode('finished');
+        // identifier - required
+        $identifier = new FHIRIdentifier();
+        $identifier->setValue($dataRecord['euuid']);
+        $identifier->setSystem(FhirCodeSystemConstants::RFC_3986);
+        $encounterResource->addIdentifier($identifier);
+
+        // status - required
+        $status = new FHIRCode(self::ENCOUNTER_STATUS_FINISHED);
         $encounterResource->setStatus($status);
 
+        // class
+        if (!empty($dataRecord['class_code'])) {
+            $class = new FHIRCoding();
+            $class->setSystem(FhirCodeSystemConstants::HL7_V3_ACT_CODE);
+            $class->setCode($dataRecord['class_code']);
+            $class->setDisplay($dataRecord['class_title']);
+            $encounterResource->setClass($class);
+        }
+        else
+        {
+            $encounterResource->setClass(UtilsService::createDataAbsentUnknownCodeableConcept());
+        }
+
+        // TODO: @adunsulag check with @brady.miller and find out if this really is the only possible encounter type...  it was here originally
+        $type = UtilsService::createCodeableConcept([self::ENCOUNTER_TYPE_CHECK_UP => self::ENCOUNTER_TYPE_CHECK_UP_DESCRIPTION]
+            , FhirCodeSystemConstants::SNOMED_CT);
+        $encounterResource->addType($type);
+
+        // subject - required
+        if (!empty($dataRecord['puuid'])) {
+            $encounterResource->setSubject(UtilsService::createRelativeReference('Patient', $dataRecord['puuid']));
+        }
+        else
+        {
+            $encounterResource->setSubject(UtilsService::createDataMissingExtension());
+        }
+
+        // participant - must support
         if (!empty($dataRecord['provider_uuid'])) {
-            $parctitioner = new FHIRReference(['reference' => 'Practitioner/' . $dataRecord['provider_uuid']]);
-            $participant = new FHIREncounterParticipant(array(
-                'individual' => $parctitioner,
-                'period' => ['start' => gmdate('c', strtotime($dataRecord['date']))]
-            ));
-            $participantType = new FHIRCodeableConcept();
-            $participantType->addCoding(array(
-                "system" => "http://terminology.hl7.org/CodeSystem/v3-ParticipationType",
-                "code" => "PPRF"
-            ));
-            $participantType->setText("Primary Performer");
+            $participant = new FHIREncounterParticipant();
+            $participant->setIndividual(UtilsService::createRelativeReference("Practitioner", $dataRecord['provider_uuid']));
+            $period = new FHIRPeriod();
+            $period->setStart(gmdate('c', strtotime($dataRecord['date'])));
+            $participant->setPeriod($period);
+
+            $participantType = UtilsService::createCodeableConcept([self::ENCOUNTER_PARTICIPANT_TYPE_PRIMARY_PERFORMER =>
+                self::ENCOUNTER_PARTICIPANT_TYPE_PRIMARY_PERFORMER_TEXT], FhirCodeSystemConstants::HL7_PARTICIPATION_TYPE);
             $participant->addType($participantType);
             $encounterResource->addParticipant($participant);
         }
 
-        if (!empty($dataRecord['facility_uuid'])) {
-            $serviceOrg = new FHIRReference(['reference' => 'Organization/' . $dataRecord['facility_uuid']]);
-            $encounterResource->setServiceProvider($serviceOrg);
-        }
-
-        if (!empty($dataRecord['reason'])) {
-            $reason = new FHIRCodeableConcept();
-            $reason->setText($dataRecord['reason']);
-            $encounterResource->addReasonCode($reason);
-        }
-
-        if (!empty($dataRecord['puuid'])) {
-            $patient = new FHIRReference(['reference' => 'Patient/' . $dataRecord['puuid']]);
-            $encounterResource->setSubject($patient);
-        }
-
+        // period - must support
         if (!empty($dataRecord['date'])) {
             $period = new FHIRPeriod();
             $period->setStart(gmdate('c', strtotime($dataRecord['date'])));
             $encounterResource->setPeriod($period);
         }
 
-        if (!empty($dataRecord['class_code'])) {
-            $class = new FHIRCoding();
-            $class->setSystem("http://terminology.hl7.org/CodeSystem/v3-ActCode");
-            $class->setCode($dataRecord['class_code']);
-            $class->setDisplay($dataRecord['class_title']);
-            $encounterResource->setClass($class);
+        // reasonCode - must support OR must support reasonReference
+        if (!empty($dataRecord['reason'])) {
+            // Note: that we use the encounter textual representation for the reason here which is just fine as ccda
+            // uses a textual representation of this.  According to HL7 chat this is just fine as epoch and other systems
+            // do it this way
+            // @see https://chat.fhir.org/#narrow/stream/179175-argonaut/topic/Encounter.20Reason.20For.20Visit (beware of link rot)
+            $reason = new FHIRCodeableConcept();
+            $reason->setText($dataRecord['reason']);
+            $encounterResource->addReasonCode($reason);
+        }
+        // hospitalization - must support
+
+        // hospitalization.dischargeDisposition - must support
+        if (!empty($dataRecord['discharge_disposition'])) {
+            $code = $dataRecord['discharge_disposition'];
+            $text = $dataRecord['discharge_disposition_text'];
+
+            $hospitalization = new FHIREncounterHospitalization();
+            $hospitalization->setDischargeDisposition(UtilsService::createCodeableConcept([$code => $text],
+                FhirCodeSystemConstants::HL7_DISCHARGE_DISPOSITION));
+            $encounterResource->setHospitalization($hospitalization);
         }
 
-        // Encounter.type
-        $type = new FHIRCodeableConcept();
-        $type->addCoding(array(
-            "system" => "http://snomed.info/sct",
-            "code" => "185349003"
-        ));
-        $type->setText("Encounter for check up (procedure)");
-        $encounterResource->addType($type);
+        // SHALL support either location.location OR serviceProvider
+        // location.location - must support
+
+        // serviceProvider - must support
+        if (!empty($dataRecord['facility_uuid'])) {
+            $encounterResource->setServiceProvider(UtilsService::createRelativeReference('Organization', $dataRecord['facility_uuid']));
+
+            // grab the facility location address
+        }
 
         if ($encode) {
             return json_encode($encounterResource);

--- a/src/Services/FHIR/FhirEncounterService.php
+++ b/src/Services/FHIR/FhirEncounterService.php
@@ -10,6 +10,7 @@ use OpenEMR\FHIR\Export\ExportWillShutdownException;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRIdentifier;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRMeta;
 use OpenEMR\FHIR\R4\FHIRResource\FHIREncounter\FHIREncounterHospitalization;
+use OpenEMR\FHIR\R4\FHIRResource\FHIREncounter\FHIREncounterLocation;
 use OpenEMR\Services\EncounterService;
 use OpenEMR\Services\FHIR\FhirServiceBase;
 use OpenEMR\FHIR\R4\FHIRDomainResource\FHIREncounter;
@@ -168,13 +169,19 @@ class FhirEncounterService extends FhirServiceBase implements IFhirExportableRes
         }
 
         // SHALL support either location.location OR serviceProvider
+        // however ONC inferno requires both serviceProvider AND location.location
         // location.location - must support
-
         // serviceProvider - must support
         if (!empty($dataRecord['facility_uuid'])) {
             $encounterResource->setServiceProvider(UtilsService::createRelativeReference('Organization', $dataRecord['facility_uuid']));
 
             // grab the facility location address
+            if (!empty($dataRecord['facility_location_uuid']))
+            {
+                $location = new FHIREncounterLocation();
+                $location->setLocation(UtilsService::createRelativeReference("Location", $dataRecord['facility_location_uuid']));
+                $encounterResource->addLocation($location);
+            }
         }
 
         if ($encode) {

--- a/src/Services/FHIR/FhirLocationService.php
+++ b/src/Services/FHIR/FhirLocationService.php
@@ -16,10 +16,16 @@ use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRLocation;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRContactPoint;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRId;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRMeta;
 use OpenEMR\Services\LocationService;
+use OpenEMR\Services\Search\CompositeSearchField;
 use OpenEMR\Services\Search\FhirSearchParameterDefinition;
+use OpenEMR\Services\Search\ISearchField;
 use OpenEMR\Services\Search\SearchFieldType;
+use OpenEMR\Services\Search\SearchModifier;
 use OpenEMR\Services\Search\ServiceField;
+use OpenEMR\Services\Search\TokenSearchField;
+use OpenEMR\Services\Search\TokenSearchValue;
 use OpenEMR\Validators\ProcessingResult;
 
 class FhirLocationService extends FhirServiceBase
@@ -28,6 +34,12 @@ class FhirLocationService extends FhirServiceBase
      * @var LocationService
      */
     private $locationService;
+
+    /**
+     * The patient uuid bound in the current request
+     * @var string
+     */
+    private $patientUuid;
 
     public function __construct()
     {
@@ -57,7 +69,9 @@ class FhirLocationService extends FhirServiceBase
     {
         $locationResource = new FHIRLocation();
 
-        $meta = array('versionId' => '1', 'lastUpdated' => gmdate('c'));
+        $meta = new FHIRMeta();
+        $meta->setVersionId('1');
+        $meta->setLastUpdated(gmdate('c'));
         $locationResource->setMeta($meta);
 
         $id = new FHIRId();
@@ -66,15 +80,18 @@ class FhirLocationService extends FhirServiceBase
 
         $locationResource->setStatus("active");
 
-        // TODO: what is this `s Home thing, seems really wierd... and its not documented
-        if (!empty($dataRecord['name'] && $dataRecord['name'] != "`s Home")) {
-            $locationResource->setName($dataRecord['name']);
+        if (!empty($dataRecord['name'])) {
+            $name = $dataRecord['name'];
+            if ($dataRecord['type'] != 'facility') {
+                $name = xlt($name);
+            }
+            $locationResource->setName($name);
         } else {
             $locationResource->setName(UtilsService::createDataMissingExtension());
         }
 
         // TODO: @brady.miller is this the right security ACL for a facilities organization?
-        if ($this->shouldIncludeContactInformationForLocationType($dataRecord['type'])) {
+        if ($this->shouldIncludeContactInformationForLocationType($dataRecord['type'], $dataRecord['uuid'])) {
             $locationResource->setAddress(UtilsService::createAddressFromRecord($dataRecord));
 
             if (!empty($dataRecord['phone'])) {
@@ -113,15 +130,49 @@ class FhirLocationService extends FhirServiceBase
         }
     }
 
+    public function getOne($fhirResourceId, $puuidBind = null): ProcessingResult
+    {
+        try {
+            $this->patientUuid = $puuidBind;
+            return parent::getOne($fhirResourceId, $puuidBind);
+        }
+        finally
+        {
+            $this->patientUuid = null;
+        }
+    }
+
+    public function getAll($fhirSearchParameters, $puuidBind = null): ProcessingResult
+    {
+        try {
+            $this->patientUuid = $puuidBind;
+            return parent::getAll($fhirSearchParameters, $puuidBind);
+        }
+        finally
+        {
+            $this->patientUuid = null;
+        }
+    }
+
     /**
      * Searches for OpenEMR records using OpenEMR search parameters
      *
      * @param  array openEMRSearchParameters OpenEMR search fields
-     * @param $puuidBind - NOT USED
      * @return ProcessingResult
      */
-    protected function searchForOpenEMRRecords($openEMRSearchParameters, $puuidBind = null): ProcessingResult
+    protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {
+        // even though its not a patient compartment issue we still don't want certain location data such as clinician home addresses
+        // being returned... or other patient locations...  Wierd that its not in the patient compartment
+        if (!empty($this->patientUuid))
+        {
+            // when we are patient bound we only want facility data returned or return just that patient's information.
+            $patientType = new CompositeSearchField('patient-type', [], false);
+            // patient id is the target_uuid, the uuid column is the mapped 'Location' resource in FHIR
+            $patientType->addChild(new TokenSearchField('table_uuid', [new TokenSearchValue($this->patientUuid, null, true)]));
+            $patientType->addChild(new TokenSearchField('type', [new TokenSearchValue(LocationService::TYPE_FACILITY)]));
+            $openEMRSearchParameters['patient-type'] = $patientType;
+        }
         return $this->locationService->getAll($openEMRSearchParameters, false);
     }
 
@@ -144,14 +195,21 @@ class FhirLocationService extends FhirServiceBase
         // TODO: If Required in Future
     }
 
-    private function shouldIncludeContactInformationForLocationType($type)
+    private function hasAccessToUserLocationData()
     {
-        if ($type == 'patient') {
+        return AclMain::aclCheckCore('admin', 'users') !== false;
+    }
+
+    private function shouldIncludeContactInformationForLocationType($type, $recordUuid)
+    {
+        $isPatientBoundUuid = !empty($this->patientUuid) && $this->patientUuid == $recordUuid;
+        // if its not a patient requesting their own record location information we need to check permissions on this.
+        if ($type == 'patient' && !$isPatientBoundUuid) {
             // only those with access to a patient's demographic information can get their data
             return AclMain::aclCheckCore("patients", "demo") !== false;
         } else if ($type == 'user') {
             // only those with access to the user information can get address information about a user.
-            return AclMain::aclCheckCore('admin', 'users') !== false;
+            return $this->hasAccessToUserLocationData();
         } else {
             // facilities we just let all contact information be displayed for the location.
             return true;

--- a/src/Services/FHIR/FhirLocationService.php
+++ b/src/Services/FHIR/FhirLocationService.php
@@ -146,17 +146,13 @@ class FhirLocationService extends FhirServiceBase
 
     private function shouldIncludeContactInformationForLocationType($type)
     {
-        if ($type == 'patient')
-        {
+        if ($type == 'patient') {
             // only those with access to a patient's demographic information can get their data
             return AclMain::aclCheckCore("patients", "demo") !== false;
-        }
-        else if ($type == 'user')
-        {
+        } else if ($type == 'user') {
             // only those with access to the user information can get address information about a user.
             return AclMain::aclCheckCore('admin', 'users') !== false;
-        }
-        else {
+        } else {
             // facilities we just let all contact information be displayed for the location.
             return true;
         }

--- a/src/Services/FHIR/FhirLocationService.php
+++ b/src/Services/FHIR/FhirLocationService.php
@@ -135,9 +135,7 @@ class FhirLocationService extends FhirServiceBase
         try {
             $this->patientUuid = $puuidBind;
             return parent::getOne($fhirResourceId, $puuidBind);
-        }
-        finally
-        {
+        } finally {
             $this->patientUuid = null;
         }
     }
@@ -147,9 +145,7 @@ class FhirLocationService extends FhirServiceBase
         try {
             $this->patientUuid = $puuidBind;
             return parent::getAll($fhirSearchParameters, $puuidBind);
-        }
-        finally
-        {
+        } finally {
             $this->patientUuid = null;
         }
     }
@@ -164,8 +160,7 @@ class FhirLocationService extends FhirServiceBase
     {
         // even though its not a patient compartment issue we still don't want certain location data such as clinician home addresses
         // being returned... or other patient locations...  Wierd that its not in the patient compartment
-        if (!empty($this->patientUuid))
-        {
+        if (!empty($this->patientUuid)) {
             // when we are patient bound we only want facility data returned or return just that patient's information.
             $patientType = new CompositeSearchField('patient-type', [], false);
             // patient id is the target_uuid, the uuid column is the mapped 'Location' resource in FHIR

--- a/src/Services/LocationService.php
+++ b/src/Services/LocationService.php
@@ -111,8 +111,7 @@ class LocationService extends BaseService
         $statementResults =  QueryUtils::sqlStatementThrowException($sql, $sqlBindArray);
 
         $processingResult = new ProcessingResult();
-        foreach ($statementResults as $result)
-        {
+        foreach ($statementResults as $result) {
             $record = $this->createResultRecordFromDatabaseResult($result);
             $processingResult->addData($record);
         }

--- a/src/Services/LocationService.php
+++ b/src/Services/LocationService.php
@@ -87,7 +87,7 @@ class LocationService extends BaseService
                     fax,
                     website,
                     email,
-                   "' . self::TYPE_FACILITY. '" AS `type`
+                   "' . self::TYPE_FACILITY . '" AS `type`
                 from 
                      facility
                 UNION SELECT

--- a/src/Services/LocationService.php
+++ b/src/Services/LocationService.php
@@ -67,8 +67,10 @@ class LocationService extends BaseService
                     phone_cell as phone,
                     null as fax,
                     null as website,
-                    email from patient_data,
-                    `type` AS "patient"
+                    email,
+                    "patient" AS `type`
+                from 
+                    patient_data
                 UNION SELECT
                     uuid as target_uuid,
                     name,
@@ -80,8 +82,10 @@ class LocationService extends BaseService
                     phone,
                     fax,
                     website,
-                    email from facility,
-                   `type` AS "facility"
+                    email,
+                   "facility" AS `type`
+                from 
+                     facility
                 UNION SELECT
                     uuid as target_uuid,
                     CONCAT(fname,"\'s Home") as name,
@@ -93,10 +97,12 @@ class LocationService extends BaseService
                     phone,
                     fax,
                     url as website,
-                    email from users
-                    `type` AS "user"
+                    email,
+                    "user" AS `type`
+                from 
+                     users
             ) as location
-                    LEFT JOIN uuid_mapping ON uuid_mapping.target_uuid=location.target_uuid AND uuid_mapping.resource="Location"';
+            LEFT JOIN uuid_mapping ON uuid_mapping.target_uuid=location.target_uuid AND uuid_mapping.resource="Location"';
 
         $whereClause = FhirSearchWhereClauseBuilder::build($search, $isAndCondition);
 

--- a/src/Services/LocationService.php
+++ b/src/Services/LocationService.php
@@ -25,6 +25,10 @@ class LocationService extends BaseService
     private const PRACTITIONER_TABLE = "users";
     private const FACILITY_TABLE = "facility";
 
+    const TYPE_FACILITY = "facility";
+    const TYPE_USER = "user";
+    const TYPE_PATIENT = "patient";
+
     /**
      * Default constructor.
      */
@@ -57,8 +61,8 @@ class LocationService extends BaseService
 
         $sql = 'SELECT location.*, uuid_mapping.uuid FROM
                 (SELECT
-                    uuid as target_uuid,
-                    CONCAT(fname,"\'s Home") as name,
+                    uuid as table_uuid,
+                    "Home Address" as name,
                     street,
                     city,
                     postal_code,
@@ -68,11 +72,11 @@ class LocationService extends BaseService
                     null as fax,
                     null as website,
                     email,
-                    "patient" AS `type`
+                    "' . self::TYPE_PATIENT . '" AS `type`
                 from 
                     patient_data
                 UNION SELECT
-                    uuid as target_uuid,
+                    uuid as table_uuid,
                     name,
                     street,
                     city,
@@ -83,12 +87,12 @@ class LocationService extends BaseService
                     fax,
                     website,
                     email,
-                   "facility" AS `type`
+                   "' . self::TYPE_FACILITY. '" AS `type`
                 from 
                      facility
                 UNION SELECT
-                    uuid as target_uuid,
-                    CONCAT(fname,"\'s Home") as name,
+                    uuid as table_uuid,
+                    "Home Address" as name,
                     street,
                     city,
                     zip as postal_code,
@@ -98,15 +102,16 @@ class LocationService extends BaseService
                     fax,
                     url as website,
                     email,
-                    "user" AS `type`
+                    "' . self::TYPE_USER . '" AS `type`
                 from 
                      users
             ) as location
-            LEFT JOIN uuid_mapping ON uuid_mapping.target_uuid=location.target_uuid AND uuid_mapping.resource="Location"';
+            LEFT JOIN uuid_mapping ON uuid_mapping.target_uuid=location.table_uuid AND uuid_mapping.resource="Location"';
 
         $whereClause = FhirSearchWhereClauseBuilder::build($search, $isAndCondition);
 
         $sql .= $whereClause->getFragment();
+
         $sqlBindArray = $whereClause->getBoundValues();
         $statementResults =  QueryUtils::sqlStatementThrowException($sql, $sqlBindArray);
 

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@ $v_realpatch = '0';
 // is a database change in the course of development.  It is used
 // internally to determine when a database upgrade is needed.
 //
-$v_database = 406;
+$v_database = 407;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
Implemented FHIR encounters endpoint.  I had to change a couple of minor things in the encounter service, but the biggest change involved adding a discharge_disposition to form_encounters and showing the dropdown on the encounters form.  FHIR requires we at least support the property and have some resources flagged with it, fortunately its optional and doesn't have to be filled in for historical data.  

Here is all the happy green checkmarks from Inferno.
![image](https://user-images.githubusercontent.com/228117/127531960-cae50ec7-fd3e-48fc-b929-23b6cf4a6dbc.png)

Here is what the discharge dropdown looks like:
![image](https://user-images.githubusercontent.com/228117/127532145-dc7e266a-044d-463e-91bf-28c4193ce2b9.png)

Available list options are here.  Note I specifically called it Discharge Disposition for the list as the Appointment FHIR resource (not ONC required) also has a dischargeDisposition property which would likely use this same list.
![image](https://user-images.githubusercontent.com/228117/127532247-ab55214d-d23f-443a-86fb-c41814d2a96e.png)