### PR TITLE
Fixes #5127 mapped uuids not saving in registry

### DIFF
--- a/src/Common/Uuid/UuidMapping.php
+++ b/src/Common/Uuid/UuidMapping.php
@@ -91,6 +91,8 @@ class UuidMapping
                 sqlStatementNoLog($insertStatement, $bindValues, true);
                 $index++;
             }
+            // now insert the mapped uuids into the registry
+            $uuidRegistry->insertUuidsIntoRegistry($uuids);
         }
         return $uuids;
     }


### PR DESCRIPTION
Fixes #5127  Made it so the uuids for mapped resources such as vitals are being populated in the uuid registry.  Users will need to run the sql_upgrade.php for any existing installation in order for any new vitals to be retrievable via FHIR for the single resource GET operation.