### PR TITLE
removal of ^M line endings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
         "vlucas/phpdotenv": "5.4.1",
         "waryway/php-traits-library": "1.0.4",
         "yubico/u2flib-server": "1.0.2",
-        "openemr/mustache": "^2.15"
+        "openemr/mustache": "2.15"
     },
     "config": {
         "platform": {

--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
         "vlucas/phpdotenv": "5.4.1",
         "waryway/php-traits-library": "1.0.4",
         "yubico/u2flib-server": "1.0.2",
-        "openemr/mustache": "2.15"
+        "openemr/mustache": "2.15.2"
     },
     "config": {
         "platform": {


### PR DESCRIPTION
hi @kchapple and @sjpadgett ,
The ^M line endings ended up in composer.json and all the mustache files. I only addressed composer.json in this PR (this is something we needed to address a long time ago since was causing issues and will figure out how to do the mustache files later). Ensure repos are correctly set for line endings here: https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings (if this is set correctly, then the ^M character won't be included in the commits)