### PR TITLE
Fixes #4560 Support multiple care team records.

### DIFF
--- a/interface/patient_file/deleter.php
+++ b/interface/patient_file/deleter.php
@@ -233,6 +233,7 @@ function popup_close() {
                 row_delete("employer_data", "pid = '" . add_escape_custom($patient) . "'");
                 row_delete("history_data", "pid = '" . add_escape_custom($patient) . "'");
                 row_delete("insurance_data", "pid = '" . add_escape_custom($patient) . "'");
+                row_delete("patient_careteam_history", "pid ='" . add_escape_custom($patient) . "'");
 
                 $res = sqlStatement("SELECT * FROM forms WHERE pid = ?", array($patient));
                 while ($row = sqlFetchArray($res)) {

--- a/interface/super/edit_layout.php
+++ b/interface/super/edit_layout.php
@@ -247,6 +247,7 @@ function isColumnReserved($tablename, $field_id)
             'dupscore',
             'cmsportal_login',
             'care_team_provider',
+            'care_team_status',
             'billing_note',
             'uuid',
             'care_team_facility',

--- a/sql/6_0_0-to-6_1_0_upgrade.sql
+++ b/sql/6_0_0-to-6_1_0_upgrade.sql
@@ -856,13 +856,13 @@ UPDATE `list_options` SET `notes` = 'LOINC:11502-2' WHERE `list_options`.`list_i
 ALTER TABLE patient_data ADD COLUMN care_team_status VARCHAR(100) NULL DEFAULT NULL;
 #EndIf
 
-#IfNotTable patient_careteam_history
-CREATE TABLE `patient_careteam_history` (
+#IfNotTable patient_history
+CREATE TABLE `patient_history` (
     `id` BIGINT(20) NOT NULL AUTO_INCREMENT
     , `uuid` BINARY(16) NULL
+    , `date` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
     , `care_team_provider` TEXT NULL
     , `care_team_facility` TEXT NULL
-    , `date` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
     , `pid` BIGINT(20) NOT NULL
     , PRIMARY KEY (`id`)
     , UNIQUE `uuid` (`uuid`)

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -7242,6 +7242,18 @@ CREATE TABLE `patient_data` (
 -- --------------------------------------------------------
 
 --
+-- Table structure for table `patient_careteam_history` that is a dependent table on `patient_data`
+CREATE TABLE `patient_careteam_history` (
+    `id` BIGINT(20) NOT NULL AUTO_INCREMENT
+    , `uuid` BINARY(16) NULL
+    , `care_team_provider` TEXT NULL
+    , `care_team_facility` TEXT NULL
+    , `date` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+    , `pid` BIGINT(20) NOT NULL
+    , PRIMARY KEY (`id`)
+    , UNIQUE `uuid` (`uuid`)
+) ENGINE = InnoDB;
+--
 -- Table structure for table `patient_portal_menu`
 --
 

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -7242,14 +7242,14 @@ CREATE TABLE `patient_data` (
 -- --------------------------------------------------------
 
 --
--- Table structure for table `patient_careteam_history` that is a dependent table on `patient_data`
-CREATE TABLE `patient_careteam_history` (
+-- Table structure for table `patient_history` that is a dependent table on `patient_data`
+CREATE TABLE `patient_history` (
     `id` BIGINT(20) NOT NULL AUTO_INCREMENT
     , `uuid` BINARY(16) NULL
+    , `pid` BIGINT(20) NOT NULL
     , `care_team_provider` TEXT NULL
     , `care_team_facility` TEXT NULL
     , `date` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
-    , `pid` BIGINT(20) NOT NULL
     , PRIMARY KEY (`id`)
     , UNIQUE `uuid` (`uuid`)
 ) ENGINE = InnoDB;

--- a/src/Common/Uuid/UuidRegistry.php
+++ b/src/Common/Uuid/UuidRegistry.php
@@ -52,6 +52,7 @@ class UuidRegistry
         'insurance_data' => ['table_name' => 'insurance_data'],
         'lists' => ['table_name' => 'lists'],
         'patient_data' => ['table_name' => 'patient_data'],
+        'patient_careteam_history' => ['table_name' => 'patient_careteam_history'],
         'prescriptions' => ['table_name' => 'prescriptions'],
         'procedure_order' => ['table_name' => 'procedure_order', 'table_id' => 'procedure_order_id'],
         'procedure_providers' => ['table_name' => 'procedure_providers', 'table_id' => 'ppid'],

--- a/src/Common/Uuid/UuidRegistry.php
+++ b/src/Common/Uuid/UuidRegistry.php
@@ -52,7 +52,7 @@ class UuidRegistry
         'insurance_data' => ['table_name' => 'insurance_data'],
         'lists' => ['table_name' => 'lists'],
         'patient_data' => ['table_name' => 'patient_data'],
-        'patient_careteam_history' => ['table_name' => 'patient_careteam_history'],
+        'patient_history' => ['table_name' => 'patient_history'],
         'prescriptions' => ['table_name' => 'prescriptions'],
         'procedure_order' => ['table_name' => 'procedure_order', 'table_id' => 'procedure_order_id'],
         'procedure_providers' => ['table_name' => 'procedure_providers', 'table_id' => 'ppid'],

--- a/src/Services/CareTeamService.php
+++ b/src/Services/CareTeamService.php
@@ -29,16 +29,16 @@ class CareTeamService extends BaseService
     private const PATIENT_TABLE = "patient_data";
     private const PRACTITIONER_TABLE = "users";
     private const FACILITY_TABLE = "facility";
-    private const CARE_TEAM_HISTORY_TABLE = "patient_careteam_history";
+    private const PATIENT_HISTORY_TABLE = "patient_history";
 
     /**
      * Default constructor.
      */
     public function __construct()
     {
-        UuidRegistry::createMissingUuidsForTables([self::PATIENT_TABLE, self::PRACTITIONER_TABLE, self::FACILITY_TABLE, self::CARE_TEAM_HISTORY_TABLE]);
+        UuidRegistry::createMissingUuidsForTables([self::PATIENT_TABLE, self::PRACTITIONER_TABLE, self::FACILITY_TABLE, self::PATIENT_HISTORY_TABLE]);
         UuidMapping::createMissingResourceUuids("CareTeam", self::PATIENT_TABLE);
-        parent::__construct(self::CARE_TEAM_HISTORY_TABLE);
+        parent::__construct(self::PATIENT_HISTORY_TABLE);
     }
 
     public function search($search, $isAndCondition = true)
@@ -234,11 +234,11 @@ class CareTeamService extends BaseService
     {
         $insertData = [
             'pid' => $pid, 'care_team_provider' => $oldProviders, 'care_team_facility' => $oldFacilities,
-            'uuid' => UuidRegistry::getRegistryForTable(self::CARE_TEAM_HISTORY_TABLE)->createUuid()
+            'uuid' => UuidRegistry::getRegistryForTable(self::PATIENT_HISTORY_TABLE)->createUuid()
         ];
         $insert = $this->buildInsertColumns($insertData);
 
-        $sql = "INSERT INTO " . self::CARE_TEAM_HISTORY_TABLE . " SET " . $insert['set'];
+        $sql = "INSERT INTO " . self::PATIENT_HISTORY_TABLE . " SET " . $insert['set'];
         return QueryUtils::sqlInsert($sql, $insert['bind']);
     }
 }

--- a/src/Services/CareTeamService.php
+++ b/src/Services/CareTeamService.php
@@ -29,14 +29,16 @@ class CareTeamService extends BaseService
     private const PATIENT_TABLE = "patient_data";
     private const PRACTITIONER_TABLE = "users";
     private const FACILITY_TABLE = "facility";
+    private const CARE_TEAM_HISTORY_TABLE = "patient_careteam_history";
 
     /**
      * Default constructor.
      */
     public function __construct()
     {
-        UuidRegistry::createMissingUuidsForTables([self::PATIENT_TABLE, self::PRACTITIONER_TABLE, self::FACILITY_TABLE]);
+        UuidRegistry::createMissingUuidsForTables([self::PATIENT_TABLE, self::PRACTITIONER_TABLE, self::FACILITY_TABLE, self::CARE_TEAM_HISTORY_TABLE]);
         UuidMapping::createMissingResourceUuids("CareTeam", self::PATIENT_TABLE);
+        parent::__construct(self::CARE_TEAM_HISTORY_TABLE);
     }
 
     public function search($search, $isAndCondition = true)
@@ -48,13 +50,15 @@ class CareTeamService extends BaseService
                     careteam_mapping.uuid,
                     careteam_mapping.care_team_provider as providers,
                     careteam_mapping.care_team_facility as facilities,
-                    careteamStatus.careteam_status
+                    careteam_mapping.care_team_status,
+                    care_team_status_title
                 FROM (
                     SELECT
                         uuid_mapping.target_uuid AS puuid
                         ,uuid_mapping.uuid
                         ,patient_data.care_team_provider
                         ,patient_data.care_team_facility
+                        ,patient_data.care_team_status
                     FROM
                         uuid_mapping
                     -- we join on this to make sure we've got data integrity since we don't actually use foreign keys right now
@@ -62,10 +66,26 @@ class CareTeamService extends BaseService
                         patient_data ON uuid_mapping.target_uuid = patient_data.uuid
                     WHERE
                         uuid_mapping.resource='CareTeam'
+                    UNION
+                    SELECT
+                        patient_data.uuid AS puuid
+                        ,patient_careteam_history.uuid
+                        ,patient_careteam_history.care_team_provider
+                        ,patient_careteam_history.care_team_facility
+                        ,'inactive' AS care_team_status
+                    FROM
+                        patient_careteam_history
+                    JOIN patient_data ON patient_careteam_history.pid = patient_data.pid
                 ) careteam_mapping
-                CROSS JOIN (
-                    select 'active' AS careteam_status
-                ) careteamStatus";
+                LEFT JOIN
+                    (
+                        select
+                            option_id
+                            ,list_id
+                            ,title AS care_team_status_title
+                        FROM list_options
+                        WHERE list_id = 'Care_Team_Status'
+                ) care_team_statii ON care_team_statii.option_id = careteam_mapping.care_team_status";
 
         $whereClause = FhirSearchWhereClauseBuilder::build($search, $isAndCondition);
 
@@ -126,6 +146,11 @@ class CareTeamService extends BaseService
 
     public function createResultRecordFromDatabaseResult($row)
     {
+        /**
+         * Note this has the pretty poor performance as we are fetching P providers + F facilities for N records
+         * Runtime is O(N*(P+F))
+         * TODO: at some point the DB table should be normalized so we could do a single DB fetch...
+         */
         $row['providers'] = $this->getProvidersWithType($row['providers']);
         $row['facilities'] = $this->getFacilities($row['facilities']);
         $row['uuid'] = UuidRegistry::uuidToString($row['uuid']);
@@ -203,5 +228,17 @@ class CareTeamService extends BaseService
         $search['uuid'] = new TokenSearchField('uuid', $uuid, true);
 
         return $this->search($search);
+    }
+
+    public function createCareTeamHistory($pid, $oldProviders, $oldFacilities)
+    {
+        $insertData = [
+            'pid' => $pid, 'care_team_provider' => $oldProviders, 'care_team_facility' => $oldFacilities,
+            'uuid' => UuidRegistry::getRegistryForTable(self::CARE_TEAM_HISTORY_TABLE)->createUuid()
+        ];
+        $insert = $this->buildInsertColumns($insertData);
+
+        $sql = "INSERT INTO " . self::CARE_TEAM_HISTORY_TABLE . " SET " . $insert['set'];
+        return QueryUtils::sqlInsert($sql, $insert['bind']);
     }
 }

--- a/src/Services/FHIR/FhirCareTeamService.php
+++ b/src/Services/FHIR/FhirCareTeamService.php
@@ -15,7 +15,6 @@ namespace OpenEMR\Services\FHIR;
 use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRCareTeam;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRCoding;
-use OpenEMR\FHIR\R4\FHIRElement\FHIRContactPoint;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRId;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRMeta;
 use OpenEMR\FHIR\R4\FHIRResource\FHIRCareTeam\FHIRCareTeamParticipant;
@@ -61,7 +60,7 @@ class FhirCareTeamService extends FhirServiceBase implements IResourceUSCIGProfi
     {
         return  [
             'patient' => $this->getPatientContextSearchField(),
-            'status' => new FhirSearchParameterDefinition('status', SearchFieldType::TOKEN, ['careteam_status']),
+            'status' => new FhirSearchParameterDefinition('status', SearchFieldType::TOKEN, ['care_team_status']),
             '_id' => new FhirSearchParameterDefinition('_id', SearchFieldType::TOKEN, [new ServiceField('uuid', ServiceField::TYPE_UUID)]),
         ];
     }
@@ -86,8 +85,8 @@ class FhirCareTeamService extends FhirServiceBase implements IResourceUSCIGProfi
         $id->setValue($dataRecord['uuid']);
         $careTeamResource->setId($id);
 
-        if (array_search($dataRecord['status'], self::CARE_TEAM_STATII) !== false) {
-            $careTeamResource->setStatus($dataRecord['status']);
+        if (array_search($dataRecord['care_team_status'], self::CARE_TEAM_STATII) !== false) {
+            $careTeamResource->setStatus($dataRecord['care_team_status']);
         } else {
             // default is active
             $careTeamResource->setStatus(self::CARE_TEAM_STATUS_ACTIVE);

--- a/src/Services/PatientService.php
+++ b/src/Services/PatientService.php
@@ -215,6 +215,14 @@ class PatientService extends BaseService
         array_push($query['bind'], $data['pid']);
         $sqlResult = sqlStatement($sql, $query['bind']);
 
+        if (
+            $dataBeforeUpdate['care_team_provider'] != $data['care_team_provider']
+            || $dataBeforeUpdate['care_team_facility'] != $data['care_team_facility']
+        ) {
+            // need to save off our care team
+            $this->saveCareTeamHistory($data, $dataBeforeUpdate['care_team_provider'], $dataBeforeUpdate['care_team_facility']);
+        }
+
         if ($sqlResult) {
             // Tell subscribers that a new patient has been updated
             $patientUpdatedEvent = new PatientUpdatedEvent($dataBeforeUpdate, $data);
@@ -386,5 +394,11 @@ class PatientService extends BaseService
     public function getUuid($pid)
     {
         return self::getUuidById($pid, self::TABLE_NAME, 'pid');
+    }
+
+    private function saveCareTeamHistory($patientData, $oldProviders, $oldFacilities)
+    {
+        $careTeamService = new CareTeamService();
+        $careTeamService->createCareTeamHistory($patientData['pid'], $oldProviders, $oldFacilities);
     }
 }

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@ $v_realpatch = '0';
 // is a database change in the course of development.  It is used
 // internally to determine when a database upgrade is needed.
 //
-$v_database = 407;
+$v_database = 409;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@ $v_realpatch = '0';
 // is a database change in the course of development.  It is used
 // internally to determine when a database upgrade is needed.
 //
-$v_database = 409;
+$v_database = 408;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
Added a history table for the a patient's Care Team.  Any changes to the
care team providers or facilities that are part of the care team are
saved off to the patient_careteam_history table.  Note the status column
in patient_data is specifically for the current Care Team.  Past care
teams in the history table always have a status of 'inactive'.

I changed up the queries and report these changes back via FHIR.

I also made sure the records are cleaned up if a patient is deleted via the deleter.php script.

Long term we probably want to break up the care team properties in patient_data but that is a bigger engineering effort that hopefully can be taken on in the future.