### PR TITLE
make e2e run a bit more efficient; rather than always run 3 times, only do that if needed

### DIFF
--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -93,15 +93,20 @@ build_test_unit() {
 
 build_test_e2e() {
     # Since e2e testing is a bit inconsistent, gonna do up to three runs (and only one needs to pass to pass the e2e testing)
+    # first run
     failTest=false
     docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c "${CHROMIUM_INSTALL}; export PANTHER_NO_SANDBOX=1; cd ${OPENEMR_DIR}; php ${OPENEMR_DIR}/vendor/bin/phpunit --testsuite e2e --testdox" || failTest=true
     if [ "$failTest" == false ]; then
       exit
     fi
+    # try run again
+    failTest=false
     docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c "${CHROMIUM_INSTALL}; export PANTHER_NO_SANDBOX=1; cd ${OPENEMR_DIR}; php ${OPENEMR_DIR}/vendor/bin/phpunit --testsuite e2e --testdox" || failTest=true
     if [ "$failTest" == false ]; then
       exit
     fi
+    # hail mary run
+    failTest=false
     docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c "${CHROMIUM_INSTALL}; export PANTHER_NO_SANDBOX=1; cd ${OPENEMR_DIR}; php ${OPENEMR_DIR}/vendor/bin/phpunit --testsuite e2e --testdox" || failTest=true
     if [ "$failTest" == false ]; then
       exit

--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -92,16 +92,22 @@ build_test_unit() {
 }
 
 build_test_e2e() {
-    # Since e2e testing is a bit inconsistent, gonna do three runs (and only one needs to pass to pass the e2e testing)
-    failTestOne=false
-    failTestTwo=false
-    failTestThree=false
-    docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c "${CHROMIUM_INSTALL}; export PANTHER_NO_SANDBOX=1; cd ${OPENEMR_DIR}; php ${OPENEMR_DIR}/vendor/bin/phpunit --testsuite e2e --testdox" || failTestOne=true
-    docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c "${CHROMIUM_INSTALL}; export PANTHER_NO_SANDBOX=1; cd ${OPENEMR_DIR}; php ${OPENEMR_DIR}/vendor/bin/phpunit --testsuite e2e --testdox" || failTestTwo=true
-    docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c "${CHROMIUM_INSTALL}; export PANTHER_NO_SANDBOX=1; cd ${OPENEMR_DIR}; php ${OPENEMR_DIR}/vendor/bin/phpunit --testsuite e2e --testdox" || failTestThree=true
-    if [ "$failTestOne" == true ] && [ "$failTestTwo" == true ] && [ "$failTestThree" == true ]; then
-      exit 1
+    # Since e2e testing is a bit inconsistent, gonna do up to three runs (and only one needs to pass to pass the e2e testing)
+    failTest=false
+    docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c "${CHROMIUM_INSTALL}; export PANTHER_NO_SANDBOX=1; cd ${OPENEMR_DIR}; php ${OPENEMR_DIR}/vendor/bin/phpunit --testsuite e2e --testdox" || failTest=true
+    if [ "$failTest" == false ]; then
+      exit
     fi
+    docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c "${CHROMIUM_INSTALL}; export PANTHER_NO_SANDBOX=1; cd ${OPENEMR_DIR}; php ${OPENEMR_DIR}/vendor/bin/phpunit --testsuite e2e --testdox" || failTest=true
+    if [ "$failTest" == false ]; then
+      exit
+    fi
+    docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c "${CHROMIUM_INSTALL}; export PANTHER_NO_SANDBOX=1; cd ${OPENEMR_DIR}; php ${OPENEMR_DIR}/vendor/bin/phpunit --testsuite e2e --testdox" || failTest=true
+    if [ "$failTest" == false ]; then
+      exit
+    fi
+    # failed 3 tests, so send the official fail
+    exit 1
 }
 
 build_test_api() {


### PR DESCRIPTION
make e2e run a bit more efficient; rather than always run 3 times, only do that if needed

of course, ideally would figure out why e2e runs are so flaky in the github action environments