### PR TITLE
Add Rest API metadata event. Added swagger doc

### DIFF
--- a/FHIR_README.md
+++ b/FHIR_README.md
@@ -60,6 +60,10 @@ _Example:_ `https://localhost:9300/apis/default/fhir/Patient` returns a Patient'
 
 The Bearer token is required for each OpenEMR FHIR request (except for the Capability Statement), and is conveyed using an Authorization header. Note that the Bearer token is the access_token that is obtained in the [Authorization](API_README.md#authorization) section.
 
+When registering an API client to use with Swagger the following for the redirect url and launch url for the client.
+- Redirect URL -> <base_site_address>/swagger/oauth2-redirect.html
+- Launch URL -> <base_site_address>/swagger/index.html
+
 Request:
 
 ```sh

--- a/src/Events/RestApiExtend/RestApiResourceServiceEvent.php
+++ b/src/Events/RestApiExtend/RestApiResourceServiceEvent.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace OpenEMR\Events\RestApiExtend;
+
+class RestApiResourceServiceEvent
+{
+    /**
+     * Used whenever the service for a rest api resource needs to be returned for metadata or other kind of resource purposes
+     */
+    const EVENT_HANDLE = 'restapi.service.get';
+
+    /**
+     * @var string The API resource that we need to locate a service for
+     */
+    private $resource;
+
+    /**
+     * @var string The original system resource for service
+     */
+    private $serviceClass;
+
+    public function __construct($resource, $serviceClass)
+    {
+        $this->resource = $resource;
+        $this->serviceClass = $serviceClass;
+    }
+
+    /**
+     * @return string
+     */
+    public function getResource(): string
+    {
+        return $this->resource;
+    }
+
+    /**
+     * @param string $resource
+     * @return RestApiResourceServiceEvent
+     */
+    public function setResource(string $resource): RestApiResourceServiceEvent
+    {
+        $this->resource = $resource;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getServiceClass(): ?string
+    {
+        return $this->serviceClass;
+    }
+
+    /**
+     * @param string $serviceClass
+     * @return RestApiResourceServiceEvent
+     */
+    public function setServiceClass(?string $serviceClass): RestApiResourceServiceEvent
+    {
+        $this->serviceClass = $serviceClass;
+        return $this;
+    }
+}

--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -539,7 +539,11 @@ class AuthorizationController
         } catch (OAuthServerException $exception) {
             $this->logger->error(
                 "AuthorizationController->oauthAuthorizationFlow() OAuthServerException",
-                ["hint" => $exception->getHint(), "message" => $exception->getMessage(), 'hint' => $exception->getHint(), 'trace' => $exception->getTraceAsString()]
+                ["hint" => $exception->getHint(), "message" => $exception->getMessage()
+                    , 'payload' => $exception->getPayload()
+                    , 'trace' => $exception->getTraceAsString()
+                    , 'redirectUri' => $exception->getRedirectUri()
+                    , 'errorType' => $exception->getErrorType()]
             );
             SessionUtil::oauthSessionCookieDestroy();
             $this->emitResponse($exception->generateHttpResponse($response));


### PR DESCRIPTION
In order to make sure that a module REST resource shows up in the FHIR
metadata api and to allow us to override service classes in the metadata
we needed a new event.

Made a change to the fhir readme to explain how to register with
swagger.