### PR TITLE
allow options (reporting period) to be passed down to cat i export

### DIFF
--- a/src/Services/Qrda/ExportCat1Service.php
+++ b/src/Services/Qrda/ExportCat1Service.php
@@ -18,13 +18,28 @@ class ExportCat1Service
         $this->request = $request;
     }
 
-    public function export($measures = [])
+    /**
+     * @param array $measures
+     * @param array $options
+     * @return string
+     * @throws \Exception
+     *
+     * Takes an array of measures (paths to measures) and an array of options
+     * to produce a string representing a QRDA Cat I XML document
+     *
+     * options
+     *  - performance_period_start
+     *  - performance_period_end
+     *  - provider
+     *  - submission_program
+     */
+    public function export($measures = [], $options = [])
     {
         $measure_arr = MeasureService::fetchAllMeasuresArray($measures);
         $patientModels = $this->builder->build($this->request);
         $string = "";
         foreach ($patientModels as $patient) {
-            $cat1 = new Cat1($patient, $measure_arr);
+            $cat1 = new Cat1($patient, $measure_arr, $options);
             $string .= $cat1->renderCat1Xml();
         }
 

--- a/src/Services/Qrda/QrdaReportService.php
+++ b/src/Services/Qrda/QrdaReportService.php
@@ -131,10 +131,11 @@ class QrdaReportService
 
     /**
      * @param  $pid
-     * @param  $measures
+     * @param array $measures
+     * @param array $options
      * @return string
      */
-    public function generateCategoryIXml($pid, $measures = []): string
+    public function generateCategoryIXml($pid, $measures = [], $options = []): string
     {
         if ($pid) {
             $request = new QdmRequestOne($pid);
@@ -142,7 +143,7 @@ class QrdaReportService
             $request = new QdmRequestAll();
         }
         $exportService = new ExportCat1Service($this->builder, $request);
-        $xml = $exportService->export($measures);
+        $xml = $exportService->export($measures, $options);
 
         return $xml;
     }


### PR DESCRIPTION
@sjpadgett I think this will allow you to pass the options into the cat i export. It was supported by the template's view-model, but we didn't have a path to get the options down to it.

Something like this will need to be added in order to get the data from the UI or database, into the exporter:

L45 of QrdaReportController.php
```
$options = [
    'performance_period_start' => 'some date',
    'performance_period_end' => 'some date'
];

$document = $this->reportService->generateCategoryIXml($pid, $measures_resolved, $options);
```

