### PR TITLE
Fixes #5182 set correct patient language system

### DIFF
--- a/src/Services/FHIR/FhirCodeSystemConstants.php
+++ b/src/Services/FHIR/FhirCodeSystemConstants.php
@@ -72,4 +72,6 @@ class FhirCodeSystemConstants
     const OID_RACE_AND_ETHNICITY = "urn:oid:2.16.840.1.113883.6.238";
 
     const HL7_US_CORE_RACE = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race";
+
+    const LANGUAGE_BCP_47 = "urn:ietf:bcp:47";
 }

--- a/src/Services/FHIR/FhirPatientService.php
+++ b/src/Services/FHIR/FhirPatientService.php
@@ -416,7 +416,7 @@ class FhirPatientService extends FhirServiceBase implements IFhirExportableResou
             $communication = new FHIRPatientCommunication();
             $languageConcept = new FHIRCodeableConcept();
             $language = new FHIRCoding();
-            $language->setSystem(new FHIRUri("http://hl7.org/fhir/us/core/ValueSet/simple-language"));
+            $language->setSystem(new FHIRUri(FhirCodeSystemConstants::LANGUAGE_BCP_47));
             $language->setCode(new FHIRCode($record['notes']));
             $language->setDisplay(xlt($record['title']));
             $languageConcept->addCoding($language);


### PR DESCRIPTION
The system property was not set correctly for the patient language.
Went and found inferno's sample patients and changed the system property
to be what it has listed.
Fixes #5182 