### PR TITLE
Force the tagline and acknowledgements link to white

### DIFF
--- a/templates/login/login_core.html.twig
+++ b/templates/login/login_core.html.twig
@@ -161,11 +161,11 @@
                 {% endif %}
 
                 {% if displayTagline %}
-                    <p class="text-center lead font-weight-normal login-bg-text-color">{{ tagline|xlt }}</p>
+                    <p class="text-center text-white lead">{{ tagline|xlt }}</p>
                 {% endif %}
 
                 {% if displayAck %}
-                    <p class="text-center small"><a href="../../acknowledge_license_cert.html" class="login-bg-text-color" target="main">{{ "Acknowledgments, Licensing and Certification"|xlt }}</a></p>
+                    <p class="text-center small"><a href="../../acknowledge_license_cert.html" class="text-white" target="main">{{ "Acknowledgments, Licensing and Certification"|xlt }}</a></p>
                 {% endif %}
             </div>
         </div>


### PR DESCRIPTION
The tagline and ack link needed explicit `text-white` which was missed during the login page refactoring.