### PR TITLE
Allow per-site credentials to be modified by the SqlConfigEvent

### DIFF
--- a/interface/globals.php
+++ b/interface/globals.php
@@ -200,19 +200,6 @@ $GLOBALS['OE_SITE_DIR'] = $GLOBALS['OE_SITES_BASE'] . "/" . $_SESSION['site_id']
 // Set a site-specific uri root path.
 $GLOBALS['OE_SITE_WEBROOT'] = $web_root . "/sites/" . $_SESSION['site_id'];
 
-// Collecting the utf8 disable flag from the sqlconf.php file in order
-// to set the correct html encoding. utf8 vs iso-8859-1. If flag is set
-// then set to iso-8859-1.
-require_once(__DIR__ . "/../library/sqlconf.php");
-if (!$disable_utf8_flag) {
-    ini_set('default_charset', 'utf-8');
-    $HTML_CHARSET = "UTF-8";
-    mb_internal_encoding('UTF-8');
-} else {
-    ini_set('default_charset', 'iso-8859-1');
-    $HTML_CHARSET = "ISO-8859-1";
-    mb_internal_encoding('ISO-8859-1');
-}
 
 // Root directory, relative to the webserver root:
 $GLOBALS['rootdir'] = "$web_root/interface";
@@ -295,12 +282,6 @@ if (file_exists("{$webserver_root}/.env")) {
     $dotenv->load();
 }
 
-// This will open the openemr mysql connection.
-require_once(__DIR__ . "/../library/sql.inc");
-
-// Include the version file
-require_once(__DIR__ . "/../version.php");
-
 // The logging level for common/logging/logger.php
 // Value can be TRACE, DEBUG, INFO, WARN, ERROR, or OFF:
 //    - DEBUG/INFO are great for development
@@ -314,6 +295,26 @@ try {
 } catch (\Exception $e) {
     error_log(errorLogEscape($e->getMessage()));
     die();
+}
+
+// This will open the openemr mysql connection.
+require_once(__DIR__ . "/../library/sql.inc");
+
+// Include the version file
+require_once(__DIR__ . "/../version.php");
+
+// Collecting the utf8 disable flag from the sqlconf.php file in order
+// to set the correct html encoding. utf8 vs iso-8859-1. If flag is set
+// then set to iso-8859-1.
+require_once(__DIR__ . "/../library/sqlconf.php");
+if (!$disable_utf8_flag) {
+    ini_set('default_charset', 'utf-8');
+    $HTML_CHARSET = "UTF-8";
+    mb_internal_encoding('UTF-8');
+} else {
+    ini_set('default_charset', 'iso-8859-1');
+    $HTML_CHARSET = "ISO-8859-1";
+    mb_internal_encoding('ISO-8859-1');
 }
 
 // Defaults for specific applications.

--- a/library/sqlconf.php
+++ b/library/sqlconf.php
@@ -1,14 +1,38 @@
 <?php
+/**
+ * The sqlconf.php file is the central place to load the SITE_ID SQL credentials. It allows allows modules to manage the
+ * credential variables
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Robert Down <robertdown@live.com>
+ * @copyright Copyright (c) 2022 Robert Down <robertdown@live.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
 
-// This program is free software; you can redistribute it and/or
-// modify it under the terms of the GNU General Public License
-// as published by the Free Software Foundation; either version 2
-// of the License, or (at your option) any later version.
+use OpenEMR\Events\Core\SqlConfigEvent;
 
-//  OpenEMR
-//  MySQL Config
-//  Needed by sql.inc
+$eventDispatcher = $GLOBALS['kernel']->getEventDispatcher();
+$sqlConfigEvent = new SqlConfigEvent;
 
-// Database parameters are now site-specific.
-// $GLOBALS['OE_SITE_DIR'] is set in interface/globals.php.
 require_once $GLOBALS['OE_SITE_DIR'] . "/sqlconf.php";
+
+if ($eventDispatcher->hasListeners(SqlConfigEvent::EVENT_NAME)) {
+
+    /**
+     * @var SqlConfigEvent
+     */
+    $configEvent = $eventDispatcher->dispatch(new SqlConfigEvent(), SqlConfigEvent::EVENT_NAME);
+
+    $configEntity = $configEvent->getConfig();
+
+    // Override the variables set in sites/<site_id>/sqlconf.php file that was required above.
+    $host = $configEntity->getHost();
+    $port = $configEntity->getPort();
+    $login = $configEntity->getUser();
+    $pass = $configEntity->getPass();
+    $dbase = $configEntity->getDatabaseName();
+    $db_encoding = $configEntity->getEncoding();
+    $disable_utf8_flag = $configEntity->getDisableUTF8();
+    $config = $configEntity->getConfig();
+}

