### PR TITLE
Changing the order from ascending to descending

### DIFF
--- a/interface/billing/billing_tracker.php
+++ b/interface/billing/billing_tracker.php
@@ -94,7 +94,7 @@ use OpenEMR\OeUI\OemrUI;
                     { "data": "created_at" },
                     { "data": "updated_at" },
                 ],
-                "order": [[4, 'asc']] // Order by 'Date Created' with newest first
+                "order": [[4, 'desc']] // Order by 'Date Created' with newest first
             });
 
             oTable.on('preXhr.dt', function (e, settings, data) {


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:
The billing tracker shows the claims sent in ascending order which means you have to click all the way to the end to see the latest claims.

#### Changes proposed in this pull request:
Change to descending order so that on load the lastest claims are sent 