### PR TITLE
fix validate only in billing manager

### DIFF
--- a/interface/billing/billing_report.php
+++ b/interface/billing/billing_report.php
@@ -384,6 +384,7 @@ $partners = $x->_utility_array($x->x12_partner_factory());
 
         function SubmitTheScreen() { //Action on Update List link
             if (!ProcessBeforeSubmitting()) return false;
+            if (!criteriaSelectHasValue('final_this_page_criteria')) return false;
             $("#update-tooltip").replaceWith("<i class='fa fa-sync fa-spin fa-1x' style=\"color:red\"></i>");
             top.restoreSession();
             document.the_form.mode.value = 'change';
@@ -487,6 +488,16 @@ $partners = $x->_utility_array($x->x12_partner_factory());
                         jsText(<?php echo xlj('Collapse'); ?>);
                 }
             }
+        }
+
+        function criteriaSelectHasValue(select) {
+            obj = document.getElementById(select);
+            if (obj.options.length == 0) {
+                if (!confirm("Do you really want to submit with no criteria selected?")) {
+                    return false;
+                }
+            }
+            return true;
         }
     </script>
     <?php require_once "$srcdir/../interface/reports/report.script.php"; ?>
@@ -679,8 +690,10 @@ $partners = $x->_utility_array($x->x12_partner_factory());
                         // It is labled(Included for Insurance ajax criteria)(Line:-279-299).
                         $TPSCriteriaIncludeMaster[1] = "OpenEMR\Billing\BillingReport::insuranceCompanyDisplay";
                         if (!isset($_REQUEST['mode'])) {// default case
-                            $_REQUEST['final_this_page_criteria'][0] = "billing.billed|=|0";
-                            $_REQUEST['final_this_page_criteria_text'][0] = xl("Billing Status = Unbilled");
+                            $_REQUEST['final_this_page_criteria'][0] = "form_encounter.date|between|" . date("Y-m-d 00:00:00") . "|" . date("Y-m-d 23:59:59");
+                            $_REQUEST['final_this_page_criteria_text'][0] = xl("Date of Service = Today");
+                            $_REQUEST['final_this_page_criteria'][1] = "billing.billed|=|0";
+                            $_REQUEST['final_this_page_criteria_text'][1] = xl("Billing Status = Unbilled");
                             $_REQUEST['date_master_criteria_form_encounter_date'] = "today";
                             $_REQUEST['master_from_date_form_encounter_date'] = date("Y-m-d");
                             $_REQUEST['master_to_date_form_encounter_date'] = date("Y-m-d");
@@ -828,59 +841,57 @@ $partners = $x->_utility_array($x->x12_partner_factory());
             }
             $list = BillingReport::getBillsListBetween("%");
             // don't query the whole encounter table if no criteria selected
