### PR TITLE
Adding support for another fax module

### DIFF
--- a/interface/main/tabs/menu/menus/standard.json
+++ b/interface/main/tabs/menu/menus/standard.json
@@ -2100,7 +2100,8 @@
         ],
         "global_req": [
           "enable_hylafax",
-          "enable_scanner"
+          "enable_scanner",
+          "oedocumofax_enable"
         ]
       },
       {


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #
support for fax module being built
#### Short description of what this resolves:
The change to the menu to show the fax/scan feature if this module is enabled

#### Changes proposed in this pull request:
Add documofax_enable to the globals req in the menu to show the fax/scan