### PR TITLE
clarify the can_access() function

### DIFF
--- a/_rest_routes.inc.php
+++ b/_rest_routes.inc.php
@@ -8596,7 +8596,7 @@ RestConfig::$FHIR_ROUTE_MAP = array(
 
         // Grab the document id
         $docController = new \OpenEMR\RestControllers\FHIR\FhirDocumentRestController($request);
-        $response = $docController->downloadDocument($documentId, $request->getRequestUserId());
+        $response = $docController->downloadDocument($documentId);
         return $response;
     },
 

--- a/interface/main/finder/document_select.php
+++ b/interface/main/finder/document_select.php
@@ -74,7 +74,7 @@ if (!empty($searchparm)) {
 $result = [];
 foreach ($searchResult as $docResult) {
     $document = new \Document($docResult['id']);
-    if ($document->can_access($_SESSION['user_id'])) {
+    if ($document->can_access()) {
         $result[] = $docResult;
     }
 }

--- a/interface/main/messages/trusted-messages-ajax.php
+++ b/interface/main/messages/trusted-messages-ajax.php
@@ -67,7 +67,7 @@ if (!CsrfUtils::verifyCsrfToken($csrf)) {
             $document = new \Document($documentId);
 
             // make sure the user can access this document
-            if (!$document->can_access($_SESSION['user_id'])) {
+            if (!$document->can_access()) {
                 throw new AccessDeniedException("patients", "demo", "Access to patient data is denied");
             }
         }

--- a/library/classes/Document.class.php
+++ b/library/classes/Document.class.php
@@ -282,10 +282,10 @@ class Document extends ORDataObject
      * permissions for the categories the document is in.  If there are any categories that the document is tied to
      * that the owner does NOT have access rights to, the request is denied.  If there are no categories tied to the
      * document, default access is granted.
-     * @param int|null $user  The user we are checking.  If no user is provided it checks against the currently logged in user
+     * @param string|null $username The user (username) we are checking.  If no user is provided it checks against the currently logged in user
      * @return bool True if the passed in user or current user can access this document, false otherwise.
      */
-    public function can_access($user = null)
+    public function can_access($username = null)
     {
         $categories = $this->get_categories();
 
@@ -296,7 +296,7 @@ class Document extends ORDataObject
 
         // verify that we can access every single category this document is tied to
         foreach ($categories as $category) {
-            if (AclMain::aclCheckAcoSpec($category['aco_spec'], $user) === false) {
+            if (AclMain::aclCheckAcoSpec($category['aco_spec'], $username) === false) {
                 return false;
             }
         }

--- a/src/RestControllers/FHIR/FhirDocumentRestController.php
+++ b/src/RestControllers/FHIR/FhirDocumentRestController.php
@@ -46,9 +46,8 @@ class FhirDocumentRestController
      * Given a document and user, attempt to download the document to the calling agent.  Access rights and document
      * expiration are checked against the document.
      * @param $documentId  The document we are requesting to access
-     * @param $userId The user we are checking for access rights to this document.
      */
-    public function downloadDocument($documentId, $userId): ResponseInterface
+    public function downloadDocument($documentId): ResponseInterface
     {
         $document = new \Document($documentId);
 
@@ -60,7 +59,7 @@ class FhirDocumentRestController
             return (new Psr17Factory())->createResponse(StatusCode::NOT_FOUND);
         }
 
-        if (!$document->can_access($userId)) {
+        if (!$document->can_access()) {
             return (new Psr17Factory())->createResponse(StatusCode::UNAUTHORIZED);
         }
 
@@ -74,7 +73,7 @@ class FhirDocumentRestController
                 // we just continue as we still wanto to reject the response
                 $this->logger->error(
                     "FhirDocumentRestController->downloadDocument() Failed to delete document with id",
-                    ['document' => $documentId, 'user' => $userId, 'exception' => $exception->getMessage()]
+                    ['document' => $documentId, 'username' => $_SESSION['authUser'], 'exception' => $exception->getMessage()]
                 );
             }
             // need to return the fact that the document has expired
@@ -88,12 +87,12 @@ class FhirDocumentRestController
             }
             $this->logger->debug(
                 "FhirDocumentRestController->downloadDocument() Sending to default mime type handler",
-                ['document' => $documentId, 'user' => $userId]
+                ['document' => $documentId, 'username' => $_SESSION['authUser']]
             );
             $response = $this->defaultMimeTypeHandler->downloadDocument($document);
             $this->logger->debug(
                 "FhirDocumentRestController->downloadDocument() Response returned",
-                ['document' => $documentId, 'user' => $userId, 'contentLength' => $response->getHeader("Content-Length")]
+                ['document' => $documentId, 'username' => $_SESSION['authUser'], 'contentLength' => $response->getHeader("Content-Length")]
             );
             return $response;
         }


### PR DESCRIPTION
clarify the can_access() function
Generally, the parameter to choose the user that is being checked in acl calls are the username. The can_access parameter also follows this, so corrected it. And clarified some calls using it.
