### PR TITLE
Openemr render events

### DIFF
--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -288,6 +288,17 @@ $esignApi = new Api();
 </head>
 
 <body class="min-vw-100">
+<?php
+    // fire off an event here
+if (!empty($GLOBALS['kernel']->getEventDispatcher())) {
+    /**
+     * @var \Symfony\Component\EventDispatcher\EventDispatcher
+     */
+    $dispatcher = $GLOBALS['kernel']->getEventDispatcher();
+    // TODO: @adunsulag need to look at making this an actual typed event
+    $dispatcher->dispatch('main.body.render.pre');
+}
+?>
     <!-- Below iframe is to support logout, which needs to be run in an inner iframe to work as intended -->
     <iframe name="logoutinnerframe" id="logoutinnerframe" style="visibility:hidden; position:absolute; left:0; top:0; height:0; width:0; border:none;" src="about:blank"></iframe>
     <?php // mdsupport - app settings
@@ -360,6 +371,17 @@ $esignApi = new Api();
             goRepeaterServices();
         });
     </script>
+    <?php
+    // fire off an event here
+    if (!empty($GLOBALS['kernel']->getEventDispatcher())) {
+        /**
+         * @var \Symfony\Component\EventDispatcher\EventDispatcher
+         */
+        $dispatcher = $GLOBALS['kernel']->getEventDispatcher();
+        // TODO: @adunsulag need to look at making this an actual typed event
+        $dispatcher->dispatch('main.body.render.post');
+    }
+    ?>
 </body>
 
 </html>

--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -23,6 +23,7 @@ use Esign\Api;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
+use OpenEMR\Events\Main\Tabs\RenderEvent;
 
 // Ensure token_main matches so this script can not be run by itself
 //  If do not match, then destroy the session and go back to login screen
@@ -295,8 +296,7 @@ if (!empty($GLOBALS['kernel']->getEventDispatcher())) {
      * @var \Symfony\Component\EventDispatcher\EventDispatcher
      */
     $dispatcher = $GLOBALS['kernel']->getEventDispatcher();
-    // TODO: @adunsulag need to look at making this an actual typed event
-    $dispatcher->dispatch('main.body.render.pre');
+    $dispatcher->dispatch(new RenderEvent(), RenderEvent::EVENT_BODY_RENDER_PRE);
 }
 ?>
     <!-- Below iframe is to support logout, which needs to be run in an inner iframe to work as intended -->
@@ -378,8 +378,7 @@ if (!empty($GLOBALS['kernel']->getEventDispatcher())) {
          * @var \Symfony\Component\EventDispatcher\EventDispatcher
          */
         $dispatcher = $GLOBALS['kernel']->getEventDispatcher();
-        // TODO: @adunsulag need to look at making this an actual typed event
-        $dispatcher->dispatch('main.body.render.post');
+        $dispatcher->dispatch(new RenderEvent(), RenderEvent::EVENT_BODY_RENDER_POST);
     }
     ?>
 </body>

