### PR TITLE
fix deprecation exception in code types

### DIFF
--- a/custom/code_types.inc.php
+++ b/custom/code_types.inc.php
@@ -198,7 +198,7 @@ $ct_external_options = array(
  */
 $eventDispatcher = $GLOBALS['kernel']->getEventDispatcher();
 $externalCodesEvent = new ExternalCodesCreatedEvent($ct_external_options);
-$eventDispatcher->dispatch(ExternalCodesCreatedEvent::EVENT_HANDLE, $externalCodesEvent);
+$eventDispatcher->dispatch($externalCodesEvent, ExternalCodesCreatedEvent::EVENT_HANDLE);
 $ct_external_options = $externalCodesEvent->getExternalCodeData();
 
 /**


### PR DESCRIPTION
`
Symfony\Component\EventDispatcher\EventDispatcherInterface::dispatch()" method with the event name as the first argument is deprecated since Symfony 4.3
`
I thought we had this licked awhile back. Is this just a newly missed dispatched or is this still an issue elsewhere?
I'm not seeing except in portal dashboard so far...