### PR TITLE
Fixes #5095 Patient,Goals,Immunization

### DIFF
--- a/_rest_routes.inc.php
+++ b/_rest_routes.inc.php
@@ -10419,10 +10419,10 @@ RestConfig::$FHIR_ROUTE_MAP = array(
     "GET /fhir/Patient/:uuid" => function ($uuid, HttpRestRequest $request) {
         if ($request->isPatientRequest()) {
             // only allow access to data of binded patient
-            if (empty($id) || ($id != $request->getPatientUUIDString())) {
+            if (empty($uuid) || ($uuid != $request->getPatientUUIDString())) {
                 throw new AccessDeniedException("patients", "demo", "patient id invalid");
             }
-            $id = $request->getPatientUUIDString();
+            $uuid = $request->getPatientUUIDString();
         } else {
             RestConfig::authorization_check("patients", "demo");
         }

--- a/src/Services/CarePlanService.php
+++ b/src/Services/CarePlanService.php
@@ -52,7 +52,7 @@ class CarePlanService extends BaseService
 
     function getUuidFields(): array
     {
-        return ['puuid', 'euuid'];
+        return ['puuid', 'euuid', 'provider_uuid'];
     }
 
     public function __construct($carePlanType = self::TYPE_PLAN_OF_CARE)

--- a/src/Services/ImmunizationService.php
+++ b/src/Services/ImmunizationService.php
@@ -57,7 +57,7 @@ class ImmunizationService extends BaseService
 
     public function getUuidFields(): array
     {
-        return ['uuid', 'puuid'];
+        return ['uuid', 'puuid', 'provider_uuid'];
     }
 
     public function search($search, $isAndCondition = true)


### PR DESCRIPTION
Fixes #5095 Not sure what happened but it looks like provider_uuid got stomped on in
CarePlan and Immunization.  Adding that in to our uuid mappings fixes
the problem with the resources returning 500.

For Patient it looks like the patient/* context was broken in the
Patient resource endpoint when we refactored the parameter name for
documentation purposes.  I've updated the $id parameter in the patient
route to be $uuid.