### PR TITLE
Fixes for User About tab open

### DIFF
--- a/interface/main/tabs/templates/patient_data_template.php
+++ b/interface/main/tabs/templates/patient_data_template.php
@@ -180,7 +180,7 @@ switch ($search_any_type) {
             <!-- /ko --><!-- messages -->
             <!-- ko if: portal() -->
             <span class="btn-group dropdown mr-auto">
-                <button class="btn btn-secondary dropdown-toggle"
+                <button class="btn btn-secondary btn-sm dropdown-toggle"
                     type="button" id="portalMsgAlerts"
                     data-toggle="dropdown"
                     aria-haspopup="true"

--- a/interface/main/tabs/templates/user_data_template.php
+++ b/interface/main/tabs/templates/user_data_template.php
@@ -32,7 +32,7 @@
                         <li class="menuLabel" data-bind="click: changePassword"><i class="fa fa-fw pr-2 text-muted fa-lock"></i>&nbsp;<?php echo xlt("Change Password");?></li>
                         <li class="menuLabel" data-bind="click: changeMFA"><i class="fa fa-fw pr-2 text-muted fa-key"></i>&nbsp;<?php echo xlt("MFA Management");?></li>
                         <div class="dropdown-divider"></div>
-                        <li class="menuLabel" data-bind="click: function() {navigateTab('/interface/main/about_page.php', 'About');activateTabByName('msc');}"><i class="fa fa-fw pr-2 text-muted fa-info"></i>&nbsp;<?php echo xlt("About");?> <?php echo text($GLOBALS['openemr_name']); ?></li>
+                        <li class="menuLabel" data-bind="click: function() {navigateTab('/interface/main/about_page.php', 'About', function() {activateTabByName('About',true);});}"><i class="fa fa-fw pr-2 text-muted fa-info"></i>&nbsp;<?php echo xlt("About");?> <?php echo text($GLOBALS['openemr_name']); ?></li>
                         <div class="dropdown-divider"></div>
                         <li class="menuLabel" data-bind="click: logout"><i class="fa fa-fw pr-2 text-muted fa-sign-out-alt"></i>&nbsp;<?php echo xlt("Logout");?></li>
                     </ul>


### PR DESCRIPTION
- Add callback to ativate correct tab.
- add btn-sm to Portal notification to match messages button.
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:
The About page link in User dropdown required two clicks to view the about page.
Also mismatched button sizes for message and portal notifications.