### PR TITLE
Fix portal fatal errors due to not found class.

### DIFF
--- a/portal/messaging/secure_chat.php
+++ b/portal/messaging/secure_chat.php
@@ -51,10 +51,10 @@ use OpenEMR\PatientPortal\Chat\ChatController;
 define('C_USER', IS_PORTAL ?  IS_PORTAL : IS_DASHBOARD);
 
 if (isset($_REQUEST['fullscreen'])) {
-    OpenEMR\Common\Session\SessionUtil::setSession('whereto', '#messagescard');
+    \OpenEMR\Common\Session\SessionUtil::setSession('whereto', '#messagescard');
     define('IS_FULLSCREEN', true);
 } else {
-    OpenEMR\Common\Session\SessionUtil::setSession('whereto', '#messagescard');
+    \OpenEMR\Common\Session\SessionUtil::setSession('whereto', '#messagescard');
     define('IS_FULLSCREEN', false);
 }
 


### PR DESCRIPTION
Fixes #4761

Recent portal changes introduced a bug with the SessionUtil class.  This post adds the namespace escape for the OpenEMR namespace.  Essentially 2 character changes so going to bring this in.