### PR TITLE
Openemr fhir single patient api #5122

### DIFF
--- a/src/Services/CarePlanService.php
+++ b/src/Services/CarePlanService.php
@@ -30,7 +30,17 @@ use Twig\Token;
 
 class CarePlanService extends BaseService
 {
-    const SURROGATE_KEY_SEPARATOR = "_";
+    // Note: FHIR 4.0.1 id columns put a constraint on ids such that:
+    // Ids can be up to 64 characters long, and contain any combination of upper and lowercase ASCII letters,
+    // numerals, "-" and ".".  Logical ids are opaque to the resource server and should NOT be changed once they've
+    // been issued by the resource server
+    // Up to OpenEMR 6.1.0 patch 0 we used underscores as our separator
+    const SURROGATE_KEY_SEPARATOR_V1 = "_";
+    // use the abbreviation SK for Surrogate key and hyphens.  Since Logical ids are opaque we can do this as long as
+    // our UUID NEVER generates a two digit hyphenated id which none of the standards currently do.
+    // the best approach would be to completely overhaul Careplan but for historical reasons we aren't doing that right now.
+    const SURROGATE_KEY_SEPARATOR_V2 = "-SK-";
+    const V2_TIMESTAMP = 1649476800; // strtotime("2022-04-09");
     private const PATIENT_TABLE = "patient_data";
     private const ENCOUNTER_TABLE = "form_encounter";
     private const CARE_PLAN_TABLE = "form_care_plan";
@@ -134,7 +144,9 @@ class CarePlanService extends BaseService
                 ,patients.pid
                 ,encounters.euuid
                 ,encounters.eid
-                ,fcp.form_id
+                ,fcp_forms.form_id
+                ,fcp_forms.creation_date
+                ,UNIX_TIMESTAMP(fcp_forms.creation_date) AS 'creation_timestamp'
                 ,fcp.code
                 ,fcp.codetext
                 ,fcp.description
@@ -147,7 +159,7 @@ class CarePlanService extends BaseService
                  FROM
                  (
                     select
-                        id AS form_id
+                        id
                         ,code
                         ,codetext
                         ,description
@@ -171,6 +183,16 @@ class CarePlanService extends BaseService
                     FROM
                         form_encounter
                  ) encounters ON fcp.encounter = encounters.eid
+                -- we need the form date information
+                 JOIN (
+                      SELECT
+                      id
+                      ,form_id
+                      ,encounter AS form_encounter
+                      ,date AS creation_date
+                      FROM forms
+                      WHERE form_name = 'Care Plan Form'
+                 ) fcp_forms ON fcp.id = fcp_forms.form_id AND encounters.eid = fcp_forms.form_encounter
                  LEFT JOIN (
                     select
                         pid
@@ -270,9 +292,15 @@ class CarePlanService extends BaseService
      */
     public function getSurrogateKeyForRecord(array $record)
     {
+        // note that logical ids are allowed to be 64 characters.  Our UUID is 32 characters so as long as
+        // the form_id + separator never exceeds 64 characters we are good here.
         $form_id = $record['form_id'] ?? '';
         $encounter = $record['euuid'] ?? '';
-        return $encounter . self::SURROGATE_KEY_SEPARATOR . $form_id;
+        $separator = self::SURROGATE_KEY_SEPARATOR_V2;
+        if (intval($record['creation_timestamp'] ?? 0) <= self::V2_TIMESTAMP) {
+            $separator = self::SURROGATE_KEY_SEPARATOR_V1;
+        }
+        return $encounter . $separator . $form_id;
     }
 
     /**
@@ -282,7 +310,11 @@ class CarePlanService extends BaseService
      */
     public function splitSurrogateKeyIntoParts($key)
     {
-        $parts = explode(self::SURROGATE_KEY_SEPARATOR, $key);
+        $delimiter = self::SURROGATE_KEY_SEPARATOR_V2;
+        if (strpos($key, self::SURROGATE_KEY_SEPARATOR_V1) !== false) {
+            $delimiter = self::SURROGATE_KEY_SEPARATOR_V1;
+        }
+        $parts = explode($delimiter, $key);
         $key = [
             "euuid" => $parts[0] ?? ""
             ,"form_id" => $parts[1] ?? ""

--- a/src/Services/FHIR/DocumentReference/FhirClinicalNotesService.php
+++ b/src/Services/FHIR/DocumentReference/FhirClinicalNotesService.php
@@ -230,7 +230,12 @@ class FhirClinicalNotesService extends FhirServiceBase
             throw new \BadMethodCallException("Data record should be correct instance class");
         }
         $fhirProvenanceService = new FhirProvenanceService();
-        $fhirProvenance = $fhirProvenanceService->createProvenanceForDomainResource($dataRecord, $dataRecord->getAuthor());
+        $authors = $dataRecord->getAuthor();
+        $author = null;
+        if (!empty($authors)) {
+            $author = reset($authors); // grab the first one, as we only populate one anyways.
+        }
+        $fhirProvenance = $fhirProvenanceService->createProvenanceForDomainResource($dataRecord, $author);
         if ($encode) {
             return json_encode($fhirProvenance);
         } else {

--- a/src/Services/FHIR/DocumentReference/FhirPatientDocumentReferenceService.php
+++ b/src/Services/FHIR/DocumentReference/FhirPatientDocumentReferenceService.php
@@ -212,7 +212,12 @@ class FhirPatientDocumentReferenceService extends FhirServiceBase
         }
 
         $fhirProvenanceService = new FhirProvenanceService();
-        $fhirProvenance = $fhirProvenanceService->createProvenanceForDomainResource($dataRecord, $dataRecord->getAuthor());
+        $authors = $dataRecord->getAuthor();
+        $author = null;
+        if (!empty($authors)) {
+            $author = reset($authors); // grab the first one, as we only populate one anyways.
+        }
+        $fhirProvenance = $fhirProvenanceService->createProvenanceForDomainResource($dataRecord, $author);
         if ($encode) {
             return json_encode($fhirProvenance);
         } else {

--- a/src/Services/FHIR/FhirCarePlanService.php
+++ b/src/Services/FHIR/FhirCarePlanService.php
@@ -113,7 +113,7 @@ class FhirCarePlanService extends FhirServiceBase implements IResourceUSCIGProfi
         }
 
         if (!empty($dataRecord['provider_uuid']) && !empty($dataRecord['provider_npi'])) {
-            $carePlanResource->getAuthor(UtilsService::createRelativeReference("Practitioner", $dataRecord['provider_uuid']));
+            $carePlanResource->setAuthor(UtilsService::createRelativeReference("Practitioner", $dataRecord['provider_uuid']));
         }
 
         if ($encode) {

--- a/src/Services/FHIR/FhirMedicationRequestService.php
+++ b/src/Services/FHIR/FhirMedicationRequestService.php
@@ -180,6 +180,17 @@ class FhirMedicationRequestService extends FhirServiceBase implements IResourceU
         $medRequestResource->setReportedBoolean(self::MEDICATION_REQUEST_REPORTED_PRIMARY_SOURCE);
 
         // medication[x] required
+        /**
+         * US Core Requirements
+         * The MedicationRequest resources can represent a medication using either a code, or reference a Medication resource.
+         * When referencing a Medication resource, the resource may be contained or an external resource.
+         * The server systems are not required to support both a code and a reference, but SHALL support at least one of these methods.
+         * If an external reference to Medication is used, the server SHALL support the _include parameter for searching this element.
+         * The client application SHALL support all methods.
+         *
+         * NOTE: for our requirements we support ONLY the medicationCodeableConcept requirement ie code option and NOT the
+         * embedded medication.
+         */
         if (!empty($dataRecord['drugcode'])) {
 //            $rxnormCoding = new FHIRCoding();
             $rxnormCode = UtilsService::createCodeableConcept($dataRecord['drugcode'], FhirCodeSystemConstants::RXNORM);

--- a/src/Services/FHIR/FhirOrganizationService.php
+++ b/src/Services/FHIR/FhirOrganizationService.php
@@ -154,7 +154,8 @@ class FhirOrganizationService implements IResourceSearchableService, IResourceRe
      * @param FHIRReference $user Practitioner that we want to return the corresponding organization
      * @return FHIRReference|null
      */
-    public function getOrganizationReferenceFromUserReference(FHIRReference $user) {
+    public function getOrganizationReferenceFromUserReference(FHIRReference $user)
+    {
         $referenceUuid = UtilsService::getUuidFromReference($user);
         if ($user->getType() == (new FHIRPractitioner())->get_fhirElementName()) {
             return $this->facilityService->getOrganizationReferenceForUser($referenceUuid);

--- a/src/Services/FHIR/FhirOrganizationService.php
+++ b/src/Services/FHIR/FhirOrganizationService.php
@@ -4,6 +4,9 @@ namespace OpenEMR\Services\FHIR;
 
 use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\FHIR\R4\FHIRDomainResource\FHIROrganization;
+use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRPatient;
+use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRPerson;
+use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRPractitioner;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRReference;
 use OpenEMR\Services\FHIR\Organization\FhirOrganizationFacilityService;
 use OpenEMR\Services\FHIR\Organization\FhirOrganizationInsuranceService;
@@ -11,6 +14,7 @@ use OpenEMR\Services\FHIR\Organization\FhirOrganizationProcedureProviderService;
 use OpenEMR\Services\FHIR\Traits\BulkExportSupportAllOperationsTrait;
 use OpenEMR\Services\FHIR\Traits\FhirBulkExportDomainResourceTrait;
 use OpenEMR\Services\FHIR\Traits\MappedServiceTrait;
+use OpenEMR\Services\PatientService;
 use OpenEMR\Services\Search\FhirSearchParameterDefinition;
 use OpenEMR\Services\Search\SearchFieldException;
 use OpenEMR\Services\Search\SearchFieldType;
@@ -143,6 +147,21 @@ class FhirOrganizationService implements IResourceSearchableService, IResourceRe
     {
         $ref = $this->facilityService->getPrimaryBusinessEntityReference();
         return $ref;
+    }
+
+    /**
+     * Returns the organization that we can find connected to the user.
+     * @param FHIRReference $user Practitioner that we want to return the corresponding organization
+     * @return FHIRReference|null
+     */
+    public function getOrganizationReferenceFromUserReference(FHIRReference $user) {
+        $referenceUuid = UtilsService::getUuidFromReference($user);
+        if ($user->getType() == (new FHIRPractitioner())->get_fhirElementName()) {
+            return $this->facilityService->getOrganizationReferenceForUser($referenceUuid);
+        } else {
+            // TODO: if we need to support person, patient, or another mapping put that here
+            return null;
+        }
     }
 
     /**

--- a/src/Services/FHIR/FhirProvenanceService.php
+++ b/src/Services/FHIR/FhirProvenanceService.php
@@ -110,6 +110,14 @@ class FhirProvenanceService extends FhirServiceBase implements IResourceUSCIGPro
         // TODO: adunsulag check with @sjpadgett or @brady.miller to see if we will always have a primary business entity.
         $primaryBusinessEntity = $fhirOrganizationService->getPrimaryBusinessEntityReference();
         if (empty($primaryBusinessEntity)) {
+            if (!empty($userWHO)) {
+                (new SystemLogger())->debug(self::class . "->createProvenanceForDomainResource() primary business entity not found, attempting to find user organization");
+                $primaryBusinessEntity = $fhirOrganizationService->getOrganizationReferenceForUser($userWHO->getId());
+            }
+        }
+
+        if (empty($primaryBusinessEntity)) {
+            // see if we can get this from the who if we
             (new SystemLogger())->debug(self::class . "->createProvenanceForDomainResource() could not find organization reference");
             return null;
         }

--- a/src/Services/FHIR/FhirProvenanceService.php
+++ b/src/Services/FHIR/FhirProvenanceService.php
@@ -17,6 +17,7 @@ use OpenEMR\FHIR\R4\FHIRDomainResource\FHIROrganization;
 use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRProvenance;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRCoding;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRMeta;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRReference;
 use OpenEMR\FHIR\R4\FHIRResource\FHIRDomainResource;
 use OpenEMR\FHIR\R4\FHIRResource\FHIRProvenance\FHIRProvenanceAgent;
@@ -39,6 +40,23 @@ class FhirProvenanceService extends FhirServiceBase implements IResourceUSCIGPro
     use FhirServiceBaseEmptyTrait;
     use BulkExportSupportAllOperationsTrait;
     use FhirBulkExportDomainResourceTrait;
+
+    // Note: FHIR 4.0.1 id columns put a constraint on ids such that:
+    // Ids can be up to 64 characters long, and contain any combination of upper and lowercase ASCII letters,
+    // numerals, "-" and ".".  Logical ids are opaque to the resource server and should NOT be changed once they've
+    // been issued by the resource server
+    // Up to OpenEMR 6.1.0 patch 0 we used : as our separator for Provenance, and _ as our separator for resources such
+    // as CarePlan and Goals.
+    const SURROGATE_KEY_SEPARATOR_V1 = ":";
+    // use the abbreviation PSK for Provenance Surrogate key and hyphens.  Since Logical ids are opaque we can do this as long as
+    // our UUID NEVER generates a three digit hyphenated id which none of the standards currently do.
+    // our other resources use -SK- as a surrogate key
+    // the best approach would be to have a complete accessible provenance data table with its own uuids that's
+    // searchable but right now provenance is tracked so dispararately across the system we go to each resource
+    // in order to grab these ids.
+    const SURROGATE_KEY_SEPARATOR_V2 = "-PSK-";
+    const V2_TIMESTAMP = 1649476800; // strtotime("2022-04-09");
+
 
     const USCGI_PROFILE_URI = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance';
 
@@ -87,7 +105,8 @@ class FhirProvenanceService extends FhirServiceBase implements IResourceUSCIGPro
     {
 
         $fhirProvenance = new FHIRProvenance();
-        $fhirProvenance->setId($resource->get_fhirElementName() . ":" . $resource->getId());
+
+        $fhirProvenance->setId($this->getSurrogateKeyForResource($resource));
         /**
          * Attributes required/must support for US.Core
          */
@@ -107,12 +126,11 @@ class FhirProvenanceService extends FhirServiceBase implements IResourceUSCIGPro
         }
 
         $fhirOrganizationService = new FhirOrganizationService();
-        // TODO: adunsulag check with @sjpadgett or @brady.miller to see if we will always have a primary business entity.
         $primaryBusinessEntity = $fhirOrganizationService->getPrimaryBusinessEntityReference();
         if (empty($primaryBusinessEntity)) {
             if (!empty($userWHO)) {
                 (new SystemLogger())->debug(self::class . "->createProvenanceForDomainResource() primary business entity not found, attempting to find user organization");
-                $primaryBusinessEntity = $fhirOrganizationService->getOrganizationReferenceForUser($userWHO->getId());
+                $primaryBusinessEntity = $fhirOrganizationService->getOrganizationReferenceFromUserReference($userWHO);
             }
         }
 
@@ -273,10 +291,10 @@ class FhirProvenanceService extends FhirServiceBase implements IResourceUSCIGPro
     private function getProvenanceRecordsForId($id, $puuidBind)
     {
         $processingResult = new ProcessingResult();
-        $idParts = explode(":", $id);
-        $resourceName = array_shift($idParts);
+        $idParts = $this->splitSurrogateKeyIntoParts($id);
+        $resourceName = $idParts['resource'];
+        $innerId = $idParts['id'];
 
-        $innerId = implode(":", $idParts);
         $className = RestControllerHelper::FHIR_SERVICES_NAMESPACE . $resourceName . "Service";
         if (!class_exists($className)) {
             throw new SearchFieldException("_id", "Provenance _id was invalid");
@@ -367,5 +385,54 @@ class FhirProvenanceService extends FhirServiceBase implements IResourceUSCIGPro
     function getProfileURIs(): array
     {
         return [self::USCGI_PROFILE_URI];
+    }
+
+    /**
+     * Given a FHIRDomainResource resource generate the surrogate key.  If either column is empty it uses an empty string as the value.
+     * @param array $resource The domain resource
+     * @return string The surrogate key.
+     */
+    public function getSurrogateKeyForResource(FHIRDomainResource $resource)
+    {
+        $separator = self::SURROGATE_KEY_SEPARATOR_V2;
+
+        // lastUpdated is a timesecond instant so we are going to get int value for comparison
+        if (empty($resource->getMeta()))
+        {
+            (new SystemLogger())->errorLogCaller("Resource missing required Meta field",
+                ['resource' => $resource->getId(), 'type' => $resource->get_fhirElementName()]);
+        }
+        else if (empty($resource->getMeta()->getLastUpdated()))
+        {
+            (new SystemLogger())->errorLogCaller("Resource missing required Meta->lastUpdated field",
+                ['resource' => $resource->getId(), 'type' => $resource->get_fhirElementName()]);
+        } else {
+            $lastUpdated = \DateTime::createFromFormat(DATE_ISO8601, $resource->getMeta()->getLastUpdated());
+
+            if ($lastUpdated !== false && $lastUpdated->getTimestamp() < self::V2_TIMESTAMP) {
+                $separator = self::SURROGATE_KEY_SEPARATOR_V1;
+            }
+        }
+
+        return $resource->get_fhirElementName() . $separator . $resource->getId();
+    }
+
+    /**
+     * Given the surrogate key representing a Provenance, split the key into its component parts.
+     * @param $key string the key to parse
+     * @return array The broken up key parts.
+     */
+    public function splitSurrogateKeyIntoParts($key)
+    {
+        $delimiter = self::SURROGATE_KEY_SEPARATOR_V2;
+        if (strpos($key, self::SURROGATE_KEY_SEPARATOR_V1) !== false) {
+            $delimiter = self::SURROGATE_KEY_SEPARATOR_V1;
+        }
+        $parts = explode($delimiter, $key);
+        $key = [
+            "resource" => $parts[0] ?? ""
+            ,"id" => $parts[1] ?? ""
+        ];
+        return $key;
     }
 }

--- a/src/Services/FHIR/FhirProvenanceService.php
+++ b/src/Services/FHIR/FhirProvenanceService.php
@@ -397,15 +397,16 @@ class FhirProvenanceService extends FhirServiceBase implements IResourceUSCIGPro
         $separator = self::SURROGATE_KEY_SEPARATOR_V2;
 
         // lastUpdated is a timesecond instant so we are going to get int value for comparison
-        if (empty($resource->getMeta()))
-        {
-            (new SystemLogger())->errorLogCaller("Resource missing required Meta field",
-                ['resource' => $resource->getId(), 'type' => $resource->get_fhirElementName()]);
-        }
-        else if (empty($resource->getMeta()->getLastUpdated()))
-        {
-            (new SystemLogger())->errorLogCaller("Resource missing required Meta->lastUpdated field",
-                ['resource' => $resource->getId(), 'type' => $resource->get_fhirElementName()]);
+        if (empty($resource->getMeta())) {
+            (new SystemLogger())->errorLogCaller(
+                "Resource missing required Meta field",
+                ['resource' => $resource->getId(), 'type' => $resource->get_fhirElementName()]
+            );
+        } else if (empty($resource->getMeta()->getLastUpdated())) {
+            (new SystemLogger())->errorLogCaller(
+                "Resource missing required Meta->lastUpdated field",
+                ['resource' => $resource->getId(), 'type' => $resource->get_fhirElementName()]
+            );
         } else {
             $lastUpdated = \DateTime::createFromFormat(DATE_ISO8601, $resource->getMeta()->getLastUpdated());
 

--- a/src/Services/FHIR/Procedure/FhirProcedureOEProcedureService.php
+++ b/src/Services/FHIR/Procedure/FhirProcedureOEProcedureService.php
@@ -236,7 +236,7 @@ class FhirProcedureOEProcedureService extends FhirServiceBase
         $fhirProvenanceService = new FhirProvenanceService();
         $reference = null;
         if (!empty($dataRecord->getPerformer()) && count($dataRecord->getPerformer()) == 1) {
-            $dataRecord->getPerformer()[0]->getActor();
+            $reference = $dataRecord->getPerformer()[0]->getActor();
         }
         $fhirProvenance = $fhirProvenanceService->createProvenanceForDomainResource($dataRecord, $reference);
 

--- a/src/Services/SurgeryService.php
+++ b/src/Services/SurgeryService.php
@@ -70,7 +70,7 @@ class SurgeryService extends BaseService
                         ,`uuid`
                         ,`pid`
                         ,`comments`
-                        ,`username` as surgery_recorder
+                        ,`user` as surgery_recorder
                     FROM lists
                     WHERE
                         `type` = 'surgery'


### PR DESCRIPTION
This PR holds the fixes to many of the sub issues in #5122.  

I will keep it as a draft for now, but it does the following:

- Fixes #5123 
- Fixes #5124 
- Fixes #5125 

I add the username to the SurgerService.

I fix all the provenance queries for DiagnosticReports,DocumentReference,Immunization,Procedure,CarePlan,Goals.

I switch Careplan and Goal to use -SK- for the uuid separator instead of an underscore(_).

I switch Provenance to use -PSK- for the id separator (since a CarePlan/Goal can be inside a Provenance logical id).  

I put in code to handle old resources for the ids to handle consumers of the API prior to this fix.