### PR TITLE
possible pathing fix

### DIFF
--- a/src/Common/Auth/OpenIDConnect/IdTokenSMARTResponse.php
+++ b/src/Common/Auth/OpenIDConnect/IdTokenSMARTResponse.php
@@ -166,7 +166,7 @@ class IdTokenSMARTResponse extends IdTokenResponse
      */
     private function getSmartStyleURL()
     {
-        return $GLOBALS['site_addr_oath'] . "/public/smart-styles/smart-light.json";
+        return $GLOBALS['site_addr_oath'] . $GLOBALS['web_root'] . "/public/smart-styles/smart-light.json";
     }
 
     /**


### PR DESCRIPTION
@adunsulag , I just noticed this when searching the pathing to ensure the MU3 demos will work (the ones with `a`, `b`, and `c` in the paths). Noted this one was missing the webroot in it.