### PR TITLE
CCD import Labs and Encounter fix for HL7 v2.1

### DIFF
--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php
@@ -219,7 +219,7 @@ class CarecoordinationTable extends AbstractTableGateway
         $this->documentData['field_name_value_array']['patient_data'][1]['lname'] = $name['family'] ?? null;
         $this->documentData['field_name_value_array']['patient_data'][1]['DOB'] = $xml['recordTarget']['patientRole']['patient']['birthTime']['value'] ?? null;
         $this->documentData['field_name_value_array']['patient_data'][1]['sex'] = $xml['recordTarget']['patientRole']['patient']['administrativeGenderCode']['displayName'] ?? null;
-        $this->documentData['field_name_value_array']['patient_data'][1]['pubpid'] = $xml['recordTarget']['patientRole']['id'][0]['extension'] ?? null;
+        $this->documentData['field_name_value_array']['patient_data'][1]['pubpid'] = $xml['recordTarget']['patientRole']['id']['extension'] ?? null;
         $this->documentData['field_name_value_array']['patient_data'][1]['ss'] = $xml['recordTarget']['patientRole']['id'][1]['extension'] ?? null;
         $this->documentData['field_name_value_array']['patient_data'][1]['street'] = $xml['recordTarget']['patientRole']['addr']['streetAddressLine'] ?? null;
         $this->documentData['field_name_value_array']['patient_data'][1]['city'] = $xml['recordTarget']['patientRole']['addr']['city'] ?? null;

--- a/src/Services/Cda/CdaTemplateImportDispose.php
+++ b/src/Services/Cda/CdaTemplateImportDispose.php
@@ -994,7 +994,7 @@ class CdaTemplateImportDispose
                 $res_q_sel_pres_r_cnt = $res_q_sel_pres_r->count();
             }
 
-            if ((empty($value['extension']) && $res_q_sel_pres_r_cnt == 0) || ($res_q_sel_pres_cnt == 0)) {
+            if ((empty($value['extension']) && $res_q_sel_pres_r_cnt === 0) || ($res_q_sel_pres_cnt === 0)) {
                 $query = "INSERT INTO prescriptions
                   ( patient_id,
                     date_added,


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:
See title

#### Changes proposed in this pull request:
Our CCD import is based on HL7 rel C-32/1.0 so templates have changed up to rel 2.1+. Also we don't handle dates well  mainly, dates including time zone(needs addressing). 
Apparently HL7 dropped using extensions that reference a root for observations(lab result ob's here) so now the root is the observation identifier(ho hum).
CDA IG allows for a time observation to describe the period for encompassing encounters in the section container. QRDA send encounter individually in an act template so have to allow for it. 

So import results now make better sense in our chart views.(see attached screen shots below)