### PR TITLE
Openemr fix #5220 direct send attachment

### DIFF
--- a/interface/main/finder/document_select.php
+++ b/interface/main/finder/document_select.php
@@ -144,7 +144,7 @@ foreach ($searchResult as $docResult) {
                 <?php if (!empty($pid)) : ?>
                 <input type="hidden" name="pid" value="<?php echo attr($pid); ?>" />
                 <p>
-                    <?php echo xlt("Showing documents for patient"); ?>: <?php echo $patientName; ?>
+                    <?php echo xlt("Showing documents for patient"); ?>: <?php echo text($patientName); ?>
                 </p>
                 <?php endif; ?>
             </div>
@@ -227,7 +227,7 @@ foreach ($searchResult as $docResult) {
 
         function selectDocument(did, name, category, date) {
             if (opener.closed || ! opener.setSelectedDocument)
-                alert("<?php echo htmlspecialchars(xl('The destination form was closed; I cannot act on your selection.'), ENT_QUOTES); ?>");
+                alert(<?php echo xlj('The destination form was closed; I cannot act on your selection.'); ?>);
             else
                 opener.setSelectedDocument(did, name, category, date);
             dlgclose();

--- a/interface/main/finder/document_select.php
+++ b/interface/main/finder/document_select.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * document_select.php is intended to be used in a dialog finder window for searching and selecting an individual
  * document from the calling window.

--- a/interface/main/finder/document_select.php
+++ b/interface/main/finder/document_select.php
@@ -1,0 +1,259 @@
+<?php
+/**
+ * document_select.php is intended to be used in a dialog finder window for searching and selecting an individual
+ * document from the calling window.
+ *
+ * A sample of how to open the finder is here:
+ *
+ * window.dlgopen('/interface/main/finder/document_select.php?csrf_token_form=csrf, '_blank', 700, 400);
+ *
+ * When a document is selected the file will make a call out to the calling window/iframe and call a function
+ * that must be in scope of the calling window/iframe called setDocument.  setDocument has the following signature:
+ * function setSelectedDocument(did:number, docName:string, categoryName:string, date:string) : void
+ *
+ * Note that only documents the currently logged in user has access to via the document category ACOs will be displayed
+ * in the search.
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2022 Discover and Change <snielson@discoverandchange.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+require_once("../../globals.php");
+
+use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Core\Header;
+use OpenEMR\Services\DocumentService;
+use OpenEMR\Services\PatientService;
+use OpenEMR\Services\Search\StringSearchField;
+use OpenEMR\Services\Search\SearchModifier;
+
+if (!empty($_REQUEST)) {
+    if (!CsrfUtils::verifyCsrfToken($_REQUEST["csrf_token_form"])) {
+        CsrfUtils::csrfNotVerified();
+    }
+}
+$searchArray = [];
+$pid = $_REQUEST['pid'] ?? $_SESSION['pid'] ?? null;
+$patientName = "";
+if (!empty($_REQUEST['pid'])) {
+    $pid = intval($_REQUEST['pid']);
+    $patientService = new PatientService();
+    $patientArray = $patientService->findByPid($pid);
+    if (!empty($patientArray)) {
+        // TODO: log the fact that pid is null
+        // note for documents that foreign_id is ALWAYS the pid
+        $searchArray['foreign_id'] = $pid;
+        $patientName = trim(($patientArray['fname'] ?? '') . ' ' . ($patientArray['lname'] ?? ''));
+    }
+}
+$MAX_RECORDS = 25;
+$searchparm = trim($_REQUEST['searchparm'] ?? '');
+$searchResult = [];
+if (!empty($searchparm)) {
+    $fuzzySearchName = new StringSearchField("name", [$searchparm], SearchModifier::CONTAINS);
+    $searchArray['name'] = $fuzzySearchName;
+    $documentService = new DocumentService();
+    // we throw a warning if we do more than a 100
+    $processingResult = $documentService->search($searchArray, true, ['order' => '`date` DESC', 'limit' => $MAX_RECORDS + 1]);
+    if ($processingResult->hasData()) {
+        $searchResult = $processingResult->getData();
+    }
+} else {
+    $documentService = new DocumentService();
+    $processingResult = $documentService->search($searchArray, true, ['order' => '`date` DESC', 'limit' => $MAX_RECORDS + 1]);
+    if ($processingResult->hasData()) {
+        $searchResult = $processingResult->getData();
+    }
+}
+
+// now we have to filter by our permissions for the user, slow process and we can optimize it later, for now we will
+// brute force this. Note this does O(2n) mysql queries for each document record
+$result = [];
+foreach ($searchResult as $docResult) {
+    $document = new \Document($docResult['id']);
+    if ($document->can_access($_SESSION['user_id'])) {
+        $result[] = $docResult;
+    }
+}
+?>
+
+<!DOCTYPE html>
+<html>
+<head>
+    <?php Header::setupHeader(['common', 'opener']); ?>
+    <title><?php echo htmlspecialchars(xl('Document Finder'), ENT_NOQUOTES); ?></title>
+
+    <style>
+        form {
+            padding: 0;
+            margin: 0;
+        }
+        #searchCriteria {
+            text-align: center;
+            width: 100%;
+            font-weight: bold;
+            padding: 3px;
+        }
+        #searchResultsHeader {
+            width: 100%;
+            border-collapse: collapse;
+        }
+        #searchResults {
+            width: 100%;
+            border-collapse: collapse;
+            background-color: var(--white);
+            overflow: auto;
+        }
+
+        #searchResults tr {
+            cursor: hand;
+            cursor: pointer;
+        }
+        #searchResults td {
+            /*font-size: 0.7em;*/
+            border-bottom: 1px solid var(--light);
+        }
+        /* for search results or 'searching' notification */
+        #searchstatus {
+            font-weight: bold;
+            font-style: italic;
+            color: var(--black);
+            text-align: center;
+        }
+        #searchspinner {
+            display: inline;
+            visibility: hidden;
+        }
+
+        /* highlight for the mouse-over */
+        .oneresult:hover {
+            background-color: #336699;
+            color: var(--white);
+        }
+    </style>
+</head>
+
+<body class="body_top">
+<div class="container-responsive">
+    <div id="searchCriteria" class="bg-light p-2 pt-3">
+        <form method='post' name='theform' id="theform" action='document_select.php'>
+            <div class="form-row">
+                <?php if (!empty($pid)) : ?>
+                <input type="hidden" name="pid" value="<?php echo attr($pid); ?>" />
+                <p>
+                    <?php echo xlt("Showing documents for patient"); ?>: <?php echo $patientName; ?>
+                </p>
+                <?php endif; ?>
+            </div>
+            <div class="form-row">
+                <label for="searchby" class="col-form-label col-form-label-sm col"><?php echo htmlspecialchars(xl('Search by name:'), ENT_NOQUOTES); ?></label>
+                <input type='text' class="form-control form-control-sm col" id='searchparm' name='searchparm' size='12'
+                       value='<?php echo attr($_REQUEST['searchparm'] ?? ''); ?>'
+                       title='<?php echo xla('Any part of the document name'); ?>' />
+                <div class="col">
+                    <input class='btn btn-primary btn-sm' type='submit' id="submitbtn" value='<?php echo htmlspecialchars(xl('Search'), ENT_QUOTES); ?>' />
+                    <div id="searchspinner"><img src="<?php echo $GLOBALS['webroot'] ?>/interface/pic/ajax-loader.gif" /></div>
+                </div>
+            </div>
+            <input type="hidden" name="csrf_token_form" value="<?php echo attr(CsrfUtils::collectCsrfToken()); ?>" />
+        </form>
+    </div>
+
+    <?php if (! isset($_REQUEST['searchparm'])) : ?>
+        <div id="searchstatus"><?php echo htmlspecialchars(xl('Enter your search criteria above'), ENT_NOQUOTES); ?></div>
+    <?php elseif (! is_countable($result)) : ?>
+        <div id="searchstatus" class="alert alert-danger rounded-0"><?php echo htmlspecialchars(xl('No records found. Please expand your search criteria.'), ENT_NOQUOTES); ?>
+        </div>
+    <?php elseif (count($result) >= $MAX_RECORDS) : ?>
+        <div id="searchstatus" class="alert alert-danger rounded-0"><?php echo htmlspecialchars(xl('More records found than could be displayed. Please narrow your search criteria.'), ENT_NOQUOTES); ?></div>
+    <?php elseif (count($result) < $MAX_RECORDS) : ?>
+        <div id="searchstatus" class="alert alert-success rounded-0"><?php echo htmlspecialchars(count($result), ENT_NOQUOTES); ?> <?php echo htmlspecialchars(xl('records found.'), ENT_NOQUOTES); ?></div>
+    <?php endif; ?>
+
+    <?php if (isset($result)) : ?>
+        <table class="table table-sm">
+            <thead id="searchResultsHeader" class="head">
+            <tr>
+                <th class="srName"><?php echo htmlspecialchars(xl('Name'), ENT_NOQUOTES); ?></th>
+                <th class="srCategory"><?php echo htmlspecialchars(xl('Category'), ENT_NOQUOTES); ?></th> <!-- (CHEMED) Search by phone number -->
+                <th class="srDate"><?php echo htmlspecialchars(xl('Date'), ENT_NOQUOTES); ?></th>
+                <th class="srID"><?php echo htmlspecialchars(xl('ID'), ENT_NOQUOTES); ?></th>
+            </tr>
+            </thead>
+            <tbody id="searchResults">
+            <?php
+            if (is_countable($result)) {
+                foreach ($result as $iter) {
+                    $name   = $iter['name'];
+                    $category = $iter['category_name'];
+                    $date = $iter['date'];
+                    $id = $iter['id'];
+
+                    // If billing note exists, then it gets special coloring and an extra line of output
+                    // in the 'name' column.
+                    $trClass = "oneresult";
+
+                    echo " <tr class='" . $trClass . "' id='" . attr($id) . "' data-name='" . attr($name)
+                        . "' data-category=" . attr($category) . "' data-date='" . attr($date) . "'>";
+                    echo "  <td class='srName'>" . text($name) . "</td>\n";
+                    echo "  <td class='srCategory'>" . text($category) . "</td>\n";
+                    echo "  <td class='srDate'>" . text($date) . "</td>\n";
+                    echo "  <td class='srID'>" . text($id) . "</td>\n";
+                    echo " </tr>";
+                }
+            }
+            ?>
+            </tbody>
+        </table>
+
+    <?php endif; ?>
+
+    <script>
+
+        // jQuery stuff to make the page a little easier to use
+
+        $(function () {
+            $("#searchparm").focus();
+            $(".oneresult").click(function() { selectDocumentEventHandler(this); });
+            //ViSolve
+            $(".noresult").click(function () { SubmitForm(this);});
+
+            //$(".event").dblclick(function() { EditEvent(this); });
+            $("#theform").submit(function() { SubmitForm(this); });
+        });
+
+        function selectDocument(did, name, category, date) {
+            if (opener.closed || ! opener.setSelectedDocument)
+                alert("<?php echo htmlspecialchars(xl('The destination form was closed; I cannot act on your selection.'), ENT_QUOTES); ?>");
+            else
+                opener.setSelectedDocument(did, name, category, date);
+            dlgclose();
+            return false;
+        }
+
+        // show the 'searching...' status and submit the form
+        var SubmitForm = function(eObj) {
+            $("#submitbtn").css("disabled", "true");
+            $("#searchspinner").css("visibility", "visible");
+            return true;
+        }
+
+
+        // another way to select a patient from the list of results
+        // parts[] ==>  0=PID, 1=LName, 2=FName, 3=DOB
+        var selectDocumentEventHandler = function (eObj) {
+            objID = eObj.id;
+            let docId = eObj.id;
+            let category = eObj.dataset['category'] || "";
+            let name = eObj.dataset['name'] || "";
+            let date = eObj.dataset['date'] || "";
+            return selectDocument(docId, name, category, date);
+        }
+
+    </script>
+
+</div>
+</body>
+</html>

