### PR TITLE
Remove broken endif for twig for erx newcrop

### DIFF
--- a/interface/patient_file/summary/stats.php
+++ b/interface/patient_file/summary/stats.php
@@ -132,6 +132,7 @@ foreach ($ISSUE_TYPES as $key => $arr) {
         if ($GLOBALS['erx_enable']) {
             $res = sqlStatement("SELECT * FROM prescriptions WHERE patient_id=? AND active='1'", [$pid]);
             $list = [];
+            $rxArr = [];
             while ($row = sqlFetchArray($res)) {
                 $row['unit'] = generate_display_field(array('data_type' => '1', 'list_id' => 'drug_units'), $row['unit']);
                 $row['form'] = generate_display_field(array('data_type' => '1', 'list_id' => 'drug_form'), $row['form']);

--- a/templates/patient/partials/erx.html.twig
+++ b/templates/patient/partials/erx.html.twig
@@ -7,7 +7,7 @@ The Patient Portal card for the Medical Record Dashboard
 #}
 
 {% block erx %}
-    <a href="{{ urlWebRoot|attr }}/interface/eRx.php?page=medentry" class="btn btn-secondary btn-sm btn-add erx" onclick="top.restoreSession();">{{ "NewCrop MedEntry"|xlt }}</a>
-    <a href="{{ urlWebRoot|attr }}/interface/soap_functions/soap_accountStatusDetails.php" onclick="top.restoreSession()" class="btn btn-secondary btn-sm btn save iframe1">{{ "NewCrop Account Status"|xlt }}</a>
+    <a href="{{ webroot|attr }}/interface/eRx.php?page=medentry" class="btn btn-secondary btn-sm btn-add erx" onclick="top.restoreSession();">{{ "NewCrop MedEntry"|xlt }}</a>
+    <a href="{{ webroot|attr }}/interface/soap_functions/soap_accountStatusDetails.php" onclick="top.restoreSession()" class="btn btn-secondary btn-sm btn save iframe1">{{ "NewCrop Account Status"|xlt }}</a>
     <div id="accountstatus"></div>
 {% endblock %}

--- a/templates/patient/partials/erx.html.twig
+++ b/templates/patient/partials/erx.html.twig
@@ -9,5 +9,5 @@ The Patient Portal card for the Medical Record Dashboard
 {% block erx %}
     <a href="{{ urlWebRoot|attr }}/interface/eRx.php?page=medentry" class="btn btn-secondary btn-sm btn-add erx" onclick="top.restoreSession();">{{ "NewCrop MedEntry"|xlt }}</a>
     <a href="{{ urlWebRoot|attr }}/interface/soap_functions/soap_accountStatusDetails.php" onclick="top.restoreSession()" class="btn btn-secondary btn-sm btn save iframe1">{{ "NewCrop Account Status"|xlt }}</a>
-    <div id="accountstatus"></div>    {% endif %}
+    <div id="accountstatus"></div>
 {% endblock %}


### PR DESCRIPTION
Fixes #4921 

Fix the broken endif statement in twig that was throwing a fatal error on the patient demographics screen.

When the dashboard pieces were refactored into twig files one of the
global options was not tested.