--- a/src/Entity/Core/SqlConfig.php
+++ b/src/Entity/Core/SqlConfig.php
@@ -1,0 +1,166 @@
+<?php
+
+/**
+ * Standard SqlConfig entity for database credentials.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ *
+ * @author    Robert Down <robertdown@live.com>
+ * @copyright Copyright (c) 2022 Robert Down <robertdown@live.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Entity\Core;
+
+use OpenEMR\Events\Core\Interfaces\SqlConfigInterface;
+
+class SqlConfig implements SqlConfigInterface
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    private $host;
+
+    /**
+     * {@inheritDoc}
+     */
+    private $port;
+
+    /**
+     * {@inheritDoc}
+     */
+    private $user;
+
+    /**
+     * {@inheritDoc}
+     */
+    private $pass;
+
+    /**
+     * {@inheritDoc}
+     */
+    private $databaseName;
+
+    /**
+     * {@inheritDoc}
+     */
+    private $encoding;
+
+    /**
+     * {@inheritDoc}
+     */
+    private $config;
+
+    /**
+     * {@inheritDoc}
+     */
+    private $disableUTF8;
+
+    /**
+     * Constructor can accept an associative array of key/value pairs to help auto-populate object properties. Key name
+     * must match property name.
+     *
+     * @param array $opts
+     */
+    public function __construct(array $opts)
+    {
+        if (array_key_exists('host', $opts)) {
+            $this->host = $opts['host'];
+        }
+
+        if (array_key_exists('port', $opts)) {
+            $this->port = $opts['port'];
+        }
+
+        if (array_key_exists('user', $opts)) {
+            $this->user = $opts['user'];
+        }
+
+        if (array_key_exists('pass', $opts)) {
+            $this->pass = $opts['pass'];
+        }
+
+        if (array_key_exists('databaseName', $opts)) {
+            $this->databaseName = $opts['databaseName'];
+        }
+
+        if (array_key_exists('encoding', $opts)) {
+            $this->encoding = $opts['encoding'];
+        }
+
+        if (array_key_exists('config', $opts)) {
+            $this->config = $opts['config'];
+        }
+
+        if (array_key_exists('disableUTF8', $opts)) {
+            $this->disableUTF8 = $opts['disableUTF8'];
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getHost(): string
+    {
+        return $this->host;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getPort(): string
+    {
+        return $this->port;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getUser(): string
+    {
+        return $this->user;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getPass(): string
+    {
+        return $this->pass;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDatabaseName(): string
+    {
+        return $this->databaseName;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getEncoding(): string
+    {
+        return $this->encoding;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getConfig(): int
+    {
+        return $this->config;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDisableUTF8(): int
+    {
+        return $this->disableUTF8;
+    }
+
+}

--- a/src/Events/Core/Interfaces/SqlConfigInterface.php
+++ b/src/Events/Core/Interfaces/SqlConfigInterface.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Interface defining the requirements to use the SqlConfigEvent.
+ *
+ * @author Robert Down <robertdown@live.com>
+ * @copyright Copyright (c) 2022 Robert Down <robertdown@live.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ *
+ */
+
+namespace OpenEMR\Events\Core\Interfaces;
+
+/**
+ * SqlConfigInterface
+ */
+interface SqlConfigInterface
+{
+
+    /**
+     * Get the hostname of the database server
+     *
+     * @return string
+     */
+    public function getHost(): string;
+
+    /**
+     * Get the database port
+     *
+     * @return string
+     */
+    public function getPort(): string;
+
+    /**
+     * Get the username to connect to the database server
+     *
+     * @return string
+     */
+    public function getUser(): string;
+
+    /**
+     * Get the password of the user connecting to the database server
+     *
+     * @return string
+     */
+    public function getPass(): string;
+
+    /**
+     * Get the name of the database
+     *
+     * @return string
+     */
+    public function getDatabaseName(): string;
+
+    /**
+     * Get the encoding (Probably utf8mb4)
+     *
+     * @return string
+     */
+    public function getEncoding(): string;
+
+    /**
+     * Get the config status. 1 for configured, 0 for not configured
+     *
+     * @return integer
+     */
+    public function getConfig(): int;
+
+    /**
+     * Get whether or not to disable UTF-8 (Probably always 0)
+     *
+     * @return integer
+     */
+    public function getDisableUTF8(): int;
+}

--- a/src/Events/Core/SqlConfigEvent.php
+++ b/src/Events/Core/SqlConfigEvent.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * SqlConfigEvent class is fired when attemtping to set the SQL credentials and is used to manage how we set credentials
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ *
+ * @author    Robert Down <robertdown@live.com>
+ * @copyright Copyright (c) 2022 Robert Down <robertdown@live.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\Core;
+
+use OpenEMR\Events\Core\Interfaces\SqlConfigInterface;
+
+class SqlConfigEvent
+{
+    public const EVENT_NAME = "sql.config";
+
+    /**
+     * @var SqlConfigInterface
+     */
+    private $config;
+
+    /**
+     * Get the configuration details
+     *
+     * @return SqlConfigInterface
+     */
+    public function getConfig()
+    {
+        return $this->config;
+    }
+
+    /**
+     * Set the configuration options
+     *
+     * @param SqlConfigInterface $config
+     * @return SqlConfigEvent
+     */
+    public function setConfig(SqlConfigInterface $config): SqlConfigEvent
+    {
+        $this->config = $config;
+        return $this;
+    }
+}


### PR DESCRIPTION
Introduction of a new event that fires when loading up the sqlconfig.php files from each site. This provides full backwards-compatibility and only fires the event if there is an active listener.

Why introduce this? Provides a pathway for module-based management of sql credentials and could allow sensitive credentials to be removed from the filesystem all together.