### PR TITLE
Multi site install rm keys for new site that wasn't cloned

### DIFF
--- a/library/classes/Installer.class.php
+++ b/library/classes/Installer.class.php
@@ -472,8 +472,8 @@ class Installer
                 $this->error_message = "unable to copy directory: '$source_directory' to '$destination_directory'. " . $this->error_message;
                 return false;
             }
+            array_map('unlink', glob($destination_directory . "/documents/logs_and_misc/methods/*"));
         }
-
         return true;
     }
 

--- a/library/classes/Installer.class.php
+++ b/library/classes/Installer.class.php
@@ -473,7 +473,9 @@ class Installer
                 return false;
             }
             // the new site will create it's own keys so okay to delete these copied from the source site
-            array_map('unlink', glob($destination_directory . "/documents/logs_and_misc/methods/*"));
+            if (!$this->clone_database) {
+                array_map('unlink', glob($destination_directory . "/documents/logs_and_misc/methods/*"));
+            }
         }
 
         return true;

--- a/library/classes/Installer.class.php
+++ b/library/classes/Installer.class.php
@@ -472,8 +472,10 @@ class Installer
                 $this->error_message = "unable to copy directory: '$source_directory' to '$destination_directory'. " . $this->error_message;
                 return false;
             }
+            // the new site will create it's own keys so okay to delete these copied from the source site
             array_map('unlink', glob($destination_directory . "/documents/logs_and_misc/methods/*"));
         }
+
         return true;
     }
 

--- a/setup.php
+++ b/setup.php
@@ -32,12 +32,12 @@ set_time_limit(0);
 // Warning. If you set $allow_multisite_setup to true, this is a potential security vulnerability.
 // Recommend setting it back to false (or removing this setup.php script entirely) after you
 //  are done with the multisite procedure.
-$allow_multisite_setup = false;
+$allow_multisite_setup = true;
 
 // Warning. If you set $allow_cloning_setup to true, this is a potential security vulnerability.
 // Recommend setting it back to false (or removing this setup.php script entirely) after you
 //  are done with the cloning setup procedure.
-$allow_cloning_setup = false;
+$allow_cloning_setup = true;
 if (!$allow_cloning_setup && !empty($_REQUEST['clone_database'])) {
     die("To turn on support for cloning setup, need to edit this script and change \$allow_cloning_setup to true. After you are done setting up the cloning, ensure you change \$allow_cloning_setup back to false or remove this script altogether");
 }

--- a/setup.php
+++ b/setup.php
@@ -32,12 +32,12 @@ set_time_limit(0);
 // Warning. If you set $allow_multisite_setup to true, this is a potential security vulnerability.
 // Recommend setting it back to false (or removing this setup.php script entirely) after you
 //  are done with the multisite procedure.
-$allow_multisite_setup = true;
+$allow_multisite_setup = false;
 
 // Warning. If you set $allow_cloning_setup to true, this is a potential security vulnerability.
 // Recommend setting it back to false (or removing this setup.php script entirely) after you
 //  are done with the cloning setup procedure.
-$allow_cloning_setup = true;
+$allow_cloning_setup = false;
 if (!$allow_cloning_setup && !empty($_REQUEST['clone_database'])) {
     die("To turn on support for cloning setup, need to edit this script and change \$allow_cloning_setup to true. After you are done setting up the cloning, ensure you change \$allow_cloning_setup back to false or remove this script altogether");
 }


### PR DESCRIPTION
Fixes #5082 , thanks @gutiersa

Short description of what this resolves:

removes source keys from new site unless site was a clone

the keys for the new site are created on first login
Changes proposed in this pull request: