### PR TITLE
Fixes #4912 direct message patient update fails

### DIFF
--- a/interface/main/finder/multi_patients_finder.php
+++ b/interface/main/finder/multi_patients_finder.php
@@ -232,7 +232,7 @@ $('#add-to-list').on('click', function (e) {
     e.preventDefault();
 
     if($('#by-name').val() == '') {
-        alert("<?php echo xls("You must provide a patient name or id to add to the list"); ?>");
+        alert(<?php echo xlj("You must provide a patient name or id to add to the list"); ?>);
         return;
     }
 
@@ -246,7 +246,7 @@ $('#add-to-list').on('click', function (e) {
         if (patient.pid == currentResult.pid) exist = true;
     })
     if(exist){
-        alert("<?php echo xls("This patient has already been added to the list"); ?>");
+        alert(<?php echo xlj("This patient has already been added to the list"); ?>);
         return;
     }
 
@@ -280,11 +280,11 @@ function removePatient(pid) {
 //send array of patients to function 'setMultiPatients' of the opener
 function selPatients() {
     if (!(patientsList && patientsList.length)) {
-        alert("<?php echo xls("You must add a patient to the list before hitting ok"); ?>");
+        alert(<?php echo xlj("You must add a patient to the list before hitting ok"); ?>);
         return false;
     }
     if (opener.closed || ! opener.setMultiPatients) {
-        alert("<?php echo xls('The destination form was closed; I cannot act on your selection.'); ?>");
+        alert(<?php echo xlj('The destination form was closed; I cannot act on your selection.'); ?>);
     } else {
         opener.setMultiPatients(patientsList);
     }

--- a/interface/main/finder/multi_patients_finder.php
+++ b/interface/main/finder/multi_patients_finder.php
@@ -231,7 +231,10 @@ $('#by-name').on('change', function () {
 $('#add-to-list').on('click', function (e) {
     e.preventDefault();
 
-    if($('#by-name').val() == '')return;
+    if($('#by-name').val() == '') {
+        alert("<?php echo xls("You must provide a patient name or id to add to the list"); ?>");
+        return;
+    }
 
     if(patientsList.length === 0){
         $('#results-table').show();
@@ -242,7 +245,10 @@ $('#add-to-list').on('click', function (e) {
     $.each(patientsList, function (key, patient) {
         if (patient.pid == currentResult.pid) exist = true;
     })
-    if(exist)return;
+    if(exist){
+        alert("<?php echo xls("This patient has already been added to the list"); ?>");
+        return;
+    }
 
 
     // add to array
@@ -273,10 +279,15 @@ function removePatient(pid) {
 
 //send array of patients to function 'setMultiPatients' of the opener
 function selPatients() {
-    if (opener.closed || ! opener.setMultiPatients)
+    if (!(patientsList && patientsList.length)) {
+        alert("<?php echo xls("You must add a patient to the list before hitting ok"); ?>");
+        return false;
+    }
+    if (opener.closed || ! opener.setMultiPatients) {
         alert("<?php echo xls('The destination form was closed; I cannot act on your selection.'); ?>");
-    else
+    } else {
         opener.setMultiPatients(patientsList);
+    }
     dlgclose();
     return false;
 }

--- a/interface/main/messages/messages.php
+++ b/interface/main/messages/messages.php
@@ -343,7 +343,9 @@ if (!empty($_REQUEST['go'])) { ?>
                                         $title = $result['title'];
                                     }
                                     $body = $result['body'];
-                                    if ($reply_to == "") {
+                                    // if our reply-to is 0 it breaks multi patient select and other functionality
+                                    // this most likely didn't break before due to php implicit type conversion of 0 to ""
+                                    if ($reply_to == "" && $result['pid'] != 0) {
                                         $reply_to = $result['pid'];
                                     }
                                     $form_message_status = $result['message_status'];

--- a/library/pnotes.inc
+++ b/library/pnotes.inc
@@ -11,6 +11,7 @@
  * 2013-02-08 EMR Direct: changes to allow notes added by background-services with pid=0
  */
 
+use OpenEMR\Common\Logging\SystemLogger;
 
 /**
  * Retrieve a note, given its ID
@@ -497,7 +498,7 @@ function updatePnotePatient($id, $patient_id)
     $pid = $row['pid'];
 
     if ($pid != 0 || (int)$patient_id < 1) {
-        (new \OpenEMR\Common\Logging\SystemLogger())->errorLogCaller("invalid operation", ['id' => $id, 'patient_id' => $patient_id, 'pid' => $pid]);
+        (new SystemLogger())->errorLogCaller("invalid operation", ['id' => $id, 'patient_id' => $patient_id, 'pid' => $pid]);
         die("updatePnotePatient invalid operation");
     }
 

--- a/library/pnotes.inc
+++ b/library/pnotes.inc
@@ -495,7 +495,9 @@ function updatePnotePatient($id, $patient_id)
     $activity = $assigned_to ? '1' : '0';
 
     $pid = $row['pid'];
+
     if ($pid != 0 || (int)$patient_id < 1) {
+        (new \OpenEMR\Common\Logging\SystemLogger())->errorLogCaller("invalid operation", ['id' => $id, 'patient_id' => $patient_id, 'pid' => $pid]);
         die("updatePnotePatient invalid operation");
     }
 


### PR DESCRIPTION
Fixes #4912 Made it so you can update the patient for a direct message.

There's been a lot of hands in the messages.php file and it really needs to be refactored into multiple files due to how many branches and its cyclomatic complexity.  I'd greatly appreciate people taking a review of it to make sure I'm not breaking something else here.

Also added helper error messages to the multi select so you know that you need to add at list one patient to the selection before hitting the ok button.