### PR TITLE
QRDA Cat1 codesystem fix

### DIFF
--- a/src/Services/Qrda/Helpers/Cat1View.php
+++ b/src/Services/Qrda/Helpers/Cat1View.php
@@ -20,7 +20,7 @@ trait Cat1View
     public function negation_ind(Mustache_Context $context): string
     {
         $negationRationale = $context->find('negationRationale');
-        return empty($negationRationale) ? "" : "negationInd=\"true\"";
+        return empty($negationRationale) ? "" : " negationInd=\"true\"";
     }
 
     public function negated(Mustache_Context $context): bool
@@ -63,17 +63,19 @@ trait Cat1View
             return "<id root=\"" . $namingSystem . "\" extension=\"" . $value . "\"/>";
         }
     }
+
     public function code_and_codesystem(Mustache_Context $context)
     {
-        $oid = $context->find('oid');
-        if ($oid == '1.2.3.4.5.6.7.8.9.10') {
-            return "nullFlavor=\"NA\" sdtc:valueSet=\"#{self['code']}\"";
+        $oid = $context->find('system');
+        $code = $context->find('code');
+        if (empty($oid)) {
+            return "nullFlavor=\"NA\" sdtc:valueSet=\"$code\"";
         } else {
-            $code = $context->find('code');
             $codeSystem = $this->get_code_system_for_oid($oid);
             return "code=\"" . $code . "\" codeSystem=\"" . $oid . "\" codeSystemName=\"" . $codeSystem . "\"";
         }
     }
+
     public function primary_code_and_codesystem(Mustache_Context $context)
     {
         $codes = $context->find('dataElementCodes');
@@ -82,6 +84,7 @@ trait Cat1View
         $system = $this->get_code_system_for_oid($oid);
         return "code=\"" . $code . "\" codeSystem=\"" . $oid . "\" codeSystemName=\"" . $system . "\"";
     }
+
     public function translation_codes_and_codesystem_list(Mustache_Context $context)
     {
         $translation_list = "";
@@ -133,7 +136,7 @@ trait Cat1View
                 $result_string = $this->result_value_as_string($result);
             }
             // string
-        } else if (is_string($result)) {
+        } elseif (is_string($result)) {
             $result_string = "<value xsi:type=\"ST\">" . $result . "</value>";
             // non-null value
         } else {
@@ -147,15 +150,17 @@ trait Cat1View
         if (empty($result)) {
             return "<value xsi:type=\"CD\" nullFlavor=\"UNK\"/>";
         }
+
         $oid = $result['system'] ?? $result['codeSystem'];
         $system = $this->get_code_system_for_oid($oid);
         if (!empty($result['code'])) {
             return "<value xsi:type=\"CD\" code=\"" . $result['code'] . "\" codeSystem=\"" . $oid
                 . "\" codeSystemName=\"" . $system . "\"/>";
-        } else if ($result['unit']) {
-            return "<value xsi:type=\"PQ\" value=\"" . $result['value'] . "' unit='" . $result['unit'] . "'/>";
+        } elseif (!empty($result['value'])) {
+            return "<value xsi:type=\"PQ\" value=\"" . $result['value'] . "\" unit=\"" . ($result['unit'] ?: "UNK") . "\"/>";
         } else {
             // TODO: @sjpadgett, @adunsulag, @ken.matrix the ruby code didn't handle this case... what happens here?
+            // no result so template shouldn't show.
             return "";
         }
     }

