### PR TITLE
Update API.php

### DIFF
--- a/library/MedEx/API.php
+++ b/library/MedEx/API.php
@@ -367,12 +367,17 @@ class Events extends Base
                     $timing2 = ($timing + 1) . ":1:1";
                 }
 
+                if ($info['ME_hipaa_default_override'] != '1') {
+                    $hipaa_override = " and hipaa_notice='YES' AND ";
+                }
+
                 if (!empty($prefs['ME_facilities'])) {
                     $places = str_replace("|", ",", $prefs['ME_facilities']);
                     $query  = "SELECT * FROM openemr_postcalendar_events AS cal
                                 LEFT JOIN patient_data AS pat ON cal.pc_pid=pat.pid
                                 WHERE
                                 " . $target_lang . "
+                                " . $hipaa_override . "
                                 (
                                   (
                                     pc_eventDate > CURDATE() " . $interval . " INTERVAL " . $timing . " DAY AND


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->


#### Short description of what this resolves:

MedEx update to ensure the preference "Assume patients receive HIPAA policy" is honored.
If this is left unchecked, each patient must have the Demographics Choice "HIPAA Notice Received" set to "Yes" to allow messages to be sent through MedEx

#### Changes proposed in this pull request:
