### PR TITLE
Fixes #5169 Goal Date in FHIR

### DIFF
--- a/src/Services/FHIR/FhirGoalService.php
+++ b/src/Services/FHIR/FhirGoalService.php
@@ -110,7 +110,8 @@ class FhirGoalService extends FhirServiceBase implements IResourceUSCIGProfileSe
                 $fhirGoalTarget = new FHIRGoalTarget();
                 if (!empty($detail['date'])) {
                     $fhirDate = new FHIRDate();
-                    $fhirDate->setValue($detail['date']);
+                    $parsedDateTime = \DateTime::createFromFormat("Y-m-d H:i:s", $detail['date']);
+                    $fhirDate->setValue($parsedDateTime->format("Y-m-d"));
                     $fhirGoalTarget->setDueDate($fhirDate);
                 } else {
                     $fhirGoalTarget->setDueDate(UtilsService::createDataMissingExtension());


### PR DESCRIPTION
Fixes #5169 Goal was changed for its date to become a datetime at the database level which was messing up the public FHIR inferno server.  CCDA and QRDA requires Goal to be a datetime.  FHIR however reports it as a date so we modify the FHIR service to transform the dates into the right format.