### PR TITLE
QRDA cat i measure section rendering

### DIFF
--- a/src/Services/Qdm/MeasureService.php
+++ b/src/Services/Qdm/MeasureService.php
@@ -2,6 +2,9 @@
 
 namespace OpenEMR\Services\Qdm;
 
+use GuzzleHttp\Psr7\LazyOpenStream;
+use GuzzleHttp\Psr7;
+
 class MeasureService
 {
     public static $measure_sources = [
@@ -40,5 +43,24 @@ class MeasureService
             'measure' => $measurePath . '/' . basename($measurePath) . '.json',
             'valueSets' => $measurePath . '/value_sets.json'
         ];
+    }
+
+    public static function fetchAllMeasuresArray($measures = [])
+    {
+        $measureObjects = [];
+        foreach ($measures as $measure) {
+            $measureObjects[]= self::fetchMeasureJson($measure);
+        }
+        return $measureObjects;
+    }
+
+    public static function fetchMeasureJson($measure, $assoc = true)
+    {
+        $measureFiles = MeasureService::fetchMeasureFiles($measure);
+        $json = file_get_contents($measureFiles['measure']);
+        if ($assoc) {
+            return json_decode($json, true);
+        }
+        return $json;
     }
 }

--- a/src/Services/Qrda/Cat1.php
+++ b/src/Services/Qrda/Cat1.php
@@ -47,7 +47,7 @@ class Cat1 extends \Mustache_Engine
         $this->provider = $options['provider'] ?? null;
         $this->performance_period_end = $options['performance_period_start'] ?? null;
         $this->performance_period_end = $options['performance_period_end'] ?? null;
-        $this->_measures = $measures;
+        $this->_measures = $measures; // Lambda for measures is in View "helper"
         $this->submission_program = $options['submission_program'] ?? null;
         parent::__construct(
             array(
@@ -56,7 +56,6 @@ class Cat1 extends \Mustache_Engine
             )
         );
     }
-
 
     public function renderCat1Xml()
     {

--- a/src/Services/Qrda/ExportService.php
+++ b/src/Services/Qrda/ExportService.php
@@ -15,12 +15,12 @@ class ExportService
         $this->request = $request;
     }
 
-    public function export()
+    public function export($measures = [])
     {
         $patientModels = $this->builder->build($this->request);
         $string = "";
         foreach ($patientModels as $patient) {
-            $cat1 = new Cat1($patient);
+            $cat1 = new Cat1($patient, $measures);
             $string .= $cat1->renderCat1Xml();
         }
 

--- a/src/Services/Qrda/Helpers/Cat1View.php
+++ b/src/Services/Qrda/Helpers/Cat1View.php
@@ -152,15 +152,19 @@ trait Cat1View
         }
 
         $oid = $result['system'] ?? $result['codeSystem'];
-        $system = $this->get_code_system_for_oid($oid);
-        if (!empty($result['code'])) {
-            return "<value xsi:type=\"CD\" code=\"" . $result['code'] . "\" codeSystem=\"" . $oid
-                . "\" codeSystemName=\"" . $system . "\"/>";
-        } elseif (!empty($result['value'])) {
-            return "<value xsi:type=\"PQ\" value=\"" . $result['value'] . "\" unit=\"" . ($result['unit'] ?: "UNK") . "\"/>";
+        if (!empty($oid)) {
+            $system = $this->get_code_system_for_oid($oid);
+            if (!empty($result['code'])) {
+                return "<value xsi:type=\"CD\" code=\"" . $result['code'] . "\" codeSystem=\"" . $oid
+                    . "\" codeSystemName=\"" . $system . "\"/>";
+            } elseif (!empty($result['value'])) {
+                return "<value xsi:type=\"PQ\" value=\"" . $result['value'] . "\" unit=\"" . ($result['unit'] ?: "UNK") . "\"/>";
+            } else {
+                // TODO: @sjpadgett, @adunsulag, @ken.matrix the ruby code didn't handle this case... what happens here?
+                // no result so template shouldn't show.
+                return "";
+            }
         } else {
-            // TODO: @sjpadgett, @adunsulag, @ken.matrix the ruby code didn't handle this case... what happens here?
-            // no result so template shouldn't show.
             return "";
         }
     }

--- a/src/Services/Qrda/Helpers/PatientView.php
+++ b/src/Services/Qrda/Helpers/PatientView.php
@@ -95,7 +95,10 @@ trait PatientView
     public function familyName(Mustache_Context $context)
     {
         $family = $context->find('patientName');
-        return trim($family->family);
+        if (is_object($family)) {
+            return trim($family->family);
+        }
+        return "";
     }
 
     public function gender()

--- a/src/Services/Qrda/Helpers/View.php
+++ b/src/Services/Qrda/Helpers/View.php
@@ -14,6 +14,7 @@ namespace OpenEMR\Services\Qrda\Helpers;
 
 use Mustache_Context;
 use Ramsey\Uuid\Rfc4122\UuidV4;
