### PR TITLE
Allow encounter menu items to override onclick option

### DIFF
--- a/templates/encounter/forms/navbar.html.twig
+++ b/templates/encounter/forms/navbar.html.twig
@@ -24,8 +24,6 @@
                                     {% set formURL = rootdir ~ "/patient_file/encounter/load_form.php?formname=" ~ item.directory|url_encode %}
                                     {% set onclick = "openNewForm(" ~ formURL|attr_js ~ "," ~ item.displayText|xlFormTitle|attr_js ~ ")" %}
                                 {% endif %}
-
-                                {# <a href="#" class="dropdown-item" onclick="openNewForm({{ formURL|attr_js }}, {{ item.displayText|xlFormTitle|attr_js }})">{{ item.displayText|xlFormTitle|text }}</a> #}
                                 <a href="#" class="dropdown-item" onclick="{{ onclick }}">{{ item.displayText|xlFormTitle|text }}</a>
                             {% endfor %}
                         </div>

--- a/templates/encounter/forms/navbar.html.twig
+++ b/templates/encounter/forms/navbar.html.twig
@@ -18,8 +18,15 @@
                         </a>
                         <div class="dropdown-menu" aria-labelledby="category_{{ category|attr }}">
                             {% for item in details.children %}
-                                {% set formURL = rootdir ~ "/patient_file/encounter/load_form.php?formname=" ~ item.directory|url_encode %}
-                                <a href="#" class="dropdown-item" onclick="openNewForm({{ formURL|attr_js }}, {{ item.displayText|xlFormTitle|attr_js }})">{{ item.displayText|xlFormTitle|text }}</a>
+                                {% if item.onclick is defined %}
+                                    {% set onclick = item.onclick %}
+                                {% else %}
+                                    {% set formURL = rootdir ~ "/patient_file/encounter/load_form.php?formname=" ~ item.directory|url_encode %}
+                                    {% set onclick = "openNewForm(" ~ formURL|attr_js ~ "," ~ item.displayText|xlFormTitle|attr_js ~ ")" %}
+                                {% endif %}
+
+                                {# <a href="#" class="dropdown-item" onclick="openNewForm({{ formURL|attr_js }}, {{ item.displayText|xlFormTitle|attr_js }})">{{ item.displayText|xlFormTitle|text }}</a> #}
+                                <a href="#" class="dropdown-item" onclick="{{ onclick }}">{{ item.displayText|xlFormTitle|text }}</a>
                             {% endfor %}
                         </div>
                     </li>


### PR DESCRIPTION
Allow encounter menu items to change behavior of link action by injecting an "onclick" attribute. This allows non-forms to be opened in the encounter tabs