### PR TITLE
Fix typo on immunization fhir service.

### DIFF
--- a/src/Services/ImmunizationService.php
+++ b/src/Services/ImmunizationService.php
@@ -123,7 +123,7 @@ class ImmunizationService extends BaseService
                         ,id AS provider_id
                     FROM
                         users
-                ) provider ON immunizations.administered_by_id = providers.provider_id";
+                ) providers ON immunizations.administered_by_id = providers.provider_id";
 
         $whereClause = FhirSearchWhereClauseBuilder::build($search, $isAndCondition);
 


### PR DESCRIPTION
Not sure how we didn't catch this until now, but ImmunizationService was
failing with the Provenance export due to typo.  Discovered this by
testing the bulk fhir export service.