### PR TITLE
first php 8.2 fix

### DIFF
--- a/src/Common/Crypto/CryptoGen.php
+++ b/src/Common/Crypto/CryptoGen.php
@@ -30,6 +30,7 @@ namespace OpenEMR\Common\Crypto;
 
 use OpenEMR\Common\Utils\RandomGenUtils;
 
+#[AllowDynamicProperties]
 class CryptoGen
 {
     # This is the current encrypt/decrypt version
@@ -48,6 +49,9 @@ class CryptoGen
 
     # Note that dynamic variables in this class in the collectCryptoKey()
     #  function are used to store the key cache.
+    #   (note this is why this class has the been marked with the
+    #    [AllowDynamicProperties] attribute, or will throw deprecation
+    #    message in PHP 8.2 and throw error in PHP 9.0)
 
     public function __construct()
     {

--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -514,7 +514,6 @@ MSG;
     {
         // Set up crypto object that will be used by this singleton class for encryption/decryption (if not set up already)
         if (!isset($this->cryptoGen)) {
-            error_log("DEBUG1");
             $this->cryptoGen = new CryptoGen();
         }
 

--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -22,7 +22,7 @@ class EventAuditLogger
 {
     use Singleton;
 
-    private $cryptoGen = null;
+    private $cryptoGen;
 
     /**
      * Event action codes indicate whether the event is read/write.
@@ -513,7 +513,8 @@ MSG;
     public function auditSQLEvent($statement, $outcome, $binds = null)
     {
         // Set up crypto object that will be used by this singleton class for encryption/decryption (if not set up already)
-        if (is_null($this->cryptoGen)) {
+        if (!isset($this->cryptoGen)) {
+            error_log("DEBUG1");
             $this->cryptoGen = new CryptoGen();
         }
 
@@ -734,7 +735,7 @@ MSG;
         }
 
         // Encrypt if applicable
-        if (is_null($this->cryptoGen)) {
+        if (!isset($this->cryptoGen)) {
             $this->cryptoGen = new CryptoGen();
         }
         $encrypt = 'No';

--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -18,10 +18,11 @@ use DateTime;
 use OpenEMR\Common\Crypto\CryptoGen;
 use Waryway\PhpTraitsLibrary\Singleton;
 
-#[AllowDynamicProperties]
 class EventAuditLogger
 {
     use Singleton;
+
+    private $cryptoGen = null;
 
     /**
      * Event action codes indicate whether the event is read/write.
@@ -511,9 +512,8 @@ MSG;
      */
     public function auditSQLEvent($statement, $outcome, $binds = null)
     {
-
         // Set up crypto object that will be used by this singleton class for encryption/decryption (if not set up already)
-        if (!isset($this->cryptoGen)) {
+        if (is_null($this->cryptoGen)) {
             $this->cryptoGen = new CryptoGen();
         }
 
@@ -734,7 +734,7 @@ MSG;
         }
 
         // Encrypt if applicable
-        if (!isset($this->cryptoGen)) {
+        if (is_null($this->cryptoGen)) {
             $this->cryptoGen = new CryptoGen();
         }
         $encrypt = 'No';

--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -18,6 +18,7 @@ use DateTime;
 use OpenEMR\Common\Crypto\CryptoGen;
 use Waryway\PhpTraitsLibrary\Singleton;
 
+#[AllowDynamicProperties]
 class EventAuditLogger
 {
     use Singleton;
@@ -511,7 +512,7 @@ MSG;
     public function auditSQLEvent($statement, $outcome, $binds = null)
     {
 
-        // Set up crypto object that will be used by this singleton class for for encryption/decryption (if not set up already)
+        // Set up crypto object that will be used by this singleton class for encryption/decryption (if not set up already)
         if (!isset($this->cryptoGen)) {
             $this->cryptoGen = new CryptoGen();
         }


### PR DESCRIPTION
Related to an interesting deprecated error in future PHP 8.2 (noted it while was updating the insane dev environment) that is discussed by php folks here:
https://wiki.php.net/rfc/deprecate_dynamic_properties

Notably, the deprecation errors do not actually go away with this, but assuming this is simply because of a bug in php 8.2 since very early in development.

Makes sense to do this for CryptoGen class since it is using dynamic properties to cache keys (much more efficient doing this).

Will reengineer the EventAuditLogger class a tiny bit since really don't need a dynamic property for this. Prob just initiate it to null and then create the new CryptoGen call if the variable is not instance of CryptoGen class (or something like that). (btw caching that CryptoGen isntance also makes things much more efficient since will then cache the keys on the potential numerous encryptions done while logging)
