### PR TITLE
Add the inserted id to the patient event data

### DIFF
--- a/src/Services/PatientService.php
+++ b/src/Services/PatientService.php
@@ -149,6 +149,7 @@ class PatientService extends BaseService
             $sql,
             $query['bind']
         );
+        $data['id'] = $results;
 
         // Tell subscribers that a new patient has been created
         $patientCreatedEvent = new PatientCreatedEvent($data);


### PR DESCRIPTION
Really quick and simple fix as apparently we weren't sending the inserted id into the patient event data.  Didn't realize I needed this until everything else was done... should be my last thing tonight lol.