### PR TITLE
Openemr events scope vitals

### DIFF
--- a/_rest_config.php
+++ b/_rest_config.php
@@ -322,7 +322,7 @@ class RestConfig
                 $scope = $scopeType . '/' . $resource . '.' . $permission;
             }
             if (!in_array($scope, $GLOBALS['oauth_scopes'])) {
-                (new SystemLogger())->debug("RestConfig::scope_check scope not in access token", ['scope' => $scope]);
+                (new SystemLogger())->debug("RestConfig::scope_check scope not in access token", ['scope' => $scope, 'scopes_granted' => $GLOBALS['oauth_scopes']]);
                 http_response_code(401);
                 exit;
             }

--- a/apis/dispatch.php
+++ b/apis/dispatch.php
@@ -249,7 +249,7 @@ if ($isLocalApi) {
     } elseif ($userRole === 'system' && ($gbl::is_fhir_request($resource))) {
         $logger->debug("dispatch.php valid role and system has access to api/fhir resource", ['resource' => $resource]);
     } else {
-        $logger->error("OpenEMR Error: api failed because user role does not have access to the resource");
+        $logger->error("OpenEMR Error: api failed because user role does not have access to the resource", ['resource' => $resource, 'userRole' => $userRole]);
         $gbl::destroySession();
         http_response_code(401);
         exit();

--- a/src/Common/Auth/OpenIDConnect/Repositories/ScopeRepository.php
+++ b/src/Common/Auth/OpenIDConnect/Repositories/ScopeRepository.php
@@ -19,6 +19,8 @@ use OpenEMR\Common\Auth\OpenIDConnect\Entities\ClientEntity;
 use OpenEMR\Common\Auth\OpenIDConnect\Entities\ScopeEntity;
 use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Common\System\System;
+use OpenEMR\Events\RestApiExtend\RestApiCreateEvent;
+use OpenEMR\Events\RestApiExtend\RestApiScopeEvent;
 use OpenEMR\RestControllers\RestControllerHelper;
 use Psr\Log\LoggerInterface;
 
@@ -687,7 +689,18 @@ class ScopeRepository implements ScopeRepositoryInterface
         $scopesSupported = array_keys(array_merge($fhir, $oidc, $serverScopes, $scopesSupported));
         (new SystemLogger())->debug("ScopeRepository->getCurrentSmartScopes() scopes supported ", ["scopes" => $scopesSupported]);
 
-        return $scopesSupported;
+        $scopesEvent = new RestApiScopeEvent();
+        $scopesEvent->setApiType(RestApiScopeEvent::API_TYPE_FHIR);
+        $scopesEvent->setScopes($scopesSupported);
+
+        $scopesEvent = $GLOBALS["kernel"]->getEventDispatcher()->dispatch(RestApiScopeEvent::EVENT_TYPE_GET_SUPPORTED_SCOPES, $scopesEvent, 10);
+
+        if ($scopesEvent instanceof RestApiScopeEvent)
+        {
+            $scopesSupportedList = $scopesEvent->getScopes();
+        }
+
+        return $scopesSupportedList;
     }
 
     public function getCurrentStandardScopes(): array
@@ -764,9 +777,19 @@ class ScopeRepository implements ScopeRepositoryInterface
         }
         asort($scopesSupported);
 
-        // TODO: @adunsulag we need to fire off an event here so that people can extend the scopes and add additional scopes / endpoints here via modules.s
+        $scopesEvent = new RestApiScopeEvent();
+        $scopesEvent->setApiType(RestApiScopeEvent::API_TYPE_STANDARD);
+        $scopesSupportedList = array_keys($scopesSupported);
+        $scopesEvent->setScopes($scopesSupportedList);
 
-        return array_keys($scopesSupported);
+        $scopesEvent = $GLOBALS["kernel"]->getEventDispatcher()->dispatch(RestApiScopeEvent::EVENT_TYPE_GET_SUPPORTED_SCOPES, $scopesEvent, 10);
+
+        if ($scopesEvent instanceof RestApiScopeEvent)
+        {
+            $scopesSupportedList = $scopesEvent->getScopes();
+        }
+
+        return $scopesSupportedList;
     }
 
     /**

--- a/src/Common/Auth/OpenIDConnect/Repositories/ScopeRepository.php
+++ b/src/Common/Auth/OpenIDConnect/Repositories/ScopeRepository.php
@@ -695,8 +695,7 @@ class ScopeRepository implements ScopeRepositoryInterface
 
         $scopesEvent = $GLOBALS["kernel"]->getEventDispatcher()->dispatch(RestApiScopeEvent::EVENT_TYPE_GET_SUPPORTED_SCOPES, $scopesEvent, 10);
 
-        if ($scopesEvent instanceof RestApiScopeEvent)
-        {
+        if ($scopesEvent instanceof RestApiScopeEvent) {
             $scopesSupportedList = $scopesEvent->getScopes();
         }
 
@@ -784,8 +783,7 @@ class ScopeRepository implements ScopeRepositoryInterface
 
         $scopesEvent = $GLOBALS["kernel"]->getEventDispatcher()->dispatch(RestApiScopeEvent::EVENT_TYPE_GET_SUPPORTED_SCOPES, $scopesEvent, 10);
 
-        if ($scopesEvent instanceof RestApiScopeEvent)
-        {
+        if ($scopesEvent instanceof RestApiScopeEvent) {
             $scopesSupportedList = $scopesEvent->getScopes();
         }
 

--- a/src/Common/Database/QueryUtils.php
+++ b/src/Common/Database/QueryUtils.php
@@ -55,7 +55,7 @@ class QueryUtils
     /**
      * Executes the SQL statement passed in and returns a list of all of the values contained in the column
      * @param $sqlStatement
-     * @param $column The column you want returned
+     * @param $column string column you want returned
      * @param array $binds
      * @throws SqlQueryException Thrown if there is an error in the database executing the statement
      * @return array

--- a/src/Common/Http/HttpRestRequest.php
+++ b/src/Common/Http/HttpRestRequest.php
@@ -112,6 +112,12 @@ class HttpRestRequest
      */
     private $queryParams;
 
