### PR TITLE
Rolling back #4767

### DIFF
--- a/interface/super/edit_layout.php
+++ b/interface/super/edit_layout.php
@@ -399,20 +399,6 @@ natsort($sorted_datatypes);
 // The layout ID identifies the layout to be edited.
 $layout_id = empty($_REQUEST['layout_id']) ? '' : $_REQUEST['layout_id'];
 $layout_tbl = !empty($layout_id) ? tableNameFromLayout($layout_id) : '';
-// Setup alert for table layouts
-$layout_alert = "";
-if (($layout_id !== "") && ($layout_tbl !== "")) {
-    $layout_alert = sprintf(
-        '<div class="alert alert-warning alert-dismissible fade show my-0 py-0" role="alert">
-            <strong>%s</strong> %s
-            <button type="button" class="close my-0 py-0" data-dismiss="alert">
-                <span>&times;</span>
-            </button>
-        </div>',
-        xlt('Do not delete standard fields!'),
-        xlt('Select "UOR" option "Unused" to hide the field.')
-    );
-}
 
 // Tag style for stuff to hide if not an LBF layout. Currently just for the Source column.
 $lbfonly = substr($layout_id, 0, 3) == 'LBF' ? "" : "style='display:none;'";


### PR DESCRIPTION
Rolls back #4767 

The dialog does not actually indicate _what_ the standard fields are, it just says do not delete them. This leads to confusion for the user as they are being told to not do something but are not being given enough information to safely act on the info given. A better approach would be to identify the standard fields identify them on a row-level in the UI. Additionally, some javascript could be used to check if any standard field is checked, if so, disable the delete button. Additionally, the alert clashes with UI changes made in #4744 