### PR TITLE
Fixes #5181 CareTeams,Minor FHIR bug fixes

### DIFF
--- a/src/Common/Auth/OpenIDConnect/SMARTSessionTokenContextBuilder.php
+++ b/src/Common/Auth/OpenIDConnect/SMARTSessionTokenContextBuilder.php
@@ -25,7 +25,7 @@ class SMARTSessionTokenContextBuilder
     private $sessionArray;
     public function __construct($sessionArray = array())
     {
-        $this->sessionArray = !empty($sessionArray) ? $sessionArray : $_SESSION;
+        $this->sessionArray = !empty($sessionArray) ? $sessionArray : $_SESSION ?? [];
         $this->logger = new SystemLogger();
     }
 

--- a/src/RestControllers/FHIR/FhirExportRestController.php
+++ b/src/RestControllers/FHIR/FhirExportRestController.php
@@ -633,7 +633,7 @@ class FhirExportRestController
     {
         $patientUuids = [];
         $fhirGroupService = new FhirGroupService();
-        $result = $fhirGroupService->getAll(['_id' => $groupId]);
+        $result = $fhirGroupService->getOne($groupId);
         if ($result->hasData()) {
             foreach ($result->getData() as $group) {
                 if ($group instanceof FHIRGroup && !empty($group->getMember())) {

--- a/src/Services/FHIR/FhirCodeSystemConstants.php
+++ b/src/Services/FHIR/FhirCodeSystemConstants.php
@@ -74,4 +74,10 @@ class FhirCodeSystemConstants
     const HL7_US_CORE_RACE = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race";
 
     const LANGUAGE_BCP_47 = "urn:ietf:bcp:47";
+
+    /**
+     * Required for US Core CareTeam Role.  Requires UMLS subscription to view valueset
+     * available here: https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.27/expansion/Latest
+     */
+    const CARE_TEAM_MEMBER_FUNCTION_SNOMEDCT = "2.16.840.1.113762.1.4.1099.27";
 }

--- a/src/Services/FHIR/UtilsService.php
+++ b/src/Services/FHIR/UtilsService.php
@@ -63,12 +63,13 @@ class UtilsService
     public static function createCoding($code, $display, $system): FHIRCoding
     {
         if (!is_string($code)) {
-            $code = "$code"; // FHIR expects a string
+            $code = trim("$code"); // FHIR expects a string
         }
+        // make sure there are no whitespaces.
         $coding = new FHIRCoding();
         $coding->setCode($code);
-        $coding->setDisplay($display);
-        $coding->setSystem($system);
+        $coding->setDisplay(trim($display ?? ""));
+        $coding->setSystem(trim($system ?? ""));
         return $coding;
     }
 

--- a/src/Services/PractitionerRoleService.php
+++ b/src/Services/PractitionerRoleService.php
@@ -60,7 +60,10 @@ class PractitionerRoleService extends BaseService
                 role_codes.role_code,
                 role_codes.role_title,
                 specialty_codes.specialty_code,
-                specialty_codes.specialty_title
+                specialty_codes.specialty_title,
+                physician_types.physician_type_codes,
+                physician_types.physician_type,
+                physician_types.physician_type_title
                 FROM (
                     select
                         facility_user_ids.uuid AS facility_role_uuid,
@@ -72,6 +75,7 @@ class PractitionerRoleService extends BaseService
                         -- TODO: @adunsulag figure out whether we should actually be using the user entered provider_id
                         uid AS provider_id,
                         users.uuid AS provider_uuid,
+                        users.physician_type,
                         CONCAT(COALESCE(users.fname,''),
                            IF(users.mname IS NULL OR users.mname = '','',' '),COALESCE(users.mname,''),
                            IF(users.lname IS NULL OR users.lname = '','',' '),COALESCE(users.lname,'')
@@ -124,7 +128,15 @@ class PractitionerRoleService extends BaseService
                         field_id='specialty_code'
                         AND specialty.list_id='us-core-provider-specialty'
                 ) specialty_codes ON
-                    providers.user_id = specialty_codes.user_id AND providers.facility_id = specialty_codes.facility_id AND specialty_codes.field_id='specialty_code'";
+                    providers.user_id = specialty_codes.user_id AND providers.facility_id = specialty_codes.facility_id AND specialty_codes.field_id='specialty_code'
+                LEFT JOIN (
+                    select
+                           codes AS physician_type_codes
+                           ,option_id AS physician_type
+                           ,title AS physician_type_title
+                    FROM list_options types
+                    WHERE types.list_id = 'physician_type'
+                ) physician_types ON physician_types.physician_type = providers.physician_type ";
         $whereClause = FhirSearchWhereClauseBuilder::build($search, $isAndCondition);
 
         $sql .= $whereClause->getFragment();


### PR DESCRIPTION
Changed up the care team value sets since we can't use NUCC anymore and
instead need to use a SNOMED-CT valuset for the care team provider.
Oddly there is no 'valid' value for facilities as the role is all
provider centric.  However, SNOMED-CT still has values for health care
organization so we use that for our code.

Added some fixes to get rid of warnings with the smart session context
builder.

Also Changed up the group export to use getOne which is what we really
want instead of hitting getAll.