### PR TITLE
Fix facility code to be NUCC for FHIR.

### DIFF
--- a/src/Services/CodeTypesService.php
+++ b/src/Services/CodeTypesService.php
@@ -86,6 +86,17 @@ class CodeTypesService
         return ['code' => $parsedCode, 'code_type' => $parsedType];
     }
 
+    /**
+     * Returns a code with the code type prefixed
+     * @param $code The value for the code that exists in the given code_type datadatabse
+     * @param $type The code_type that the code belongs to (SNOMED, RXCUI, ICD10, etc).
+     * @return string  The fully typed code (TYPE:CODE)
+     */
+    public function getCodeWithType($code, $type)
+    {
+        return ($type ?? "") . ":" . ($code ?? "");
+    }
+
     public function getCodeTypeForCode($code)
     {
         $parsedCode = $this->parseCode($code);

--- a/src/Services/FHIR/FhirCareTeamService.php
+++ b/src/Services/FHIR/FhirCareTeamService.php
@@ -141,12 +141,16 @@ class FhirCareTeamService extends FhirServiceBase implements IResourceUSCIGProfi
                 if (empty($dataRecordFacility['facility_taxonomy'])) {
                     $role = UtilsService::createDataAbsentUnknownCodeableConcept();
                 } else {
-                    $codes = $codeTypesService->parseCode($dataRecordFacility['facility_taxonomy']);
-                    $codes['description'] = $codeTypesService->lookup_code_description($dataRecordFacility['facility_taxonomy']);
+                    $codes = [
+                        'code' => $dataRecordFacility['facility_taxonomy']
+                        ,'system' => FhirCodeSystemConstants::NUCC_PROVIDER
+                        ,'description' => null
+                    ];
+                    $fullCode = $codeTypesService->getCodeWithType($codes['code'], CodeTypesService::CODE_TYPE_NUCC);
+                    $codes['description'] = $codeTypesService->lookup_code_description($fullCode);
                     if (empty($codes['description'])) {
                         $codes['description'] = xlt('Healthcare facility');
                     }
-                    $codes['system'] = $codeTypesService->getSystemForCodeType($codes['code_type']) ?? FhirCodeSystemConstants::NUCC_PROVIDER;
                     $role = UtilsService::createCodeableConcept([$codes['code'] => $codes]);
                 }
                 $organization->addRole($role);


### PR DESCRIPTION
As discussed in this issue #4590 instead of changing the facility column size we needed to fix the FHIR code to always use NUCC for the facility taxonomy when reporting in FHIR.