### PR TITLE
Normalize buttons, improve readability of patient name

### DIFF
--- a/interface/main/tabs/templates/patient_data_template.php
+++ b/interface/main/tabs/templates/patient_data_template.php
@@ -59,11 +59,12 @@ switch ($search_any_type) {
             </div>
             <div class="form-group">
                 <!-- ko if: patient -->
-                <a class="ptName btn btn-small btn-info" data-bind="click:refreshPatient,with: patient" href="#" title="<?php echo xla("To Dashboard") ?>">
-                    <span data-bind="text: pname()"></span>
-                    (<span data-bind="text: pubpid"></span>)
-                </a>&ensp;
-                <a href="#" class="btn btn-sm btn-warning" data-bind="click:clearPatient" title="<?php echo xla("Clear") ?>">
+                <h4 class="d-inline">
+                    <a class="ptName" data-bind="click:refreshPatient,with: patient" href="#" title="<?php echo xla("To Dashboard") ?>">
+                        <span data-bind="text: pname()"></span>&nbsp;<small class="text-muted">(<span data-bind="text: pubpid"></span>)</small>
+                    </a>
+                </h4>
+                <a href="#" class="pl-3" data-bind="click:clearPatient" title="<?php echo xla("Clear") ?>">
                     <i class="fa fa-times"></i>
                 </a>
                 <div>
@@ -75,11 +76,11 @@ switch ($search_any_type) {
         <div class="flex-fill ml-2">
             <!-- ko if: patient -->
             <!-- ko with: patient -->
-            <a class="btn btn-sm btn-info" data-bind="click: clickEncounterList" href="#"
+            <a class="btn btn-sm btn-secondary" data-bind="click: clickEncounterList" href="#"
                 title="<?php echo xla("Visit History"); ?>">
                 <i class="fas fa-history"></i>
             </a>
-            <a class="btn btn-sm btn-primary" data-bind="click: clickNewEncounter" href="#"
+            <a class="btn btn-sm btn-secondary" data-bind="click: clickNewEncounter" href="#"
                 title="<?php echo xla("New Encounter"); ?>">
                 <i class="fa fa-plus"></i>
             </a>


### PR DESCRIPTION
A bit more work on the recent changes to the patient banner bar. Since the new encounter button is not the primary action button, swapped over to `btn-secondary`, moved the View History button to btn-secondary as well to remain consistent. Instead of the btn-info on the patient name, I dropped the button styling (It's more of a secondary navigation element versus a button with action) and turned it into an `<h3>` - this promotes it, making it easier to see (and, by extension, easier to click). The Close Patient button had a btn-warning class on it, which we need to reserve for critical actions or for things that need our attention (think the way we display the delete patient button).

We should really strive to avoid using red, yellow, and orange colors in places that do not require immediate clinician attention. I have seen many charts (not in OpenEMR) that have full-width, high-impact color background banner alerts. One or two grabs my attention, but it's not uncommon to see 7 of them stacked on each other... it gets to be overwhelming.

![image](https://user-images.githubusercontent.com/1381170/155438892-65242dc5-26a2-4e3d-bbf7-e2e486af7627.png)
