### PR TITLE
random patient generator related updates

### DIFF
--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php
@@ -177,7 +177,7 @@ class CarecoordinationTable extends AbstractTableGateway
         // Document various sectional components
         $components = $xml['component']['structuredBody']['component'];
         // test if a QRDA QDM CAT I document type from header OIDs
-        $qrda = $xml['templateId'][2]['root'];
+        $qrda = $xml['templateId'][2]['root'] ?? null;
         if ($qrda === '2.16.840.1.113883.10.20.24.1.2') {
             $this->is_qrda_import = true;
             // Offset to Patient Data section
@@ -348,7 +348,7 @@ class CarecoordinationTable extends AbstractTableGateway
             }
         }
         foreach ($res as $row) {
-            $this->is_qrda_import = $row['is_qrda_document'];
+            $this->is_qrda_import = $row['is_qrda_document'] ?? false;
             if (!empty($audit_master_id)) {
                 $resfield = $appTable->zQuery(
                     "SELECT *

--- a/interface/super/edit_layout.php
+++ b/interface/super/edit_layout.php
@@ -917,7 +917,7 @@ function writeFieldLine($linedata)
         }
     }
     echo "  <td class='text-center optcell'>";
-    echo "<input type='text' name='fld[" . attr($fld_line_no) . "][datacols]' id='codes_fld[" . attr($fld_line_no) . "][datacols]' value='" . attr($linedata['codes']) . "' title='" . xla('Code(s)') . "' onclick='select_clin_term_code(this)' size='10' maxlength='255' class='form-control optin' />";
+    echo "<input type='text' name='fld[" . attr($fld_line_no) . "][codes]' id='codes_fld[" . attr($fld_line_no) . "][codes]' value='" . attr($linedata['codes']) . "' title='" . xla('Code(s)') . "' onclick='select_clin_term_code(this)' size='10' maxlength='255' class='form-control optin' />";
     echo "</td>\n";
 
     // The "?" to click on for yet more field attributes.

--- a/library/forms.inc
+++ b/library/forms.inc
@@ -56,11 +56,11 @@ function addForm(
 
     global $attendant_type;
     if (!$user) {
-        $user = $_SESSION['authUser'];
+        $user = $_SESSION['authUser'] ?? null;
     }
 
     if (!$group) {
-        $group = $_SESSION['authProvider'];
+        $group = $_SESSION['authProvider'] ?? null;
     }
 
     if ($therapy_group == 'not_given') {

--- a/src/Services/Cda/CdaTemplateImportDispose.php
+++ b/src/Services/Cda/CdaTemplateImportDispose.php
@@ -1050,7 +1050,7 @@ class CdaTemplateImportDispose
                     $provider_id,
                     $value['extension'],
                     0,
-                    $value['request_intent']));
+                    ($value['request_intent'] ?? null)));
             } else {
                 $q_upd_pres = "UPDATE prescriptions
                        SET patient_id=?,
@@ -1089,7 +1089,7 @@ class CdaTemplateImportDispose
                     $value['extension'],
                     $pid,
                     0,
-                    $value['request_intent']));
+                    ($value['request_intent'] ?? null)));
             }
         }
     }
@@ -1305,7 +1305,7 @@ class CdaTemplateImportDispose
 
             //procedure_order
             $query_insert_po = "INSERT INTO procedure_order(provider_id,patient_id,encounter_id,date_collected,date_ordered,order_priority,order_status,activity,lab_id,procedure_order_type) VALUES (?,?,?,?,?,?,?,?,?,'laboratory_test')";
-            $result_po = $appTable->zQuery($query_insert_po, array('', $pid, $enc_id, $date, $date, 'normal', $value['status'] ?? 'complete', 1, $pro_id));
+            $result_po = $appTable->zQuery($query_insert_po, array('', $pid, $enc_id, ($date ?? null), ($date ?? null), 'normal', $value['status'] ?? 'complete', 1, $pro_id));
             $po_id = $result_po->getGeneratedValue();
 
             //procedure_order_code
