### PR TITLE
Fixes #5130 code type selector when no default code type is passed in.

### DIFF
--- a/interface/patient_file/encounter/find_code_popup.php
+++ b/interface/patient_file/encounter/find_code_popup.php
@@ -30,6 +30,8 @@ $info_msg = "";
 $codetype = $_REQUEST['codetype'] ?? '';
 if (!empty($codetype)) {
     $allowed_codes = split_csv_line($codetype);
+} else {
+    $allowed_codes = array_keys($code_types);
 }
 
 $form_code_type = $_POST['form_code_type'] ?? '';
@@ -38,6 +40,8 @@ $form_code_type = $_POST['form_code_type'] ?? '';
 $default = '';
 if (!empty($form_code_type)) {
     $default = $form_code_type;
+    // if they've submitted a code type we only want to use those.
+    $allowed_codes = [$default];
 } elseif (!empty($allowed_codes) && count($allowed_codes) == 1) {
     $default = $allowed_codes[0];
 } elseif (!empty($_REQUEST['default'])) {


### PR DESCRIPTION
Set the allowed_code_types to be populated if no default code type is passed in as a query parameter.  This fixes #5130 