### PR TITLE
Bulk Export, Security Fixes, Group endpoint support

### DIFF
--- a/_rest_routes.inc.php
+++ b/_rest_routes.inc.php
@@ -589,6 +589,7 @@ use OpenEMR\RestControllers\FHIR\FhirExportRestController;
 use OpenEMR\RestControllers\FHIR\FhirObservationRestController;
 use OpenEMR\RestControllers\FHIR\FhirImmunizationRestController;
 use OpenEMR\RestControllers\FHIR\FhirGoalRestController;
+use OpenEMR\RestControllers\FHIR\FhirGroupRestController;
 use OpenEMR\RestControllers\FHIR\FhirLocationRestController;
 use OpenEMR\RestControllers\FHIR\FhirMedicationRestController;
 use OpenEMR\RestControllers\FHIR\FhirMedicationRequestRestController;
@@ -834,7 +835,29 @@ RestConfig::$FHIR_ROUTE_MAP = array(
         RestConfig::apiLog($return);
         return $return;
     },
-
+    'GET /fhir/Group' => function (HttpRestRequest $request) {
+        RestConfig::authorization_check("admin", "users");
+        $getParams = $request->getQueryParams();
+        if ($request->isPatientRequest()) {
+            // only allow access to data of binded patient
+            $return = (new FhirGroupRestController())->getAll($getParams, $request->getPatientUUIDString());
+        } else {
+            $return = (new FhirGroupRestController())->getAll($getParams);
+        }
+        RestConfig::apiLog($return);
+        return $return;
+    },
+    "GET /fhir/Group/:id" => function ($id, HttpRestRequest $request) {
+        RestConfig::authorization_check("admin", "users");
+        if ($request->isPatientRequest()) {
+            // only allow access to data of binded patient
+            $return = (new FhirGroupRestController())->getOne($id, $request->getPatientUUIDString());
+        } else {
+            $return = (new FhirGroupRestController())->getOne($id);
+        }
+        RestConfig::apiLog($return);
+        return $return;
+    },
     'GET /fhir/Group/:id/$export' => function ($groupId, HttpRestRequest $request) {
         RestConfig::authorization_check("admin", "users");
         $fhirExportService = new FhirExportRestController($request);

--- a/interface/smart/register-app.php
+++ b/interface/smart/register-app.php
@@ -58,7 +58,7 @@ $scopeRepo = new ScopeRepository(RestConfig::GetInstance());
 $scopes = $scopeRepo->getCurrentSmartScopes();
 // TODO: adunsulag there's gotta be a better way for this url...
 $fhirRegisterURL = AuthorizationController::getAuthBaseFullURL() . AuthorizationController::getRegistrationPath();
-$fhirTokenUrl = AuthorizationController::getAuthBaseFullURL() . AuthorizationController::getTokenPath();
+$audienceUrl = $GLOBALS['site_addr_oath'] . $GLOBALS['web_root'] . '/apis/' . $_SESSION['site_id'] . "/fhir";
 ?>
 <html>
 <head>
@@ -357,7 +357,7 @@ $fhirTokenUrl = AuthorizationController::getAuthBaseFullURL() . AuthorizationCon
                     </div>
                     <div class="form-group">
                         <label for="audURL" class="text-right"><?php echo xlt('Aud URI (use this in the "aud" claim of your JWT)'); ?></label>
-                        <input type="text" disabled class="form-control" id="audURL" name="audURL" value="<?php echo attr($fhirTokenUrl); ?>" />
+                        <input type="text" disabled class="form-control" id="audURL" name="audURL" value="<?php echo attr($audienceUrl); ?>" />
                     </div>
                 </div>
                 <div class="form-group errorResponse hidden">

--- a/library/standard_tables_capture.inc
+++ b/library/standard_tables_capture.inc
@@ -178,7 +178,8 @@ function snomed_import($us_extension = false)
             `InitialCapitalStatus` tinyint(1) NOT NULL,
             `DescriptionType` int(11) NOT NULL,
             `LanguageCode` varchar(8) NOT NULL,
-            PRIMARY KEY (`DescriptionId`)
+            PRIMARY KEY (`DescriptionId`),
+            KEY `idx_concept_id` (`ConceptId`)
             ) ENGINE=InnoDB",
         "sct_relationships_drop" => "DROP TABLE IF EXISTS `sct_relationships`",
         "sct_relationships_structure" => "CREATE TABLE IF NOT EXISTS `sct_relationships` (
@@ -323,7 +324,8 @@ function snomedRF2_import()
             `typeId` bigint(25) NOT NULL,
             `term` varchar(255) NOT NULL,
             `caseSignificanceId` bigint(25) NOT NULL,
-             PRIMARY KEY (`id`, `active`, `conceptId`)
+             PRIMARY KEY (`id`, `active`, `conceptId`),
+             KEY `idx_concept_id` (`conceptId`)
             ) ENGINE=InnoDB",
         "sct2_identifier_drop" => "DROP TABLE IF EXISTS `sct2_identifier`",
         "sct2_identifier_structure" => "CREATE TABLE IF NOT EXISTS `sct2_identifier` (