@@ -1316,7 +1316,7 @@ class CdaTemplateImportDispose
 
             //procedure_report
             $query_insert_pr = 'INSERT INTO procedure_report(procedure_order_id,date_collected,date_report,report_status,review_status) VALUES (?,?,?,?,?)';
-            $result_pr = $appTable->zQuery($query_insert_pr, array($po_id, $date, $date, 'final', 'reviewed'));
+            $result_pr = $appTable->zQuery($query_insert_pr, array($po_id, ($date ?? null), ($date ?? null), 'final', 'reviewed'));
             $res_id = $result_pr->getGeneratedValue();
 
             foreach ($value['result'] as $res) {
@@ -1343,7 +1343,7 @@ class CdaTemplateImportDispose
                         $result_pt = $appTable->zQuery($query_insert_pt, array($res['result_text'], $pro_id, $res['result_code'], 'res', 1, 'laboratory_test'));
                         $res_pt_id_res = $result_pt->getGeneratedValue();
                         $query_update_pt = 'UPDATE procedure_type SET parent = ? WHERE procedure_type_id = ?';
-                        $appTable->zQuery($query_update_pt, array($res_pt_id, $res_pt_id_res));
+                        $appTable->zQuery($query_update_pt, array(($res_pt_id ?? null), $res_pt_id_res));
                     }
 
                     if (!empty($res['result_code'])) {

--- a/src/Services/Cda/CdaTemplateImportDispose.php
+++ b/src/Services/Cda/CdaTemplateImportDispose.php
@@ -1228,21 +1228,21 @@ class CdaTemplateImportDispose
         $userName = "";
 
         if (!empty($value['provider_fname'])) {
-            $value['provider_name'] = $value['provider_fname'] ?? 'External';
-            $value['provider_family'] = $value['provider_lname'] ?? 'Provider';
+            $value['provider_name'] = ($value['provider_fname'] ?? '') ?: 'External';
+            $value['provider_family'] = ($value['provider_lname'] ?? '') ?: 'Provider';
         }
 
         if ($create_user_name) {
-            $userName = ($value['provider_name'] ?? 'External') . ($value['provider_family'] ?? 'Provider');
+            $userName = (($value['provider_name'] ?? '') ?: 'External') . (($value['provider_family'] ?? '') ?: 'Provider');
         }
         $query_ins_users = "INSERT INTO users
         ( username, fname, lname, npi, authorized, organization, street, city, state, zip, active, abook_type)
         VALUES(?, ?, ?, ?, 1, ?, ?, ?, ?, ?, 1, 'external_provider')";
         $res_query_ins_users = $appTable->zQuery($query_ins_users, array(
             $userName,
-            $value['provider_name'] ?? 'External',
-            $value['provider_family'] ?? 'Provider',
-            $value['provider_npi'] ?? CarecoordinationTable::NPI_SAMPLE,
+            ($value['provider_name'] ?? '') ?: 'External',
+            ($value['provider_family'] ?? '') ?: 'Provider',
+            ($value['provider_npi'] ?? '') ?: CarecoordinationTable::NPI_SAMPLE,
             $value['represented_organization_name'] ?? null,
             $value['provider_address'] ?? null,
             $value['provider_city'] ?? null,

--- a/src/Services/Cda/CdaTemplateImportDispose.php
+++ b/src/Services/Cda/CdaTemplateImportDispose.php
@@ -1228,21 +1228,21 @@ class CdaTemplateImportDispose
         $userName = "";
 
         if (!empty($value['provider_fname'])) {
-            $value['provider_name'] = $value['provider_fname'] ?: 'External';
-            $value['provider_family'] = $value['provider_lname'] ?: 'Provider';
+            $value['provider_name'] = $value['provider_fname'] ?? 'External';
+            $value['provider_family'] = $value['provider_lname'] ?? 'Provider';
         }
 
         if ($create_user_name) {
-            $userName = ($value['provider_name'] ?: 'External') . ($value['provider_family'] ?: 'Provider');
+            $userName = ($value['provider_name'] ?? 'External') . ($value['provider_family'] ?? 'Provider');
         }
         $query_ins_users = "INSERT INTO users
         ( username, fname, lname, npi, authorized, organization, street, city, state, zip, active, abook_type)
         VALUES(?, ?, ?, ?, 1, ?, ?, ?, ?, ?, 1, 'external_provider')";
         $res_query_ins_users = $appTable->zQuery($query_ins_users, array(
             $userName,
-            $value['provider_name'] ?: 'External',
-            $value['provider_family'] ?: 'Provider',
-            $value['provider_npi'] ?: CarecoordinationTable::NPI_SAMPLE,
+            $value['provider_name'] ?? 'External',
+            $value['provider_family'] ?? 'Provider',
+            $value['provider_npi'] ?? CarecoordinationTable::NPI_SAMPLE,
             $value['represented_organization_name'] ?? null,
             $value['provider_address'] ?? null,
             $value['provider_city'] ?? null,

--- a/src/Services/Cda/CdaTemplateParse.php
+++ b/src/Services/Cda/CdaTemplateParse.php
@@ -251,7 +251,7 @@ class CdaTemplateParse
 
             $code = $this->codeService->resolveCode(
                 $entry['act']['entryRelationship']['observation']['value']['code'],
-                $entry['act']['entryRelationship']['observation']['value']['codeSystemName'] ?: $entry['act']['entryRelationship']['observation']['value']['codeSystem'] ?? '',
+                $entry['act']['entryRelationship']['observation']['value']['codeSystemName'] ?? ($entry['act']['entryRelationship']['observation']['value']['codeSystem'] ?? ''),
                 $entry['act']['entryRelationship']['observation']['value']['displayName']
             );
             $this->templateData['field_name_value_array']['lists1'][$i]['list_code'] = $code['formatted_code'];
@@ -264,7 +264,7 @@ class CdaTemplateParse
             $this->templateData['field_name_value_array']['lists1'][$i]['enddate'] = $entry['act']['effectiveTime']['high']['value'] ?? null;
             $this->templateData['field_name_value_array']['lists1'][$i]['observation'] = $entry['act']['entryRelationship']['observation']['entryRelationship'][1]['observation']['value']['code'] ?? null;
             $this->templateData['field_name_value_array']['lists1'][$i]['observation_text'] = $entry['act']['entryRelationship']['observation']['entryRelationship'][1]['observation']['value']['displayName'] ?? null;
-            $this->templateData['field_name_value_array']['lists1'][$i]['status'] = $entry['act']['entryRelationship']['observation']['entryRelationship'][2]['observation']['value']['displayName'] ?: $entry['act']['entryRelationship']['observation']['statusCode'];
+            $this->templateData['field_name_value_array']['lists1'][$i]['status'] = $entry['act']['entryRelationship']['observation']['entryRelationship'][2]['observation']['value']['displayName'] ?? ($entry['act']['entryRelationship']['observation']['statusCode'] ?? null);
             $this->templateData['field_name_value_array']['lists1'][$i]['modified_time'] = $entry['act']['entryRelationship']['observation']['performer']['assignedEntity']['time']['value'] ?? null;
             $this->templateData['entry_identification_array']['lists1'][$i] = $i;
         }
@@ -398,7 +398,7 @@ class CdaTemplateParse
 
             $code = $this->codeService->resolveCode(
                 $entry['substanceAdministration']['consumable']['manufacturedProduct']['manufacturedMaterial']['code']['code'] ?? null,
-                $entry['substanceAdministration']['consumable']['manufacturedProduct']['manufacturedMaterial']['code']['codeSystemName'],
+                $entry['substanceAdministration']['consumable']['manufacturedProduct']['manufacturedMaterial']['code']['codeSystemName'] ?? null,
                 $entry['substanceAdministration']['consumable']['manufacturedProduct']['manufacturedMaterial']['code']['displayName']
             );
             $this->templateData['field_name_value_array']['immunization'][$i]['cvx_code'] = $code['code'];
@@ -434,7 +434,7 @@ class CdaTemplateParse
 
             $code = $this->codeService->resolveCode(
                 $entry['procedure']['code']['code'] ?? '',
-                $entry['procedure']['code']['codeSystemName'] ?: $entry['procedure']['code']['codeSystem'] ?? null,
+                $entry['procedure']['code']['codeSystemName'] ?? ($entry['procedure']['code']['codeSystem'] ?? null),
                 $entry['procedure']['code']['displayName'] ?? ''
             );
             $procedure_type = 'order';
@@ -647,7 +647,7 @@ class CdaTemplateParse
                 if (!empty($value['observation']['code']['code'])) {
                     $code = $this->codeService->resolveCode(
                         $lab_result_data['organizer']['code']['code'] ?? '',
-                        $lab_result_data['organizer']['code']['codeSystemName'] ?: $lab_result_data['organizer']['code']['codeSystem'] ?? '',
+                        $lab_result_data['organizer']['code']['codeSystemName'] ?? ($lab_result_data['organizer']['code']['codeSystem'] ?? ''),
                         $lab_result_data['organizer']['code']['displayName'] ?? ''
                     );
                     if (empty($lab_result_data['organizer']['id']['extension'])) {

--- a/src/Services/Cda/CdaTemplateParse.php
+++ b/src/Services/Cda/CdaTemplateParse.php
@@ -773,7 +773,7 @@ class CdaTemplateParse
                 $this->fetchVitalSignData($value);
             }
         } else {
-            $this->fetchVitalSignData($component['section']['entry']);
+            $this->fetchVitalSignData($component['section']['entry'] ?? null);
         }
     }
 

--- a/src/Services/Cda/CdaTemplateParse.php
+++ b/src/Services/Cda/CdaTemplateParse.php
@@ -251,7 +251,7 @@ class CdaTemplateParse
 
             $code = $this->codeService->resolveCode(
                 $entry['act']['entryRelationship']['observation']['value']['code'],
-                $entry['act']['entryRelationship']['observation']['value']['codeSystemName'] ?? ($entry['act']['entryRelationship']['observation']['value']['codeSystem'] ?? ''),
+                ($entry['act']['entryRelationship']['observation']['value']['codeSystemName'] ?? '') ?: $entry['act']['entryRelationship']['observation']['value']['codeSystem'] ?? '',
                 $entry['act']['entryRelationship']['observation']['value']['displayName']
             );
             $this->templateData['field_name_value_array']['lists1'][$i]['list_code'] = $code['formatted_code'];
@@ -264,7 +264,7 @@ class CdaTemplateParse
             $this->templateData['field_name_value_array']['lists1'][$i]['enddate'] = $entry['act']['effectiveTime']['high']['value'] ?? null;
             $this->templateData['field_name_value_array']['lists1'][$i]['observation'] = $entry['act']['entryRelationship']['observation']['entryRelationship'][1]['observation']['value']['code'] ?? null;
             $this->templateData['field_name_value_array']['lists1'][$i]['observation_text'] = $entry['act']['entryRelationship']['observation']['entryRelationship'][1]['observation']['value']['displayName'] ?? null;
-            $this->templateData['field_name_value_array']['lists1'][$i]['status'] = $entry['act']['entryRelationship']['observation']['entryRelationship'][2]['observation']['value']['displayName'] ?? ($entry['act']['entryRelationship']['observation']['statusCode'] ?? null);
+            $this->templateData['field_name_value_array']['lists1'][$i]['status'] = ($entry['act']['entryRelationship']['observation']['entryRelationship'][2]['observation']['value']['displayName'] ?? '') ?: $entry['act']['entryRelationship']['observation']['statusCode'] ?? null;
             $this->templateData['field_name_value_array']['lists1'][$i]['modified_time'] = $entry['act']['entryRelationship']['observation']['performer']['assignedEntity']['time']['value'] ?? null;
             $this->templateData['entry_identification_array']['lists1'][$i] = $i;
         }
@@ -434,7 +434,7 @@ class CdaTemplateParse
 
             $code = $this->codeService->resolveCode(
                 $entry['procedure']['code']['code'] ?? '',
-                $entry['procedure']['code']['codeSystemName'] ?? ($entry['procedure']['code']['codeSystem'] ?? null),
+                ($entry['procedure']['code']['codeSystemName'] ?? '') ?: $entry['procedure']['code']['codeSystem'] ?? null,
                 $entry['procedure']['code']['displayName'] ?? ''
             );
             $procedure_type = 'order';
@@ -647,7 +647,7 @@ class CdaTemplateParse
                 if (!empty($value['observation']['code']['code'])) {
                     $code = $this->codeService->resolveCode(
                         $lab_result_data['organizer']['code']['code'] ?? '',
-                        $lab_result_data['organizer']['code']['codeSystemName'] ?? ($lab_result_data['organizer']['code']['codeSystem'] ?? ''),
+                        ($lab_result_data['organizer']['code']['codeSystemName'] ?? '') ?: $lab_result_data['organizer']['code']['codeSystem'] ?? '',
                         $lab_result_data['organizer']['code']['displayName'] ?? ''
                     );
                     if (empty($lab_result_data['organizer']['id']['extension'])) {


### PR DESCRIPTION
@sjpadgett , just had several php8 related warnings to fix. The time per patient has increased from average of 0.4 seconds per patient to 1.5 seconds per patient, which is likely because the labs are now correctly being imported (by the way, all the importing looks great and much improved from before, so the OpenEMR fans are happy!). I'll see if can find any way to speed things up, although it's currently at a really good speed (would work out to 57600 patient imports per day, so getting to 1 million would take awhile :) ). Another really good thing is that the speed isn't slowly down as more patients are added (this was an issue in past that was a pain to fix), so overall the random patient generator is in great shape! thanks!

Pasted a sample run of 1000 patients below:
```
Starting patients import
50 patients imported (65 total seconds) (1.3 average seconds per patient for last 50 patients)
100 patients imported (145 total seconds) (1.6 average seconds per patient for last 50 patients)
150 patients imported (212 total seconds) (1.34 average seconds per patient for last 50 patients)
200 patients imported (288 total seconds) (1.52 average seconds per patient for last 50 patients)
250 patients imported (362 total seconds) (1.48 average seconds per patient for last 50 patients)
300 patients imported (480 total seconds) (2.36 average seconds per patient for last 50 patients)
350 patients imported (550 total seconds) (1.4 average seconds per patient for last 50 patients)
400 patients imported (607 total seconds) (1.14 average seconds per patient for last 50 patients)
450 patients imported (672 total seconds) (1.3 average seconds per patient for last 50 patients)
500 patients imported (745 total seconds) (1.46 average seconds per patient for last 50 patients)
550 patients imported (827 total seconds) (1.64 average seconds per patient for last 50 patients)
600 patients imported (890 total seconds) (1.26 average seconds per patient for last 50 patients)
650 patients imported (959 total seconds) (1.38 average seconds per patient for last 50 patients)
700 patients imported (1034 total seconds) (1.5 average seconds per patient for last 50 patients)
750 patients imported (1126 total seconds) (1.84 average seconds per patient for last 50 patients)
800 patients imported (1187 total seconds) (1.22 average seconds per patient for last 50 patients)
850 patients imported (1248 total seconds) (1.22 average seconds per patient for last 50 patients)
900 patients imported (1308 total seconds) (1.2 average seconds per patient for last 50 patients)
950 patients imported (1388 total seconds) (1.6 average seconds per patient for last 50 patients)
1000 patients imported (1456 total seconds) (1.36 average seconds per patient for last 50 patients)
Completed patients import (1000 patients) (1456 total seconds) (1.456 average seconds per patient)
Started uuid creation
Completed uuid creation (1509 total seconds; 0.41916666666667 total hours)
Completed run for following number of random patients: 1000
```

fixes #4720