### PR TITLE
Blank Referral form bug fix SQL

### DIFF
--- a/interface/patient_file/transaction/print_referral.php
+++ b/interface/patient_file/transaction/print_referral.php
@@ -77,7 +77,7 @@ if ($transid) {
     if (empty($_REQUEST['patient_id'])) {
         // If no transaction ID or patient ID, this will be a totally blank form.
         $patient_id = 0;
-        $refer_date = '';
+        $refer_date = date('Y-m-d');
     } else {
         $patient_id = $_REQUEST['patient_id'] + 0;
         $refer_date = date('Y-m-d');


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:
If the patient does not have any vitals  and SQL error is thrown

#### Changes proposed in this pull request:
The referral date must always be set or an incorrect date format will be passed 