+use function Clue\StreamFilter\fun;
 
 trait View
 {
@@ -21,12 +22,42 @@ trait View
 
     public function measures()
     {
-        // TODO: we don't know if this is the correct implementation or not, depends on how the measures are sent.
-        $hqmf_id = $this->_measures['hqmf_id'] ?? null;
-        $hqmf_set_id = $this->_measures['hqmf_set_id'] ?? null;
-        $description = $this->_measures['description'] ?? null;
-        return json_encode(['hqmf_id' => $hqmf_id, 'hqmf_set_id' => $hqmf_set_id, 'description' => $description]);
+//        // TODO: we don't know if this is the correct implementation or not, depends on how the measures are sent.
+//        $hqmf_id = $this->_measures['hqmf_id'] ?? null;
+//        $hqmf_set_id = $this->_measures['hqmf_set_id'] ?? null;
+//        $description = $this->_measures['description'] ?? null;
+//        return [
+//            'hqmf_id' => $hqmf_id,
+//            'hqmf_set_id' => $hqmf_set_id,
+//            'description' => $description
+//        ];
+
+        return array_map(function ($measure) {
+            return [
+                'hqmf_id' => $measure['hqmf_id'] ?? null,
+                'hqmf_set_id' => $measure['hqmf_set_id'] ?? null,
+                'description' => $measure['description'] ?? null
+            ];
+        }, $this->_measures);
+
+        //return $this->_measures;
     }
+
+//    public function hqmf_id(Mustache_Context $context)
+//    {
+//        $hqmf_id = $context->find('hqmf_id');
+//        return $hqmf_id;
+//    }
+
+//    public function hqmf_set_id(Mustache_Context $context)
+//    {
+//        return $context->find('hqmf_set_id');
+//    }
+//
+//    public function description(Mustache_Context $context)
+//    {
+//        return $context->find('description');
+//    }
 
     public function random_id()
     {


### PR DESCRIPTION
Renders the measure section (which measures are being run) to the QRDA cat i XML document export.

```
<section>
        <!-- 
          *****************************************************************
          Measure Section
          *****************************************************************
        -->
        <!-- This is the templateId for Measure Section -->
        <templateId root="2.16.840.1.113883.10.20.24.2.2"/>
        <!-- This is the templateId for Measure Section QDM -->
        <templateId root="2.16.840.1.113883.10.20.24.2.3"/>
        <!-- This is the LOINC code for "Measure document". This stays the same for all measure section required by QRDA standard -->
        <code code="55186-1" codeSystem="2.16.840.1.113883.6.1"/>
        <title>Measure Section</title>
        <text>
          <table border="1" width="100%">
            <thead>
              <tr>
                <th>eMeasure Title</th>
                <th>Version specific identifier</th>
              </tr>
            </thead>
            <tbody>
              <tr>
                <td>Percentage of children 2 years of age who had four diphtheria, tetanus and acellular pertussis (DTaP); three polio (IPV), one measles, mumps and rubella (MMR); three or four H influenza type B (Hib); three hepatitis B (Hep B); one chicken pox (VZV); four pneumococcal conjugate (PCV); one hepatitis A (Hep A); two or three rotavirus (RV); and two influenza (flu) vaccines by their second birthday</td>
                <td>2C928085-7198-38EE-0171-9D6E75580676</td>
                <td/>
              </tr>
            </tbody>
          </table>
        </text>
        <!-- 1..* Organizers, each containing a reference to an eMeasure -->
        <entry>
          <organizer classCode="CLUSTER" moodCode="EVN">
            <!-- This is the templateId for Measure Reference -->
            <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
            <!-- This is the templateId for eMeasure Reference QDM -->
            <templateId root="2.16.840.1.113883.10.20.24.3.97"/>
            <id extension="480fe5cf-20d2-4865-85bf-5f951af4066c" root="1.3.6.1.4.1.115"/>
            <statusCode code="completed"/>
            <!-- Containing isBranch external references -->
            <reference typeCode="REFR">
              <externalDocument classCode="DOC" moodCode="EVN">
                <!-- SHALL: This is the version specific identifier for eMeasure: QualityMeasureDocument/id it is a GUID-->
                <id extension="2C928085-7198-38EE-0171-9D6E75580676" root="2.16.840.1.113883.4.738"/>
                <!-- SHOULD This is the title of the eMeasure -->
                <text>Percentage of children 2 years of age who had four diphtheria, tetanus and acellular pertussis (DTaP); three polio (IPV), one measles, mumps and rubella (MMR); three or four H influenza type B (Hib); three hepatitis B (Hep B); one chicken pox (VZV); four pneumococcal conjugate (PCV); one hepatitis A (Hep A); two or three rotavirus (RV); and two influenza (flu) vaccines by their second birthday</text>
                <!-- SHOULD: setId is the eMeasure version neutral id  -->
                <setId root="B2802B7A-3580-4BE8-9458-921AEA62B78C"/>
              </externalDocument>
            </reference>
          </organizer>
        </entry>
      </section>
```