### PR TITLE
#5043 - FIX for - Save button should become active once an appointment is selected

### DIFF
--- a/interface/main/calendar/add_edit_event.php
+++ b/interface/main/calendar/add_edit_event.php
@@ -1294,6 +1294,8 @@ function dateChanged() {
 
 // This is for callback by the find-available popup.
 function setappt(year,mon,mday,hours,minutes) {
+    //Infeg Save button should become active once an appointment is selected.
+    $('#form_save').attr('disabled', false);
     var f = document.forms[0];
     <?php
     $currentDateFormat = $GLOBALS['date_display_format'];


### PR DESCRIPTION

<!-- #5043 -->
Fixes #5043 

#### Short description of what this resolves:
Fix for the issues #5043 - where the Save button will become active once an appointment is selected (As mentioned in the PR thread)


#### Changes proposed in this pull request:
