### PR TITLE
Openemr fix #5191 refresh token

### DIFF
--- a/src/Common/Auth/OpenIDConnect/Grant/CustomRefreshTokenGrant.php
+++ b/src/Common/Auth/OpenIDConnect/Grant/CustomRefreshTokenGrant.php
@@ -54,8 +54,7 @@ class CustomRefreshTokenGrant extends RefreshTokenGrant
                 try {
                     $decodedContext = \json_decode($context, true);
                     $this->accessTokenRepository->setContextForNewTokens($decodedContext);
-                    if ($responseType instanceof IdTokenSMARTResponse)
-                    {
+                    if ($responseType instanceof IdTokenSMARTResponse) {
                         $responseType->setContextForNewTokens($decodedContext);
                     }
                 } catch (\Exception $exception) {

--- a/src/Common/Auth/OpenIDConnect/Grant/CustomRefreshTokenGrant.php
+++ b/src/Common/Auth/OpenIDConnect/Grant/CustomRefreshTokenGrant.php
@@ -20,6 +20,7 @@ use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Grant\RefreshTokenGrant;
 use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
 use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
+use OpenEMR\Common\Auth\OpenIDConnect\IdTokenSMARTResponse;
 use OpenEMR\Common\Auth\OpenIDConnect\Repositories\AccessTokenRepository;
 use OpenEMR\Common\Auth\OpenIDConnect\Repositories\ScopeRepository;
 use OpenEMR\Common\Logging\SystemLogger;
@@ -53,6 +54,10 @@ class CustomRefreshTokenGrant extends RefreshTokenGrant
                 try {
                     $decodedContext = \json_decode($context, true);
                     $this->accessTokenRepository->setContextForNewTokens($decodedContext);
+                    if ($responseType instanceof IdTokenSMARTResponse)
+                    {
+                        $responseType->setContextForNewTokens($decodedContext);
+                    }
                 } catch (\Exception $exception) {
                     (new SystemLogger())->error("OpenEMR Error: failed to decode token context json", ['exception' => $exception->getMessage()
                         , 'tokenId' => $oldRefreshToken['access_token_id']]);

--- a/src/Common/Auth/OpenIDConnect/Repositories/ScopeRepository.php
+++ b/src/Common/Auth/OpenIDConnect/Repositories/ScopeRepository.php
@@ -913,6 +913,8 @@ class ScopeRepository implements ScopeRepositoryInterface
             case 'Condition':
                 $description .= xl("conditions including health concerns, problems, and encounter diagnoses");
                 break;
+            case 'Device':
+                $description .= xl("implantable medical device records");
             case 'DiagnosticReport':
                 $description .= xl("diagnostic reports including laboratory,cardiology,radiology, and pathology reports");
                 break;
@@ -950,6 +952,10 @@ class ScopeRepository implements ScopeRepositoryInterface
                 $description .= xl("procedures");
                 break;
             case 'Location':
+                $description .= xl("locations associated with a patient, provider, or organization");
+                break;
+            case 'Provenance':
+                $description .= xl("provenance information (including person(s) responsible for the information, author organizations, and transmitter organizations)");
                 break;
             default:
                 $description .= xl("medical records for this resource type");


### PR DESCRIPTION
Fixes #5191 

Made it so the refresh_grant will provide patient context and other
SMART context variables if scopes are omitted or if a subset of scopes
are sent.

Had a few resources that didn't have scope permission messages setup which this commit
fixes.