### PR TITLE
Openemr fhir data absent reasons

### DIFF
--- a/src/Common/Http/HttpRestRouteHandler.php
+++ b/src/Common/Http/HttpRestRouteHandler.php
@@ -91,7 +91,11 @@ class HttpRestRouteHandler
                     if ($return_method === 'standard') {
                         header('Content-Type: application/json');
                         // if we fail to encode we WANT an error thrown
-                        echo json_encode($result, JSON_THROW_ON_ERROR);
+                        // PHP default json_encode will escape forward slash characters '/' so you can embed the JSON
+                        // inside of a <script> tag.  However, since forward slash escaping is optional as part of the
+                        // JSON spec some servers (looking at you ONC FHIR Inferno and your missing data tests) don't
+                        // know how to handle the unescaped slashes so we remove the forward slash escaping.
+                        echo json_encode($result, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
                         break;
                     }
                     if ($return_method === 'direct-json') {

--- a/src/Services/FHIR/FhirAllergyIntoleranceService.php
+++ b/src/Services/FHIR/FhirAllergyIntoleranceService.php
@@ -195,6 +195,9 @@ class FhirAllergyIntoleranceService extends FhirServiceBase implements IResource
             }
             $reaction->addManifestation($reactionConcept);
             $allergyIntoleranceResource->addReaction($reaction);
+        } else {
+            $reaction = new FHIRAllergyIntoleranceReaction();
+            $reaction->addManifestation(UtilsService::createDataAbsentUnknownCodeableConcept());
         }
 
         if (!empty($dataRecord['diagnosis'])) {
@@ -215,13 +218,11 @@ class FhirAllergyIntoleranceService extends FhirServiceBase implements IResource
             }
             $allergyIntoleranceResource->setCode($diagnosisCode);
         } else {
-            $diagnosisCode = new FHIRCodeableConcept();
-            $diagnosisCoding = new FHIRCoding();
-            $diagnosisCoding->setCode("unknown");
-            $diagnosisCoding->setDisplay(xlt("Unknown"));
-            $diagnosisCode->addCoding($diagnosisCoding);
-            $allergyIntoleranceResource->setCode($diagnosisCode);
+            $allergyIntoleranceResource->setCode(UtilsService::createDataAbsentUnknownCodeableConcept());
         }
+        // we don't have title anywhere else so we mark it as an additional narrative.  If we don't have an actual code
+        // this becomes very helpful.
+        $allergyIntoleranceResource->setText(UtilsService::createNarrative($dataRecord['title'], "additional"));
 
         $verificationStatus = new FHIRCodeableConcept();
         $verificationCoding = array(


### PR DESCRIPTION
This fixes #4593  which removes escaping for the forward slash as well as adding a data absent reason to the Allergy Intolerance resource.  This was many, many hours of debugging ruby code to figure out what was happening.  I'm glad I finally figured this out.

Hooray for more check marks!
![image](https://user-images.githubusercontent.com/228117/129925479-996008f2-b803-4cae-86f3-743d6830b54f.png)


Here is my original commit message:
Our api endpoints were escaping the forward slashes in the JSON
responses.  This is optional in the JSON spec and is really only
necessary as far as I can tell when embedding JSON inside of an html
<script> tag.

However, some servers don't handle this forward slash escaping well.  In
the ONC Inferno test suite it does a strict string match for a URL.  The
match fails because of the escaped forward-slashes in the URL.  This is
why the data absent reason codes/extensions were failing.  It took many,
many hours to trace this down and fortunately its a simple fix.

This shouldn't effect any spec compliant clients who are consuming the
API as the forward slash escaping is an optional component and their
deserializers should still work.  Any non-spec compliant API client
could have issues.