### PR TITLE
fix psr4 ECQM tests

### DIFF
--- a/tests/Tests/ECQM/AllPatientsTest.php
+++ b/tests/Tests/ECQM/AllPatientsTest.php
@@ -8,7 +8,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU GeneralPublic License 3
  */
 
-namespace OpenEMR\Tests\Qdm;
+namespace OpenEMR\Tests\ECQM;
 
 use OpenEMR\Services\Qdm\QdmBuilder;
 use OpenEMR\Services\Qdm\QdmRequestAll;

--- a/tests/Tests/ECQM/MeasureResultsTest.php
+++ b/tests/Tests/ECQM/MeasureResultsTest.php
@@ -8,7 +8,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU GeneralPublic License 3
  */
 
-namespace OpenEMR\Tests\Qdm;
+namespace OpenEMR\Tests\ECQM;
 
 use GuzzleHttp\Psr7\LazyOpenStream;
 use GuzzleHttp\Psr7;


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
```
Generating optimized autoload files
Class OpenEMR\Tests\Qdm\AllPatientsTest located in ./tests/Tests/ECQM/AllPatientsTest.php does not comply with psr-4 autoloading standard. Skipping.
Class OpenEMR\Tests\Qdm\MeasureResultsTest located in ./tests/Tests/ECQM/MeasureResultsTest.php does not comply with psr-4 autoloading standard. Skipping.
Generated optimized autoload files containing 23403 classes
```

#### Short description of what this resolves:


#### Changes proposed in this pull request:
