### PR TITLE
Introduce machine_name as a global option

### DIFF
--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -450,6 +450,13 @@ $GLOBALS_METADATA = array(
             xl('Application name used throughout the user interface.')
         ),
 
+        'machine_name' => [
+            xl('Application Machine Name'),
+            'text',
+            'openemr',
+            xl('The machine name of the application. Used to identify the EMR in various messaging systems like HL7. Should not contain spaces'),
+        ],
+
         'display_main_menu_logo' => [
             xl('Display main menu logo'),
             'bool',


### PR DESCRIPTION
New global for the machine name of the application. Used to identify the EMR when working with HL7 and other systems that may want this information.