### PR TITLE
Enhancing Login Page Customizations and Twig Migration

### DIFF
--- a/interface/login/login.php
+++ b/interface/login/login.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Login screen.
  *
@@ -25,22 +24,23 @@
 
 use OpenEMR\Core\Header;
 use OpenEMR\Services\FacilityService;
+use OpenEMR\Common\Twig\TwigContainer;
 
 $ignoreAuth = true;
 // Set $sessionAllowWrite to true to prevent session concurrency issues during authorization related code
 $sessionAllowWrite = true;
 require_once("../globals.php");
 
+$twig = new TwigContainer("login", $GLOBALS["kernel"]);
+$t = $twig->getTwig();
+
 // mdsupport - Add 'App' functionality for user interfaces without standard menu and frames
 // If this script is called with app parameter, validate it without showing other apps.
 //
 // Build a list of valid entries
 $emr_app = array();
-$rs = sqlStatement(
-    "SELECT option_id, title,is_default FROM list_options
-        WHERE list_id=? and activity=1 ORDER BY seq, option_id",
-    array ('apps')
-);
+$sql = "SELECT option_id, title,is_default FROM list_options WHERE list_id=? and activity=1 ORDER BY seq, option_id";
+$rs = sqlStatement($sql, ['apps']);
 if (sqlNumRows($rs)) {
     while ($app = sqlFetchArray($rs)) {
         $app_req = explode('?', trim($app['title']));
@@ -48,7 +48,7 @@ if (sqlNumRows($rs)) {
             continue;
         }
 
-            $emr_app [trim($app ['option_id'])] = trim($app ['title']);
+        $emr_app [trim($app ['option_id'])] = trim($app ['title']);
         if ($app ['is_default']) {
             $emr_app_def = $app ['option_id'];
         }
@@ -77,12 +77,12 @@ if (count($emr_app)) {
 
         $div_app = sprintf(
             '
-<div id="divApp" class="form-group">
-	<label for="appChoice" class="text-right">%s:</label>
-    <div>
-        <select class="form-control" id="selApp" name="appChoice" size="1">%s</select>
-    </div>
-</div>',
+            <div id="divApp" class="form-group">
+                <label for="appChoice" class="text-right">%s:</label>
+                <div>
+                    <select class="form-control" id="selApp" name="appChoice" size="1">%s</select>
+                </div>
+            </div>',
             xlt('App'),
             $opt_htm
         );
@@ -104,350 +104,131 @@ if ($GLOBALS['login_page_layout'] == 'left') {
     $loginrow = "row login-row login-row-center align-items-center";
 }
 
-?>
-<html>
-<head>
-    <?php Header::setupHeader(); ?>
+function getDefaultLanguage(): array {
+    $sql = "SELECT * FROM lang_languages where lang_description = ?";
+    $res = sqlStatement($sql, [$GLOBALS['language_default']]);
+    $langs = [];
 
-    <title><?php echo text($openemr_name) . " " . xlt('Login'); ?></title>
-
-    <?php
-    if (!empty($GLOBALS['google_signin_enabled']) && !empty($GLOBALS['google_signin_client_id'])) { ?>
-        <meta name="google-signin-client_id" content="<?php echo $GLOBALS['google_signin_client_id']; ?>">
-    <?php } ?>
-    <script>
-        var registrationTranslations = <?php echo json_encode(array(
-            'title' => xla('OpenEMR Product Registration'),
-            'pleaseProvideValidEmail' => xla('Please provide a valid email address'),
-            'success' => xla('Success'),
-            'registeredSuccess' => xla('Your installation of OpenEMR has been registered'),
-            'submit' => xla('Submit'),
-            'noThanks' => xla('No Thanks'),
-            'registeredEmail' => xla('Registered email'),
-            'registeredId' => xla('Registered id'),
-            'genericError' => xla('Error. Try again later'),
-            'closeTooltip' => ''
-        )); ?>;
-
-        var registrationConstants = <?php echo json_encode(array(
-            'webroot' => $GLOBALS['webroot']
-        )); ?>;
-    </script>
-
-    <script src="<?php echo $webroot ?>/interface/product_registration/product_registration_service.js?v=<?php echo $v_js_includes; ?>"></script>
-    <script src="<?php echo $webroot ?>/interface/product_registration/product_registration_controller.js?v=<?php echo $v_js_includes; ?>"></script>
-
-    <script>
-        $(function () {
-            init();
-
-            var productRegistrationController = new ProductRegistrationController();
-            productRegistrationController.getProductRegistrationStatus(function(err, data) {
-                if (err) { return; }
-
-                if (data.statusAsString === 'UNREGISTERED') {
-                    productRegistrationController.showProductRegistrationModal();
-                }
-            });
-        });
-
-        function init() {
-            $("#authUser").focus();
-        }
-
-        function transmit_form(element) {
-            // disable submit button to insert a notification of working
-            element.disabled = true;
-            // nothing fancy. mainly for mobile.
-            element.innerHTML = '<i class="fa fa-sync fa-spin"></i> ' + jsText(<?php echo xlj("Authenticating"); ?>);
-            <?php if (session_name()) { ?>
-                <?php $scparams = session_get_cookie_params(); ?>
-                // Delete the session cookie by setting its expiration date in the past.
-                // This forces the server to create a new session ID.
-                var olddate = new Date();
-                olddate.setFullYear(olddate.getFullYear() - 1);
-                var mycookie = <?php echo json_encode(urlencode(session_name())); ?> + '=' + <?php echo json_encode(urlencode(session_id())); ?> +
-                    '; path=' + <?php echo json_encode($scparams['path']); ?> +
-                    '; domain=' + <?php echo json_encode($scparams['domain']); ?> +
-                    '; expires=' + olddate.toGMTString();
-                var samesite = <?php echo json_encode(empty($scparams['samesite']) ? '' : $scparams['samesite']); ?>;
-                if (samesite) {
-                    mycookie += '; SameSite=' + samesite;
-                }
-                document.cookie = mycookie;
-            <?php } ?>
-            document.forms[0].submit();
-            return true;
-        }
-    </script>
-</head>
-<body class="login">
-  <form method="POST" id="login_form" autocomplete="off" action="../main/main_screen.php?auth=login&site=<?php echo attr($_SESSION['site_id']); ?>" target="_top" name="login_form">
-      <div class="<?php echo $loginrow; ?>">
-          <div class="<?php echo $formarea; ?>">
-              <input type='hidden' name='new_login_session_management' value='1' />
-
-              <?php
-              // collect default language id
-                $res2 = sqlStatement("select * from lang_languages where lang_description = ?", array($GLOBALS['language_default']));
-                for ($iter = 0; $row = sqlFetchArray($res2); $iter++) {
-                    $result2[$iter] = $row;
-                }
-
-                if (count($result2) == 1) {
-                    $defaultLangID = $result2[0]["lang_id"];
-                    $defaultLangName = $result2[0]["lang_description"];
-                } else {
-                    //default to english if any problems
-                    $defaultLangID = 1;
-                    $defaultLangName = "English";
-                }
-
-              // set session variable to default so login information appears in default language
-                $_SESSION['language_choice'] = $defaultLangID;
-              // collect languages if showing language menu
-                if ($GLOBALS['language_menu_login']) {
-                    // sorting order of language titles depends on language translation options.
-                    $mainLangID = empty($_SESSION['language_choice']) ? '1' : $_SESSION['language_choice'];
-                    // Use and sort by the translated language name.
-                    $sql = "SELECT ll.lang_id, " .
-                      "IF(LENGTH(ld.definition),ld.definition,ll.lang_description) AS trans_lang_description, " .
-                      "ll.lang_description " .
-                      "FROM lang_languages AS ll " .
-                      "LEFT JOIN lang_constants AS lc ON lc.constant_name = ll.lang_description " .
-                      "LEFT JOIN lang_definitions AS ld ON ld.cons_id = lc.cons_id AND " .
-                      "ld.lang_id = ? " .
-                      "ORDER BY IF(LENGTH(ld.definition),ld.definition,ll.lang_description), ll.lang_id";
-                    $res3 = SqlStatement($sql, array($mainLangID));
-
-                    for ($iter = 0; $row = sqlFetchArray($res3); $iter++) {
-                        $result3[$iter] = $row;
-                    }
-
-                    if (count($result3) == 1) {
-                        //default to english if only return one language
-                        echo "<input type='hidden' name='languageChoice' value='1' />\n";
-                    }
-                } else {
-                    echo "<input type='hidden' name='languageChoice' value='" . attr($defaultLangID) . "' />\n";
-                }
-
-                if ($GLOBALS['login_into_facility']) {
-                    $facilityService = new FacilityService();
-                    $facilities = $facilityService->getAllFacility();
-                    $facilitySelected = ($GLOBALS['set_facility_cookie'] && isset($_COOKIE['pc_facility'])) ? $_COOKIE['pc_facility'] : null;
-                }
-                ?>
-              <?php if (isset($_SESSION['relogin']) && ($_SESSION['relogin'] == 1)) { // Begin relogin dialog ?>
-              <div class="alert alert-info m-1 font-weight-bold">
-                    <?php echo xlt('Password security has recently been upgraded.') . '&nbsp;&nbsp;' . xlt('Please login again.'); ?>
-              </div>
-                    <?php unset($_SESSION['relogin']);
-              }
-              if (isset($_SESSION['loginfailure']) && ($_SESSION['loginfailure'] == 1)) { // Begin login failure block ?>
-              <div class="alert alert-danger login-failure m-1">
-                  <?php echo xlt('Invalid username or password'); ?>
-              </div>
-            <?php } // End login failure block ?>
-            <div id="standard-auth-username" class="form-group">
-                <label for="authUser" class="text-right"><?php echo xlt('Username:'); ?></label>
-                <input type="text" class="form-control" id="authUser" name="authUser" placeholder="<?php echo xla('Username:'); ?>" />
-            </div>
-            <div id="standard-auth-password" class="form-group">
-                <label for="clearPass" class="text-right"><?php echo xlt('Password:'); ?></label>
-                <input type="password" class="form-control" id="clearPass" name="clearPass" placeholder="<?php echo xla('Password:'); ?>" />
-            </div>
-            <?php echo $div_app; ?>
-            <?php if ($GLOBALS['language_menu_login'] && (count($result3) != 1)) : // Begin language menu block ?>
-                <div class="form-group">
-                    <label for="language" class="text-right"><?php echo xlt('Language'); ?>:</label>
-                    <div>
-                        <select class="form-control" name="languageChoice" size="1">
-                            <?php
-                            echo "<option selected='selected' value='" . attr($defaultLangID) . "'>" . xlt('Default') . " - " . xlt($defaultLangName) . "</option>\n";
-                            foreach ($result3 as $iter) :
-                                if ($GLOBALS['language_menu_showall']) {
-                                    if (!$GLOBALS['allow_debug_language'] && $iter['lang_description'] == 'dummy') {
-                                        continue; // skip the dummy language
-                                    }
-
-                                        echo "<option value='" . attr($iter['lang_id']) . "'>" . text($iter['trans_lang_description']) . "</option>\n";
-                                } else {
-                                    if (in_array($iter['lang_description'], $GLOBALS['language_menu_show'])) {
-                                        if (!$GLOBALS['allow_debug_language'] && $iter['lang_description'] == 'dummy') {
-                                            continue; // skip the dummy language
-                                        }
-
-                                            echo "<option value='" . attr($iter['lang_id']) . "'>" . text($iter['trans_lang_description']) . "</option>\n";
-                                    }
-                                }
-                            endforeach; ?>
-                        </select>
-                    </div>
-                </div>
-            <?php endif; // End language menu block ?>
-            <?php if ($GLOBALS['login_into_facility']) { // Begin facilities menu block ?>
-                <div class="form-group">
-                    <label for="facility" class="text-right"><?php echo xlt('Facility'); ?>:</label>
-                    <div>
-                        <select class="form-control" name="facility" size="1">
-                            <option value="user_default"><?php echo xlt('My default facility'); ?></option>
-                            <?php foreach ($facilities as $facility) { ?>
-                                <?php if (!is_null($facilitySelected) && $facilitySelected == $facility['id']) { ?>
-                                    <option value="<?php echo attr($facility['id']);?>" selected><?php echo text($facility['name']);?></option>
-                                <?php } else { ?>
-                                    <option value="<?php echo attr($facility['id']);?>"><?php echo text($facility['name']);?></option>
-                                <?php } ?>
-                            <?php } ?>
-                        </select>
-                    </div>
-                </div>
-            <?php } // End facilities menu block ?>
-            <div class="form-group oe-pull-away">
-                <button id="login-button" type="submit" class="btn btn-login btn-lg" onClick="transmit_form(this)"><i class="fa fa-sign-in-alt"></i>&nbsp;&nbsp;<?php echo xlt('Login');?></button>
-            </div>
-            <div class="form-group">
-                  <?php if (!empty($GLOBALS['google_signin_enabled']) && !empty($GLOBALS['google_signin_client_id'])) { ?>
-                <input type="hidden" id="used-google-signin" name="used_google_signin" value="">
-                <input type="hidden" id="google-signin-token" name="google_signin_token" value="">
-                <div id="google-signin" onclick="return do_google_signin();">
-                    <!-- This message is displayed if the google platform API cannot render the button -->
-                    <span id="google-signin-service-unreachable-alert" style="display:none;"><?php echo xlt('Google Sign-In is enabled but the service is unreachable.'); ?></span>
-                </div>
-                <div id="google-signout">
-                    <a href="#" onclick="signOut();"><?php echo xlt('Sign out'); ?></a>
-                </div>
-                  <?php } ?>
-            </div>
-          </div>
-          <div class="<?php echo $logoarea; ?>">
-            <?php $extraLogo = $GLOBALS['extra_logo_login']; ?>
-            <?php if ($extraLogo) { ?>
-            <div class="text-center">
-              <span class="d-inline-block w-40"><?php echo file_get_contents($GLOBALS['images_static_absolute'] . "/login-logo.svg"); ?></span>
-              <span class="d-inline-block w-15 login-bg-text-color"><i class="fas fa-plus fa-2x"></i></span>
-              <span class="d-inline-block w-40"><?php echo $logocode; ?></span>
-            </div>
-            <?php } else { ?>
-              <div class="mx-auto m-4 w-75">
-                  <?php echo file_get_contents($GLOBALS['images_static_absolute'] . "/login-logo.svg"); ?>
-              </div>
-            <?php } ?>
-            <div class="text-center login-title-label">
-                <?php if ($GLOBALS['show_label_login']) { ?>
-                    <?php echo text($openemr_name); ?>
-                <?php } ?>
-            </div>
-                <?php
-                // Figure out how to display the tiny logos
-                $t1 = $GLOBALS['tiny_logo_1'];
-                $t2 = $GLOBALS['tiny_logo_2'];
-                if ($t1 && !$t2) {
-                    echo $tinylogocode1;
-                } if ($t2 && !$t1) {
-                    echo $tinylogocode2;
-                } if ($t1 && $t2) { ?>
-                  <div class="row mb-3">
-                    <div class="col-sm-6"><?php echo $tinylogocode1;?></div>
-                    <div class="col-sm-6"><?php echo $tinylogocode2;?></div>
-                  </div>
-                <?php } ?>
-            <p class="text-center lead font-weight-normal login-bg-text-color"><?php echo xlt('The most popular open-source Electronic Health Record and Medical Practice Management solution.'); ?></p>
-            <p class="text-center small"><a href="../../acknowledge_license_cert.html" class="login-bg-text-color" target="main"><?php echo xlt('Acknowledgments, Licensing and Certification'); ?></a></p>
-          </div>
-      </div>
-      <div class="product-registration-modal modal fade">
-          <div class="modal-dialog modal-dialog-centered">
-              <div class="modal-content">
-                  <div class="modal-header"></div>
-                  <div class="modal-body">
-                      <p class="context"><?php echo xlt("Register your installation with OEMR to receive important notifications, such as security fixes and new release announcements."); ?></p>
-                      <input placeholder="<?php echo xlt('email'); ?>" type="email" class="email w-100 text-body form-control" />
-                      <p class="message font-italic"></p>
-                  </div>
-                  <div class="modal-footer">
-                      <button type="button" class="btn btn-secondary submit"><?php echo xlt("Submit"); ?></button>
-                      <button type="button" class="btn btn-secondary nothanks"><?php echo xlt("No Thanks"); ?></button>
-                  </div>
-              </div>
-          </div>
-      </div>
-  </form>
-</body>
-</html>
-<?php if (!empty($GLOBALS['google_signin_enabled']) && !empty($GLOBALS['google_signin_client_id'])) { ?>
-<script type="text/javascript">
-
-    // This variable controls whether we should login to OpenEMR
-    // so we only login if "Sign in with Google button" was clicked
-    let google_signin = false;
-
-    // Hide the google signout link unless we are signed-in
-    // This isn't really ever displayed, because once we sign-in with google,
-    // we automatically log into the app
-    $('#google-signout').hide();
-
-    // Click-handler for signin button
-    function do_google_signin() {
-        google_signin = true;
+    while ($row = sqlFetchArray($res)) {
+        $langs[] = $row;
     }
 
-    // When Google sign-in successful, sign in to the app, but only
-    // if the button was clicked (otherwise we would automatically login)
-    function onSignInSuccess(googleUser) {
-        if (google_signin === true) {
-            const auth_response = googleUser.getAuthResponse();
-            const id_token = auth_response.id_token;
-            $('.login-failure').hide();
-            $('#used-google-signin').val(true);
-            $('#google-signin-token').val(id_token);
-            $('#google-signout').show();
-            $('#standard-auth-username, #standard-auth-password').hide();
-            var element = document.getElementById('login-button');
-            transmit_form(element);
-        }
+    $id = 1;
+    $desc = "English";
+
+    if (count($langs) == 1) {
+        $id = $langs[0]["lang_id"];
+        $desc = $langs[0]["lang_description"];
     }
 
-    function onSignInFailure(error) {
-        $('.login-failure').show();
+    return ["id" => $id, "language" => $desc];
+}
+
+function getLanguagesList(): array {
+    $mainLangID = empty($_SESSION['language_choice']) ? '1' : $_SESSION['language_choice'];
+    $sql = "SELECT ll.lang_id, IF(LENGTH(ld.definition), ld.definition, ll.lang_description) AS trans_lang_description, ll.lang_description
+        FROM lang_languages AS ll
+        LEFT JOIN lang_constants AS lc ON lc.constant_name = ll.lang_description
+        LEFT JOIN lang_definitions AS ld ON ld.cons_id = lc.cons_id AND ld.lang_id = ?
+        ORDER BY IF(LENGTH(ld.definition),ld.definition,ll.lang_description), ll.lang_id";
+    $res = sqlStatement($sql, [$mainLangID]);
+    $langList = [];
+
+    while ($row = sqlFetchArray($res)) {
+        $langList[] = $row;
     }
 
-    function renderButton() {
-        gapi.signin2.render('google-signin', {
-            'prompt': 'select_account',
-            'scope': 'profile email',
-            'width': 240,
-            'height': 50,
-            'longtitle': true,
-            'theme': 'dark',
-            'onsuccess': onSignInSuccess,
-            'onfailure': onSignInFailure
-        });
+    return $langList;
+}
+
+$facilities = [];
+$facilitySelected = false;
+if ($GLOBALS['login_into_facility']) {
+    $facilityService = new FacilityService();
+    $facilities = $facilityService->getAllFacility();
+    $facilitySelected = ($GLOBALS['set_facility_cookie'] && isset($_COOKIE['pc_facility'])) ? $_COOKIE['pc_facility'] : null;
+}
+
+$defaultLanguage = getDefaultLanguage();
+$languageList = getLanguagesList();
+$_SESSION['language_choice'] = $defaultLanguage['id'];
+
+$relogin = (isset($_SESSION['relogin']) && ($_SESSION['relogin'] == 1)) ? true : false;
+if ($relogin) {
+    unset($_SESSION["relogin"]);
+}
+
+$t1 = $GLOBALS['tiny_logo_1'];
+$t2 = $GLOBALS['tiny_logo_2'];
+$displayTinyLogo = false;
+if ($t1 && !$t2) {
+    $displayTinyLogo = 1;
+} if ($t2 && !$t1) {
+    $displayTinyLogo = 2;
+} if ($t1 && $t2) {
+    $displayTinyLogo = 3;
+}
+
+$regTranslations = json_encode(array(
+    'title' => xla('OpenEMR Product Registration'),
+    'pleaseProvideValidEmail' => xla('Please provide a valid email address'),
+    'success' => xla('Success'),
+    'registeredSuccess' => xla('Your installation of OpenEMR has been registered'),
+    'submit' => xla('Submit'),
+    'noThanks' => xla('No Thanks'),
+    'registeredEmail' => xla('Registered email'),
+    'registeredId' => xla('Registered id'),
+    'genericError' => xla('Error. Try again later'),
+    'closeTooltip' => ''
+));
+
+$cookie = '';
+if (session_name()) {
+    $sid = json_encode(urlencode(session_id()));
+    $sname = json_encode(urlencode(session_name()));
+    $scparams = session_get_cookie_params();
+    $domain = json_encode($scparams['domain']);
+    $path = json_encode($scparams['path']);
+    $oldDate = gmdate('Y', strtotime("-1 years"));
+    $expires = gmdate(DATE_RFC1123, $oldDate);
+    $sameSite = json_encode(empty($scparams['samesite']) ? '' : $scparams['samesite']);
+    $cookie = "{$sname}={$sid}; path={$path}; domain={$domain}; expires={$expires}";
+
+    if ($sameSite) {
+        $cookie .= "; SameSite={$sameSite}";
     }
+}
 
-    function signOut() {
-        google_signin = false;
-        const auth2 = gapi.auth2.getAuthInstance();
-        auth2.signOut().then(function () {
-            $('#used-google-signin').val('');
-            $('#google-signin-token').val('');
-            $('#google-signout').hide();
-            $('#standard-auth-username, #standard-auth-password').show();
-        });
-    }
-
-    $.getScript('https://apis.google.com/js/platform.js', function(data, textStatus, jqxh ) {
-        // When the auth2 library is loaded, log out so the user has to sign into google
-        gapi.load('auth2', function() {
-            gapi.auth2.init().then(function () {
-                signOut();
-            });
-        });
-
-        // Render the "Sign in with Google" button
-        renderButton();
-    }).fail(function (jqxhr, settings, exception) {
-        $('#google-signin-service-unreachable-alert').show();
-    });
-</script>
-<?php } ?>
+$viewArgs = [
+    'displayLanguage' => ($GLOBALS["language_menu_login"] && (count($languageList) != 1)) ? true : false,
+    'defaultLangID' => $defaultLanguage['id'],
+    'defaultLangName' => $defaultLanguage['language'],
+    'languageList' => $languageList,
+    'relogin' => $relogin,
+    'loginFail' => (isset($_SESSION["loginfailure"]) && $_SESSION["loginfailure"] == 1) ? true : false,
+    'displayFacilities' => ($GLOBALS["login_into_facility"]) ? true : false,
+    'facilityList' => $facilities,
+    'facilitySelected' => $facilitySelected,
+    'displayGoogleSignin' => (!empty($GLOBALS['google_signin_enabled']) && !empty($GLOBALS['google_signin_client_id'])) ? true : false,
+    'logoArea' => $logoarea,
+    'displayExtraLogo' => $GLOBALS['extra_logo_login'],
+    'primaryLogoSrc' => file_get_contents($GLOBALS["images_static_absolute"] . "/login-logo.svg"),
+    'logocode' => $logocode,
+    'displayLoginLabel' => ($GLOBALS["show_label_login"]) ? true : false,
+    'openemrName' => $openemr_name,
+    'displayTinyLogo' => $displayTinyLogo,
+    'tinyLogo1' => $tinylogocode1,
+    'tinyLogo2' => $tinylogocode2,
+    'displayTagline' => $GLOBALS['show_tagline_on_login'],
+    'tagline' => $GLOBALS['login_tagline_text'],
+    'displayAck' => $GLOBALS['show_ack_on_login'],
+    'hasSession' => (session_name()) ? true : false,
+    'cookieText' => $cookie,
+    'regTranslations' => $regTranslations,
+    'regConstants' => ['webroot' => $GLOBALS['webroot']],
+    'jsIncludes' => $v_js_includes,
+    'siteID' => $_SESSION['site_id'],
+    'loginRow' => $loginrow,
+    'formArea' => $formarea,
+];
+echo $t->render("login_core.html.twig", $viewArgs);

--- a/interface/login/login.php
+++ b/interface/login/login.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Login screen.
  *
@@ -104,7 +105,8 @@ if ($GLOBALS['login_page_layout'] == 'left') {
     $loginrow = "row login-row login-row-center align-items-center";
 }
 
-function getDefaultLanguage(): array {
+function getDefaultLanguage(): array
+{
     $sql = "SELECT * FROM lang_languages where lang_description = ?";
     $res = sqlStatement($sql, [$GLOBALS['language_default']]);
     $langs = [];
@@ -124,7 +126,8 @@ function getDefaultLanguage(): array {
     return ["id" => $id, "language" => $desc];
 }
 
-function getLanguagesList(): array {
+function getLanguagesList(): array
+{
     $mainLangID = empty($_SESSION['language_choice']) ? '1' : $_SESSION['language_choice'];
     $sql = "SELECT ll.lang_id, IF(LENGTH(ld.definition), ld.definition, ll.lang_description) AS trans_lang_description, ll.lang_description
         FROM lang_languages AS ll

--- a/interface/themes/login_page.scss
+++ b/interface/themes/login_page.scss
@@ -65,7 +65,7 @@ $login-button-primary: false !default;
   .login-bg-left,
   .login-bg-right,
   .login-bg-center {
-    background: linear-gradient(140deg, $login-color-1 0%, $login-color-2 35%, $login-color-3 100%);
+    background: map-get($theme-colors, "primary");
   }
 
   @media (max-width: map-get($grid-breakpoints, "md")) {

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -448,6 +448,27 @@ $GLOBALS_METADATA = array(
             xl('What kind of sorting will be in the drop lists.')
         ),
 
+        'show_tagline_on_login' => [
+            xl('Show Tagline on Login Page') . "*",
+            'bool',
+            '1',
+            xl('Hide the tagline from the login screen'),
+        ],
+
+        'login_tagline_text' => [
+            xl('Login Page Tagline') . "*",
+            'text',
+            xl("The most popular open-source Electronic Health Record and Medical Practice Management solution."),
+            xl("Tagline text on the login page")
+        ],
+
+        'show_ack_on_login' => [
+            xl('Show Acknowledgment Link on Login Page') . "*",
+            'bool',
+            '1',
+            xl('Hide the tagline from the login screen'),
+        ],
+
         'show_label_login' => array(
             xl('Show Title on Login'),
             'bool',                           // data type

--- a/templates/login/login_core.html.twig
+++ b/templates/login/login_core.html.twig
@@ -1,0 +1,267 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    {% if displayGoogleSigning %}
+        <meta name="google-signin-client_id" content="{{ googleSigninClientID }}">
+    {% endif %}
+    <title>{{ title }}</title>
+    {% block head %}{% endblock %}
+    <script src="{{ webroot }}/interface/product_registration/product_registration_service.js?v={{ jsIncludes }}"></script>
+    <script src="{{ webroot }}/interface/product_registration/product_registration_controller.js?v={{ jsIncludes }}"></script>
+
+    <script type="text/javascript">
+        document.addEventListener('DOMContentLoaded', () => {
+            document.getElementById('authUser').focus();
+        });
+        $(function () {
+            init();
+
+            var productRegistrationController = new ProductRegistrationController();
+            productRegistrationController.getProductRegistrationStatus(function (err, data) {
+                if (err) { return; }
+
+                if (data.statusAsString === 'UNREGISTERED') {
+                    productRegistrationController.showProductRegistrationModal();
+                }
+            });
+        });
+
+        function transmit_form(element) {
+            // disable submit button to insert a notification of working
+            element.disabled = true;
+            // nothing fancy. mainly for mobile.
+            element.innerHTML = '<i class="fa fa-sync fa-spin"></i> ' + jsText({{ "Authenticating"|xlj }});
+                {% if hasSession %}
+                document.cookie = {{ cookieText|xlj }};
+                {% endif %}
+                document.forms[0].submit();
+            return true;
+        }
+
+        var registrationTranslations = {{ regTranslations }};
+
+        var registrationConstants = {{ regConstants|json_encode }};
+    </script>
+    {{ setupHeader() }}
+</head>
+<body class="login">
+    <form method="POST" id="login_form" autocomplete="off" action="../main/main_screen.php?auth=login&site={{ siteID|attr }}" target="_top" name="login_form">
+        <div class="{{ loginRow|attr }}">
+            <div class="{{ formArea|attr }}">
+                <input type="hidden" name="new_login_session_management" value="1">
+                <input type="hidden" name="languageChoice" value="{{ defaultLangID|attr }}">
+
+                {% if relogin == 1 %}
+                <div class="alert alert-info m-1 font-weight-bold">
+                    {{ "password security has recently been upgraded"|xlt }}. {{ "Please login again"|xlt }}
+                </div>
+                {% endif %}
+
+                {% if loginFail == 1 %}
+                <div class="alert alert-danger login-failure m-1 font-weight-bold">
+                    {{ "Invalid usernamem or password"|xlt }}
+                </div>
+                {% endif %}
+
+                <div id="standard-auth-username" class="form-group">
+                    <label for="authUser" class="text-right sr-only">{{ "Username"|xlt }}</label>
+                    <input type="text" class="form-control" id="authUser" name="authUser" placeholder="{{ "Username"|xla }}">
+                </div>
+
+                <div id="standard-auth-password" class="form-group">
+                    <label for="clearPass" class="text-right sr-only">{{ "Password"|xlt }}</label>
+                    <input type="password" class="form-control" id="clearPass" name="clearPass" placeholder="{{ "Password"|xla }}">
+                </div>
+
+                {{ divApp }}
+
+                {% if displayLanguage %}
+                <div class="form-group">
+                    <label for="language" class="text-right">{{ "Language"|xlt }}</label>
+                    <div>
+                        <select class="form-control" name="languageChoice" size="1">
+                            <option value="{{ defaultLangID|attr }}" selected>{{ "Default"|xlt }} - {{ defaultLangName|xlt }}</option>
+                            {% for l in languageList %}
+                                <option value="{{ l.lang_id }}|attr">{{ l.trans_lang_description|text }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                </div>
+                {% endif %}
+
+                {% if displayFacilities %}
+                <div class="form-group">
+                    <label for="facility" class="text-right">{{ "Facility"|xlt }}</label>
+                    <div>
+                        <select class="form-control" name="facility" size="1">
+                            <option value="user_default">{{ "My default facility"|xlt }}</option>
+                            {% for f in facilityList %}
+                                <option value="{{ f.id|attr }}" {{ facilitySelected == f.id ? "selected" : "" }}>{{ f.name|text }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                </div>
+                {% endif %}
+
+                <div class="form-group oe-pull-away">
+                    <button id="login-button" class="btn btn-primary" type="submit" onclick="transmit_form(this)">{{ "Login"|xlt }}</button>
+                </div>
+
+                <div class="form-group">
+                    {% if displayGoogleSignin %}
+                    <input type="hidden" id="used-google-signin" name="used_google_signin" value="">
+                    <input type="hidden" id="google-signin-token" name="google_signin_token" value="">
+                    <div id="google-signin" onclick="return do_google_signin();">
+                        <!-- This message is displayed if the google platform API cannot render the button -->
+                        <span id="google-signin-service-unreachable-alert" style="display:none;">
+                            {{ "Google Sign-In is enabled but the service is unreachable."|xlt }}
+                        </span>
+                    </div>
+                    <div id="google-signout">
+                        <a href="#" onclick="signOut();">{{ "Sign out"|xlt }}</a>
+                    </div>
+                    {% endif %}
+                </div>
+            </div>
+
+            <div class="{{ logoArea|attr }}">
+                {% if displayExtraLogo %}
+                <div class="text-center">
+                    <span class="d-inline-block w-40">
+                        {{ primaryLogoSrc|raw }}
+                    </span>
+                    <span class="d-inline-block w-15 login-bg-text-color"><i class="fas fa-plus fa-2x"></i></span>
+                    <span class="d-inline-block w-40">
+                        {{ logocode }}
+                    </span>
+                </div>
+                {% else %}
+                <div class="mx-auto m-4 w-75">
+                    {{ primaryLogoSrc|raw }}
+                </div>
+                {% endif %}
+
+                {% if displayLoginLabel %}
+                <div class="text-center login-title-label">
+                        {{ openemrName|text }}
+                    </div>
+                {% endif %}
+
+                {% if displayTinyLogo == 1 %}
+                    {{ tinyLogo1 }}
+                {% endif %}
+                {% if displayTinyLogo == 2 %}
+                    {{ tinyLogo2 }}
+                {% endif %}
+                {% if displayTinyLogo == 3 %}
+                    <div class="row mb-3">
+                        <div class="col-sm-6">{{ tinyLogo1 }}</div>
+                        <div class="col-sm-6">{{ tinyLogo2 }}</div>
+                    </div>
+                {% endif %}
+
+                {% if displayTagline %}
+                    <p class="text-center lead font-weight-normal login-bg-text-color">{{ tagline|xlt }}</p>
+                {% endif %}
+
+                {% if displayAck %}
+                    <p class="text-center small"><a href="../../acknowledge_license_cert.html" class="login-bg-text-color" target="main">{{ "Acknowledgments, Licensing and Certification"|xlt }}</a></p>
+                {% endif %}
+            </div>
+        </div>
+        <div class="product-registration-modal modal fade">
+            <div class="modal-dialog modal-dialog-centered">
+                <div class="modal-content">
+                    <div class="modal-header"></div>
+                    <div class="modal-body">
+                        <p class="context">
+                            {{ "Register your installation with OEMR to receive important notifications, such as security fixes and new release announcements."|xlt }}
+                        </p>
+                        <input placeholder="{{ "email"|xlt }}" type="email" class="email w-100 text-body form-control" />
+                        <p class="message font-italic"></p>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary submit">{{ "Submit"|xlt }}</button>
+                        <button type="button" class="btn btn-secondary nothanks">{{ "No Thanks"|xlt }}</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </form>
+</body>
+</html>
+{% if displayGoogleSignin %}
+<script type="text/javascript">
+    // This variable controls whether we should login to OpenEMR
+    // so we only login if "Sign in with Google button" was clicked
+    let google_signin = false;
+
+    // Hide the google signout link unless we are signed-in
+    // This isn't really ever displayed, because once we sign-in with google,
+    // we automatically log into the app
+    $('#google-signout').hide();
+
+    // Click-handler for signin button
+    function do_google_signin() {
+        google_signin = true;
+    }
+
+    // When Google sign-in successful, sign in to the app, but only
+    // if the button was clicked (otherwise we would automatically login)
+    function onSignInSuccess(googleUser) {
+        if (google_signin === true) {
+            const auth_response = googleUser.getAuthResponse();
+            const id_token = auth_response.id_token;
+            $('.login-failure').hide();
+            $('#used-google-signin').val(true);
+            $('#google-signin-token').val(id_token);
+            $('#google-signout').show();
+            $('#standard-auth-username, #standard-auth-password').hide();
+            var element = document.getElementById('login-button');
+            transmit_form(element);
+        }
+    }
+
+    function onSignInFailure(error) {
+        $('.login-failure').show();
+    }
+
+    function renderButton() {
+        gapi.signin2.render('google-signin', {
+            'prompt': 'select_account',
+            'scope': 'profile email',
+            'width': 240,
+            'height': 50,
+            'longtitle': true,
+            'theme': 'dark',
+            'onsuccess': onSignInSuccess,
+            'onfailure': onSignInFailure
+        });
+    }
+
+    function signOut() {
+        google_signin = false;
+        const auth2 = gapi.auth2.getAuthInstance();
+        auth2.signOut().then(function () {
+            $('#used-google-signin').val('');
+            $('#google-signin-token').val('');
+            $('#google-signout').hide();
+            $('#standard-auth-username, #standard-auth-password').show();
+        });
+    }
+
+    $.getScript('https://apis.google.com/js/platform.js', function (data, textStatus, jqxh) {
+        // When the auth2 library is loaded, log out so the user has to sign into google
+        gapi.load('auth2', function () {
+            gapi.auth2.init().then(function () {
+                signOut();
+            });
+        });
+
+        // Render the "Sign in with Google" button
+        renderButton();
+    }).fail(function (jqxhr, settings, exception) {
+        $('#google-signin-service-unreachable-alert').show();
+    });
+</script>
+{% endif %}


### PR DESCRIPTION
#### Changes proposed in this pull request:
This PR adds customization to the login page by creating 3 new global options in the Appearance section. First, a boolean that will hide the tagline. Second, a textbox to customize the tagline if you wanted (The default is now what the previously hard-coded text was). Third, a boolean that hides the Acknowledgement link. The defaults of these new settings match current state to minimize disruption.

The login.scss file was updated doing away with the gradient behind the logo and instead uses the primary theme color of the theme as defined by the bootstrap theme-colors map.

The entire login.php page was moved over to a Twig template to improve separation of business logic from display logic.

The labels on the username and password were hidden by default using `.sr-only` as they already have a Placeholder attribute, effectively resulting in duplicate directions. 

The login icon was removed from the Login button.