### PR TITLE
Fix patient scopes when used by users

### DIFF
--- a/_rest_config.php
+++ b/_rest_config.php
@@ -21,6 +21,7 @@ use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7Server\ServerRequestCreator;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Auth\OpenIDConnect\Repositories\AccessTokenRepository;
+use OpenEMR\Common\Http\HttpRestRequest;
 use OpenEMR\Common\Logging\EventAuditLogger;
 use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Common\Session\SessionUtil;
@@ -502,6 +503,61 @@ class RestConfig
         }
 
         return false;
+    }
+
+    /**
+     * Grabs all of the context information for the request's access token and populates any context variables the
+     * request needs (such as patient binding information).  Returns the populated request
+     * @param HttpRestRequest $restRequest
+     * @return HttpRestRequest
+     */
+    public function populateTokenContextForRequest(HttpRestRequest $restRequest)
+    {
+
+        $context = $this->getTokenContextForRequest($restRequest);
+        // note that the context here is the SMART value that is returned in the response for an AccessToken in this
+        // case it is the patient value which is the logical id (ie uuid) of the patient.
+        $patientUuid = $context['patient'] ?? null;
+        if (!empty($patientUuid)) {
+            // we only set the bound patient access if the underlying user can still access the patient
+            if ($this->checkUserHasAccessToPatient($restRequest->getRequestUserId(), $patientUuid)) {
+                $restRequest->setPatientUuidString($patientUuid);
+            }
+        } else {
+            (new SystemLogger())->error(("OpenEMR Error: api had patient launch scope but no patient was set in the "
+            . " session cache.  Resources restricted with patient scopes will not return results"));
+        }
+        return $restRequest;
+    }
+
+    public function getTokenContextForRequest(HttpRestRequest $restRequest) {
+        $accessTokenRepo = new AccessTokenRepository();
+        // note this is pretty confusing as getAccessTokenId comes from the oauth_access_id which is the token NOT
+        // the database id even though this is called accessTokenId....
+        $token = $accessTokenRepo->getTokenByToken($restRequest->getAccessTokenId());
+        $context = $token['context'] ?? "{}"; // if there is no populated context we just return an empty return
+        try {
+            return json_decode($context, true);
+        }
+        catch (\Exception $exception) {
+            (new SystemLogger())->error("OpenEMR Error: failed to decode token context json", ['exception' => $exception->getMessage()
+                , 'tokenId' => $restRequest->getAccessTokenId()]);
+        }
+        return [];
+    }
+
+
+    /**
+     * Checks whether a user has access to the patient. Returns true if the user can access the given patient, false otherwise
+     * @param $userId The id from the users table that represents the user
+     * @param $patientUuid The uuid from the patient_data table that represents the patient
+     * @return bool True if has access, false otherwise
+     */
+    private function checkUserHasAccessToPatient($userId, $patientUuid) {
+        // TODO: the session should never be populated with the pid from the access token unless the user had access to
+        // it.  However, if we wanted an additional check or if we anted to fire off any kind of event that does
+        // patient filtering by provider / clinic we would handle that here.
+        return true;
     }
 
 

--- a/_rest_config.php
+++ b/_rest_config.php
@@ -530,7 +530,8 @@ class RestConfig
         return $restRequest;
     }
 