-            if (isset($_POST["mode"]) && !array_key_exists('final_this_page_criteria', $_POST)) {
-                $alertmsg = "Please select at least one criteria.";
+
+            if (!isset($_POST["mode"])) {
+                if (!isset($_POST["from_date"])) {
+                    $from_date = date("Y-m-d");
+                } else {
+                    $from_date = $_POST["from_date"];
+                }
+                if (empty($_POST["to_date"])) {
+                    $to_date = '';
+                } else {
+                    $to_date = $_POST["to_date"];
+                }
+                if (!isset($_POST["code_type"])) {
+                    $code_type = "all";
+                } else {
+                    $code_type = $_POST["code_type"];
+                }
+                if (!isset($_POST["unbilled"])) {
+                    $unbilled = "on";
+                } else {
+                    $unbilled = $_POST["unbilled"];
+                }
+                if (!isset($_POST["authorized"])) {
+                    $my_authorized = "on";
+                } else {
+                    $my_authorized = $_POST["authorized"];
+                }
             } else {
-                if (!isset($_POST["mode"])) {
-                    if (!isset($_POST["from_date"])) {
-                        $from_date = date("Y-m-d");
-                    } else {
-                        $from_date = $_POST["from_date"];
-                    }
-                    if (empty($_POST["to_date"])) {
-                        $to_date = '';
-                    } else {
-                        $to_date = $_POST["to_date"];
-                    }
-                    if (!isset($_POST["code_type"])) {
-                        $code_type = "all";
-                    } else {
-                        $code_type = $_POST["code_type"];
-                    }
-                    if (!isset($_POST["unbilled"])) {
-                        $unbilled = "on";
-                    } else {
-                        $unbilled = $_POST["unbilled"];
-                    }
-                    if (!isset($_POST["authorized"])) {
-                        $my_authorized = "on";
-                    } else {
-                        $my_authorized = $_POST["authorized"];
-                    }
-                } else {
-                    $from_date = $_POST["from_date"] ?? null;
-                    $to_date = $_POST["to_date"] ?? null;
-                    $code_type = $_POST["code_type"] ?? null;
-                    $unbilled = $_POST["unbilled"] ?? null;
-                    $my_authorized = $_POST["authorized"] ?? null;
-                }
+                $from_date = $_POST["from_date"] ?? null;
+                $to_date = $_POST["to_date"] ?? null;
+                $code_type = $_POST["code_type"] ?? null;
+                $unbilled = $_POST["unbilled"] ?? null;
+                $my_authorized = $_POST["authorized"] ?? null;
+            }
 
-                if ($my_authorized == "on") {
-                    $my_authorized = "1";
-                } else {
-                    $my_authorized = "%";
-                }
+            if ($my_authorized == "on") {
+                $my_authorized = "1";
+            } else {
+                $my_authorized = "%";
+            }
 
-                if ($unbilled == "on") {
-                    $unbilled = "0";
-                } else {
-                    $unbilled = "%";
-                }
+            if ($unbilled == "on") {
+                $unbilled = "0";
+            } else {
+                $unbilled = "%";
+            }
 
-                if (isset($_POST["mode"]) && $_POST["mode"] == "bill") {
-                    billCodesList($list);
-                }
-                ?>
+            if (isset($_POST["mode"]) && $_POST["mode"] == "bill") {
+                billCodesList($list);
+            }
+            ?>
             <div class="table-responsive">
                 <table class="table table-sm">
                     <?php
@@ -1406,7 +1417,6 @@ $partners = $x->_utility_array($x->x12_partner_factory());
 
     </div>
     <!--end of container div -->
-    <?php } // end if no criteria selected ?>
     <?php $oemr_ui->oeBelowContainerDiv(); ?>
     <script>
         set_button_states();

--- a/interface/billing/billing_report.php
+++ b/interface/billing/billing_report.php
@@ -493,9 +493,8 @@ $partners = $x->_utility_array($x->x12_partner_factory());
         function criteriaSelectHasValue(select) {
             obj = document.getElementById(select);
             if (obj.options.length == 0) {
-                if (!confirm("Do you really want to submit with no criteria selected?")) {
-                    return false;
-                }
+                var checkstr = confirm(<?php echo xlj("Do you really want to submit with no criteria selected?"); ?>);
+                return checkstr;
             }
             return true;
         }

