### PR TITLE
Twig module author extensions

### DIFF
--- a/src/Common/Twig/TwigContainer.php
+++ b/src/Common/Twig/TwigContainer.php
@@ -16,8 +16,8 @@
 namespace OpenEMR\Common\Twig;
 
 use OpenEMR\Core\Kernel;
-use OpenEMR\Services\Globals\GlobalsService;
 use OpenEMR\Events\Core\TwigEnvironmentEvent;
+use OpenEMR\Services\Globals\GlobalsService;
 use Twig\Environment;
 use Twig\Extension\DebugExtension;
 use Twig\Loader\FilesystemLoader;

--- a/src/Common/Twig/TwigContainer.php
+++ b/src/Common/Twig/TwigContainer.php
@@ -17,6 +17,7 @@ namespace OpenEMR\Common\Twig;
 
 use OpenEMR\Core\Kernel;
 use OpenEMR\Services\Globals\GlobalsService;
+use OpenEMR\Events\Core\TwigEnvironmentEvent;
 use Twig\Environment;
 use Twig\Extension\DebugExtension;
 use Twig\Loader\FilesystemLoader;
@@ -58,11 +59,15 @@ class TwigContainer
         $twigLoader = new FilesystemLoader($this->paths);
         $twigEnv = new Environment($twigLoader, ['autoescape' => false]);
         $globalsService = new GlobalsService($GLOBALS, [], []);
-        $twigEnv->addExtension(new TwigExtension($globalsService));
+        $twigEnv->addExtension(new TwigExtension($globalsService, $this->kernel));
 
-        if ($this->kernel && $this->kernel->isDev()) {
-            $twigEnv->addExtension(new DebugExtension());
-            $twigEnv->enableDebug();
+        if ($this->kernel) {
+            if ($this->kernel->isDev()) {
+                $twigEnv->addExtension(new DebugExtension());
+                $twigEnv->enableDebug();
+            }
+            $event = new TwigEnvironmentEvent($twigEnv);
+            $this->kernel->getEventDispatcher()->dispatch($event, TwigEnvironmentEvent::EVENT_CREATED, 10);
         }
 
         return $twigEnv;

--- a/src/Common/Twig/TwigExtension.php
+++ b/src/Common/Twig/TwigExtension.php
@@ -16,8 +16,8 @@
 namespace OpenEMR\Common\Twig;
 
 use OpenEMR\Core\Header;
-use OpenEMR\Services\Globals\GlobalsService;
 use OpenEMR\Core\Kernel;
+use OpenEMR\Services\Globals\GlobalsService;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\GlobalsInterface;

--- a/src/Common/Twig/TwigExtension.php
+++ b/src/Common/Twig/TwigExtension.php
@@ -17,6 +17,8 @@ namespace OpenEMR\Common\Twig;
 
 use OpenEMR\Core\Header;
 use OpenEMR\Services\Globals\GlobalsService;
+use OpenEMR\Core\Kernel;
+use Symfony\Component\EventDispatcher\GenericEvent;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\GlobalsInterface;
 use Twig\TwigFilter;
@@ -24,10 +26,14 @@ use Twig\TwigFunction;
 
 class TwigExtension extends AbstractExtension implements GlobalsInterface
 {
-
     protected $globals;
 
-    public function __construct(GlobalsService $globals)
+    /**
+     * TwigExtension constructor.
+     * @param GlobalsService $globals
+     * @param Kernel|null $kernel
+     */
+    public function __construct(GlobalsService $globals, ?Kernel $kernel)
     {
         $this->globals = $globals->getGlobalsMetadata();
     }
@@ -91,6 +97,17 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
                     return ob_get_clean();
                 }
             ),
+            new TwigFunction(
+                'fireEvent',
+                function ($eventName, $eventData = array()) {
+                    if (empty($this->kernel)) {
+                        return '';
+                    }
+                    ob_start();
+                    $this->kernel->getEventDispatcher()->dispatch(new GenericEvent($eventName, $eventData), $eventName);
+                    return ob_get_clean();
+                }
+            )
         ];
     }
 

