### PR TITLE
Hide refresh icon in tabs

### DIFF
--- a/interface/main/tabs/templates/tabs_template.php
+++ b/interface/main/tabs/templates/tabs_template.php
@@ -20,7 +20,7 @@
         <!-- ko  foreach: tabsList -->
             <div class="tabSpan bgcolor2" data-bind="click: tabClicked, css: {tabsNoHover: !visible()}">
                 <span class="tabTitle pr-2" data-bind="text: title, click: tabClicked, css: {tabHidden: !visible()}"></span>
-                <span class="fa fa-fw fa-xs mr-1 fa-sync" data-bind="click: tabRefresh, class: spinner"></span>
+                <span class="fa fa-fw fa-xs mr-1 fa-sync d-none" data-bind="click: tabRefresh, class: spinner"></span>
                 <!--ko if:!locked() -->
                     <span class="fa fa-fw fa-xs mr-1 fa-unlock" data-bind="click: tabLockToggle"></span>
                 <!-- /ko -->


### PR DESCRIPTION
It just adds `d-none` to the icon for now. I had a bootstrap dropdown but there's some z-index'ing issues that was pushing the dropdown underneath the main frame.