### PR TITLE
Fixes #5089 Remove unused CDR menu items.

### DIFF
--- a/interface/main/tabs/menu/menus/standard.json
+++ b/interface/main/tabs/menu/menus/standard.json
@@ -1474,19 +1474,6 @@
             "global_req": "enable_cdr"
           },
           {
-            "label": "Quality Measures (CQM)",
-            "menu_id": "rep0",
-            "target": "rep",
-            "url": "/interface/reports/cqm.php?type=cqm",
-            "children": [],
-            "requirement": 0,
-            "acl_req": [
-              "patients",
-              "med"
-            ],
-            "global_req": "enable_cqm"
-          },
-          {
             "label": "Automated Measures (AMC)",
             "menu_id": "rep0",
             "target": "rep",
@@ -1498,19 +1485,6 @@
               "med"
             ],
             "global_req": "enable_amc"
-          },
-          {
-            "label": "AMC Tracking",
-            "menu_id": "rep0",
-            "target": "rep",
-            "url": "/interface/reports/amc_tracking.php",
-            "children": [],
-            "requirement": 0,
-            "acl_req": [
-              "patients",
-              "med"
-            ],
-            "global_req": "enable_amc_tracking"
           },
           {
             "label": "Alerts Log",


### PR DESCRIPTION
Fixes #5089 Removes the CQM menu since that is now done in carecoordination module.
Removes the AMC tracking since it uses old rule sets and we aren't
certifying against it.