### PR TITLE
Fixes #5201 Report US Core Profiles for capability

### DIFF
--- a/src/Services/FHIR/FhirDeviceService.php
+++ b/src/Services/FHIR/FhirDeviceService.php
@@ -36,7 +36,7 @@ class FhirDeviceService extends FhirServiceBase implements IResourceUSCIGProfile
     private $deviceService;
 
 
-    const USCGI_PROFILE_URI = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-device';
+    const USCGI_PROFILE_URI = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device';
 
     public function __construct()
     {

--- a/src/Services/FHIR/FhirDiagnosticReportService.php
+++ b/src/Services/FHIR/FhirDiagnosticReportService.php
@@ -108,6 +108,7 @@ class FhirDiagnosticReportService extends FhirServiceBase implements IPatientCom
     {
         return [
             'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note'
+            ,'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab'
         ];
     }
 }

--- a/src/Services/FHIR/FhirEncounterService.php
+++ b/src/Services/FHIR/FhirEncounterService.php
@@ -30,7 +30,7 @@ use OpenEMR\Services\Search\SearchFieldType;
 use OpenEMR\Services\Search\ServiceField;
 use OpenEMR\Validators\ProcessingResult;
 
-class FhirEncounterService extends FhirServiceBase implements IFhirExportableResourceService, IPatientCompartmentResourceService
+class FhirEncounterService extends FhirServiceBase implements IFhirExportableResourceService, IPatientCompartmentResourceService, IResourceUSCIGProfileService
 {
     use PatientSearchTrait;
     use FhirServiceBaseEmptyTrait;
@@ -213,5 +213,19 @@ class FhirEncounterService extends FhirServiceBase implements IFhirExportableRes
     protected function searchForOpenEMRRecords($searchParam, $puuidBind = null): ProcessingResult
     {
         return $this->encounterService->search($searchParam, true, $puuidBind);
+    }
+
+    /**
+     * Returns the Canonical URIs for the FHIR resource for each of the US Core Implementation Guide Profiles that the
+     * resource implements.  Most resources have only one profile, but several like DiagnosticReport and Observation
+     * has multiple profiles that must be conformed to.
+     * @see https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html for the list of profiles
+     * @return string[]
+     */
+    function getProfileURIs(): array
+    {
+        return [
+            'http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter'
+        ];
     }
 }

--- a/src/Services/FHIR/FhirLocationService.php
+++ b/src/Services/FHIR/FhirLocationService.php
@@ -30,7 +30,7 @@ use OpenEMR\Services\Search\TokenSearchField;
 use OpenEMR\Services\Search\TokenSearchValue;
 use OpenEMR\Validators\ProcessingResult;
 
-class FhirLocationService extends FhirServiceBase implements IFhirExportableResourceService
+class FhirLocationService extends FhirServiceBase implements IFhirExportableResourceService, IResourceUSCIGProfileService
 {
     use BulkExportSupportAllOperationsTrait;
     use FhirBulkExportDomainResourceTrait;
@@ -214,5 +214,19 @@ class FhirLocationService extends FhirServiceBase implements IFhirExportableReso
             // facilities we just let all contact information be displayed for the location.
             return true;
         }
+    }
+
+    /**
+     * Returns the Canonical URIs for the FHIR resource for each of the US Core Implementation Guide Profiles that the
+     * resource implements.  Most resources have only one profile, but several like DiagnosticReport and Observation
+     * has multiple profiles that must be conformed to.
+     * @see https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html for the list of profiles
+     * @return string[]
+     */
+    function getProfileURIs(): array
+    {
+        return [
+            'http://hl7.org/fhir/us/core/StructureDefinition/us-core-location'
+        ];
     }
 }

--- a/src/Services/FHIR/FhirMedicationService.php
+++ b/src/Services/FHIR/FhirMedicationService.php
@@ -25,7 +25,7 @@ use OpenEMR\Validators\ProcessingResult;
  * @copyright          Copyright (c) 2020 Yash Bothra <yashrajbothra786gmail.com>
  * @license            https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
-class FhirMedicationService extends FhirServiceBase
+class FhirMedicationService extends FhirServiceBase implements IResourceUSCIGProfileService
 {
     /**
      * @var MedicationService
@@ -160,5 +160,19 @@ class FhirMedicationService extends FhirServiceBase
     public function createProvenanceResource($dataRecord = array(), $encode = false)
     {
         // TODO: If Required in Future
+    }
+
+    /**
+     * Returns the Canonical URIs for the FHIR resource for each of the US Core Implementation Guide Profiles that the
+     * resource implements.  Most resources have only one profile, but several like DiagnosticReport and Observation
+     * has multiple profiles that must be conformed to.
+     * @see https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html for the list of profiles
+     * @return string[]
+     */
+    function getProfileURIs(): array
+    {
+        return [
+            'http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication'
+        ];
     }
 }