+    /**
+     * The raw POST or PUT body contents
+     * @var null|string
+     */
+    private $requestBody;
+
     public function __construct($restConfig, $server)
     {
         $this->restConfig = $restConfig;
@@ -126,6 +132,28 @@ class HttpRestRequest
             unset($queryParams['_REWRITE_COMMAND']);
         }
         $this->setQueryParams($queryParams);
+
+        if ($this->getRequestMethod() == "POST" || $this->getRequestMethod() == "PUT")
+        {
+            $this->requestBody = file_get_contents("php://input") ?? null;
+        }
+    }
+
+    /**
+     * Returns the raw request body if this is a POST or PUT request
+     */
+    public function getRequestBody()
+    {
+        return $this->requestBody;
+    }
+
+    public function getRequestBodyJSON()
+    {
+        if (!empty($this->requestBody))
+        {
+            return (array) (json_decode($this->requestBody));
+        }
+        return null;
     }
 
     public function setRequestMethod($requestMethod)

--- a/src/Common/Http/HttpRestRequest.php
+++ b/src/Common/Http/HttpRestRequest.php
@@ -133,8 +133,7 @@ class HttpRestRequest
         }
         $this->setQueryParams($queryParams);
 
-        if ($this->getRequestMethod() == "POST" || $this->getRequestMethod() == "PUT")
-        {
+        if ($this->getRequestMethod() == "POST" || $this->getRequestMethod() == "PUT") {
             $this->requestBody = file_get_contents("php://input") ?? null;
         }
     }
@@ -149,8 +148,7 @@ class HttpRestRequest
 
     public function getRequestBodyJSON()
     {
-        if (!empty($this->requestBody))
-        {
+        if (!empty($this->requestBody)) {
             return (array) (json_decode($this->requestBody));
         }
         return null;

--- a/src/Events/RestApiExtend/RestApiScopeEvent.php
+++ b/src/Events/RestApiExtend/RestApiScopeEvent.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * RestApiScopeEvent.php
  * @package openemr
@@ -9,7 +10,6 @@
  */
 
 namespace OpenEMR\Events\RestApiExtend;
-
 
 use Symfony\Contracts\EventDispatcher\Event;
 

--- a/src/Events/RestApiExtend/RestApiScopeEvent.php
+++ b/src/Events/RestApiExtend/RestApiScopeEvent.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * RestApiScopeEvent.php
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\RestApiExtend;
+
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+class RestApiScopeEvent extends Event
+{
+    const API_TYPE_STANDARD = "standard";
+    const API_TYPE_FHIR = "fhir";
+
+    const EVENT_TYPE_GET_SUPPORTED_SCOPES = "api.scope.get-supported-scopes";
+
+    private $scopes;
+    private $apiType;
+
+    public function __construct()
+    {
+        $this->scopes = [];
+        $this->type = self::API_TYPE_STANDARD;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getScopes()
+    {
+        return $this->scopes;
+    }
+
+    /**
+     * @param mixed $scopes
+     * @return RestApiScopeEvent
+     */
+    public function setScopes($scopes)
+    {
+        $this->scopes = $scopes;
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getApiType()
+    {
+        return $this->apiType;
+    }
+
+    /**
+     * @param mixed $apiType
+     * @return RestApiScopeEvent
+     */
+    public function setApiType($apiType)
+    {
+        $this->apiType = $apiType;
+        return $this;
+    }
+}

--- a/src/Events/Services/ServiceSaveEvent.php
+++ b/src/Events/Services/ServiceSaveEvent.php
@@ -46,6 +46,11 @@ class ServiceSaveEvent extends Event
         $this->saveData = $saveData;
     }
 
+    public function getService() : BaseService
+    {
+        return $this->service;
+    }
+
     /**
      * @return array
      */

--- a/src/Events/Services/ServiceSaveEvent.php
+++ b/src/Events/Services/ServiceSaveEvent.php
@@ -46,7 +46,7 @@ class ServiceSaveEvent extends Event
         $this->saveData = $saveData;
     }
 
-    public function getService() : BaseService
+    public function getService(): BaseService
     {
         return $this->service;
     }


### PR DESCRIPTION
Added an event to handle adding additional scopes via event listeners.
If a module adds to the REST api the api is pretty useless if there is
not an accompanying scope added with the api.

Also added some helper methods to the http request object and some
more api logging.  I needed this for a module I am building and it
will be useful for the community to have it in core.