### PR TITLE
couple fixes in edit layout

### DIFF
--- a/interface/super/edit_layout.php
+++ b/interface/super/edit_layout.php
@@ -1472,9 +1472,9 @@ function myChangeCheck() {
 
 <?php if ($layout_id) { ?>
 <div class="btn-group ml-auto">
-    <button type='button' class='btn btn-secondary btn-sm' onclick='edit_layout_props("")'><?php echo xla('Layout Properties'); ?></button>
-    <button type='button' class='btn btn-secondary btn-sm addgroup' id='addgroup'><?php echo xla('Add Group'); ?></button>
-    <button type='button' class="btn btn-primary btn-save btn-sm" name='save' id='save'><?php echo xla('Save Changes'); ?></button>
+    <button type='button' class='btn btn-secondary btn-sm' onclick='edit_layout_props("")'><?php echo xlt('Layout Properties'); ?></button>
+    <button type='button' class='btn btn-secondary btn-sm addgroup' id='addgroup'><?php echo xlt('Add Group'); ?></button>
+    <button type='button' class="btn btn-primary btn-save btn-sm" name='save' id='save'><?php echo xlt('Save Changes'); ?></button>
 </div>
 <br>
     <?php echo xlt('With selected');?>:&nbsp;
@@ -1488,7 +1488,7 @@ function myChangeCheck() {
 <input type='button' class='btn btn-secondary btn-sm' value='<?php echo xla('Tips'); ?>' onclick='$("#tips").toggle();' />&nbsp;
 <input type='button' class='btn btn-secondary btn-sm' value='<?php echo xla('Encounter Preview'); ?>' onclick='layoutLook();' />
 <?php } else { ?>
-<button type='button' class='btn btn-primary btn-sm btn-add btn-new' onclick='edit_layout_props("")'><?php echo xla('New Layout'); ?></button>
+<button type='button' class='btn btn-primary btn-sm btn-add btn-new' onclick='edit_layout_props("")'><?php echo xlt('New Layout'); ?></button>
 <?php } ?>
 
 <div id="tips" class="container tips">
@@ -1567,31 +1567,31 @@ if ($layout_id) {
             $group_id_attr = attr($group_id);
             $group_id_attr_js = attr_js($group_id);
             $t_vars = [
-                "xla_add_field" => xla("Add Field"),
-                "xla_rename_group" => xla("Rename Group"),
-                "xla_delete_group" => xla("Delete Group"),
-                "xla_move_up" => xla("Move Up"),
-                "xla_move_down" => xla("Move Down"),
-                "xla_group_props" => xla("Group Properties"),
+                "xlt_add_field" => xlt("Add Field"),
+                "xlt_rename_group" => xlt("Rename Group"),
+                "xlt_delete_group" => xlt("Delete Group"),
+                "xlt_move_up" => xlt("Move Up"),
+                "xlt_move_down" => xlt("Move Down"),
+                "xlt_group_props" => xlt("Group Properties"),
                 'text_group_name' => text($gdispname),
-                'translate_layout' > ($GLOBALS['translate_layout'] && $_SESSION['language_choice'] > 1) ? xlt($gdispname) : "",
+                'translate_group_name' => ($GLOBALS['translate_layout'] && $_SESSION['language_choice'] > 1) ? xlt($gdispname) : "",
                 'attr_gmyname' => attr($gmyname),
             ];
             echo <<<HTML
             <nav class="navbar navbar-expand-lg navbar-light bg-light sticky-top">
-                <span class="navbar-brand">{$t_vars['translate_layout']}&nbsp;{$t_vars['text_group_name']}</span>
+                <span class="navbar-brand">{$t_vars['text_group_name']}&nbsp;<span class='text-success'>{$t_vars['translate_group_name']}</span></span>
                 <div class="btn-toolbar" role="toolbar" aria-label="Group Toolbar">
                     <div class="btn-group mr-2" role="group" aria-label="Field Group">
-                        <button type="button" class="addfield btn btn-secondary btn-add btn-sm" id="addto~{$group_id_attr}">{$t_vars['xla_add_field']}</button>
+                        <button type="button" class="addfield btn btn-secondary btn-add btn-sm" id="addto~{$group_id_attr}">{$t_vars['xlt_add_field']}</button>
                     </div>
                     <div class="btn-group ml-2 mr-2" role="group" aria-label="Move Group">
-                        <button type="button" class="movegroup btn btn-secondary btn-sm" id="{$group_id_attr}~up"><i class="fa fa-angle-up"></i>&nbsp;{$t_vars['xla_move_up']}</button>
-                        <button type="button" class="movegroup btn btn-secondary btn-sm" id="{$group_id_attr}~down"><i class="fa fa-angle-down"></i>&nbsp;{$t_vars['xla_move_down']}</button>
+                        <button type="button" class="movegroup btn btn-secondary btn-sm" id="{$group_id_attr}~up"><i class="fa fa-angle-up"></i>&nbsp;{$t_vars['xlt_move_up']}</button>
+                        <button type="button" class="movegroup btn btn-secondary btn-sm" id="{$group_id_attr}~down"><i class="fa fa-angle-down"></i>&nbsp;{$t_vars['xlt_move_down']}</button>
                     </div>
                     <div class="btn-group mr-2" role="group" aria-label="Group Options">
-                        <button type="button" class="renamegroup btn btn-secondary btn-sm" id="{$group_id_attr}~{$t_vars['attr_gmyname']}">{$t_vars['xla_rename_group']}</button>
-                        <button type="button" class="btn btn-secondary btn-sm" onclick="edit_layout_props({$group_id_attr_js})">{$t_vars['xla_group_props']}</button>
-                        <button type="button" class="deletegroup btn btn-secondary text-danger btn-sm" id="{$group_id_attr}">{$t_vars['xla_delete_group']}</button>
+                        <button type="button" class="renamegroup btn btn-secondary btn-sm" id="{$group_id_attr}~{$t_vars['attr_gmyname']}">{$t_vars['xlt_rename_group']}</button>
+                        <button type="button" class="btn btn-secondary btn-sm" onclick="edit_layout_props({$group_id_attr_js})">{$t_vars['xlt_group_props']}</button>
+                        <button type="button" class="deletegroup btn btn-secondary text-danger btn-sm" id="{$group_id_attr}">{$t_vars['xlt_delete_group']}</button>
                     </div>
                 </div>
 

--- a/templates/admin/lbf/edit_lbf/partials/group_header.html.twig
+++ b/templates/admin/lbf/edit_lbf/partials/group_header.html.twig
@@ -1,0 +1,30 @@
+{% block nav %}
+<header class="d-flex w-100 p-2 bg-light border-bottom sticky-top align-items-center group-header">
+    <div>
+        <h5>{{ displayName|text }}&nbsp;<span class='text-success'>{{ translateGroupName|xlt }}</span></h5>
+    </div>
+    <div class="btn-toolbar ml-auto" role="toolbar" aria-label="Group Toolbar">
+        <div class="btn-group btn-group-sm mr-2" role="group" aria-label="Field Group">
+            <button type="button" class="addfield btn btn-secondary btn-add" id="addto~{{ groupID|attr}}">{{ "Add Field"|xlt }}</button>
+        </div>
+        <div class="btn-group btn-group-sm ml-2 mr-2" role="group" aria-label="Move Group">
+            <button type="button" class="movegroup btn btn-secondary" id="{{ groupID|attr }}~up">
+                <i class="fa fa-angle-up"></i>&nbsp;{{ "Move Up"|xlt }}
+            </button>
+            <button type="button" class="movegroup btn btn-secondary" id="{{ groupID|attr }}~down">
+                <i class="fa fa-angle-down"></i>&nbsp;{{ "Move Down"|xlt }}
+            </button>
+        </div>
+        <div class="btn-group btn-group-sm mr-2" role="group" aria-label="Group Options">
+            <div class="btn-group btn-group-sm" role="group">
+                <button id="btnGroupProps" type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-expanded="false">{{ "Group Settings"|xlt }}</button>
+                <div class="dropdown-menu dropdown-menu-right" aria-labelledby="btnGroupProps">
+                    <a href="#" class="dropdown-item renamegroup" id="{{ groupID|attr}}~{{ gMyName|attr }}">{{ "Rename Group"|xlt }}</a>
+                    <a href="#" class="dropdown-item" onclick="edit_layout_props({{ groupID|json_encode|attr }})">{{ "Group Properties"|xlt }}</a>
+                    <a href="#" class="dropdown-item text-danger deletegroup" id="{{ groupID|attr }}">{{ "Delete Group"|xlt }}</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</header>
+{% endblock %}

--- a/templates/admin/lbf/edit_lbf/partials/hidden_fields.html.twig
+++ b/templates/admin/lbf/edit_lbf/partials/hidden_fields.html.twig
@@ -1,0 +1,14 @@
+<input type="hidden" name="csrf_token_form" value="{{ csrf|attr }}" />
+<input type="hidden" name="formaction" id="formaction" value="" />
+<!-- elements used to identify a field to delete -->
+<input type="hidden" name="deletefieldid" id="deletefieldid" value="" />
+<input type="hidden" name="deletefieldgroup" id="deletefieldgroup" value="" />
+<!-- elements used to identify a group to delete -->
+<input type="hidden" name="deletegroupid" id="deletegroupid" value="">
+<!-- elements used to change the group order -->
+<input type="hidden" name="movegroupname" id="movegroupname" value="" />
+<input type="hidden" name="movedirection" id="movedirection" value="" />
+<!-- elements used to select more than one field -->
+<input type="hidden" name="selectedfields" id="selectedfields" value="" />
+<input type="hidden" id="targetgroup" name="targetgroup" value="" />
+<input type="hidden" id="targetlayout" name="targetlayout" value="" />

--- a/templates/admin/lbf/edit_lbf/partials/layout_toolbar.html.twig
+++ b/templates/admin/lbf/edit_lbf/partials/layout_toolbar.html.twig
@@ -1,0 +1,19 @@
+<div class="btn-toolbar ml-auto" role="toolbar" aria-label="{{ "Layout toolbar"|xla }}">
+    {% if layoutID %}
+    <div class="mr-2 btn-group btn-group-sm">
+        <button type="button" class="btn btn-secondary" onclick="edit_layout_props('')">
+            <i class="fa fa-cog"></i>&nbsp;{{ "Layout Properties"|xlt }}
+        </button>
+        <button type="button" class="btn btn-secondary btn-add" data-toggle="modal" data-target="#newgroup" onclidk="AddGroup()">{{ "Add Group"|xlt }}</button>
+        <button type="button" class="btn btn-primary btn-save" name="save" id="save">{{ "Save Changes"|xlt }}</button>
+    </div>
+    {% else %}
+    <div class="mr-2 btn-group btn-group-sm">
+        <button type="button" class="btn btn-primary btn-add btn-new" onclick="edit_layout_props('')">{{ "New Layout"|xlt }}</button>
+    </div>
+    {% endif %}
+    <div class="mr-2 btn-group btn-group-sm">
+        <button type="button" class="btn btn-secondary" data-toggle="modal" data-target="#tips">{{ "Tips"|xlt }}</button>
+        <button type="button" class="btn btn-secondary" onclick="layoutLook();">{{ "Encounter Preview"|xlt }}</button>
+    </div>
+</div>

--- a/templates/admin/lbf/edit_lbf/partials/main_menu.html.twig
+++ b/templates/admin/lbf/edit_lbf/partials/main_menu.html.twig
@@ -1,0 +1,18 @@
+<div class="fixed-top p-1 bg-light text-dark">
+    <div class="d-flex">
+        <div class="mr-3">
+            {{ "Edit layout"|xlt }}&nbsp;
+            <select name='layout_id' id='layout_id' class='form-control form-control-sm d-inline-block w-50 mb-1'>
+                {{ layoutIDOpts }}
+            </select>
+            <label>
+                <input type='checkbox' name='form_inactive' value='1'
+                    title='{{ "This will abandon any edits!"|xla }}'
+                    onclick='inactiveClicked()' {{ (formInactive) ? "checked" : "" }} />
+                    {{ "Include inactive"|xlt }}
+            </label>
+        </div>
+        {{ include("admin/lbf/edit_lbf/partials/layout_toolbar.html.twig") }}
+        {{ include("admin/lbf/edit_lbf/partials/with_selected.html.twig") }}
+    </div>
+</div>

--- a/templates/admin/lbf/edit_lbf/partials/modify_group.html.twig
+++ b/templates/admin/lbf/edit_lbf/partials/modify_group.html.twig
@@ -1,0 +1,37 @@
+<!-- template DIV that appears when user chooses to add a new group -->
+<div class="modal" id="{{ id }}group" tabindex="-1" aria-labelledby="{{ id }}GroupModal" aria-hidden="false">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                {% set modalTitle = (id == "rename") ? "Rename Group" : "Add New Group" %}
+                {% set btnSaveValue = (id == "rename") ? "Rename Group" : "Save New Group" %}
+                <h5 class="modal-title" id="{{ id }}GroupModal">{{ modalTitle|xlt }}</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="{{ 'Close'|xla }}">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                {% if id == "rename" %}
+                    <input type="hidden" name="renameoldgroupname" id="renameoldgroupname" value="" />
+                {% endif %}
+                <div class="form-group">
+                    <label for="{{ id }}groupname" class="form-label">{{ "Group Name"|xlt }}</label>
+                    <input type="text" size="20" maxlength="30" name="{{ id }}groupname" id="{{ id }}groupname" class="form-control">
+                </div>
+                <div class="form-group">
+                    <label for="{{ id }}groupparent" class="form-label">{{ "Parent"|xlt }}</label>
+                    <select name="{{ id }}groupparent" class="select2 form-control" id="{{ id }}group_parent">
+                        <option value="">{{ "None{{group}}"|xlt }}</option>
+                        {% for group in groups %}
+                            <option value="{{ group.id|attr }}" {{ group.default }}>{{ group.title|text }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-link cancel{{ id }}group" data-dismiss="modal">{{ 'Cancel'|xl }}</button>
+                <button type="button" class="btn btn-primary btn-save save{{ id }}group">{{ btnSaveValue|xl }}</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/templates/admin/lbf/edit_lbf/partials/tips.html.twig
+++ b/templates/admin/lbf/edit_lbf/partials/tips.html.twig
@@ -1,0 +1,26 @@
+<div class="modal" id="tips" tabindex="-1" aria-labelledby="tipsModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="tipsModalLabel">{{ "Usage Tips"|xlt }}</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="{{ 'Close'|xla }}">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <ul>
+            <li>{{ "Clicking Options will present a multiselection drop menu to add behaviors to the selected data type. Typing after pull down activates allows search in options."|xlt }}</li>
+            <li>{{ "The option Span Entire Row is useful when using Static Text in allowing text to wrap and span entire row regardless of column settings. Another use could be to create an empty row as spacer or add additional option Add Bottom Border to create a line break.Only Bottom Border Row is useful here."|xlt }}</li>
+            <li>{{ "The options for Outline and Border will either wrap a row in thin border or add a border to the bottom of an item."|xlt }}</li>
+            <li>{{ "If a field's Label Col = 0 the label will immediately follow the previous data field in the Order sequence, on the same line as the Data field."|xlt }}</li>
+            <li>{{ "If a field's Data Col = 0 the data field will immediately follow its label field on the same line"|xlt }}</li>
+            <li>{{ "If a field's Label Col = 1 the label field will go to a new line unless the previous field's total column values (Label + Data) is less than number of Layout columns from Group Properties or Layout Properties."|xlt }}</li>
+            <li>{{ "Generally, the first field in a group should be Label Cols = 1 Data Cols = number of Layout columns from Group Properties."|xlt }}</li>
+            <li>{{ "Make subsequent fields in the same row, Label = 0 Data = 0 and ensure enough columns are available from previous items to allow space for this new item. Otherwise result could be unpredictable"|xlt }}</li>
+            <li>{{ "The Encounter Preview button is useful for showing encounter type layout forms as seen when using form in an encounter. Note, this feature is only useful for showing encounter forms and won't display system forms like Demographics"|xlt }}</li>
+            <li>{{ "Please see http://www.open-emr.org/wiki/index.php/LBV_Forms for more on this topic"|xlt }}</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>

--- a/templates/admin/lbf/edit_lbf/partials/with_selected.html.twig
+++ b/templates/admin/lbf/edit_lbf/partials/with_selected.html.twig
@@ -1,0 +1,13 @@
+{% block withSelected %}
+{% set layoutID = true %}
+    {% if layoutID %}
+        <div class="with-selected mr-auto d-none border-left pl-2">
+            <span>{{ 'With selected'|xlt }}:&nbsp;</span>
+            <div class="btn-group btn-group-sm">
+                <button type='button' class='btn btn-secondary btn-sm' name='movefields' id='movefields' disabled><i class="fa fa-angle-double-right"></i>&nbsp;{{ "Move"|xlt }}</button>
+                <button type="button" class="btn btn-secondary btn-sm" name="copyfields" id="copyfields" disabled><i class="fa fa-copy"></i>&nbsp;{{ "Copy"|xlt }}</button>
+                <button type='button' class='btn btn-secondary btn-sm btn-delete' name='deletefields' id='deletefields' disabled>{{ "Delete"|xlt }}</button>
+            </div>
+        </div>
+    {% endif %}
+{% endblock %}


### PR DESCRIPTION
hi @robertdown , couple very minor fixes in edit layout and noted some things that I couldn't figure out how to fix.

First want to make sure this will work for when a translation is shown for the group name (note this only happens when not using english where it shows translated group name; just made it green to match the translations that are done below that):
![image](https://user-images.githubusercontent.com/278968/141670248-e4a6531d-e936-4144-903f-32fde1749abf.png)

I was unable to fix odd looking big buttons that show up after clicking the 'Add Field' and 'Rename Group' buttons:
![image](https://user-images.githubusercontent.com/278968/141670302-85ec4505-e76d-4531-b55d-9ca544455579.png)

![image](https://user-images.githubusercontent.com/278968/141670312-dd158c05-30d8-4fc9-8815-f9e4a6625df1.png)
