### PR TITLE
New Twig function, csrfToken() to auto generate the input field

### DIFF
--- a/src/Common/Twig/TwigExtension.php
+++ b/src/Common/Twig/TwigExtension.php
@@ -15,6 +15,7 @@
 
 namespace OpenEMR\Common\Twig;
 
+use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\Kernel;
 use OpenEMR\Services\Globals\GlobalsService;
@@ -113,7 +114,13 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
                     $this->kernel->getEventDispatcher()->dispatch(new GenericEvent($eventName, $eventData), $eventName);
                     return ob_get_clean();
                 }
-            )
+            ),
+            new TwigFunction(
+                'csrfToken',
+                function ($subject = 'default') {
+                    return sprintf('<input type="hidden" name="_token" value="%s">', CsrfUtils::collectCsrfToken($subject));
+                }
+            ),
         ];
     }
 


### PR DESCRIPTION
Creates a new Twig function called `csrfToken()` which optionally accepts 1 parameter for the subject.

Returns a hidden field named `_token` with the value from `CsrfUtils::collectCsrfToken()`