--- a/sql/6_0_0-to-6_1_0_upgrade.sql
+++ b/sql/6_0_0-to-6_1_0_upgrade.sql
@@ -1033,7 +1033,7 @@ CREATE TABLE `jwt_grant_history` (
      `id` INT NOT NULL AUTO_INCREMENT
     , `jti` VARCHAR(100) NOT NULL COMMENT 'Unique JWT id'
     , `client_id` VARCHAR(80) NOT NULL COMMENT 'FK oauth2_clients.client_id'
-    , `jti_exp` TIMESTAMP NOT NULL COMMENT 'jwt exp claim when the jwt expires'
+    , `jti_exp` TIMESTAMP NULL DEFAULT NULL COMMENT 'jwt exp claim when the jwt expires'
     , `creation_date` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'datetime the grant authorization was requested'
     , PRIMARY KEY (`id`)
     , KEY `jti` (`jti`)

--- a/sql/6_0_0-to-6_1_0_upgrade.sql
+++ b/sql/6_0_0-to-6_1_0_upgrade.sql
@@ -1027,4 +1027,15 @@ SET @group_id = (SELECT group_id FROM layout_options WHERE field_id='lname' AND 
 UPDATE `layout_options` SET `seq` = `seq`*10 WHERE group_id = @group_id AND form_id='DEM';
 SET @seq_add_to = (SELECT seq FROM layout_options WHERE group_id = @group_id AND field_id='lname' AND form_id='DEM');
 INSERT INTO `layout_options` (`form_id`,`field_id`,`group_id`,`title`,`seq`,`data_type`,`uor`,`fld_length`,`max_length`,`list_id`,`titlecols`,`datacols`,`default_value`,`edit_options`,`description`,`fld_rows`) VALUES ('DEM', 'suffix', @group_id, '', @seq_add_to+5, 2, 1, 5, 63, '', 0, 0, '', '[\"EP\"]', 'Name Suffix', 0);
+
+#IfNotTable jwt_grant_history
+CREATE TABLE `jwt_grant_history` (
+     `id` INT NOT NULL AUTO_INCREMENT
+    , `jti` VARCHAR(100) NOT NULL COMMENT 'Unique JWT id'
+    , `client_id` VARCHAR(80) NOT NULL COMMENT 'FK oauth2_clients.client_id'
+    , `jti_exp` TIMESTAMP NOT NULL COMMENT 'jwt exp claim when the jwt expires'
+    , `creation_date` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'datetime the grant authorization was requested'
+    , PRIMARY KEY (`id`)
+    , KEY `jti` (`jti`)
+) ENGINE = InnoDB COMMENT = 'Holds JWT authorization grant ids to prevent replay attacks';
 #EndIf

--- a/sql/6_0_0-to-6_1_0_upgrade.sql
+++ b/sql/6_0_0-to-6_1_0_upgrade.sql
@@ -1039,3 +1039,11 @@ CREATE TABLE `jwt_grant_history` (
     , KEY `jti` (`jti`)
 ) ENGINE = InnoDB COMMENT = 'Holds JWT authorization grant ids to prevent replay attacks';
 #EndIf
+
+#IfNotIndex sct_description idx_concept_id
+ALTER TABLE sct_description ADD INDEX `idx_concept_id` (`ConceptId`);
+#EndIf
+
+#IfNotIndex sct2_description idx_concept_id
+ALTER TABLE sct2_description ADD INDEX `idx_concept_id` (`conceptId`);
+#EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -12716,3 +12716,14 @@ PRIMARY KEY (`id`),
 KEY `fk_form_id` (`form_id`),
 KEY `fk_list_options_id` (`interpretation_list_id`, `interpretation_option_id`)
 ) ENGINE=InnoDB COMMENT='Detailed information of each vital_forms observation column';
+
+DROP TABLE IF EXISTS `jwt`;
+CREATE TABLE `jwt_grant_history` (
+`id` INT NOT NULL AUTO_INCREMENT
+ , `jti` VARCHAR(100) NOT NULL COMMENT 'Unique JWT id'
+ , `client_id` VARCHAR(80) NOT NULL COMMENT 'FK oauth2_clients.client_id'
+ , `jti_exp` TIMESTAMP NOT NULL COMMENT 'jwt exp claim when the jwt expires'
+ , `creation_date` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'datetime the grant authorization was requested'
+ , PRIMARY KEY (`id`)
+ , KEY `jti` (`jti`)
+) ENGINE = InnoDB COMMENT = 'Holds JWT authorization grant ids to prevent replay attacks';

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -12722,7 +12722,7 @@ CREATE TABLE `jwt_grant_history` (
 `id` INT NOT NULL AUTO_INCREMENT
  , `jti` VARCHAR(100) NOT NULL COMMENT 'Unique JWT id'
  , `client_id` VARCHAR(80) NOT NULL COMMENT 'FK oauth2_clients.client_id'
- , `jti_exp` TIMESTAMP NOT NULL COMMENT 'jwt exp claim when the jwt expires'
+ , `jti_exp` TIMESTAMP NULL DEFAULT NULL COMMENT 'jwt exp claim when the jwt expires'
  , `creation_date` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'datetime the grant authorization was requested'
  , PRIMARY KEY (`id`)
  , KEY `jti` (`jti`)

--- a/src/Common/Auth/OpenIDConnect/Grant/CustomAuthCodeGrant.php
+++ b/src/Common/Auth/OpenIDConnect/Grant/CustomAuthCodeGrant.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * CustomAuthCodeGrant.php
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Common\Auth\OpenIDConnect\Grant;
+
+
+use DateInterval;
+use League\OAuth2\Server\Exception\OAuthServerException;
+use League\OAuth2\Server\Grant\AuthCodeGrant;
+use League\OAuth2\Server\Repositories\AuthCodeRepositoryInterface;
+use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
+use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\FHIR\SMART\SMARTLaunchToken;
+use OpenEMR\RestControllers\AuthorizationController;
+use Psr\Http\Message\ServerRequestInterface;
+
+class CustomAuthCodeGrant extends AuthCodeGrant
+{
+    /**
+     * @var string The expected 'aud' query parameter to validate a JWT grant against
+     */
+    private $expectedAudience;
+
+    public function __construct(AuthCodeRepositoryInterface $authCodeRepository, RefreshTokenRepositoryInterface $refreshTokenRepository, DateInterval $authCodeTTL, $expectedAudience)
+    {
+        parent::__construct($authCodeRepository, $refreshTokenRepository, $authCodeTTL);
+        $this->expectedAudience = $expectedAudience;
+    }
+
+    public function validateAuthorizationRequest(ServerRequestInterface $request)
+    {
+        $audience = $this->getQueryStringParameter(
+            'aud',
+            $request
+        );
+        if ($audience != $this->expectedAudience)
+        {
+            (new SystemLogger())->errorLogCaller("Aud parameter did not match authorized server", ['audience' => $audience, 'expected' => $this->expectedAudience]);
+            throw OAuthServerException::invalidRequest("aud", "Aud parameter did not match authorized server");
+        }
+
+        // let's validate the launch param
+        $launch = $this->getQueryStringParameter(
+            'launch'
+            ,$request
+        );
+        if (!empty($launch))
+        {
+            try {
+                $launchToken = SMARTLaunchToken::deserializeToken($launch);
+                if (empty($launchToken))
+                {
+                    throw OAuthServerException::invalidRequest("launch", "launch parameter was incorrectly formatted or did not originate from this server");
+                }
+            }
+            catch (\Exception $exception)
+            {
+                (new SystemLogger())->errorLogCaller("Failed to deserialize launch token", ['launch' => $launch, 'message' => $exception->getMessage(), 'trace' => $exception->getTraceAsString()]);
+                throw OAuthServerException::invalidRequest('launch', "launch parameter was incorrectly formatted or did not originate from this server");
+            }
+        }
+        return parent::validateAuthorizationRequest($request);
+    }
+}

--- a/src/Common/Auth/OpenIDConnect/Grant/CustomAuthCodeGrant.php
+++ b/src/Common/Auth/OpenIDConnect/Grant/CustomAuthCodeGrant.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * CustomAuthCodeGrant.php
  * @package openemr
@@ -9,7 +10,6 @@
  */
 
 namespace OpenEMR\Common\Auth\OpenIDConnect\Grant;
-
 
 use DateInterval;
 use League\OAuth2\Server\Exception\OAuthServerException;
@@ -40,28 +40,23 @@ class CustomAuthCodeGrant extends AuthCodeGrant
             'aud',
             $request
         );
-        if ($audience != $this->expectedAudience)
-        {
+        if ($audience != $this->expectedAudience) {
             (new SystemLogger())->errorLogCaller("Aud parameter did not match authorized server", ['audience' => $audience, 'expected' => $this->expectedAudience]);
             throw OAuthServerException::invalidRequest("aud", "Aud parameter did not match authorized server");
         }
 
         // let's validate the launch param
         $launch = $this->getQueryStringParameter(
-            'launch'
-            ,$request
+            'launch',
+            $request
         );
-        if (!empty($launch))
-        {
+        if (!empty($launch)) {
             try {
                 $launchToken = SMARTLaunchToken::deserializeToken($launch);
-                if (empty($launchToken))
-                {
+                if (empty($launchToken)) {
                     throw OAuthServerException::invalidRequest("launch", "launch parameter was incorrectly formatted or did not originate from this server");
                 }
-            }
-            catch (\Exception $exception)
-            {
+            } catch (\Exception $exception) {
                 (new SystemLogger())->errorLogCaller("Failed to deserialize launch token", ['launch' => $launch, 'message' => $exception->getMessage(), 'trace' => $exception->getTraceAsString()]);
                 throw OAuthServerException::invalidRequest('launch', "launch parameter was incorrectly formatted or did not originate from this server");
             }

--- a/src/Common/Auth/OpenIDConnect/Grant/CustomClientCredentialsGrant.php
+++ b/src/Common/Auth/OpenIDConnect/Grant/CustomClientCredentialsGrant.php
@@ -398,11 +398,11 @@ class CustomClientCredentialsGrant extends ClientCredentialsGrant
             }
             $jti = $token->claims()->get("jti");
             $jwtRepository->saveJwtHistory($jti, $clientId, $exp);
-        }
-        catch (SqlQueryException $exception)
-        {
-            (new SystemLogger())->error("Failed to save jti to database Exception: " . $exception->getMessage()
-                , ['clientId' => $clientId, 'exp' => $exp, 'jti' => $jti]);
+        } catch (SqlQueryException $exception) {
+            (new SystemLogger())->error(
+                "Failed to save jti to database Exception: " . $exception->getMessage(),
+                ['clientId' => $clientId, 'exp' => $exp, 'jti' => $jti]
+            );
             throw OAuthServerException::serverError("Server error occurred in parsing JWT", $exception);
         }
     }

--- a/src/Common/Auth/OpenIDConnect/Grant/CustomClientCredentialsGrant.php
+++ b/src/Common/Auth/OpenIDConnect/Grant/CustomClientCredentialsGrant.php
@@ -73,6 +73,11 @@ class CustomClientCredentialsGrant extends ClientCredentialsGrant
     private $userService;
 
     /**
+     * @var JWTRepository
+     */
+    private $jwtRepository;
+
+    /**
      * The required value for the jwt assertion type
      */
     const OAUTH_JWT_CLIENT_ASSERTION_TYPE = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
@@ -87,6 +92,7 @@ class CustomClientCredentialsGrant extends ClientCredentialsGrant
         $this->authTokenUrl = $authTokenUrl;
         $this->trustedUserService = new TrustedUserService();
         $this->userService = new UserService();
+        $this->jwtRepository = new JWTRepository();
     }
 
     /**
@@ -137,6 +143,22 @@ class CustomClientCredentialsGrant extends ClientCredentialsGrant
     public function setUserService(UserService $userService): void
     {
         $this->userService = $userService;
+    }
+
+    /**
+     * @return JWTRepository
+     */
+    public function getJwtRepository(): JWTRepository
+    {
+        return $this->jwtRepository;
+    }
+
+    /**
+     * @param JWTRepository $jwtRepository
+     */
+    public function setJwtRepository(JWTRepository $jwtRepository): void
+    {
+        $this->jwtRepository = $jwtRepository;
     }
 
     /**
@@ -292,7 +314,7 @@ class CustomClientCredentialsGrant extends ClientCredentialsGrant
         // @see https://tools.ietf.org/html/rfc7523#section-3.2
         // IF ERROR set "error" parameter to "invalid_client" use "error_description" or "error_uri" to provide error
         // information
-        $jwtRepository = new JWTRepository();
+        $jwtRepository = $this->getJwtRepository();
         $token = null;
         try {
             // http client required for fetching jwks from the jwks uri and makes unit testing easier

--- a/src/Common/Auth/OpenIDConnect/JWT/JsonWebKeySet.php
+++ b/src/Common/Auth/OpenIDConnect/JWT/JsonWebKeySet.php
@@ -13,6 +13,7 @@
 
 namespace OpenEMR\Common\Auth\OpenIDConnect\JWT;
 
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request;
 use Lcobucci\JWT\Signer\Key;
@@ -101,7 +102,12 @@ class JsonWebKeySet extends Key
             $body = $this->httpClient->sendRequest($request)->getBody();
             $json = $body->getContents();
             return $json;
-        } catch (RequestException $exception) {
+        } catch (RequestException|ConnectException $exception) {
+            throw new JWKValidatorException("failed to retrieve jwk contents from jwk_uri", 0, $exception);
+        }
+        catch (\Exception $exception)
+        {
+            (new SystemLogger())->errorLogCaller("Failed to retrieve jwk contents from jwk_uri and unknown error occurred", ['jwk_uri' => $jwk_uri]);
             throw new JWKValidatorException("failed to retrieve jwk contents from jwk_uri", 0, $exception);
         }
     }

--- a/src/Common/Auth/OpenIDConnect/JWT/JsonWebKeySet.php
+++ b/src/Common/Auth/OpenIDConnect/JWT/JsonWebKeySet.php
@@ -102,11 +102,9 @@ class JsonWebKeySet extends Key
             $body = $this->httpClient->sendRequest($request)->getBody();
             $json = $body->getContents();
             return $json;
-        } catch (RequestException|ConnectException $exception) {
+        } catch (RequestException | ConnectException $exception) {
             throw new JWKValidatorException("failed to retrieve jwk contents from jwk_uri", 0, $exception);
-        }
-        catch (\Exception $exception)
-        {
+        } catch (\Exception $exception) {
             (new SystemLogger())->errorLogCaller("Failed to retrieve jwk contents from jwk_uri and unknown error occurred", ['jwk_uri' => $jwk_uri]);
             throw new JWKValidatorException("failed to retrieve jwk contents from jwk_uri", 0, $exception);
         }

--- a/src/Common/Auth/OpenIDConnect/JWT/Validation/UniqueID.php
+++ b/src/Common/Auth/OpenIDConnect/JWT/Validation/UniqueID.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * UniqueID.php
  * @package openemr
@@ -9,7 +10,6 @@
  */
 
 namespace OpenEMR\Common\Auth\OpenIDConnect\JWT\Validation;
-
 
 use Lcobucci\JWT\Token;
 use Lcobucci\JWT\Validation\Constraint;
@@ -36,20 +36,19 @@ class UniqueID implements Constraint
         $exp = $token->claims()->get('exp');
         $iss = $token->claims()->get('iss');
 
-        if (empty($jti))
-        {
+        if (empty($jti)) {
             throw new ConstraintViolation("jti claim is required for JWT");
         }
         $expCheck = null;
-        if ($exp instanceof \DateTimeInterface)
-        {
+        if ($exp instanceof \DateTimeInterface) {
             $expCheck = $exp->getTimestamp();
         }
         $existingJWT = $this->jwtRepository->getJwtGrantHistoryForJTI($jti, $expCheck);
-        if (!empty($existingJWT))
-        {
-            (new SystemLogger())->emergency(get_class($this) . "->assert() Attempted duplicate usage of JWT token.  This could be a replay attack",
-                ['clientId' => $iss, 'exp' => $exp, 'jti' => $jti]);
+        if (!empty($existingJWT)) {
+            (new SystemLogger())->emergency(
+                get_class($this) . "->assert() Attempted duplicate usage of JWT token.  This could be a replay attack",
+                ['clientId' => $iss, 'exp' => $exp, 'jti' => $jti]
+            );
             throw new ConstraintViolation("jti claim has already been used");
         }
     }

--- a/src/Common/Auth/OpenIDConnect/JWT/Validation/UniqueID.php
+++ b/src/Common/Auth/OpenIDConnect/JWT/Validation/UniqueID.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * UniqueID.php
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Common\Auth\OpenIDConnect\JWT\Validation;
+
+
+use Lcobucci\JWT\Token;
+use Lcobucci\JWT\Validation\Constraint;
+use Lcobucci\JWT\Validation\ConstraintViolation;
+use OpenEMR\Common\Auth\OpenIDConnect\Repositories\JWTRepository;
+use OpenEMR\Common\Logging\SystemLogger;
+
+class UniqueID implements Constraint
+{
+    /**
+     * @var JWTRepository
+     */
+    private $jwtRepository;
+
+    public function __construct(JWTRepository $jwtRepository)
+    {
+        $this->jwtRepository = $jwtRepository;
+    }
+
+    /** @throws ConstraintViolation */
+    public function assert(Token $token)
+    {
+        $jti = $token->claims()->get('jti');
+        $exp = $token->claims()->get('exp');
+        $iss = $token->claims()->get('iss');
+
+        if (empty($jti))
+        {
+            throw new ConstraintViolation("jti claim is required for JWT");
+        }
+        $expCheck = null;
+        if ($exp instanceof \DateTimeInterface)
+        {
+            $expCheck = $exp->getTimestamp();
+        }
+        $existingJWT = $this->jwtRepository->getJwtGrantHistoryForJTI($jti, $expCheck);
+        if (!empty($existingJWT))
+        {
+            (new SystemLogger())->emergency(get_class($this) . "->assert() Attempted duplicate usage of JWT token.  This could be a replay attack",
+                ['clientId' => $iss, 'exp' => $exp, 'jti' => $jti]);
+            throw new ConstraintViolation("jti claim has already been used");
+        }
+    }
+}

--- a/src/Common/Auth/OpenIDConnect/Repositories/JWTRepository.php
+++ b/src/Common/Auth/OpenIDConnect/Repositories/JWTRepository.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * JWTRepository.php
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Common\Auth\OpenIDConnect\Repositories;
+
+
+use OpenEMR\Common\Database\QueryUtils;
+
+class JWTRepository
+{
+    /**
+     * Retrieves the jwt grant history for a given jti and expiration.  If the expiration is null it returns all records
+     * for that jti.  If an expiration is provided it will return only jti records that are have not expired within the given time frame.
+     * @param $jti string
+     * @param int|null $expiration timestamp in milliseconds of when the jti should expire
+     * @return array
+     */
+    public function getJwtGrantHistoryForJTI($jti, $expiration = null)
+    {
+        $sql = "select * FROM jwt_grant_history WHERE jti = ?";
+        $params = [$jti];
+        if (!empty($expiration))
+        {
+            $sql .= " AND jti_exp > ?";
+            $params[] = $expiration;
+        }
+        $records = QueryUtils::fetchRecords($sql, $params, true);
+        return $records;
+    }
+
+    /**
+     * Saves off a historical record of the JWT unique id that was used for requesting a grant access token.  By saving
+     * off the client's requesting JTI and the date the JWT is valid for we can avoid replay attacks.
+     * @param $jti string The unique JWT token id that was used for requesting a grant access token
+     * @param $client_id string the client id that the jwt was requested from
+     * @param $expiration int|null timestamp in milliseconds of when the jti should expire
+     */
+    public function saveJwtHistory($jti, $client_id, $expiration)
+    {
+        $sql = "INSERT INTO jwt_grant_history (jti, client_id, `jti_exp`, `creation_date`) VALUES(?, ?, FROM_UNIXTIME(?), NOW())";
+        QueryUtils::sqlStatementThrowException($sql, [$jti, $client_id, $expiration], true);
+    }
+}

--- a/src/Common/Auth/OpenIDConnect/Repositories/JWTRepository.php
+++ b/src/Common/Auth/OpenIDConnect/Repositories/JWTRepository.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * JWTRepository.php
  * @package openemr
@@ -9,7 +10,6 @@
  */
 
 namespace OpenEMR\Common\Auth\OpenIDConnect\Repositories;
-
 
 use OpenEMR\Common\Database\QueryUtils;
 
@@ -26,8 +26,7 @@ class JWTRepository
     {
         $sql = "select * FROM jwt_grant_history WHERE jti = ?";
         $params = [$jti];
-        if (!empty($expiration))
-        {
+        if (!empty($expiration)) {
             $sql .= " AND jti_exp > ?";
             $params[] = $expiration;
         }

--- a/src/Common/Uuid/UuidMapping.php
+++ b/src/Common/Uuid/UuidMapping.php
@@ -30,7 +30,8 @@ class UuidMapping
         ['resource' => 'Location', 'table' => 'users'],
         ['resource' => 'Location', 'table' => 'facility'],
         ['resource' => 'Observation', 'table' => 'form_vitals', 'codes' => FhirObservationVitalsService::COLUMN_MAPPINGS, 'category' => FhirObservationVitalsService::CATEGORY],
-        ['resource' => 'Observation', 'table' => 'history_data', 'codes' => FhirObservationSocialHistoryService::COLUMN_MAPPINGS, 'category' => FhirObservationSocialHistoryService::CATEGORY]
+        ['resource' => 'Observation', 'table' => 'history_data', 'codes' => FhirObservationSocialHistoryService::COLUMN_MAPPINGS, 'category' => FhirObservationSocialHistoryService::CATEGORY],
+        ['resource' => 'Group', 'table' => 'users']
     ];
 
     public static function getMappedRecordsForTableUUID($table_uuid)

--- a/src/FHIR/Export/ExportJob.php
+++ b/src/FHIR/Export/ExportJob.php
@@ -131,6 +131,11 @@ class ExportJob
      */
     private $exportType;
 
+    /**
+     * @var string[] The specific patient uuids to export
+     */
+    private $patientUuidsToExport;
+
     public function __construct()
     {
         $this->setStatus(self::STATUS_PROCESSING);
@@ -431,5 +436,21 @@ class ExportJob
             throw new \InvalidArgumentException("exportType is invalid");
         }
         $this->exportType = $exportType;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getPatientUuidsToExport(): array
+    {
+        return $this->patientUuidsToExport;
+    }
+
+    /**
+     * @param string[] $patientUuidsToExport
+     */
+    public function setPatientUuidsToExport(?array $patientUuidsToExport): void
+    {
+        $this->patientUuidsToExport = $patientUuidsToExport;
     }
 }

--- a/src/FHIR/SMART/SMARTLaunchToken.php
+++ b/src/FHIR/SMART/SMARTLaunchToken.php
@@ -122,8 +122,7 @@ class SMARTLaunchToken
         $decoded = base64_decode($serialized);
         $cryptoGen = new CryptoGen();
         $jsonEncoded = $cryptoGen->decryptStandard($decoded);
-        if ($jsonEncoded === false)
-        {
+        if ($jsonEncoded === false) {
             throw new \InvalidArgumentException("serialized token could not be decrypted.  Token was either invalid or something is wrong with the encryption keys");
         }
 

--- a/src/FHIR/SMART/SMARTLaunchToken.php
+++ b/src/FHIR/SMART/SMARTLaunchToken.php
@@ -99,15 +99,14 @@ class SMARTLaunchToken
         if (!empty($intent)) {
             $context['i'] = $intent;
         }
-        $cryptoGen = new CryptoGen();
-        $jsonEncoded = json_encode($context);
-        $launchParams = $cryptoGen->encryptStandard($jsonEncoded);
 
         // no security is really needed here... just need to be able to wrap
         // the current context into some kind of opaque id that the app will pass to the server and we can then
         // return to system
-        $serialized = base64_encode($launchParams);
-        return $serialized;
+        $cryptoGen = new CryptoGen();
+        $jsonEncoded = json_encode($context);
+        $launchParams = $cryptoGen->encryptStandard($jsonEncoded);
+        return $launchParams;
     }
 
     public static function deserializeToken($serialized)
@@ -119,9 +118,8 @@ class SMARTLaunchToken
 
     public function deserialize($serialized)
     {
-        $decoded = base64_decode($serialized);
         $cryptoGen = new CryptoGen();
-        $jsonEncoded = $cryptoGen->decryptStandard($decoded);
+        $jsonEncoded = $cryptoGen->decryptStandard($serialized);
         if ($jsonEncoded === false) {
             throw new \InvalidArgumentException("serialized token could not be decrypted.  Token was either invalid or something is wrong with the encryption keys");
         }

--- a/src/FHIR/SMART/SmartLaunchController.php
+++ b/src/FHIR/SMART/SmartLaunchController.php
@@ -86,7 +86,8 @@ class SmartLaunchController
             // appear to be required in the spec.
 
             $issuer = $GLOBALS['site_addr_oath'] . $GLOBALS['web_root'] . '/apis/' . $_SESSION['site_id'] . "/fhir";
-            $launchParams = "?launch=" . urlencode($launchCode) . "&iss=" . urlencode($issuer);
+            // issuer and audience are the same in a EHR SMART Launch
+            $launchParams = "?launch=" . urlencode($launchCode) . "&iss=" . urlencode($issuer) . "&aud=" . urlencode($issuer);
 
             expand_collapse_widget(
                 $widgetTitle,

--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -39,6 +39,7 @@ use OpenEMR\Common\Auth\OAuth2KeyException;
 use OpenEMR\Common\Auth\OpenIDConnect\Entities\ClientEntity;
 use OpenEMR\Common\Auth\OpenIDConnect\Entities\ScopeEntity;
 use OpenEMR\Common\Auth\OpenIDConnect\Entities\UserEntity;
+use OpenEMR\Common\Auth\OpenIDConnect\Grant\CustomAuthCodeGrant;
 use OpenEMR\Common\Auth\OpenIDConnect\Grant\CustomClientCredentialsGrant;
 use OpenEMR\Common\Auth\OpenIDConnect\Grant\CustomPasswordGrant;
 use OpenEMR\Common\Auth\OpenIDConnect\Grant\CustomRefreshTokenGrant;
@@ -602,10 +603,14 @@ class AuthorizationController
 
         $this->logger->debug("AuthorizationController->getAuthorizationServer() grantType is " . $this->grantType);
         if ($this->grantType === 'authorization_code') {
-            $grant = new AuthCodeGrant(
+            (new SystemLogger())->errorLogCaller("logging global params",
+                ['site_addr_oath' => $GLOBALS['site_addr_oath'], 'web_root' => $GLOBALS['web_root'], 'site_id' => $_SESSION['site_id']]);
+            $expectedAudience = $GLOBALS['site_addr_oath'] . $GLOBALS['web_root'] . '/apis/' . $_SESSION['site_id'] . "/fhir";
+            $grant = new CustomAuthCodeGrant(
                 new AuthCodeRepository(),
                 new RefreshTokenRepository($includeAuthGrantRefreshToken),
-                new \DateInterval('PT1M') // auth code. should be short turn around.
+                new \DateInterval('PT1M'), // auth code. should be short turn around.
+                $expectedAudience
             );
 
             // ONC Inferno does not support the code challenge PKCE standard right now so we disable it in the grant.

--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -603,8 +603,10 @@ class AuthorizationController
 
         $this->logger->debug("AuthorizationController->getAuthorizationServer() grantType is " . $this->grantType);
         if ($this->grantType === 'authorization_code') {
-            (new SystemLogger())->errorLogCaller("logging global params",
-                ['site_addr_oath' => $GLOBALS['site_addr_oath'], 'web_root' => $GLOBALS['web_root'], 'site_id' => $_SESSION['site_id']]);
+            (new SystemLogger())->errorLogCaller(
+                "logging global params",
+                ['site_addr_oath' => $GLOBALS['site_addr_oath'], 'web_root' => $GLOBALS['web_root'], 'site_id' => $_SESSION['site_id']]
+            );
             $expectedAudience = $GLOBALS['site_addr_oath'] . $GLOBALS['web_root'] . '/apis/' . $_SESSION['site_id'] . "/fhir";
             $grant = new CustomAuthCodeGrant(
                 new AuthCodeRepository(),

--- a/src/RestControllers/FHIR/FhirExportRestController.php
+++ b/src/RestControllers/FHIR/FhirExportRestController.php
@@ -166,8 +166,7 @@ class FhirExportRestController
             // TODO: make sure the patient ids are returned
             // need to add patient ids to the export job
             // need to modify fhir bulk export domain resource trait to use the patient ids and verify that is all working.
-            if ($exportType == ExportJob::EXPORT_OPERATION_GROUP)
-            {
+            if ($exportType == ExportJob::EXPORT_OPERATION_GROUP) {
                 $job->setPatientUuidsToExport($this->getPatientUuidsForGroup($groupId));
             }
 
@@ -635,19 +634,13 @@ class FhirExportRestController
         $patientUuids = [];
         $fhirGroupService = new FhirGroupService();
         $result = $fhirGroupService->getAll(['_id' => $groupId]);
-        if ($result->hasData())
-        {
-            foreach ($result->getData() as $group)
-            {
-                if ($group instanceof FHIRGroup && !empty($group->getMember()))
-                {
-                    foreach ($group->getMember() as $member)
-                    {
-                        if (!empty($member->getEntity()) && !empty($member->getEntity()->getReference()))
-                        {
+        if ($result->hasData()) {
+            foreach ($result->getData() as $group) {
+                if ($group instanceof FHIRGroup && !empty($group->getMember())) {
+                    foreach ($group->getMember() as $member) {
+                        if (!empty($member->getEntity()) && !empty($member->getEntity()->getReference())) {
                             $uuid = UtilsService::getUuidFromReference($member->getEntity());
-                            if (!empty($uuid))
-                            {
+                            if (!empty($uuid)) {
                                 $patientUuids[] = $uuid;
                             }
                         }

--- a/src/RestControllers/FHIR/FhirGroupRestController.php
+++ b/src/RestControllers/FHIR/FhirGroupRestController.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * FhirGroupRestController.php
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\RestControllers\FHIR;
+
+
+use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRGroup;
+use OpenEMR\FHIR\R4\FHIRResource\FHIRBundle\FHIRBundleEntry;
+use OpenEMR\RestControllers\RestControllerHelper;
+use OpenEMR\Services\FHIR\FhirGroupService;
+use OpenEMR\Services\FHIR\FhirResourcesService;
+
+class FhirGroupRestController
+{
+    private $fhirService;
+
+    /**
+     * @var FhirGroupService
+     */
+    private $service;
+
+    public function __construct()
+    {
+        $this->fhirService = new FhirResourcesService();
+        $this->service = new FhirGroupService();
+    }
+
+    /**
+     * Queries for a single FHIR resource by FHIR id
+     * @param $fhirId The FHIR resource id (uuid)
+     * @param $puuidBind - Optional variable to only allow visibility of the patient with this puuid.
+     * @returns 200 if the operation completes successfully
+     */
+    public function getOne($fhirId, $puuidBind = null)
+    {
+        $processingResult = $this->service->getOne($fhirId, $puuidBind);
+        return RestControllerHelper::handleFhirProcessingResult($processingResult, 200);
+    }
+
+    /**
+     * Queries for FHIR resources using various search parameters.
+     * @param $puuidBind - Optional variable to only allow visibility of the patient with this puuid.
+     * @return FHIR bundle with query results, if found
+     */
+    public function getAll($searchParams, $puuidBind = null)
+    {
+        $processingResult = $this->service->getAll($searchParams, $puuidBind);
+        $bundleEntries = array();
+        foreach ($processingResult->getData() as $index => $searchResult) {
+            $bundleEntry = [
+                'fullUrl' =>  $GLOBALS['site_addr_oath'] . ($_SERVER['REDIRECT_URL'] ?? '') . '/' . $searchResult->getId(),
+                'resource' => $searchResult
+            ];
+            $fhirBundleEntry = new FHIRBundleEntry($bundleEntry);
+            array_push($bundleEntries, $fhirBundleEntry);
+        }
+        $fhirGroup = new FHIRGroup();
+        $bundleSearchResult = $this->fhirService->createBundle($fhirGroup->get_fhirElementName(), $bundleEntries, false);
+        $searchResponseBody = RestControllerHelper::responseHandler($bundleSearchResult, null, 200);
+        return $searchResponseBody;
+    }
+}

--- a/src/RestControllers/FHIR/FhirGroupRestController.php
+++ b/src/RestControllers/FHIR/FhirGroupRestController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * FhirGroupRestController.php
  * @package openemr
@@ -9,7 +10,6 @@
  */
 
 namespace OpenEMR\RestControllers\FHIR;
-
 
 use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRGroup;
 use OpenEMR\FHIR\R4\FHIRResource\FHIRBundle\FHIRBundleEntry;

--- a/src/RestControllers/PractitionerRestController.php
+++ b/src/RestControllers/PractitionerRestController.php
@@ -51,7 +51,8 @@ class PractitionerRestController
         "phonew1",
         "phonecell",
         "notes",
-        "state_license_number"
+        "state_license_number",
+        "username"
     );
 
     public function __construct()

--- a/src/Services/CareTeamService.php
+++ b/src/Services/CareTeamService.php
@@ -97,7 +97,10 @@ class CareTeamService extends BaseService
         $processingResult = new ProcessingResult();
         while ($row = sqlFetchArray($statementResults)) {
             $resultRecord = $this->createResultRecordFromDatabaseResult($row);
-            $processingResult->addData($resultRecord);
+            // if we couldn't retrieve any providers / facilities we will ignore the care team.
+            if (!empty($resultRecord['providers']) || !empty($resultRecord['facilities'])) {
+                $processingResult->addData($resultRecord);
+            }
         }
         return $processingResult;
     }

--- a/src/Services/FHIR/DocumentReference/FhirPatientDocumentReferenceService.php
+++ b/src/Services/FHIR/DocumentReference/FhirPatientDocumentReferenceService.php
@@ -175,10 +175,8 @@ class FhirPatientDocumentReferenceService extends FhirServiceBase
         $orgReference = $fhirOrganizationService->getPrimaryBusinessEntityReference();
         $docReference->setCustodian($orgReference);
 
-        // TODO: @adunsulag check with @sjpadgett and @brady.miller how are patient documents setup?  Do they populate the owner column?
-        // how do you determine if a patient uploaded a document vs a regular user?
         if (!empty($dataRecord['user_uuid'])) {
-            if (!empty($dataRecord['npi'])) {
+            if (!empty($dataRecord['user_npi'])) {
                 $docReference->addAuthor(UtilsService::createRelativeReference('Practitioner', $dataRecord['user_uuid']));
             } else {
                 // if we don't have a practitioner reference then it is the business owner that will be the author on

--- a/src/Services/FHIR/FhirCarePlanService.php
+++ b/src/Services/FHIR/FhirCarePlanService.php
@@ -155,7 +155,8 @@ class FhirCarePlanService extends FhirServiceBase implements IResourceUSCIGProfi
             // use description or fallback on codetext if needed
             $descriptions[] = $detail['description'] ?? $detail['codetext'] ?? "";
         }
-        $carePlanText = ['text' => implode("\n", $descriptions), "xhtml" => ""];
+        // make sure we clear any white space out that blows up FHIR validation
+        $carePlanText = ['text' => trim(implode("\n", $descriptions)), "xhtml" => ""];
         if (!empty($descriptions)) {
             $carePlanText['xhtml'] = "<p>" . implode("</p><p>", $descriptions) . "</p>";
         }

--- a/src/Services/FHIR/FhirConditionService.php
+++ b/src/Services/FHIR/FhirConditionService.php
@@ -28,7 +28,7 @@ use OpenEMR\Validators\ProcessingResult;
  * @copyright          Copyright (c) 2020 Yash Bothra <yashrajbothra786gmail.com>
  * @license            https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
-class FhirConditionService extends FhirServiceBase implements IResourceUSCIGProfileService, IFhirExportableResourceService
+class FhirConditionService extends FhirServiceBase implements IResourceUSCIGProfileService, IFhirExportableResourceService, IPatientCompartmentResourceService
 {
     use FhirServiceBaseEmptyTrait;
     use BulkExportSupportAllOperationsTrait;
@@ -56,7 +56,7 @@ class FhirConditionService extends FhirServiceBase implements IResourceUSCIGProf
     protected function loadSearchParameters()
     {
         return  [
-            'patient' => new FhirSearchParameterDefinition('patient', SearchFieldType::REFERENCE, [new ServiceField('puuid', ServiceField::TYPE_UUID)]),
+            'patient' => $this->getPatientContextSearchField(),
             '_id' => new FhirSearchParameterDefinition('_id', SearchFieldType::TOKEN, [new ServiceField('condition_uuid', ServiceField::TYPE_UUID)]),
         ];
     }
@@ -210,7 +210,8 @@ class FhirConditionService extends FhirServiceBase implements IResourceUSCIGProf
      */
     protected function searchForOpenEMRRecords($openEMRSearchParameters, $puuidBind = null): ProcessingResult
     {
-        return $this->conditionService->getAll($openEMRSearchParameters, true, $puuidBind);
+        $result = $this->conditionService->getAll($openEMRSearchParameters, true, $puuidBind);
+        return $result;
     }
 
     public function createProvenanceResource($dataRecord = array(), $encode = false)
@@ -237,5 +238,10 @@ class FhirConditionService extends FhirServiceBase implements IResourceUSCIGProf
     function getProfileURIs(): array
     {
         return [self::USCGI_PROFILE_URI];
+    }
+
+    public function getPatientContextSearchField(): FhirSearchParameterDefinition
+    {
+        return new FhirSearchParameterDefinition('patient', SearchFieldType::REFERENCE, [new ServiceField('puuid', ServiceField::TYPE_UUID)]);
     }
 }

--- a/src/Services/FHIR/FhirDeviceService.php
+++ b/src/Services/FHIR/FhirDeviceService.php
@@ -24,7 +24,7 @@ use OpenEMR\Services\Search\SearchFieldType;
 use OpenEMR\Services\Search\ServiceField;
 use OpenEMR\Validators\ProcessingResult;
 
-class FhirDeviceService extends FhirServiceBase implements IResourceUSCIGProfileService, IFhirExportableResourceService
+class FhirDeviceService extends FhirServiceBase implements IResourceUSCIGProfileService, IFhirExportableResourceService, IPatientCompartmentResourceService
 {
     use FhirServiceBaseEmptyTrait;
     use BulkExportSupportAllOperationsTrait;

--- a/src/Services/FHIR/FhirEncounterService.php
+++ b/src/Services/FHIR/FhirEncounterService.php
@@ -163,7 +163,8 @@ class FhirEncounterService extends FhirServiceBase implements IFhirExportableRes
             // do it this way
             // @see https://chat.fhir.org/#narrow/stream/179175-argonaut/topic/Encounter.20Reason.20For.20Visit (beware of link rot)
             $reason = new FHIRCodeableConcept();
-            $reason->setText($dataRecord['reason']);
+            $reasonText = $dataRecord['reason'] ?? "";
+            $reason->setText(trim($reasonText));
             $encounterResource->addReasonCode($reason);
         }
         // hospitalization - must support

--- a/src/Services/FHIR/FhirEncounterService.php
+++ b/src/Services/FHIR/FhirEncounterService.php
@@ -214,33 +214,4 @@ class FhirEncounterService extends FhirServiceBase implements IFhirExportableRes
     {
         return $this->encounterService->search($searchParam, true, $puuidBind);
     }
-
-    /**
-     * Grabs all the objects in my service that match the criteria specified in the ExportJob.  If a
-     * $lastResourceIdExported is provided, The service executes the same data collection query it used previously and
-     * startes processing at the resource that is immediately after (ordered by date) the resource that matches the id of
-     * $lastResourceIdExported.  This allows processing of the service to be resumed or paused.
-     * @param ExportStreamWriter $writer Object that writes out to a stream any object that extend the FhirResource object
-     * @param ExportJob $job The export job we are processing the request for.  Holds all of the context information needed for the export service.
-     * @return void
-     * @throws ExportWillShutdownException  Thrown if the export is about to be shutdown and all processing must be halted.
-     * @throws ExportException  If there is an error in processing the export
-     * @throws ExportCannotEncodeException Thrown if the resource cannot be properly converted into the right format (ie JSON).
-     */
-//    public function export(ExportStreamWriter $writer, ExportJob $job, $lastResourceIdExported = null): void
-//    {
-//        // TODO: encounter search should support multiple date parameter searches for interval period search
-////        $date = [
-////            'le' . $job->getStartTime()->format(\DateTime::RFC3339_EXTENDED)
-////            ,'ge' . $job->getResourceIncludeTime()->format(\DateTime::RFC3339_EXTENDED)
-////        ];
-//        $date = 'le' . $job->getStartTime()->format(\DateTime::RFC3339_EXTENDED);
-//        $result = $this->getAll(['date' => $date]);
-//        $encounters = $result->getData();
-//        if (!empty($encounters)) {
-//            foreach ($encounters as $encounter) {
-//                $writer->append($encounter);
-//            }
-//        }
-//    }
 }

--- a/src/Services/FHIR/FhirGoalService.php
+++ b/src/Services/FHIR/FhirGoalService.php
@@ -29,7 +29,7 @@ use OpenEMR\Services\Search\SearchFieldType;
 use OpenEMR\Services\Search\ServiceField;
 use OpenEMR\Validators\ProcessingResult;
 
-class FhirGoalService extends FhirServiceBase implements IResourceUSCIGProfileService, IFhirExportableResourceService
+class FhirGoalService extends FhirServiceBase implements IResourceUSCIGProfileService, IFhirExportableResourceService, IPatientCompartmentResourceService
 {
     use FhirServiceBaseEmptyTrait;
     use BulkExportSupportAllOperationsTrait;

--- a/src/Services/FHIR/FhirGoalService.php
+++ b/src/Services/FHIR/FhirGoalService.php
@@ -96,7 +96,7 @@ class FhirGoalService extends FhirServiceBase implements IResourceUSCIGProfileSe
         // ONC only requires a descriptive text.  Future FHIR implementors can grab these details and populate the
         // activity element if they so choose, for now we just return the combined description of the care plan.
         if (!empty($dataRecord['details'])) {
-            $text = $this->getCarePlanTextFromDetails($dataRecord['details']);
+            $text = $this->getGoalTextFromDetails($dataRecord['details']);
             $codeableConcept = new FHIRCodeableConcept();
             $codeableConcept->setText($text['text']);
             $goal->setDescription($codeableConcept);
@@ -111,10 +111,10 @@ class FhirGoalService extends FhirServiceBase implements IResourceUSCIGProfileSe
                 } else {
                     $fhirGoalTarget->setDueDate(UtilsService::createDataMissingExtension());
                 }
-
-                if (!empty($detail['description'])) {
+                $detailDescription = trim($detail['description'] ?? "");
+                if (!empty($detailDescription)) {
                     // if description is populated we also have to populate the measure with the correct code
-                    $fhirGoalTarget->setDetailString($detail['description']);
+                    $fhirGoalTarget->setDetailString($detailDescription);
 
                     if (!empty($detail['code'])) {
                         $codeText = $codeTypeService->lookup_code_description($detail['code']);
@@ -176,14 +176,14 @@ class FhirGoalService extends FhirServiceBase implements IResourceUSCIGProfileSe
         return new FhirSearchParameterDefinition('patient', SearchFieldType::REFERENCE, [new ServiceField('puuid', ServiceField::TYPE_UUID)]);
     }
 
-    private function getCarePlanTextFromDetails($details)
+    private function getGoalTextFromDetails($details)
     {
         $descriptions = [];
         foreach ($details as $detail) {
             // use description or fallback on codetext if needed
             $descriptions[] = $detail['description'] ?? $detail['codetext'] ?? "";
         }
-        $carePlanText = ['text' => implode("\n", $descriptions), "xhtml" => ""];
+        $carePlanText = ['text' => trim(implode("\n", $descriptions)), "xhtml" => ""];
         if (!empty($descriptions)) {
             $carePlanText['xhtml'] = "<p>" . implode("</p><p>", $descriptions) . "</p>";
         }

--- a/src/Services/FHIR/FhirGroupService.php
+++ b/src/Services/FHIR/FhirGroupService.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * FhirGroupService.php
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Services\FHIR;
+
+
+use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Services\FHIR\Group\FhirPatientProviderGroupService;
+use OpenEMR\Services\FHIR\Traits\BulkExportSupportAllOperationsTrait;
+use OpenEMR\Services\FHIR\Traits\FhirBulkExportDomainResourceTrait;
+use OpenEMR\Services\FHIR\Traits\FhirServiceBaseEmptyTrait;
+use OpenEMR\Services\FHIR\Traits\MappedServiceTrait;
+use OpenEMR\Services\FHIR\Traits\PatientSearchTrait;
+use OpenEMR\Services\Search\FhirSearchParameterDefinition;
+use OpenEMR\Services\Search\SearchFieldException;
+use OpenEMR\Services\Search\SearchFieldType;
+use OpenEMR\Services\Search\ServiceField;
+use OpenEMR\Validators\ProcessingResult;
+
+class FhirGroupService extends FhirServiceBase implements IFhirExportableResourceService
+{
+    use FhirServiceBaseEmptyTrait;
+    use BulkExportSupportAllOperationsTrait;
+    use FhirBulkExportDomainResourceTrait;
+    use MappedServiceTrait;
+    use PatientSearchTrait;
+
+    public function __construct($fhirApiURL = null)
+    {
+        parent::__construct($fhirApiURL);
+        // we can add all kinds of groups here such as therapy groups, groups by facilities, for now we will support
+        // groups by providers
+        $this->addMappedService(new FhirPatientProviderGroupService());
+    }
+
+    /**
+     * Returns an array mapping FHIR Resource search parameters to OpenEMR search parameters
+     */
+    protected function loadSearchParameters()
+    {
+        return  [
+            'patient' => $this->getPatientContextSearchField(),
+            '_id' => new FhirSearchParameterDefinition('_id', SearchFieldType::TOKEN, [new ServiceField('uuid', ServiceField::TYPE_UUID)]),
+        ];
+    }
+
+    /**
+     * Retrieves all of the fhir observation resources mapped to the underlying openemr data elements.
+     * @param $fhirSearchParameters The FHIR resource search parameters
+     * @param $puuidBind - Optional variable to only allow visibility of the patient with this puuid.
+     * @return processing result
+     */
+    public function getAll($fhirSearchParameters, $puuidBind = null): ProcessingResult
+    {
+        $fhirSearchResult = new ProcessingResult();
+        try {
+            if (isset($puuidBind)) {
+                $field = $this->getPatientContextSearchField();
+                $fhirSearchParameters[$field->getName()] = $puuidBind;
+            }
+
+            $fhirSearchResult = $this->searchAllServicesWithSupportedFields($fhirSearchParameters, $puuidBind);
+        } catch (SearchFieldException $exception) {
+            (new SystemLogger())->errorLogCaller("exception thrown while searching", ['message' => $exception->getMessage(),
+                'field' => $exception->getField()]);
+            // put our exception information here
+            $fhirSearchResult->setValidationMessages([$exception->getField() => $exception->getMessage()]);
+        }
+        return $fhirSearchResult;
+    }
+}

--- a/src/Services/FHIR/FhirGroupService.php
+++ b/src/Services/FHIR/FhirGroupService.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * FhirGroupService.php
  * @package openemr
@@ -9,7 +10,6 @@
  */
 
 namespace OpenEMR\Services\FHIR;
-
 
 use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Services\FHIR\Group\FhirPatientProviderGroupService;

--- a/src/Services/FHIR/FhirImmunizationService.php
+++ b/src/Services/FHIR/FhirImmunizationService.php
@@ -33,7 +33,7 @@ use OpenEMR\Validators\ProcessingResult;
  * @copyright Copyright (c) 2020 Yash Bothra <yashrajbothra786gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
-class FhirImmunizationService extends FhirServiceBase implements IResourceUSCIGProfileService, IFhirExportableResourceService,IPatientCompartmentResourceService
+class FhirImmunizationService extends FhirServiceBase implements IResourceUSCIGProfileService, IFhirExportableResourceService, IPatientCompartmentResourceService
 {
     use FhirServiceBaseEmptyTrait;
     use BulkExportSupportAllOperationsTrait;

--- a/src/Services/FHIR/FhirImmunizationService.php
+++ b/src/Services/FHIR/FhirImmunizationService.php
@@ -33,7 +33,7 @@ use OpenEMR\Validators\ProcessingResult;
  * @copyright Copyright (c) 2020 Yash Bothra <yashrajbothra786gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
-class FhirImmunizationService extends FhirServiceBase implements IResourceUSCIGProfileService, IFhirExportableResourceService
+class FhirImmunizationService extends FhirServiceBase implements IResourceUSCIGProfileService, IFhirExportableResourceService,IPatientCompartmentResourceService
 {
     use FhirServiceBaseEmptyTrait;
     use BulkExportSupportAllOperationsTrait;
@@ -59,7 +59,7 @@ class FhirImmunizationService extends FhirServiceBase implements IResourceUSCIGP
     protected function loadSearchParameters()
     {
         return  [
-            'patient' => new FhirSearchParameterDefinition('patient', SearchFieldType::REFERENCE, [new ServiceField('puuid', ServiceField::TYPE_UUID)]),
+            'patient' => $this->getPatientContextSearchField(),
             '_id' => new FhirSearchParameterDefinition('uuid', SearchFieldType::TOKEN, [new ServiceField('uuid', ServiceField::TYPE_UUID)]),
         ];
     }
@@ -215,5 +215,10 @@ class FhirImmunizationService extends FhirServiceBase implements IResourceUSCIGP
     public function getProfileURIs(): array
     {
         return [self::USCGI_PROFILE_URI];
+    }
+
+    public function getPatientContextSearchField(): FhirSearchParameterDefinition
+    {
+        return new FhirSearchParameterDefinition('patient', SearchFieldType::REFERENCE, [new ServiceField('puuid', ServiceField::TYPE_UUID)]);
     }
 }

--- a/src/Services/FHIR/FhirMedicationRequestService.php
+++ b/src/Services/FHIR/FhirMedicationRequestService.php
@@ -35,7 +35,7 @@ use OpenEMR\Validators\ProcessingResult;
  * Class FhirMedicationRequestService
  * @package OpenEMR\Services\FHIR
  */
-class FhirMedicationRequestService extends FhirServiceBase implements IResourceUSCIGProfileService, IFhirExportableResourceService
+class FhirMedicationRequestService extends FhirServiceBase implements IResourceUSCIGProfileService, IFhirExportableResourceService, IPatientCompartmentResourceService
 {
     use PatientSearchTrait;
     use FhirServiceBaseEmptyTrait;

--- a/src/Services/FHIR/FhirPatientService.php
+++ b/src/Services/FHIR/FhirPatientService.php
@@ -12,6 +12,7 @@ use OpenEMR\FHIR\R4\FHIRElement\FHIRExtension;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRIdentifier;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRIdentifierUse;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRMeta;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRPeriod;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRString;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRUri;
 use OpenEMR\FHIR\R4\FHIRResource\FHIRDomainResource;

--- a/src/Services/FHIR/FhirPractitionerService.php
+++ b/src/Services/FHIR/FhirPractitionerService.php
@@ -87,6 +87,10 @@ class FhirPractitionerService extends FhirServiceBase implements IFhirExportable
 
         $practitionerResource->setActive($dataRecord['active'] == "1" ? true : false);
 
+        $id = new FHIRId();
+        $id->setValue($dataRecord['uuid']);
+        $practitionerResource->setId($id);
+
         $narrativeText = '';
         if (isset($dataRecord['fname'])) {
             $narrativeText = $dataRecord['fname'];
@@ -94,17 +98,19 @@ class FhirPractitionerService extends FhirServiceBase implements IFhirExportable
         if (isset($dataRecord['lname'])) {
             $narrativeText .= ' ' . $dataRecord['lname'];
         }
-        $text = array(
-            'status' => 'generated',
-            'div' => '<div xmlns="http://www.w3.org/1999/xhtml"> <p>' . $narrativeText . '</p></div>'
-        );
-        $practitionerResource->setText($text);
+        // why in some cases are users with an empty name... that seems so wierd but we have them so we are supporting them.
+        if (empty(trim($narrativeText)))
+        {
+            $practitionerResource->addName(UtilsService::createDataMissingExtension());
+        } else {
+            $text = array(
+                'status' => 'generated',
+                'div' => '<div xmlns="http://www.w3.org/1999/xhtml"> <p>' . $narrativeText . '</p></div>'
+            );
+            $practitionerResource->setText($text);
 
-        $id = new FHIRId();
-        $id->setValue($dataRecord['uuid']);
-        $practitionerResource->setId($id);
-
-        $practitionerResource->addName(UtilsService::createHumanNameFromRecord($dataRecord));
+            $practitionerResource->addName(UtilsService::createHumanNameFromRecord($dataRecord));
+        }
         $address = UtilsService::createAddressFromRecord($dataRecord);
         if (isset($address)) {
             $practitionerResource->addAddress($address);

--- a/src/Services/FHIR/FhirPractitionerService.php
+++ b/src/Services/FHIR/FhirPractitionerService.php
@@ -261,8 +261,7 @@ class FhirPractitionerService extends FhirServiceBase implements IFhirExportable
     public function insertOpenEMRRecord($openEmrRecord)
     {
         // practitioners HAVE to have a username
-        if (!isset($openEmrRecord['username']))
-        {
+        if (!isset($openEmrRecord['username'])) {
             $username = $openEmrRecord['lname'] ?? '';
             $username .= $openEmrRecord['fname'] ?? '';
             $openEmrRecord['username'] = uniqid($username);

--- a/src/Services/FHIR/FhirPractitionerService.php
+++ b/src/Services/FHIR/FhirPractitionerService.php
@@ -260,6 +260,13 @@ class FhirPractitionerService extends FhirServiceBase implements IFhirExportable
      */
     public function insertOpenEMRRecord($openEmrRecord)
     {
+        // practitioners HAVE to have a username
+        if (!isset($openEmrRecord['username']))
+        {
+            $username = $openEmrRecord['lname'] ?? '';
+            $username .= $openEmrRecord['fname'] ?? '';
+            $openEmrRecord['username'] = uniqid($username);
+        }
         return $this->practitionerService->insert($openEmrRecord);
     }
 

--- a/src/Services/FHIR/FhirPractitionerService.php
+++ b/src/Services/FHIR/FhirPractitionerService.php
@@ -99,8 +99,7 @@ class FhirPractitionerService extends FhirServiceBase implements IFhirExportable
             $narrativeText .= ' ' . $dataRecord['lname'];
         }
         // why in some cases are users with an empty name... that seems so wierd but we have them so we are supporting them.
-        if (empty(trim($narrativeText)))
-        {
+        if (empty(trim($narrativeText))) {
             $practitionerResource->addName(UtilsService::createDataMissingExtension());
         } else {
             $text = array(

--- a/src/Services/FHIR/FhirProcedureService.php
+++ b/src/Services/FHIR/FhirProcedureService.php
@@ -28,7 +28,7 @@ use OpenEMR\Services\Search\SearchFieldType;
 use OpenEMR\Services\Search\ServiceField;
 use OpenEMR\Validators\ProcessingResult;
 
-class FhirProcedureService extends FhirServiceBase implements IResourceUSCIGProfileService, IFhirExportableResourceService
+class FhirProcedureService extends FhirServiceBase implements IResourceUSCIGProfileService, IFhirExportableResourceService, IPatientCompartmentResourceService
 {
     use MappedServiceTrait;
     use PatientSearchTrait;

--- a/src/Services/FHIR/Group/FhirPatientProviderGroupService.php
+++ b/src/Services/FHIR/Group/FhirPatientProviderGroupService.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * FhirPatientProviderGroupService.php
  * @package openemr
@@ -9,7 +10,6 @@
  */
 
 namespace OpenEMR\Services\FHIR\Group;
-
 
 use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRGroup;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRMeta;
@@ -62,10 +62,8 @@ class FhirPatientProviderGroupService extends FhirServiceBase
         $fhirGroup->setId($dataRecord['uuid']);
         $fhirGroup->setName($dataRecord['name']);
 
-        if (!empty($dataRecord['patients']))
-        {
-            foreach ($dataRecord['patients'] as $patient)
-            {
+        if (!empty($dataRecord['patients'])) {
+            foreach ($dataRecord['patients'] as $patient) {
                 $fhirGroupMember = new FHIRGroupMember();
                 // we could display the name of the patient here in the group list... but I think for information leakage we will leave just the reference
                 $fhirGroupMember->setEntity(UtilsService::createRelativeReference("Patient", $patient['uuid']));

--- a/src/Services/FHIR/Group/FhirPatientProviderGroupService.php
+++ b/src/Services/FHIR/Group/FhirPatientProviderGroupService.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * FhirPatientProviderGroupService.php
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Services\FHIR\Group;
+
+
+use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRGroup;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRMeta;
+use OpenEMR\FHIR\R4\FHIRResource\FHIRGroup\FHIRGroupMember;
+use OpenEMR\Services\FHIR\FhirServiceBase;
+use OpenEMR\Services\FHIR\Traits\FhirServiceBaseEmptyTrait;
+use OpenEMR\Services\FHIR\Traits\PatientSearchTrait;
+use OpenEMR\Services\FHIR\UtilsService;
+use OpenEMR\Services\GroupService;
+use OpenEMR\Services\Search\FhirSearchParameterDefinition;
+use OpenEMR\Services\Search\SearchFieldType;
+use OpenEMR\Services\Search\ServiceField;
+use OpenEMR\Validators\ProcessingResult;
+
+class FhirPatientProviderGroupService extends FhirServiceBase
+{
+    use FhirServiceBaseEmptyTrait;
+    use PatientSearchTrait;
+
+    public function __construct($fhirApiURL = null)
+    {
+        parent::__construct($fhirApiURL);
+        $this->service = new GroupService();
+    }
+
+    /**
+     * Returns an array mapping FHIR Resource search parameters to OpenEMR search parameters
+     */
+    protected function loadSearchParameters()
+    {
+        return  [
+            'patient' => $this->getPatientContextSearchField(),
+            '_id' => new FhirSearchParameterDefinition('_id', SearchFieldType::TOKEN, [new ServiceField('uuid', ServiceField::TYPE_UUID)]),
+        ];
+    }
+
+    protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
+    {
+        return $this->service->searchPatientProviderGroups($openEMRSearchParameters);
+    }
+
+    public function parseOpenEMRRecord($dataRecord = array(), $encode = false)
+    {
+        $fhirGroup = new FHIRGroup();
+        $fhirMeta = new FHIRMeta();
+        $fhirMeta->setVersionId("1");
+        $fhirMeta->setLastUpdated(gmdate('c'));
+        $fhirGroup->setMeta($fhirMeta);
+
+        $fhirGroup->setId($dataRecord['uuid']);
+        $fhirGroup->setName($dataRecord['name']);
+
+        if (!empty($dataRecord['patients']))
+        {
+            foreach ($dataRecord['patients'] as $patient)
+            {
+                $fhirGroupMember = new FHIRGroupMember();
+                // we could display the name of the patient here in the group list... but I think for information leakage we will leave just the reference
+                $fhirGroupMember->setEntity(UtilsService::createRelativeReference("Patient", $patient['uuid']));
+                $fhirGroup->addMember($fhirGroupMember);
+            }
+        }
+        return $fhirGroup;
+    }
+}

--- a/src/Services/FHIR/Observation/FhirObservationSocialHistoryService.php
+++ b/src/Services/FHIR/Observation/FhirObservationSocialHistoryService.php
@@ -314,7 +314,9 @@ class FhirObservationSocialHistoryService extends FhirServiceBase implements IPa
     private function populateSmokingCessation(FHIRObservation $observation, $dataRecord)
     {
         if (empty($dataRecord['smoking_status_codes'])) {
-            $observation->setDataAbsentReason(UtilsService::createDataAbsentUnknownCodeableConcept());
+            // we are going to create our null flavor code here
+            $concept = UtilsService::createDataAbsentUnknownCodeableConcept();
+            $observation->setValueCodeableConcept($concept);
         } else {
             $concept = UtilsService::createCodeableConcept($dataRecord['smoking_status_codes'], FhirCodeSystemConstants::SNOMED_CT);
             $observation->setValueCodeableConcept($concept);

--- a/src/Services/FHIR/Organization/FhirOrganizationFacilityService.php
+++ b/src/Services/FHIR/Organization/FhirOrganizationFacilityService.php
@@ -167,15 +167,14 @@ class FhirOrganizationFacilityService extends FhirServiceBase
         // facilities have no active / inactive state
         $organizationResource->setActive(true);
 
-        $narrativeText = '';
-        if (isset($dataRecord['name'])) {
-            $narrativeText = $dataRecord['name'];
+        $narrativeText = trim($dataRecord['name'] ?? "");
+        if (!empty($narrativeText)) {
+            $text = array(
+                'status' => 'generated',
+                'div' => '<div xmlns="http://www.w3.org/1999/xhtml"> <p>' . $narrativeText . '</p></div>'
+            );
+            $organizationResource->setText($text);
         }
-        $text = array(
-            'status' => 'generated',
-            'div' => '<div xmlns="http://www.w3.org/1999/xhtml"> <p>' . $narrativeText . '</p></div>'
-        );
-        $organizationResource->setText($text);
 
         $id = new FHIRId();
         $id->setValue($dataRecord['uuid']);

--- a/src/Services/FHIR/Organization/FhirOrganizationInsuranceService.php
+++ b/src/Services/FHIR/Organization/FhirOrganizationInsuranceService.php
@@ -97,15 +97,14 @@ class FhirOrganizationInsuranceService extends FhirServiceBase
         $organizationResource->setMeta($fhirMeta);
         $organizationResource->setActive($dataRecord['inactive'] == '0');
 
-        $narrativeText = '';
-        if (isset($dataRecord['name'])) {
-            $narrativeText = $dataRecord['name'];
+        $narrativeText = trim($dataRecord['name'] ?? "");
+        if (!empty($narrativeText)) {
+            $text = array(
+                'status' => 'generated',
+                'div' => '<div xmlns="http://www.w3.org/1999/xhtml"> <p>' . $narrativeText . '</p></div>'
+            );
+            $organizationResource->setText($text);
         }
-        $text = array(
-            'status' => 'generated',
-            'div' => '<div xmlns="http://www.w3.org/1999/xhtml"> <p>' . $narrativeText . '</p></div>'
-        );
-        $organizationResource->setText($text);
 
         $id = new FHIRId();
         $id->setValue($dataRecord['uuid']);

--- a/src/Services/FHIR/Organization/FhirOrganizationProcedureProviderService.php
+++ b/src/Services/FHIR/Organization/FhirOrganizationProcedureProviderService.php
@@ -68,7 +68,7 @@ class FhirOrganizationProcedureProviderService extends FhirServiceBase
             $name->setModifier(SearchModifier::MISSING);
             $npi = new TokenSearchField('npi', [new TokenSearchValue(false)]);
             $npi->setModifier(SearchModifier::MISSING);
-            $openEMRSearchParameters['identifier-name'] = new CompositeSearchField('identifier-name', [], false);
+            $openEMRSearchParameters['identifier-name'] = new CompositeSearchField('identifier-name', [], true);
             $openEMRSearchParameters['identifier-name']->setChildren([$name, $npi]);
         }
         return $this->service->search($openEMRSearchParameters);
@@ -91,15 +91,14 @@ class FhirOrganizationProcedureProviderService extends FhirServiceBase
         $organizationResource->setMeta($fhirMeta);
         $organizationResource->setActive($dataRecord['active'] == '1');
 
-        $narrativeText = '';
-        if (isset($dataRecord['name'])) {
-            $narrativeText = $dataRecord['name'];
+        $narrativeText = trim($dataRecord['name'] ?? "");
+        if (!empty($narrativeText)) {
+            $text = array(
+                'status' => 'generated',
+                'div' => '<div xmlns="http://www.w3.org/1999/xhtml"> <p>' . $narrativeText . '</p></div>'
+            );
+            $organizationResource->setText($text);
         }
-        $text = array(
-            'status' => 'generated',
-            'div' => '<div xmlns="http://www.w3.org/1999/xhtml"> <p>' . $narrativeText . '</p></div>'
-        );
-        $organizationResource->setText($text);
 
         $id = new FHIRId();
         $id->setValue($dataRecord['uuid']);

--- a/src/Services/FHIR/Organization/FhirOrganizationProcedureProviderService.php
+++ b/src/Services/FHIR/Organization/FhirOrganizationProcedureProviderService.php
@@ -66,10 +66,7 @@ class FhirOrganizationProcedureProviderService extends FhirServiceBase
 
             $name = new TokenSearchField('name', [new TokenSearchValue(false)]);
             $name->setModifier(SearchModifier::MISSING);
-            $npi = new TokenSearchField('npi', [new TokenSearchValue(false)]);
-            $npi->setModifier(SearchModifier::MISSING);
-            $openEMRSearchParameters['identifier-name'] = new CompositeSearchField('identifier-name', [], true);
-            $openEMRSearchParameters['identifier-name']->setChildren([$name, $npi]);
+            $openEMRSearchParameters['name'] = $name;
         }
         return $this->service->search($openEMRSearchParameters);
     }

--- a/src/Services/FHIR/Traits/FhirBulkExportDomainResourceTrait.php
+++ b/src/Services/FHIR/Traits/FhirBulkExportDomainResourceTrait.php
@@ -59,8 +59,7 @@ trait FhirBulkExportDomainResourceTrait
             $group = $job->getGroupId();
 
             $patientUuids = $job->getPatientUuidsToExport();
-            if ($this instanceof IPatientCompartmentResourceService)
-            {
+            if ($this instanceof IPatientCompartmentResourceService) {
                 $searchField = $this->getPatientContextSearchField();
                 $searchParams[$searchField->getName()] = implode(",", $patientUuids);
             }

--- a/src/Services/FHIR/Traits/FhirBulkExportDomainResourceTrait.php
+++ b/src/Services/FHIR/Traits/FhirBulkExportDomainResourceTrait.php
@@ -19,7 +19,9 @@ use OpenEMR\FHIR\Export\ExportJob;
 use OpenEMR\FHIR\Export\ExportStreamWriter;
 use OpenEMR\FHIR\Export\ExportWillShutdownException;
 use OpenEMR\FHIR\R4\FHIRResource\FHIRDomainResource;
+use OpenEMR\Services\FHIR\IPatientCompartmentResourceService;
 use OpenEMR\Services\FHIR\IResourceReadableService;
+use OpenEMR\Services\Search\TokenSearchField;
 
 trait FhirBulkExportDomainResourceTrait
 {
@@ -42,6 +44,29 @@ trait FhirBulkExportDomainResourceTrait
             throw new \BadMethodCallException("Trait can only be used in classes that implement the " . IResourceReadableService::class . " interface");
         }
         $searchParams = [];
+
+        // TODO: in order to handle bulk export for the group... we will need to grab our patient context resource and filter everything against
+        // the patients from the export
+
+        $type = $job->getExportType();
+
+
+        // we would need to grab all of the patient ids that belong to this group
+        // TODO: @adunsulag if we fully implement groups of patient populations we would set our patient ids into $searchParams
+        // or filter the results here.  Right now we treat all patients as belonging to the same '1' group.
+        $searchParams = [];
+        if ($type == ExportJob::EXPORT_OPERATION_GROUP) {
+            $group = $job->getGroupId();
+
+            $patientUuids = $job->getPatientUuidsToExport();
+            if ($this instanceof IPatientCompartmentResourceService)
+            {
+                $searchField = $this->getPatientContextSearchField();
+                $searchParams[$searchField->getName()] = implode(",", $patientUuids);
+            }
+        }
+        // if we can grab our list of patient ids from the export job...
+
         $processingResult = $this->getAll($searchParams);
         $records = $processingResult->getData();
         foreach ($records as $record) {

--- a/src/Services/FHIR/UtilsService.php
+++ b/src/Services/FHIR/UtilsService.php
@@ -30,12 +30,27 @@ class UtilsService
     const UNKNOWNABLE_CODE_NULL_FLAVOR = "UNK";
     const UNKNOWNABLE_CODE_DATA_ABSENT = "unknown";
 
-    public static function createRelativeReference($type, $uuid)
+    public static function createRelativeReference($type, $uuid, $displayName = null)
     {
         $reference = new FHIRReference();
         $reference->setType($type);
         $reference->setReference($type . "/" . $uuid);
+        if (!empty($displayName) && is_string($displayName))
+        {
+            $reference->setDisplay($displayName);
+        }
         return $reference;
+    }
+
+    public static function getUuidFromReference(FHIRReference $reference)
+    {
+        $uuid = null;
+        if (!empty($reference->getReference()))
+        {
+            $parts = explode("/", $reference->getReference());
+            $uuid = $parts[1] ?? null;
+        }
+        return $uuid;
     }
 
     public static function createQuantity($value, $unit, $code)

--- a/src/Services/FHIR/UtilsService.php
+++ b/src/Services/FHIR/UtilsService.php
@@ -35,8 +35,7 @@ class UtilsService
         $reference = new FHIRReference();
         $reference->setType($type);
         $reference->setReference($type . "/" . $uuid);
-        if (!empty($displayName) && is_string($displayName))
-        {
+        if (!empty($displayName) && is_string($displayName)) {
             $reference->setDisplay($displayName);
         }
         return $reference;
@@ -45,8 +44,7 @@ class UtilsService
     public static function getUuidFromReference(FHIRReference $reference)
     {
         $uuid = null;
-        if (!empty($reference->getReference()))
-        {
+        if (!empty($reference->getReference())) {
             $parts = explode("/", $reference->getReference());
             $uuid = $parts[1] ?? null;
         }

--- a/src/Services/GroupService.php
+++ b/src/Services/GroupService.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * GroupService.php
  * @package openemr
@@ -9,7 +10,6 @@
  */
 
 namespace OpenEMR\Services;
-
 
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Uuid\UuidMapping;
@@ -103,10 +103,9 @@ class GroupService extends BaseService
             if (!isset($recordsByUuid[$recordUuid])) {
                 $providerName = $dbRecord['provider_fname'] ?? "";
                 $providerName .= !empty($dbRecord['provider_mname']) ? " " . $dbRecord['provider_mname'] : "";
-                $providerName .= !empty($dbRecord['provider_lname']) ? " " . $dbRecord['provider_lname' ]: "";
+                $providerName .= !empty($dbRecord['provider_lname']) ? " " . $dbRecord['provider_lname' ] : "";
 
-                if (empty($providerName))
-                {
+                if (empty($providerName)) {
                     $providerName = "(Provider Name Unknown)";
                 }
                 $groupName = $providerName . " " . xl("Patients");

--- a/src/Services/GroupService.php
+++ b/src/Services/GroupService.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * GroupService.php
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Services;
+
+
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Uuid\UuidMapping;
+use OpenEMR\Common\Uuid\UuidRegistry;
+use OpenEMR\Services\Search\FhirSearchWhereClauseBuilder;
+use OpenEMR\Validators\ProcessingResult;
+
+class GroupService extends BaseService
+{
+    const PRACTITIONER_TABLE = "users";
+
+    /**
+     * Default constructor.
+     */
+    public function __construct()
+    {
+        UuidRegistry::createMissingUuidsForTables([self::PRACTITIONER_TABLE]);
+        UuidMapping::createMissingResourceUuids("Group", self::PRACTITIONER_TABLE);
+        parent::__construct(self::PRACTITIONER_TABLE);
+    }
+
+    public function getUuidFields(): array
+    {
+        return ['uuid', 'puuid'];
+    }
+
+    /**
+     * Searches for patient provider groups
+     * @param array $search
+     * @param bool $isAndCondition
+     * @return ProcessingResult
+     */
+    public function searchPatientProviderGroups($search = array(), $isAndCondition = true)
+    {
+        // we inner join on status in case we ever decide to add a status property (and layers above this one can rely
+        // on the property without changing code).
+        $sql = "SELECT
+                    patient_provider_groups.uuid
+                    ,patient_provider_groups.provider_id
+                    ,patient_provider_groups.provider_fname
+                    ,patient_provider_groups.provider_mname
+                    ,patient_provider_groups.provider_lname
+                    ,patient_provider_groups.puuid
+                    ,patient_provider_groups.patient_title
+                    ,patient_provider_groups.patient_fname
+                    ,patient_provider_groups.patient_mname
+                    ,patient_provider_groups.patient_lname
+                FROM (
+                    SELECT
+                        uuid_mapping.target_uuid AS pruuid
+                        ,uuid_mapping.uuid
+                        ,users.id AS provider_id
+                        ,users.fname AS provider_fname
+                        ,users.lname AS provider_lname
+                        ,users.mname AS provider_mname
+                        ,patients.uuid AS puuid
+                        ,patients.title AS patient_title
+                        ,patients.fname AS patient_fname
+                        ,patients.mname AS patient_mname
+                        ,patients.lname AS patient_lname
+                    FROM
+                        uuid_mapping
+                    JOIN
+                        users ON uuid_mapping.target_uuid = users.uuid
+                    LEFT JOIN patient_data AS patients ON patients.providerID = users.id
+                    WHERE users.npi IS NOT NULL and users.npi != '' AND uuid_mapping.resource = 'Group'
+                ) patient_provider_groups ";
+
+        $whereClause = FhirSearchWhereClauseBuilder::build($search, $isAndCondition);
+
+        $sql .= $whereClause->getFragment();
+        $sqlBindArray = $whereClause->getBoundValues();
+        $statementResults =  QueryUtils::sqlStatementThrowException($sql, $sqlBindArray);
+
+        $processingResult = $this->hydratePatientProviderSearchResultsFromQueryResource($statementResults);
+        return $processingResult;
+    }
+
+    private function hydratePatientProviderSearchResultsFromQueryResource($queryResource)
+    {
+        $processingResult = new ProcessingResult();
+        $recordsByUuid = [];
+        $recordFields = array_combine($this->getFields(), $this->getFields());
+        $previousNameColumns = ['previous_name_prefix', 'previous_name_first', 'previous_name_middle'
+            , 'previous_name_last', 'previous_name_suffix', 'previous_name_enddate'];
+        $previousNamesFields = array_combine($previousNameColumns, $previousNameColumns);
+        $orderedList = [];
+        while ($row = sqlFetchArray($queryResource)) {
+            $dbRecord = $this->createResultRecordFromDatabaseResult($row);
+            $recordUuid = $dbRecord['uuid'];
+            if (!isset($recordsByUuid[$recordUuid])) {
+                $providerName = $dbRecord['provider_fname'] ?? "";
+                $providerName .= !empty($dbRecord['provider_mname']) ? " " . $dbRecord['provider_mname'] : "";
+                $providerName .= !empty($dbRecord['provider_lname']) ? " " . $dbRecord['provider_lname' ]: "";
+
+                if (empty($providerName))
+                {
+                    $providerName = "(Provider Name Unknown)";
+                }
+                $groupName = $providerName . " " . xl("Patients");
+                $record = [
+                    'uuid' => $recordUuid
+                    ,'name' => $groupName
+                    ,'patients' => []
+                ];
+                $orderedList[] = $recordUuid;
+            } else {
+                $record = $recordsByUuid[$recordUuid];
+            }
+            if (!empty($dbRecord['puuid'])) {
+                $patientName = $dbRecord['patient_title'] ?? "";
+                $patientName .= !empty($dbRecord['patient_fname']) ? " " . $dbRecord['patient_fname'] : "";
+                $patientName .= !empty($dbRecord['patient_mname']) ? " " . $dbRecord['patient_mname'] : "";
+                $patientName .= !empty($dbRecord['patient_lname']) ? " " . $dbRecord['patient_lname'] : "";
+                $record['patients'][] = [
+                    'uuid' => $dbRecord['puuid']
+                    ,'name' => $patientName
+                ];
+            }
+
+            // now let's grab our history
+            $recordsByUuid[$recordUuid] = $record;
+        }
+        foreach ($orderedList as $uuid) {
+            $patient = $recordsByUuid[$uuid];
+            $processingResult->addData($patient);
+        }
+        return $processingResult;
+    }
+}

--- a/src/Services/PractitionerService.php
+++ b/src/Services/PractitionerService.php
@@ -78,7 +78,7 @@ class PractitionerService extends BaseService
         // we only retrieve from our database when our practitioners are not null
         if (!empty($search['npi'])) {
             if (!$search['npi'] instanceof ISearchField) {
-                throw new \BadMethodCallException("npi search must be instance of " . ISearchField::class);
+                throw new SearchFieldException("npi", "field must be instance of " . ISearchField::class);
             }
             if ($search['npi']->getModifier() === SearchModifier::MISSING) {
                 // force our value to be false as the only thing that differentiates users as practitioners is our npi number
@@ -87,6 +87,18 @@ class PractitionerService extends BaseService
         } else {
             $search['npi'] = new TokenSearchField('npi', [new TokenSearchValue(false)]);
             $search['npi']->setModifier(SearchModifier::MISSING);
+        }
+        if (!empty($search['username'])) {
+            if (!$search['username'] instanceof ISearchField) {
+                throw new SearchFieldException("username", "field must be instance of " . ISearchField::class);
+            }
+            if ($search['username']->getModifier() === SearchModifier::MISSING) {
+                // force our value to be false as we don't count users as practitioners if there is no username
+                $search['username'] = new TokenSearchField('username', [new TokenSearchValue(false)]);
+            }
+        } else {
+            $search['username'] = new TokenSearchField('username', [new TokenSearchValue(false)]);
+            $search['username']->setModifier(SearchModifier::MISSING);
         }
         return parent::search($search, $isAndCondition);
     }

--- a/src/Services/PractitionerService.php
+++ b/src/Services/PractitionerService.php
@@ -27,6 +27,9 @@ class PractitionerService extends BaseService
 {
 
     private const PRACTITIONER_TABLE = "users";
+    /**
+     * @var PractitionerValidator
+     */
     private $practitionerValidator;
 
     /**

--- a/src/Services/PractitionerService.php
+++ b/src/Services/PractitionerService.php
@@ -88,6 +88,10 @@ class PractitionerService extends BaseService
             $search['npi'] = new TokenSearchField('npi', [new TokenSearchValue(false)]);
             $search['npi']->setModifier(SearchModifier::MISSING);
         }
+        // TODO: @adunsulag check with @brady.miller or @sjpadgett and find out if all practitioners will have usernames.
+        //  I noticed that in the test database that adding entries to the addressbook appears to create users... which
+        // seems bizarre and that those users don't have usernames.  I noticed that all of the users displayed in the OpenEMR
+        // user selector will exclude anything w/o a username so I add the same logic here.
         if (!empty($search['username'])) {
             if (!$search['username'] instanceof ISearchField) {
                 throw new SearchFieldException("username", "field must be instance of " . ISearchField::class);
@@ -161,7 +165,7 @@ class PractitionerService extends BaseService
         }
 
         // there should not be a single duplicate id so we will grab that
-        $search = ['uuid' => new TokenSearchField('uuid', new TokenSearchValue(UuidRegistry::uuidToBytes($uuid)))];
+        $search = ['uuid' => new TokenSearchField('uuid', new TokenSearchValue($uuid, null, true))];
         $results = $this->search($search);
         $data = $results->getData();
         if (count($data) > 1) {
@@ -191,7 +195,7 @@ class PractitionerService extends BaseService
             return $processingResult;
         }
 
-        $data['uuid'] = (new UuidRegistry(['table_name' => 'users']))->createUuid();
+        $data['uuid'] = UuidRegistry::getRegistryForTable(self::PRACTITIONER_TABLE)->createUuid();
 
         $query = $this->buildInsertColumns($data);
         $sql = " INSERT INTO users SET ";

--- a/src/Services/Search/CompositeSearchField.php
+++ b/src/Services/Search/CompositeSearchField.php
@@ -50,7 +50,7 @@ class CompositeSearchField implements ISearchField
         $this->field = $name; // we will give the field the same name as our name.
         $this->values = $values;
         $this->children = [];
-        $this->isAnd === true;
+        $this->isAnd = $isAnd === true;
     }
 
     /**

--- a/src/Services/Search/SearchFieldStatementResolver.php
+++ b/src/Services/Search/SearchFieldStatementResolver.php
@@ -46,7 +46,7 @@ class SearchFieldStatementResolver
         } else if ($field instanceof CompositeSearchField) {
             return self::resolveCompositeSearchField($field, $count);
         } else {
-            throw new \InvalidArgumentException("Provided search field type was not implemented");
+            throw new SearchFieldException($field->getName(), "Provided search field type was not implemented");
         }
     }
 
@@ -59,7 +59,7 @@ class SearchFieldStatementResolver
     public static function resolveDateField(DateSearchField $searchField)
     {
         if (empty($searchField->getValues())) {
-            throw new \InvalidArgumentException("Search field " . $searchField->getField() . " does not have a value to search on");
+            throw new SearchFieldException($searchField->getField(), " field does not have a value to search on");
         }
 
         $clauses = [];
@@ -82,7 +82,7 @@ class SearchFieldStatementResolver
                 $lowerBoundDateRange = $value;
                 $upperBoundDateRange = $value;
             } else {
-                throw new \InvalidArgumentException("DateSearchField " . $searchField->getField() . " contained value that was not a DatePeriod or DateTime object");
+                throw new SearchFieldException($searchField->getField(), "DateSearchField contained value that was not a DatePeriod or DateTime object");
             }
 
             switch ($comparableValue->getComparator()) {
@@ -174,7 +174,7 @@ class SearchFieldStatementResolver
     public static function resolveReferenceField(ReferenceSearchField $searchField)
     {
         if (empty($searchField->getValues())) {
-            throw new \InvalidArgumentException("Search field " . $searchField->getField() . " does not have a value to search on");
+            throw new SearchFieldException($searchField->getField(), "field does not have a value to search on");
         }
 
         $searchFragment = new SearchQueryFragment();
@@ -204,7 +204,7 @@ class SearchFieldStatementResolver
     public static function resolveTokenField(TokenSearchField $searchField)
     {
         if (empty($searchField->getValues())) {
-            throw new \InvalidArgumentException("Search field " . $searchField->getField() . " does not have a value to search on");
+            throw new SearchFieldException($searchField->getField(), "field does not have a value to search on");
         }
 
         $searchFragment = new SearchQueryFragment();
@@ -251,7 +251,7 @@ class SearchFieldStatementResolver
     public static function resolveStringSearchField(StringSearchField $searchField)
     {
         if (empty($searchField->getValues())) {
-            throw new \InvalidArgumentException("Search field " . $searchField->getField() . " does not have a value to search on");
+            throw new SearchFieldException($searchField->getField(), "does not have a value to search on");
         }
 
         $clauses = [];

--- a/tests/Tests/Api/PractitionerApiTest.php
+++ b/tests/Tests/Api/PractitionerApiTest.php
@@ -19,6 +19,10 @@ use OpenEMR\Tests\Fixtures\PractitionerFixtureManager;
 class PractitionerApiTest extends TestCase
 {
     const PRACTITIONER_API_ENDPOINT = "/apis/default/api/practitioner";
+
+    /**
+     * @var ApiTestClient
+     */
     private $testClient;
     private $fixtureManager;
 
@@ -116,6 +120,7 @@ class PractitionerApiTest extends TestCase
         $this->assertEquals(0, count($responseBody["internalErrors"]));
 
         $updatedResource = $responseBody["data"];
+
         $this->assertEquals($this->practitionerRecord["email"], $updatedResource["email"]);
     }
 

--- a/tests/Tests/Fixtures/practitioners.json
+++ b/tests/Tests/Fixtures/practitioners.json
@@ -27,7 +27,8 @@
     "phonew1": "{619} 555-7822",
     "phonecell": "{619} 555-7821",
     "notes": null,
-    "state_license_number": "123456"
+    "state_license_number": "123456",
+    "username": "kperez"
 }, {
     "id": "-2",
     "title": "Mrs.",
@@ -57,7 +58,8 @@
     "phonew1": "(619) 555-2222",
     "phonecell": "(619) 555-3333",
     "notes": null,
-    "state_license_number": "123456"
+    "state_license_number": "123456",
+    "username": "lcohen"
 }, {
     "id": "-3",
     "title": "Mr.",
@@ -87,7 +89,8 @@
     "phonew1": "(567) 789-7891",
     "phonecell": "(567) 789-1235",
     "notes": null,
-    "state_license_number": "123456"
+    "state_license_number": "123456",
+    "username": "jmoses"
 }, {
     "id": "-4",
     "title": "Mr.",
@@ -117,7 +120,8 @@
     "phonew1": "(323) 555-4444",
     "phonecell": "(909) 555-6768",
     "notes": null,
-    "state_license_number": "123456"
+    "state_license_number": "123456",
+    "username": "cjones"
 }, {
     "id": "-5",
     "title": "Mr.",
@@ -147,5 +151,6 @@
     "phonew1": "(213) 555-5555",
     "phonecell": "(213) 555-4444",
     "notes": null,
-    "state_license_number": "123456"
+    "state_license_number": "123456",
+    "username": "ajenane"
 }]

--- a/tests/Tests/RestControllers/PractitionerRestControllerTest.php
+++ b/tests/Tests/RestControllers/PractitionerRestControllerTest.php
@@ -20,6 +20,9 @@ class PractitionerRestControllerTest extends TestCase
     const PRACTITIONER_API_URL = "/apis/api/practitioner";
 
     private $practitionerData;
+    /**
+     * @var PractitionerRestController
+     */
     private $practitionerController;
     private $fixtureManager;
 
@@ -58,7 +61,8 @@ class PractitionerRestControllerTest extends TestCase
             "state_license_number" => "123456",
             "abook_title" => "Specialist",
             "physician_title" => "Attending physician",
-            "physician_code" => "SNOMED-CT =>405279007"
+            "physician_code" => "SNOMED-CT =>405279007",
+            "username" => "kperez"
         );
 
         $this->fixtureManager = new PractitionerFixtureManager();

--- a/tests/Tests/Unit/Common/Auth/OpenIDConnect/Grant/CustomClientCredentialsGrantTest.php
+++ b/tests/Tests/Unit/Common/Auth/OpenIDConnect/Grant/CustomClientCredentialsGrantTest.php
@@ -27,6 +27,7 @@ use OpenEMR\Common\Auth\OpenIDConnect\Entities\AccessTokenEntity;
 use OpenEMR\Common\Auth\OpenIDConnect\Entities\ClientEntity;
 use OpenEMR\Common\Auth\OpenIDConnect\Grant\CustomClientCredentialsGrant;
 use OpenEMR\Common\Auth\OpenIDConnect\Repositories\AccessTokenRepository;
+use OpenEMR\Common\Auth\OpenIDConnect\Repositories\JWTRepository;
 use OpenEMR\Services\UserService;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
@@ -63,6 +64,7 @@ class CustomClientCredentialsGrantTest extends TestCase
         $grant->setHttpClient(new Client());
         $grant->setAccessTokenRepository($this->getMockAccessTokenRepository($accessToken));
         $grant->setScopeRepository($this->getMockScopeRepository());
+        $grant->setJwtRepository($this->getMockJwtRepository());
 
         $response = $this->createMock(ResponseTypeInterface::class);
 
@@ -113,6 +115,7 @@ class CustomClientCredentialsGrantTest extends TestCase
         $grant->setHttpClient($httpClient);
         $grant->setAccessTokenRepository($this->getMockAccessTokenRepository($accessToken));
         $grant->setScopeRepository($this->getMockScopeRepository());
+        $grant->setJwtRepository($this->getMockJwtRepository());
 
         $response = $this->createMock(ResponseTypeInterface::class);
 
@@ -207,6 +210,12 @@ class CustomClientCredentialsGrantTest extends TestCase
         return $repo;
     }
 
+    public function getMockJwtRepository()
+    {
+        $repo = $this->createMock(JWTRepository::class);
+        return $repo;
+    }
+
     private function getMockServerRequestForJWT($jwt)
     {
         $request = $this->createMock(ServerRequestInterface::class);
@@ -224,6 +233,7 @@ class CustomClientCredentialsGrantTest extends TestCase
         $clientEntity = new ClientEntity();
         $clientEntity->setIdentifier(self::TEST_CLIENT_ID);
         $clientEntity->setIsConfidential(true);
+        $clientEntity->setIsEnabled(true);
         return $clientEntity;
     }
 

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@ $v_realpatch = '0';
 // is a database change in the course of development.  It is used
 // internally to determine when a database upgrade is needed.
 //
-$v_database = 415;
+$v_database = 416;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@ $v_realpatch = '0';
 // is a database change in the course of development.  It is used
 // internally to determine when a database upgrade is needed.
 //
-$v_database = 414;
+$v_database = 415;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
Bulk Export, Security Fixes, Group endpoints

Got all of the bulk export working as well as implementing bulk exports for a group.  I made it so each clinician has a group for their own patient list and you can query a practitioner's patient list by hitting the group endpoint for them.

Implemented all of the data fixes that were needed to validate for the bulk export.

Implemented security fixes to check the audience, issuer, and launch parameter for the SMART on FHIR apps.

Fixed a bug where system clients could function even if they were disabled.

Put in code to prevent replay attacks with system credential JTIs.

Got the patient compartment for bulk export working by filtering on the specific patient ids for each FHIR resource that implements the patient compartment interface.

Fixed minor text formatting issues on goals, careplans, and some other resources.

Prevented practitioners w/o usernames from showing up in our practitioner lists.

There were a number of other minor fixes but this should make the system code complete.  We will verify on the MU3 demos once the code gets pushed up there.  You can see that on my local test systems we are fully passing the Inferno test suite.
![image](https://user-images.githubusercontent.com/228117/130340204-d42dbeb0-43d6-4798-a06b-c4088622e743.png)
