### PR TITLE
Openemr fhir provenance

### DIFF
--- a/_rest_routes.inc.php
+++ b/_rest_routes.inc.php
@@ -1128,6 +1128,32 @@ RestConfig::$FHIR_ROUTE_MAP = array(
         RestConfig::apiLog($return);
         return $return;
     },
+    "GET /fhir/Provenance/:uuid" => function ($uuid, HttpRestRequest $request) {
+        if ($request->isPatientRequest()) {
+            // only allow access to data of binded patient
+            $return = (new FhirProvenanceRestController())->getOne($uuid, $request->getPatientUUIDString());
+        } else {
+            // TODO: it seems like regular users should be able to grab authorship / provenance information
+            RestConfig::authorization_check("admin", "super");
+            $return = (new FhirProvenanceRestController())->getOne($uuid);
+        }
+        RestConfig::apiLog($return);
+        return $return;
+    },
+    // NOTE: this GET request only supports requests with an _id parameter.  FHIR inferno test tool requires the 'search'
+    // property to support which is why this endpoint exists.
+    "GET /fhir/Provenance" => function ($uuid, HttpRestRequest $request) {
+        if ($request->isPatientRequest()) {
+            // only allow access to data of binded patient
+            $return = (new FhirProvenanceRestController())->getAll($request->getQueryParams(), $request->getPatientUUIDString());
+        } else {
+            // TODO: it seems like regular users should be able to grab authorship / provenance information
+            RestConfig::authorization_check("admin", "super");
+            $return = (new FhirProvenanceRestController())->getOne($request->getQueryParams());
+        }
+        RestConfig::apiLog($return);
+        return $return;
+    },
     // other endpoints
     "GET /fhir/metadata" => function () {
         $return = (new FhirMetaDataRestController())->getMetaData();

--- a/src/Common/Http/HttpRestParsedRoute.php
+++ b/src/Common/Http/HttpRestParsedRoute.php
@@ -149,7 +149,7 @@ class HttpRestParsedRoute
     private function getRouteMatchExpression($path)
     {
         // Taken from https://stackoverflow.com/questions/11722711/url-routing-regex-php/11723153#11723153
-        return "@^" . preg_replace('/\\\:[a-zA-Z0-9\_\-]+/', '([a-zA-Z0-9\-\_\$]+)', preg_quote($path)) . "$@D";
+        return "@^" . preg_replace('/\\\:[a-zA-Z0-9\_\-]+/', '([a-zA-Z0-9\-\_\$\:]+)', preg_quote($path)) . "$@D";
     }
 
     /**

--- a/src/RestControllers/FHIR/FhirProvenanceRestController.php
+++ b/src/RestControllers/FHIR/FhirProvenanceRestController.php
@@ -62,13 +62,12 @@ class FhirProvenanceRestController
      */
     public function getAll($searchParams, $puuidBind = null)
     {
-        if (empty($searchParams['_id']))
-        {
+        if (empty($searchParams['_id'])) {
             $processingResult = new ProcessingResult();
             $processingResult->setValidationMessages(['_id' => "search requires '_id' parameter to be specified"]);
             return $processingResult;
         }
-        
+
         $processingResult = $this->provenanceService->getAll($searchParams, $puuidBind);
         $bundleEntries = array();
         foreach ($processingResult->getData() as $index => $searchResult) {

--- a/src/RestControllers/FHIR/FhirProvenanceRestController.php
+++ b/src/RestControllers/FHIR/FhirProvenanceRestController.php
@@ -20,7 +20,9 @@
 
 namespace OpenEMR\RestControllers\FHIR;
 
+use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRProvenance;
 use OpenEMR\Services\FHIR\FhirCareTeamService;
+use OpenEMR\Services\FHIR\FhirProvenanceService;
 use OpenEMR\Services\FHIR\FhirResourcesService;
 use OpenEMR\RestControllers\RestControllerHelper;
 use OpenEMR\FHIR\R4\FHIRResource\FHIRBundle\FHIRBundleEntry;
@@ -30,9 +32,15 @@ class FhirProvenanceRestController
 {
     private $fhirService;
 
+    /**
+     * @var FhirProvenanceService
+     */
+    private $provenanceService;
+
     public function __construct()
     {
         $this->fhirService = new FhirResourcesService();
+        $this->provenanceService = new FhirProvenanceService();
     }
 
     /**
@@ -43,7 +51,7 @@ class FhirProvenanceRestController
      */
     public function getOne($fhirId, $puuidBind = null)
     {
-        $processingResult = new ProcessingResult(); // return nothing for now
+        $processingResult = $this->provenanceService->getOne($fhirId, $puuidBind);
         return RestControllerHelper::handleFhirProcessingResult($processingResult, 200);
     }
 
@@ -54,7 +62,7 @@ class FhirProvenanceRestController
      */
     public function getAll($searchParams, $puuidBind = null)
     {
-        $processingResult = new ProcessingResult(); // return nothing for now
+        $processingResult = $this->provenanceService->getAll($searchParams, $puuidBind);
         $bundleEntries = array();
         foreach ($processingResult->getData() as $index => $searchResult) {
             $bundleEntry = [

--- a/src/RestControllers/FHIR/FhirProvenanceRestController.php
+++ b/src/RestControllers/FHIR/FhirProvenanceRestController.php
@@ -62,6 +62,13 @@ class FhirProvenanceRestController
      */
     public function getAll($searchParams, $puuidBind = null)
     {
+        if (empty($searchParams['_id']))
+        {
+            $processingResult = new ProcessingResult();
+            $processingResult->setValidationMessages(['_id' => "search requires '_id' parameter to be specified"]);
+            return $processingResult;
+        }
+        
         $processingResult = $this->provenanceService->getAll($searchParams, $puuidBind);
         $bundleEntries = array();
         foreach ($processingResult->getData() as $index => $searchResult) {

--- a/src/RestControllers/RestControllerHelper.php
+++ b/src/RestControllers/RestControllerHelper.php
@@ -38,6 +38,8 @@ class RestControllerHelper
 
     /**
      * The default FHIR services class namespace
+     * TODO: should we build a fhir service locator class?  There are two places this is now used, in this class and
+     * in the FhirProvenanceService...
      */
     const FHIR_SERVICES_NAMESPACE = "OpenEMR\\Services\\FHIR\\Fhir";
 

--- a/src/Services/FHIR/FhirPatientService.php
+++ b/src/Services/FHIR/FhirPatientService.php
@@ -580,32 +580,8 @@ class FhirPatientService extends FhirServiceBase implements IFhirExportableResou
         if (!($dataRecord instanceof FHIRPatient)) {
             throw new \BadMethodCallException("Data record should be correct instance class");
         }
-        $targetReference = new FHIRReference();
-        $targetReference->setType("Patient");
-        $targetReference->setReference("Patient/" . $dataRecord->getId());
-
-        $fhirProvenance = new FHIRProvenance();
-        $fhirProvenance->addTarget($targetReference);
-        $fhirProvenance->setRecorded($dataRecord->getMeta()->getLastUpdated());
-
-        $agent = new FHIRProvenanceAgent();
-        $agentConcept = new FHIRCodeableConcept();
-        $agentConceptCoding = new FHIRCoding();
-        $agentConceptCoding->setSystem("http://terminology.hl7.org/CodeSystem/provenance-participant-type");
-        $agentConceptCoding->setCode("author");
-        $agentConceptCoding->setDisplay(xlt("Author"));
-        $agentConcept->addCoding($agentConceptCoding);
-        $agent->setType($agentConcept);
-
-        // easiest provenance is to make the primary business entity organization be the author of the provenance
-        // resource.
-        $fhirOrganizationService = new FhirOrganizationService();
-        // TODO: adunsulag check with @sjpadgett or @brady.miller to see if we will always have a primary business entity.
-        $organizationReference = $fhirOrganizationService->getPrimaryBusinessEntityReference();
-
-        $agent->setWho($organizationReference);
-        $fhirProvenance->addAgent($agent);
-        return $fhirProvenance;
+        $provenanceService = new FhirProvenanceService();
+        return $provenanceService->createProvenanceForDomainResource($dataRecord);
     }
 
     /**

--- a/src/Services/FHIR/FhirProvenanceService.php
+++ b/src/Services/FHIR/FhirProvenanceService.php
@@ -28,12 +28,12 @@ use OpenEMR\Services\Search\SearchFieldType;
 use OpenEMR\Services\Search\ServiceField;
 use OpenEMR\Services\Search\TokenSearchField;
 use OpenEMR\Validators\ProcessingResult;
-use \Exception;
+use Exception;
 
 class FhirProvenanceService extends FhirServiceBase implements IResourceUSCIGProfileService
 {
     use FhirServiceBaseEmptyTrait;
-    
+
     const USCGI_PROFILE_URI = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance';
 
     /**
@@ -59,9 +59,7 @@ class FhirProvenanceService extends FhirServiceBase implements IResourceUSCIGPro
         // recorded - required
         if (!empty($resource->getMeta())) {
             $fhirProvenance->setRecorded($resource->getMeta()->getLastUpdated());
-        }
-        else
-        {
+        } else {
             // we should ALWAYS have a last updated date... but we will log this if we don't
             $fhirProvenance->setRecorded(UtilsService::createDataMissingExtension());
             (new SystemLogger())->error("Meta element was missing to populate recorded date in " . self::class . "->createProvenanceForDomainResource()", [
@@ -72,8 +70,7 @@ class FhirProvenanceService extends FhirServiceBase implements IResourceUSCIGPro
         $fhirOrganizationService = new FhirOrganizationService();
         // TODO: adunsulag check with @sjpadgett or @brady.miller to see if we will always have a primary business entity.
         $primaryBusinessEntity = $fhirOrganizationService->getPrimaryBusinessEntityReference();
-        if (empty($primaryBusinessEntity))
-        {
+        if (empty($primaryBusinessEntity)) {
             (new SystemLogger())->debug(self::class . "->createProvenanceForDomainResource() could not find organization reference");
             return null;
         }
@@ -107,8 +104,7 @@ class FhirProvenanceService extends FhirServiceBase implements IResourceUSCIGPro
         $agentConcept->addCoding($agentConceptCoding);
         $agent->setType($agentConcept);
 
-        if (empty($who))
-        {
+        if (empty($who)) {
             $who = $primaryBusinessEntity;
         }
         $agent->setWho($who);
@@ -162,12 +158,10 @@ class FhirProvenanceService extends FhirServiceBase implements IResourceUSCIGPro
     {
         $fhirSearchResult = new ProcessingResult();
         try {
-            if (empty($fhirSearchParameters['_id']))
-            {
+            if (empty($fhirSearchParameters['_id'])) {
                 throw new SearchFieldException('_id', '_id parameter is required to retrieve provenance records');
             }
             $fhirSearchResult = $this->getProvenanceRecordsForId($fhirSearchParameters['_id'], $puuidBind);
-
         } catch (SearchFieldException $exception) {
             $systemLogger = new SystemLogger();
             $systemLogger->error(get_class($this) . "->getAll() exception thrown", ['message' => $exception->getMessage(),
@@ -204,12 +198,9 @@ class FhirProvenanceService extends FhirServiceBase implements IResourceUSCIGPro
                     ,'_revinclude' => 'Provenance:target'
                 ];
                 $results = $newServiceClass->getAll($searchParams, $puuidBind);
-                if ($results->hasData())
-                {
-                    foreach ($results->getData() as $datum)
-                    {
-                        if ($datum instanceof  FHIRProvenance)
-                        {
+                if ($results->hasData()) {
+                    foreach ($results->getData() as $datum) {
+                        if ($datum instanceof  FHIRProvenance) {
                             $processingResult->addData($datum);
                         }
                     }
@@ -217,9 +208,7 @@ class FhirProvenanceService extends FhirServiceBase implements IResourceUSCIGPro
                     $processingResult->addProcessingResult($results);
                 }
             }
-        }
-        catch (Exception $exception)
-        {
+        } catch (Exception $exception) {
             $processingResult->addInternalError("Server error occurred in returning provenance for _id " . $id);
         }
         return $processingResult;
@@ -240,8 +229,7 @@ class FhirProvenanceService extends FhirServiceBase implements IResourceUSCIGPro
          */
         $id = $openEMRSearchParameters['_id'] ?? new TokenSearchField('_id', []);
         $processingResult = new ProcessingResult();
-        foreach ($id->getValues() as $value)
-        {
+        foreach ($id->getValues() as $value) {
             // should be in format of ResourceType/uuid
             $code = $value->getCode() ?? "";
             try {
@@ -258,12 +246,9 @@ class FhirProvenanceService extends FhirServiceBase implements IResourceUSCIGPro
                             ,'_revinclude' => 'Provenance:target'
                         ];
                         $results = $newServiceClass->getAll($searchParams, $patientBinding);
-                        if ($results->hasData())
-                        {
-                            foreach ($results->getData() as $datum)
-                            {
-                                if ($datum instanceof  FHIRProvenance)
-                                {
+                        if ($results->hasData()) {
+                            foreach ($results->getData() as $datum) {
+                                if ($datum instanceof  FHIRProvenance) {
                                     $processingResult->addData($datum);
                                 }
                             }
@@ -272,9 +257,7 @@ class FhirProvenanceService extends FhirServiceBase implements IResourceUSCIGPro
                         }
                     }
                 }
-            }
-            catch (\Exception $exception)
-            {
+            } catch (\Exception $exception) {
                 // TODO: @adunsulag log the exception
                 $processingResult->addInternalError("Server error occurred in returning provenance for _id " . $code);
             }

--- a/src/Services/FHIR/FhirProvenanceService.php
+++ b/src/Services/FHIR/FhirProvenanceService.php
@@ -12,17 +12,28 @@
 namespace OpenEMR\Services\FHIR;
 
 use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\FHIR\R4\FHIRDomainResource\FHIROrganization;
 use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRProvenance;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRCoding;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRReference;
 use OpenEMR\FHIR\R4\FHIRResource\FHIRDomainResource;
 use OpenEMR\FHIR\R4\FHIRResource\FHIRProvenance\FHIRProvenanceAgent;
+use OpenEMR\RestControllers\RestControllerHelper;
+use OpenEMR\Services\FHIR\Traits\FhirServiceBaseEmptyTrait;
+use OpenEMR\Services\Search\FhirSearchParameterDefinition;
 use OpenEMR\Services\Search\ReferenceSearchValue;
+use OpenEMR\Services\Search\SearchFieldException;
+use OpenEMR\Services\Search\SearchFieldType;
+use OpenEMR\Services\Search\ServiceField;
+use OpenEMR\Services\Search\TokenSearchField;
 use OpenEMR\Validators\ProcessingResult;
+use \Exception;
 
 class FhirProvenanceService extends FhirServiceBase implements IResourceUSCIGProfileService
 {
+    use FhirServiceBaseEmptyTrait;
+    
     const USCGI_PROFILE_URI = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance';
 
     /**
@@ -41,6 +52,7 @@ class FhirProvenanceService extends FhirServiceBase implements IResourceUSCIGPro
         $targetReference->setReference($resource->get_fhirElementName() . "/" . $resource->getId());
 
         $fhirProvenance = new FHIRProvenance();
+        $fhirProvenance->setId($resource->get_fhirElementName() . ":" . $resource->getId());
         $fhirProvenance->addTarget($targetReference);
 
         // we are only going to provide the meta if we have it
@@ -78,7 +90,6 @@ class FhirProvenanceService extends FhirServiceBase implements IResourceUSCIGPro
             $whoReference = $orgReference; // if we didn't get an org reference from our WHO we will overwrite our WHO
         }
         if (!empty($orgReference)) {
-            $fhirProvenance->setId($orgReference->getId());
             $agent->setWho($whoReference);
             $agent->setOnBehalfOf($orgReference);
         } else {
@@ -94,7 +105,9 @@ class FhirProvenanceService extends FhirServiceBase implements IResourceUSCIGPro
      */
     protected function loadSearchParameters()
     {
-        // TODO: Implement loadSearchParameters() method.
+        return  [
+            '_id' => new FhirSearchParameterDefinition('_id', SearchFieldType::TOKEN, ['_id']),
+        ];
     }
 
     /**
@@ -106,38 +119,74 @@ class FhirProvenanceService extends FhirServiceBase implements IResourceUSCIGPro
      */
     public function parseOpenEMRRecord($dataRecord = array(), $encode = false)
     {
-        // TODO: Implement parseOpenEMRRecord() method.
+        return $dataRecord; //
+    }
+
+    public function getAll($fhirSearchParameters, $puuidBind = null): ProcessingResult
+    {
+        $fhirSearchResult = new ProcessingResult();
+        try {
+            if (empty($fhirSearchParameters['_id']))
+            {
+                throw new SearchFieldException('_id', '_id parameter is required to retrieve provenance records');
+            }
+            $fhirSearchResult = $this->getProvenanceRecordsForId($fhirSearchParameters['_id'], $puuidBind);
+
+        } catch (SearchFieldException $exception) {
+            $systemLogger = new SystemLogger();
+            $systemLogger->error(get_class($this) . "->getAll() exception thrown", ['message' => $exception->getMessage(),
+                'field' => $exception->getField(), 'trace' => $exception->getTraceAsString()]);
+            // put our exception information here
+            $fhirSearchResult->setValidationMessages([$exception->getField() => $exception->getMessage()]);
+        }
+        return $fhirSearchResult;
     }
 
     /**
-     * Parses a FHIR Resource, returning the equivalent OpenEMR record.
-     *
-     * @param $fhirResource The source FHIR resource
-     * @return a mapped OpenEMR data record (array)
+     * Given a provenance record id retrieve the provenance record for the given resource and its uuid
+     * @param $id string in the format of <resource>:<uuid>
+     * @param $puuidBind string The patient uuid we will bind requests to in order to avoid patient data leaking
+     * @return ProcessingResult
      */
-    public function parseFhirResource($fhirResource = array())
+    private function getProvenanceRecordsForId($id, $puuidBind)
     {
-        // TODO: Implement parseFhirResource() method.
-    }
+        $processingResult = new ProcessingResult();
+        $idParts = explode(":", $id);
+        $resourceName = array_shift($idParts);
 
-    /**
-     * Inserts an OpenEMR record into the sytem.
-     * @return The OpenEMR processing result.
-     */
-    protected function insertOpenEMRRecord($openEmrRecord)
-    {
-        // TODO: Implement insertOpenEMRRecord() method.
-    }
+        $innerId = implode(":", $idParts);
+        $className = RestControllerHelper::FHIR_SERVICES_NAMESPACE . $resourceName . "Service";
+        if (!class_exists($className)) {
+            throw new SearchFieldException("_id", "Provenance _id was invalid");
+        }
 
-    /**
-     * Updates an existing OpenEMR record.
-     * @param $fhirResourceId The OpenEMR record's FHIR Resource ID.
-     * @param $updatedOpenEMRRecord The "updated" OpenEMR record.
-     * @return The OpenEMR Service Result
-     */
-    protected function updateOpenEMRRecord($fhirResourceId, $updatedOpenEMRRecord)
-    {
-        // TODO: Implement updateOpenEMRRecord() method.
+        try {
+            $newServiceClass = new $className();
+            if ($newServiceClass instanceof IResourceReadableService) {
+                $searchParams = [
+                    '_id' => $innerId
+                    ,'_revinclude' => 'Provenance:target'
+                ];
+                $results = $newServiceClass->getAll($searchParams, $puuidBind);
+                if ($results->hasData())
+                {
+                    foreach ($results->getData() as $datum)
+                    {
+                        if ($datum instanceof  FHIRProvenance)
+                        {
+                            $processingResult->addData($datum);
+                        }
+                    }
+                } else {
+                    $processingResult->addProcessingResult($results);
+                }
+            }
+        }
+        catch (Exception $exception)
+        {
+            $processingResult->addInternalError("Server error occurred in returning provenance for _id " . $id);
+        }
+        return $processingResult;
     }
 
     /**
@@ -148,20 +197,53 @@ class FhirProvenanceService extends FhirServiceBase implements IResourceUSCIGPro
      */
     protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {
-        // TODO: Implement searchForOpenEMRRecords() method.
-        return new ProcessingResult();
-    }
+        $patientToken = $openEMRSearchParameters['patient'] ?? new TokenSearchField('patient', []);
+        $patientBinding = !empty($patientToken->getValues()) ? $patientToken->getValues()[0]->getCode() : null;
+        /**
+         * @var TokenSearchField
+         */
+        $id = $openEMRSearchParameters['_id'] ?? new TokenSearchField('_id', []);
+        $processingResult = new ProcessingResult();
+        foreach ($id->getValues() as $value)
+        {
+            // should be in format of ResourceType/uuid
+            $code = $value->getCode() ?? "";
+            try {
+                $idParts = explode(":", $code);
+                $resourceName = array_shift($idParts);
 
-    /**
-     * Creates the Provenance resource  for the equivalent FHIR Resource
-     *
-     * @param $dataRecord The source OpenEMR data record
-     * @param $encode Indicates if the returned resource is encoded into a string. Defaults to True.
-     * @return the FHIR Resource. Returned format is defined using $encode parameter.
-     */
-    public function createProvenanceResource($dataRecord, $encode = false)
-    {
-        // TODO: Implement createProvenanceResource() method.
+                $innerId = implode(":", $idParts);
+                $className = RestControllerHelper::FHIR_SERVICES_NAMESPACE . $resourceName . "Service";
+                if (class_exists($className)) {
+                    $newServiceClass = new $className();
+                    if ($newServiceClass instanceof IResourceReadableService) {
+                        $searchParams = [
+                            '_id' => $innerId
+                            ,'_revinclude' => 'Provenance:target'
+                        ];
+                        $results = $newServiceClass->getAll($searchParams, $patientBinding);
+                        if ($results->hasData())
+                        {
+                            foreach ($results->getData() as $datum)
+                            {
+                                if ($datum instanceof  FHIRProvenance)
+                                {
+                                    $processingResult->addData($datum);
+                                }
+                            }
+                        } else {
+                            $processingResult->addProcessingResult($results);
+                        }
+                    }
+                }
+            }
+            catch (\Exception $exception)
+            {
+                // TODO: @adunsulag log the exception
+                $processingResult->addInternalError("Server error occurred in returning provenance for _id " . $code);
+            }
+        }
+        return $processingResult;
     }
 
     /**

--- a/tests/Tests/Unit/Common/Http/HttpRestParsedRouteTest.php
+++ b/tests/Tests/Unit/Common/Http/HttpRestParsedRouteTest.php
@@ -128,4 +128,17 @@ class HttpRestParsedRouteTest extends TestCase
         $this->assertEquals('$export', $parsedRoute->getOperation());
         $this->assertEquals('Patient', $parsedRoute->getResource());
     }
+
+    public function testGetRouteWithRouteParamSpecialCharacter()
+    {
+        $request = '/fhir/Patient/unique-id:with:colons';
+        $definition = 'GET /fhir/Patient/:uid';
+
+        $parsedRoute = new HttpRestParsedRoute("GET", $request, $definition);
+        $this->assertTrue($parsedRoute->isValid(), "route should match definition");
+
+        $params = $parsedRoute->getRouteParams();
+        $this->assertNotEmpty($params, "Params should be populated");
+        $this->assertEquals('unique-id:with:colons', $params[0]);
+    }
 }


### PR DESCRIPTION
I took a creative approach to implementing the provenance. Instead of trying to figure out how to tie the provenance to each individual resource I use the resource and the resource uuid to uniquely identify the provenance resource.  Using that ID I can load the corresponding FHIR resource service and re-run all of the queries and grab the correct Provenance exactly as it was generated.  If we ever do need to grab a list of all Provenance records... that is going to be pretty hard to do as we don't track anything globally except for perhaps the uuid_registry which wouldn't be a perfect map for resources but could be implemented to do this...

I still am not sure that only putting the OpenEMR organization as the provenance source is the right approach as I would imagine most people would like to know the specific user who authored / created a resource.  However, based on Brady's and Jerry's recommendation we went with just the organization and it is passing the ONC test tool.

Since us-core doesn't require we list the provenance resources and we just need to handle the read operation I put in a search operation that requires the _id element to be listed.  

I had to modify the route parser so we could handle colon characters inside the route.

![image](https://user-images.githubusercontent.com/228117/128563319-536ebc48-78b2-4201-8550-867073d53b3b.png)

You can see how the provenance ids are created through this list of GET requests that Inferno fires off.
![image](https://user-images.githubusercontent.com/228117/128563407-869db36f-9f22-48c8-9b48-9488652a1462.png)
