### PR TITLE
Fixes #4888 Direct Message Whitelist

### DIFF
--- a/library/direct_message_check.inc
+++ b/library/direct_message_check.inc
@@ -592,8 +592,6 @@ function phimail_store($name, $mime_type, $fn)
 {
     global $phimail_direct_message_check_allowed_mimetype;
 
-    (new SystemLogger())->debug("Attempting to store phimail attachment in OpenEMR", ['name' => $name, 'mime_type' => $mime_type]);
-
     $allowMimeTypeFunction = 'phimail_allow_document_mimetype';
     // we bypass the whitelisting JUST for phimail documents
     if (isset($GLOBALS['kernel'])) {
@@ -610,7 +608,6 @@ function phimail_store($name, $mime_type, $fn)
         if (is_array($return)) {
             $return['filesize'] = $filesize;
         }
-        (new SystemLogger())->debug("addNewDocument finished", ['return' => $return]);
     } catch (\Exception $exception) {
         (new SystemLogger())->errorLogCaller($exception->getMessage(), ['name' => $name, 'mime_type' => $mime_type, 'fn' => $fn]);
         phimail_logit(0, "problem storing attachment in OpenEMR");

--- a/library/direct_message_check.inc
+++ b/library/direct_message_check.inc
@@ -566,8 +566,7 @@ function phimail_service_userID($name = 'phimail-service')
 
 /**
  * Given an IsAcceptedFileFilterEvent from our isWhitelist function we check to make sure that we allow
- * the mime type of the Direct message attachment that was sent by the server.  We check to make sure that the mime
- * type is only the mime type of the specific document sent via EMRDirect
+ * the mime type of the Direct message attachment that was sent by the server.
  * @param IsAcceptedFileFilterEvent $event The event with the mimetype to check if we allow it or not
  * @return IsAcceptedFileFilterEvent
  */
@@ -576,9 +575,10 @@ function phimail_allow_document_mimetype(IsAcceptedFileFilterEvent $event)
     global $phimail_direct_message_check_allowed_mimetype;
     $isAllowedFile = $event->isAllowedFile();
     if (!$isAllowedFile) {
-        if ($phimail_direct_message_check_allowed_mimetype == $event->getMimeType()) {
-            $event->setAllowedFile(true);
-        }
+        // we used to only bypass if the Direct mime type matched with what comes through in the event.
+        // This fails though if there are multiple possible mime types such as application/xml vs text/xml and the Direct
+        // mime type differs from the local OS detection. We will just bypass the mime check alltogether.
+        $event->setAllowedFile(true);
     }
     return $event;
 }
@@ -591,6 +591,8 @@ function phimail_allow_document_mimetype(IsAcceptedFileFilterEvent $event)
 function phimail_store($name, $mime_type, $fn)
 {
     global $phimail_direct_message_check_allowed_mimetype;
+
+    (new SystemLogger())->debug("Attempting to store phimail attachment in OpenEMR", ['name' => $name, 'mime_type' => $mime_type]);
 
     $allowMimeTypeFunction = 'phimail_allow_document_mimetype';
     // we bypass the whitelisting JUST for phimail documents
@@ -608,6 +610,7 @@ function phimail_store($name, $mime_type, $fn)
         if (is_array($return)) {
             $return['filesize'] = $filesize;
         }
+        (new SystemLogger())->debug("addNewDocument finished", ['return' => $return]);
     } catch (\Exception $exception) {
         (new SystemLogger())->errorLogCaller($exception->getMessage(), ['name' => $name, 'mime_type' => $mime_type, 'fn' => $fn]);
         phimail_logit(0, "problem storing attachment in OpenEMR");


### PR DESCRIPTION
Fixes #4888 

I discovered that the document white listing fails if the local
operating system's mime type detection on the document is
different than the mime type received via direct. This was
discovered with a CCDA xml file. EMRDirect was sending a mime type
of application/xml mime type and the local OS detected it as
text/xml. This breaks our current solution as we temporarily allow
the EMRDirect mime type if it matches the document mime type and
then we remove the temporary bypass.

Since we don't want to build a file quarantine process I went
with our original design approach and bypass the mime type check
altogether during the document storage process.
The files are protected on the drive as is so this should be fine.