### PR TITLE
Revert Cat1 mustache to cqm-report version 3.1.8

### DIFF
--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php
@@ -527,6 +527,7 @@ class CarecoordinationTable extends AbstractTableGateway
                 $arr_encounter['encounter'][$k]['encounter_diagnosis_date'] = $newdata['encounter']['encounter_diagnosis_date'];
                 $arr_encounter['encounter'][$k]['encounter_diagnosis_code'] = $newdata['encounter']['encounter_diagnosis_code'];
                 $arr_encounter['encounter'][$k]['encounter_diagnosis_issue'] = $newdata['encounter']['encounter_diagnosis_issue'];
+                $arr_encounter['encounter'][$k]['encounter_discharge_code'] = $newdata['encounter']['encounter_discharge_code'];
                 $k++;
             } elseif ($table == 'vital_sign') {
                 $arr_vitals['vitals'][$q]['extension'] = $newdata['vital_sign']['extension'];
@@ -1325,6 +1326,7 @@ class CarecoordinationTable extends AbstractTableGateway
                                 $arr_encounter['encounter'][$k]['encounter_diagnosis_date'] = $data['encounter-encounter_diagnosis_date'][$i];
                                 $arr_encounter['encounter'][$k]['encounter_diagnosis_code'] = $data['encounter-encounter_diagnosis_code'][$i];
                                 $arr_encounter['encounter'][$k]['encounter_diagnosis_issue'] = $data['encounter-encounter_diagnosis_issue'][$i];
+                                $arr_encounter['encounter'][$k]['encounter_discharge_code'] = $data['encounter-encounter_discharge_code'][$i] ?? '';
                                 $k++;
                             } elseif (substr($key, 0, -4) == 'procedure_result') {
                                 $arr_procedure_res['procedure_result'][$j]['proc_text'] = $data['procedure_result-proc_text'][$i];

--- a/sql/6_1_0-to-7_0_0_upgrade.sql
+++ b/sql/6_1_0-to-7_0_0_upgrade.sql
@@ -217,3 +217,24 @@ INSERT INTO `layout_options` (`form_id`,`field_id`,`group_id`,`title`,`seq`,`dat
     VALUES ('LBTref', 'encounter_id', '1', 'Patient Referral Encounter', 10, 53, 1, 0, 0, '', 1, 1, '', ''
     ,'Encounter that the referral/transfer of care is based on', 0);
 #EndIf
+
+#IfNotRow2D list_options list_id discharge-disposition option_id home-hospice
+DELETE FROM list_options WHERE list_id = "discharge-disposition";
+DELETE FROM list_options WHERE list_id = 'lists' AND option_id = "discharge-disposition";
+
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `option_value`, `mapping`, `notes`, `codes`, `toggle_setting_1`, `toggle_setting_2`, `activity`) VALUES ('lists','discharge-disposition','Discharge Disposition',0,1,0,'',NULL,'',0,0,1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `option_value`, `mapping`, `notes`, `codes`, `toggle_setting_1`, `toggle_setting_2`, `activity`) VALUES ('discharge-disposition','home','Home',10,1,0,'','','SNOMED-CT:10161009',0,0,1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `option_value`, `mapping`, `notes`, `codes`, `toggle_setting_1`, `toggle_setting_2`, `activity`) VALUES ('discharge-disposition','home-hospice','Discharge to home for hospice care',20,0,0,'','','SNOMED-CT:428361000124107',0,0,1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `option_value`, `mapping`, `notes`, `codes`, `toggle_setting_1`, `toggle_setting_2`, `activity`) VALUES ('discharge-disposition','alt-home','Alternative Home',30,0,0,'','','',0,0,1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `option_value`, `mapping`, `notes`, `codes`, `toggle_setting_1`, `toggle_setting_2`, `activity`) VALUES ('discharge-disposition','other-hcf','Other healthcare facility',40,0,0,'','','',0,0,1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `option_value`, `mapping`, `notes`, `codes`, `toggle_setting_1`, `toggle_setting_2`, `activity`) VALUES ('discharge-disposition','hosp','Hospice',50,0,0,'','','SNOMED-CT:428371000124100',0,0,1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `option_value`, `mapping`, `notes`, `codes`, `toggle_setting_1`, `toggle_setting_2`, `activity`) VALUES ('discharge-disposition','long','Long-term care',60,0,0,'','','',0,0,1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `option_value`, `mapping`, `notes`, `codes`, `toggle_setting_1`, `toggle_setting_2`, `activity`) VALUES ('discharge-disposition','aadvice','Left against advice (Finding)',70,0,0,'','','SNOMED-CT:445060000',0,0,1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `option_value`, `mapping`, `notes`, `codes`, `toggle_setting_1`, `toggle_setting_2`, `activity`) VALUES ('discharge-disposition','self-aadvice','Patient self-discharge against medical advice',80,0,0,'','','SNOMED-CT:225928004',0,0,1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `option_value`, `mapping`, `notes`, `codes`, `toggle_setting_1`, `toggle_setting_2`, `activity`) VALUES ('discharge-disposition','exp','Expired',90,0,0,'','','SNOMED-CT:371828006',0,0,1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `option_value`, `mapping`, `notes`, `codes`, `toggle_setting_1`, `toggle_setting_2`, `activity`) VALUES ('discharge-disposition','psy','Psychiatric hospital',100,0,0,'','','',0,0,1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `option_value`, `mapping`, `notes`, `codes`, `toggle_setting_1`, `toggle_setting_2`, `activity`) VALUES ('discharge-disposition','rehab','Rehabilitation',110,0,0,'','','SNOMED-CT:433591000124103',0,0,1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `option_value`, `mapping`, `notes`, `codes`, `toggle_setting_1`, `toggle_setting_2`, `activity`) VALUES ('discharge-disposition','snf','Skilled nursing facility',120,0,0,'','','',0,0,1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `option_value`, `mapping`, `notes`, `codes`, `toggle_setting_1`, `toggle_setting_2`, `activity`) VALUES ('discharge-disposition','comm-hospital','Discharge to community hospital',130,0,0,'','','SNOMED-CT:306701001',0,0,1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `option_value`, `mapping`, `notes`, `codes`, `toggle_setting_1`, `toggle_setting_2`, `activity`) VALUES ('discharge-disposition','oth','Other',140,0,0,'','','',0,0,1);
+#EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -6547,18 +6547,21 @@ INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUE
 INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('vitals-interpretation','LU','Significantly low',90,0,1);
 
 -- Discharge Disposition (for encounters and eventually appointments)
-INSERT INTO list_options (list_id,option_id,title, seq, is_default, option_value) VALUES ('lists','discharge-disposition','Discharge Disposition',0, 1, 0);
-INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','home','Home',10,1,1);
-INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','alt-home','Alternative Home',20,0,1);
-INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','other-hcf','Other healthcare facility',30,0,1);
-INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','hosp','Hospice',40,0,1);
-INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','long','Long-term care',50,0,1);
-INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','aadvice','Left against advice',60,0,1);
-INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','exp','Expired',70,0,1);
-INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','psy','Psychiatric hospital',80,0,1);
-INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','rehab','Rehabilitation',90,0,1);
-INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','snf','Skilled nursing facility',100,0,1);
-INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('discharge-disposition','oth','Other',110,0,1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `option_value`, `mapping`, `notes`, `codes`, `toggle_setting_1`, `toggle_setting_2`, `activity`) VALUES ('lists','discharge-disposition','Discharge Disposition',0,1,0,'',NULL,'',0,0,1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `option_value`, `mapping`, `notes`, `codes`, `toggle_setting_1`, `toggle_setting_2`, `activity`) VALUES ('discharge-disposition','home','Home',10,1,0,'','','SNOMED-CT:10161009',0,0,1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `option_value`, `mapping`, `notes`, `codes`, `toggle_setting_1`, `toggle_setting_2`, `activity`) VALUES ('discharge-disposition','home-hospice','Discharge to home for hospice care',20,0,0,'','','SNOMED-CT:428361000124107',0,0,1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `option_value`, `mapping`, `notes`, `codes`, `toggle_setting_1`, `toggle_setting_2`, `activity`) VALUES ('discharge-disposition','alt-home','Alternative Home',30,0,0,'','','',0,0,1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `option_value`, `mapping`, `notes`, `codes`, `toggle_setting_1`, `toggle_setting_2`, `activity`) VALUES ('discharge-disposition','other-hcf','Other healthcare facility',40,0,0,'','','',0,0,1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `option_value`, `mapping`, `notes`, `codes`, `toggle_setting_1`, `toggle_setting_2`, `activity`) VALUES ('discharge-disposition','hosp','Hospice',50,0,0,'','','SNOMED-CT:428371000124100',0,0,1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `option_value`, `mapping`, `notes`, `codes`, `toggle_setting_1`, `toggle_setting_2`, `activity`) VALUES ('discharge-disposition','long','Long-term care',60,0,0,'','','',0,0,1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `option_value`, `mapping`, `notes`, `codes`, `toggle_setting_1`, `toggle_setting_2`, `activity`) VALUES ('discharge-disposition','aadvice','Left against advice (Finding)',70,0,0,'','','SNOMED-CT:445060000',0,0,1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `option_value`, `mapping`, `notes`, `codes`, `toggle_setting_1`, `toggle_setting_2`, `activity`) VALUES ('discharge-disposition','self-aadvice','Patient self-discharge against medical advice',80,0,0,'','','SNOMED-CT:225928004',0,0,1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `option_value`, `mapping`, `notes`, `codes`, `toggle_setting_1`, `toggle_setting_2`, `activity`) VALUES ('discharge-disposition','exp','Expired',90,0,0,'','','SNOMED-CT:371828006',0,0,1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `option_value`, `mapping`, `notes`, `codes`, `toggle_setting_1`, `toggle_setting_2`, `activity`) VALUES ('discharge-disposition','psy','Psychiatric hospital',100,0,0,'','','',0,0,1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `option_value`, `mapping`, `notes`, `codes`, `toggle_setting_1`, `toggle_setting_2`, `activity`) VALUES ('discharge-disposition','rehab','Rehabilitation',110,0,0,'','','SNOMED-CT:433591000124103',0,0,1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `option_value`, `mapping`, `notes`, `codes`, `toggle_setting_1`, `toggle_setting_2`, `activity`) VALUES ('discharge-disposition','snf','Skilled nursing facility',120,0,0,'','','',0,0,1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `option_value`, `mapping`, `notes`, `codes`, `toggle_setting_1`, `toggle_setting_2`, `activity`) VALUES ('discharge-disposition','comm-hospital','Discharge to community hospital',130,0,0,'','','SNOMED-CT:306701001',0,0,1);
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `option_value`, `mapping`, `notes`, `codes`, `toggle_setting_1`, `toggle_setting_2`, `activity`) VALUES ('discharge-disposition','oth','Other',140,0,0,'','','',0,0,1);
 
 -- External Patient Education
 INSERT INTO list_options (list_id,option_id,title,seq,is_default,option_value) VALUES ('lists', 'external_patient_education', 'External Patient Education', 0, 0, 0);

--- a/src/Services/Cda/CdaTemplateImportDispose.php
+++ b/src/Services/Cda/CdaTemplateImportDispose.php
@@ -535,11 +535,13 @@ class CdaTemplateImportDispose
                             provider_id,
                             external_id,
                             reason,
+                            discharge_disposition,
                             encounter_type_code,
                             encounter_type_description
                            )
                            VALUES
                            (
+                            ?,
                             ?,
                             ?,
                             ?,
@@ -562,6 +564,7 @@ class CdaTemplateImportDispose
                         $provider_id,
                         $value['extension'] ?? null,
                         $value['code_text'] ?? null,
+                        $value['encounter_discharge_code'] ?? null,
                         $value['code'] ?? null,
                         $value['code_text'] ?? null
                     )

--- a/src/Services/Cda/CdaTemplateParse.php
+++ b/src/Services/Cda/CdaTemplateParse.php
@@ -323,6 +323,15 @@ class CdaTemplateParse
             $this->templateData['field_name_value_array']['encounter'][$i]['encounter_diagnosis_issue'] = $code['code_text'];
 
             $this->templateData['field_name_value_array']['encounter'][$i]['encounter_diagnosis_date'] = $entry['encounter']['entryRelationship'][1]['act']['entryRelationship']['observation']['effectiveTime']['low']['value'];
+
+            $discharge = $entry['encounter']['sdtc:dischargeDispositionCode'] ?? null;
+            $code = '';
+            if (!empty($discharge)) {
+                $code = $this->codeService->getCodeWithType(($discharge['code'] ?? ''), ($discharge['codeSystemName'] ?? ''), true) ?? '';
+                $option = $this->codeService->dischargeOptionIdFromCode($code) ?? '';
+            }
+            $this->templateData['field_name_value_array']['encounter'][$i]['encounter_discharge_code'] = $option;
+
             $this->templateData['entry_identification_array']['encounter'][$i] = $i;
         }
     }

--- a/src/Services/CodeTypesService.php
+++ b/src/Services/CodeTypesService.php
@@ -368,4 +368,17 @@ class CodeTypesService
         );
         return $value;
     }
+
+    public function dischargeOptionIdFromCode($formatted_code)
+    {
+        $listService = new ListService();
+        $ret = $listService->getOptionsByListName('discharge-disposition', ['codes' => $formatted_code]) ?? '';
+        return $ret[0]['option_id'];
+    }
+
+    public function dischargeCodeFromOptionId($option_id)
+    {
+        $listService = new ListService();
+        return $listService->getListOption('discharge-disposition', $option_id)['codes'] ?? '';
+    }
 }

--- a/src/Services/Qrda/Helpers/Cat1View.php
+++ b/src/Services/Qrda/Helpers/Cat1View.php
@@ -123,9 +123,8 @@ trait Cat1View
 
     public function result_value(Mustache_Context $context)
     {
-        // TODO Do patient models ever return a string for results?
         $result = $context->find('result');
-        if (empty($result['value'])) {
+        if (empty($result)) {
             return "<value xsi:type=\"CD\" nullFlavor=\"UNK\"/>";
         }
         if (is_array($result)) {

--- a/src/Services/Qrda/Helpers/Cat1View.php
+++ b/src/Services/Qrda/Helpers/Cat1View.php
@@ -139,7 +139,11 @@ trait Cat1View
             $result_string = "<value xsi:type=\"ST\">" . $result . "</value>";
             // non-null value
         } else {
-            $result_string = "<value xsi:type=\"PQ\" value=\"" . $result . "\" unit=\"1\"/>";
+            if (is_numeric($result ?? null)) {
+                $result_string = "<value xsi:type=\"PQ\" value=\"" . $result . "\" unit=\"1\"/>";
+            } else {
+                return "<value xsi:type=\"CD\" nullFlavor=\"UNK\"/>";
+            }
         }
         return $result_string;
     }
@@ -155,10 +159,10 @@ trait Cat1View
             $system = $this->get_code_system_for_oid($oid) ?: $result['codeSystem'];
             return "<value xsi:type=\"CD\" code=\"" . $result['code'] . "\" codeSystem=\"" . $oid
                 . "\" codeSystemName=\"" . $system . "\"/>";
-        } elseif (!empty($result['value'] && array_key_exists('unit', $result))) {
-            // Almost always should have unit. TODO unsure if any patient models return just value.
+        } elseif (is_numeric($result['value'])) {
+            // Such as value 10.2 unit ml/??
             return "<value xsi:type=\"PQ\" value=\"" . $result['value'] . "\" unit=\"" . ($result['unit'] ?: "UNK") . "\"/>";
-        } elseif (!empty($result['value'] && empty($result['unit'] ?? null))) {
+        } elseif (is_string($result['value'])) {
             // Such as urine color YELLOW
             return "<value xsi:type=\"ST\" value=\"" . $result['value'] . "\"/>";
         }

--- a/src/Services/Qrda/qrda-export/catI-r5/_header.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/_header.mustache
@@ -6,9 +6,8 @@
 <!-- QRDA templateId -->
 <templateId root="2.16.840.1.113883.10.20.24.1.1" extension="2017-08-01"/>
 <!-- QDM-based QRDA templateId -->
-<templateId root="2.16.840.1.113883.10.20.24.1.2" extension="2021-08-01"/>
+<templateId root="2.16.840.1.113883.10.20.24.1.2" extension="2019-12-01"/>
 <!-- CMS QRDA templateId -->
-<!-- TODO: THIS will also change -->
 <templateId root="2.16.840.1.113883.10.20.24.1.3" extension="2020-02-01"/>
 <!-- This is the globally unique identifier for this QRDA document -->
 <id root="{{random_id}}"/>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda1_r5.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda1_r5.mustache
@@ -12,8 +12,7 @@
           <!-- This is the templateId for Patient Data section -->
           <templateId root="2.16.840.1.113883.10.20.17.2.4"/>
           <!-- This is the templateId for Patient Data QDM section -->
-          <templateId extension="2021-08-01" root="2.16.840.1.113883.10.20.24.2.1"/>
-          <!-- TODO: This will also change -->
+          <templateId extension="2019-12-01" root="2.16.840.1.113883.10.20.24.2.1"/>
           <templateId extension="2020-02-01" root="2.16.840.1.113883.10.20.24.2.1.1"/>
           <code code="55188-7" codeSystem="2.16.840.1.113883.6.1"/>
           <title>Patient Data</title>
@@ -46,6 +45,10 @@
           {{#diagnosis}}
             {{> qrda_templates/diagnosis}}
           {{/diagnosis}}
+
+          {{#device_applied}}
+            {{> qrda_templates/device_applied}}
+          {{/device_applied}}
 
           {{#device_order}}
             {{> qrda_templates/device_order}}

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_header/_record_target.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_header/_record_target.mustache
@@ -4,7 +4,7 @@
     {{#patient_addresses}}
       <addr use="{{use}}">
         {{#street}}
-        <streetAddressLine>{{.}}</streetAddressLine>
+          <streetAddressLine>{{.}}</streetAddressLine>
         {{/street}}
         <city>{{city}}</city>
         <state>{{state}}</state>
@@ -13,46 +13,46 @@
       </addr>
     {{/patient_addresses}}
     {{#patient_telecoms}}
-      <telecom use="{{use}}" value="tel:{{value}}" />
+      <telecom use="{{use}}" value="tel:{{value}}"/>
     {{/patient_telecoms}}
     <patient>
       {{#patient}}
-      <name>
-        <given>{{given_name}}</given>
-        <family>{{familyName}}</family>
-      </name>
+        <name>
+          <given>{{given_name}}</given>
+          <family>{{familyName}}</family>
+        </name>
       {{/patient}}
       {{#patient_characteristic_sex}}
-      {{#dataElementCodes}}
-      <administrativeGenderCode {{> _code}}/>
-      {{/dataElementCodes}}
+        {{#dataElementCodes}}
+          <administrativeGenderCode {{> _code}}/>
+        {{/dataElementCodes}}
       {{/patient_characteristic_sex}}
       {{^patient_characteristic_sex}}
-      <administrativeGenderCode nullFlavor="UNK" />
+          <administrativeGenderCode nullFlavor="UNK"/>
       {{/patient_characteristic_sex}}
       {{#patient_characteristic_birthdate}}
-      {{{birth_date_time}}}
+        {{{birth_date_time}}}
       {{/patient_characteristic_birthdate}}
       {{#patient_characteristic_race}}
         {{#dataElementCodes}}
-      <raceCode {{> _code}}/>
+          <raceCode {{> _code}}/>
         {{/dataElementCodes}}
       {{/patient_characteristic_race}}
       {{^patient_characteristic_race}}
-      <raceCode nullFlavor="UNK" />
+          <raceCode nullFlavor="UNK"/>
       {{/patient_characteristic_race}}
       {{#patient_characteristic_ethnicity}}
         {{#dataElementCodes}}
-      <ethnicGroupCode {{> _code}}/>
+          <ethnicGroupCode {{> _code}}/>
         {{/dataElementCodes}}
       {{/patient_characteristic_ethnicity}}
       {{^patient_characteristic_ethnicity}}
-      <ethnicGroupCode nullFlavor="UNK" />
+          <ethnicGroupCode nullFlavor="UNK"/>
       {{/patient_characteristic_ethnicity}}
       <languageCommunication>
-        <templateId root="2.16.840.1.113883.3.88.11.83.2" assigningAuthorityName="HITSP/C83" />
-        <templateId root="1.3.6.1.4.1.19376.1.5.3.1.2.1" assigningAuthorityName="IHE/PCC" />
-        <languageCode code="eng" />
+        <templateId root="2.16.840.1.113883.3.88.11.83.2" assigningAuthorityName="HITSP/C83"/>
+        <templateId root="1.3.6.1.4.1.19376.1.5.3.1.2.1" assigningAuthorityName="IHE/PCC"/>
+        <languageCode code="eng"/>
       </languageCommunication>
     </patient>
   </patientRole>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/adverse_event.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/adverse_event.mustache
@@ -1,7 +1,7 @@
 <entry>
   <observation classCode="OBS" moodCode="EVN">
     <!-- Adverse Event -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.146" extension="2021-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.146" extension="2019-12-01"/>
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
     <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
     <statusCode code="completed"/>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/allergy_intolerance.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/allergy_intolerance.mustache
@@ -3,7 +3,7 @@
     <!-- Conforms to C-CDA R2.1 Substance or Device Allergy - Intolerance Observation (V2) -->
     <templateId root="2.16.840.1.113883.10.20.24.3.90" extension="2014-06-09"/>
     <!-- Allergy Intolerance -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.147" extension="2021-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.147" extension="2019-12-01"/>
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
     <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
     <statusCode code="completed" />

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/assessment_order.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/assessment_order.mustache
@@ -1,9 +1,9 @@
 <entry>
-  <observation classCode="OBS" moodCode="RQO"{{{negation_ind}}}>
+  <observation classCode="OBS" moodCode="RQO" {{{negation_ind}}}>
     <!-- Conforms to C-CDA R2.1 Planned Observation (V2) -->
     <templateId root="2.16.840.1.113883.10.20.22.4.44" extension="2014-06-09" />
     <!-- Assessment Order -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.158" extension="2021-08-01" />
+    <templateId root="2.16.840.1.113883.10.20.24.3.158" extension="2019-12-01" />
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
     <!-- QDM Attribute: Code -->
     {{> _codes}}

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/assessment_performed.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/assessment_performed.mustache
@@ -1,7 +1,7 @@
 <entry>
-  <observation classCode="OBS" moodCode="EVN"{{{negation_ind}}}>
+  <observation classCode="OBS" moodCode="EVN" {{{negation_ind}}}>
     <!-- Assessment Performed -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.144" extension="2021-08-01" />
+    <templateId root="2.16.840.1.113883.10.20.24.3.144" extension="2019-12-01" />
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
     {{> _codes}}
     <text>{{description}}</text>
@@ -11,10 +11,6 @@
     <!-- QDM Attribute: Result -->
     {{{result_value}}}
     {{/result}}
-    {{#interpretation}}
-      <!-- QDM Attribute: Interpretation -->
-      {{> qrda_templates/template_partials/_interpretation}}
-    {{/interpretation}}
     {{#method}}
       <!-- QDM Attribute: Method -->
       {{> qrda_templates/template_partials/_method}}
@@ -42,8 +38,8 @@
       {{> qrda_templates/template_partials/_component}}
     {{/components}}
     {{#relatedTo}}
-      <!-- QDM Attribute: Related To -->
-      {{> qrda_templates/template_partials/_related_to}}
+        <!-- QDM Attribute: Related To -->
+        {{> qrda_templates/template_partials/_related_to}}
     {{/relatedTo}}
   </observation>
 </entry>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/assessment_recommended.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/assessment_recommended.mustache
@@ -1,9 +1,9 @@
 <entry>
-  <observation classCode="OBS" moodCode="INT"{{{negation_ind}}}>
+  <observation classCode="OBS" moodCode="INT" {{{negation_ind}}}>
     <!-- Conforms to C-CDA R2.1 Planned Observation (V2) -->
     <templateId root="2.16.840.1.113883.10.20.22.4.44" extension="2014-06-09" />
     <!-- Assessment Recommended (V2) -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.145" extension="2021-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.145" extension="2019-12-01"/>
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
     <!-- QDM Attribute: Code -->
     {{> _codes}}

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/communication_performed.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/communication_performed.mustache
@@ -1,6 +1,6 @@
 <entry>
-    <act classCode="ACT" moodCode="EVN"{{{negation_ind}}}>
-        <templateId root="2.16.840.1.113883.10.20.24.3.156" extension="2021-08-01"/>
+    <act classCode="ACT" moodCode="EVN" {{{negation_ind}}}>
+        <templateId root="2.16.840.1.113883.10.20.24.3.156" extension="2019-12-01"/>
         <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
         {{#category}}
           <!-- QDM Attribute: Category -->

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/device_order.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/device_order.mustache
@@ -1,13 +1,13 @@
 <entry>
-  <act classCode="ACT" moodCode="RQO"{{{negation_ind}}}>
-    <templateId root="2.16.840.1.113883.10.20.24.3.130" extension="2021-08-01"/>
+  <act classCode="ACT" moodCode="RQO" {{{negation_ind}}}>
+    <templateId root="2.16.840.1.113883.10.20.24.3.130" extension="2019-12-01"/>
     <code code="SPLY" codeSystem="2.16.840.1.113883.5.6" displayName="Supply" codeSystemName="ActClass"/>
     <entryRelationship typeCode="SUBJ">
       <supply classCode="SPLY" moodCode="RQO">
         <!-- Plan of Care Activity Supply -->
         <templateId root="2.16.840.1.113883.10.20.22.4.43" extension="2014-06-09"/>
         <!-- Device, Order -->
-        <templateId root="2.16.840.1.113883.10.20.24.3.9" extension="2021-08-01"/>
+        <templateId root="2.16.840.1.113883.10.20.24.3.9" extension="2019-12-01"/>
         <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
         <text>{{description}}</text>
         <statusCode code="active"/>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/device_recommended.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/device_recommended.mustache
@@ -1,13 +1,13 @@
 <entry>
-  <act classCode="ACT" moodCode="INT"{{{negation_ind}}}>
-    <templateId root="2.16.840.1.113883.10.20.24.3.131" extension="2021-08-01"/>
+  <act classCode="ACT" moodCode="INT" {{{negation_ind}}}>
+    <templateId root="2.16.840.1.113883.10.20.24.3.131" extension="2019-12-01"/>
     <code code="SPLY" codeSystem="2.16.840.1.113883.5.6" displayName="Supply" codeSystemName="ActClass"/>
     <entryRelationship typeCode="SUBJ">
       <supply classCode="SPLY" moodCode="INT">
         <!-- C-CDA R2.1 : Planned Supply (V2) -->
         <templateId root="2.16.840.1.113883.10.20.22.4.43" extension="2014-06-09"/>
         <!-- Device Recommended (V4) -->
-        <templateId root="2.16.840.1.113883.10.20.24.3.10" extension="2021-08-01"/>
+        <templateId root="2.16.840.1.113883.10.20.24.3.10" extension="2019-12-01"/>
         <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
         <text>{{description}}</text>
         <statusCode code="active"/>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/diagnosis.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/diagnosis.mustache
@@ -3,7 +3,7 @@
     <!-- Conforms to C-CDA 2.1 Problem Concern Act (V3) -->
     <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01" />
     <!-- Diagnosis Concern Act -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.137" extension="2021-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.137" extension="2019-12-01"/>
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
     <code code="CONC" codeSystem="2.16.840.1.113883.5.6" displayName="Concern" />
     {{#prevalencePeriod}}
@@ -20,7 +20,7 @@
         <!-- Conforms to C-CDA R2.1 Problem Observation (V3) -->
         <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01" />
         <!-- Diagnosis template -->
-        <templateId root="2.16.840.1.113883.10.20.24.3.135" extension="2021-08-01" />
+        <templateId root="2.16.840.1.113883.10.20.24.3.135" extension="2019-12-01" />
         <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
         <code code="29308-4" codeSystem="2.16.840.1.113883.6.1">
           <translation code="282291009" codeSystem="2.16.840.1.113883.6.96"/>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/diagnostic_study_order.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/diagnostic_study_order.mustache
@@ -1,10 +1,10 @@
 <entry>
-  <observation classCode="OBS" moodCode="RQO"{{{negation_ind}}}>
+  <observation classCode="OBS" moodCode="RQO" {{{negation_ind}}}>
   <!-- Consolidated Plan of Care Activity Observation
        templateId (Implied Template) -->
   <templateId root="2.16.840.1.113883.10.20.22.4.44" extension="2014-06-09"/>
   <!-- Diagnostic Study, Order template -->
-  <templateId root="2.16.840.1.113883.10.20.24.3.17" extension="2021-08-01"/>
+  <templateId root="2.16.840.1.113883.10.20.24.3.17" extension="2019-12-01"/>
   <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
   {{> _codes}}
   <text>{{description}}</text>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/diagnostic_study_performed.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/diagnostic_study_performed.mustache
@@ -1,20 +1,16 @@
 <entry>
-  <observation classCode="OBS" moodCode="EVN"{{{negation_ind}}}>
+  <observation classCode="OBS" moodCode="EVN" {{{negation_ind}}}>
     <!-- Consolidated Procedure Activity Observation templateId 
        (Implied Template) -->
     <templateId root="2.16.840.1.113883.10.20.22.4.13" extension="2014-06-09"/>
     <!-- Diagnostic Study, Performed template -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.18" extension="2021-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.18" extension="2019-12-01"/>
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
     {{> _codes}}
     <text>{{description}}</text>
     <statusCode code="completed"/>
     {{{relevant_date_period_or_null_flavor}}}
     <value nullFlavor="NA" xsi:type="CD" />
-    {{#interpretation}}
-      <!-- QDM Attribute: Interpretation -->
-      {{> qrda_templates/template_partials/_interpretation}}
-    {{/interpretation}}
     {{#method}}
       <!-- QDM Attribute: Method -->
       {{> qrda_templates/template_partials/_method}}
@@ -53,9 +49,5 @@
       <!-- QDM Attribute: Components -->
       {{> qrda_templates/template_partials/_component}}
     {{/components}}
-    {{#relatedTo}}
-      <!-- QDM Attribute: relatedTo -->
-      {{> qrda_templates/template_partials/_related_to}}
-    {{/relatedTo}}
   </observation>
 </entry>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/diagnostic_study_recommended.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/diagnostic_study_recommended.mustache
@@ -1,9 +1,9 @@
 <entry>
-  <observation classCode="OBS" moodCode="INT"{{{negation_ind}}}>
+  <observation classCode="OBS" moodCode="INT" {{{negation_ind}}}>
     <!-- Conforms to C-CDA R2.1 Planned Observation (V2) -->
     <templateId root="2.16.840.1.113883.10.20.22.4.44" extension="2014-06-09"/>
     <!-- Diagnostic Study Recommended (V4) -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.19" extension="2021-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.19" extension="2019-12-01"/>
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
     {{> _codes}}
     <text>{{description}}</text>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/encounter_order.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/encounter_order.mustache
@@ -1,13 +1,13 @@
 <entry>
-  <act classCode="ACT" moodCode="RQO"{{{negation_ind}}}>
-    <templateId root="2.16.840.1.113883.10.20.24.3.132" extension="2021-08-01"/>
+  <act classCode="ACT" moodCode="RQO" {{{negation_ind}}}>
+    <templateId root="2.16.840.1.113883.10.20.24.3.132" extension="2019-12-01"/>
     <code code="ENC" codeSystem="2.16.840.1.113883.5.6" displayName="Encounter" codeSystemName="ActClass"/>
     <entryRelationship typeCode="SUBJ">
       <encounter classCode="ENC" moodCode="RQO">
         <!--  Plan of Care Activity Encounter template -->
         <templateId root="2.16.840.1.113883.10.20.22.4.40" extension="2014-06-09"/>
         <!-- Encounter order template -->
-        <templateId root="2.16.840.1.113883.10.20.24.3.22" extension="2021-08-01"/>
+        <templateId root="2.16.840.1.113883.10.20.24.3.22" extension="2019-12-01"/>
         <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
         <!-- QDM Attribute: Code -->
         {{> _codes}}

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/encounter_performed.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/encounter_performed.mustache
@@ -1,14 +1,14 @@
 <entry>
-  <act classCode="ACT" moodCode="EVN">
+  <act classCode="ACT" moodCode="EVN" {{{negation_ind}}}>
     <!--Encounter performed Act -->
-    <templateId extension="2021-08-01" root="2.16.840.1.113883.10.20.24.3.133"/>
+    <templateId extension="2019-12-01" root="2.16.840.1.113883.10.20.24.3.133"/>
     <code code="ENC" codeSystem="2.16.840.1.113883.5.6" codeSystemName="ActClass" displayName="Encounter"/>
     <entryRelationship typeCode="SUBJ">
       <encounter classCode="ENC" moodCode="EVN">
         <!--  Encounter activities template -->
         <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.49"/>
         <!-- Encounter performed template -->
-        <templateId extension="2021-08-01" root="2.16.840.1.113883.10.20.24.3.23"/>
+        <templateId extension="2019-12-01" root="2.16.840.1.113883.10.20.24.3.23"/>
         <id extension="{{object_id}}" root="1.3.6.1.4.1.115"/>
         <!-- QDM Attribute: Code -->
         {{> _codes}}
@@ -40,19 +40,15 @@
             {{> qrda_templates/template_partials/_entity}}
           </participant>
         {{/participant}}
-        {{#clazz}}
-          <!-- QDM Attribute: Class -->
-          {{> qrda_templates/template_partials/_encounter_class}}
-        {{/clazz}}
         {{#diagnoses}}
           <!-- QDM Attribute: Diagnoses -->
           {{> qrda_templates/template_partials/_encounter_diagnosis_qdm}}
         {{/diagnoses}}
-        {{#relatedTo}}
-          <!-- QDM Attribute: relatedTo -->
-          {{> qrda_templates/template_partials/_related_to}}
-        {{/relatedTo}}
       </encounter>
     </entryRelationship>
+    {{#negationRationale}}
+      <!-- QDM Attribute: Negation Rationale -->
+      {{> qrda_templates/template_partials/_reason}}
+    {{/negationRationale}}
   </act>
 </entry>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/encounter_recommended.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/encounter_recommended.mustache
@@ -1,14 +1,14 @@
 <entry>
-  <act classCode="ACT" moodCode="INT"{{{negation_ind}}}>
+  <act classCode="ACT" moodCode="INT" {{{negation_ind}}}>
     <!--Encounter Recommended Act (V2) -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.134" extension="2021-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.134" extension="2019-12-01"/>
     <code code="ENC" codeSystem="2.16.840.1.113883.5.6" codeSystemName="ActClass" displayName="Encounter"/>
     <entryRelationship typeCode="SUBJ">
       <encounter classCode="ENC" moodCode="INT">
         <!-- Conforms to C-CDA R2.1 Planned Encounter (V2) template -->
         <templateId root="2.16.840.1.113883.10.20.22.4.40" extension="2014-06-09"/>
         <!-- Encounter Recommended (V4) template -->
-        <templateId root="2.16.840.1.113883.10.20.24.3.24" extension="2021-08-01"/>
+        <templateId root="2.16.840.1.113883.10.20.24.3.24" extension="2019-12-01"/>
         <id extension="{{object_id}}" root="1.3.6.1.4.1.115"/>
         <!-- QDM Attribute: Code -->
         {{> _codes}}

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/family_history.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/family_history.mustache
@@ -3,7 +3,7 @@
     <!-- C-CDA R2.1 Family History Organizer (V3) -->
     <templateId root="2.16.840.1.113883.10.20.22.4.45" extension="2015-08-01"/>
     <!-- Family History Organizer QDM (V4) -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.12" extension="2021-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.12" extension="2019-12-01"/>
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
     <statusCode code="completed" />
     {{#relationship}}
@@ -19,7 +19,7 @@
         <!-- Conforms to C-CDA R2.1 Family History Observation (V3) -->
         <templateId root="2.16.840.1.113883.10.20.22.4.46" extension="2015-08-01"/>
         <!-- Family History QDM (V3) -->
-        <templateId root="2.16.840.1.113883.10.20.24.3.112" extension="2021-08-01"/>
+        <templateId root="2.16.840.1.113883.10.20.24.3.112" extension="2019-12-01"/>
         <id root="1.3.6.1.4.1.115" extension="{{random_id}}"/>
         <code code="75323-6" displayName="Condition" codeSystemName="LOINC" codeSystem="2.16.840.1.113883.6.1">
           <translation code="64572001" displayName="Condition" codeSystemName="SNOMED CT" codeSystem="2.16.840.1.113883.6.96"/>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/immunization_administered.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/immunization_administered.mustache
@@ -1,6 +1,6 @@
 <entry>
     {{#negated}}
-      <substanceAdministration classCode="SBADM" moodCode="EVN"{{{negation_ind}}}>
+      <substanceAdministration classCode="SBADM" moodCode="EVN" {{{negation_ind}}}>
     {{/negated}}
     {{^negated}}
       <substanceAdministration classCode="SBADM" moodCode="EVN" negationInd="false">
@@ -8,7 +8,7 @@
     <!-- C-CDA R2 Immunization Activity -->
     <templateId root="2.16.840.1.113883.10.20.22.4.52" extension="2015-08-01"/>
     <!-- Immunization Administered -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.140" extension="2021-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.140" extension="2019-12-01"/>
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
     <code code="416118004" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Administration"/>
     <statusCode code="completed"/>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/immunization_order.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/immunization_order.mustache
@@ -1,9 +1,9 @@
 <entry>
-  <substanceAdministration classCode="SBADM" moodCode="RQO"{{{negation_ind}}}>
+  <substanceAdministration classCode="SBADM" moodCode="RQO" {{{negation_ind}}}>
     <!-- Conforms to C-CDA R2.1 Planned Immunization Activity -->
     <templateId root="2.16.840.1.113883.10.20.22.4.120"/>
     <!-- Immunization Order (V2) -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.143" extension="2021-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.143" extension="2019-12-01"/>
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
     <text>{{description}}</text>
     <statusCode code="active"/>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/intervention_order.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/intervention_order.mustache
@@ -1,9 +1,9 @@
 <entry>
-  <act classCode="ACT" moodCode="RQO"{{{negation_ind}}}>
+  <act classCode="ACT" moodCode="RQO" {{{negation_ind}}}>
     <!-- Conforms to C-CDA R2 Planned Act (V2) template -->
     <templateId root="2.16.840.1.113883.10.20.22.4.39" extension="2014-06-09"/>
     <!-- Intervention Order (V4) -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.31" extension="2021-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.31" extension="2019-12-01"/>
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
     {{> _codes}}
     <text>{{description}}</text>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/intervention_performed.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/intervention_performed.mustache
@@ -1,9 +1,9 @@
 <entry>
-  <act classCode="ACT" moodCode="EVN"{{{negation_ind}}}>
+  <act classCode="ACT" moodCode="EVN" {{{negation_ind}}}>
     <!-- Consolidation CDA: Procedure Activity Act template -->
     <templateId root="2.16.840.1.113883.10.20.22.4.12" extension="2014-06-09"/>
     <!-- Intervention Performed Template -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.32" extension="2021-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.32" extension="2019-12-01"/>
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
     {{> _codes}}
     <text>{{description}}</text>
@@ -35,9 +35,5 @@
       <!-- QDM Attribute: Status -->
       {{> qrda_templates/template_partials/_status}}
     {{/status}}
-    {{#relatedTo}}
-      <!-- QDM Attribute: relatedTo -->
-      {{> qrda_templates/template_partials/_related_to}}
-    {{/relatedTo}}
   </act>
 </entry>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/intervention_recommended.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/intervention_recommended.mustache
@@ -1,9 +1,9 @@
 <entry>
-  <act classCode="ACT" moodCode="INT"{{{negation_ind}}}>
+  <act classCode="ACT" moodCode="INT" {{{negation_ind}}}>
     <!-- Conforms to C-CDA R2.1 Planned Act (V2) template -->
     <templateId root="2.16.840.1.113883.10.20.22.4.39" extension="2014-06-09"/>
     <!-- Intervention Recommended (V4) template -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.33" extension="2021-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.33" extension="2019-12-01"/>
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
     <!--  QDM Attribute: Code -->
     {{> _codes}}

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/laboratory_test_order.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/laboratory_test_order.mustache
@@ -1,9 +1,9 @@
 <entry>
-  <observation classCode="OBS" moodCode="RQO"{{{negation_ind}}}>
+  <observation classCode="OBS" moodCode="RQO" {{{negation_ind}}}>
     <!-- Consolidation Plan of Care Activity Observation -->
     <templateId root="2.16.840.1.113883.10.20.22.4.44" extension="2014-06-09"/>
     <!-- Laboratory Test, Order (V4) -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.37" extension="2021-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.37" extension="2019-12-01"/>
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
     {{> _codes}}
     <text>{{description}}</text>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/laboratory_test_performed.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/laboratory_test_performed.mustache
@@ -1,7 +1,7 @@
 <entry>
-  <observation classCode="OBS" moodCode="EVN"{{{negation_ind}}}>
+  <observation classCode="OBS" moodCode="EVN" {{{negation_ind}}}>
     <!-- Laboratory Test Performed (V4) -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.38" extension="2021-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.38" extension="2019-12-01"/>
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
     {{> _codes}}
     <text>{{description}}</text>
@@ -41,9 +41,9 @@
       <!-- QDM Attribute: Components -->
       {{> qrda_templates/template_partials/_component}}
     {{/components}}
-    {{#relatedTo}}
+    {{#encounter_id}}
       <!-- QDM Attribute: relatedTo -->
       {{> qrda_templates/template_partials/_related_to}}
-    {{/relatedTo}}
+    {{/encounter_id}}
     </observation>
 </entry>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/laboratory_test_recommended.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/laboratory_test_recommended.mustache
@@ -1,9 +1,9 @@
 <entry>
-  <observation classCode="OBS" moodCode="INT"{{{negation_ind}}}>
+  <observation classCode="OBS" moodCode="INT" {{{negation_ind}}}>
     <!-- Conforms to C-CDA R2.1 Planned Observation (V2) -->
     <templateId root="2.16.840.1.113883.10.20.22.4.44" extension="2014-06-09"/>
     <!-- Laboratory Test, Recommended (V4) -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.39" extension="2021-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.39" extension="2019-12-01"/>
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
     <!-- QDM Attribute: Code -->
     {{> _codes}}

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/medication_active.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/medication_active.mustache
@@ -3,7 +3,7 @@
     <!-- Medication Activity (consolidation) template -->
     <templateId root="2.16.840.1.113883.10.20.22.4.16" extension="2014-06-09"/>
     <!-- Medication, Active template -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.41" extension="2021-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.41" extension="2019-12-01"/>
 
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
     <text>{{description}}</text>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/medication_administered.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/medication_administered.mustache
@@ -1,9 +1,9 @@
 <entry>
-  <substanceAdministration classCode="SBADM" moodCode="EVN"{{{negation_ind}}}>
+  <substanceAdministration classCode="SBADM" moodCode="EVN" {{{negation_ind}}}>
     <!-- Medication Activity (consolidation) template -->
     <templateId root="2.16.840.1.113883.10.20.22.4.16" extension="2014-06-09"/>
     <!-- Medication, Administered template -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.42" extension="2021-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.42" extension="2019-12-01"/>
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
     <code code="416118004" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Administration"/>
     <statusCode code="completed"/>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/medication_discharge.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/medication_discharge.mustache
@@ -1,7 +1,7 @@
 <entry>
-  <act classCode="ACT" moodCode="RQO"{{{negation_ind}}}>
+  <act classCode="ACT" moodCode="RQO" {{{negation_ind}}}>
     <!-- Discharge Medication Entry -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.105" extension="2021-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.105" extension="2019-12-01"/>
     <code code="75311-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Discharge medications"/> 
     <statusCode code="active"/>
     {{#prescriber}}
@@ -20,6 +20,8 @@
       <substanceAdministration moodCode="EVN" classCode="SBADM">
         <!-- Medication Activity (consolidation) template -->
         <templateId root="2.16.840.1.113883.10.20.22.4.16" extension="2014-06-09"/> 
+        <!-- Medication, Active template -->
+        <templateId root="2.16.840.1.113883.10.20.24.3.41" extension="2019-12-01"/>
         <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
         <text>{{description}}</text>
         <statusCode code="active"/> 
@@ -42,7 +44,7 @@
           </manufacturedProduct>
         </consumable>
         {{#authorDatetime}}
-          {{> qrda_templates/template_partials/_author}}
+          {{> qrda_templates/template_partials/_author_participation}}
         {{/authorDatetime}}
       </substanceAdministration>
     </entryRelationship>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/medication_dispensed.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/medication_dispensed.mustache
@@ -1,13 +1,13 @@
 <entry>
-  <act classCode="ACT" moodCode="EVN"{{{negation_ind}}}>
+  <act classCode="ACT" moodCode="EVN" {{{negation_ind}}}>
     <!-- Medication Dispensed Act -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.139" extension="2021-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.139" extension="2019-12-01"/>
     <code code="SPLY" codeSystem="2.16.840.1.113883.5.6" displayName="supply" codeSystemName="ActClass"/>
     <entryRelationship typeCode="SUBJ">
       <!--Medication dispensed -->
       <supply classCode="SPLY" moodCode="EVN">
         <!--  Medication Dispensed template -->
-        <templateId root="2.16.840.1.113883.10.20.24.3.45" extension="2021-08-01"/>
+        <templateId root="2.16.840.1.113883.10.20.24.3.45" extension="2019-12-01"/>
         <!-- Medication Dispense template -->
         <templateId root="2.16.840.1.113883.10.20.22.4.18" extension="2014-06-09"/>
         <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/medication_order.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/medication_order.mustache
@@ -1,9 +1,9 @@
 <entry>
   <!--Medication Order -->
-  <substanceAdministration classCode="SBADM" moodCode="RQO"{{{negation_ind}}}>
+  <substanceAdministration classCode="SBADM" moodCode="RQO" {{{negation_ind}}}>
     <templateId root="2.16.840.1.113883.10.20.22.4.42" extension="2014-06-09"/>
     <!-- Medication, Order template -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.47" extension="2021-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.47" extension="2019-12-01"/>
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
     <text>{{description}}</text>
     <statusCode code="active"/>
@@ -66,9 +66,5 @@
           {{> qrda_templates/template_partials/_medication_supply_request}}
       </entryRelationship>
     {{/supply}}
-    {{#relatedTo}}
-      <!-- QDM Attribute: relatedTo -->
-      {{> qrda_templates/template_partials/_related_to}}
-    {{/relatedTo}}
   </substanceAdministration>
 </entry>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/patient_care_experience.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/patient_care_experience.mustache
@@ -1,7 +1,7 @@
 <entry>
   <observation classCode="OBS" moodCode="EVN">
     <!-- Patient Care Experience (V4) -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.48" extension="2021-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.48" extension="2019-12-01"/>
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
     <code code="77218-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Patient satisfaction with healthcare delivery"/>
     <statusCode code="completed"/>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/physical_exam_order.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/physical_exam_order.mustache
@@ -1,9 +1,9 @@
 <entry>
-  <observation classCode="OBS" moodCode="RQO"{{{negation_ind}}}>
+  <observation classCode="OBS" moodCode="RQO" {{{negation_ind}}}>
     <!-- Conforms to C-CDA R2.1 Planned Observation (V2) -->
     <templateId root="2.16.840.1.113883.10.20.22.4.44" extension="2014-06-09"/>
     <!-- Physical Exam Order (V4) -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.58" extension="2021-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.58" extension="2019-12-01"/>
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
     <code code="29545-1" codeSystem="2.16.840.1.113883.6.1" displayName="physical examination" codeSystemName="LOINC"/>
     <text>{{description}}</text>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/physical_exam_performed.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/physical_exam_performed.mustache
@@ -1,9 +1,9 @@
 <entry>
-  <observation classCode="OBS" moodCode="EVN"{{{negation_ind}}}>
+  <observation classCode="OBS" moodCode="EVN" {{{negation_ind}}}>
     <!-- Procedure Activity Procedure (Consolidation) template -->
     <templateId root="2.16.840.1.113883.10.20.22.4.13" extension="2014-06-09"/>
     <!-- Physical Exam, Performed template -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.59" extension="2021-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.59" extension="2019-12-01"/>
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
     <!-- QDM Attribute: Code -->
     {{> _codes}}
@@ -48,9 +48,9 @@
       <!-- QDM Attribute: Components -->
       {{> qrda_templates/template_partials/_component}}
     {{/components}}
-    {{#relatedTo}}
+    {{#encounter_id}}
       <!-- QDM Attribute: relatedTo -->
       {{> qrda_templates/template_partials/_related_to}}
-    {{/relatedTo}}
+    {{/encounter_id}}
   </observation>
 </entry>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/physical_exam_recommended.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/physical_exam_recommended.mustache
@@ -1,9 +1,9 @@
 <entry>
-  <observation classCode="OBS" moodCode="INT"{{{negation_ind}}}>
+  <observation classCode="OBS" moodCode="INT" {{{negation_ind}}}>
     <!-- Conforms to C-CDA R2.1 Planned Observation (V2) -->
     <templateId root="2.16.840.1.113883.10.20.22.4.44" extension="2014-06-09"/>
     <!-- Physical Exam Recommeded (V4) -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.60" extension="2021-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.60" extension="2019-12-01"/>
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
     <code code="29545-1" codeSystem="2.16.840.1.113883.6.1" displayName="physical examination" codeSystemName="LOINC"/>
     <text>{{description}}</text>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/procedure_order.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/procedure_order.mustache
@@ -1,9 +1,9 @@
 <entry>
-  <procedure classCode="PROC" moodCode="RQO"{{{negation_ind}}}>
+  <procedure classCode="PROC" moodCode="RQO" {{{negation_ind}}}>
     <!-- Consolidated Plan of Care Activity Procedure TemplateId (Implied Template) -->
     <templateId root="2.16.840.1.113883.10.20.22.4.41" extension="2014-06-09"/> 
     <!-- QRDA Procedure, Order TemplateId --> 
-    <templateId root="2.16.840.1.113883.10.20.24.3.63" extension="2021-08-01"/> 
+    <templateId root="2.16.840.1.113883.10.20.24.3.63" extension="2019-12-01"/> 
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
     {{> _codes}}
     <text>{{description}}</text>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/procedure_performed.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/procedure_performed.mustache
@@ -1,7 +1,7 @@
 <entry>
-  <procedure classCode="PROC" moodCode="EVN"{{{negation_ind}}}>
+  <procedure classCode="PROC" moodCode="EVN" {{{negation_ind}}}>
     <!--  Procedure performed template -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.64" extension="2021-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.64" extension="2019-12-01"/>
     <!-- Procedure Activity Procedure-->
     <templateId root="2.16.840.1.113883.10.20.22.4.14" extension="2014-06-09"/>
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
@@ -62,10 +62,6 @@
       <!-- QDM Attribute: Components -->
       {{> qrda_templates/template_partials/_component}}
     {{/components}}
-    {{#relatedTo}}
-      <!-- QDM Attribute: relatedTo -->
-      {{> qrda_templates/template_partials/_related_to}}
-    {{/relatedTo}}
   </procedure>
 </entry>
 

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/procedure_recommended.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/procedure_recommended.mustache
@@ -1,9 +1,9 @@
 <entry>
-  <procedure classCode="PROC" moodCode="INT"{{{negation_ind}}}>
+  <procedure classCode="PROC" moodCode="INT" {{{negation_ind}}}>
     <!-- Conforms to C-CDA R2.1 Planned Procedure (V2) -->
     <templateId root="2.16.840.1.113883.10.20.22.4.41" extension="2014-06-09"/>
     <!-- Procedure Recommended (V5) -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.65" extension="2021-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.65" extension="2019-12-01"/>
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
     <!-- QDM Attribute: Code -->
     {{> _codes}}

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/program_participation.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/program_participation.mustache
@@ -1,7 +1,7 @@
 <entry>
   <observation classCode="OBS" moodCode="EVN">
     <!-- Program Participation (V2) -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.154" extension="2021-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.154" extension="2019-12-01"/>
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
     <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
     <statusCode code="completed" />
@@ -11,5 +11,11 @@
     {{/participationPeriod}}
     <!-- QDM Attribute: Code -->
     {{> qrda_templates/template_partials/_data_element_codes_as_values}}
+    {{#recorder}}
+      <!-- QDM Attribute: Recorder -->
+      <participant typeCode="PRF">
+        {{> qrda_templates/template_partials/_entity}}
+      </participant>
+    {{/recorder}}
   </observation>
 </entry>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/provider_care_experience.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/provider_care_experience.mustache
@@ -1,7 +1,7 @@
 <entry>
   <observation classCode="OBS" moodCode="EVN">
     <!-- Provider Care Experience (V4) -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.67" extension="2021-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.67" extension="2019-12-01"/>
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
     <code code="77219-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Provider satisfaction with healthcare delivery"/>
     <statusCode code="completed" />

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/substance_recommended.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/substance_recommended.mustache
@@ -1,9 +1,9 @@
 <entry>
-  <substanceAdministration classCode="SBADM" moodCode="INT"{{{negation_ind}}}>
+  <substanceAdministration classCode="SBADM" moodCode="INT" {{{negation_ind}}}>
     <!-- Conforms to C-CDA R2.1 Planned Medication Activity (V2) -->
     <templateId root="2.16.840.1.113883.10.20.22.4.42" extension="2014-06-09"/>
     <!-- Substance Recommended (V4) -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.75" extension="2021-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.75" extension="2019-12-01"/>
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
     <statusCode code="active"/>
     <effectiveTime xsi:type="IVL_TS">

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/symptom.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/symptom.mustache
@@ -3,7 +3,7 @@
     <!-- Conforms to C-CDA 2.1 Problem Concern Act (V3) -->
     <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
     <!-- Symptom Concern Act (V3) -->
-    <templateId root="2.16.840.1.113883.10.20.24.3.138" extension="2021-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.138" extension="2019-12-01"/>
     <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
     <code code="CONC" codeSystem="2.16.840.1.113883.5.6" displayName="Concern"/>
     {{#prevalencePeriod}}
@@ -21,7 +21,7 @@
         <!-- Conforms to C-CDA R2.1 Problem Observation (V3) -->
         <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01"/>
         <!-- Symptom (V2) -->
-        <templateId root="2.16.840.1.113883.10.20.24.3.136" extension="2021-08-01"/>
+        <templateId root="2.16.840.1.113883.10.20.24.3.136" extension="2019-12-01"/>
         <id root="1.3.6.1.4.1.115" extension="{{object_id}}"/>
         <code code="75325-1" codeSystem="2.16.840.1.113883.6.1">
           <translation code="418799008" displayName="Symptom" codeSystem="2.16.840.1.113883.6.96"/>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/template_partials/_encounter_diagnosis_qdm.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/template_partials/_encounter_diagnosis_qdm.mustache
@@ -1,7 +1,7 @@
 <entryRelationship typeCode="REFR">
   <observation classCode="OBS" moodCode="EVN">
     <!--  Encounter Diagnosis QDM  -->
-    <templateId extension="2021-08-01" root="2.16.840.1.113883.10.20.24.3.168"/>
+    <templateId extension="2019-12-01" root="2.16.840.1.113883.10.20.24.3.168"/>
     <code code="29308-4" codeSystem="2.16.840.1.113883.6.1"/>
     <statusCode code="completed"/>
     {{#code}}
@@ -14,7 +14,7 @@
     {{#presentOnAdmissionIndicator}}
       <entryRelationship typeCode="REFR">
         <observation classCode="OBS" moodCode="EVN">
-          <templateId root="2.16.840.1.113883.10.20.24.3.169" extension="2021-08-01"/>
+          <templateId root="2.16.840.1.113883.10.20.24.3.169" extension="2019-12-01"/>
           <code code="78026-2" displayName="Present on admission" codeSystem="2.16.840.1.113883.6.1"/>
           <value {{> _code}} xsi:type="CD"/>
         </observation>

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/template_partials/_entity.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/template_partials/_entity.mustache
@@ -1,9 +1,6 @@
 {{#care_partner_entity?}}
 	{{> qrda_templates/template_partials/_entity_care_partner}}
 {{/care_partner_entity?}}
-{{#location_entity?}}
-	{{> qrda_templates/template_partials/_entity_location}}
-{{/location_entity?}}
 {{#patient_entity?}}
 	{{> qrda_templates/template_partials/_entity_patient}}
 {{/patient_entity?}}

--- a/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/template_partials/_entity_organization.mustache
+++ b/src/Services/Qrda/qrda-export/catI-r5/qrda_templates/template_partials/_entity_organization.mustache
@@ -3,9 +3,9 @@
     {{#identifier}}
       <id root="{{{namingSystem}}}" extension="{{{value}}}"/>
     {{/identifier}}
-    {{#organizationType}}
+    {{#type}}
       <playingEntity>
         <code {{> _code}}/>
       </playingEntity>
-    {{/organizationType}}
+    {{/type}}
 </participantRole>

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@ $v_realpatch = '0';
 // is a database change in the course of development.  It is used
 // internally to determine when a database upgrade is needed.
 //
-$v_database = 443;
+$v_database = 444;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
#### Short description of what this resolves:
@adunsulag @kchapple 
So what happen. Thought these template were to be brought to same cqm-reports version as the Cat3 template 3.1.8 with Stephens push.

#### Changes proposed in this pull request:
Bring in projects 3.1.8 version templates to match cypress testing.
