### PR TITLE
Make fhir search service classes easier to use

### DIFF
--- a/src/Services/Search/FhirSearchWhereClauseBuilder.php
+++ b/src/Services/Search/FhirSearchWhereClauseBuilder.php
@@ -34,7 +34,12 @@ class FhirSearchWhereClauseBuilder
             foreach ($search as $key => $field) {
                 if (!$field instanceof ISearchField) {
                     // developer logic error
-                    throw new \BadMethodCallException("Method called with invalid parameter.  Expected SearchField object for parameter '" . $key . "'");
+                    // treat the field as an exact string match if they send us a primitive
+                    if (is_string($field) || is_numeric($field)) {
+                        $field = new StringSearchField($key, $field, SearchModifier::EXACT);
+                    } else {
+                        throw new \BadMethodCallException("Method called with invalid parameter.  Expected SearchField object for parameter '" . $key . "'");
+                    }
                 }
                 $whereType = $isAndCondition ? "and" : "or";
 

--- a/src/Services/Search/FhirSearchWhereClauseBuilder.php
+++ b/src/Services/Search/FhirSearchWhereClauseBuilder.php
@@ -38,7 +38,7 @@ class FhirSearchWhereClauseBuilder
                     if (is_string($field) || is_numeric($field)) {
                         $field = new StringSearchField($key, $field, SearchModifier::EXACT);
                     } else {
-                        throw new \BadMethodCallException("Method called with invalid parameter.  Expected SearchField object for parameter '" . $key . "'");
+                        throw new \BadMethodCallException("Method called with invalid parameter.  Expected string, number, or SearchField object for parameter '" . $key . "'");
                     }
                 }
                 $whereType = $isAndCondition ? "and" : "or";


### PR DESCRIPTION
Made it so the fhir search classes will convert strings and numbers into
an exact string match.  This makes it so that search methods can pass in
simple array values without having to create the search field objects each time.  This
was a request from @sjpadgett to make the classes a little easier to
use.