--- a/interface/billing/sl_eob_invoice.php
+++ b/interface/billing/sl_eob_invoice.php
@@ -434,6 +434,9 @@ if (!empty($_POST['form_save']) || !empty($_POST['form_cancel']) || !empty($_POS
             sqlStatement("UPDATE form_encounter SET last_level_closed = ?, stmt_count = ? WHERE pid = ? AND encounter = ?", array($form_done, $form_stmt_count, $patient_id, $encounter_id));
             // also update billing for aging
             sqlStatement("UPDATE billing SET bill_date = ? WHERE pid = ? AND encounter = ?", array($form_deposit_date, $patient_id, $encounter_id));
+            if (!empty($_POST['form_secondary'])) {
+                SLEOB::arSetupSecondary($patient_id, $encounter_id, $debug);
+            }
         }
         // will reload page w/o reposting
         echo "location.replace(location)\n";

--- a/interface/forms/newpatient/report.php
+++ b/interface/forms/newpatient/report.php
@@ -30,7 +30,7 @@ function newpatient_report($pid, $encounter, $cols, $id)
             print "<span class=bold>" . xlt('Category') . ": </span><span class=text>" . text($calendar_category[0]['pc_catname']) . "</span><br />\n";
             print "<span class=bold>" . xlt('Reason') . ": </span><span class=text>" . nl2br(text($result["reason"])) . "</span><br />\n";
             print "<span>" . xlt('Provider') . ": </span><span class=text>" . text($provider['lname'] . ", " . $provider['fname']) . "</span><br />\n";
-            print "<span>" . xlt('Referring Provider') . ": </span><span class=text>" . text($referringProvider['lname'] . ", " . $referringProvider['fname']) . "</span><br />\n";
+            print "<span>" . xlt('Referring Provider') . ": </span><span class=text>" . text(($referringProvider['lname'] ?? '') . ", " . ($referringProvider['fname'] ?? '')) . "</span><br />\n";
             print "<span>" . xlt('POS Code') . ": </span><span class=text>" . text(sprintf('%02d', trim($result['pos_code']))) . "</span><br />\n";
         }
     }

--- a/interface/main/tabs/templates/patient_data_template.php
+++ b/interface/main/tabs/templates/patient_data_template.php
@@ -94,12 +94,12 @@ switch ($search_any_type) {
                 echo "<$wrapperElement class=\"$wrapperElementClass\">";
                 ?>
 
-                    <a class="ptName <?php echo $classes; ?> " data-bind="click:refreshPatient,with: patient" href="#" title="<?php echo xla("To Dashboard") ?>">
+                    <a class="ptName <?php echo $classes ?? ''; ?> " data-bind="click:refreshPatient,with: patient" href="#" title="<?php echo xla("To Dashboard") ?>">
                         <span data-bind="text: pname()"></span>
                         <<?php echo $pubpidElement;?> class="text-muted">(<span data-bind="text: pubpid"></span>)</<?php echo $pubpidElement;?>>
                     </a>
                     <?php echo ($closeElement !== '') ? "<$closeElement class=\"$closeElementClass\">" : ''; ?>
-                    <a href="#" class="pt-1<?php echo ($classes !== "") ? " " . $classes : "";?> <?php echo ($closeAnchorClasses !== "") ? " " . $closeAnchorClasses : ""; ?>" data-bind="click:clearPatient" title="<?php echo xla("Close Patient Chart") ?>">
+                    <a href="#" class="pt-1<?php echo (($classes ?? '') !== "") ? " " . $classes : "";?> <?php echo ($closeAnchorClasses !== "") ? " " . $closeAnchorClasses : ""; ?>" data-bind="click:clearPatient" title="<?php echo xla("Close Patient Chart") ?>">
                         <i class="fa fa-times<?php echo ($closeIconClass !== "") ? " " . $closeIconClass : ""; ?>"></i>
                     </a>
                     <?php echo ($closeElement !== '') ? "</$closeElement>" : ''; ?>

--- a/library/FeeSheet.class.php
+++ b/library/FeeSheet.class.php
@@ -102,6 +102,9 @@ class FeeSheet
 
         $this->pid = $pid;
         $this->encounter = $encounter;
+        // get provider field for pid's primary insurance from insurance_data to be added to billing row table as payer_id
+        $primary_insurance = getInsuranceData($this->pid);
+        $this->payer_id = $primary_insurance['provider'];
 
         // IPPF doesn't want any payments to be made or displayed in the Fee Sheet.
         $this->ALLOW_COPAYS = empty($GLOBALS['ippf_specific']);
@@ -1143,7 +1146,8 @@ class FeeSheet
                         0,
                         $notecodes,
                         $pricelevel,
-                        $revenue_code
+                        $revenue_code,
+                        $this->payer_id
                     );
                 }
             } // end for

--- a/src/Billing/BillingUtilities.php
+++ b/src/Billing/BillingUtilities.php
@@ -1393,7 +1393,8 @@ class BillingUtilities
         $billed = 0,
         $notecodes = '',
         $pricelevel = '',