--- a/src/Services/Qrda/Helpers/PatientView.php
+++ b/src/Services/Qrda/Helpers/PatientView.php
@@ -86,10 +86,16 @@ trait PatientView
 
     public function given_name(Mustache_Context $context)
     {
-        $names = $context->find('givenNames');
+        $names = $context->find('patientName');
         if (!empty($names)) {
-            return implode(' ', $names);
+            return trim($names->given . ' ' . $names->middle);
         }
+    }
+
+    public function familyName(Mustache_Context $context)
+    {
+        $family = $context->find('patientName');
+        return trim($family->family);
     }
 
     public function gender()

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_header/_record_target.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_header/_record_target.mustache
@@ -4,7 +4,7 @@
     {{#patient_addresses}}
       <addr use="{{use}}">
         {{#street}}
-          <streetAddressLine>{{.}}</streetAddressLine>
+        <streetAddressLine>{{.}}</streetAddressLine>
         {{/street}}
         <city>{{city}}</city>
         <state>{{state}}</state>
@@ -13,46 +13,46 @@
       </addr>
     {{/patient_addresses}}
     {{#patient_telecoms}}
-      <telecom use="{{use}}" value="tel:{{value}}"/>
+      <telecom use="{{use}}" value="tel:{{value}}" />
     {{/patient_telecoms}}
     <patient>
       {{#patient}}
-        <name>
-          <given>{{given_name}}</given>
-          <family>{{familyName}}</family>
-        </name>
+      <name>
+        <given>{{given_name}}</given>
+        <family>{{familyName}}</family>
+      </name>
       {{/patient}}
       {{#patient_characteristic_sex}}
-        {{#dataElementCodes}}
-          <administrativeGenderCode {{> _code}}/>
-        {{/dataElementCodes}}
+      {{#dataElementCodes}}
+      <administrativeGenderCode {{> _code}}/>
+      {{/dataElementCodes}}
       {{/patient_characteristic_sex}}
       {{^patient_characteristic_sex}}
-          <administrativeGenderCode nullFlavor="UNK"/>
+      <administrativeGenderCode nullFlavor="UNK" />
       {{/patient_characteristic_sex}}
       {{#patient_characteristic_birthdate}}
-        {{{birth_date_time}}}
+      {{{birth_date_time}}}
       {{/patient_characteristic_birthdate}}
       {{#patient_characteristic_race}}
         {{#dataElementCodes}}
-          <raceCode {{> _code}}/>
+      <raceCode {{> _code}}/>
         {{/dataElementCodes}}
       {{/patient_characteristic_race}}
       {{^patient_characteristic_race}}
-          <raceCode nullFlavor="UNK"/>
+      <raceCode nullFlavor="UNK" />
       {{/patient_characteristic_race}}
       {{#patient_characteristic_ethnicity}}
         {{#dataElementCodes}}
-          <ethnicGroupCode {{> _code}}/>
+      <ethnicGroupCode {{> _code}}/>
         {{/dataElementCodes}}
       {{/patient_characteristic_ethnicity}}
       {{^patient_characteristic_ethnicity}}
-          <ethnicGroupCode nullFlavor="UNK"/>
+      <ethnicGroupCode nullFlavor="UNK" />
       {{/patient_characteristic_ethnicity}}
       <languageCommunication>
-        <templateId root="2.16.840.1.113883.3.88.11.83.2" assigningAuthorityName="HITSP/C83"/>
-        <templateId root="1.3.6.1.4.1.19376.1.5.3.1.2.1" assigningAuthorityName="IHE/PCC"/>
-        <languageCode code="eng"/>
+        <templateId root="2.16.840.1.113883.3.88.11.83.2" assigningAuthorityName="HITSP/C83" />
+        <templateId root="1.3.6.1.4.1.19376.1.5.3.1.2.1" assigningAuthorityName="IHE/PCC" />
+        <languageCode code="eng" />
       </languageCommunication>
     </patient>
   </patientRole>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/assessment_order.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/assessment_order.mustache
@@ -1,5 +1,5 @@
 <entry>
-  <observation classCode="OBS" moodCode="RQO" {{{negation_ind}}}>
+  <observation classCode="OBS" moodCode="RQO"{{{negation_ind}}}>
     <!-- Conforms to C-CDA R2.1 Planned Observation (V2) -->
     <templateId root="2.16.840.1.113883.10.20.22.4.44" extension="2014-06-09" />
     <!-- Assessment Order -->

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/assessment_performed.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/assessment_performed.mustache
@@ -1,5 +1,5 @@
 <entry>
-  <observation classCode="OBS" moodCode="EVN" {{{negation_ind}}}>
+  <observation classCode="OBS" moodCode="EVN"{{{negation_ind}}}>
     <!-- Assessment Performed -->
     <templateId root="2.16.840.1.113883.10.20.24.3.144" extension="2021-08-01" />
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/assessment_recommended.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/assessment_recommended.mustache
@@ -1,5 +1,5 @@
 <entry>
-  <observation classCode="OBS" moodCode="INT" {{{negation_ind}}}>
+  <observation classCode="OBS" moodCode="INT"{{{negation_ind}}}>
     <!-- Conforms to C-CDA R2.1 Planned Observation (V2) -->
     <templateId root="2.16.840.1.113883.10.20.22.4.44" extension="2014-06-09" />
     <!-- Assessment Recommended (V2) -->

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/communication_performed.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/communication_performed.mustache
@@ -1,5 +1,5 @@
 <entry>
-    <act classCode="ACT" moodCode="EVN" {{{negation_ind}}}>
+    <act classCode="ACT" moodCode="EVN"{{{negation_ind}}}>
         <templateId root="2.16.840.1.113883.10.20.24.3.156" extension="2021-08-01"/>
         <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
         {{#category}}

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/device_order.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/device_order.mustache
@@ -1,5 +1,5 @@
 <entry>
-  <act classCode="ACT" moodCode="RQO" {{{negation_ind}}}>
+  <act classCode="ACT" moodCode="RQO"{{{negation_ind}}}>
     <templateId root="2.16.840.1.113883.10.20.24.3.130" extension="2021-08-01"/>
     <code code="SPLY" codeSystem="2.16.840.1.113883.5.6" displayName="Supply" codeSystemName="ActClass"/>
     <entryRelationship typeCode="SUBJ">

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/device_recommended.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/device_recommended.mustache
@@ -1,5 +1,5 @@
 <entry>
-  <act classCode="ACT" moodCode="INT" {{{negation_ind}}}>
+  <act classCode="ACT" moodCode="INT"{{{negation_ind}}}>
     <templateId root="2.16.840.1.113883.10.20.24.3.131" extension="2021-08-01"/>
     <code code="SPLY" codeSystem="2.16.840.1.113883.5.6" displayName="Supply" codeSystemName="ActClass"/>
     <entryRelationship typeCode="SUBJ">

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/diagnostic_study_order.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/diagnostic_study_order.mustache
@@ -1,5 +1,5 @@
 <entry>
-  <observation classCode="OBS" moodCode="RQO" {{{negation_ind}}}>
+  <observation classCode="OBS" moodCode="RQO"{{{negation_ind}}}>
   <!-- Consolidated Plan of Care Activity Observation
        templateId (Implied Template) -->
   <templateId root="2.16.840.1.113883.10.20.22.4.44" extension="2014-06-09"/>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/diagnostic_study_performed.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/diagnostic_study_performed.mustache
@@ -1,5 +1,5 @@
 <entry>
-  <observation classCode="OBS" moodCode="EVN" {{{negation_ind}}}>
+  <observation classCode="OBS" moodCode="EVN"{{{negation_ind}}}>
     <!-- Consolidated Procedure Activity Observation templateId 
        (Implied Template) -->
     <templateId root="2.16.840.1.113883.10.20.22.4.13" extension="2014-06-09"/>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/diagnostic_study_recommended.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/diagnostic_study_recommended.mustache
@@ -1,5 +1,5 @@
 <entry>
-  <observation classCode="OBS" moodCode="INT" {{{negation_ind}}}>
+  <observation classCode="OBS" moodCode="INT"{{{negation_ind}}}>
     <!-- Conforms to C-CDA R2.1 Planned Observation (V2) -->
     <templateId root="2.16.840.1.113883.10.20.22.4.44" extension="2014-06-09"/>
     <!-- Diagnostic Study Recommended (V4) -->

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/encounter_order.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/encounter_order.mustache
@@ -1,5 +1,5 @@
 <entry>
-  <act classCode="ACT" moodCode="RQO" {{{negation_ind}}}>
+  <act classCode="ACT" moodCode="RQO"{{{negation_ind}}}>
     <templateId root="2.16.840.1.113883.10.20.24.3.132" extension="2021-08-01"/>
     <code code="ENC" codeSystem="2.16.840.1.113883.5.6" displayName="Encounter" codeSystemName="ActClass"/>
     <entryRelationship typeCode="SUBJ">

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/encounter_recommended.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/encounter_recommended.mustache
@@ -1,5 +1,5 @@
 <entry>
-  <act classCode="ACT" moodCode="INT" {{{negation_ind}}}>
+  <act classCode="ACT" moodCode="INT"{{{negation_ind}}}>
     <!--Encounter Recommended Act (V2) -->
     <templateId root="2.16.840.1.113883.10.20.24.3.134" extension="2021-08-01"/>
     <code code="ENC" codeSystem="2.16.840.1.113883.5.6" codeSystemName="ActClass" displayName="Encounter"/>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/immunization_administered.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/immunization_administered.mustache
@@ -1,6 +1,6 @@
 <entry>
     {{#negated}}
-      <substanceAdministration classCode="SBADM" moodCode="EVN" {{{negation_ind}}}>
+      <substanceAdministration classCode="SBADM" moodCode="EVN"{{{negation_ind}}}>
     {{/negated}}
     {{^negated}}
       <substanceAdministration classCode="SBADM" moodCode="EVN" negationInd="false">

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/immunization_order.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/immunization_order.mustache
@@ -1,5 +1,5 @@
 <entry>
-  <substanceAdministration classCode="SBADM" moodCode="RQO" {{{negation_ind}}}>
+  <substanceAdministration classCode="SBADM" moodCode="RQO"{{{negation_ind}}}>
     <!-- Conforms to C-CDA R2.1 Planned Immunization Activity -->
     <templateId root="2.16.840.1.113883.10.20.22.4.120"/>
     <!-- Immunization Order (V2) -->

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/intervention_order.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/intervention_order.mustache
@@ -1,5 +1,5 @@
 <entry>
-  <act classCode="ACT" moodCode="RQO" {{{negation_ind}}}>
+  <act classCode="ACT" moodCode="RQO"{{{negation_ind}}}>
     <!-- Conforms to C-CDA R2 Planned Act (V2) template -->
     <templateId root="2.16.840.1.113883.10.20.22.4.39" extension="2014-06-09"/>
     <!-- Intervention Order (V4) -->

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/intervention_performed.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/intervention_performed.mustache
@@ -1,5 +1,5 @@
 <entry>
-  <act classCode="ACT" moodCode="EVN" {{{negation_ind}}}>
+  <act classCode="ACT" moodCode="EVN"{{{negation_ind}}}>
     <!-- Consolidation CDA: Procedure Activity Act template -->
     <templateId root="2.16.840.1.113883.10.20.22.4.12" extension="2014-06-09"/>
     <!-- Intervention Performed Template -->

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/intervention_recommended.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/intervention_recommended.mustache
@@ -1,5 +1,5 @@
 <entry>
-  <act classCode="ACT" moodCode="INT" {{{negation_ind}}}>
+  <act classCode="ACT" moodCode="INT"{{{negation_ind}}}>
     <!-- Conforms to C-CDA R2.1 Planned Act (V2) template -->
     <templateId root="2.16.840.1.113883.10.20.22.4.39" extension="2014-06-09"/>
     <!-- Intervention Recommended (V4) template -->

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/laboratory_test_order.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/laboratory_test_order.mustache
@@ -1,5 +1,5 @@
 <entry>
-  <observation classCode="OBS" moodCode="RQO" {{{negation_ind}}}>
+  <observation classCode="OBS" moodCode="RQO"{{{negation_ind}}}>
     <!-- Consolidation Plan of Care Activity Observation -->
     <templateId root="2.16.840.1.113883.10.20.22.4.44" extension="2014-06-09"/>
     <!-- Laboratory Test, Order (V4) -->

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/laboratory_test_performed.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/laboratory_test_performed.mustache
@@ -1,5 +1,5 @@
 <entry>
-  <observation classCode="OBS" moodCode="EVN" {{{negation_ind}}}>
+  <observation classCode="OBS" moodCode="EVN"{{{negation_ind}}}>
     <!-- Laboratory Test Performed (V4) -->
     <templateId root="2.16.840.1.113883.10.20.24.3.38" extension="2021-08-01"/>
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/laboratory_test_recommended.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/laboratory_test_recommended.mustache
@@ -1,5 +1,5 @@
 <entry>
-  <observation classCode="OBS" moodCode="INT" {{{negation_ind}}}>
+  <observation classCode="OBS" moodCode="INT"{{{negation_ind}}}>
     <!-- Conforms to C-CDA R2.1 Planned Observation (V2) -->
     <templateId root="2.16.840.1.113883.10.20.22.4.44" extension="2014-06-09"/>
     <!-- Laboratory Test, Recommended (V4) -->

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/medication_administered.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/medication_administered.mustache
@@ -1,5 +1,5 @@
 <entry>
-  <substanceAdministration classCode="SBADM" moodCode="EVN" {{{negation_ind}}}>
+  <substanceAdministration classCode="SBADM" moodCode="EVN"{{{negation_ind}}}>
     <!-- Medication Activity (consolidation) template -->
     <templateId root="2.16.840.1.113883.10.20.22.4.16" extension="2014-06-09"/>
     <!-- Medication, Administered template -->

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/medication_discharge.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/medication_discharge.mustache
@@ -1,5 +1,5 @@
 <entry>
-  <act classCode="ACT" moodCode="RQO" {{{negation_ind}}}>
+  <act classCode="ACT" moodCode="RQO"{{{negation_ind}}}>
     <!-- Discharge Medication Entry -->
     <templateId root="2.16.840.1.113883.10.20.24.3.105" extension="2021-08-01"/>
     <code code="75311-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Discharge medications"/> 

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/medication_dispensed.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/medication_dispensed.mustache
@@ -1,5 +1,5 @@
 <entry>
-  <act classCode="ACT" moodCode="EVN" {{{negation_ind}}}>
+  <act classCode="ACT" moodCode="EVN"{{{negation_ind}}}>
     <!-- Medication Dispensed Act -->
     <templateId root="2.16.840.1.113883.10.20.24.3.139" extension="2021-08-01"/>
     <code code="SPLY" codeSystem="2.16.840.1.113883.5.6" displayName="supply" codeSystemName="ActClass"/>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/medication_order.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/medication_order.mustache
@@ -1,6 +1,6 @@
 <entry>
   <!--Medication Order -->
-  <substanceAdministration classCode="SBADM" moodCode="RQO" {{{negation_ind}}}>
+  <substanceAdministration classCode="SBADM" moodCode="RQO"{{{negation_ind}}}>
     <templateId root="2.16.840.1.113883.10.20.22.4.42" extension="2014-06-09"/>
     <!-- Medication, Order template -->
     <templateId root="2.16.840.1.113883.10.20.24.3.47" extension="2021-08-01"/>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/physical_exam_order.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/physical_exam_order.mustache
@@ -1,5 +1,5 @@
 <entry>
-  <observation classCode="OBS" moodCode="RQO" {{{negation_ind}}}>
+  <observation classCode="OBS" moodCode="RQO"{{{negation_ind}}}>
     <!-- Conforms to C-CDA R2.1 Planned Observation (V2) -->
     <templateId root="2.16.840.1.113883.10.20.22.4.44" extension="2014-06-09"/>
     <!-- Physical Exam Order (V4) -->

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/physical_exam_performed.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/physical_exam_performed.mustache
@@ -1,5 +1,5 @@
 <entry>
-  <observation classCode="OBS" moodCode="EVN" {{{negation_ind}}}>
+  <observation classCode="OBS" moodCode="EVN"{{{negation_ind}}}>
     <!-- Procedure Activity Procedure (Consolidation) template -->
     <templateId root="2.16.840.1.113883.10.20.22.4.13" extension="2014-06-09"/>
     <!-- Physical Exam, Performed template -->

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/physical_exam_recommended.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/physical_exam_recommended.mustache
@@ -1,5 +1,5 @@
 <entry>
-  <observation classCode="OBS" moodCode="INT" {{{negation_ind}}}>
+  <observation classCode="OBS" moodCode="INT"{{{negation_ind}}}>
     <!-- Conforms to C-CDA R2.1 Planned Observation (V2) -->
     <templateId root="2.16.840.1.113883.10.20.22.4.44" extension="2014-06-09"/>
     <!-- Physical Exam Recommeded (V4) -->

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/procedure_order.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/procedure_order.mustache
@@ -1,5 +1,5 @@
 <entry>
-  <procedure classCode="PROC" moodCode="RQO" {{{negation_ind}}}>
+  <procedure classCode="PROC" moodCode="RQO"{{{negation_ind}}}>
     <!-- Consolidated Plan of Care Activity Procedure TemplateId (Implied Template) -->
     <templateId root="2.16.840.1.113883.10.20.22.4.41" extension="2014-06-09"/> 
     <!-- QRDA Procedure, Order TemplateId --> 

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/procedure_performed.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/procedure_performed.mustache
@@ -1,5 +1,5 @@
 <entry>
-  <procedure classCode="PROC" moodCode="EVN" {{{negation_ind}}}>
+  <procedure classCode="PROC" moodCode="EVN"{{{negation_ind}}}>
     <!--  Procedure performed template -->
     <templateId root="2.16.840.1.113883.10.20.24.3.64" extension="2021-08-01"/>
     <!-- Procedure Activity Procedure-->

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/procedure_recommended.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/procedure_recommended.mustache
@@ -1,5 +1,5 @@
 <entry>
-  <procedure classCode="PROC" moodCode="INT" {{{negation_ind}}}>
+  <procedure classCode="PROC" moodCode="INT"{{{negation_ind}}}>
     <!-- Conforms to C-CDA R2.1 Planned Procedure (V2) -->
     <templateId root="2.16.840.1.113883.10.20.22.4.41" extension="2014-06-09"/>
     <!-- Procedure Recommended (V5) -->

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/substance_recommended.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/substance_recommended.mustache
@@ -1,5 +1,5 @@
 <entry>
-  <substanceAdministration classCode="SBADM" moodCode="INT" {{{negation_ind}}}>
+  <substanceAdministration classCode="SBADM" moodCode="INT"{{{negation_ind}}}>
     <!-- Conforms to C-CDA R2.1 Planned Medication Activity (V2) -->
     <templateId root="2.16.840.1.113883.10.20.22.4.42" extension="2014-06-09"/>
     <!-- Substance Recommended (V4) -->


### PR DESCRIPTION
syntax remove whitespace on negate substitution render
#### Short description of what this resolves:
fix resolving codeSystem and codeSystemName from system oids
fix resolving lab and procedure results.
#### Changes proposed in this pull request:
just required some minor refactors

Looks like we are getting most codes I see thus far.

Result
```
<observation classCode="OBS" moodCode="EVN">
        <!-- Conforms to C-CDA R2 Result Observation (V2) -->
        <templateId root="2.16.840.1.113883.10.20.22.4.2" extension="2015-08-01"/>
        <!-- Conforms Result (V4) -->
        <templateId root="2.16.840.1.113883.10.20.24.3.87" extension="2019-12-01"/>
        <id root="1.3.6.1.4.1.115" extension="976a80d6-922b-4e56-8e4b-b25972e002bb"/>
        <statusCode code="completed"/>
          <effectiveTime nullFlavor='UNK'/>
        <value xsi:type="PQ" value="YELLOW" unit="UNK"/>
</observation>
<observation classCode="OBS" moodCode="EVN">
          <!-- Conforms to C-CDA R2 Result Observation (V2) -->
          <templateId root="2.16.840.1.113883.10.20.22.4.2" extension="2015-08-01"/>
          <!-- Conforms Result (V4) -->
          <templateId root="2.16.840.1.113883.10.20.24.3.87" extension="2019-12-01"/>
          <id root="1.3.6.1.4.1.115" extension="0cbc2580-a99b-4758-be61-40ac54d345f7"/>
          <statusCode code="completed"/>
            <effectiveTime nullFlavor='UNK'/>
          <value xsi:type="PQ" value="5.0" unit="[pH]"/>
</observation>
```
Codes

```
<consumable>
      <manufacturedProduct classCode="MANU">
        <!-- Medication Information (consolidation) template -->
        <templateId root="2.16.840.1.113883.10.20.22.4.23" extension="2014-06-09"/>
        <id root="42367f7a-cd30-422e-82d7-f36ba6bea1a0"/>
        <manufacturedMaterial>
            <code code="209459" codeSystem="2.16.840.1.113883.6.88" codeSystemName="RXNORM"/>
        </manufacturedMaterial>
        <manufacturerOrganization>
          <name>Medication Factory Inc.</name>
        </manufacturerOrganization>
      </manufacturedProduct>
</consumable>
```