### PR TITLE
Encounter Menu Hook

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
         "symfony/config": "4.4.33",
         "symfony/dependency-injection": "4.4.33",
         "symfony/event-dispatcher": "4.4.30",
+        "symfony/event-dispatcher-contract": "2.4.0",
         "symfony/http-foundation": "4.4.33",
         "symfony/yaml": "4.4.29",
         "twig/twig": "3.3.3",

--- a/interface/patient_file/encounter/forms.php
+++ b/interface/patient_file/encounter/forms.php
@@ -46,6 +46,15 @@ if ($is_group && !AclMain::aclCheckCore("groups", "glog", false, array('view','w
     exit();
 }
 
+if ($GLOBALS['kernel']->getEventDispatcher() instanceof EventDispatcher) {
+    /**
+     * @var EventDispatcher
+     */
+    $eventDispatcher = $GLOBALS['kernel']->getEventDispatcher();
+} else {
+    throw new Exception("Could not get EventDispatcher from kernel", 1);
+}
+
 ?>
 <html>
 
@@ -520,26 +529,33 @@ if (
 
 // Convert the flat list of menu items into a multi-dimensional array based on the category
 // decide what will be displayed (name or nickname)
-$menuArray = [];
-foreach ($reg as $item) {
-    $tmp = explode('|', $item['aco_spec']);
-    if (!empty($tmp[1])) {
-        if (!AclMain::aclCheckCore($tmp[0], $tmp[1], '', 'write') && !AclMain::aclCheckCore($tmp[0], $tmp[1], '', 'addonly')) {
-            continue;
+$eventDispatcher->addListener(EncounterMenuEvent::MENU_RENDER, function(EncounterMenuEvent $menuEvent) {
+    $menuArray = $menuEvent->getMenuData();
+    $reg = getFormsByCategory();
+    foreach ($reg as $item) {
+        $tmp = explode('|', $item['aco_spec']);
+        if (!empty($tmp[1])) {
+            if (!AclMain::aclCheckCore($tmp[0], $tmp[1], '', 'write') && !AclMain::aclCheckCore($tmp[0], $tmp[1], '', 'addonly')) {
+                continue;
+            }
         }
+
+        $_cat = trim($item['category']);
+        $_cat = ($_cat == '') ? xl("Miscellaneous") : xl($_cat);
+        $item['displayText'] = (trim($item['nickname']) != '') ? trim($item['nickname']) : trim($item['name']);
+        unset($item['category']);
+        unset($item['name']);
+        unset($item['nickname']);
+        $menuArray[$_cat]['children'][] = $item;
     }
+    $menuEvent->setMenuData($menuArray);
+    return $menuEvent;
+});
 
-    $_cat = trim($item['category']);
-    $_cat = ($_cat == '') ? xl("Miscellaneous") : xl($_cat);
-    $item['displayText'] = (trim($item['nickname']) != '') ? trim($item['nickname']) : trim($item['name']);
-    unset($item['category']);
-    unset($item['name']);
-    unset($item['nickname']);
-    $menuArray[$_cat]['children'][] = $item;
-}
 
-// Module hooks
-$module_query = sqlStatement("SELECT msh.*, ms.menu_name, ms.path, m.mod_ui_name, m.type
+// Zend Module hooks
+$eventDispatcher->addListener(EncounterMenuEvent::MENU_RENDER, function(EncounterMenuEvent $menuEvent) {
+    $module_query = sqlStatement("SELECT msh.*, ms.menu_name, ms.path, m.mod_ui_name, m.type
         FROM modules_hooks_settings AS msh
         LEFT OUTER JOIN modules_settings AS ms ON obj_name=enabled_hooks AND ms.mod_id=msh.mod_id
         LEFT OUTER JOIN modules AS m ON m.mod_id=ms.mod_id
@@ -549,23 +565,27 @@ $module_query = sqlStatement("SELECT msh.*, ms.menu_name, ms.path, m.mod_ui_name
             AND attached_to='encounter'
         ORDER BY mod_id");
 
-$moduleMenuArray = [];
+    $menuData = $menuEvent->getMenuData();
 
-while ($row = sqlFetchArray($module_query)) {
-    $_cat = $row['mod_ui_name'];
-    if ($row['type'] == 0) {
-        $modulePath = $GLOBALS['customModDir'];
-        $added = "";
-    } else {
-        $modulePath = $GLOBALS['zendModDir'];
-        $added = "index";
+    while ($row = sqlFetchArray($module_query)) {
+        $_cat = $row['mod_ui_name'];
+        if ($row['type'] == 0) {
+            $modulePath = $GLOBALS['customModDir'];
+            $added = "";
+        } else {
+            $modulePath = $GLOBALS['zendModDir'];
+            $added = "index";
+        }
+
+        $relativeLink = "../../modules/{$modulePath}/public/{$row['path']}";
+        $row['menu_name'] = $row['menu_name'] ?: "No_Name";
+        $row['href'] = $relativeLink;
+        $menuData[$_cat]['children'][] = $row;
     }
 
-    $relativeLink = "../../modules/{$modulePath}/public/{$row['path']}";
-    $row['menu_name'] = $row['menu_name'] ?: "No_Name";
-    $row['href'] = $relativeLink;
-    $moduleMenuArray[$_cat]['children'][] = $row;
-}
+    $menuEvent->setMenuData($menuData);
+    return $menuEvent;
+});
 
 $dateres = getEncounterDateByEncounter($encounter);
 $encounter_date = date("Y-m-d", strtotime($dateres["date"]));
@@ -604,14 +624,8 @@ if ($attendant_type == 'pid' && is_numeric($pid)) {
     }
 }
 
-if ($GLOBALS['kernel']->getEventDispatcher() instanceof EventDispatcher) {
-    /**
-     * @var EventDispatcher
-     */
-    $dispatcher = $GLOBALS['kernel']->getEventDispatcher();
-    $encounterMenuEvent = new EncounterMenuEvent($menuArray);
-    $dispatcher->dispatch($encounterMenuEvent, EncounterMenuEvent::MENU_RENDER);
-}
+$encounterMenuEvent = new EncounterMenuEvent();
+$menu = $eventDispatcher->dispatch($encounterMenuEvent, EncounterMenuEvent::MENU_RENDER);
 
 $twig = new TwigContainer(null, $GLOBALS['kernel']);
 $t = $twig->getTwig();
@@ -620,8 +634,7 @@ echo $t->render('encounter/forms/navbar.html.twig', [
     'patientName' => $patientName,
     'isAdminSuper' => AclMain::aclCheckCore("admin", "super"),
     'enableFollowUpEncounters' => $GLOBALS['enable_follow_up_encounters'],
-    'menuArray' => $encounterMenuEvent->getM,
-    'moduleMenuArray' => $moduleMenuArray,
+    'menuArray' => $menu->getMenuData(),
 ]);
 ?>
 

--- a/interface/patient_file/encounter/forms.php
+++ b/interface/patient_file/encounter/forms.php
@@ -529,7 +529,7 @@ if (
 
 // Convert the flat list of menu items into a multi-dimensional array based on the category
 // decide what will be displayed (name or nickname)
-$eventDispatcher->addListener(EncounterMenuEvent::MENU_RENDER, function(EncounterMenuEvent $menuEvent) {
+$eventDispatcher->addListener(EncounterMenuEvent::MENU_RENDER, function (EncounterMenuEvent $menuEvent) {
     $menuArray = $menuEvent->getMenuData();
     $reg = getFormsByCategory();
     foreach ($reg as $item) {
@@ -554,7 +554,7 @@ $eventDispatcher->addListener(EncounterMenuEvent::MENU_RENDER, function(Encounte
 
 
 // Zend Module hooks
-$eventDispatcher->addListener(EncounterMenuEvent::MENU_RENDER, function(EncounterMenuEvent $menuEvent) {
+$eventDispatcher->addListener(EncounterMenuEvent::MENU_RENDER, function (EncounterMenuEvent $menuEvent) {
     $module_query = sqlStatement("SELECT msh.*, ms.menu_name, ms.path, m.mod_ui_name, m.type
         FROM modules_hooks_settings AS msh
         LEFT OUTER JOIN modules_settings AS ms ON obj_name=enabled_hooks AND ms.mod_id=msh.mod_id

--- a/interface/patient_file/encounter/forms.php
+++ b/interface/patient_file/encounter/forms.php
@@ -25,8 +25,9 @@ use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Core\Header;
+use OpenEMR\Events\Encounter\EncounterMenuEvent;
 use OpenEMR\Services\UserService;
-
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 $expand_default = (int)$GLOBALS['expand_form'] ? 'show' : 'hide';
 $reviewMode = false;
@@ -603,6 +604,15 @@ if ($attendant_type == 'pid' && is_numeric($pid)) {
     }
 }
 
+if ($GLOBALS['kernel']->getEventDispatcher() instanceof EventDispatcher) {
+    /**
+     * @var EventDispatcher
+     */
+    $dispatcher = $GLOBALS['kernel']->getEventDispatcher();
+    $encounterMenuEvent = new EncounterMenuEvent($menuArray);
+    $dispatcher->dispatch($encounterMenuEvent, EncounterMenuEvent::MENU_RENDER);
+}
+
 $twig = new TwigContainer(null, $GLOBALS['kernel']);
 $t = $twig->getTwig();
 echo $t->render('encounter/forms/navbar.html.twig', [
@@ -610,7 +620,7 @@ echo $t->render('encounter/forms/navbar.html.twig', [
     'patientName' => $patientName,
     'isAdminSuper' => AclMain::aclCheckCore("admin", "super"),
     'enableFollowUpEncounters' => $GLOBALS['enable_follow_up_encounters'],
-    'menuArray' => $menuArray,
+    'menuArray' => $encounterMenuEvent->getM,
     'moduleMenuArray' => $moduleMenuArray,
 ]);
 ?>

--- a/src/Events/Encounter/EncounterMenuEvent.php
+++ b/src/Events/Encounter/EncounterMenuEvent.php
@@ -32,7 +32,7 @@ class EncounterMenuEvent extends Event
      *
      * @param array $menu
      */
-    public function __construct(array $menu)
+    public function __construct(array $menu = [])
     {
         $this->menu = $menu;
     }

--- a/src/Events/Encounter/EncounterMenuEvent.php
+++ b/src/Events/Encounter/EncounterMenuEvent.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * EncounterMenuEvent
+ *
+ * This event is used to hook into the encounter menu (in forms.php).
+ *
+ * @package    OpenEMR
+ * @subpackage Events
+ * @link       http://www.open-emr.org
+ * @author     Robert Down <robertdown@live.com>
+ * @copyright  Copyright (c) 2021 Robert Down <robertdown@live.com>
+ * @license    https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\Encounter;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+class EncounterMenuEvent extends Event
+{
+    /**
+     * This event is fired prior to rendering the encounter menu, and an assoc
+     * array of menu data is passed to the event object
+     */
+    const MENU_RENDER = 'menu.render';
+
+    private $menu;
+
+    /**
+     * EncounterMenuEvent constructor takes a multidimensional array
+     * of menu items.
+     *
+     * @param array $menu
+     */
+    public function __construct(array $menu)
+    {
+        $this->menu = $menu;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getMenuData()
+    {
+        return $this->menu;
+    }
+
+    /**
+     * @param mixed $menu
+     */
+    public function setMenuData(array $menu): void
+    {
+        $this->menu = $menu;
+    }
+}

--- a/src/Events/Encounter/EncounterMenuEvent.php
+++ b/src/Events/Encounter/EncounterMenuEvent.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * EncounterMenuEvent
  *

--- a/templates/encounter/forms/navbar.html.twig
+++ b/templates/encounter/forms/navbar.html.twig
@@ -25,25 +25,7 @@
                     </li>
                 {% else %}
                     <li class="nav-item">
-                        <a class="nav-link" href="#">{{ category|text }}</a>
-                    </li>
-                {% endif %}
-            {% endfor %}
-            {% for category, details in moduleMenuArray %}
-                {% if details.children is iterable %}
-                    <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle" href="#" id="category_{{ category|attr }}" role="button" data-toggle="dropdown" aria-expanded="false">
-                            {{ category|text }}
-                        </a>
-                        <div class="dropdown-menu" aria-labelledby="category_{{ category|attr }}">
-                            {% for item in details.children %}
-                                <a href="#" class="dropdown-item" onclick="openNewForm({{ item.href|attr_js }}, {{ item.menu_name|xlFormTitle|attr_js }})">{{ item.menu_name|xlFormTitle|text }}</a>
-                            {% endfor %}
-                        </div>
-                    </li>
-                {% else %}
-                    <li class="nav-item">
-                        <a class="nav-link" href="#">{{ category|text }}</a>
+                        <a class="nav-link" href="#" onclick="openNewForm({{ details.formURL|attr_js }}, {{ details.displayText|xlFormTitle|attr_js }})">{{ details.displayText|text }}</a>
                     </li>
                 {% endif %}
             {% endfor %}


### PR DESCRIPTION
Support for `EncounterMenuEvent`. Currently only support for `MENU_RENDER` which is used to populate the Twig variable for output.

Forms.php builds traditional forms menu and zend hooks. Both of those were wrapped in event listeners to streamline a future project to move those out of forms.php and into a better location. (Just means technically this page both adds 2 listeners and then fires the dispatch()).

Is testing well