### PR TITLE
Corrected stylelint syntax

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,7 +1,6 @@
 {
     "plugins": ["stylelint-order", "stylelint-scss"],
-    "extends": "stylelint-config-standard",
-    "extends": "stylelint-config-sass-guidelines",
+    "extends": [ "stylelint-config-standard", "stylelint-config-sass-guidelines" ],
     "ignoreFiles": [
         "swagger/*.css"
     ],


### PR DESCRIPTION
Removed the duplicated keys and followed the officially suggested syntax from the [StyleLint website](https://stylelint.io/user-guide/configure/#extends).