### PR TITLE
Fixing medical problem GET api - StringSearchField

### DIFF
--- a/src/Services/ConditionService.php
+++ b/src/Services/ConditionService.php
@@ -130,10 +130,10 @@ class ConditionService extends BaseService
 
         // override puuid, this replaces anything in search if it is already specified.
         if (isset($puuidBind)) {
-            $search['puuid'] = new TokenSearchField('puuid', $puuidBind, true);
+            $newSearch['puuid'] = new TokenSearchField('puuid', $puuidBind, true);
         }
 
-        return $this->search($search, $isAndCondition);
+        return $this->search($newSearch, $isAndCondition);
     }
 
     /**


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:
The medical problem API fails with the following error:
_{{ _.base_url }}/apis/default/api/patient/961b34f1-2244-4826-bbac-8ee62af69499/medical_problem_

`
Fatal error: Uncaught TypeError: Cannot access offset of type string on string in /var/www/localhost/htdocs/openemr/src/Services/ConditionService.php:80 Stack trace: #0 /var/www/localhost/htdocs/openemr/src/Services/ConditionService.php(137): OpenEMR\Services\ConditionService->search() #1 /var/www/localhost/htdocs/openemr/src/RestControllers/ConditionRestController.php(57): OpenEMR\Services\ConditionService->getAll() #2 /var/www/localhost/htdocs/openemr/_rest_routes.inc.php(3642): OpenEMR\RestControllers\ConditionRestController->getAll() #3 /var/www/localhost/htdocs/openemr/src/Common/Http/HttpRestRouteHandler.php(84): {closure}() #4 /var/www/localhost/htdocs/openemr/apis/dispatch.php(370): OpenEMR\Common\Http\HttpRestRouteHandler::dispatch() #5 {main} thrown in /var/www/localhost/htdocs/openemr/src/Services/ConditionService.php on line 80`

#### Changes proposed in this pull request:
Fixing the StringSearchField issue.
