### PR TITLE
handle empty pubpid for documents linked via messages

### DIFF
--- a/interface/main/messages/messages.php
+++ b/interface/main/messages/messages.php
@@ -504,7 +504,7 @@ if (!empty($_REQUEST['go'])) { ?>
                                                     $str_dob = xl("DOB") . ":" . $prow['DOB'] . " " . xl("Age") . ":" . getPatientAge($prow['DOB']);
                                                     $pname = $prow['fname'] . " " . $prow['lname'];
                                                     echo "<a href='javascript:void(0);' ";
-                                                    echo "onClick=\"gotoReport(" . attr(addslashes($d->get_id())) . ",'" . attr(addslashes($pname)) . "'," . attr(addslashes($prow['pid'])) . "," . attr(addslashes($prow['pubpid'])) . ",'" . attr(addslashes($str_dob)) . "');\">";
+                                                    echo "onClick=\"gotoReport(" . attr(addslashes($d->get_id())) . ",'" . attr(addslashes($pname)) . "'," . attr(addslashes($prow['pid'])) . "," . attr(addslashes($prow['pubpid'] ?? $prow['pid'])) . ",'" . attr(addslashes($str_dob)) . "');\">";
                                                     echo text($d->get_name()) . "-" . text($d->get_id());
                                                     echo "</a>\n";
                                                 }


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #5126

#### Short description of what this resolves:
`pubpid` can be saved as an empty value which causes the document display function `gotoReport()` to fail

#### Changes proposed in this pull request:
use the pid in such cases