--- a/portal/home.php
+++ b/portal/home.php
@@ -24,6 +24,8 @@ require_once(__DIR__ . '/../library/appointments.inc.php');
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\Events\PatientPortal\RenderEvent;
+use OpenEMR\Events\PatientPortal\AppointmentFilterEvent;
 
 if (isset($_SESSION['register']) && $_SESSION['register'] === true) {
     require_once(__DIR__ . '/../src/Common/Session/SessionUtil.php');
@@ -86,7 +88,7 @@ if ($appts) {
             $etitle = '';
         }
 
-        $appointments[] = [
+        $formattedRecord = [
             'appointmentDate' => $dayname . ', ' . $row['pc_eventDate'] . ' ' . $disphour . ':' . $dispmin . ' ' . $dispampm,
             'appointmentType' => xl('Type') . ': ' . $row['pc_catname'],
             'provider' => xl('Provider') . ': ' . $row['ufname'] . ' ' . $row['ulname'],
@@ -96,6 +98,8 @@ if ($appts) {
             'etitle' => $etitle,
             'pc_eid' => $row['pc_eid'],
         ];
+        $filteredEvent = $GLOBALS['kernel']->getEventDispatcher()->dispatch(new AppointmentFilterEvent($row, $formattedRecord), AppointmentFilterEvent::EVENT_NAME);
+        $appointments[] = $filteredEvent->getAppointment() ?? $formattedRecord;
     }
 }
 
@@ -247,7 +251,8 @@ function buildNav($newcnt, $pid, $result)
 
 $navMenu = buildNav($newcnt, $pid, $result);
 
-echo (new TwigContainer(''))->getTwig()->render('portal/home.html.twig', [
+$twig = (new TwigContainer('', $GLOBALS['kernel']))->getTwig();
+echo $twig->render('portal/home.html.twig', [
     'user' => $user,
     'whereto' => $_SESSION['whereto'] ?: ($whereto ?? '#documentscard'),
     'result' => $result,
@@ -276,4 +281,8 @@ echo (new TwigContainer(''))->getTwig()->render('portal/home.html.twig', [
     'appointmentLimit' => $apptLimit,
     'appointmentCount' => $count,
     'displayLimitLabel' => xl('Display limit reached'),
+    'eventNames' => [
+        'sectionRenderPost' => RenderEvent::EVENT_SECTION_RENDER_POST,
+        'scriptsRenderPre' => RenderEvent::EVENT_SCRIPTS_RENDER_PRE
+    ]
 ]);

--- a/src/Events/Main/Tabs/RenderEvent.php
+++ b/src/Events/Main/Tabs/RenderEvent.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * RenderEvent is used to launch different rendering action points that developers can output their own HTML content
+ * during the main tabs page.  It allows HTML content to be rendered that will stick around through every sub tab content
+ * frame.
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\Main\Tabs;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class RenderEvent extends Event
+{
+    const EVENT_BODY_RENDER_PRE = "main.body.render.pre";
+    const EVENT_BODY_RENDER_POST = "main.body.render.post";
+}

--- a/src/Events/PatientPortal/AppointmentFilterEvent.php
+++ b/src/Events/PatientPortal/AppointmentFilterEvent.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * AppointmentFilterEvent allows you to filter the patient appointment records and add any additional data elements or
+ * properties to appointments that will be sent to the patient appointment templates
+ * @see templates/portal/appointment-item.html.twig for reference
+ *
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\PatientPortal;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class AppointmentFilterEvent extends Event
+{
+    /**
+     * ,
+    ['dbRecord' => $row, 'appointment' => $formattedRecord]
+     */
+    public const EVENT_NAME = 'home.appointment.filter';
+
+    /**
+     * @var array
+     */
+    private $dbRecord;
+
+    /**
+     * @var array
+     */
+    private $appointment;
+
+    public function __construct($dbRecord, $appointment)
+    {
+        $this->setDbRecord($dbRecord);
+        $this->setAppointment($appointment);
+    }
+
+    /**
+     * @return array
+     */
+    public function getDbRecord(): array
+    {
+        return $this->dbRecord;
+    }
+
+    /**
+     * @param array $dbRecord
+     * @return AppointmentFilterEvent
+     */
+    public function setDbRecord(array $dbRecord): AppointmentFilterEvent
+    {
+        $this->dbRecord = $dbRecord;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAppointment(): array
+    {
+        return $this->appointment;
+    }
+
+    /**
+     * @param array $appointment
+     * @return AppointmentFilterEvent
+     */
+    public function setAppointment(array $appointment): AppointmentFilterEvent
+    {
+        $this->appointment = $appointment;
+        return $this;
+    }
+}

--- a/src/Events/PatientPortal/RenderEvent.php
+++ b/src/Events/PatientPortal/RenderEvent.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * RenderEvent is used to launch different rendering action points that developers can output their own HTML content
+ * during the portal's SPA page lifecycle.
+ * frame.
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\PatientPortal;
+
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+class RenderEvent extends GenericEvent
+{
+    /**
+     * Allows screen output after all of the sections have been rendered for the portal home Single Page Application (SPA)
+     */
+    const EVENT_SECTION_RENDER_POST = "home.section.render.post";
+
+    /**
+     * Allows screen output in the scripts section before any other scripts have been loaded
+     */
+    const EVENT_SCRIPTS_RENDER_PRE = 'home.scripts.render.pre';
+}

--- a/templates/portal/appointment-item.html.twig
+++ b/templates/portal/appointment-item.html.twig
@@ -1,0 +1,15 @@
+<div class="card p-2">
+    <div class="card-header">
+        <a href="#" onclick="editAppointment({{ appt.mode | attr_js }},{{ appt.pc_eid | attr_js }})" title="{{ appt.etitle | attr }}">
+            <i class='float-right fa fa-edit {% if appt.pc_recurrtype > 0 %} text-danger {% else %} text-success {% endif %} bg-light'></i>
+        </a>
+    </div>
+    <div class="body font-weight-bold">
+        <p>
+            {{ appt.appointmentDate | text }}<br>
+            {{ appt.appointmentType | text }}<br>
+            {{ appt.provider | text }}<br>
+            {{ appt.status | text }}
+        </p>
+    </div>
+</div>

--- a/templates/portal/home.html.twig
+++ b/templates/portal/home.html.twig
@@ -318,6 +318,7 @@
 
 		{% endif %}
 	</script>
+	{{ fireEvent(eventNames.scriptsRenderPre) }}
 
 {% endblock %}
 
@@ -394,21 +395,7 @@
 
 							{% for appt in appointments %}
 
-								<div class="card p-2">
-									<div class="card-header">
-										<a href="#" onclick="editAppointment({{ appt.mode | attr_js }},{{ appt.pc_eid | attr_js }})" title="{{ appt.etitle | attr }}">
-											<i class='float-right fa fa-edit {% if appt.pc_recurrtype > 0 %} text-danger {% else %} text-success {% endif %} bg-light'></i>
-										</a>
-									</div>
-									<div class="body font-weight-bold">
-										<p>
-											{{ appt.appointmentDate | text }}<br>
-											{{ appt.appointmentType | text }}<br>
-											{{ appt.provider | text }}<br>
-											{{ appt.status | text }}
-										</p>
-									</div>
-								</div>
+								{% include 'portal/appointment-item.html.twig' with {appt: appt} %}
 							{% endfor %}
 
 							{% if appointmentLimit == appointmentCount %}
@@ -483,6 +470,8 @@
 					<div id="pro" class="card-body bg-light"></div>
 				</div>
 			{% endif %}
+
+		{{ fireEvent(eventNames.sectionRenderPost) }}
 
 		</section>
 	{% endblock %}


### PR DESCRIPTION
Added events to OpenEMR main tabs screen for outputting html at the end of the body tag and at the start of the body tag.
Added event to filter appointments in the portal home page.
Added event to render output at the end of the portal sections and before the scripts of the portal.
Refactored the appointments into a separate twig file that module writers can overwrite.