### PR TITLE
Ensure the array key exists prior to checking it to suppress a log wa…

### DIFF
--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -62,7 +62,7 @@ class Kernel
      */
     public function isDev()
     {
-        return ($_ENV['OPENEMR__ENVIRONMENT'] === 'dev') ? true : false;
+        return (array_key_exists('OPENEMR__ENVIRONMENT', $_ENV) && $_ENV['OPENEMR__ENVIRONMENT'] === 'dev') ? true : false;
     }
 
     /**


### PR DESCRIPTION
Fixes #4633 

#### Short description of what this resolves:
Ensures the array key exists prior to referencing it which ensures undefined key warnings no longer logged.