-        $revenue_code = ""
+        $revenue_code = "",
+        $payer_id = "",
     ) {
         if (!$authorized) {
             $authorized = "0";
@@ -1410,12 +1411,12 @@ class BillingUtilities
 
         $sql = "INSERT INTO billing (date, encounter, code_type, code, code_text, " .
             "pid, authorized, user, groupname, activity, billed, provider_id, " .
-            "modifier, units, fee, ndc_info, justify, notecodes, pricelevel, revenue_code) VALUES (" .
-            "NOW(), ?, ?, ?, ?, ?, ?, ?, ?,  1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+            "modifier, units, fee, ndc_info, justify, notecodes, pricelevel, revenue_code, payer_id) VALUES (" .
+            "NOW(), ?, ?, ?, ?, ?, ?, ?, ?,  1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
         return sqlInsert($sql, array($encounter_id, $code_type, $code, $code_text, $pid, $authorized,
             $_SESSION['authUserID'], $_SESSION['authProvider'], $billed, $provider, $modifier, $units, $fee,
-            $ndc_info, $justify, $notecodes, $pricelevel, $revenue_code));
+            $ndc_info, $justify, $notecodes, $pricelevel, $revenue_code, $payer_id));
     }
 
     public static function authorizeBilling($id, $authorized = "1")

--- a/src/Billing/BillingUtilities.php
+++ b/src/Billing/BillingUtilities.php
@@ -1394,7 +1394,7 @@ class BillingUtilities
         $notecodes = '',
         $pricelevel = '',
         $revenue_code = "",
-        $payer_id = "",
+        $payer_id = ""
     ) {
         if (!$authorized) {
             $authorized = "0";

--- a/src/Billing/Claim.php
+++ b/src/Billing/Claim.php
@@ -238,7 +238,7 @@ class Claim
             }
 
             $ins = count($this->payers);
-            if ($drow['provider'] == $billrow['payer_id'] && empty($this->payers[0]['data'])) {
+            if (($drow['provider'] == $billrow['payer_id']  || $billrow['payer_id'] == null) && empty($this->payers[0]['data'])) {
                 $ins = 0;
             }
 
@@ -328,7 +328,7 @@ class Claim
             // Compute this procedure's patient responsibility amount as of this
             // prior payer, which is the original charge minus all insurance
             // payments and "hard" adjustments up to this payer.
-            $ptresp = $this->invoice[$code]['chg'] + $this->invoice[$code]['adj'];
+            $ptresp = $this->invoice[$code]['chg'] + $this->invoice[$code]['adj'] ?? '';
             foreach ($this->invoice[$code]['dtl'] as $key => $value) {
                 // plv (from ar_activity.payer_type) exists to
                 // indicate the payer level.

--- a/src/Billing/SLEOB.php
+++ b/src/Billing/SLEOB.php
@@ -289,6 +289,6 @@ class SLEOB
             }
         }
 
-        return xl("Encounter ") . $encounter . xl(" is ready for re-billing.");
+        return xl("Encounter ") . $encounter_id . xl(" is ready for re-billing.");
     }
 }

--- a/src/Services/EncounterService.php
+++ b/src/Services/EncounterService.php
@@ -684,7 +684,7 @@ class EncounterService extends BaseService
     {
         $encounterResult = $this->search(['pid' => $pid, 'eid' => $encounter_id], $options = ['limit' => '1']);
         if ($encounterResult->hasData()) {
-            return $encounterResult->getData()[0]['referring_provider_id'];
+            return $encounterResult->getData()[0]['referring_provider_id'] ?? '';
         }
         return [];
     }


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #4979 by checking for null payer id 

#### Short description of what this resolves:
Insurance information was missing with validate only option in billing manager
restores ability to see all encounters in billing manager, even those with no fee sheet in the encounter but warns if no criteria selected
fix setup secondary when save level in invoice

#### Changes proposed in this pull request:
adds payer id to billing from fee sheet 
