### PR TITLE
Fixes #5202 Patient Suffix support

### DIFF
--- a/src/Common/Auth/OpenIDConnect/Repositories/ScopeRepository.php
+++ b/src/Common/Auth/OpenIDConnect/Repositories/ScopeRepository.php
@@ -915,6 +915,7 @@ class ScopeRepository implements ScopeRepositoryInterface
                 break;
             case 'Device':
                 $description .= xl("implantable medical device records");
+                break;
             case 'DiagnosticReport':
                 $description .= xl("diagnostic reports including laboratory,cardiology,radiology, and pathology reports");
                 break;

--- a/src/Services/PatientService.php
+++ b/src/Services/PatientService.php
@@ -760,6 +760,10 @@ class PatientService extends BaseService
 
     private function parseSuffixForPatientRecord($patientRecord)
     {
+        // if we have a suffix populated (that wasn't entered into last name) let's use that.
+        if (!empty($patientRecord['suffix'])) {
+            return $patientRecord['suffix'];
+        }
         // parse suffix from last name. saves messing with LBF
         $suffixes = $this->getPatientSuffixKeys();
         $suffix = null;


### PR DESCRIPTION
#5202 Use the LBF suffix field first if we can then fallback to last name parsing if we don't have a suffix value.