### PR TITLE
Adding a link to modules

### DIFF
--- a/interface/modules/zend_modules/module/Installer/view/installer/installer/index.phtml
+++ b/interface/modules/zend_modules/module/Installer/view/installer/installer/index.phtml
@@ -186,7 +186,6 @@ $coreModules = $this->coreModules ?? [];
                 </table>
             </div>
         </div>
-
     </div>
 
     <style>
@@ -329,6 +328,9 @@ $coreModules = $this->coreModules ?? [];
 
         </table>
     </div>
+</div>
+<div>
+    <a class="btn btn-primary" href="https://www.open-emr.org/wiki/index.php/OpenEMR_Modules" target="_blank" ><?php echo $listener->z_xla('Additional Modules'); ?></a>
 </div>
 <?php
 if ($slno > 0) {


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:


#### Changes proposed in this pull request:
Add a link on the modules to the listing of modules. This way people can be alerted that there are more modules than the ones contained in the code base.   
