### PR TITLE
Enhance patient service search method

### DIFF
--- a/src/Services/PatientService.php
+++ b/src/Services/PatientService.php
@@ -328,6 +328,12 @@ class PatientService extends BaseService
                     $querySearch[$field] = new StringSearchField($field, $search[$field], SearchModifier::CONTAINS, $isAndCondition);
                 }
             }
+            // for backwards compatability, we will make sure we do exact matches on the keys using string comparisons if no object is used
+            foreach ($search as $field => $key) {
+                if (!isset($querySearch[$field]) && !($key instanceof ISearchField)) {
+                    $querySearch[$field] = new StringSearchField($field, $search[$field], SearchModifier::EXACT, $isAndCondition);
+                }
+            }
         }
         return $this->search($querySearch, $isAndCondition);
     }


### PR DESCRIPTION
Made it so the patient search can use an associative array in the getAll
without having to use the ISearchField objects.  Anything that isn't an
ISearchObject gets set to be an exact string match value which is the
way the queries were before we did FHIR.