### PR TITLE
increase max length of sftp host name

### DIFF
--- a/templates/x12_partners/general_edit.html
+++ b/templates/x12_partners/general_edit.html
@@ -152,7 +152,7 @@
     <div class="form-row my-sm-2">
         <label for="x12_sftp_host" class="col-form-label col-sm-2">{xlt t='SFTP Host'}</label>
         <div class="col-sm-8">
-            <input type="text" maxlength="15" id="x12_sftp_host" name="x12_sftp_host" class="form-control" value="{$partner->get_x12_sftp_host()|attr}" onKeyDown="PreventIt(event)">
+            <input type="text" maxlength="45" id="x12_sftp_host" name="x12_sftp_host" class="form-control" value="{$partner->get_x12_sftp_host()|attr}" onKeyDown="PreventIt(event)">
         </div>
     </div>
     <div class="form-row my-sm-2">


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #5133

#### Short description of what this resolves:
inability to specify full sftp host name in x12 partner edit field