-    public function getTokenContextForRequest(HttpRestRequest $restRequest) {
+    public function getTokenContextForRequest(HttpRestRequest $restRequest)
+    {
         $accessTokenRepo = new AccessTokenRepository();
         // note this is pretty confusing as getAccessTokenId comes from the oauth_access_id which is the token NOT
         // the database id even though this is called accessTokenId....
@@ -538,8 +539,7 @@ class RestConfig
         $context = $token['context'] ?? "{}"; // if there is no populated context we just return an empty return
         try {
             return json_decode($context, true);
-        }
-        catch (\Exception $exception) {
+        } catch (\Exception $exception) {
             (new SystemLogger())->error("OpenEMR Error: failed to decode token context json", ['exception' => $exception->getMessage()
                 , 'tokenId' => $restRequest->getAccessTokenId()]);
         }
@@ -553,7 +553,8 @@ class RestConfig
      * @param $patientUuid The uuid from the patient_data table that represents the patient
      * @return bool True if has access, false otherwise
      */
-    private function checkUserHasAccessToPatient($userId, $patientUuid) {
+    private function checkUserHasAccessToPatient($userId, $patientUuid)
+    {
         // TODO: the session should never be populated with the pid from the access token unless the user had access to
         // it.  However, if we wanted an additional check or if we anted to fire off any kind of event that does
         // patient filtering by provider / clinic we would handle that here.

--- a/apis/dispatch.php
+++ b/apis/dispatch.php
@@ -134,6 +134,10 @@ $sessionAllowWrite = true;
 require_once("./../interface/globals.php");
 
 // we now can check the database to see if the token is revoked
+// Note despite League\OAuth2\Server\AuthorizationValidators\BearerTokenValidator.php:L117 already checking for revoked
+// access token we have to do this logic here as we use the access token SCOPE parameter to determine our multi-site setting
+// and load up the correct database, our earlier access token logic returns false for revoked as we don't have db access
+//  for that reason we have this double check on validating the access token.
 if (!empty($tokenId)) {
     $result = $gbl::validateAccessTokenRevoked($tokenId);
     if ($result instanceof ResponseInterface) {
@@ -268,17 +272,7 @@ if ($isLocalApi) {
             exit();
         }
         if ($restRequest->requestHasScope(SmartLaunchController::CLIENT_APP_STANDALONE_LAUNCH_SCOPE)) {
-            // attempt to pull from our session store and populate our patient contexts here
-            $sessionCache = $isTrusted['session_cache'] ?? '[]';
-            $cache = json_decode($sessionCache, true);
-            if (!empty($cache['pid'])) { // really strange how we are using the pid for the UUID
-            // TODO: do we want to hit the database and make sure the user has access to this patient?
-                // its another sanity check to make sure somehow the trusted user session didn't get contaminated...
-                // will slow down the request though.
-                $restRequest->setPatientUuidString($cache['pid']);
-            } else {
-                $logger->error(("OpenEMR Error: api had patient launch scope but no patient was set in the session cache.  Resources restricted with patient scopes will not return results"));
-            }
+            $restRequest = $gbl->populateTokenContextForRequest($restRequest);
         }
     } elseif ($userRole == 'patient') {
         $_SESSION['pid'] = $user['pid'] ?? null;

--- a/sql/6_1_0-to-7_0_0_upgrade.sql
+++ b/sql/6_1_0-to-7_0_0_upgrade.sql
@@ -311,3 +311,7 @@ ALTER TABLE `form_observation` ADD `date_end` DATETIME NULL DEFAULT NULL;
 #IfNotColumnType form_care_plan date datetime
 ALTER TABLE `form_care_plan` CHANGE `date` `date` DATETIME NULL DEFAULT NULL;
 #EndIf
+
+#IfMissingColumn api_token context
+ALTER TABLE api_token ADD COLUMN `context` TEXT COMMENT 'context values that change/govern how access token are used';
+#EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -114,6 +114,7 @@ CREATE TABLE `api_token` (
   `client_id` varchar(80) DEFAULT NULL,
   `scope` text COMMENT 'json encoded',
   `revoked` TINYINT(1) NOT NULL DEFAULT 0 COMMENT '1=revoked,0=not revoked',
+  `context` TEXT COMMENT 'context values that change/govern how access token are used',
   PRIMARY KEY (`id`),
   UNIQUE KEY `token` (`token`)
 ) ENGINE = InnoDB;

--- a/src/Common/Auth/OpenIDConnect/Grant/CustomClientCredentialsGrant.php
+++ b/src/Common/Auth/OpenIDConnect/Grant/CustomClientCredentialsGrant.php
@@ -361,7 +361,7 @@ class CustomClientCredentialsGrant extends ClientCredentialsGrant
                 // a 400 HTTP status code, despite the SMART spec specifically stating that invalid_client w/ 401 is
                 // the response https://hl7.org/fhir/uv/bulkdata/authorization/index.html#signature-verification
                 // so we force this to be a 400 exception
-                // TODO: @adunsulag is there an update to inferno that fixes this issue?
+                // TODO: @adunsulag is there an update to inferno that fixes this issue? (as of inferno 1.9.0 there is no update).
                 $exception = new OAuthServerException('Client authentication failed', 4, 'invalid_client', 400);
                 $exception->setServerRequest($request);
                 throw $exception;

--- a/src/Common/Auth/OpenIDConnect/Grant/CustomRefreshTokenGrant.php
+++ b/src/Common/Auth/OpenIDConnect/Grant/CustomRefreshTokenGrant.php
@@ -48,13 +48,12 @@ class CustomRefreshTokenGrant extends RefreshTokenGrant
         // we are going to grab our old access token and grab any context information that we may have
         if ($this->accessTokenRepository instanceof AccessTokenRepository) {
             $oldToken = $this->accessTokenRepository->getTokenByToken($oldRefreshToken['access_token_id']);
-            $context= $oldToken['context'] ?? '{}';
+            $context = $oldToken['context'] ?? '{}';
             if (!empty($context)) {
                 try {
                     $decodedContext = \json_decode($context, true);
                     $this->accessTokenRepository->setContextForNewTokens($decodedContext);
-                }
-                catch (\Exception $exception) {
+                } catch (\Exception $exception) {
                     (new SystemLogger())->error("OpenEMR Error: failed to decode token context json", ['exception' => $exception->getMessage()
                         , 'tokenId' => $oldRefreshToken['access_token_id']]);
                 }

--- a/src/Common/Auth/OpenIDConnect/Grant/CustomRefreshTokenGrant.php
+++ b/src/Common/Auth/OpenIDConnect/Grant/CustomRefreshTokenGrant.php
@@ -14,11 +14,13 @@
 namespace OpenEMR\Common\Auth\OpenIDConnect\Grant;
 
 use DateInterval;
+use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Entities\ScopeEntityInterface;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Grant\RefreshTokenGrant;
 use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
 use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
+use OpenEMR\Common\Auth\OpenIDConnect\Repositories\AccessTokenRepository;
 use OpenEMR\Common\Auth\OpenIDConnect\Repositories\ScopeRepository;
 use OpenEMR\Common\Logging\SystemLogger;
 use Psr\Http\Message\ServerRequestInterface;
@@ -42,6 +44,22 @@ class CustomRefreshTokenGrant extends RefreshTokenGrant
             "requestParameter['scopes']" => $this->getRequestParameter('scope', $request, null),
             "_REQUEST['scope']" => $_REQUEST['scope']
             ]);
+
+        // we are going to grab our old access token and grab any context information that we may have
+        if ($this->accessTokenRepository instanceof AccessTokenRepository) {
+            $oldToken = $this->accessTokenRepository->getTokenByToken($oldRefreshToken['access_token_id']);
+            $context= $oldToken['context'] ?? '{}';
+            if (!empty($context)) {
+                try {
+                    $decodedContext = \json_decode($context, true);
+                    $this->accessTokenRepository->setContextForNewTokens($decodedContext);
+                }
+                catch (\Exception $exception) {
+                    (new SystemLogger())->error("OpenEMR Error: failed to decode token context json", ['exception' => $exception->getMessage()
+                        , 'tokenId' => $oldRefreshToken['access_token_id']]);
+                }
+            }
+        }
         return parent::respondToAccessTokenRequest($request, $responseType, $accessTokenTTL);
     }
 

--- a/src/Common/Auth/OpenIDConnect/IdTokenSMARTResponse.php
+++ b/src/Common/Auth/OpenIDConnect/IdTokenSMARTResponse.php
@@ -46,12 +46,18 @@ class IdTokenSMARTResponse extends IdTokenResponse
      */
     private $isAuthorizationGrant;
 
+    /**
+     * @var SMARTSessionTokenContextBuilder
+     */
+    private $contextBuilder;
+
     public function __construct(
         IdentityProviderInterface $identityProvider,
         ClaimExtractor $claimExtractor
     ) {
         $this->isAuthorizationGrant = false;
         $this->logger = new SystemLogger();
+        $this->contextBuilder = new SMARTSessionTokenContextBuilder($_SESSION);
         parent::__construct($identityProvider, $claimExtractor);
     }
 
@@ -109,48 +115,8 @@ class IdTokenSMARTResponse extends IdTokenResponse
         $scopes = $accessToken->getScopes();
         $this->logger->debug("IdTokenSMARTResponse->getExtraParams() params from parent ", ["params" => $extraParams]);
 
-        if ($this->isStandaloneLaunchPatientRequest($scopes)) {
-            // patient id that is currently selected in the session.
-            if (!empty($_SESSION['pid'])) {
-                $extraParams['patient'] = $_SESSION['pid'];
-                $extraParams['need_patient_banner'] = true;
-                $extraParams['smart_style_url'] = $this->getSmartStyleURL();
-            } else {
-                throw new OAuthServerException("launch/patient scope requested but patient 'pid' was not present in session", 0, 'invalid_patient_context');
-            }
-        } else if ($this->isLaunchRequest($scopes)) {
-            $this->logger->debug("launch scope requested");
-            if (!empty($_SESSION['launch'])) {
-                $this->logger->debug("IdTokenSMARTResponse->getExtraParams() launch set in session", ['launch' => $_SESSION['launch']]);
-                // this is where the launch context is deserialized and we extract any SMART context state we wanted to
-                // pass on as part of the EHR request, we only have encounter and patient at this point
-                try {
-                    // TODO: adunsulag do we want any kind of hmac signature to verify the request hasn't been
-                    // tampered with?  Not sure that it matters as the ACL's will verify that the app only has access
-                    // to the data the currently authorized oauth2 user can access.
-                    $launchToken = SMARTLaunchToken::deserializeToken($_SESSION['launch']);
-                    $this->logger->debug("IdTokenSMARTResponse->getExtraParams() decoded launch context is", ['context' => $launchToken]);
-
-                    // we assume that if a patient is provided we are already displaying the patient
-                    // we may in the future need to adjust the need_patient_banner depending on the 'intent' chosen.
-                    if (!empty($launchToken->getPatient())) {
-                        $extraParams['patient'] = $launchToken->getPatient();
-                        $extraParams['need_patient_banner'] = false;
-                    }
-                    if (!empty($launchToken->getEncounter())) {
-                        $extraParams['encounter'] = $launchToken->getEncounter();
-                    }
-                    if (!empty($launchToken->getIntent())) {
-                        $extraParams['intent'] = $launchToken->getIntent();
-                    }
-                    $extraParams['smart_style_url'] = $this->getSmartStyleURL();
-                } catch (\Exception $ex) {
-                    $this->logger->error("IdTokenSMARTResponse->getExtraParams() Failed to decode launch context parameter", ['error' => $ex->getMessage()]);
-                    throw new OAuthServerException("Invalid launch parameter", 0, 'invalid_launch_context');
-                }
-            }
-        }
-
+        $contextParams = $this->contextBuilder->getContextForScopes($scopes);
+        $extraParams = array_merge($extraParams, $contextParams);
         // response should return the scopes we authorized inside the accessToken to be smart compatible
         // I would think this would be better put in the id_token but to be spec compliant we have to have this here
         $extraParams['scope'] = $this->getScopeString($accessToken->getScopes());
@@ -159,44 +125,6 @@ class IdTokenSMARTResponse extends IdTokenResponse
         return $extraParams;
     }
 
-    /**
-     * Needed for OpenEMR\FHIR\SMART\Capability::CONTEXT_STYLE support
-     * TODO: adunsulag do we want to try and read from the scss files and generate some kind of styles...
-     * Reading the SMART FHIR spec author forums so few app writers are actually using this at all, it seems like we
-     * can just use defaults without getting trying to load up based upon which skin we have, or using node &
-     * gulp to auto generate a skin.
-     */
-    private function getSmartStyleURL()
-    {
-        return $GLOBALS['site_addr_oath'] . $GLOBALS['web_root'] . "/public/smart-styles/smart-light.json";
-    }
-
-    /**
-     * @param ScopeEntityInterface[] $scopes
-     * @return bool
-     */
-    private function isLaunchRequest($scopes)
-    {
-        // if we are not in an authorization grant context we don't support SMART launch context params
-        if (!$this->isAuthorizationGrant) {
-            return false;
-        }
-
-        return $this->hasScope($scopes, 'launch');
-    }
-
-    /**
-     * @param ScopeEntityInterface[] $scopes
-     * @return bool
-     */
-    private function isStandaloneLaunchPatientRequest($scopes)
-    {
-        // if we are not in an authorization grant context we don't support SMART launch context params
-        if (!$this->isAuthorizationGrant) {
-            return false;
-        }
-        return $this->hasScope($scopes, 'launch/patient');
-    }
 
     private function hasScope($scopes, $searchScope)
     {

--- a/src/Common/Auth/OpenIDConnect/Repositories/AccessTokenRepository.php
+++ b/src/Common/Auth/OpenIDConnect/Repositories/AccessTokenRepository.php
@@ -18,11 +18,30 @@ use League\OAuth2\Server\Entities\Traits\AccessTokenTrait;
 use League\OAuth2\Server\Exception\UniqueTokenIdentifierConstraintViolationException;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
 use OpenEMR\Common\Auth\OpenIDConnect\Entities\AccessTokenEntity;
+use OpenEMR\Common\Auth\OpenIDConnect\SMARTSessionTokenContextBuilder;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Logging\SystemLogger;
 
 class AccessTokenRepository implements AccessTokenRepositoryInterface
 {
+    /**
+     * @var SMARTSessionTokenContextBuilder
+     */
+    private $builder;
+
+    /**
+     * The context values to use for issuing new tokens.  This is populated when a refresh grant is generating a new
+     * access token.  We have to use our existing values.
+     * @var array
+     */
+    private $contextForNewTokens;
+
+    public function __construct()
+    {
+        $this->builder = new SMARTSessionTokenContextBuilder($_SESSION ?? []);
+        $this->contextForNewTokens = null;
+    }
+
     /**
      * Returns the token expiration date for the given token id.
      * @param $tokenId string The access token id
@@ -49,13 +68,16 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
         $user_id = $accessTokenEntity->getUserIdentifier();
         $unique_id = $accessTokenEntity->getIdentifier();
         $client_id = $accessTokenEntity->getClient()->getIdentifier();
-        $scope = \json_encode($accessTokenEntity->getScopes());
+        $scopes = $accessTokenEntity->getScopes();
+        $context = $this->getContextForNewAccessTokens($scopes);
+        $scope = \json_encode($scopes);
+        $encodedContext = \json_encode($context);
 
         $sql = " INSERT INTO api_token SET";
         $sql .= " `user_id` = ?,";
         $sql .= " `token` = ?,";
-        $sql .= " `expiry` = ?, `client_id` = ?, `scope` = ?";
-        sqlStatementNoLog($sql, [$user_id, $unique_id, $exp_date, $client_id, $scope]);
+        $sql .= " `expiry` = ?, `client_id` = ?, `scope` = ?, `context` = ? ";
+        sqlStatementNoLog($sql, [$user_id, $unique_id, $exp_date, $client_id, $scope, $encodedContext]);
     }
 
     public function revokeAccessToken($tokenId)
@@ -123,5 +145,28 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
         $sql = "SELECT * FROM api_token WHERE token = ? ";
         $records = QueryUtils::fetchRecords($sql, [$token], true);
         return $records[0] ?? null;
+    }
+
+    /**
+     * Sets the context array that will be saved to the database for new acess tokens.
+     * @param $context The array of context variables.  If this is not an array the context is set to null;
+     */
+    public function setContextForNewTokens($context) {
+        $this->contextForNewTokens = is_array($context) && !empty($context) ? $context : null;
+    }
+
+    /**
+     * Retrieves the context to use for new access tokens based upon the passed in scopes.  It will use the existing
+     * context saved in the repositoryor will build a new context from the passed in scopes.
+     * @param $scopes The scopes in the access token that determines what context variables to use in the access token
+     * @return array The built context session.
+     */
+    private function getContextForNewAccessTokens($scopes) {
+        if (!empty($this->contextForNewTokens)) {
+            $context = $this->builder->getContextForScopesWithExistingContext($this->contextForNewTokens, $scopes) ?? [];
+        } else {
+            $context = $this->builder->getContextForScopes($scopes) ?? [];
+        }
+        return $context;
     }
 }

--- a/src/Common/Auth/OpenIDConnect/Repositories/AccessTokenRepository.php
+++ b/src/Common/Auth/OpenIDConnect/Repositories/AccessTokenRepository.php
@@ -151,7 +151,8 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
      * Sets the context array that will be saved to the database for new acess tokens.
      * @param $context The array of context variables.  If this is not an array the context is set to null;
      */
-    public function setContextForNewTokens($context) {
+    public function setContextForNewTokens($context)
+    {
         $this->contextForNewTokens = is_array($context) && !empty($context) ? $context : null;
     }
 
@@ -161,7 +162,8 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
      * @param $scopes The scopes in the access token that determines what context variables to use in the access token
      * @return array The built context session.
      */
-    private function getContextForNewAccessTokens($scopes) {
+    private function getContextForNewAccessTokens($scopes)
+    {
         if (!empty($this->contextForNewTokens)) {
             $context = $this->builder->getContextForScopesWithExistingContext($this->contextForNewTokens, $scopes) ?? [];
         } else {

--- a/src/Common/Auth/OpenIDConnect/SMARTSessionTokenContextBuilder.php
+++ b/src/Common/Auth/OpenIDConnect/SMARTSessionTokenContextBuilder.php
@@ -15,7 +15,6 @@
 
 namespace OpenEMR\Common\Auth\OpenIDConnect;
 
-
 use League\OAuth2\Server\Exception\OAuthServerException;
 use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\FHIR\SMART\SmartLaunchController;
@@ -30,10 +29,10 @@ class SMARTSessionTokenContextBuilder
         $this->logger = new SystemLogger();
     }
 
-    public function getEHRLaunchContext() {
+    public function getEHRLaunchContext()
+    {
         $launch = $this->sessionArray['launch'] ?? null;
-        if (empty($launch))
-        {
+        if (empty($launch)) {
             return [];
         }
         $context = [];
@@ -64,7 +63,8 @@ class SMARTSessionTokenContextBuilder
         return $context;
     }
 
-    public function getContextForScopesWithExistingContext(array $context, array $scopes) : array {
+    public function getContextForScopesWithExistingContext(array $context, array $scopes): array
+    {
         $returnContext = [];
         $populateKeys = ['patient'];
         if ($this->isStandaloneLaunchPatientRequest($scopes)) {
@@ -90,7 +90,8 @@ class SMARTSessionTokenContextBuilder
         return $returnContext;
     }
 
-    public function getContextForScopes($scopes) : array {
+    public function getContextForScopes($scopes): array
+    {
         $context = [];
         if ($this->isStandaloneLaunchPatientRequest($scopes)) {
             $context = $this->getStandaloneLaunchContext();
@@ -100,7 +101,8 @@ class SMARTSessionTokenContextBuilder
         return $context;
     }
 
-    public function getStandaloneLaunchContext() {
+    public function getStandaloneLaunchContext()
+    {
         $context = [];
         if (empty($this->sessionArray['puuid'])) {
             return $context;

--- a/src/Common/Auth/OpenIDConnect/SMARTSessionTokenContextBuilder.php
+++ b/src/Common/Auth/OpenIDConnect/SMARTSessionTokenContextBuilder.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * Handles the building and aggregation of SMART on FHIR session context information that are returned in the Access
+ * Token request response body.  These include context information such as selected patient, launch, encounter, etc.
+ *
+ * @see http://hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2022 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Common\Auth\OpenIDConnect;
+
+
+use League\OAuth2\Server\Exception\OAuthServerException;
+use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\FHIR\SMART\SmartLaunchController;
+use OpenEMR\FHIR\SMART\SMARTLaunchToken;
+
+class SMARTSessionTokenContextBuilder
+{
+    private $sessionArray;
+    public function __construct($sessionArray = array())
+    {
+        $this->sessionArray = !empty($sessionArray) ? $sessionArray : $_SESSION;
+        $this->logger = new SystemLogger();
+    }
+
+    public function getEHRLaunchContext() {
+        $launch = $this->sessionArray['launch'] ?? null;
+        if (empty($launch))
+        {
+            return [];
+        }
+        $context = [];
+        try {
+            // TODO: adunsulag do we want any kind of hmac signature to verify the request hasn't been
+            // tampered with?  Not sure that it matters as the ACL's will verify that the app only has access
+            // to the data the currently authorized oauth2 user can access.
+            $launchToken = SMARTLaunchToken::deserializeToken($launch);
+            $this->logger->debug("SMARTSessionTokenContextBuilder->getEHRLaunchContext() decoded launch context is", ['context' => $launchToken]);
+
+            // we assume that if a patient is provided we are already displaying the patient
+            // we may in the future need to adjust the need_patient_banner depending on the 'intent' chosen.
+            if (!empty($launchToken->getPatient())) {
+                $context['patient'] = $launchToken->getPatient();
+                $context['need_patient_banner'] = false;
+            }
+            if (!empty($launchToken->getEncounter())) {
+                $context['encounter'] = $launchToken->getEncounter();
+            }
+            if (!empty($launchToken->getIntent())) {
+                $context['intent'] = $launchToken->getIntent();
+            }
+            $context['smart_style_url'] = $this->getSmartStyleURL();
+        } catch (\Exception $ex) {
+            $this->logger->error("SMARTSessionTokenContextBuilder->getAccessTokenContextParameters() Failed to decode launch context parameter", ['error' => $ex->getMessage()]);
+            throw new OAuthServerException("Invalid launch parameter", 0, 'invalid_launch_context');
+        }
+        return $context;
+    }
+
+    public function getContextForScopesWithExistingContext(array $context, array $scopes) : array {
+        $returnContext = [];
+        $populateKeys = ['patient'];
+        if ($this->isStandaloneLaunchPatientRequest($scopes)) {
+            $returnContext = [
+                'need_patient_banner' => true
+                ,'smart_style_url' => $this->getSmartStyleURL()
+            ];
+        } else if ($this->isEHRLaunchRequest($scopes)) {
+            $returnContext = [
+                'need_patient_banner' => false
+                ,'smart_style_url' => $this->getSmartStyleURL()
+            ];
+            $populateKeys[] = 'encounter';
+            $populateKeys[] = 'intent';
+        }
+
+        // populate any values we have from our orig context into our return array
+        foreach ($populateKeys as $item) {
+            if (isset($context[$item])) {
+                $returnContext[$item] = $context[$item];
+            }
+        }
+        return $returnContext;
+    }
+
+    public function getContextForScopes($scopes) : array {
+        $context = [];
+        if ($this->isStandaloneLaunchPatientRequest($scopes)) {
+            $context = $this->getStandaloneLaunchContext();
+        } else if ($this->isEHRLaunchRequest($scopes)) {
+            $context = $this->getEHRLaunchContext();
+        }
+        return $context;
+    }
+
+    public function getStandaloneLaunchContext() {
+        $context = [];
+        if (empty($this->sessionArray['puuid'])) {
+            return $context;
+        }
+        $context['patient'] = $this->sessionArray['puuid'];
+        $context['need_patient_banner'] = true;
+        $context['smart_style_url'] = $this->getSmartStyleURL();
+        return $context;
+    }
+
+    /**
+     * Needed for OpenEMR\FHIR\SMART\Capability::CONTEXT_STYLE support
+     * TODO: adunsulag do we want to try and read from the scss files and generate some kind of styles...
+     * Reading the SMART FHIR spec author forums so few app writers are actually using this at all, it seems like we
+     * can just use defaults without getting trying to load up based upon which skin we have, or using node &
+     * gulp to auto generate a skin.
+     */
+    private function getSmartStyleURL()
+    {
+        return $GLOBALS['site_addr_oath'] . $GLOBALS['web_root'] . "/public/smart-styles/smart-light.json";
+    }
+
+    /**
+     * @param ScopeEntityInterface[] $scopes
+     * @return bool
+     */
+    public function isStandaloneLaunchPatientRequest($scopes)
+    {
+        return $this->hasScope($scopes, SmartLaunchController::CLIENT_APP_STANDALONE_LAUNCH_SCOPE);
+    }
+
+    /**
+     * @param ScopeEntityInterface[] $scopes
+     * @return bool
+     */
+    public function isEHRLaunchRequest($scopes)
+    {
+        return $this->hasScope($scopes, SmartLaunchController::CLIENT_APP_REQUIRED_LAUNCH_SCOPE);
+    }
+
+    private function hasScope($scopes, $searchScope)
+    {
+        // Verify scope and make sure openid exists.
+        $valid  = false;
+
+        foreach ($scopes as $scope) {
+            if ($scope->getIdentifier() == $searchScope) {
+                $valid = true;
+                break;
+            }
+        }
+
+        return $valid;
+    }
+}

--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -854,6 +854,7 @@ class AuthorizationController
             $this->logger->debug("AuthorizationController->verifyLogin() login attempt failed", ['username' => $username, 'email' => $email, 'type' => $type]);
             return false;
         }
+        // TODO: should user_id be set to be a uuid here?
         if ($this->userId = $auth->getUserId()) {
             $_SESSION['user_id'] = $this->getUserUuid($this->userId, 'users');
             $this->logger->debug("AuthorizationController->verifyLogin() user login", ['user_id' => $_SESSION['user_id'],
@@ -861,10 +862,13 @@ class AuthorizationController
             return true;
         }
         if ($id = $auth->getPatientId()) {
-            $_SESSION['user_id'] = $this->getUserUuid($id, 'patient');
+            $puuid = $this->getUserUuid($id, 'patient');
+            // TODO: @adunsulag check with @sjpadgett on where this user_id is even used as we are assigning it to be a uuid
+            $_SESSION['user_id'] = $puuid;
             $this->logger->debug("AuthorizationController->verifyLogin() patient login", ['pid' => $_SESSION['user_id']
                 , 'username' => $username, 'email' => $email, 'type' => $type]);
-            $_SESSION['pid'] = $_SESSION['user_id'];
+            $_SESSION['pid'] = $id;
+            $_SESSION['puuid'] = $puuid;
             return true;
         }
 

--- a/src/RestControllers/SMART/SMARTAuthorizationController.php
+++ b/src/RestControllers/SMART/SMARTAuthorizationController.php
@@ -124,8 +124,8 @@ class SMARTAuthorizationController
      */
     public function needSMARTAuthorization()
     {
-        if (empty($_SESSION['pid']) && strpos($_SESSION['scopes'], SmartLaunchController::CLIENT_APP_STANDALONE_LAUNCH_SCOPE) !== false) {
-            $this->logger->debug("AuthorizationController->userLogin() SMART app request for patient context ", ['scopes' => $_SESSION['scopes'], $_SESSION['pid']]);
+        if (empty($_SESSION['puuid']) && strpos($_SESSION['scopes'], SmartLaunchController::CLIENT_APP_STANDALONE_LAUNCH_SCOPE) !== false) {
+            $this->logger->debug("AuthorizationController->userLogin() SMART app request for patient context ", ['scopes' => $_SESSION['scopes'], 'puuid' => $_SESSION['puuid'] ?? null]);
             return true;
         }
         return false;
@@ -167,7 +167,7 @@ class SMARTAuthorizationController
             // throws access denied if user doesn't have access
             $foundPatient = $searchController->getPatientForUser($patient_id, $user_uuid);
             // put PID in session
-            $_SESSION['pid'] = $patient_id;
+            $_SESSION['puuid'] = $patient_id;
 
             // now redirect to our scope-authorize
             $redirect = $this->smartFinalRedirectURL;

--- a/src/RestControllers/SMART/SMARTAuthorizationController.php
+++ b/src/RestControllers/SMART/SMARTAuthorizationController.php
@@ -162,9 +162,10 @@ class SMARTAuthorizationController
 
         // set our patient information up in our pid so we can handle our code property...
         try {
-            $patient_id = $_POST['patient_id'];
+            $patient_id = $_POST['patient_id']; // this patient_id is actually a uuid.. wierd
             $searchController = new PatientContextSearchController(new PatientService(), $this->logger);
-            $searchController->getPatientForUser($patient_id, $user_uuid);
+            // throws access denied if user doesn't have access
+            $foundPatient = $searchController->getPatientForUser($patient_id, $user_uuid);
             // put PID in session
             $_SESSION['pid'] = $patient_id;
 


### PR DESCRIPTION
Fixes #5157 

We need to handle in the standalone application context the ability to use patient scopes while logged in as a practitioner.  We originally restricted patient scopes to JUST patients and user scopes to JUST users.  However, latest inferno and v2 of smart on FHIR is expecting a practitioner to be able to select a user and have their scopes
restricted to JUST that user.

Currently I have this working when used for a single patient.  I did this by overriding the http request's isPatientRequest and getPatientStringUUID properties to populate these values IF we are in a user/system context and the launch/patient scope is present (meaning the user has requested to have a patient context bound) and the resource endpoint being requested has a patient scope (but no overriding privilege of a user/system scope).

I made it so that each access token has a uniquely bound session context rather than using a shared session context that was populated from the trusted user session cache.  Now SMART applications can have different patients open using different access tokens for the same application without stomping on each other's data.

Modified refresh token grant so we can pull our access token context and repopulate it when a new access token is issued from the refresh token.

Refactored IdTokenSmartResponse to pull the Access Token response context variables into its own class called SMARTSessionTokenContextBuilder that is used to build the context information.  This is needed to deal with patient bound contexts and contexts that are re-issued via refresh tokens.

Changed up AccessTokenRepository to save off the access token context information (such as a selected patient, encounter, etc) that needs to be retrieved / filtered for each access token (or reissued when a refresh token
generates a new access token).

Changed up AuthorizationController,SMARTAuthorizationController to set the session pid to be the actual patient pid and not the uuid of the patient. Added the puuid to the session.

Modified dispatch.php to call RestConfig to populate the access token context instead of grabbing it from the trusted_user session_cache.