--- a/interface/main/messages/js/trusted-messages.js
+++ b/interface/main/messages/js/trusted-messages.js
@@ -108,6 +108,8 @@
     }
     function sendTrustedMessage(event) {
         event.preventDefault();
+        // reset any alerts back to what they were
+        hideAlerts();
         const formData = new FormData(event.target);
         if (!validateForm(formData)) {
             return;

--- a/interface/main/messages/js/trusted-messages.js
+++ b/interface/main/messages/js/trusted-messages.js
@@ -1,0 +1,214 @@
+/**
+ * trusted-messages.js handles all of the frontend validation and backend communications for sending messages using the
+ * Direct protocol
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2022 Discover and Change <snielson@discoverandchange.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+(function() {
+    function hideAlerts() {
+        let alerts = document.querySelectorAll(('.alert'));
+        let length = alerts.length;
+        alerts.forEach(function(item) {
+            item.classList.add('d-none');
+        });
+    }
+    function showAlert(alertId) {
+        hideAlerts();
+        let alert = document.getElementById(alertId);
+        if (!alert) {
+            alert = document.getElementById('error-serverError');
+            if (!alert) {
+                console.error("HTML dom element for error-serverError is missing from system");
+                return;
+            }
+        }
+
+        if (alert) {
+            alert.classList.remove("d-none");
+        } else {
+
+            console.error("Failed to find dom node alert with id " + alertId);
+        }
+    }
+
+    function processTrustedMessageResponse(data) {
+        hideAlerts();
+        console.log(data);
+        if (data.errorCode) {
+            showAlert('error-' + data.errorCode);
+            if (data.errorCode && data.errorMessage) {
+                let errorMessage = document.getElementById('directErrorMessage');
+                if (errorMessage) {
+                    // we use innerText as we want don't want any HTML or script being executed
+                    errorMessage.innerText = data.errorMessage;
+                }
+            }
+            // we don't want to do anything else here
+            return;
+        }
+        showAlert('success');
+        // save off the csrf, reset the form and then reset it
+        let form = window.document.forms[0];
+        let csrfNode = document.querySelector("form input[name='csrf']");
+        let csrfValue = "";
+        if (csrfNode) {
+            csrfValue = csrfNode.value;
+        }
+        form.reset();
+        if (csrfNode) {
+            csrfNode.value = csrfValue;
+        }
+    }
+    function validateForm(formData) {
+        if (!(formData.has('message') && formData.has('documentId')))
+        {
+            console.error("Failed to find message and documentId inputs in form");
+            showAlert('error-serverError');
+            return false;
+        }
+
+        let message = formData.get("message") || "";
+        let documentId = +(formData.get("documentId") || 0);
+
+        if (message.trim() == "" && (isNaN(documentId) || documentId < 1)) {
+            showAlert("error-validation-failed");
+            return false;
+        }
+
+        if (!formData.has('trusted_email'))
+        {
+            console.error("Failed to find trusted_email inputs in form");
+            showAlert('error-serverError');
+            return false;
+        }
+        let trusted_email = formData.get("trusted_email") || "";
+        if (trusted_email.trim() == "") {
+            showAlert("error-validation-failed");
+            return false;
+        }
+
+        if (!formData.has('pid'))
+        {
+            console.error("Failed to find pid inputs in form");
+            showAlert('error-serverError');
+            return false;
+        }
+
+        let pid = +(formData.get("pid") || 0);
+
+        if (isNaN(pid) || pid < 1) {
+            showAlert("error-validation-failed");
+            return false;
+        }
+
+        return true;
+    }
+    function sendTrustedMessage(event) {
+        event.preventDefault();
+        const formData = new FormData(event.target);
+        if (!validateForm(formData)) {
+            return;
+        }
+
+
+        window.fetch("trusted-messages-ajax.php", {method: 'POST', body: formData})
+            .then(result => {
+                if (result.ok) {
+                    return result.json();
+                } else {
+                    return Promise.reject();
+                }
+            })
+            .then(json => {
+                processTrustedMessageResponse(json);
+            })
+            .catch(error => {
+                console.error(error);
+                processTrustedMessageResponse({errorCode: "networkError"});
+            });
+        return false;
+    }
+
+    // This is for callback by the find-patient popup.
+    function setpatient(pid, lname, fname, dob) {
+        var patientNameNode = document.getElementById("patientName");
+        var pidNode = document.getElementById("patientPid");
+        if (pidNode) {
+            pidNode.value = pid;
+        } else {
+            console.error("Could not find pid node");
+        }
+        if (patientNameNode) {
+            patientNameNode.value = fname + " " + lname;
+        } else {
+            console.error("Could not find patientName node");
+        }
+        window.top.restoreSession();
+    }
+
+
+    function selectPatient() {
+        dlgopen('../../main/calendar/find_patient_popup.php', '_blank', 625, 400);
+    }
+
+    function selectDocument() {
+        let pidInput = document.getElementById('patientPid');
+        let csrfNode = document.querySelector("form input[name='csrf_token_form']");
+        let csrfValue = "";
+        if (csrfNode) {
+            csrfValue = csrfNode.value;
+        } else {
+            console.error("Failed to find csrf node");
+            return;
+        }
+
+        let url = "../../main/finder/document_select.php?csrf_token_form="
+            + encodeURIComponent(csrfValue);
+        if (pidInput) {
+            url += "&pid=" + encodeURIComponent(pidInput.value);
+        } else {
+
+        }
+        window.dlgopen(url, '_blank', 700, 400);
+    }
+
+    function setSelectedDocument(did, docName, categoryName, date) {
+        let documentIdInput = document.getElementById('documentId');
+        let documentNameInput = document.getElementById('documentName');
+        if (documentIdInput) {
+            documentIdInput.value = did;
+        }
+        if (documentNameInput)
+        {
+            // TODO: do we want to put category here somewhere?
+            documentNameInput.value = docName;
+        }
+    }
+
+    function initDocument() {
+        let form = document.getElementById('trustedForm');
+        if (form) {
+            form.addEventListener('submit', sendTrustedMessage);
+        } else {
+            console.error("Could not find form to submit");
+        }
+        var patientNameNode = document.getElementById("patientName");
+        if (patientNameNode)
+        {
+            patientNameNode.addEventListener('click', selectPatient);
+        }
+        var documentNameNode = document.getElementById("documentName");
+        if (documentNameNode) {
+            documentNameNode.addEventListener('click', selectDocument);
+        }
+    }
+
+    window.addEventListener('DOMContentLoaded', initDocument);
+
+    // we add these to the global scope as the patient dialog popups need to be able to find them.
+    window.setpatient = setpatient;
+    window.setSelectedDocument = setSelectedDocument;
+})(window);

--- a/interface/main/messages/js/trusted-messages.js
+++ b/interface/main/messages/js/trusted-messages.js
@@ -112,7 +112,7 @@
         if (!validateForm(formData)) {
             return;
         }
-
+        toggleSubmitSpinner(true);
 
         window.fetch("trusted-messages-ajax.php", {method: 'POST', body: formData})
             .then(result => {
@@ -123,13 +123,38 @@
                 }
             })
             .then(json => {
+                toggleSubmitSpinner(false);
                 processTrustedMessageResponse(json);
             })
             .catch(error => {
                 console.error(error);
+                toggleSubmitSpinner(false);
                 processTrustedMessageResponse({errorCode: "networkError"});
             });
         return false;
+    }
+
+    function toggleSubmitSpinner(display) {
+
+        let spinner = document.getElementById('message-spinner');
+        let submitButton = document.getElementById('message-submit');
+
+        if (spinner) {
+            if (display) {
+                spinner.classList.remove('d-none');
+            } else {
+                spinner.classList.add('d-none');
+            }
+        }
+
+        if (submitButton) {
+            if (display) {
+                submitButton.disabled = true;
+            } else {
+                submitButton.disabled = false;
+            }
+        }
+
     }
 
     // This is for callback by the find-patient popup.

--- a/interface/main/messages/js/trusted-messages.js
+++ b/interface/main/messages/js/trusted-messages.js
@@ -115,6 +115,7 @@
             return;
         }
         toggleSubmitSpinner(true);
+        window.top.restoreSession();
 
         window.fetch("trusted-messages-ajax.php", {method: 'POST', body: formData})
             .then(result => {
@@ -173,11 +174,11 @@
         } else {
             console.error("Could not find patientName node");
         }
-        window.top.restoreSession();
     }
 
 
     function selectPatient() {
+        window.top.restoreSession();
         dlgopen('../../main/calendar/find_patient_popup.php', '_blank', 625, 400);
     }
 
@@ -196,9 +197,8 @@
             + encodeURIComponent(csrfValue);
         if (pidInput) {
             url += "&pid=" + encodeURIComponent(pidInput.value);
-        } else {
-
         }
+        window.top.restoreSession();
         window.dlgopen(url, '_blank', 700, 400);
     }
 

--- a/interface/main/messages/messages.php
+++ b/interface/main/messages/messages.php
@@ -683,7 +683,12 @@ if (!empty($_REQUEST['go'])) { ?>
 
                                                 <div class=\"col-12 col-md-12 col-lg-12\"><a href=\"messages.php?showall=" . attr_url($showall) . "&sortby=" . attr_url($sortby) . "&sortorder=" . attr_url($sortorder) . "&begin=" . attr_url($begin) . "&task=addnew&$activity_string_html\" class=\"btn btn-primary btn-add\" onclick=\"top.restoreSession()\">" .
                                                 xlt('Add New{{Message}}') . "</a> &nbsp; <a href=\"javascript:confirmDeleteSelected()\" class=\"btn btn-danger btn-delete\" onclick=\"top.restoreSession()\">" .
-                                                xlt('Delete') . "</a>
+                                                xlt('Delete') . "</a>";
+
+                            if ($GLOBALS['phimail_enable']) {
+                                echo "&nbsp; <a href='trusted-messages.php' onclick='top.restoreSession()' class='btn btn-secondary btn-mail'>" . xlt("Compose Trusted Direct Message") . "</a>";
+                            }
+                            echo "
                                                 <div  class=\"text-right\">$prevlink &nbsp; " . text($end) . " " . xlt('of') . " " . text($total) . " &nbsp; $nextlink</div>
                                                 </div>
                                             </div>

--- a/interface/main/messages/messages.php
+++ b/interface/main/messages/messages.php
@@ -499,12 +499,18 @@ if (!empty($_REQUEST['go'])) { ?>
                                                 echo "  <td class='text'><span class='font-weight-bold'>" . xlt('Linked document') . ":</span>\n";
                                                 while ($gprow = sqlFetchArray($tmp)) {
                                                     $d = new Document($gprow['id1']);
-                                                    $enc_list = sqlStatement("SELECT fe.encounter,fe.date,openemr_postcalendar_categories.pc_catname FROM form_encounter AS fe " .
-                                                        " LEFT JOIN openemr_postcalendar_categories ON fe.pc_catid=openemr_postcalendar_categories.pc_catid  WHERE fe.pid = ? ORDER BY fe.date DESC", array($prow['pid']));
-                                                    $str_dob = xl("DOB") . ":" . $prow['DOB'] . " " . xl("Age") . ":" . getPatientAge($prow['DOB']);
-                                                    $pname = $prow['fname'] . " " . $prow['lname'];
                                                     echo "<a href='javascript:void(0);' ";
-                                                    echo "onClick=\"gotoReport(" . attr(addslashes($d->get_id())) . ",'" . attr(addslashes($pname)) . "'," . attr(addslashes($prow['pid'])) . "," . attr(addslashes($prow['pubpid'] ?? $prow['pid'])) . ",'" . attr(addslashes($str_dob)) . "');\">";
+                                                    if (empty($prow)) {
+                                                        // when a direct message is received we can't open the document unless its linked to a patient.
+                                                        echo "onClick=\"previewDocument('" . attr(addslashes($d->get_id())) . "');\">";
+                                                    } else {
+                                                        $enc_list = sqlStatement("SELECT fe.encounter,fe.date,openemr_postcalendar_categories.pc_catname FROM form_encounter AS fe " .
+                                                            " LEFT JOIN openemr_postcalendar_categories ON fe.pc_catid=openemr_postcalendar_categories.pc_catid  WHERE fe.pid = ? ORDER BY fe.date DESC", array($prow['pid']));
+                                                        $str_dob = xl("DOB") . ":" . $prow['DOB'] . " " . xl("Age") . ":" . getPatientAge($prow['DOB']);
+                                                        $pname = $prow['fname'] . " " . $prow['lname'];
+
+                                                        echo "onClick=\"gotoReport(" . attr(addslashes($d->get_id())) . ",'" . attr(addslashes($pname)) . "'," . attr(addslashes($prow['pid'])) . "," . attr(addslashes($prow['pubpid'] ?? $prow['pid'])) . ",'" . attr(addslashes($str_dob)) . "');\">";
+                                                    }
                                                     echo text($d->get_name()) . "-" . text($d->get_id());
                                                     echo "</a>\n";
                                                 }
@@ -998,6 +1004,18 @@ if (!empty($_REQUEST['go'])) { ?>
             $("#task").val("");
             $("#new_note").submit();
         };
+
+        /**
+         * Given a document that we don't know what patient to attach the document to we need to look at a preview of
+         * the document.  This loads up the document from the Miscellaneous -> New Documents page.  To access the page
+         * the user must have the following ACLs:  "patients","docs","write","addonly"
+         * @param doc_id The id of the document we want to preview in OpenEMR
+         */
+        function previewDocument(doc_id) {
+            top.restoreSession();
+            var docurl = '../controller.php?document&view' + "&patient_id=0&document_id=" + encodeURIComponent(doc_id) + "&";
+            parent.left_nav.loadFrame('adm0', 'msc', docurl);
+        }
 
         function gotoReport(doc_id, pname, pid, pubpid, str_dob) {
             EncounterDateArray = [];

--- a/interface/main/messages/messages.php
+++ b/interface/main/messages/messages.php
@@ -502,7 +502,7 @@ if (!empty($_REQUEST['go'])) { ?>
                                                     echo "<a href='javascript:void(0);' ";
                                                     if (empty($prow)) {
                                                         // when a direct message is received we can't open the document unless its linked to a patient.
-                                                        echo "onClick=\"previewDocument('" . attr(addslashes($d->get_id())) . "');\">";
+                                                        echo "onClick=\"previewDocument(" . attr_js($d->get_id()) . ");\">";
                                                     } else {
                                                         $enc_list = sqlStatement("SELECT fe.encounter,fe.date,openemr_postcalendar_categories.pc_catname FROM form_encounter AS fe " .
                                                             " LEFT JOIN openemr_postcalendar_categories ON fe.pc_catid=openemr_postcalendar_categories.pc_catid  WHERE fe.pid = ? ORDER BY fe.date DESC", array($prow['pid']));

--- a/interface/main/messages/trusted-messages-ajax.php
+++ b/interface/main/messages/trusted-messages-ajax.php
@@ -63,12 +63,14 @@ if (!CsrfUtils::verifyCsrfToken($csrf)) {
             throw new InvalidArgumentException("document_id is required if no message is sent and must be a valid document id");
         }
 
-        // now we need to lookup the document
-        $document = new \Document($documentId);
+        if (!empty($documentId) && intval($documentId) > 0) {
+            // now we need to lookup the document
+            $document = new \Document($documentId);
 
-        // make sure the user can access this document
-        if (!$document->can_access($_SESSION['user_id'])) {
-            throw new AccessDeniedException("patients", "demo", "Access to patient data is denied");
+            // make sure the user can access this document
+            if (!$document->can_access($_SESSION['user_id'])) {
+                throw new AccessDeniedException("patients", "demo", "Access to patient data is denied");
+            }
         }
         $isValid = true;
     } catch (AccessDeniedException $exception) {

--- a/interface/main/messages/trusted-messages-ajax.php
+++ b/interface/main/messages/trusted-messages-ajax.php
@@ -12,7 +12,6 @@
 
 require_once("../../globals.php");
 require_once("../../../ccr/transmitCCD.php");
-require_once("../../../library/classes/Document.class.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Logging\SystemLogger;

--- a/interface/main/messages/trusted-messages-ajax.php
+++ b/interface/main/messages/trusted-messages-ajax.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * trusted-messages-ajax.php takes data from the POST/GET request, validates the data and then sends a message via the
+ * Direct protocol to the trusted email address.  Results / errors are returned via JSON
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2022 Discover and Change <snielson@discoverandchange.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+require_once("../../globals.php");
+require_once("../../../ccr/transmitCCD.php");
+require_once("../../../library/classes/Document.class.php");
+
+use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Services\PatientService;
+use OpenEMR\Common\Acl\AccessDeniedException;
+
+$result = ['success' => false];
+
+$csrf = $_REQUEST['csrf_token_form'] ?? null;
+if (!CsrfUtils::verifyCsrfToken($csrf)) {
+    $result['errorCode'] = 'invalidCsrf';
+    $isValid = false;
+} else {
+    $document = null;
+
+    try {
+        $pid = $_REQUEST['pid'] ?? null;
+
+        if (empty($pid) || intval($pid) <= 0) {
+            throw new InvalidArgumentException("pid is required and must be a valid patient id");
+        }
+        $patientService = new PatientService();
+        $patient = $patientService->findByPid($pid);
+        if (empty($patient)) {
+            throw new InvalidArgumentException("pid is required and must be a valid patient id");
+        }
+
+        $requested_by = $_SESSION['authUser'];
+        if (empty($requested_by)) {
+            throw new AccessDeniedException("patients", "demo", "authUser was missing and could not validate sender");
+        }
+
+        $recipient = $_REQUEST['trusted_email'] ?? null;
+        if (empty($recipient)) {
+            throw new InvalidArgumentException("trusted_email is required and must be a valid Direct email address");
+        }
+
+        $documentId = $_REQUEST['documentId'] ?? null;
+        $message = $_REQUEST['message'] ?? '';
+        if ((empty($documentId) || intval($documentId) <= 0) && empty($message)) {
+            throw new InvalidArgumentException("document_id is required if no message is sent and must be a valid document id");
+        }
+
+        // now we need to lookup the document
+        $document = new \Document($documentId);
+
+        // make sure the user can access this document
+        if (!$document->can_access($_SESSION['user_id'])) {
+            throw new AccessDeniedException("patients", "demo", "Access to patient data is denied");
+        }
+        $isValid = true;
+    } catch (AccessDeniedException $exception) {
+        http_response_code(401);
+        $result['errorCode'] = 'permissionDenied';
+        $isValid = false;
+        (new SystemLogger())->error("Access was denied", ['trace' => $error->getTraceAsString(), 'message' => $error->getMessage()]);
+    } catch (\Exception $error) {
+        $result['errorCode'] = 'invalidRequest';
+        (new SystemLogger())->error("Data was invalid", ['trace' => $error->getTraceAsString(), 'message' => $error->getMessage()]);
+        $isValid = false;
+    }
+}
+
+if ($isValid) {
+    try {
+        if (empty($document)) {
+            $transmitResult = transmitMessage($message, $recipient);
+        } else {
+            $dataToSend = $document->get_data();
+            $transmitResult = transmitCCD($pid, $dataToSend, $recipient, $requested_by, $xml_type = "CCD", 'xml', $message);
+        }
+        if ($transmitResult !== "SUCCESS") {
+            $result['errorCode'] = 'directError';
+            $result['errorMessage'] = $transmitResult;
+        } else {
+            $result['success'] = true;
+        }
+    } catch (\Exception $error) {
+        (new SystemLogger())->error(
+            "transmitCCD threw an exception when attempting to send",
+            ['trace' => $error->getTraceAsString(), 'message' => $error->getMessage(), 'pid' => $pid
+                , 'document' => $documentId, 'requestor' => $requested_by, 'recipient' => $recipient
+            ]
+        );
+        $result['errorCode'] = 'serverError';
+    }
+}
+
+try {
+    (new SystemLogger())->debug("trusted-messages-ajax.php result object", $result);
+    echo json_encode($result, JSON_THROW_ON_ERROR);
+} catch (\Exception $error) {
+    (new SystemLogger())->error("Failed to encode json response", ['trace' => $error->getTraceAsString(), 'message' => $error->getMessage(), 'result' => $result]);
+    http_response_code(500);
+}
+exit;

--- a/interface/main/messages/trusted-messages-ajax.php
+++ b/interface/main/messages/trusted-messages-ajax.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * trusted-messages-ajax.php takes data from the POST/GET request, validates the data and then sends a message via the
  * Direct protocol to the trusted email address.  Results / errors are returned via JSON

--- a/interface/main/messages/trusted-messages.php
+++ b/interface/main/messages/trusted-messages.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * trusted-messages.php displays the GUI and handles the interactions with the backend ajax processor for sending
+ * messages and file attachments to Trusted email addresses using the Direct protocol.
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2022 Discover and Change <snielson@discoverandchange.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+use OpenEMR\Core\Header;
+use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\OeUI\OemrUI;
+use OpenEMR\Services\PatientService;
+
+require_once("../../globals.php");
+
+$message = '';
+if (isset($_REQUEST['message_code'])) {
+    $message_code = $_REQUEST['message_code'] ?? null;
+    switch ($message_code) {
+        case 'success':
+            $message = xlt("Trusted message was sent");
+            break;
+    }
+}
+
+// check if we have a selected patient already
+$pid = "";
+$patientName = "";
+if (!empty($_SESSION['pid'])) {
+    $patientService = new PatientService();
+    $patientArray = $patientService->findByPid($_SESSION['pid']);
+    if (!empty($patientArray)) {
+        $pid = $_SESSION['pid'];
+        // if things are empty this ends up being blank.
+        $patientName = trim(($patientArray['fname'] ?? '') . ' ' . ($patientArray['lname'] ?? ''));
+    }
+}
+
+if ($GLOBALS['medex_enable'] == '1') {
+    if ($_REQUEST['SMS_bot']) {
+        $result = $MedEx->login('');
+        $MedEx->display->SMS_bot($result);
+        exit();
+    }
+    $logged_in = $MedEx->login();
+} else {
+    $logged_in = null;
+}
+
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <?php Header::setupHeader(['datetime-picker', 'opener', 'moment', 'select2']); ?>
+    <link rel="stylesheet" href="<?php echo $webroot; ?>/interface/main/messages/css/reminder_style.css?v=<?php echo $v_js_includes; ?>">
+
+    <?php
+
+    $arrOeUiSettings = array(
+        'heading_title' => xlt('Messages, Reminders, Recalls'),
+        'include_patient_name' => false,// use only in appropriate pages
+        'expandable' => false,
+        'expandable_files' => array(""),//all file names need suffix _xpd
+        'action' => "",//conceal, reveal, search, reset, link or back
+        'action_title' => "",
+        'action_href' => "",//only for actions - reset, link or back
+        'show_help_icon' => false,
+//        'help_file_name' => ""
+    );
+    $oemr_ui = new OemrUI($arrOeUiSettings);
+
+    echo "<title>" .  xlt('Messages, Reminders, Recalls') . "</title>";
+    ?>
+    <script src="js/trusted-messages.js" type="text/javascript"></script>
+</head>
+<body class='body_top'>
+    <div id="container_div" class="<?php echo attr($oemr_ui->oeContainer()); ?>">
+        <div class="row">
+            <div class="col-sm-12">
+                <div class="clearfix">
+                    <?php echo  $oemr_ui->pageHeading() . "\r\n"; ?>
+                </div>
+            </div>
+        </div>
+        <div class="container-fluid mb-3">
+            <ul class="nav nav-pills">
+                <li class="nav-item" id='li-mess'>
+                    <a href='messages.php' class="active nav-link font-weight-bold" id='messages-li'><?php echo xlt('Back to Messages'); ?></a>
+                </li>
+            </ul>
+        </div>
+        <div class="container-fluid mb-3">
+            <div class="row" id="messages-div">
+                <div class="col-sm-12">
+                    <form class="jumbotron jumbotron-fluid p-3" id="trustedForm">
+                        <h4><?php echo text("Create New Trusted Direct Message"); ?></h4>
+
+                        <div class="row">
+                            <div id="error-validation-failed" class="col-12 d-none alert alert-danger">
+                                <p>
+                                    <?php echo xlt("One or more required fields are missing in order to send your message"); ?>.
+                                    <?php echo xlt("The following fields are required to send your message"); ?>.
+                                </p>
+                                <ul>
+                                    <li><?php echo xlt("Trusted Email Address"); ?></li>
+                                    <li><?php echo xlt("Patient"); ?></li>
+                                    <li><?php echo xlt("Message or an attached document"); ?></li>
+                                </ul>
+                            </div>
+                            <div id='error-serverError' class="col-12 d-none alert alert-danger">
+                                <p>
+                                    <?php echo xlt("There was an unknown system error"); ?>.
+                                    <?php echo xlt("Check the server logs for more details"); ?>.
+                                </p>
+                            </div>
+                            <div id='error-networkError' class="col-12 d-none alert alert-danger">
+                                <p>
+                                    <?php echo xlt("There was an error in communicating with the network"); ?>.
+                                    <?php echo xlt("Please try again or check your internet connection"); ?>.
+                                    <?php echo xlt("Contact support if you continue to have issues"); ?>.
+                                </p>
+                            </div>
+                            <div id='error-directError' class="col-12 d-none alert alert-danger">
+                                <p>
+                                    <?php echo xlt("There was an error in sending the message to your target recipient"); ?>.
+                                </p>
+
+                                <p id="directErrorMessage">
+                                </p>
+                            </div>
+                            <div id='success' class="col-12 d-none alert alert-success">
+                                <p>
+                                    <?php echo xlt("Your message was successfully sent"); ?>.
+                                </p>
+
+                                <p id="directErrorMessage">
+                                </p>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-12 oe-custom-line">
+                                <div class="row">
+                                    <div class="col-6 col-md-4">
+                                        <label class='font-weight-bold' for="patientName"><?php echo xlt('Patient'); ?></label>
+                                        <input id="patientName" class="form-control" type="textbox" name="patientName" value="<?php echo attr($patientName); ?>" placeholder="<?php echo xla('Choose a patient'); ?>" readonly />
+                                        <input id="patientPid" type="hidden" name="pid" value="<?php echo attr($pid); ?>" />
+                                    </div>
+                                    <div class="col-6 col-md-8 d-flex align-items-end flex-wrap">
+                                        <label class='font-weight-bold' for="trusted_email"><?php echo xlt("To (Trusted Email Address)"); ?>*</label>
+                                        <input class="form-control" type="textbox" name="trusted_email" value="" />
+                                        <?php
+                                        // TODO: good future improvement is to allow selecting the address from the address book
+                                        ?>
+                                        <input class="btn btn-secondary d-none" type="button" value="<?php xla('Open Address Book'); ?>" />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-12 oe-custom-line">
+                                <div class="row">
+                                    <div class="col-12">
+                                        <label><?php echo xlt("Message"); ?></label><textarea class="form-control" name="message"></textarea>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-12 oe-custom-line">
+                                <div class="row">
+                                    <div class="col-12">
+                                        <label for="documentName"><?php echo xlt("Attachment"); ?></label>
+                                        <input id="documentId" type="hidden" name="documentId" value="" />
+                                        <input id="documentName" class="form-control" type="textbox" name="documentName" value="" placeholder="<?php echo xla('Choose a document to attach'); ?>" />
+                                        <p class="alert alert-info mt-2"><?php echo xlt("CCD/CCR/CCDA Documents must be in a xml,html, or pdf format in order to send via Direct"); ?></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-12 oe-custom-line">
+                                <div class="row">
+                                    <div class="col-12">
+                                        <input type="hidden" name="csrf_token_form" value="<?php echo CsrfUtils::collectCsrfToken(); ?>" />
+                                        <input type="submit" class="btn-transmit btn btn-primary" name="submit" value="<?php echo xla("Send"); ?>" />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/interface/main/messages/trusted-messages.php
+++ b/interface/main/messages/trusted-messages.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * trusted-messages.php displays the GUI and handles the interactions with the backend ajax processor for sending
  * messages and file attachments to Trusted email addresses using the Direct protocol.

--- a/interface/main/messages/trusted-messages.php
+++ b/interface/main/messages/trusted-messages.php
@@ -10,12 +10,12 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+require_once("../../globals.php");
+
 use OpenEMR\Core\Header;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\OeUI\OemrUI;
 use OpenEMR\Services\PatientService;
-
-require_once("../../globals.php");
 
 $message = '';
 if (isset($_REQUEST['message_code'])) {
@@ -38,17 +38,6 @@ if (!empty($_SESSION['pid'])) {
         // if things are empty this ends up being blank.
         $patientName = trim(($patientArray['fname'] ?? '') . ' ' . ($patientArray['lname'] ?? ''));
     }
-}
-
-if ($GLOBALS['medex_enable'] == '1') {
-    if ($_REQUEST['SMS_bot']) {
-        $result = $MedEx->login('');
-        $MedEx->display->SMS_bot($result);
-        exit();
-    }
-    $logged_in = $MedEx->login();
-} else {
-    $logged_in = null;
 }
 
 ?>
@@ -201,7 +190,7 @@ if ($GLOBALS['medex_enable'] == '1') {
                             <div class="col-12 oe-custom-line">
                                 <div class="row">
                                     <div class="col-12">
-                                        <input type="hidden" name="csrf_token_form" value="<?php echo CsrfUtils::collectCsrfToken(); ?>" />
+                                        <input type="hidden" name="csrf_token_form" value="<?php echo attr(CsrfUtils::collectCsrfToken()); ?>" />
                                         <input id='message-submit' type="submit" class="btn-transmit btn btn-primary" name="submit" value="<?php echo xla("Send"); ?>" />
                                         <i id='message-spinner' class="fa fa-spinner d-none"></i>
                                     </div>

--- a/interface/main/messages/trusted-messages.php
+++ b/interface/main/messages/trusted-messages.php
@@ -132,6 +132,21 @@ if ($GLOBALS['medex_enable'] == '1') {
                                 <p id="directErrorMessage">
                                 </p>
                             </div>
+                            <div id="error-invalidDocumentFormat" class="col-12 d-none alert alert-danger">
+                                <p>
+                                    <?php echo xlt("The system received a document it does not know how to process through the Direct protocol"); ?>.
+                                    <?php echo xlt("Supported document mime types are the following"); ?>.
+                                </p>
+                                <ul>
+                                    <?php /* We don't translate these as they don't change across languages */ ?>
+                                    <li>application/pdf</li>
+                                    <li>application/xml</li>
+                                    <li>text/xml</li>
+                                </ul>
+
+                                <p id="directErrorMessage">
+                                </p>
+                            </div>
                             <div id='success' class="col-12 d-none alert alert-success">
                                 <p>
                                     <?php echo xlt("Your message was successfully sent"); ?>.
@@ -176,7 +191,7 @@ if ($GLOBALS['medex_enable'] == '1') {
                                         <label for="documentName"><?php echo xlt("Attachment"); ?></label>
                                         <input id="documentId" type="hidden" name="documentId" value="" />
                                         <input id="documentName" class="form-control" type="textbox" name="documentName" value="" placeholder="<?php echo xla('Choose a document to attach'); ?>" />
-                                        <p class="alert alert-info mt-2"><?php echo xlt("CCD/CCR/CCDA Documents must be in a xml,html, or pdf format in order to send via Direct"); ?></p>
+                                        <p class="alert alert-info mt-2"><?php echo xlt("CCD/CCR/CCDA Documents must be in a xml or pdf format in order to send via Direct"); ?></p>
                                     </div>
                                 </div>
                             </div>
@@ -186,7 +201,8 @@ if ($GLOBALS['medex_enable'] == '1') {
                                 <div class="row">
                                     <div class="col-12">
                                         <input type="hidden" name="csrf_token_form" value="<?php echo CsrfUtils::collectCsrfToken(); ?>" />
-                                        <input type="submit" class="btn-transmit btn btn-primary" name="submit" value="<?php echo xla("Send"); ?>" />
+                                        <input id='message-submit' type="submit" class="btn-transmit btn btn-primary" name="submit" value="<?php echo xla("Send"); ?>" />
+                                        <i id='message-spinner' class="fa fa-spinner d-none"></i>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
Fixes #5220 
Fixes #5229

Implemented the ability to send messages w/o attachments via the EMR
Direct service over the Direct protocol.

Built the ability to select a document that has been uploaded to the
system and send it via EMRDirect.

Built a document finder dialog window so that you can select a patient
or non-patient document using the finder.  It checks against the current
user's ACLs and the document category's acos to determine if the user
can see the document.  It only shows 25 results at a time and requires
the user to be more specific in their search if they want to see more.
By default it displays the most recent documents uploaded.

Made it so we can send a pdf attachment via direct.

Validated the mime types and reject any document that can't be sent via
Direct.  Interestingly direct supports sending HTML but our default
OpenEMR whitelist doesn't allow it.