### PR TITLE
Openemr fix #4941 direct send ccda

### DIFF
--- a/ccr/createCCR.php
+++ b/ccr/createCCR.php
@@ -186,7 +186,8 @@ function gnrtCCR($ccr, $raw = "no", $requested_by = "")
         }
     } elseif (substr($raw, 0, 4) == "send") {
         $recipient = trim(stripslashes(substr($raw, 5)));
-        $result = transmitCCD($ccr, $recipient, $requested_by, "CCR");
+        $ccd_out = $ccr->saveXml();
+        $result = transmitCCD($pid, $ccd_out, $recipient, $requested_by, "CCR");
         echo htmlspecialchars($result, ENT_NOQUOTES);
         return;
     } else {
@@ -286,7 +287,8 @@ function viewCCD($ccr, $raw = "no", $requested_by = "")
 
     if (substr($raw, 0, 4) == "send") {
         $recipient = trim(stripslashes(substr($raw, 5)));
-        $result = transmitCCD($ccd, $recipient, $requested_by);
+        $ccd_out = $ccd->saveXml();
+        $result = transmitCCD($pid, $ccd_out, $recipient, $requested_by);
         echo htmlspecialchars($result, ENT_NOQUOTES);
         return;
     }

--- a/ccr/transmitCCD.php
+++ b/ccr/transmitCCD.php
@@ -81,7 +81,7 @@ function transmitCCD($pid, $ccd_out, $recipient, $requested_by, $xml_type = "CCD
 
     $ret = phimail_write_expect_OK($fp, "TO $recipient\n");
     if ($ret !== true) {
-        return( xl(ErrorConstants::RECIPIENT_NOT_ALLOWED) . $ret );
+        return( xl(ErrorConstants::RECIPIENT_NOT_ALLOWED) . " " . $ret );
     }
 
     $ret = fgets($fp, 1024); //ignore extra server data

--- a/ccr/transmitCCD.php
+++ b/ccr/transmitCCD.php
@@ -30,17 +30,20 @@ require_once(dirname(__FILE__) . "/../library/direct_message_check.inc");
 
 use OpenEMR\Common\Crypto\CryptoGen;
 use OpenEMR\Common\Logging\EventAuditLogger;
+use OpenEMR\Common\DirectMessaging\ErrorConstants;
 
 /*
  * Connect to a phiMail Direct Messaging server and transmit
  * a CCD document to the specified recipient. If the message is accepted by the
  * server, the script will return "SUCCESS", otherwise it will return an error msg.
- * @param DOMDocument ccd the xml data to transmit, a CCDA document is assumed
+ * @param number The patient pid that we are sending a CCDA doc for
+ * @param string ccd the data to transmit, a CCDA document is assumed
  * @param string recipient the Direct Address of the recipient
  * @param string requested_by user | patient
+ * @param string The format that the document is in (pdf, xml, html)
  * @return string result of operation
  */
-function transmitCCD($ccd, $recipient, $requested_by, $xml_type = "CCD")
+function transmitCCD($pid, $ccd_out, $recipient, $requested_by, $xml_type = "CCD", $format_type = 'xml')
 {
     global $pid;
 
@@ -52,15 +55,15 @@ function transmitCCD($ccd, $recipient, $requested_by, $xml_type = "CCD")
         $patientName2 = "";
     } else {
         //spaces are the argument delimiter for the phiMail API calls and must be removed
-        $att_filename = " " .
-         str_replace(" ", "_", $xml_type . "_" . $patientData[0]['lname']
-         . "_" . $patientData[0]['fname']) . ".xml";
+        // CCDA format requires patient name in last, first format
+        $att_filename = str_replace(" ", "_", $xml_type . "_" . $patientData[0]['lname']
+         . "_" . $patientData[0]['fname']);
         $patientName2 = $patientData[0]['fname'] . " " . $patientData[0]['lname'];
     }
 
-    $config_err = xl("Direct messaging is currently unavailable.") . " EC:";
+    $config_err = xl(ErrorConstants::MESSAGING_DISABLED) . " " . ErrorConstants::ERROR_CODE_ABBREVIATION . ":";
     if ($GLOBALS['phimail_enable'] == false) {
-        return("$config_err 1");
+        return("$config_err " . ErrorConstants::ERROR_CODE_MESSAGING_DISABLED);
     }
 
     $fp = phimail_connect($err);
@@ -73,12 +76,12 @@ function transmitCCD($ccd, $recipient, $requested_by, $xml_type = "CCD")
     $phimail_password = $cryptoGen->decryptStandard($GLOBALS['phimail_password']);
     $ret = phimail_write_expect_OK($fp, "AUTH $phimail_username $phimail_password\n");
     if ($ret !== true) {
-        return("$config_err 4");
+        return("$config_err " . ErrorConstants::ERROR_CODE_AUTH_FAILED);
     }
 
     $ret = phimail_write_expect_OK($fp, "TO $recipient\n");
     if ($ret !== true) {
-        return( xl("Delivery is not allowed to the specified Direct Address.") );
+        return( xl(ErrorConstants::RECIPIENT_NOT_ALLOWED) . $ret );
     }
 
     $ret = fgets($fp, 1024); //ignore extra server data
@@ -96,27 +99,39 @@ function transmitCCD($ccd, $recipient, $requested_by, $xml_type = "CCD")
     $ret = @fgets($fp, 256);
     if ($ret != "BEGIN\n") {
         phimail_close($fp);
-        return("$config_err 5");
+        return("$config_err " . ErrorConstants::ERROR_CODE_MESSAGE_BEGIN_FAILED);
     }
 
     $ret = phimail_write_expect_OK($fp, $text_out);
     if ($ret !== true) {
-        return("$config_err 6");
+        return("$config_err " . ErrorConstants::ERROR_CODE_MESSAGE_BEGIN_OK_FAILED);
     }
 
-    $ccd_out = $ccd->saveXml();
-    $ccd_len = strlen($ccd_out);
+    // MU2 CareCoordination added the need to send CCDAs formatted as html,pdf, or xml
+    if ($format_type == 'html') {
+        $add_type = "TEXT";
+    } else if ($format_type == 'pdf') {
+        $add_type = "RAW";
+    } else if ($format_type == 'xml') {
+        $add_type = $xml_type == "CCR" ? "CCR" : "CDA";
+    } else {
+        // unsupported format
+        return ("$config_err " . ErrorConstants::ERROR_CODE_INVALID_FORMAT_TYPE);
+    }
 
-    phimail_write($fp, "ADD " . ($xml_type == "CCR" ? "CCR " : "CDA ") . $ccd_len . $att_filename . "\n");
+    $ccd_len = strlen($ccd_out);
+    $extension = "." . $format_type;
+
+    phimail_write($fp, "ADD " . $add_type . " " . $ccd_len . " " . $att_filename . $extension . "\n");
     $ret = fgets($fp, 256);
     if ($ret != "BEGIN\n") {
         phimail_close($fp);
-        return("$config_err 7");
+        return("$config_err " . ErrorConstants::ERROR_CODE_ADD_FILE_FAILED);
     }
 
     $ret = phimail_write_expect_OK($fp, $ccd_out);
     if ($ret !== true) {
-        return("$config_err 8");
+        return("$config_err " . ErrorConstants::ERROR_CODE_ADD_FILE_CONFIRM_FAILED);
     }
 
     phimail_write($fp, "SEND\n");
@@ -144,7 +159,7 @@ function transmitCCD($ccd, $recipient, $requested_by, $xml_type = "CCD")
         //log the failure
 
         EventAuditLogger::instance()->newEvent("transmit-ccd", $reqBy, $_SESSION['authProvider'], 0, $ret, $pid);
-        return( xl("The message could not be sent at this time."));
+        return( xl(ErrorConstants::ERROR_MESSAGE_FILE_SEND_FAILED));
     }
 
    /**
@@ -156,7 +171,7 @@ function transmitCCD($ccd, $recipient, $requested_by, $xml_type = "CCD")
     if ($msg_id[0] != "QUEUED" || !isset($msg_id[2])) { //unexpected response
         $ret = "UNEXPECTED RESPONSE: " . $ret;
         EventAuditLogger::instance()->newEvent("transmit-ccd", $reqBy, $_SESSION['authProvider'], 0, $ret, $pid);
-        return( xl("There was a problem sending the message."));
+        return( xl(ErrorConstants::ERROR_MESSAGE_UNEXPECTED_RESPONSE));
     }
 
     EventAuditLogger::instance()->newEvent("transmit-" . $xml_type, $reqBy, $_SESSION['authProvider'], 1, $ret, $pid);

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncountermanagerTable.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncountermanagerTable.php
@@ -232,9 +232,7 @@ class EncountermanagerTable extends AbstractTableGateway
         }
 
         try {
-
             foreach ($rec_arr as $recipient) {
-
                 $elec_sent = array();
                 $arr = explode('|', $ccda_combination);
                 foreach ($arr as $value) {
@@ -277,9 +275,7 @@ class EncountermanagerTable extends AbstractTableGateway
                     }
                 }
             }
-        }
-        catch (\Exception $exception)
-        {
+        } catch (\Exception $exception) {
             (new SystemLogger())->errorLogCaller($exception->getMessage(), ['data' => $data]);
             return ("Delivery failed to send");
         }

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncountermanagerTable.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncountermanagerTable.php
@@ -13,13 +13,19 @@
 
 namespace Carecoordination\Model;
 
-use OpenEMR\Common\Crypto\CryptoGen;
-use Laminas\Db\TableGateway\AbstractTableGateway;
-use Application\Model\ApplicationTable;
-use Laminas\Db\Adapter\Driver\Pdo\Result;
-use ZipArchive;
+// TODO: we need to refactor all of this so it can go into a class for this functionality
+require_once($GLOBALS['fileroot'] . '/ccr/transmitCCD.php');
+
 use CouchDB;
-use DOMPDF;
+use DOMDocument;
+use Dompdf\Dompdf;
+use Application\Model\ApplicationTable;
+use Laminas\Db\TableGateway\AbstractTableGateway;
+use Laminas\Db\Adapter\Driver\Pdo\Result;
+use OpenEMR\Common\Crypto\CryptoGen;
+use OpenEMR\Common\DirectMessaging\ErrorConstants;
+use OpenEMR\Common\Logging\SystemLogger;
+use XSLTProcessor;
 
 class EncountermanagerTable extends AbstractTableGateway
 {
@@ -177,6 +183,31 @@ class EncountermanagerTable extends AbstractTableGateway
         }
     }
 
+    private function getCcdaAsPdf($ccda)
+    {
+        $dompdf = new Dompdf();
+        $dompdf->loadHtml($this->getCcdaAsHTML($ccda));
+        $dompdf->render();
+        return $dompdf->output();
+    }
+
+    public function getCcdaAsHTML($ccda)
+    {
+        $xml = simplexml_load_string($ccda);
+        $xsl = new DOMDocument();
+        // cda.xsl is self contained with bootstrap and jquery.
+        // cda-web.xsl is used when referencing styles from internet.
+        $xsl->load(__DIR__ . '/../../../../../public/xsl/cda.xsl');
+        $proc = new XSLTProcessor();
+        if (!$proc->importStyleSheet($xsl)) { // attach the xsl rules
+            throw new \RuntimeException("CDA Stylesheet could not be found");
+        }
+        $outputFile = sys_get_temp_dir() . '/out_' . time() . '.html';
+        $proc->transformToURI($xml, $outputFile);
+
+        return file_get_contents($outputFile);
+    }
+
     /*
      * Connect to a phiMail Direct Messaging server and transmit
      * a CCDA document to the specified recipient. If the message is accepted by the
@@ -186,7 +217,7 @@ class EncountermanagerTable extends AbstractTableGateway
      * @param string requested_by user | patient
      * @return string result of operation
      */
-    public function transmitCCD($data = array())
+    public function transmitCcdToRecipients($data = array())
     {
         $appTable         = new ApplicationTable();
         $ccda_combination = $data['ccda_combination'];
@@ -194,153 +225,63 @@ class EncountermanagerTable extends AbstractTableGateway
         $xml_type         = $data['xml_type'];
         $rec_arr          = explode(";", $recipients);
         $d_Address        = '';
-        foreach ($rec_arr as $recipient) {
-            $config_err = "Direct messaging is currently unavailable." . " EC:";
-            if ($GLOBALS['phimail_enable'] == false) {
-                return("$config_err 1");
-            }
+        // no point in continuing if we are not setup here
+        $config_err = xl(ErrorConstants::MESSAGING_DISABLED) . " " . ErrorConstants::ERROR_CODE_ABBREVIATION . ":";
+        if ($GLOBALS['phimail_enable'] == false) {
+            return("$config_err " . ErrorConstants::ERROR_CODE_MESSAGING_DISABLED);
+        }
 
-            $fp = (new \Application\Plugin\Phimail())->phimail_connect($err);
-            if ($fp === false) {
-                return("$config_err $err");
-            }
+        try {
 
-            $phimail_username = $GLOBALS['phimail_username'];
-            $cryptoGen = new CryptoGen();
-            $phimail_password = $cryptoGen->decryptStandard($GLOBALS['phimail_password']);
-            $ret = (new \Application\Plugin\Phimail())->phimail_write_expect_OK($fp, "AUTH $phimail_username $phimail_password\n");
-            if ($ret !== true) {
-                return("$config_err 4");
-            }
+            foreach ($rec_arr as $recipient) {
 
-            $ret = \Application\Plugin\Phimail::phimail_write_expect_OK($fp, "TO $recipient\n");
-            if ($ret !== true) {//return("Delivery is not allowed to the specified Direct Address.") ;
-                $d_Address .= ' ' . $recipient;
-                continue;
-            }
+                $elec_sent = array();
+                $arr = explode('|', $ccda_combination);
+                foreach ($arr as $value) {
+                    $query = "SELECT id FROM  ccda WHERE pid = ? ORDER BY id DESC LIMIT 1";
+                    $result = $appTable->zQuery($query, array($value));
+                    foreach ($result as $val) {
+                        $ccda_id = $val['id'];
+                    }
 
-            $ret = fgets($fp, 1024); //ignore extra server data
-            if ($requested_by == "patient") {
-                $text_out = "Delivery of the attached clinical document was requested by the patient";
-            } else {
-                if (strpos($ccda_combination, '|') !== false) {
-                    $text_out = "Clinical documents are attached.";
-                } else {
-                    $text_out = "A clinical document is attached";
-                }
-            }
+                    // this segment of code is attempting to connect a CCDA to a Referral form (stored in the transactions)
+                    // table so we can track for Automated Measure Calculation (AMC) purposes.  This assumes that a referral
+                    // form has been created before the CCDA was sent (otherwise the transaction id is 0)
+                    $refs = $appTable->zQuery("select t.id as trans_id from ccda c inner join transactions t on (t.pid = c.pid and t.date = c.updated_date) where c.pid = ? and c.emr_transfer = 1 and t.title = 'LBTref'", array($value));
+                    if ($refs->count() == 0) {
+                        $trans = $appTable->zQuery("select id from transactions where pid = ? and title = 'LBTref' order by id desc limit 1", array($value));
+                        $trans_cur = $trans->current();
+                        $trans_id = $trans_cur['id'] ? $trans_cur['id'] : 0;
+                    } else {
+                        foreach ($refs as $r) {
+                            $trans_id = $r['trans_id'];
+                        }
+                    }
+                    $elec_sent[] = array('pid' => $value, 'map_id' => $trans_id);
 
-            $text_len = strlen($text_out);
-            (new \Application\Plugin\Phimail())->phimail_write($fp, "TEXT $text_len\n");
-            $ret = @fgets($fp, 256);
-            if ($ret != "BEGIN\n") {
-                (new \Application\Plugin\Phimail())->phimail_close($fp);
-              //return("$config_err 5");
-                $d_Address .= ' ' . $recipient;
-                continue;
-            }
+                    $ccda = $this->getFile($ccda_id);
 
-            $ret = (new \Application\Plugin\Phimail())->phimail_write_expect_OK($fp, $text_out);
-            if ($ret !== true) {
-              //return("$config_err 6");
-                $d_Address .= $recipient;
-                continue;
-            }
-
-            $elec_sent = array();
-            $arr = explode('|', $ccda_combination);
-            foreach ($arr as $value) {
-                $query  = "SELECT id FROM  ccda WHERE pid = ? ORDER BY id DESC LIMIT 1";
-                $result = $appTable->zQuery($query, array($value));
-                foreach ($result as $val) {
-                    $ccda_id = $val['id'];
-                }
-
-                $refs = $appTable->zQuery("select t.id as trans_id from ccda c inner join transactions t on (t.pid = c.pid and t.date = c.updated_date) where c.pid = ? and c.emr_transfer = 1 and t.title = 'LBTref'", array($value));
-                if ($refs->count() == 0) {
-                    $trans = $appTable->zQuery("select id from transactions where pid = ? and title = 'LBTref' order by id desc limit 1", array($value));
-                    $trans_cur = $trans->current();
-                    $trans_id  = $trans_cur['id'] ? $trans_cur['id'] : 0;
-                } else {
-                    foreach ($refs as $r) {
-                        $trans_id = $r['trans_id'];
+                    if ($xml_type == 'html') {
+                        $ccda_file = $this->getCcdaAsHTML($ccda);
+                    } elseif ($xml_type == 'pdf') {
+                        $ccda_file = $this->getCcdaAsPdf($ccda);
+                    } elseif ($xml_type == 'xml') {
+                        $xml = simplexml_load_string($ccda);
+                        $ccda_file = $xml->saveXML();
+                    }
+                    // there is no way currently to specify this came from the patient so we force to clinician.
+                    // Default xml type is CCD  (ie Continuity of Care Document)
+                    $result = transmitCCD($value, $ccda_file, $recipient, 'clinician', "CCD", strtolower($xml_type));
+                    if ($result !== "SUCCESS") {
+                        $d_Address .= ' ' . $recipient . "(" . $result . ")";
                     }
                 }
-
-                $elec_sent[] = array('pid' => $value,'map_id' => $trans_id);
-
-                $ccda = $this->getFile($ccda_id);
-
-                $xml = simplexml_load_string($ccda);
-                $xsl = new \DOMDocument();
-                $xsl->load(dirname(__FILE__) . '/../../../../../public/xsl/ccda.xsl');
-                $proc = new \XSLTProcessor();
-                $proc->importStyleSheet($xsl); // attach the xsl rules
-                $outputFile = sys_get_temp_dir() . '/out_' . time() . '.html';
-                $proc->transformToURI($xml, $outputFile);
-                $htmlContent = file_get_contents($outputFile);
-                if ($xml_type == 'html') {
-                    $ccda_file =  htmlspecialchars_decode($htmlContent);
-                } elseif ($xml_type == 'pdf') {
-                    $dompdf = new DOMPDF();
-                    $dompdf->load_html($htmlContent);
-                    $dompdf->render();
-                    //$dompdf->stream();
-                    $ccda_file = $dompdf->output();
-                } elseif ($xml_type == 'xml') {
-                    $ccda_file = $ccda;
-                }
-
-               //get patient name in Last_First format (used for CCDA filename)
-                $sql    = "SELECT pid, id, lname, fname, mname, providerID, DATE_FORMAT(DOB,'%m/%d/%Y') as DOB_TS FROM patient_data WHERE pid = ?";
-                $result = $appTable->zQuery($sql, array($value));
-                foreach ($result as $val) {
-                    $patientData[0] = $val;
-                }
-
-                if (empty($patientData[0]['lname'])) {
-                    $att_filename = "";
-                    $patientName2 = "";
-                } else {
-                    //spaces are the argument delimiter for the phiMail API calls and must be removed
-                    $extension = $xml_type == 'CCDA' ? 'xml' : strtolower($xml_type);
-                    $att_filename = " " . str_replace(" ", "_", $xml_type . "_" . $patientData[0]['lname']  . "_" . $patientData[0]['fname']) . "." . $extension;
-                    $patientName2 = $patientData[0]['fname'] . " " . $patientData[0]['lname'];
-                }
-
-                if (strtolower($xml_type) == 'xml') {
-                    $ccda     = simplexml_load_string($ccda_file);
-                    $ccda_out = $ccda->saveXml();
-                    $ccda_len = strlen($ccda_out);
-                    \Application\Plugin\Phimail::phimail_write($fp, "ADD " . ($xml_type == "CCR" ? $xml_type . ' ' : "CDA ") . $ccda_len . $att_filename . "\n");
-                } elseif (strtolower($xml_type) == 'html' || strtolower($xml_type) == 'pdf') {
-                    $ccda_out = $ccda_file;
-                    $message_length = strlen($ccda_out);
-                    $add_type = (strtolower($xml_type) == 'html') ? 'TEXT' : 'RAW';
-                    \Application\Plugin\Phimail::phimail_write($fp, "ADD " . $add_type . " " . $message_length . "" . $att_filename . "\n");
-                }
-
-                $ret = fgets($fp, 256);
-                if ($ret != "BEGIN\n") {
-                    \Application\Plugin\Phimail::phimail_close($fp);
-                    //return("$config_err 7");
-                    $d_Address .= ' ' . $recipient;
-                    continue;
-                }
-
-                $ret = \Application\Plugin\Phimail::phimail_write_expect_OK($fp, $ccda_out);
             }
-
-            if ($ret !== true) {
-//              return("$config_err 8");
-                $d_Address .= ' ' . $recipient;
-                continue;
-            }
-
-            \Application\Plugin\Phimail::phimail_write($fp, "SEND\n");
-            $ret = fgets($fp, 256);
-        //"INSERT INTO `amc_misc_data` (`amc_id`,`pid`,`map_category`,`map_id`,`date_created`) VALUES(?,?,?,?,NOW())"
-            \Application\Plugin\Phimail::phimail_close($fp);
+        }
+        catch (\Exception $exception)
+        {
+            (new SystemLogger())->errorLogCaller($exception->getMessage(), ['data' => $data]);
+            return ("Delivery failed to send");
         }
 
         if ($d_Address == '') {
@@ -351,7 +292,7 @@ class EncountermanagerTable extends AbstractTableGateway
 
             return("Successfully Sent");
         } else {
-            return("Delivery is not allowed to:" . $d_Address);
+            return("Delivery failed to send or was not allowed to:" . $d_Address);
         }
     }
     public function getFileID($pid)

--- a/library/direct_message_check.inc
+++ b/library/direct_message_check.inc
@@ -32,6 +32,7 @@ use OpenEMR\Common\Crypto\CryptoGen;
 use OpenEMR\Common\Logging\EventAuditLogger;
 use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Events\Core\Sanitize\IsAcceptedFileFilterEvent;
+use OpenEMR\Services\VersionService;
 use PHPMailer\PHPMailer\PHPMailer;
 
 /**
@@ -125,6 +126,15 @@ function phimail_connect(&$phimail_error)
         }
     } else {
         $fp = @fsockopen($server, $phimail_server['port']);
+    }
+
+    if ($fp !== false) {
+        $ret = phimail_write_expect_OK($fp, "INFO VER OEMR " . (new VersionService())->asString() . " 1.3.2 "
+            . \PHP_VERSION . "\n");
+        if ($ret !== true) {
+            $fp = false;
+            $phimail_error = 'C5';
+        }
     }
 
     if (!empty($phimail_error)) {

--- a/src/Common/DirectMessaging/ErrorConstants.php
+++ b/src/Common/DirectMessaging/ErrorConstants.php
@@ -13,7 +13,13 @@ namespace OpenEMR\Common\DirectMessaging;
 
 class ErrorConstants
 {
+    /**
+     * Note for translation purposes we duplicate the constant inside an xl() command
+     * otherwise our translation engine won't pick it up.
+     */
+
     // Message that is sent back to the user (translated) if messaging is unavailable
+    // xl("Direct messaging is currently unavailable.")
     const MESSAGING_DISABLED = "Direct messaging is currently unavailable.";
 
     // used in the message sent back to the user when something fails
@@ -21,7 +27,8 @@ class ErrorConstants
 
     // translated message sent back to the user when a Direct Address is invalid or message delivery not allowed
     // Details of the reason is attached to this message (which is not translated).
-    const RECIPIENT_NOT_ALLOWED = "Delivery is not allowed to the specified Direct Address: ";
+    // xl("Delivery is not allowed to the specified Direct Address:")
+    const RECIPIENT_NOT_ALLOWED = "Delivery is not allowed to the specified Direct Address:";
 
     // Direct Messaging is disabled in the globals
     const ERROR_CODE_MESSAGING_DISABLED = 1;
@@ -45,8 +52,10 @@ class ErrorConstants
     const ERROR_CODE_INVALID_FORMAT_TYPE = 9;
 
     // we sent the file to Direct but they failed it on their end.  Details are in the event audit log
+    // xl("The message could not be sent at this time.")
     const ERROR_MESSAGE_FILE_SEND_FAILED = "The message could not be sent at this time.";
 
     // We sent the file to Direct and we got back an unexpected response other than ERROR or QUEUED
+    // xl("There was a problem sending the message.")
     const ERROR_MESSAGE_UNEXPECTED_RESPONSE = "There was a problem sending the message.";
 }

--- a/src/Common/DirectMessaging/ErrorConstants.php
+++ b/src/Common/DirectMessaging/ErrorConstants.php
@@ -49,5 +49,4 @@ class ErrorConstants
 
     // We sent the file to Direct and we got back an unexpected response other than ERROR or QUEUED
     const ERROR_MESSAGE_UNEXPECTED_RESPONSE = "There was a problem sending the message.";
-
 }

--- a/src/Common/DirectMessaging/ErrorConstants.php
+++ b/src/Common/DirectMessaging/ErrorConstants.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * ErrorConstants holds a number of string constants and error codes
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2022 Stephen Nielson <snielson@discoverandchange.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Common\DirectMessaging;
+
+class ErrorConstants
+{
+    // Message that is sent back to the user (translated) if messaging is unavailable
+    const MESSAGING_DISABLED = "Direct messaging is currently unavailable.";
+
+    // used in the message sent back to the user when something fails
+    const ERROR_CODE_ABBREVIATION = "EC";
+
+    // translated message sent back to the user when a Direct Address is invalid or message delivery not allowed
+    // Details of the reason is attached to this message (which is not translated).
+    const RECIPIENT_NOT_ALLOWED = "Delivery is not allowed to the specified Direct Address: ";
+
+    // Direct Messaging is disabled in the globals
+    const ERROR_CODE_MESSAGING_DISABLED = 1;
+
+    // The login AUTH failed, password is likely wrong, but could be something else
+    const ERROR_CODE_AUTH_FAILED = 4;
+
+    // Failed to get back from the server that we can begin sending a message
+    const ERROR_CODE_MESSAGE_BEGIN_FAILED = 5;
+
+    // failed to get a response when sending OK after the message BEGIN command
+    const ERROR_CODE_MESSAGE_BEGIN_OK_FAILED = 6;
+
+    // The ADD <file-type> <file-length> <file-name>\n command failed
+    const ERROR_CODE_ADD_FILE_FAILED = 7;
+
+    // Failed to get an OK response from the server to begin sending the file
+    const ERROR_CODE_ADD_FILE_CONFIRM_FAILED = 8;
+
+    // attempted to send an unsupported format type
+    const ERROR_CODE_INVALID_FORMAT_TYPE = 9;
+
+    // we sent the file to Direct but they failed it on their end.  Details are in the event audit log
+    const ERROR_MESSAGE_FILE_SEND_FAILED = "The message could not be sent at this time.";
+
+    // We sent the file to Direct and we got back an unexpected response other than ERROR or QUEUED
+    const ERROR_MESSAGE_UNEXPECTED_RESPONSE = "There was a problem sending the message.";
+
+}


### PR DESCRIPTION
Fixes #4941 

The direct send was not working with the CareCoordination module as it
had a duplicate code of the ccr/transmitCCD.  Working with EMRDirect
found that the Direct community expects one message per patient instead
of bundling multiple patients into a single message per recipient.  I
changed up the code flow to make this happen as well as removed the
duplicate code.  I was able to extend the ccr/transmitCCD.php file to
handle pdf and html files.

Also pulled out some of the constants in the transmitCCD function into
a class with better explanations.  This made the code more legible.

Also documented some of the AMC stuff with the care coordination.

Per request from EMRDirect we add in the version information so they can
have better debugging facilities on their end when OpenEMR has issues.

Note @sjpadgett I refactored the HTML generation in EncountermanagerController to forward the request on to the EncountermanagerTable class since that code was being duplicated and the XSL was not updated when you made your refactor.  From my tests it looks like everything is all working but you may want to just look at those two files and make sure I didn't break anything for you.