--- a/src/Events/Core/TwigEnvironmentEvent.php
+++ b/src/Events/Core/TwigEnvironmentEvent.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * TwigEnvironmentEvent is fired when the twig environment has been created in the system and allows module writers
+ * to modify the environment (such as adding their own template folder locations)
+ *
+ * An example of this can be seen below:
+ *
+ * function addTemplateOverrideLoader(TwigEnvironmentEvent $event)
+ * {
+ *     $twig = $event->getTwigEnvironment();
+ *
+ *     // we make sure we can override our file system directory here.
+ *     $loader = $twig->getLoader();
+ *     if ($loader instanceof FilesystemLoader) {
+ *          $loader->prependPath(\dirname(__DIR__) . DIRECTORY_SEPARATOR . "templates" . DIRECTORY_SEPARATOR);
+ *     }
+ * }
+ * $GLOBALS['kernel']->getEventDispatcher()->addListener(TwigEnvironmentEvent::EVENT_CREATED, ['addTemplateOverrideLoader']);
+ *
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\Core;
+
+use Twig\Environment;
+
+class TwigEnvironmentEvent
+{
+    /**
+     * This event is triggered after the twig environment has been created in the TwigContainer
+     */
+    const EVENT_CREATED = 'core.twig.environment.create';
+
+    /**
+     * @var Environment
+     */
+    private $environment;
+
+    public function __construct(Environment $environment)
+    {
+        $this->environment = $environment;
+    }
+
+    public function getTwigEnvironment(): Environment
+    {
+        return $this->environment;
+    }
+}

--- a/templates/error/400.html.twig
+++ b/templates/error/400.html.twig
@@ -1,0 +1,2 @@
+{% extends 'error/general_http_error.html.twig' %}
+{% block title %}{{ "OpenEMR 400 Error"|xlt }}{% endblock %}

--- a/templates/error/general_http_error.html.twig
+++ b/templates/error/general_http_error.html.twig
@@ -6,7 +6,7 @@
 </head>
 <body class="error">
 {% block errorBody %}
-    {% block errorHeader %}<h1>{{  "We're Sorry!  An Error has occured!"|xlt }}  {{ "Type"|xlt }}: {{ statusCode|text }}</h1>{% endblock %}
+    {% block errorHeader %}<h1>{{ "We're Sorry! An Error has occured!"|xlt }}  {{ "Type"|xlt }}: {{ statusCode|text }}</h1>{% endblock %}
     {% block errorDetails %}
         <p>{{ errorMessage|default("Please try your request again, check the server logs, or contact the site administrator for support")|text|xlt }}</p>
     {% endblock %}

--- a/templates/error/general_http_error.html.twig
+++ b/templates/error/general_http_error.html.twig
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>{% block title %}{{ "OpenEMR Error"|xlt }}{% endblock %}</title>
+    {{ setupHeader() }}
+</head>
+<body class="error">
+{% block errorBody %}
+    {% block errorHeader %}<h1>{{  "We're Sorry!  An Error has occured!"|xlt }}  {{ "Type"|xlt }}: {{ statusCode|text }}</h1>{% endblock %}
+    {% block errorDetails %}
+        <p>{{ errorMessage|default("Please try your request again, check the server logs, or contact the site administrator for support")|text|xlt }}</p>
+    {% endblock %}
+{% endblock %}
+</body>
+</html>


### PR DESCRIPTION
Added a twig extension to fire a generic event.  For now that is helpful
in being able to migrate over some of our php/html files that dispatch
render events.

I also added a twig environment event that module authors can hook into
in order to extend the file loader and load their own template files.  I
put an example in the twig environment event header of how to go about
doing this. Here it is:
```
 function addTemplateOverrideLoader(TwigEnvironmentEvent $event)
  {
      $twig = $event->getTwigEnvironment();
 
      // we make sure we can override our file system directory here.
      $loader = $twig->getLoader();
      if ($loader instanceof FilesystemLoader) {
           $loader->prependPath(\dirname(__DIR__) . DIRECTORY_SEPARATOR . "templates" . DIRECTORY_SEPARATOR);
      }
  }
  $GLOBALS['kernel']->getEventDispatcher()->addListener(TwigEnvironmentEvent::EVENT_CREATED, ['addTemplateOverrideLoader']);
 ```

Also created some generic error handler pages with an example 400 page
so we can start having nicer looking error handling pages for when
things go wrong in OpenEMR.