--- a/src/Services/FHIR/FhirObservationService.php
+++ b/src/Services/FHIR/FhirObservationService.php
@@ -196,10 +196,18 @@ class FhirObservationService extends FhirServiceBase implements IResourceSearcha
     {
         return [
             'http://hl7.org/fhir/R4/observation-vitalsigns'
-            ,'https://www.hl7.org/fhir/us/core/StructureDefinition-pediatric-bmi-for-age'
-            ,'https://www.hl7.org/fhir/us/core/StructureDefinition-head-occipital-frontal-circumference-percentile'
-            ,'https://www.hl7.org/fhir/us/core/StructureDefinition-pediatric-weight-for-height'
-            ,'https://www.hl7.org/fhir/us/core/StructureDefinition-us-core-pulse-oximetry'
+            ,'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab'
+            ,'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age'
+            ,'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height'
+            ,'http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry'
+            ,'http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus'
+            ,'http://hl7.org/fhir/StructureDefinition/bp'
+            ,'http://hl7.org/fhir/StructureDefinition/bodyheight'
+            ,'http://hl7.org/fhir/StructureDefinition/bodyweight'
+            ,'http://hl7.org/fhir/StructureDefinition/heartrate'
+            ,'http://hl7.org/fhir/StructureDefinition/resprate'
+            ,'http://hl7.org/fhir/StructureDefinition/bodytemp'
+            ,'http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile'
         ];
     }
 }

--- a/src/Services/FHIR/FhirOrganizationService.php
+++ b/src/Services/FHIR/FhirOrganizationService.php
@@ -33,7 +33,7 @@ use OpenEMR\Validators\ProcessingResult;
  * @copyright          Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
  * @license            https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
-class FhirOrganizationService implements IResourceSearchableService, IResourceReadableService, IResourceUpdateableService, IResourceCreatableService, IFhirExportableResourceService
+class FhirOrganizationService implements IResourceSearchableService, IResourceReadableService, IResourceUpdateableService, IResourceCreatableService, IFhirExportableResourceService, IResourceUSCIGProfileService
 {
     use BulkExportSupportAllOperationsTrait;
     use FhirBulkExportDomainResourceTrait;
@@ -185,5 +185,19 @@ class FhirOrganizationService implements IResourceSearchableService, IResourceRe
     public function getOrganizationReferenceForUser($userUuid)
     {
         return $this->facilityService->getOrganizationReferenceForUser($userUuid);
+    }
+
+    /**
+     * Returns the Canonical URIs for the FHIR resource for each of the US Core Implementation Guide Profiles that the
+     * resource implements.  Most resources have only one profile, but several like DiagnosticReport and Observation
+     * has multiple profiles that must be conformed to.
+     * @see https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html for the list of profiles
+     * @return string[]
+     */
+    function getProfileURIs(): array
+    {
+        return [
+            'http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization'
+        ];
     }
 }

--- a/src/Services/FHIR/FhirPractitionerRoleService.php
+++ b/src/Services/FHIR/FhirPractitionerRoleService.php
@@ -23,7 +23,7 @@ use OpenEMR\Validators\ProcessingResult;
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  *
  */
-class FhirPractitionerRoleService extends FhirServiceBase
+class FhirPractitionerRoleService extends FhirServiceBase implements IResourceUSCIGProfileService
 {
     /**
      * @var PractitionerRoleService
@@ -154,5 +154,19 @@ class FhirPractitionerRoleService extends FhirServiceBase
     public function createProvenanceResource($dataRecord = array(), $encode = false)
     {
         // TODO: If Required in Future
+    }
+
+    /**
+     * Returns the Canonical URIs for the FHIR resource for each of the US Core Implementation Guide Profiles that the
+     * resource implements.  Most resources have only one profile, but several like DiagnosticReport and Observation
+     * has multiple profiles that must be conformed to.
+     * @see https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html for the list of profiles
+     * @return string[]
+     */
+    function getProfileURIs(): array
+    {
+        return [
+            'http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole'
+        ];
     }
 }

--- a/src/Services/FHIR/FhirPractitionerService.php
+++ b/src/Services/FHIR/FhirPractitionerService.php
@@ -30,7 +30,7 @@ use OpenEMR\Validators\ProcessingResult;
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  *
  */
-class FhirPractitionerService extends FhirServiceBase implements IFhirExportableResourceService
+class FhirPractitionerService extends FhirServiceBase implements IFhirExportableResourceService, IResourceUSCIGProfileService
 {
     use BulkExportSupportAllOperationsTrait;
     use FhirBulkExportDomainResourceTrait;
@@ -297,5 +297,19 @@ class FhirPractitionerService extends FhirServiceBase implements IFhirExportable
     public function createProvenanceResource($dataRecord = array(), $encode = false)
     {
         // TODO: If Required in Future
+    }
+
+    /**
+     * Returns the Canonical URIs for the FHIR resource for each of the US Core Implementation Guide Profiles that the
+     * resource implements.  Most resources have only one profile, but several like DiagnosticReport and Observation
+     * has multiple profiles that must be conformed to.
+     * @see https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html for the list of profiles
+     * @return string[]
+     */
+    function getProfileURIs(): array
+    {
+        return [
+            'http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner'
+        ];
     }
 }


### PR DESCRIPTION
Inferno validator changed up some of the us core profiles we had to
report.  We also were missing a bunch of them in other resources.  This
gets rid of the inferno warning on our capability statement.  It also
advertises to FHIR clients that we support the full US Core profile
spectrum.

This is the very last inferno warning!  Fingers crossed that when all the PRs are merged in that there's no cross contamination.  There shouldn't be as I've tested it locally.