### PR TITLE
Fixes the color dependency infinite loop problem.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
       },
       "devDependencies": {
         "autoprefixer": "^10.4.0",
-        "colors": "^1.4.0",
+        "colors": "1.4.0",
         "del": "^6.0.0",
         "glob": "^7.2.0",
         "gulp": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "devDependencies": {
     "autoprefixer": "^10.4.0",
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "del": "^6.0.0",
     "glob": "^7.2.0",
     "gulp": "^4.0.2",


### PR DESCRIPTION
The Node.JS colors developer introduced an infinite loop into the colors
project which breaks this project on dev environments.  We have to lock the
dependency until we figure out a replacement package.

More details can be found here: https://www.bleepingcomputer.com/news/security/dev-corrupts-npm-libs-colors-and-faker-breaking-thousands-of-apps/