### PR TITLE
Allowing the system to fire patient report/document event always

### DIFF
--- a/interface/patient_file/report/patient_report.php
+++ b/interface/patient_file/report/patient_report.php
@@ -40,12 +40,12 @@ $auth_relaxed  = AclMain::aclCheckCore('encounters', 'relaxed');
 $auth_med      = AclMain::aclCheckCore('patients', 'med');
 $auth_demo     = AclMain::aclCheckCore('patients', 'demo');
 
-$oefax = !empty($GLOBALS['oefax_enable']) ? $GLOBALS['oefax_enable'] : 0;
 /**
  * @var EventDispatcherInterface $eventDispatcher  The event dispatcher / listener object
  */
 $eventDispatcher = $GLOBALS['kernel']->getEventDispatcher();
 ?>
+<!DOCTYPE>
 <html>
 <head>
 <title><?php echo xlt("Patient Reports"); ?></title>
@@ -269,9 +269,9 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                         <button type="button" class="genpdfrep btn btn-primary btn-download btn-sm" value="<?php echo xla('Download PDF'); ?>" ><?php echo xlt('Download PDF'); ?></button>
 
                         <?php
-                        if ($oefax) {
+
                             $eventDispatcher->dispatch(PatientReportEvent::ACTIONS_RENDER_POST, new GenericEvent());
-                        }
+
                         ?>
                         <input type='hidden' name='pdf' value='0' />
                         <br />
@@ -752,9 +752,9 @@ $(function () {
     <?php } ?>
 
     <?php
-    if ($oefax) {
+        //event dispatch
         $eventDispatcher->dispatch(PatientReportEvent::JAVASCRIPT_READY_POST, new GenericEvent());
-    }
+
     ?>
 
 });

--- a/templates/documents/general_view.html
+++ b/templates/documents/general_view.html
@@ -11,9 +11,9 @@
  *}
 
 <script>
- {if !empty($GLOBALS.oefax_enable)}
+
  {dispatchPatientDocumentEvent event="javascript_ready_fax_dialog"}
- {/if}
+
  function popoutcontent(othis) {literal}{{/literal}
     let popsrc = $(othis).parents('body').find('#DocContents iframe').attr("src");
     let wname = '_' + Math.random().toString(36).substr(2, 6);
@@ -132,9 +132,7 @@ function tagProcedure() {literal}{{/literal}
               </div>
             <span class="float-right">
             <script>var file = {$file->get_url()|js_escape};var mime = {$file->get_mimetype()|js_escape};</script>
-            {if !empty($GLOBALS.oefax_enable)}
             {dispatchPatientDocumentEvent event="actions_render_fax_anchor"}
-            {/if}
             <a class="btn btn-primary" href='' onclick='return popoutcontent(this)' title="{xla t='Pop Out Full Screen.'}">{xlt t='Pop Out'}</a>
             <a class="btn btn-primary" href="{$web_path|attr}" title="{xla t='Original file'}" onclick="top.restoreSession()">{xlt t='Download'}</a>
             <a class="btn btn-primary" href='' onclick='return showpnotes({$file->get_id()|attr_js})'>{xlt t='Show Notes'}</a>
@@ -263,19 +261,19 @@ function tagProcedure() {literal}{{/literal}
 	<tr id="DocContents" class="h-100">
 		<td>
       {if $file->get_mimetype() eq "image/tiff" or $file->get_mimetype() eq "text/plain"}
-			<embed frameborder="0" style="height:84vh" type="{$file->get_mimetype()|attr}" src="{$web_path|attr}as_file=false"></embed>
+			<embed  style="height:84vh; border: 0px" type="{$file->get_mimetype()|attr}" src="{$web_path|attr}as_file=false"></embed>
 			{elseif $file->get_mimetype() eq "image/png" or
 			 $file->get_mimetype() eq "image/jpg" or
 			 $file->get_mimetype() eq "image/jpeg" or
 			 $file->get_mimetype() eq "image/gif" or
 			 $file->get_mimetype() eq "application/pdf" }
-			<iframe frameborder="0" style="height:84vh" type="{$file->get_mimetype()|attr}" src="{$web_path|attr}as_file=false"></iframe>
+			<iframe style="height:84vh; border: 0px" type="{$file->get_mimetype()|attr}" src="{$web_path|attr}as_file=false"></iframe>
       {elseif $file->get_mimetype() eq "application/dicom" or $file->get_mimetype() eq "application/dicom+zip"}
-      <iframe frameborder="0" style="height:84vh" type="{$file->get_mimetype()|attr}" src="{$webroot}/library/dicom_frame.php?web_path={$web_path|attr}as_file=false"></iframe>
+      <iframe style="height:84vh; border: 0px" type="{$file->get_mimetype()|attr}" src="{$webroot}/library/dicom_frame.php?web_path={$web_path|attr}as_file=false"></iframe>
       {elseif $file->get_mimetype() eq "audio/ogg" or $file->get_mimetype() eq "audio/wav" or $file->get_mimetype() eq "audio/mpeg"}
       <audio class="w-100" preload="metadata" controls="true" type="{$file->get_mimetype()|attr}" src="{$web_path|attr}as_file=false">{xlt t='Your browser does not support HTML5 audio'}</audio>
       {elseif $file->get_ccr_type($file->get_id()) ne "CCR" and $file->get_ccr_type($file->get_id()) ne "CCD"}
-      <iframe frameborder="0" style="height:84vh" type="{$file->get_mimetype()|attr}" src="{$web_path|attr}as_file=true"></iframe>
+      <iframe style="height:84vh; border: 0px" type="{$file->get_mimetype()|attr}" src="{$web_path|attr}as_file=true"></iframe>
 			{/if}
 		</td>
 	</tr>


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #
These events were wrapped in if statements checking if oefax is installed
#### Short description of what this resolves:
I am building a fax module. I need to use the current event dispatcher that is in the system. 

#### Changes proposed in this pull request:
Remove the if statements so that the event fire always and not only when the faxsms module is installed.
