### PR TITLE
Openemr encounters twig kernel

### DIFF
--- a/interface/forms/newpatient/common.php
+++ b/interface/forms/newpatient/common.php
@@ -550,6 +550,7 @@ $ires = sqlStatement("SELECT id, type, title, begdate FROM lists WHERE " .
                         </div>
                         <div class="col-sm">
                             <select name='discharge_disposition' id='discharge_disposition' class='form-control'>
+                                <option value='_blank'>-- <?php echo xlt('Select One'); ?> --</option>
                                 <?php
                                 $dischargeListDisposition = new ListService();
                                 $dischargeDisposiitons = $dischargeListDisposition->getOptionsByListName('discharge-disposition') ?? [];

--- a/interface/forms/newpatient/save.php
+++ b/interface/forms/newpatient/save.php
@@ -43,6 +43,7 @@ $encounter_provider = $_POST['provider_id'] ?? null;
 $external_id = isset($_POST['form_gid']) ? $_POST['form_gid'] : '';
 
 $discharge_disposition = $_POST['discharge_disposition'] ?? null;
+$discharge_disposition = $discharge_disposition != '_blank' ? $discharge_disposition : null;
 
 $facilityresult = $facilityService->getById($facility_id);
 $facility = $facilityresult['name'];

--- a/src/Common/Twig/TwigContainer.php
+++ b/src/Common/Twig/TwigContainer.php
@@ -22,7 +22,7 @@ use Twig\Loader\FilesystemLoader;
 
 class TwigContainer
 {
-    private $path;  // path in /templates
+    private $paths = [];  // path in /templates
 
     /**
      * Instance of Kernel
@@ -37,9 +37,9 @@ class TwigContainer
      */
     public function __construct(string $path = null, Kernel $kernel = null)
     {
-        $this->path = $GLOBALS['fileroot'] . '/templates';
+        $this->paths[] = $GLOBALS['fileroot'] . '/templates';
         if (!empty($path)) {
-            $this->path = $this->path . '/' . $path;
+            $this->paths[] = $path;
         }
 
         if ($kernel) {
@@ -54,7 +54,7 @@ class TwigContainer
      */
     public function getTwig()
     {
-        $twigLoader = new FilesystemLoader($this->path);
+        $twigLoader = new FilesystemLoader($this->paths);
         $twigEnv = new Environment($twigLoader, ['autoescape' => false]);
         $twigEnv->addExtension(new TwigExtension());
 

--- a/src/FHIR/SMART/SmartLaunchController.php
+++ b/src/FHIR/SMART/SmartLaunchController.php
@@ -160,15 +160,6 @@ class SmartLaunchController
             // work...
             if ($client->isEnabled() && $client->hasScope(self::CLIENT_APP_REQUIRED_LAUNCH_SCOPE)) {
                 $smartList[] = $client;
-            } else {
-                (new SystemLogger())->debug(
-                    "Skipping over client ",
-                    [
-                        "clientId" => $client->getIdentifier()
-                        , "enabled" => $client->isEnabled()
-                        , "hasLaunchScope" => $client->hasScope(self::CLIENT_APP_REQUIRED_LAUNCH_SCOPE)
-                    ]
-                );
             }
         }
         return $smartList;

--- a/src/Services/EncounterService.php
+++ b/src/Services/EncounterService.php
@@ -77,15 +77,14 @@ class EncounterService extends BaseService
      * @param $pid The unique public id (pid) for the patient.
      * @return array|null Returns the encounter if found, null otherwise
      */
-    public function getMostRecentEncounterForPatient($pid) : ?array
+    public function getMostRecentEncounterForPatient($pid): ?array
     {
         $pid = new TokenSearchField('pid', [new TokenSearchValue($pid, null)]);
         // we discovered that most queries were ordering by encounter id which may NOT be the most recent encounter as
         // an older historical encounter may be entered after a more recent encounter, so ordering be encounter id screws
         // this up.
         $result = $this->search(['pid' => $pid], true, '', ['limit' => 1, 'order' => '`date` DESC']);
-        if ($result->hasData())
-        {
+        if ($result->hasData()) {
             return array_pop($result->getData());
         }
         return null;
@@ -254,16 +253,14 @@ class EncounterService extends BaseService
             $whereFragment = FhirSearchWhereClauseBuilder::build($search, $isAndCondition);
             $sql .= $whereFragment->getFragment();
 
-            if (empty($options['order']))
-            {
+            if (empty($options['order'])) {
                 $sql .= " ORDER BY fe.eid DESC";
             } else {
                 $sql .= " ORDER BY " . $options['order'];
             }
 
 
-            if (is_int($limit) && $limit > 0)
-            {
+            if (is_int($limit) && $limit > 0) {
                 $sql .= " LIMIT " . $limit;
             }
 

--- a/src/Services/EncounterService.php
+++ b/src/Services/EncounterService.php
@@ -73,10 +73,28 @@ class EncounterService extends BaseService
     }
 
     /**
+     * Given a patient pid return the most recent patient encounter for that patient
+     * @param $pid The unique public id (pid) for the patient.
+     * @return array|null Returns the encounter if found, null otherwise
+     */
+    public function getMostRecentEncounterForPatient($pid) : ?array
+    {
+        $pid = new TokenSearchField('pid', [new TokenSearchValue($pid, null)]);
+        // we discovered that most queries were ordering by encounter id which may NOT be the most recent encounter as
+        // an older historical encounter may be entered after a more recent encounter, so ordering be encounter id screws
+        // this up.
+        $result = $this->search(['pid' => $pid], true, '', ['limit' => 1, 'order' => '`date` DESC']);
+        if ($result->hasData())
+        {
+            return array_pop($result->getData());
+        }
+        return null;
+    }
+
+    /**
      * Returns a list of encounters matching optional search criteria.
      * Search criteria is conveyed by array where key = field/column name, value = field value.
      * If no search criteria is provided, all records are returned.
-     * TODO: @adunsulag rename this to be search() to be consistent with other services.
      *
      * @param array  $search         search array parameters
      * @param bool   $isAndCondition specifies if AND condition is used for multiple criteria. Defaults to true.
@@ -84,8 +102,9 @@ class EncounterService extends BaseService
      * @return bool|ProcessingResult|true|null ProcessingResult which contains validation messages, internal error messages, and the data
      *                               payload.
      */
-    public function search($search = array(), $isAndCondition = true, $puuidBindValue = '')
+    public function search($search = array(), $isAndCondition = true, $puuidBindValue = '', $options = array())
     {
+        $limit = $options['limit'] ?? null;
         $sqlBindArray = array();
         $processingResult = new ProcessingResult();
 
@@ -183,7 +202,7 @@ class EncounterService extends BaseService
                                class_code,
                                facility_id,
                                discharge_disposition,
-                               pid
+                               pid as encounter_pid
                            FROM form_encounter
                        ) fe
                        LEFT JOIN openemr_postcalendar_categories as opc
@@ -204,7 +223,7 @@ class EncounterService extends BaseService
                                   pid
                                  ,uuid AS puuid
                            FROM patient_data
-                       ) patient ON fe.pid = patient.pid
+                       ) patient ON fe.encounter_pid = patient.pid
                        LEFT JOIN (
                            select
                                 id AS provider_provider_id
@@ -234,7 +253,19 @@ class EncounterService extends BaseService
         try {
             $whereFragment = FhirSearchWhereClauseBuilder::build($search, $isAndCondition);
             $sql .= $whereFragment->getFragment();
-            $sql .= " ORDER BY fe.eid DESC";
+
+            if (empty($options['order']))
+            {
+                $sql .= " ORDER BY fe.eid DESC";
+            } else {
+                $sql .= " ORDER BY " . $options['order'];
+            }
+
+
+            if (is_int($limit) && $limit > 0)
+            {
+                $sql .= " LIMIT " . $limit;
+            }
 
             $records = QueryUtils::fetchRecords($sql, $whereFragment->getBoundValues());
 


### PR DESCRIPTION
Add empty option for encounter discharge.  Right now there is no way to opt out of setting an encounter's hospital discharge status.  Looking at the ONC FHIR encounter spec it looks like this is a MUST Support requirement and not a Required attribute.  Adding the optional value allows people to not fill this encounter in.

Made it so you can add additional search directories for twig.   This makes it so modules can use twig templates inside their own folders.

Added a helper method to the EncounterService to be able to get the most recent encounter for a patient based on the encounter date.

Modified the search method in EncounterService so you can have order by and limit conditions.

Removed spam log from patient demographics.