### PR TITLE
CQM Matched Patient Ids with calculator

### DIFF
--- a/src/Services/Qdm/CqmCalculator.php
+++ b/src/Services/Qdm/CqmCalculator.php
@@ -31,7 +31,8 @@ class CqmCalculator
         $this->client = CqmServiceManager::makeCqmClient();
     }
 
-    private function convertToObjectIdBSONFormat($id) {
+    private function convertToObjectIdBSONFormat($id)
+    {
         $hexValue = dechex($id);
         // max bigint size will fit in 16 characters so we will always have enough space for this.
         return sprintf("%024x", $hexValue);
@@ -82,7 +83,8 @@ class CqmCalculator
         return $this->convertResultsFromBSONObjectIdFormat($results);
     }
 
-    public function convertResultsFromBSONObjectIdFormat($results) {
+    public function convertResultsFromBSONObjectIdFormat($results)
+    {
         $newResult = [];
         if (!empty($results)) {
             foreach ($results as $key => $result) {
@@ -94,13 +96,13 @@ class CqmCalculator
                     $popResult['patient_id'] = $convertedKey;
                     $newResult[$convertedKey][$popKey] = $popResult;
                 }
-
             }
         }
         return $newResult;
     }
 
-    private function convertIdFromBSONObjectIdFormat($id) {
+    private function convertIdFromBSONObjectIdFormat($id)
+    {
         // max bigint size is 8 bytes which will fit fine
         // string ID should be prefixed with 0s so the converted data type should be far smaller
         $trimmedId = ltrim($id, '\x0');

--- a/src/Services/Qdm/ResultsCalculator.php
+++ b/src/Services/Qdm/ResultsCalculator.php
@@ -43,16 +43,19 @@ class ResultsCalculator
 
     public function add_patient_to_sup_map(Patient $patient)
     {
+        //        $defaultCode = null;
+        // TODO: @kchapple once patient characters are fixed, REMOVE DEFAULT CODE OR CHANGE THIS TO NULL
+        $defaultCode = 1;
         $patient_id = $patient->id->value;
         $this->patient_sup_map[$patient_id] = [];
         $sex = json_decode(json_encode($patient->get_data_elements('patient_characteristic', 'gender')), true);
-        $this->patient_sup_map[$patient_id]['SEX'] = $sex['code'];
+        $this->patient_sup_map[$patient_id]['SEX'] = $sex['code'] ?? 1;
         $race = json_decode(json_encode($patient->get_data_elements('patient_characteristic', 'race')), true);
-        $this->patient_sup_map[$patient_id]['RACE'] = $race['code'];
+        $this->patient_sup_map[$patient_id]['RACE'] = $race['code'] ?? 1;
         $ethnicity = json_decode(json_encode($patient->get_data_elements('patient_characteristic', 'ethnicity')), true);
-        $this->patient_sup_map[$patient_id]['ETHNICITY'] = $ethnicity['code'];
+        $this->patient_sup_map[$patient_id]['ETHNICITY'] = $ethnicity['code'] ?? 1;
         $payer = json_decode(json_encode($patient->get_data_elements('patient_characteristic', 'payer')), true);
-        $this->patient_sup_map[$patient_id]['PAYER'] = $payer['code'];
+        $this->patient_sup_map[$patient_id]['PAYER'] = $payer['code'] ?? 1;
     }
 
     //https://github.com/projectcypress/cypress/blob/ef09517b96b269c60671e3af651eb52df2ff22fa/lib/ext/measure.rb#L27

--- a/src/Services/Qrda/AggregateCount.php
+++ b/src/Services/Qrda/AggregateCount.php
@@ -63,7 +63,7 @@ class AggregateCount
                 if ($cache_entry['observations'] && $cache_entry['observations'][$pop_code]) {
                     $population->observation = $cache_entry['observations'][$pop_code];
                 }
-                $population->supplemental_data = $cache_entry->supplemental_data[$pop_code];
+                $population->supplemental_data = $cache_entry['supplemental_data'][$pop_code];
             }
 
             $entry_populations[] = $population;

--- a/src/Services/Qrda/ExportCat3Service.php
+++ b/src/Services/Qrda/ExportCat3Service.php
@@ -67,7 +67,11 @@ class ExportCat3Service
             'end_time' => $effectiveDateEnd
             /*
              * These are options: TODO what is required?
-            $options['provider'];
+            @see https://ecqi.healthit.gov/sites/default/files/2022-CMS-QRDA-III-Eligible-Clinicians-and-EP-IG-V1.1-508.pdf Section 5.1.4
+            for provider information.  provider is based upon group calculation vs individual calculation
+            Group calc is the TIN of the billing facility that the measure is run against
+            individual calc is the individual provider
+            $options['provider']; // @see
             $options['start_time'];
             $options['end_time'];
             $options['submission_program'];

--- a/src/Services/Qrda/ExportCat3Service.php
+++ b/src/Services/Qrda/ExportCat3Service.php
@@ -131,6 +131,7 @@ class ExportCat3Service
         $final_results = [];
         foreach ($results as $patient_id => $result) {
             // we will deviate here as we don't need the patient as we aren't saving any data for cypress with the patient
+            // need to unconvert from our hex format here
             $aggregated_results = $this->aggregate_population_results_from_individual_results($result, $patient_id);
             $final_results = array_merge($final_results, $aggregated_results);
         }


### PR DESCRIPTION
Tacoma project CQM Calculator uses Mongoose ObjectId for its id properties. For the CQM calculation we can't just pass straight through the patient id in order to get the matched patient ids back.  Instead we have to pass in a stringified format for the patient id that matches the serialized BSON format for the ObjectId.  In this case its a 24 character string in hexidecimal format that represents the pid.

Fortunately the bigint data type is only 8 bytes and ObjectId is a 12 byte format so it fits within the serialization.

@kchapple @sjpadgett This should fix the matching of patient data in the ResultsCalculator.  I noticed that the codes property are empty in my QDM models in ResultsCalculator:L44-L56.  So gender, race, ethnicity, payer are not getting codes populated on my machine.  Not sure if I need to do something specific for the data setup.