### PR TITLE
Remove unneeded globals.php from libraries

### DIFF
--- a/interface/forms/CAMOS/content_parser.php
+++ b/interface/forms/CAMOS/content_parser.php
@@ -12,7 +12,6 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . "/../../globals.php");
 require_once(dirname(__FILE__) . "/../../../library/api.inc");
 require_once(dirname(__FILE__) . "/../../forms/vitals/C_FormVitals.class.php");
 

--- a/interface/forms/track_anything/report.php
+++ b/interface/forms/track_anything/report.php
@@ -12,6 +12,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+require_once(dirname(__FILE__) . '/../../globals.php');
 require_once($GLOBALS["srcdir"] . "/api.inc");
 
 function track_anything_report($pid, $encounter, $cols, $id)

--- a/library/api.inc
+++ b/library/api.inc
@@ -10,8 +10,6 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . "/../interface/globals.php");
-
 use OpenEMR\Billing\BillingUtilities;
 use OpenEMR\Core\Header;
 


### PR DESCRIPTION
Remove unneeded globals.php requires from libraries
(in process of testing)

Did search of entire codebase for both the content_parser.php and api.inc and global.php is always required before these libraries are used (this is the standard pattern in openemr where globals.php is required and then the libraries after that in scripts).

I did note one place where globals.php was not brought in prior to api.inc in track_anything/report.php , which I added. However, this points out a good issue and that is that all the report.php files in all the forms should not need to require globals.php , but that is code cleanup for another day :)