### PR TITLE
Fix #4573 Openemr fhir token revocation

### DIFF
--- a/_rest_config.php
+++ b/_rest_config.php
@@ -214,6 +214,22 @@ class RestConfig
         return $raw;
     }
 
+    /**
+     * Returns true if the access token for the given token id is valid.  Otherwise returns the access denied response.
+     * @param $tokenId
+     * @return bool|ResponseInterface
+     */
+    public static function validateAccessTokenRevoked($tokenId)
+    {
+        $repository = new AccessTokenRepository();
+        if ($repository->isAccessTokenRevokedInDatabase($tokenId))
+        {
+            $response = self::createServerResponse();
+            return OAuthServerException::accessDenied('Access token has been revoked')->generateHttpResponse($response);
+        }
+        return true;
+    }
+
     public static function isTrustedUser($clientId, $userId)
     {
         $trustedUserService = new TrustedUserService();

--- a/_rest_config.php
+++ b/_rest_config.php
@@ -222,8 +222,7 @@ class RestConfig
     public static function validateAccessTokenRevoked($tokenId)
     {
         $repository = new AccessTokenRepository();
-        if ($repository->isAccessTokenRevokedInDatabase($tokenId))
-        {
+        if ($repository->isAccessTokenRevokedInDatabase($tokenId)) {
             $response = self::createServerResponse();
             return OAuthServerException::accessDenied('Access token has been revoked')->generateHttpResponse($response);
         }

--- a/apis/dispatch.php
+++ b/apis/dispatch.php
@@ -132,6 +132,20 @@ $restRequest->setIsLocalApi($isLocalApi);
 $sessionAllowWrite = true;
 require_once("./../interface/globals.php");
 
+// we now can check the database to see if the token is revoked
+if (!empty($tokenId))
+{
+    $result = $gbl::validateAccessTokenRevoked($tokenId);
+    if ($result instanceof ResponseInterface) {
+        $logger->error("dispatch.php access token was revoked", ["resource" => $resource]);
+        // failed token verify
+        // not a request object so send the error as response obj
+        $gbl::emitResponse($result);
+        exit;
+    }
+}
+
+
 // recollect this so the DEBUG global can be used if set
 $logger = new SystemLogger();
 

--- a/apis/dispatch.php
+++ b/apis/dispatch.php
@@ -133,8 +133,7 @@ $sessionAllowWrite = true;
 require_once("./../interface/globals.php");
 
 // we now can check the database to see if the token is revoked
-if (!empty($tokenId))
-{
+if (!empty($tokenId)) {
     $result = $gbl::validateAccessTokenRevoked($tokenId);
     if ($result instanceof ResponseInterface) {
         $logger->error("dispatch.php access token was revoked", ["resource" => $resource]);

--- a/sql/6_0_0-to-6_1_0_upgrade.sql
+++ b/sql/6_0_0-to-6_1_0_upgrade.sql
@@ -946,7 +946,7 @@ CREATE TABLE `api_refresh_token` (
     `expiry` DATETIME,
     `revoked` TINYINT(1) NOT NULL DEFAULT 0 COMMENT '1=revoked,0=not revoked',
     PRIMARY KEY (`id`),
-    INDEX `api_refresh_token_token_idx` (`token`),
+    UNIQUE KEY (`token`),
     INDEX `api_refresh_token_usr_client_idx` (`client_id`, `user_id`)
 ) ENGINE = InnoDB COMMENT = 'Holds information about api refresh tokens.';
 #EndIf

--- a/sql/6_0_0-to-6_1_0_upgrade.sql
+++ b/sql/6_0_0-to-6_1_0_upgrade.sql
@@ -932,3 +932,21 @@ INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity, notes
 INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity, notes) VALUES ('medication-request-intent','instance-order','Instance Order',70,0,1, 'The request represents an instance for the particular order, for example a medication administration record.');
 INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity, notes) VALUES ('medication-request-intent','option','Option',80,0,1, 'The request represents a component or option for a RequestGroup that establishes timing, conditionality and/or other constraints among a set of requests.');
 #EndIf
+
+#IfMissingColumn api_token revoked
+ALTER TABLE `api_token` ADD COLUMN `revoked` TINYINT(1) NOT NULL DEFAULT 0 COMMENT '1=revoked,0=not revoked';
+#EndIf
+
+#IfNotTable api_refresh_token
+CREATE TABLE `api_refresh_token` (
+    `id` BIGINT(20) NOT NULL AUTO_INCREMENT,
+    `user_id` VARCHAR(40),
+    `client_id` VARCHAR(80),
+    `token` VARCHAR(128) NOT NULL,
+    `expiry` DATETIME,
+    `revoked` TINYINT(1) NOT NULL DEFAULT 0 COMMENT '1=revoked,0=not revoked',
+    PRIMARY KEY (`id`),
+    INDEX `api_refresh_token_token_idx` (`token`),
+    INDEX `api_refresh_token_usr_client_idx` (`client_id`, `user_id`)
+) ENGINE = InnoDB COMMENT = 'Holds information about api refresh tokens.';
+#EndIf

--- a/sql/6_0_0-to-6_1_0_upgrade.sql
+++ b/sql/6_0_0-to-6_1_0_upgrade.sql
@@ -940,10 +940,10 @@ ALTER TABLE `api_token` ADD COLUMN `revoked` TINYINT(1) NOT NULL DEFAULT 0 COMME
 #IfNotTable api_refresh_token
 CREATE TABLE `api_refresh_token` (
     `id` BIGINT(20) NOT NULL AUTO_INCREMENT,
-    `user_id` VARCHAR(40),
-    `client_id` VARCHAR(80),
+    `user_id` VARCHAR(40) DEFAULT NULL,
+    `client_id` VARCHAR(80) DEFAULT NULL,
     `token` VARCHAR(128) NOT NULL,
-    `expiry` DATETIME,
+    `expiry` DATETIME DEFAULT NULL,
     `revoked` TINYINT(1) NOT NULL DEFAULT 0 COMMENT '1=revoked,0=not revoked',
     PRIMARY KEY (`id`),
     UNIQUE KEY (`token`),

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -113,10 +113,26 @@ CREATE TABLE `api_token` (
   `expiry` datetime DEFAULT NULL,
   `client_id` varchar(80) DEFAULT NULL,
   `scope` text COMMENT 'json encoded',
+  `revoked` TINYINT(1) NOT NULL DEFAULT 0 COMMENT '1=revoked,0=not revoked',
   PRIMARY KEY (`id`),
   UNIQUE KEY `token` (`token`)
 ) ENGINE = InnoDB;
 
+--
+-- Table structure for table `api_refresh_token`
+--
+DROP TABLE IF EXISTS `api_refresh_token`;
+CREATE TABLE `api_refresh_token` (
+ `id` BIGINT(20) NOT NULL AUTO_INCREMENT,
+ `user_id` VARCHAR(40) DEFAULT NULL,
+ `client_id` VARCHAR(80) DEFAULT NULL,
+ `token` VARCHAR(128) NOT NULL,
+ `expiry` DATETIME DEFAULT NULL,
+ `revoked` TINYINT(1) NOT NULL DEFAULT 0 COMMENT '1=revoked,0=not revoked',
+ PRIMARY KEY (`id`),
+ UNIQUE KEY (`token`),
+ INDEX `api_refresh_token_usr_client_idx` (`client_id`, `user_id`)
+) ENGINE = InnoDB COMMENT = 'Holds information about api refresh tokens.';
 -- --------------------------------------------------------
 
 --

--- a/src/Common/Auth/OAuth2KeyConfig.php
+++ b/src/Common/Auth/OAuth2KeyConfig.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Oauth2KeyConfig is responsible for configuring, generating, and returning oauth2 keys that are used by the OpenEMR system.
  * @package openemr
@@ -13,7 +14,6 @@
  */
 
 namespace OpenEMR\Common\Auth;
-
 
 use OpenEMR\Common\Crypto\CryptoGen;
 use OpenEMR\Common\Utils\RandomGenUtils;
@@ -42,8 +42,7 @@ class OAuth2KeyConfig
 
     public function __construct($siteDir = null)
     {
-        if (empty($siteDir))
-        {
+        if (empty($siteDir)) {
             // default to our global location
             $siteDir = $GLOBALS['OE_SITE_DIR'];
         }

--- a/src/Common/Auth/OAuth2KeyConfig.php
+++ b/src/Common/Auth/OAuth2KeyConfig.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Oauth2KeyConfig is responsible for configuring, generating, and returning oauth2 keys that are used by the OpenEMR system.
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Jerry Padgett <sjpadgett@gmail.com>
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2020 Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright Copyright (c) 2020 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Common\Auth;
+
+
+use OpenEMR\Common\Crypto\CryptoGen;
+use OpenEMR\Common\Utils\RandomGenUtils;
+
+class OAuth2KeyConfig
+{
+    /**
+     * @var string encryption key stored in the database
+     */
+    private $oaEncryptionKey;
+
+    /**
+     * @var string OAUTH2 passphrase used for the private key
+     */
+    private $passphrase;
+
+    /**
+     * @var string File location of the oauth2 private key
+     */
+    private $privateKey;
+
+    /**
+     * @var string File location of the oauth2 public key
+     */
+    private $publicKey;
+
+    public function __construct($siteDir = null)
+    {
+        if (empty($siteDir))
+        {
+            // default to our global location
+            $siteDir = $GLOBALS['OE_SITE_DIR'];
+        }
+
+        // Create a crypto object that will be used for for encryption/decryption
+        $this->cryptoGen = new CryptoGen();
+        // verify and/or setup our key pairs.
+        $this->privateKey = $siteDir . '/documents/certificates/oaprivate.key';
+        $this->publicKey = $siteDir . '/documents/certificates/oapublic.key';
+    }
+
+    public function getPassPhrase()
+    {
+        return $this->passphrase;
+    }
+
+    public function getEncryptionKey()
+    {
+        return $this->oaEncryptionKey;
+    }
+    public function getPublicKeyLocation()
+    {
+        return $this->publicKey;
+    }
+
+    public function getPrivateKeyLocation()
+    {
+        return $this->privateKey;
+    }
+
+    /**
+     * Configures the public and private keys for OpenEMR OAuth2.  If they do not exist it generates them.
+     * @throws OAuth2KeyException
+     */
+    public function configKeyPairs(): void
+    {
+        // encryption key
+        $eKey = sqlQueryNoLog("SELECT `name`, `value` FROM `keys` WHERE `name` = 'oauth2key'");
+        if (!empty($eKey['name']) && ($eKey['name'] === 'oauth2key')) {
+            // collect the encryption key from database
+            $this->oaEncryptionKey = $this->cryptoGen->decryptStandard($eKey['value']);
+            if (empty($this->oaEncryptionKey)) {
+                // if decrypted key is empty, then critical error and must exit
+                throw new OAuth2KeyException("oauth2 key was blank after it was decrypted");
+            }
+        } else {
+            // create a encryption key and store it in database
+            $this->oaEncryptionKey = RandomGenUtils::produceRandomBytes(32);
+            if (empty($this->oaEncryptionKey)) {
+                // if empty, then force exit
+                throw new OAuth2KeyException("random generator broken during oauth2 encryption key generation");
+            }
+            $this->oaEncryptionKey = base64_encode($this->oaEncryptionKey);
+            if (empty($this->oaEncryptionKey)) {
+                // if empty, then force exit
+                throw new OAuth2KeyException("base64 encoding broken during oauth2 encryption key generation");
+            }
+            sqlStatementNoLog("INSERT INTO `keys` (`name`, `value`) VALUES ('oauth2key', ?)", [$this->cryptoGen->encryptStandard($this->oaEncryptionKey)]);
+        }
+        // private key
+        if (!file_exists($this->privateKey)) {
+            // create the private/public key pair (store in filesystem) with a random passphrase (store in database)
+            // first, create the passphrase (removing any prior passphrases)
+            sqlStatementNoLog("DELETE FROM `keys` WHERE `name` = 'oauth2passphrase'");
+            $this->passphrase = RandomGenUtils::produceRandomString(60, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
+            if (empty($this->passphrase)) {
+                // if empty, then force exit
+                throw new OAuth2KeyException("random generator broken during oauth2 key passphrase generation");
+            }
+            // second, create and store the private/public key pair
+            $keysConfig = [
+                "default_md" => "sha256",
+                "private_key_type" => OPENSSL_KEYTYPE_RSA,
+                "private_key_bits" => 2048,
+                "encrypt_key" => true,
+                "encrypt_key_cipher" => OPENSSL_CIPHER_AES_256_CBC
+            ];
+            $keys = \openssl_pkey_new($keysConfig);
+            if ($keys === false) {
+                // if unable to create keys, then force exit
+                throw new OAuth2KeyException("key generation broken during oauth2");
+            }
+            $privkey = '';
+            openssl_pkey_export($keys, $privkey, $this->passphrase, $keysConfig);
+            $pubkey = openssl_pkey_get_details($keys);
+            $pubkey = $pubkey["key"];
+            if (empty($privkey) || empty($pubkey)) {
+                // if unable to construct keys, then force exit
+                throw new OAuth2KeyException("key construction broken during oauth2");
+            }
+            // third, store the keys on drive and store the passphrase in the database
+            file_put_contents($this->privateKey, $privkey);
+            chmod($this->privateKey, 0640);
+            file_put_contents($this->publicKey, $pubkey);
+            chmod($this->publicKey, 0660);
+            sqlStatementNoLog("INSERT INTO `keys` (`name`, `value`) VALUES ('oauth2passphrase', ?)", [$this->cryptoGen->encryptStandard($this->passphrase)]);
+        }
+        // confirm existence of passphrase
+        $pkey = sqlQueryNoLog("SELECT `name`, `value` FROM `keys` WHERE `name` = 'oauth2passphrase'");
+        if (!empty($pkey['name']) && ($pkey['name'] == 'oauth2passphrase')) {
+            $this->passphrase = $this->cryptoGen->decryptStandard($pkey['value']);
+            if (empty($this->passphrase)) {
+                // if decrypted pssphrase is empty, then critical error and must exit
+                throw new OAuth2KeyException("oauth2 passphrase was blank after it was decrypted");
+            }
+        } else {
+            // oauth2passphrase is missing so must exit
+            throw new OAuth2KeyException("oauth2 passphrase is missing");
+        }
+        // confirm existence of key pair
+        if (!file_exists($this->privateKey) || !file_exists($this->publicKey)) {
+            // key pair is missing so must exit
+            throw new OAuth2KeyException("oauth2 keypair is missing");
+        }
+    }
+}

--- a/src/Common/Auth/OAuth2KeyException.php
+++ b/src/Common/Auth/OAuth2KeyException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * OAuth2KeyException.php
  * @package openemr
@@ -9,7 +10,6 @@
  */
 
 namespace OpenEMR\Common\Auth;
-
 
 class OAuth2KeyException extends \Exception
 {

--- a/src/Common/Auth/OAuth2KeyException.php
+++ b/src/Common/Auth/OAuth2KeyException.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * OAuth2KeyException.php
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Common\Auth;
+
+
+class OAuth2KeyException extends \Exception
+{
+
+}

--- a/src/Common/Auth/OpenIDConnect/Entities/ClientEntity.php
+++ b/src/Common/Auth/OpenIDConnect/Entities/ClientEntity.php
@@ -37,6 +37,23 @@ class ClientEntity implements ClientEntityInterface
      */
     protected $isEnabled;
 
+    /**
+     * @var array[] Array of trusted user objects
+     */
+    protected $trustedUsers;
+
+    /**
+     * @var string[] The list of contact email addresses to reach out for questions about the client app
+     */
+    protected $contacts;
+
+    /**
+     * @var string The logout uri to send users to to logout from the application.
+     */
+    protected $logoutRedirectUris;
+
+    protected $registrationDate;
+
     public function __construct()
     {
         $this->scopes = [];
@@ -165,4 +182,59 @@ class ClientEntity implements ClientEntityInterface
     {
         $this->jwksUri = $jwksUri;
     }
+
+    /**
+     * Array of records from the oauth2_trusted_users table
+     * @return array[]
+     */
+    public function getTrustedUsers(): array
+    {
+        return $this->trustedUsers;
+    }
+
+    /**
+     * Set the trusted user records (these come from the oauth2_trusted_users table
+     * @param array $trustedUsers
+     */
+    public function setTrustedUsers(array $trustedUsers)
+    {
+        $this->trustedUsers = $trustedUsers;
+    }
+
+    public function getContacts()
+    {
+        return $this->contacts;
+    }
+
+    public function setContacts($contacts)
+    {
+        $this->contacts = $contacts;
+    }
+
+    public function setRegistrationDate($registerDate)
+    {
+        $this->registrationDate = $registerDate;
+    }
+
+    public function getRegistrationDate()
+    {
+        return $this->registrationDate;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLogoutRedirectUris(): string
+    {
+        return $this->logoutRedirectUris;
+    }
+
+    /**
+     * @param string $logoutRedirectUris
+     */
+    public function setLogoutRedirectUris(?string $logoutRedirectUris): void
+    {
+        $this->logoutRedirectUris = $logoutRedirectUris;
+    }
+
 }

--- a/src/Common/Auth/OpenIDConnect/Entities/ClientEntity.php
+++ b/src/Common/Auth/OpenIDConnect/Entities/ClientEntity.php
@@ -236,5 +236,4 @@ class ClientEntity implements ClientEntityInterface
     {
         $this->logoutRedirectUris = $logoutRedirectUris;
     }
-
 }

--- a/src/Common/Auth/OpenIDConnect/JWT/JsonWebKeyParser.php
+++ b/src/Common/Auth/OpenIDConnect/JWT/JsonWebKeyParser.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * JsonWebKeyParser.php
  * @package openemr
@@ -9,7 +10,6 @@
  */
 
 namespace OpenEMR\Common\Auth\OpenIDConnect\JWT;
-
 
 use Exception;
 use Lcobucci\JWT\Parser;
@@ -32,8 +32,7 @@ class JsonWebKeyParser
 
     public function parseRefreshToken($rawToken)
     {
-        if (empty($rawToken))
-        {
+        if (empty($rawToken)) {
             throw new \InvalidArgumentException("Token cannot be empty");
         }
         $refreshTokenData = null;
@@ -56,8 +55,7 @@ class JsonWebKeyParser
 
     public function parseAccessToken($rawToken)
     {
-        if (empty($rawToken))
-        {
+        if (empty($rawToken)) {
             throw new \InvalidArgumentException("Token cannot be empty");
         }
         // Attempt to parse and validate the JWT
@@ -93,8 +91,7 @@ class JsonWebKeyParser
 
     public function getTokenHintFromToken($rawToken)
     {
-        if (empty($rawToken))
-        {
+        if (empty($rawToken)) {
             throw new \InvalidArgumentException("Token cannot be empty");
         }
         // determine if access or refresh.

--- a/src/Common/Auth/OpenIDConnect/JWT/JsonWebKeyParser.php
+++ b/src/Common/Auth/OpenIDConnect/JWT/JsonWebKeyParser.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * JsonWebKeyParser.php
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Common\Auth\OpenIDConnect\JWT;
+
+
+use Exception;
+use Lcobucci\JWT\Parser;
+use Lcobucci\JWT\Signer\Rsa\Sha256;
+use Lcobucci\JWT\ValidationData;
+use League\OAuth2\Server\CryptTrait;
+use LogicException;
+
+class JsonWebKeyParser
+{
+    use CryptTrait;
+
+    private $publicKeyLocation;
+
+    public function __construct($oaEncryptionKey, $publicKeyLocation)
+    {
+        $this->setEncryptionKey($oaEncryptionKey);
+        $this->publicKeyLocation = $publicKeyLocation;
+    }
+
+    public function parseRefreshToken($rawToken)
+    {
+        if (empty($rawToken))
+        {
+            throw new \InvalidArgumentException("Token cannot be empty");
+        }
+        $refreshTokenData = null;
+        $refreshToken = $this->decrypt($rawToken);
+        $refreshTokenData = \json_decode($refreshToken, true);
+        $result = array(
+            'active' => true,
+            'status' => 'active',
+            'scope' => $refreshTokenData['scopes'],
+            'exp' => $refreshTokenData['expire_time'],
+            'sub' => $refreshTokenData['user_id'],
+            'jti' => $refreshTokenData['refresh_token_id']
+        );
+        if ($refreshTokenData['expire_time'] < \time()) {
+            $result['active'] = false;
+            $result['status'] = 'expired';
+        }
+        return $result;
+    }
+
+    public function parseAccessToken($rawToken)
+    {
+        if (empty($rawToken))
+        {
+            throw new \InvalidArgumentException("Token cannot be empty");
+        }
+        // Attempt to parse and validate the JWT
+        $token = (new Parser())->parse($rawToken);
+        // defaults
+        $result = array(
+            'active' => true,
+            'status' => 'active',
+            'scope' => implode(" ", $token->getClaim('scopes')),
+            'exp' => $token->claims()->get('exp'),
+            'sub' => $token->claims()->get('sub'), // user_id
+            'jti' => $token->claims()->get('jti'),
+            'aud' => $token->claims()->get('aud')
+        );
+        try {
+            if ($token->verify(new Sha256(), 'file://' . $this->publicKeyLocation) === false) {
+                $result['active'] = false;
+                $result['status'] = 'failed_verification';
+            }
+        } catch (Exception $exception) {
+            $result['active'] = false;
+            $result['status'] = 'invalid_signature';
+        }
+        // Ensure access token hasn't expired
+        $data = new ValidationData();
+        $data->setCurrentTime(\time());
+        if ($token->validate($data) === false) {
+            $result['active'] = false;
+            $result['status'] = 'expired';
+        }
+        return $result;
+    }
+
+    public function getTokenHintFromToken($rawToken)
+    {
+        if (empty($rawToken))
+        {
+            throw new \InvalidArgumentException("Token cannot be empty");
+        }
+        // determine if access or refresh.
+        $access_parts = explode(".", $rawToken);
+        if (count($access_parts) === 3) {
+            $token_hint = 'access_token';
+        } else {
+            $token_hint = 'refresh_token';
+        }
+        return $token_hint;
+    }
+}

--- a/src/Common/Auth/OpenIDConnect/Repositories/AccessTokenRepository.php
+++ b/src/Common/Auth/OpenIDConnect/Repositories/AccessTokenRepository.php
@@ -104,7 +104,7 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
     public function getActiveTokensForUser($clientId, $userUuid)
     {
         // note user_id is the STRING representation of the uuid, not the binary representation
-        $sql = "SELECT * FROM api_token WHERE user_id = ? AND client_id = ? AND expiry > NOW() ";
+        $sql = "SELECT * FROM api_token WHERE user_id = ? AND client_id = ? AND expiry > NOW() AND revoked = 0 ";
         return QueryUtils::fetchRecords($sql, [$userUuid, $clientId]);
     }
 

--- a/src/Common/Auth/OpenIDConnect/Repositories/AccessTokenRepository.php
+++ b/src/Common/Auth/OpenIDConnect/Repositories/AccessTokenRepository.php
@@ -41,8 +41,7 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
     public function persistNewAccessToken(AccessTokenEntityInterface $accessTokenEntity): void
     {
         $token = $this->getTokenByToken($accessTokenEntity->getIdentifier());
-        if (!empty($token))
-        {
+        if (!empty($token)) {
             throw UniqueTokenIdentifierConstraintViolationException::create("Duplicate id was generated");
         }
 

--- a/src/Common/Auth/OpenIDConnect/Repositories/AccessTokenRepository.php
+++ b/src/Common/Auth/OpenIDConnect/Repositories/AccessTokenRepository.php
@@ -17,6 +17,8 @@ use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Entities\Traits\AccessTokenTrait;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
 use OpenEMR\Common\Auth\OpenIDConnect\Entities\AccessTokenEntity;
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Logging\SystemLogger;
 
 class AccessTokenRepository implements AccessTokenRepositoryInterface
 {
@@ -53,6 +55,7 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
 
     public function revokeAccessToken($tokenId)
     {
+        (new SystemLogger())->debug(self::class . "->revokeAccessToken() attempting to revoke access token ", ['tokenId' => $tokenId]);
     }
 
     public function isAccessTokenRevoked($tokenId)
@@ -70,5 +73,12 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
         $accessToken->setUserIdentifier($userIdentifier);
 
         return $accessToken;
+    }
+
+    public function getActiveTokensForUser($clientId, $userUuid)
+    {
+        // note user_id is the STRING representation of the uuid, not the binary representation
+        $sql = "SELECT * FROM api_token WHERE user_id = ? AND client_id = ? AND expiry > NOW() ";
+        return QueryUtils::fetchRecords($sql, [$userUuid, $clientId]);
     }
 }

--- a/src/Common/Auth/OpenIDConnect/Repositories/AccessTokenRepository.php
+++ b/src/Common/Auth/OpenIDConnect/Repositories/AccessTokenRepository.php
@@ -122,7 +122,7 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
 
     public function getTokenByToken($token)
     {
-        $sql = "SELECT * FROM api_token WHERE id = ? ";
+        $sql = "SELECT * FROM api_token WHERE token = ? ";
         $records = QueryUtils::fetchRecords($sql, [$token], true);
         return $records[0] ?? null;
     }

--- a/src/Common/Auth/OpenIDConnect/Repositories/AccessTokenRepository.php
+++ b/src/Common/Auth/OpenIDConnect/Repositories/AccessTokenRepository.php
@@ -15,6 +15,7 @@ namespace OpenEMR\Common\Auth\OpenIDConnect\Repositories;
 use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Entities\Traits\AccessTokenTrait;
+use League\OAuth2\Server\Exception\UniqueTokenIdentifierConstraintViolationException;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
 use OpenEMR\Common\Auth\OpenIDConnect\Entities\AccessTokenEntity;
 use OpenEMR\Common\Database\QueryUtils;
@@ -39,6 +40,12 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
 
     public function persistNewAccessToken(AccessTokenEntityInterface $accessTokenEntity): void
     {
+        $token = $this->getTokenByToken($accessTokenEntity->getIdentifier());
+        if (!empty($token))
+        {
+            throw UniqueTokenIdentifierConstraintViolationException::create("Duplicate id was generated");
+        }
+
         $access_token = (string) $accessTokenEntity;
         $exp_date = $accessTokenEntity->getExpiryDateTime()->format('Y-m-d H:i:s');
         $user_id = $accessTokenEntity->getUserIdentifier();
@@ -56,11 +63,30 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
     public function revokeAccessToken($tokenId)
     {
         (new SystemLogger())->debug(self::class . "->revokeAccessToken() attempting to revoke access token ", ['tokenId' => $tokenId]);
+        // Some logic to revoke the refresh token in a database
+        $sql = "UPDATE api_token SET revoked = 1 WHERE token = ?";
+        QueryUtils::sqlStatementThrowException($sql, [$tokenId], true);
     }
 
+    /**
+     * Because of the way our access tokens contain the multi-tenant site-id in them we have to return false on this statement
+     * as we currently don't have any database functionality loaded and can't check the database to see if the token is revoked
+     * Since this logic is embedded inside the League OAUTH server we have it return false and check the token revokation
+     * later on in our api dispatch logic.
+     * @param string $tokenId
+     * @return bool
+     */
     public function isAccessTokenRevoked($tokenId)
     {
-        return false; // Access token hasn't been revoked
+        return false;
+    }
+
+    public function isAccessTokenRevokedInDatabase($tokenId)
+    {
+        $sql = " SELECT * FROM api_token WHERE token = ? AND revoked = 1 ";
+        $resource = QueryUtils::sqlStatementThrowException($sql, [$tokenId], true);
+        $result = QueryUtils::fetchArrayFromResultSet($resource);
+        return !empty($result); // if the result set is not empty then its been revoked, otherwise its a good token
     }
 
     public function getNewToken(ClientEntityInterface $clientEntity, array $scopes, $userIdentifier = null)
@@ -80,5 +106,24 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
         // note user_id is the STRING representation of the uuid, not the binary representation
         $sql = "SELECT * FROM api_token WHERE user_id = ? AND client_id = ? AND expiry > NOW() ";
         return QueryUtils::fetchRecords($sql, [$userUuid, $clientId]);
+    }
+
+    /**
+     * Retrieves a token record for given database token id.
+     * @param $id The database identifier for the token (see table api_token.id
+     * @return array|null
+     */
+    public function getTokenById($id)
+    {
+        $sql = "SELECT * FROM api_token WHERE id = ? ";
+        $records = QueryUtils::fetchRecords($sql, [$id]);
+        return $records[0] ?? null;
+    }
+
+    public function getTokenByToken($token)
+    {
+        $sql = "SELECT * FROM api_token WHERE id = ? ";
+        $records = QueryUtils::fetchRecords($sql, [$token], true);
+        return $records[0] ?? null;
     }
 }

--- a/src/Common/Auth/OpenIDConnect/Repositories/ClientRepository.php
+++ b/src/Common/Auth/OpenIDConnect/Repositories/ClientRepository.php
@@ -35,7 +35,7 @@ class ClientRepository implements ClientRepositoryInterface
      */
     public function listClientEntities(): array
     {
-        $clients = sqlStatementNoLog("Select * From oauth_clients");
+        $clients = sqlStatementNoLog("Select * From oauth_clients ORDER BY is_enabled DESC, register_date DESC");
         $list = [];
         if (!empty($clients)) {
             while ($client = $clients->FetchRow()) {
@@ -153,6 +153,9 @@ class ClientRepository implements ClientRepositoryInterface
         $client->setIsEnabled($client_record['is_enabled'] === "1");
         $client->setJwks($client_record['jwks']);
         $client->setJwksUri($client_record['jwks_uri']);
+        $client->setLogoutRedirectUris($client_record['logout_redirect_uris']);
+        $client->setContacts($client_record['contacts']);
+        $client->setRegistrationDate($client_record['register_date']);
         return $client;
     }
 }

--- a/src/Common/Auth/OpenIDConnect/Repositories/RefreshTokenRepository.php
+++ b/src/Common/Auth/OpenIDConnect/Repositories/RefreshTokenRepository.php
@@ -13,30 +13,68 @@
 namespace OpenEMR\Common\Auth\OpenIDConnect\Repositories;
 
 use League\OAuth2\Server\Entities\RefreshTokenEntityInterface;
+use League\OAuth2\Server\Exception\UniqueTokenIdentifierConstraintViolationException;
 use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
 use OpenEMR\Common\Auth\OpenIDConnect\Entities\RefreshTokenEntity;
+use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Logging\SystemLogger;
 
 class RefreshTokenRepository implements RefreshTokenRepositoryInterface
 {
     public function persistNewRefreshToken(RefreshTokenEntityInterface $refreshTokenEntity)
     {
-        // Some logic to persist the refresh token in a database
+        $token = $this->getRefreshTokenByToken($refreshTokenEntity->getIdentifier());
+        if (!empty($token))
+        {
+            throw UniqueTokenIdentifierConstraintViolationException::create("Duplicate id was generated");
+        }
+
+        $exp_date = $refreshTokenEntity->getExpiryDateTime()->format('Y-m-d H:i:s');
+        $user_id = $refreshTokenEntity->getAccessToken()->getUserIdentifier();
+        $unique_id = $refreshTokenEntity->getIdentifier();
+        $client_id = $refreshTokenEntity->getAccessToken()->getClient()->getIdentifier();
+
+        // TODO: Do we need to throw the UniqueTokenIdentifierConstraintViolationException?? if our token is already used?
+        $sql = " INSERT INTO api_refresh_token SET";
+        $sql .= " `user_id` = ?,";
+        $sql .= " `token` = ?,";
+        $sql .= " `expiry` = ?, `client_id` = ? ";
+        sqlStatementNoLog($sql, [$user_id, $unique_id, $exp_date, $client_id]);
     }
 
     public function revokeRefreshToken($tokenId)
     {
         // Some logic to revoke the refresh token in a database
         (new SystemLogger())->debug(self::class . "->revokeRefreshToken() attempting to revoke refresh token ", ['tokenId' => $tokenId]);
+        $sql = "UPDATE api_refresh_token SET revoked = 1 WHERE token = ?";
+        QueryUtils::sqlStatementThrowException($sql, [$tokenId], true);
     }
 
     public function isRefreshTokenRevoked($tokenId)
     {
-        return false; // The refresh token has not been revoked
+        $sql = " SELECT * FROM api_refresh_token WHERE token = ? AND revoked = 1 ";
+        $resource = QueryUtils::sqlStatementThrowException($sql, [$tokenId], true);
+        $result = QueryUtils::fetchArrayFromResultSet($resource);
+        return !empty($result); // if the result set is not empty then its been revoked, otherwise its a good token
     }
 
     public function getNewRefreshToken()
     {
         return new RefreshTokenEntity();
+    }
+
+    public function getActiveTokensForUser($clientId, $userUuid)
+    {
+        // note user_id is the STRING representation of the uuid, not the binary representation
+        $sql = "SELECT * FROM api_refresh_token WHERE user_id = ? AND client_id = ? AND expiry > NOW() ";
+        return QueryUtils::fetchRecords($sql, [$userUuid, $clientId]);
+    }
+
+    public function getRefreshTokenByToken($token)
+    {
+        $sql = " SELECT * FROM api_refresh_token WHERE token = ?";
+        $resource = QueryUtils::sqlStatementThrowException($sql, [$token], true);
+        $result = QueryUtils::fetchArrayFromResultSet($resource);
+        return $result[0] ?? null; // if the result set is not empty then its been revoked, otherwise its a good token
     }
 }

--- a/src/Common/Auth/OpenIDConnect/Repositories/RefreshTokenRepository.php
+++ b/src/Common/Auth/OpenIDConnect/Repositories/RefreshTokenRepository.php
@@ -24,8 +24,7 @@ class RefreshTokenRepository implements RefreshTokenRepositoryInterface
     public function persistNewRefreshToken(RefreshTokenEntityInterface $refreshTokenEntity)
     {
         $token = $this->getRefreshTokenByToken($refreshTokenEntity->getIdentifier());
-        if (!empty($token))
-        {
+        if (!empty($token)) {
             throw UniqueTokenIdentifierConstraintViolationException::create("Duplicate id was generated");
         }
 

--- a/src/Common/Auth/OpenIDConnect/Repositories/RefreshTokenRepository.php
+++ b/src/Common/Auth/OpenIDConnect/Repositories/RefreshTokenRepository.php
@@ -66,7 +66,7 @@ class RefreshTokenRepository implements RefreshTokenRepositoryInterface
     public function getActiveTokensForUser($clientId, $userUuid)
     {
         // note user_id is the STRING representation of the uuid, not the binary representation
-        $sql = "SELECT * FROM api_refresh_token WHERE user_id = ? AND client_id = ? AND expiry > NOW() ";
+        $sql = "SELECT * FROM api_refresh_token WHERE user_id = ? AND client_id = ? AND expiry > NOW() AND revoked = 0 ";
         return QueryUtils::fetchRecords($sql, [$userUuid, $clientId]);
     }
 
@@ -75,6 +75,14 @@ class RefreshTokenRepository implements RefreshTokenRepositoryInterface
         $sql = " SELECT * FROM api_refresh_token WHERE token = ?";
         $resource = QueryUtils::sqlStatementThrowException($sql, [$token], true);
         $result = QueryUtils::fetchArrayFromResultSet($resource);
-        return $result[0] ?? null; // if the result set is not empty then its been revoked, otherwise its a good token
+        return $result ?? null; // if the result set is not empty then its been revoked, otherwise its a good token
+    }
+
+    public function getTokenById($id)
+    {
+        $sql = " SELECT * FROM api_refresh_token WHERE id = ?";
+        $resource = QueryUtils::sqlStatementThrowException($sql, [$id], true);
+        $result = QueryUtils::fetchArrayFromResultSet($resource);
+        return $result ?? null; // if the result set is not empty then its been revoked, otherwise its a good token
     }
 }

--- a/src/Common/Auth/OpenIDConnect/Repositories/RefreshTokenRepository.php
+++ b/src/Common/Auth/OpenIDConnect/Repositories/RefreshTokenRepository.php
@@ -23,7 +23,7 @@ class RefreshTokenRepository implements RefreshTokenRepositoryInterface
 {
     public function persistNewRefreshToken(RefreshTokenEntityInterface $refreshTokenEntity)
     {
-        $token = $this->getRefreshTokenByToken($refreshTokenEntity->getIdentifier());
+        $token = $this->getTokenByToken($refreshTokenEntity->getIdentifier());
         if (!empty($token)) {
             throw UniqueTokenIdentifierConstraintViolationException::create("Duplicate id was generated");
         }
@@ -67,14 +67,6 @@ class RefreshTokenRepository implements RefreshTokenRepositoryInterface
         // note user_id is the STRING representation of the uuid, not the binary representation
         $sql = "SELECT * FROM api_refresh_token WHERE user_id = ? AND client_id = ? AND expiry > NOW() AND revoked = 0 ";
         return QueryUtils::fetchRecords($sql, [$userUuid, $clientId]);
-    }
-
-    public function getRefreshTokenByToken($token)
-    {
-        $sql = " SELECT * FROM api_refresh_token WHERE token = ?";
-        $resource = QueryUtils::sqlStatementThrowException($sql, [$token], true);
-        $result = QueryUtils::fetchArrayFromResultSet($resource);
-        return $result ?? null; // if the result set is not empty then its been revoked, otherwise its a good token
     }
 
     public function getTokenById($id)

--- a/src/Common/Auth/OpenIDConnect/Repositories/RefreshTokenRepository.php
+++ b/src/Common/Auth/OpenIDConnect/Repositories/RefreshTokenRepository.php
@@ -15,6 +15,7 @@ namespace OpenEMR\Common\Auth\OpenIDConnect\Repositories;
 use League\OAuth2\Server\Entities\RefreshTokenEntityInterface;
 use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
 use OpenEMR\Common\Auth\OpenIDConnect\Entities\RefreshTokenEntity;
+use OpenEMR\Common\Logging\SystemLogger;
 
 class RefreshTokenRepository implements RefreshTokenRepositoryInterface
 {
@@ -26,6 +27,7 @@ class RefreshTokenRepository implements RefreshTokenRepositoryInterface
     public function revokeRefreshToken($tokenId)
     {
         // Some logic to revoke the refresh token in a database
+        (new SystemLogger())->debug(self::class . "->revokeRefreshToken() attempting to revoke refresh token ", ['tokenId' => $tokenId]);
     }
 
     public function isRefreshTokenRevoked($tokenId)

--- a/src/Common/Auth/OpenIDConnect/Repositories/RefreshTokenRepository.php
+++ b/src/Common/Auth/OpenIDConnect/Repositories/RefreshTokenRepository.php
@@ -85,4 +85,12 @@ class RefreshTokenRepository implements RefreshTokenRepositoryInterface
         $result = QueryUtils::fetchArrayFromResultSet($resource);
         return $result ?? null; // if the result set is not empty then its been revoked, otherwise its a good token
     }
+
+    public function getTokenByToken($token)
+    {
+        $sql = " SELECT * FROM api_refresh_token WHERE token = ?";
+        $resource = QueryUtils::sqlStatementThrowException($sql, [$token], true);
+        $result = QueryUtils::fetchArrayFromResultSet($resource);
+        return $result ?? null; // if the result set is not empty then its been revoked, otherwise its a good token
+    }
 }

--- a/src/Common/Database/QueryUtils.php
+++ b/src/Common/Database/QueryUtils.php
@@ -143,9 +143,9 @@ class QueryUtils
     public static function sqlStatementThrowException($statement, $binds, $noLog = false)
     {
         if ($noLog) {
-            return sqlStatementNoLog($statement, $binds, true);
+            return \sqlStatementNoLog($statement, $binds, true);
         } else {
-            return sqlStatementThrowException($statement, $binds);
+            return \sqlStatementThrowException($statement, $binds);
         }
     }
 

--- a/src/FHIR/SMART/ClientAdminController.php
+++ b/src/FHIR/SMART/ClientAdminController.php
@@ -1023,18 +1023,18 @@ class ClientAdminController
             <?php endif; ?>
         </h3>
         <ul>
-        <li><?php echo xlt("Token JTI(DB token value)"); ?>: <?php echo $parts['jti']; ?></li>
-        <li><?php echo xlt("Token DB Id"); ?>: <?php echo $databaseRecord['id']; ?></li>
-        <li><?php echo xlt("Token Status"); ?>: <?php echo $parts['status']; ?></li>
-        <li><?php echo xlt("Token Type"); ?>: <?php echo $parts['token_type']; ?></li>
-        <li><?php echo xlt("Token Expiration"); ?>: <?php echo $databaseRecord['expiry']; ?></li>
+        <li><?php echo xlt("Token JTI(DB token value)"); ?>: <?php echo text($parts['jti']); ?></li>
+        <li><?php echo xlt("Token DB Id"); ?>: <?php echo text($databaseRecord['id']); ?></li>
+        <li><?php echo xlt("Token Status"); ?>: <?php echo text($parts['status']); ?></li>
+        <li><?php echo xlt("Token Type"); ?>: <?php echo text($parts['token_type']); ?></li>
+        <li><?php echo xlt("Token Expiration"); ?>: <?php echo text($databaseRecord['expiry']); ?></li>
         <li><?php echo xlt("User UUID"); ?>:
         <a href="<?php echo attr($parts['user_link']); ?>">
-            <?php echo $databaseRecord['user_id']; ?>
+            <?php echo text($databaseRecord['user_id']); ?>
         </a>
         </li>
         </ul>
-        <pre><?php echo json_encode($parts, JSON_PRETTY_PRINT); ?></pre>
+        <pre><?php echo text(json_encode($parts, JSON_PRETTY_PRINT)); ?></pre>
             <?php
         }
 

--- a/src/FHIR/SMART/ClientAdminController.php
+++ b/src/FHIR/SMART/ClientAdminController.php
@@ -11,10 +11,14 @@
 
 namespace OpenEMR\FHIR\SMART;
 
-use Lcobucci\JWT\Parser;use OpenEMR\Common\Acl\AccessDeniedException;
+use Lcobucci\JWT\Parser;
+use OpenEMR\Common\Acl\AccessDeniedException;
 use OpenEMR\Common\Acl\AclMain;
-use OpenEMR\Common\Auth\OAuth2KeyConfig;use OpenEMR\Common\Auth\OAuth2KeyException;use OpenEMR\Common\Auth\OpenIDConnect\Entities\ClientEntity;
-use OpenEMR\Common\Auth\OpenIDConnect\JWT\JsonWebKeyParser;use OpenEMR\Common\Auth\OpenIDConnect\Repositories\AccessTokenRepository;
+use OpenEMR\Common\Auth\OAuth2KeyConfig;
+use OpenEMR\Common\Auth\OAuth2KeyException;
+use OpenEMR\Common\Auth\OpenIDConnect\Entities\ClientEntity;
+use OpenEMR\Common\Auth\OpenIDConnect\JWT\JsonWebKeyParser;
+use OpenEMR\Common\Auth\OpenIDConnect\Repositories\AccessTokenRepository;
 use OpenEMR\Common\Auth\OpenIDConnect\Repositories\ClientRepository;
 use OpenEMR\Common\Auth\OpenIDConnect\Repositories\RefreshTokenRepository;
 use OpenEMR\Common\Csrf\CsrfInvalidException;
@@ -33,7 +37,7 @@ class ClientAdminController
     const REVOKE_ACCESS_TOKEN = 'revoke-access-token';
     const REVOKE_REFRESH_TOKEN = 'revoke-refresh-token';
     const TOKEN_TOOLS_ACTION = 'token-tools';
-    CONST PARSE_TOKEN_ACTION = "parse-token";
+    const PARSE_TOKEN_ACTION = "parse-token";
 
     private $actionURL;
 
@@ -115,7 +119,6 @@ class ClientAdminController
                 return $this->parseTokenAction($request);
             } else if ($mainActionChild == self::REVOKE_ACCESS_TOKEN) {
                 return $this->toolsRevokeAccessTokenAction($request);
-
             } else if ($mainActionChild == self::REVOKE_REFRESH_TOKEN) {
                 return $this->toolsRevokeRefreshToken($request);
             } else {
@@ -179,19 +182,16 @@ class ClientAdminController
             // TODO: do we need to optimize this query?
             if (UuidRegistry::isValidStringUUID($user['user_id'])) {
                 $registryRecord = UuidRegistry::getRegistryRecordForUuid($user['user_id']);
-                if ($registryRecord['table_name'] == 'patient_data')
-                {
+                if ($registryRecord['table_name'] == 'patient_data') {
                     $user['user_type'] = 'patient';
                     $result = $patientService->getOne($user['user_id']);
                     $patient = $result->hasData() ? $result->getData()[0] : null;
                     $user['patient'] = $patient;
                     $user['display_name'] = isset($patient) ? $patient['fname'] . ' ' . $patient['lname'] : "Patient record not found";
-                }
-                else
-                {
-                   $user['user_type'] = 'user';
-                   $user['user'] = $userService->getUserByUUID($user['user_id']);
-                   $user['display_name'] = !empty($user['user']) ? $user['user']['username'] : "Record not found";
+                } else {
+                    $user['user_type'] = 'user';
+                    $user['user'] = $userService->getUserByUUID($user['user_id']);
+                    $user['display_name'] = !empty($user['user']) ? $user['user']['username'] : "Record not found";
                 }
             }
             $user['accessTokens'] = $this->getAccessTokensForClientUser($clientId, $user['user_id']);
@@ -214,9 +214,7 @@ class ClientAdminController
             try {
                 $token['scope'] = json_decode($token['scope'], true);
                 $result[] = $token;
-            }
-            catch (\JsonException $exception)
-            {
+            } catch (\JsonException $exception) {
                 (new SystemLogger())->error("Failed to json_decode api_token scope column. "
                     . $exception->getMessage(), ['id' => $token['id'], 'clientId' => $clientId, 'user_id' => $user_id]);
             }
@@ -580,7 +578,7 @@ class ClientAdminController
                                                 </div>
                                                 <?php endif; ?>
                                                 <?php if (!empty($trustedUser['accessTokens'])) : ?>
-                                                    <?php foreach($trustedUser['accessTokens'] as $token) : ?>
+                                                    <?php foreach ($trustedUser['accessTokens'] as $token) : ?>
                                                         <div class="row">
                                                             <div class="col-3">
                                                                 <?php echo text($token['token']); ?>
@@ -625,7 +623,7 @@ class ClientAdminController
                                                     </div>
                                                 <?php endif; ?>
                                                 <?php if (!empty($trustedUser['refreshTokens'])) : ?>
-                                                    <?php foreach($trustedUser['refreshTokens'] as $token) : ?>
+                                                    <?php foreach ($trustedUser['refreshTokens'] as $token) : ?>
                                                         <div class="row">
                                                             <div class="col-7">
                                                                 <?php echo text($token['token']); ?>
@@ -864,8 +862,7 @@ class ClientAdminController
         $trustedUserService = new TrustedUserService();
         $originalUser = $trustedUserService->getTrustedUser($clientId, $trustedUserId);
         // make sure the client is the same
-        if (empty($originalUser))
-        {
+        if (empty($originalUser)) {
             throw new AccessDeniedException('admin', 'super', "Attempted to delete trusted user for different client");
         }
 
@@ -888,8 +885,7 @@ class ClientAdminController
         $service = new RefreshTokenRepository();
         $token = $service->getTokenById($tokenId);
         // make sure the client is the same
-        if (empty($token) || $token['client_id'] != $clientId)
-        {
+        if (empty($token) || $token['client_id'] != $clientId) {
             throw new AccessDeniedException('admin', 'super', "Attempted to refresh access token for different client");
         }
         $service->revokeRefreshToken($token['token']);
@@ -906,8 +902,7 @@ class ClientAdminController
         $service = new AccessTokenRepository();
         $accessToken = $service->getTokenById($token);
         // make sure the client is the same
-        if (empty($accessToken) || $accessToken['client_id'] != $clientId)
-        {
+        if (empty($accessToken) || $accessToken['client_id'] != $clientId) {
             throw new AccessDeniedException('admin', 'super', "Attempted to delete access token for different client");
         }
         $service->revokeAccessToken($accessToken['token']);
@@ -924,8 +919,7 @@ class ClientAdminController
         $service = new RefreshTokenRepository();
         $accessToken = $service->getTokenById($token);
         // make sure the client is the same
-        if (empty($accessToken) || $accessToken['client_id'] != $clientId)
-        {
+        if (empty($accessToken) || $accessToken['client_id'] != $clientId) {
             throw new AccessDeniedException('admin', 'super', "Attempted to delete refresh token for different client");
         }
         $service->revokeRefreshToken($accessToken['token']);
@@ -947,8 +941,7 @@ class ClientAdminController
         $service = new AccessTokenRepository();
         $accessToken = $service->getTokenById($accessToken);
         // make sure the client is the same
-        if (empty($accessToken) || $accessToken['client_id'] != $clientId)
-        {
+        if (empty($accessToken) || $accessToken['client_id'] != $clientId) {
             throw new AccessDeniedException('admin', 'super', "Attempted to delete access token for different client");
         }
         $service->revokeAccessToken($accessToken['token']);
@@ -988,23 +981,19 @@ class ClientAdminController
                 ,'type' => 'textarea'
                 ,'enabled' => true
         ];
-        if (!empty($request['token']))
-        {
+        if (!empty($request['token'])) {
             $parts = $this->parseTokenIntoParts($request['token']);
             $databaseRecord = $this->getDatabaseRecordForToken($parts['jti'], $parts['token_type']);
-            if (!empty($databaseRecord)){
+            if (!empty($databaseRecord)) {
                 $parts['client_id'] = $databaseRecord['client_id'];
                 $parts['status'] = $databaseRecord['revoked'] != 0 ? 'revoked' : $parts['status'];
             }
 
             $queryParams = ['token' => $databaseRecord['id'], 'clientId' => $databaseRecord['client_id']];
-            if ($parts['token_type'] == 'refresh_token')
-            {
+            if ($parts['token_type'] == 'refresh_token') {
                 $parts['revoke_link'] = $this->getActionUrl([self::TOKEN_TOOLS_ACTION, self::REVOKE_REFRESH_TOKEN], ['queryParams' => $queryParams]);
-            }
-            else {
+            } else {
                 $parts['revoke_link'] = $this->getActionUrl([self::TOKEN_TOOLS_ACTION, self::REVOKE_ACCESS_TOKEN], ['queryParams' => $queryParams]);
-
             }
             $parts['user_link'] = $this->getActionUrl(['edit', $databaseRecord['client_id']], ['fragment' => $databaseRecord['user_id']]);
         }
@@ -1012,11 +1001,11 @@ class ClientAdminController
         // now let's grab our parser and see what we can do with all of this.
         $this->renderTokenToolsHeader($request);
         if (empty($databaseRecord)) {
-        ?>
+            ?>
         <div class="alert alert-info">
-        <?php echo xlt("JWT not found in system"); ?>
+            <?php echo xlt("JWT not found in system"); ?>
         </div>
-        <?php
+            <?php
         }
         ?>
         <form method="POST" action="<?php echo $actionUrl; ?>">
@@ -1026,7 +1015,6 @@ class ClientAdminController
         <input type="submit" class="btn btn-sm btn-primary" value="<?php echo xla("Parse Token"); ?>" />
 
         <?php if (!empty($databaseRecord)) { ?>
-
         <hr />
         <h3><?php echo xlt("Token details"); ?>
             <?php if ($databaseRecord['revoked'] == 0) : ?>
@@ -1047,7 +1035,7 @@ class ClientAdminController
         </li>
         </ul>
         <pre><?php echo json_encode($parts, JSON_PRETTY_PRINT); ?></pre>
-        <?php
+            <?php
         }
 
         $this->renderTokenToolsFooter();
@@ -1055,8 +1043,7 @@ class ClientAdminController
 
     private function getDatabaseRecordForToken($tokenId, $tokenType)
     {
-        if ($tokenType == 'refresh_token')
-        {
+        if ($tokenType == 'refresh_token') {
             $repo = new RefreshTokenRepository();
         } else {
             $repo = new AccessTokenRepository();
@@ -1073,17 +1060,13 @@ class ClientAdminController
             $webKeyParser = new JsonWebKeyParser($keyConfig->getEncryptionKey(), $keyConfig->getPublicKeyLocation());
 
             $tokenType = $webKeyParser->getTokenHintFromToken($rawToken);
-            if ($tokenType == 'refresh_token')
-            {
+            if ($tokenType == 'refresh_token') {
                 $tokenParts = $webKeyParser->parseRefreshToken($rawToken);
             } else {
                 $tokenParts = $webKeyParser->parseAccessToken($rawToken);
             }
             $tokenParts['token_type'] = $tokenType;
-        }
-        catch (OAuth2KeyException $exception)
-        {
-
+        } catch (OAuth2KeyException $exception) {
             var_dump($exception->getMessage());
             // TODO: @adunsulag handle how we will work with our key exceptions
         }

--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -153,6 +153,7 @@ class AuthorizationController
             $serverException = OAuthServerException::serverError("Security error - problem with authorization server keys.", $exception);
             SessionUtil::oauthSessionCookieDestroy();
             $this->emitResponse($serverException->generateHttpResponse($response));
+            exit;
         }
     }
 
@@ -577,7 +578,6 @@ class AuthorizationController
             $responseType->markIsAuthorizationGrant(); // we have specific SMART responses for an authorization grant.
         }
 
-        $this->logger->debug("key log ", ['privateKey' => $this->privateKey, 'passphrase' => $this->passphrase, 'encryptionKey' => $this->oaEncryptionKey]);
         $authServer = new AuthorizationServer(
             new ClientRepository(),
             new AccessTokenRepository(),
@@ -1117,13 +1117,6 @@ class AuthorizationController
             // will try hard to go on if missing token hint. this is to help with universal conformance.
             if (empty($token_hint)) {
                 $token_hint = $jsonWebKeyParser->getTokenHintFromToken($rawToken);
-//                // determine if access or refresh.
-//                $access_parts = explode(".", $rawToken);
-//                if (count($access_parts) === 3) {
-//                    $token_hint = 'access_token';
-//                } else {
-//                    $token_hint = 'refresh_token';
-//                }
             } elseif (($token_hint !== 'access_token' && $token_hint !== 'refresh_token') || empty($rawToken)) {
                 throw new OAuthServerException('Missing token or unsupported hint.', 0, 'invalid_request', 400);
             }

--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -148,8 +148,7 @@ class AuthorizationController
             $this->publicKey = $oauth2KeyConfig->getPublicKeyLocation();
             $this->oaEncryptionKey = $oauth2KeyConfig->getEncryptionKey();
             $this->passphrase = $oauth2KeyConfig->getPassPhrase();
-        }
-        catch (OAuth2KeyException $exception) {
+        } catch (OAuth2KeyException $exception) {
             $this->logger->error("OpenEMR error - " . $exception->getMessage() . ", so forced exit");
             $serverException = OAuthServerException::serverError("Security error - problem with authorization server keys.", $exception);
             SessionUtil::oauthSessionCookieDestroy();
@@ -1140,14 +1139,12 @@ class AuthorizationController
                         $result['status'] = 'revoked';
                     }
                     $tokenRepository = new AccessTokenRepository();
-                    if ($tokenRepository->isAccessTokenRevokedInDatabase($result['jti']))
-                    {
+                    if ($tokenRepository->isAccessTokenRevokedInDatabase($result['jti'])) {
                         $result['active'] = false;
                         $result['status'] = 'revoked';
                     }
                     $audience = $result['aud'];
-                    if (!empty($audience))
-                    {
+                    if (!empty($audience)) {
                         // audience is an array... we will only validate against the first item
                         $audience = current($audience);
                     }
@@ -1181,8 +1178,7 @@ class AuthorizationController
                     $result['status'] = 'revoked';
                 }
                 $tokenRepository = new RefreshTokenRepository();
-                if ($tokenRepository->isRefreshTokenRevoked($result['jti']))
-                {
+                if ($tokenRepository->isRefreshTokenRevoked($result['jti'])) {
                     $result['active'] = false;
                     $result['status'] = 'revoked';
                 }

--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -32,6 +32,8 @@ use League\OAuth2\Server\RequestTypes\AuthorizationRequest;
 use Nyholm\Psr7Server\ServerRequestCreator;
 use OpenEMR\Common\Auth\AuthUtils;
 use OpenEMR\Common\Auth\MfaUtils;
+use OpenEMR\Common\Auth\OAuth2KeyConfig;
+use OpenEMR\Common\Auth\OAuth2KeyException;
 use OpenEMR\Common\Auth\OpenIDConnect\Entities\ClientEntity;
 use OpenEMR\Common\Auth\OpenIDConnect\Entities\ScopeEntity;
 use OpenEMR\Common\Auth\OpenIDConnect\Entities\UserEntity;
@@ -39,6 +41,7 @@ use OpenEMR\Common\Auth\OpenIDConnect\Grant\CustomClientCredentialsGrant;
 use OpenEMR\Common\Auth\OpenIDConnect\Grant\CustomPasswordGrant;
 use OpenEMR\Common\Auth\OpenIDConnect\Grant\CustomRefreshTokenGrant;
 use OpenEMR\Common\Auth\OpenIDConnect\IdTokenSMARTResponse;
+use OpenEMR\Common\Auth\OpenIDConnect\JWT\JsonWebKeyParser;
 use OpenEMR\Common\Auth\OpenIDConnect\Repositories\AccessTokenRepository;
 use OpenEMR\Common\Auth\OpenIDConnect\Repositories\AuthCodeRepository;
 use OpenEMR\Common\Auth\OpenIDConnect\Repositories\ClientRepository;
@@ -120,9 +123,8 @@ class AuthorizationController
         // Create a crypto object that will be used for for encryption/decryption
         $this->cryptoGen = new CryptoGen();
         // verify and/or setup our key pairs.
-        $this->privateKey = $GLOBALS['OE_SITE_DIR'] . '/documents/certificates/oaprivate.key';
-        $this->publicKey = $GLOBALS['OE_SITE_DIR'] . '/documents/certificates/oapublic.key';
         $this->configKeyPairs();
+
         // true will display client/user server sign in. false, not.
         $this->providerForm = $providerForm;
 
@@ -140,97 +142,18 @@ class AuthorizationController
     {
         $response = $this->createServerResponse();
         try {
-            // encryption key
-            $eKey = sqlQueryNoLog("SELECT `name`, `value` FROM `keys` WHERE `name` = 'oauth2key'");
-            if (!empty($eKey['name']) && ($eKey['name'] === 'oauth2key')) {
-                // collect the encryption key from database
-                $this->oaEncryptionKey = $this->cryptoGen->decryptStandard($eKey['value']);
-                if (empty($this->oaEncryptionKey)) {
-                    // if decrypted key is empty, then critical error and must exit
-                    $this->logger->error("OpenEMR error - oauth2 key was blank after it was decrypted, so forced exit");
-                    throw OAuthServerException::serverError("Security error - problem with authorization server keys.");
-                }
-            } else {
-                // create a encryption key and store it in database
-                $this->oaEncryptionKey = RandomGenUtils::produceRandomBytes(32);
-                if (empty($this->oaEncryptionKey)) {
-                    // if empty, then force exit
-                    $this->logger->error("OpenEMR error - random generator broken during oauth2 encryption key generation, so forced exit");
-                    throw OAuthServerException::serverError("Security error - problem with authorization server keys.");
-                }
-                $this->oaEncryptionKey = base64_encode($this->oaEncryptionKey);
-                if (empty($this->oaEncryptionKey)) {
-                    // if empty, then force exit
-                    $this->logger->error("OpenEMR error - base64 encoding broken during oauth2 encryption key generation, so forced exit");
-                    throw OAuthServerException::serverError("Security error - problem with authorization server keys.");
-                }
-                sqlStatementNoLog("INSERT INTO `keys` (`name`, `value`) VALUES ('oauth2key', ?)", [$this->cryptoGen->encryptStandard($this->oaEncryptionKey)]);
-            }
-            // private key
-            if (!file_exists($this->privateKey)) {
-                // create the private/public key pair (store in filesystem) with a random passphrase (store in database)
-                // first, create the passphrase (removing any prior passphrases)
-                sqlStatementNoLog("DELETE FROM `keys` WHERE `name` = 'oauth2passphrase'");
-                $this->passphrase = RandomGenUtils::produceRandomString(60, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
-                if (empty($this->passphrase)) {
-                    // if empty, then force exit
-                    $this->logger->error("OpenEMR error - random generator broken during oauth2 key passphrase generation, so forced exit");
-                    throw OAuthServerException::serverError("Security error - problem with authorization server keys.");
-                }
-                // second, create and store the private/public key pair
-                $keysConfig = [
-                    "default_md" => "sha256",
-                    "private_key_type" => OPENSSL_KEYTYPE_RSA,
-                    "private_key_bits" => 2048,
-                    "encrypt_key" => true,
-                    "encrypt_key_cipher" => OPENSSL_CIPHER_AES_256_CBC
-                ];
-                $keys = \openssl_pkey_new($keysConfig);
-                if ($keys === false) {
-                    // if unable to create keys, then force exit
-                    $this->logger->error("OpenEMR error - key generation broken during oauth2, so forced exit");
-                    throw OAuthServerException::serverError("Security error - problem with authorization server keys.");
-                }
-                $privkey = '';
-                openssl_pkey_export($keys, $privkey, $this->passphrase, $keysConfig);
-                $pubkey = openssl_pkey_get_details($keys);
-                $pubkey = $pubkey["key"];
-                if (empty($privkey) || empty($pubkey)) {
-                    // if unable to construct keys, then force exit
-                    $this->logger->error("OpenEMR error - key construction broken during oauth2, so forced exit");
-                    throw OAuthServerException::serverError("Security error - problem with authorization server keys.");
-                }
-                // third, store the keys on drive and store the passphrase in the database
-                file_put_contents($this->privateKey, $privkey);
-                chmod($this->privateKey, 0640);
-                file_put_contents($this->publicKey, $pubkey);
-                chmod($this->publicKey, 0660);
-                sqlStatementNoLog("INSERT INTO `keys` (`name`, `value`) VALUES ('oauth2passphrase', ?)", [$this->cryptoGen->encryptStandard($this->passphrase)]);
-            }
-            // confirm existence of passphrase
-            $pkey = sqlQueryNoLog("SELECT `name`, `value` FROM `keys` WHERE `name` = 'oauth2passphrase'");
-            if (!empty($pkey['name']) && ($pkey['name'] == 'oauth2passphrase')) {
-                $this->passphrase = $this->cryptoGen->decryptStandard($pkey['value']);
-                if (empty($this->passphrase)) {
-                    // if decrypted pssphrase is empty, then critical error and must exit
-                    $this->logger->error("OpenEMR error - oauth2 passphrase was blank after it was decrypted, so forced exit");
-                    throw OAuthServerException::serverError("Security error - problem with authorization server keys.");
-                }
-            } else {
-                // oauth2passphrase is missing so must exit
-                $this->logger->error("OpenEMR error - oauth2 passphrase is missing, so forced exit");
-                throw OAuthServerException::serverError("Security error - problem with authorization server keys.");
-            }
-            // confirm existence of key pair
-            if (!file_exists($this->privateKey) || !file_exists($this->publicKey)) {
-                // key pair is missing so must exit
-                $this->logger->error("OpenEMR error - oauth2 keypair is missing, so forced exit");
-                throw OAuthServerException::serverError("Security error - problem with authorization server keys.");
-            }
-        } catch (OAuthServerException $exception) {
+            $oauth2KeyConfig = new OAuth2KeyConfig($GLOBALS['OE_SITE_DIR']);
+            $oauth2KeyConfig->configKeyPairs();
+            $this->privateKey = $oauth2KeyConfig->getPrivateKeyLocation();
+            $this->publicKey = $oauth2KeyConfig->getPublicKeyLocation();
+            $this->oaEncryptionKey = $oauth2KeyConfig->getEncryptionKey();
+            $this->passphrase = $oauth2KeyConfig->getPassPhrase();
+        }
+        catch (OAuth2KeyException $exception) {
+            $this->logger->error("OpenEMR error - " . $exception->getMessage() . ", so forced exit");
+            $serverException = OAuthServerException::serverError("Security error - problem with authorization server keys.", $exception);
             SessionUtil::oauthSessionCookieDestroy();
-            $this->emitResponse($exception->generateHttpResponse($response));
-            exit;
+            $this->emitResponse($serverException->generateHttpResponse($response));
         }
     }
 
@@ -655,6 +578,7 @@ class AuthorizationController
             $responseType->markIsAuthorizationGrant(); // we have specific SMART responses for an authorization grant.
         }
 
+        $this->logger->debug("key log ", ['privateKey' => $this->privateKey, 'passphrase' => $this->passphrase, 'encryptionKey' => $this->oaEncryptionKey]);
         $authServer = new AuthorizationServer(
             new ClientRepository(),
             new AccessTokenRepository(),
@@ -1190,15 +1114,17 @@ class AuthorizationController
                     throw new OAuthServerException('Client failed security', 0, 'invalid_request', 401);
                 }
             }
+            $jsonWebKeyParser = new JsonWebKeyParser($this->oaEncryptionKey, $this->publicKey);
             // will try hard to go on if missing token hint. this is to help with universal conformance.
             if (empty($token_hint)) {
-                // determine if access or refresh.
-                $access_parts = explode(".", $rawToken);
-                if (count($access_parts) === 3) {
-                    $token_hint = 'access_token';
-                } else {
-                    $token_hint = 'refresh_token';
-                }
+                $token_hint = $jsonWebKeyParser->getTokenHintFromToken($rawToken);
+//                // determine if access or refresh.
+//                $access_parts = explode(".", $rawToken);
+//                if (count($access_parts) === 3) {
+//                    $token_hint = 'access_token';
+//                } else {
+//                    $token_hint = 'refresh_token';
+//                }
             } elseif (($token_hint !== 'access_token' && $token_hint !== 'refresh_token') || empty($rawToken)) {
                 throw new OAuthServerException('Missing token or unsupported hint.', 0, 'invalid_request', 400);
             }
@@ -1206,34 +1132,8 @@ class AuthorizationController
             // are we there yet! client's okay but, is token?
             if ($token_hint === 'access_token') {
                 try {
-                    // Attempt to parse and validate the JWT
-                    $token = (new Parser())->parse($rawToken);
-                    // defaults
-                    $result = array(
-                        'active' => true,
-                        'status' => 'active',
-                        'scope' => implode(" ", $token->getClaim('scopes')),
-                        'client_id' => $clientId,
-                        'exp' => $token->claims()->get('exp'),
-                        'sub' => $token->claims()->get('sub'), // user_id
-                        'jti' => $token->claims()->get('jti')
-                    );
-                    try {
-                        if ($token->verify(new Sha256(), 'file://' . $this->publicKey) === false) {
-                            $result['active'] = false;
-                            $result['status'] = 'failed_verification';
-                        }
-                    } catch (Exception $exception) {
-                        $result['active'] = false;
-                        $result['status'] = 'invalid_signature';
-                    }
-                    // Ensure access token hasn't expired
-                    $data = new ValidationData();
-                    $data->setCurrentTime(\time());
-                    if ($token->validate($data) === false) {
-                        $result['active'] = false;
-                        $result['status'] = 'expired';
-                    }
+                    $result = $jsonWebKeyParser->parseAccessToken($rawToken);
+                    $result['client_id'] = $clientId;
                     $trusted = $this->trustedUser($result['client_id'], $result['sub']);
                     if (empty($trusted['id'])) {
                         $result['active'] = false;
@@ -1245,7 +1145,7 @@ class AuthorizationController
                         $result['active'] = false;
                         $result['status'] = 'revoked';
                     }
-                    $audience = $token->claims()->get('aud');
+                    $audience = $result['aud'];
                     if (!empty($audience))
                     {
                         // audience is an array... we will only validate against the first item
@@ -1266,10 +1166,8 @@ class AuthorizationController
             }
             if ($token_hint === 'refresh_token') {
                 try {
-                    // Validate refresh token
-                    $this->setEncryptionKey($this->oaEncryptionKey);
-                    $refreshToken = $this->decrypt($rawToken);
-                    $refreshTokenData = \json_decode($refreshToken, true);
+                    $result = $jsonWebKeyParser->parseRefreshToken($rawToken);
+                    $result['client_id'] = $clientId;
                 } catch (Exception $exception) {
                     $body = $response->getBody();
                     $body->write($exception->getMessage());
@@ -1277,20 +1175,7 @@ class AuthorizationController
                     $this->emitResponse($response->withStatus(400)->withBody($body));
                     exit();
                 }
-                $result = array(
-                    'active' => true,
-                    'status' => 'active',
-                    'scope' => implode(" ", $refreshTokenData['scopes']),
-                    'client_id' => $clientId,
-                    'exp' => $refreshTokenData['expire_time'],
-                    'sub' => $refreshTokenData['user_id'],
-                    'jti' => $refreshTokenData['refresh_token_id']
-                );
-                if ($refreshTokenData['expire_time'] < \time()) {
-                    $result['active'] = false;
-                    $result['status'] = 'expired';
-                }
-                $trusted = $this->trustedUser($refreshTokenData['client_id'], $result['sub']);
+                $trusted = $this->trustedUser($result['client_id'], $result['sub']);
                 if (empty($trusted['id'])) {
                     $result['active'] = false;
                     $result['status'] = 'revoked';
@@ -1301,7 +1186,7 @@ class AuthorizationController
                     $result['active'] = false;
                     $result['status'] = 'revoked';
                 }
-                if ($refreshTokenData['client_id'] !== $clientId) {
+                if ($result['client_id'] !== $clientId) {
                     // return no info in this case. possible Phishing
                     $result = array('active' => false);
                 }

--- a/src/Services/TrustedUserService.php
+++ b/src/Services/TrustedUserService.php
@@ -13,6 +13,8 @@
 
 namespace OpenEMR\Services;
 
+use OpenEMR\Common\Database\QueryUtils;
+
 class TrustedUserService
 {
     public function isTrustedUser($clientId, $userId)
@@ -20,6 +22,12 @@ class TrustedUserService
             $trusted = $this->getTrustedUser($clientId, $userId);
             $isTrusted = !empty($trusted['session_cache']);
             return $isTrusted;
+    }
+
+    public function getTrustedUsersForClient($clientId)
+    {
+        $records = QueryUtils::fetchRecords("SELECT * FROM `oauth_trusted_user` WHERE `client_id`= ?", array($clientId));
+        return $records;
     }
 
     public function getTrustedUser($clientId, $userId)

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@ $v_realpatch = '0';
 // is a database change in the course of development.  It is used
 // internally to determine when a database upgrade is needed.
 //
-$v_database = 410;
+$v_database = 411;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
Fixes #4573 FHIR Inferno requires you to provide an access token and a refresh token
that will be revoked in order to pass the test cases.  The developer has
to visually demonstrate revoking the token and then run the automated
test case.  This doesn't work with the trusted user mechanism we
originally had for token revokation as there isn't a way to tie the
token back to the trusted user given just the JWT.

I implemented the access token and refresh token revocation by adding a
revoked column and implementing the methods in the repositories to
handle token revocation.  I had to implement a separate isTokenRevoked
method for the access token due to the way League and OpenEMR interact
on the token revocation.  Because we store the site id inside the token
we have to allow League to validate a token and ignore the token
revocation validation check because we don't have access to the database
at that point the in execution (no site id, no database connection).

So we add the revocation check further down in the dispatch.php file in
order to handle the revocation check.

I added a lot of user interface to the Client Admin Controller to
display the list of trusted users and allow you to revoke the trusted
user right from the interface.  You can also revoke individual access
tokens. I've also added the ability to revoke individual refresh tokens 
from the admin GUI.

My next piece of work will be to add a Token Utilities button to the
client list screen.  That Token Utilities page will let you put in a
token and get back data about the token and allow you to revoke the
token from the system.  I will add that in as part of this pull request.