### PR TITLE
Encounter Screen UI Improvements

### DIFF
--- a/interface/patient_file/encounter/forms.php
+++ b/interface/patient_file/encounter/forms.php
@@ -352,7 +352,6 @@ function refreshVisitDisplay() {
     div.formname {
         float: left;
         min-width: 160px;
-        font-weight: bold;
         padding: 0;
         margin: 0;
     }
@@ -959,24 +958,31 @@ if (
         } else {
             $form_author = ($user['fname'] ?? '') . "  " . ($user['lname'] ?? '');
         }
-        echo "<div class='form_header'>";
-        echo "<a href='#' data-toggle='collapse' data-target='#divid_" . attr($divnos) . "' class='small' id='aid_" . attr($divnos) . "'>" .
-          "<div class='formname' title='" . xla('Expand/Collapse this form') . "'>" . text($form_name) . "</div> " . xlt('by') . " " . text($form_author) . " " .
-          "</a>";
-        echo "</div>";
-
-        // a link to edit the form
-        echo "<div class='form_header_controls btn-group' role='group'>";
+        $div_nums_attr = attr($divnos);
+        $title = xla("Expand/Collapse this form");
+        $display = text($form_name) . " " . xlt("by") . " " . text($form_author);
+        $author_text = text($form_author);
+        $by_text = xlt("by");
+        $form_text = text($form_name);
+        echo <<<HTML
+        <div class="form_header">
+            <a href="#" data-toggle="collapse" data-target="#divid_{$div_nums_attr}" class="" id="aid_{$div_nums_attr}">
+                <h5>{$form_text}</h5>
+                {$by_text} {$author_text}
+            </a>
+        </div>
+        <div class='form_header_controls btn-group' role='group'>
+        HTML;
 
         // If the form is locked, it is no longer editable
         if ($esign->isLocked()) {
-                 echo "<a href=# class='btn btn-primary btn-sm form-edit-button-locked' id='form-edit-button-" . attr($formdir) . "-" . attr($iter['id']) . "'>" . xlt('Locked') . "</a>";
+                 echo "<a href=# class='btn btn-secondary btn-sm form-edit-button-locked' id='form-edit-button-" . attr($formdir) . "-" . attr($iter['id']) . "'>" . xlt('Locked') . "</a>";
         } else {
             if (
                 (!$aco_spec || AclMain::aclCheckCore($aco_spec[0], $aco_spec[1], '', 'write') and $is_group == 0 and $authPostCalendarCategoryWrite)
                 or (((!$aco_spec || AclMain::aclCheckCore($aco_spec[0], $aco_spec[1], '', 'write')) and $is_group and AclMain::aclCheckCore("groups", "glog", false, 'write')) and $authPostCalendarCategoryWrite)
             ) {
-                echo "<a class='btn btn-primary btn-sm form-edit-button btn-edit' " .
+                echo "<a class='btn btn-secondary btn-sm form-edit-button btn-edit' " .
                     "id='form-edit-button-" . attr($formdir) . "-" . attr($iter['id']) . "' " .
                     "href='#' " .
                     "title='" . xla('Edit this form') . "' " .
@@ -1000,7 +1006,7 @@ if (
             "&formid="    . attr_url($iter['form_id']) .
             "&visitid="   . attr_url($encounter)       .
             "&patientid=" . attr_url($pid)             .
-            "' class='btn btn-primary btn-sm' title='" . xla('Print this form') .
+            "' class='btn btn-secondary btn-sm' title='" . xla('Print this form') .
             "' onclick='top.restoreSession()'>" . xlt('Print') . "</a>";
         }
 
@@ -1018,7 +1024,7 @@ if (
             }
         }
 
-        echo "<a class='btn btn-primary btn-sm collapse-button-form' title='" . xla('Expand/Collapse this form') . "' data-toggle='collapse' data-target='#divid_" . attr($divnos) . "'>" . xlt('Expand / Collapse') . "</a>";
+        echo "<a class='btn btn-secondary btn-sm collapse-button-form' title='" . xla('Expand/Collapse this form') . "' data-toggle='collapse' data-target='#divid_" . attr($divnos) . "'>" . xlt('Expand / Collapse') . "</a>";
         echo "</div>\n"; // Added as bug fix.
 
         echo "</td>\n";

--- a/interface/patient_file/encounter/forms.php
+++ b/interface/patient_file/encounter/forms.php
@@ -20,7 +20,6 @@ require_once("$srcdir/amc.php");
 require_once($GLOBALS['srcdir'] . '/ESign/Api.php');
 require_once("$srcdir/../controllers/C_Document.class.php");
 
-use Acl\Model\Acl;
 use ESign\Api;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;

--- a/interface/patient_file/encounter/forms.php
+++ b/interface/patient_file/encounter/forms.php
@@ -648,8 +648,6 @@ echo $t->render('encounter/forms/navbar.html.twig', [
 
         </div>
     </div>
-</div>
-
 <div class='encounter-summary-column'>
 <?php if ($esign->isLogViewable()) {
     $esign->renderLog();

--- a/library/ESign/views/form/esign_button.php
+++ b/library/ESign/views/form/esign_button.php
@@ -23,4 +23,4 @@
  **/
 
 ?>
-<a target="<?php echo $this->target; ?>" href="#esign-mask-content" class="esign-button-form btn btn-primary btn-sm" data-formdir="<?php echo attr($this->formDir); ?>" data-formid="<?php echo attr($this->formId); ?>" data-encounterid="<?php echo attr($this->encounterId); ?>"><?php echo xlt('eSign'); ?></a>
+<a target="<?php echo $this->target; ?>" href="#esign-mask-content" class="esign-button-form btn btn-secondary btn-sm" data-formdir="<?php echo attr($this->formDir); ?>" data-formid="<?php echo attr($this->formId); ?>" data-encounterid="<?php echo attr($this->encounterId); ?>"><i class="fa fa-signature"></i>&nbsp;<?php echo xlt('eSign'); ?></a>

--- a/src/Common/Twig/TwigExtension.php
+++ b/src/Common/Twig/TwigExtension.php
@@ -207,8 +207,8 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
 
             new TwigFilter(
                 'xlFormTitle',
-                function ($string, $mode = 'r', $prepend = '', $append = '') {
-                    return xl_form_title($string, $mode, $prepend, $append);
+                function ($string) {
+                    return xl_form_title($string);
                 }
             )
         ];

--- a/src/Common/Twig/TwigExtension.php
+++ b/src/Common/Twig/TwigExtension.php
@@ -203,6 +203,13 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
                 function ($string) {
                     return xl_document_category($string);
                 }
+            ),
+
+            new TwigFilter(
+                'xlFormTitle',
+                function ($string, $mode = 'r', $prepend = '', $append = '') {
+                    return xl_form_title($string, $mode, $prepend, $append);
+                }
             )
         ];
     }

--- a/templates/encounter/forms/navbar.html.twig
+++ b/templates/encounter/forms/navbar.html.twig
@@ -13,37 +13,37 @@
             {% for category, details in menuArray %}
                 {% if details.children is iterable %}
                     <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle" href="#" id="category_{{ category|xla }}" role="button" data-toggle="dropdown" aria-expanded="false">
-                            {{ category }}
+                        <a class="nav-link dropdown-toggle" href="#" id="category_{{ category|e('html_attr') }}" role="button" data-toggle="dropdown" aria-expanded="false">
+                            {{ category|e }}
                         </a>
-                        <div class="dropdown-menu" aria-labelledby="category_{{ category|xla }}">
+                        <div class="dropdown-menu" aria-labelledby="category_{{ category|e('html_attr') }}">
                             {% for item in details.children %}
                                 {% set formURL = rootdir ~ "/patient_file/encounter/load_form.php?formname=" ~ item.directory|url_encode %}
-                                <a href="#" class="dropdown-item" onclick="openNewForm('{{ formURL }}', {{ item.displayText|xlFormTitle|attr_js }})">{{ item.displayText|xlFormTitle|text }}</a>
+                                <a href="#" class="dropdown-item" onclick="openNewForm({{ formURL|json_encode|e('html_attr') }}, {{ item.displayText|xlFormTitle|json_encode|e('html_attr') }})">{{ item.displayText|xlFormTitle|e }}</a>
                             {% endfor %}
                         </div>
                     </li>
                 {% else %}
                     <li class="nav-item">
-                        <a class="nav-link" href="#">{{ category }}</a>
+                        <a class="nav-link" href="#">{{ category|e }}</a>
                     </li>
                 {% endif %}
             {% endfor %}
             {% for category, details in moduleMenuArray %}
                 {% if details.children is iterable %}
                     <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle" href="#" id="category_{{ category|xla }}" role="button" data-toggle="dropdown" aria-expanded="false">
-                            {{ category }}
+                        <a class="nav-link dropdown-toggle" href="#" id="category_{{ category|e('html_attr') }}" role="button" data-toggle="dropdown" aria-expanded="false">
+                            {{ category|e }}
                         </a>
-                        <div class="dropdown-menu" aria-labelledby="category_{{ category|xla }}">
+                        <div class="dropdown-menu" aria-labelledby="category_{{ category|e('html_attr') }}">
                             {% for item in details.children %}
-                                <a href="#" class="dropdown-item" onclick="openNewForm('{{ item.href }}', {{ item.menu_name|xlFormTitle|attr_js }})">{{ item.menu_name|xlFormTitle|text }}</a>
+                                <a href="#" class="dropdown-item" onclick="openNewForm({{ item.href|json_encode|e('html_attr') }}, {{ item.menu_name|xlFormTitle|json_encode|e('html_attr') }})">{{ item.menu_name|xlFormTitle|e }}</a>
                             {% endfor %}
                         </div>
                     </li>
                 {% else %}
                     <li class="nav-item">
-                        <a class="nav-link" href="#">{{ category }}</a>
+                        <a class="nav-link" href="#">{{ category|e }}</a>
                     </li>
                 {% endif %}
             {% endfor %}

--- a/templates/encounter/forms/navbar.html.twig
+++ b/templates/encounter/forms/navbar.html.twig
@@ -13,37 +13,37 @@
             {% for category, details in menuArray %}
                 {% if details.children is iterable %}
                     <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle" href="#" id="category_{{ category|e('html_attr') }}" role="button" data-toggle="dropdown" aria-expanded="false">
-                            {{ category|e }}
+                        <a class="nav-link dropdown-toggle" href="#" id="category_{{ category|attr }}" role="button" data-toggle="dropdown" aria-expanded="false">
+                            {{ category|text }}
                         </a>
-                        <div class="dropdown-menu" aria-labelledby="category_{{ category|e('html_attr') }}">
+                        <div class="dropdown-menu" aria-labelledby="category_{{ category|attr }}">
                             {% for item in details.children %}
                                 {% set formURL = rootdir ~ "/patient_file/encounter/load_form.php?formname=" ~ item.directory|url_encode %}
-                                <a href="#" class="dropdown-item" onclick="openNewForm({{ formURL|json_encode|e('html_attr') }}, {{ item.displayText|xlFormTitle|json_encode|e('html_attr') }})">{{ item.displayText|xlFormTitle|e }}</a>
+                                <a href="#" class="dropdown-item" onclick="openNewForm({{ formURL|attr_js }}, {{ item.displayText|xlFormTitle|attr_js }})">{{ item.displayText|xlFormTitle|text }}</a>
                             {% endfor %}
                         </div>
                     </li>
                 {% else %}
                     <li class="nav-item">
-                        <a class="nav-link" href="#">{{ category|e }}</a>
+                        <a class="nav-link" href="#">{{ category|text }}</a>
                     </li>
                 {% endif %}
             {% endfor %}
             {% for category, details in moduleMenuArray %}
                 {% if details.children is iterable %}
                     <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle" href="#" id="category_{{ category|e('html_attr') }}" role="button" data-toggle="dropdown" aria-expanded="false">
-                            {{ category|e }}
+                        <a class="nav-link dropdown-toggle" href="#" id="category_{{ category|attr }}" role="button" data-toggle="dropdown" aria-expanded="false">
+                            {{ category|text }}
                         </a>
-                        <div class="dropdown-menu" aria-labelledby="category_{{ category|e('html_attr') }}">
+                        <div class="dropdown-menu" aria-labelledby="category_{{ category|attr }}">
                             {% for item in details.children %}
-                                <a href="#" class="dropdown-item" onclick="openNewForm({{ item.href|json_encode|e('html_attr') }}, {{ item.menu_name|xlFormTitle|json_encode|e('html_attr') }})">{{ item.menu_name|xlFormTitle|e }}</a>
+                                <a href="#" class="dropdown-item" onclick="openNewForm({{ item.href|attr_js }}, {{ item.menu_name|xlFormTitle|attr_js }})">{{ item.menu_name|xlFormTitle|text }}</a>
                             {% endfor %}
                         </div>
                     </li>
                 {% else %}
                     <li class="nav-item">
-                        <a class="nav-link" href="#">{{ category|e }}</a>
+                        <a class="nav-link" href="#">{{ category|text }}</a>
                     </li>
                 {% endif %}
             {% endfor %}

--- a/templates/encounter/forms/navbar.html.twig
+++ b/templates/encounter/forms/navbar.html.twig
@@ -1,0 +1,46 @@
+{% block navbar %}
+<nav class="navbar navbar-expand-lg navbar-light bg-light">
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+    </button>
+
+    <span class="navbar-brand">
+        {{ encounterDate|text }} {{ (groupEncounter == true) ? "Group Encounter"|xlt : "Encounter"|xlt}} {{ "for"|xlt }} {{ patientName|text }}
+    </span>
+
+    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <ul class="navbar-nav mx-auto">
+            {% for category, details in menuArray %}
+                {% if details.children is iterable %}
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle" href="#" id="category_{{ category|xla }}" role="button" data-toggle="dropdown" aria-expanded="false">
+                            {{ category }}
+                        </a>
+                        <div class="dropdown-menu" aria-labelledby="category_{{ category|xla }}">
+                            {% for item in details.children %}
+                                {% set formURL = rootdir ~ "/patient_file/encounter/load_form.php?formname=" ~ item.directory|url_encode %}
+                                <a href="#" class="dropdown-item" onclick="openNewForm('{{ formURL }}', {{ item.displayText|xlFormTitle|attr_js }})">{{ item.displayText|xlFormTitle|text }}</a>
+                            {% endfor %}
+                        </div>
+                    </li>
+                {% else %}
+                    <li class="nav-item">
+                        <a class="nav-link" href="#">{{ category }}</a>
+                    </li>
+                {% endif %}
+            {% endfor %}
+        </ul>
+
+        <ul class="navbar-nav ml-auto">
+            {% if enableFollowUpEncounters %}
+            <li class="nav-item"><a href="#" class="nav-link" onclick="return createFollowUpEncounter()">{{ "Create follow-up encounter"|xlt }}</a></li>
+            {% endif %}
+            <li class="nav-item"><a href="#" onClick="$('.formrow .collapse').collapse('hide');" class="nav-link"><i class="fa fa-compress-alt"></i>&nbsp;{{ "Collapse All"|xlt }}</a></li>
+            <li class="nav-item"><a href="#" onClick="$('.formrow .collapse').collapse('show');" class="nav-link"><i class="fa fa-expand-alt"></i>&nbsp;{{ "Expand All"|xlt }}</a></li>
+            {% if isAdminSuper %}
+            <li class="nav-item"><a href="#" class="nav-link text-danger btn-delete" onclick="return deleteme()">{{ "Delete"|xlt }}</a></li>
+            {% endif %}
+        </ul>
+    </div>
+</nav>
+{% endblock %}

--- a/templates/encounter/forms/navbar.html.twig
+++ b/templates/encounter/forms/navbar.html.twig
@@ -29,8 +29,25 @@
                     </li>
                 {% endif %}
             {% endfor %}
+            {% for category, details in moduleMenuArray %}
+                {% if details.children is iterable %}
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle" href="#" id="category_{{ category|xla }}" role="button" data-toggle="dropdown" aria-expanded="false">
+                            {{ category }}
+                        </a>
+                        <div class="dropdown-menu" aria-labelledby="category_{{ category|xla }}">
+                            {% for item in details.children %}
+                                <a href="#" class="dropdown-item" onclick="openNewForm('{{ item.href }}', {{ item.menu_name|xlFormTitle|attr_js }})">{{ item.menu_name|xlFormTitle|text }}</a>
+                            {% endfor %}
+                        </div>
+                    </li>
+                {% else %}
+                    <li class="nav-item">
+                        <a class="nav-link" href="#">{{ category }}</a>
+                    </li>
+                {% endif %}
+            {% endfor %}
         </ul>
-
         <ul class="navbar-nav ml-auto">
             {% if enableFollowUpEncounters %}
             <li class="nav-item"><a href="#" class="nav-link" onclick="return createFollowUpEncounter()">{{ "Create follow-up encounter"|xlt }}</a></li>


### PR DESCRIPTION
This PR moves the button-based, centered form-navigation on the Encounter screen to an bootstrap navbar. Additionally, it moves btn-primary buttons to more appropriate btn-secondary classes. Some small changes to the form title as well as prepping some inline code for a twig overhaul. The new navbar leverages twig. Fun fact, you don't have to migrate the ENTIRE page to twig in one go, it's flexible enough to take a phased approach.