### PR TITLE
Billing Processor Issue with Claims Validation

### DIFF
--- a/src/Billing/BillingProcessor/Tasks/GeneratorX12.php
+++ b/src/Billing/BillingProcessor/Tasks/GeneratorX12.php
@@ -95,6 +95,18 @@ class GeneratorX12 extends AbstractGenerator implements GeneratorInterface, Gene
      */
     public function validateOnly(BillingClaim $claim)
     {
+        $return = BillingUtilities::updateClaim(
+            true,
+            $claim->getPid(),
+            $claim->getEncounter(),
+            $claim->getPayorId(),
+            $claim->getPayorType(),
+            BillingClaim::STATUS_LEAVE_UNCHANGED ,
+            BillingClaim::STATUS_LEAVE_UNCHANGED , // bill_process == 1 means??
+            '', // process_file
+            $claim->getTarget(),
+            $claim->getPartner()
+        );
         $this->updateBatchFile($claim);
     }
 

--- a/src/Billing/BillingProcessor/Tasks/GeneratorX12Direct.php
+++ b/src/Billing/BillingProcessor/Tasks/GeneratorX12Direct.php
@@ -141,6 +141,18 @@ class GeneratorX12Direct extends AbstractGenerator implements GeneratorInterface
      */
     public function validateOnly(BillingClaim $claim)
     {
+        $return = BillingUtilities::updateClaim(
+            true,
+            $claim->getPid(),
+            $claim->getEncounter(),
+            $claim->getPayorId(),
+            $claim->getPayorType(),
+            BillingClaim::STATUS_LEAVE_UNCHANGED,
+            BillingClaim::STATUS_LEAVE_UNCHANGED, // bill_process == 1 means??
+            '', // process_file
+            $claim->getTarget(),
+            $claim->getPartner()
+        );
         $this->updateBatchFile($claim);
     }
 


### PR DESCRIPTION
This PR addresses an issue with the refactored billing processor, where 'validate only' displayed missing ins information for new claims.

Thanks to @stephenwaite for pointing it out!

