### PR TITLE
fix module name bug

### DIFF
--- a/interface/modules/zend_modules/module/Installer/view/installer/installer/index.phtml
+++ b/interface/modules/zend_modules/module/Installer/view/installer/installer/index.phtml
@@ -296,6 +296,7 @@ $depObj = $this->dependencyObject;
                     <td><?php echo $this->escapeHtml($slno); ?> </td>
                     <td>
                         <?php
+                        $form_title_file = null;
                         if (is_file($GLOBALS['srcdir'] . "/../{$baseModuleDir}{$zendModDir}/$fname/info.txt")) {
                           $form_title_file = file($GLOBALS['srcdir'] . "/../{$baseModuleDir}{$zendModDir}/module/$fname/info.txt");
                         }


### PR DESCRIPTION
All the modules in unregistered section were using the same name if there is a no mal module being listed (they all use the normal module name).
![image](https://user-images.githubusercontent.com/278968/134401961-b4af2646-b3d4-40f6-a08d-c854ee6097e8.png)

This PR fixes this.
![image](https://user-images.githubusercontent.com/278968/134402048-39426774-72a9-42a8-bd4d-eb552a63b5ee.png)

Will also bring this into rel-600