### PR TITLE
Openemr fix #5255 forms reason code

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -247,3 +247,6 @@ assets:
         basePath: '%assets_static_relative%/hotkeys-js/'
         script:
             - dist/hotkeys.min.js
+    reason-code-widget:
+        basePath: '%webroot%/library/js/'
+        script: reasonCodeWidget.js

--- a/interface/forms/observation/new.php
+++ b/interface/forms/observation/new.php
@@ -50,7 +50,7 @@ $reasonCodeStatii[ReasonStatusCodes::EMPTY]['description'] = xl("Select a status
     <?php Header::setupHeader(['datetime-picker', 'reason-code-widget']); ?>
 
     <!--Update the version (v flag) to cache bust if you modify this file -->
-    <script src="<?php echo attr($GLOBALS['webroot']); ?>/interface/forms/observation/observation.js?v=1" type="text/javascript"></script>
+    <script src="<?php echo attr($GLOBALS['webroot']); ?>/interface/forms/observation/observation.js?v=<?php echo attr($GLOBALS['v_js_includes']); ?>" type="text/javascript"></script>
     <script>
         window.addEventListener('DOMContentLoaded', function() {
            window.observationForm.init(<?php echo js_url($GLOBALS['webroot']); ?>);

--- a/interface/forms/observation/observation.js
+++ b/interface/forms/observation/observation.js
@@ -98,6 +98,7 @@ function sel_code(webroot, id) {
     id = id.split('tb_row_');
     var checkId = '_' + id[1];
     document.getElementById('clickId').value = checkId;
+    window.top.restoreSession();
     dlgopen(webroot + '/interface/patient_file/encounter/find_code_popup.php?default=' + encodeURIComponent('LOINC'), '_blank', 700, 400);
 }
 

--- a/interface/forms/observation/observation.js
+++ b/interface/forms/observation/observation.js
@@ -1,0 +1,161 @@
+
+(function(window, oeUI) {
+
+    function init(webroot) {
+        // we want to setup our reason code widgets
+        if (oeUI.reasonCodeWidget) {
+            oeUI.reasonCodeWidget.init(webroot);
+        } else {
+            console.error("Missing required dependency reasonCodeWidget");
+            return;
+        }
+    }
+
+    let form = {
+        "init": init
+    };
+    window.observationForm = form;
+})(window, window.oeUI || {});
+
+function clearReasonCode(newRow) {
+    // make sure we clear everything out.
+    let inputs = newRow.querySelectorAll(".reasonCodeContainer input");
+    inputs.forEach(function(input) {
+        input.value = "";
+    });
+    // make sure we are hiding the thing.
+    let container = newRow.querySelector(".reasonCodeContainer");
+    container.classList.add("d-none");
+}
+
+function duplicateRow(e) {
+    var newRow = e.cloneNode(true);
+    e.parentNode.insertBefore(newRow, e.nextSibling);
+    changeIds('tb_row');
+    changeIds('comments');
+    changeIds('code');
+    changeIds('description');
+    changeIds('code_date');
+    changeIds('displaytext');
+    changeIds('code_type');
+    changeIds('table_code');
+    changeIds('ob_value');
+    changeIds('ob_unit');
+    changeIds('ob_value_phin');
+    changeIds('ob_value_head');
+    changeIds('ob_unit_head');
+    changeIds('reason_code');
+    changeDatasetIds('toggle-container', 'toggleContainer', 'reason_code');
+    clearReasonCode(newRow);
+    removeVal(newRow.id);
+    // reload our widget event listeners.
+    window.oeUI.reasonCodeWidget.reload();
+}
+
+function removeVal(rowid) {
+    rowid1 = rowid.split('tb_row_');
+    document.getElementById("comments_" + rowid1[1]).value = '';
+    document.getElementById("code_" + rowid1[1]).value = '';
+    document.getElementById("description_" + rowid1[1]).value = '';
+    document.getElementById("code_date_" + rowid1[1]).value = '';
+    document.getElementById("displaytext_" + rowid1[1]).innerHTML = '';
+    document.getElementById("code_type_" + rowid1[1]).value = '';
+    document.getElementById("table_code_" + rowid1[1]).value = '';
+    document.getElementById("ob_value_" + rowid1[1]).value = '';
+    document.getElementById("ob_unit_" + rowid1[1]).value = '';
+    document.getElementById("ob_value_phin_" + rowid1[1]).value = '';
+    document.getElementById("ob_value_head_" + rowid1[1]).innerHTML = '';
+    document.getElementById("ob_unit_head_" + rowid1[1]).innerHTML = '';
+}
+
+function changeDatasetIds(propertySelector, dataSetProperty, keyPrefix) {
+    var elements = document.querySelectorAll('[data-' + propertySelector + ']');
+    if (elements) {
+        elements.forEach(function(element, index) {
+           element.dataset[dataSetProperty] = keyPrefix + "_" + (index + 1);
+        });
+    }
+}
+function changeIds(class_val) {
+    var elem = document.getElementsByClassName(class_val);
+    for (let i = 0; i < elem.length; i++) {
+        if (elem[i].id) {
+            index = i + 1;
+            elem[i].id = class_val + "_" + index;
+        }
+    }
+}
+
+function deleteRow(rowId) {
+    if (rowId !== 'tb_row_1') {
+        var elem = document.getElementById(rowId);
+        elem.parentNode.removeChild(elem);
+    }
+    window.oeUI.reasonCodeWidget.reload();
+}
+
+function sel_code(webroot, id) {
+    id = id.split('tb_row_');
+    var checkId = '_' + id[1];
+    document.getElementById('clickId').value = checkId;
+    dlgopen(webroot + '/interface/patient_file/encounter/find_code_popup.php?default=' + encodeURIComponent('LOINC'), '_blank', 700, 400);
+}
+
+function set_related(codetype, code, selector, codedesc) {
+    var checkId = document.getElementById('clickId').value;
+    document.getElementById("code" + checkId).value = code;
+    document.getElementById("description" + checkId).value = codedesc;
+    document.getElementById("displaytext" + checkId).innerHTML = codedesc;
+    document.getElementById("code_type" + checkId).value = codetype;
+    if (codetype === 'LOINC') {
+        document.getElementById("table_code" + checkId).value = 'LN';
+        if (code === '21612-7') {
+            document.getElementById('ob_value_head' + checkId).style.display = '';
+            document.getElementById('ob_unit_head' + checkId).style.display = '';
+            document.getElementById('ob_value' + checkId).style.display = '';
+            var sel_unit_age = document.getElementById('ob_unit' + checkId);
+            if (document.getElementById('ob_unit' + checkId).value == '') {
+                var opt = document.createElement("option");
+                opt.value = 'd';
+                opt.text = 'Day';
+                sel_unit_age.appendChild(opt);
+                var opt1 = document.createElement("option");
+                opt1.value = 'mo';
+                opt1.text = 'Month';
+                sel_unit_age.appendChild(opt1);
+                var opt2 = document.createElement("option");
+                opt2.value = 'UNK';
+                opt2.text = 'Unknown';
+                sel_unit_age.appendChild(opt2);
+                var opt3 = document.createElement("option");
+                opt3.value = 'wk';
+                opt3.text = 'Week';
+                sel_unit_age.appendChild(opt3);
+                var opt4 = document.createElement("option");
+                opt4.value = 'a';
+                opt4.text = 'Year';
+                sel_unit_age.appendChild(opt4);
+            }
+            document.getElementById('ob_unit' + checkId).style.display = 'block';
+            document.getElementById('ob_value_phin' + checkId).style.display = 'none';
+        } else if (code === '8661-1') {
+            document.getElementById('ob_unit_head' + checkId).style.display = 'none';
+            var select = document.getElementById('ob_unit' + checkId);
+            select.innerHTML = "";
+            document.getElementById('ob_unit' + checkId).style.display = 'none';
+            document.getElementById('ob_value_phin' + checkId).style.display = 'none';
+            document.getElementById('ob_value_head' + checkId).style.display = '';
+            document.getElementById('ob_value' + checkId).style.display = '';
+        }
+    } else {
+        document.getElementById("table_code" + checkId).value = 'PHINQUESTION';
+        document.getElementById('ob_value_head' + checkId).style.display = '';
+        document.getElementById('ob_unit_head' + checkId).style.display = 'none';
+        var select_unit = document.getElementById('ob_unit' + checkId);
+        select_unit.innerHTML = "";
+        document.getElementById('ob_value' + checkId).value = '';
+        document.getElementById('ob_value' + checkId).style.display = 'none';
+        document.getElementById('ob_unit' + checkId).style.display = 'none';
+        document.getElementById('ob_value_phin' + checkId).style.display = '';
+    }
+}

--- a/interface/forms/observation/save.php
+++ b/interface/forms/observation/save.php
@@ -37,6 +37,9 @@ $ob_value       = $_POST["ob_value"];
 $ob_value_phin  = $_POST["ob_value_phin"];
 $ob_unit        = $_POST["ob_unit"];
 $code_date      = $_POST["code_date"];
+$reasonCode     = $_POST['reasonCode'];
+$reasonStatusCode     = $_POST['reasonCodeStatus'];
+$reasonCodeText     = $_POST['reasonCodeText'];
 
 if ($id && $id != 0) {
     sqlStatement("DELETE FROM `form_observation` WHERE id=? AND pid = ? AND encounter = ?", array($id, $_SESSION["pid"], $_SESSION["encounter"]));
@@ -91,7 +94,10 @@ if (!empty($code_desc)) {
             table_code  = ?,
             ob_value    = ?,
             ob_unit     = ?,
-            date        = ?";
+            date        = ?,
+            ob_reason_code = ?,
+            ob_reason_status = ?,
+            ob_reason_text = ?";
         sqlStatement(
             "INSERT INTO form_observation SET $sets",
             [
@@ -108,7 +114,10 @@ if (!empty($code_desc)) {
                 $table_code[$key],
                 $ob_value[$key],
                 $ob_unit_value,
-                $code_date[$key]
+                $code_date[$key],
+                $reasonCode[$key],
+                $reasonStatusCode[$key],
+                $reasonCodeText[$key]
             ]
         );
     endforeach;

--- a/interface/forms/observation/templates/observation_actions.php
+++ b/interface/forms/observation/templates/observation_actions.php
@@ -1,0 +1,9 @@
+<button type="button" class="btn btn-primary btn-sm btn-add" onclick="duplicateRow(this.parentElement.parentElement.parentElement);" title='<?php echo xla('Click here to duplicate the row'); ?>'>
+    <?php echo xlt('Add'); ?>
+</button>
+<button type="button" class="btn btn-danger btn-sm btn-delete" onclick="deleteRow(this.parentElement.parentElement.parentElement.id);" title='<?php echo xla('Click here to delete the row'); ?>'>
+    <?php echo xlt('Delete'); ?>
+</button>
+<button class="btn btn-secondary reason-code-btn mt-2"
+        title='<?php echo xla('Click here to provide an explanation for the observation value (or lack of value)'); ?>'
+        data-toggle-container="reason_code_<?php echo attr($key); ?>"><i class="fa fa-asterisk"></i> <?php echo xlt("Add Reason"); ?></button>

--- a/interface/forms/observation/templates/observation_actions.php
+++ b/interface/forms/observation/templates/observation_actions.php
@@ -1,3 +1,15 @@
+<?php
+
+/**
+ * observation_actions.php is a template file for the action buttons displayed in the observation form
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2022 Discover and Change <snielson@discoverandchange.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+?>
 <button type="button" class="btn btn-primary btn-sm btn-add" onclick="duplicateRow(this.parentElement.parentElement.parentElement);" title='<?php echo xla('Click here to duplicate the row'); ?>'>
     <?php echo xlt('Add'); ?>
 </button>

--- a/interface/forms/observation/templates/observation_reason_row.php
+++ b/interface/forms/observation/templates/observation_reason_row.php
@@ -25,11 +25,11 @@
                 <div class="col-md-6 form-group">
                     <label><?php echo xlt("Reason Code"); ?></label>
                     <input class="code-selector-popup form-control"
-                           name="reasonCode[]" type="text" value="<?php echo $obj['ob_reason_code'] ?? ""; ?>"
+                           name="reasonCode[]" type="text" value="<?php echo attr($obj['ob_reason_code'] ?? ""); ?>"
                            placeholder="<?php echo xlt("Select a reason code"); ?>"
                     />
-                    <p class="code-selector-text-display <?php echo empty($obj['ob_reason_text']) ? "d-none" : ''; ?>"><?php echo $obj['ob_reason_text'] ?? ""; ?></p>
-                    <input type="hidden" name="reasonCodeText[]" class="code-selector-text" value="<?php echo $obj['ob_reason_text'] ?? ""; ?>" />
+                    <p class="code-selector-text-display <?php echo empty($obj['ob_reason_text']) ? "d-none" : ''; ?>"><?php echo text($obj['ob_reason_text'] ?? ""); ?></p>
+                    <input type="hidden" name="reasonCodeText[]" class="code-selector-text" value="<?php echo attr($obj['ob_reason_text'] ?? ""); ?>" />
                 </div>
                 <div class="col-md-6 form-group">
                     <label><?php echo xlt("Reason Status"); ?></label>

--- a/interface/forms/observation/templates/observation_reason_row.php
+++ b/interface/forms/observation/templates/observation_reason_row.php
@@ -1,0 +1,36 @@
+<div class="form-row reasonCodeContainer reason_code <?php echo !empty($obj['ob_reason_code']) ? "" : "d-none"; ?>" id="reason_code_<?php echo attr($key); ?>">
+    <div class="card mt-2 mb-4">
+        <div class="card-header">
+            <?php echo xlt("Observation Reason Information"); ?>
+        </div>
+        <div class="card-body">
+            <div class="row">
+                <p class="col">
+                    <?php echo xlt("When recording a reason for the value (or absence of a value) of an observation both the reason code and status of the reason are required"); ?>
+                </p>
+            </div>
+            <div class="row">
+                <div class="col-md-6 form-group">
+                    <label><?php echo xlt("Reason Code"); ?></label>
+                    <input class="code-selector-popup form-control"
+                           name="reasonCode[]" type="text" value="<?php echo $obj['ob_reason_code'] ?? ""; ?>"
+                           placeholder="<?php echo xlt("Select a reason code"); ?>"
+                    />
+                    <p class="code-selector-text-display <?php echo empty($obj['ob_reason_text']) ? "d-none" : ''; ?>"><?php echo $obj['ob_reason_text'] ?? ""; ?></p>
+                    <input type="hidden" name="reasonCodeText[]" class="code-selector-text" value="<?php echo $obj['ob_reason_text'] ?? ""; ?>" />
+                </div>
+                <div class="col-md-6 form-group">
+                    <label><?php echo xlt("Reason Status"); ?></label>
+                    <select name="reasonCodeStatus[]" class="form-control">
+                        <?php foreach($reasonCodeStatii as $code => $codeDesc) : ?>
+                            <option value="<?php echo attr($code); ?>"
+                                <?php if(($obj['ob_reason_status'] ?? "") == $code) echo "selected"; ?> >
+                                <?php echo text($codeDesc['description']); ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/interface/forms/observation/templates/observation_reason_row.php
+++ b/interface/forms/observation/templates/observation_reason_row.php
@@ -1,3 +1,15 @@
+<?php
+
+/**
+ * observation_reason_row.php is a template file for the observation reason data elements.
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2022 Discover and Change <snielson@discoverandchange.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+?>
 <div class="form-row reasonCodeContainer reason_code <?php echo !empty($obj['ob_reason_code']) ? "" : "d-none"; ?>" id="reason_code_<?php echo attr($key); ?>">
     <div class="card mt-2 mb-4">
         <div class="card-header">

--- a/interface/forms/observation/templates/observation_reason_row.php
+++ b/interface/forms/observation/templates/observation_reason_row.php
@@ -22,9 +22,10 @@
                 <div class="col-md-6 form-group">
                     <label><?php echo xlt("Reason Status"); ?></label>
                     <select name="reasonCodeStatus[]" class="form-control">
-                        <?php foreach($reasonCodeStatii as $code => $codeDesc) : ?>
+                        <?php foreach ($reasonCodeStatii as $code => $codeDesc) : ?>
                             <option value="<?php echo attr($code); ?>"
-                                <?php if(($obj['ob_reason_status'] ?? "") == $code) echo "selected"; ?> >
+                                <?php if (($obj['ob_reason_status'] ?? "") == $code) {
+                                    echo "selected";} ?> >
                                 <?php echo text($codeDesc['description']); ?>
                             </option>
                         <?php endforeach; ?>

--- a/interface/forms/vitals/C_FormVitals.class.php
+++ b/interface/forms/vitals/C_FormVitals.class.php
@@ -16,6 +16,7 @@ require_once($GLOBALS['fileroot'] . "/library/patient.inc");
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Forms\FormVitals;
 use OpenEMR\Common\Forms\FormVitalDetails;
+use OpenEMR\Common\Forms\ReasonStatusCodes;
 use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Services\VitalsService;
@@ -113,10 +114,15 @@ class C_FormVitals extends Controller
             $i++;
         }
 
+        $reasonCodeStatii = ReasonStatusCodes::getCodesWithDescriptions();
+        $reasonCodeStatii[ReasonStatusCodes::EMPTY]['description'] = xl("Select a status code");
+
         $this->assign("vitals", $vitals);
         $this->assign("results", ($results ?? null));
+        $this->assign("results_count", count(($results ?? [])));
 
         $this->assign('interpretation_options', $this->interpretationsList);
+        $this->assign('reasonCodeStatii', $reasonCodeStatii);
 
         $this->assign("VIEW", true);
         return $this->fetch($this->template_dir . $this->template_mod . "_new.html");
@@ -248,6 +254,25 @@ class C_FormVitals extends Controller
                     $details->clear_interpretation();
                 }
 
+                $details->set_vitals_column($column);
+                $detailsToUpdate[$column] = $details;
+            }
+        }
+
+        // now let's populate our reason codes if we have them.  Requires a reason code and a status code
+        if (isset($_POST['reasonCode'])) {
+            foreach ($_POST['reasonCode'] as $column => $value) {
+                $details = $detailsToUpdate[$column] ?? $this->vitals->get_details_for_column($column) ?? new FormVitalDetails();
+                if (empty($value) && empty($_POST['reasonCodeStatus'][$column]) && empty($details->get_id())) {
+                    continue; // nothing to do here if we don't have a code and a status
+                }
+                if (empty($value) || empty($_POST['reasonCodeStatus'][$column])) {
+                    $details->clear_reason();
+                } else {
+                    $details->set_reason_code($value);
+                    $details->set_reason_status($_POST['reasonCodeStatus'][$column] ?? '');
+                    $details->set_reason_description($_POST['reasonCodeText'][$column] ?? '');
+                }
                 $details->set_vitals_column($column);
                 $detailsToUpdate[$column] = $details;
             }

--- a/interface/forms/vitals/templates/vitals/general_new.html
+++ b/interface/forms/vitals/templates/vitals/general_new.html
@@ -9,136 +9,31 @@
 *}
 <html>
 <head>
-{headerTemplate assets='datetime-picker'}
-
+{headerTemplate assets='datetime-picker|reason-code-widget'}
+<!--Update the version (v flag) to cache bust if you modify this file -->
+<script src="{$webroot|attr}/interface/forms/vitals/vitals.js?v=1" type="text/javascript"></script>
 {literal}
 <script>
-function vitalsFormSubmitted() {
-    var invalid = "";
-
-    var elementsToValidate = new Array();
-
-    elementsToValidate[0] = new Array();
-    elementsToValidate[0][0] = 'weight_input';
-    elementsToValidate[0][1] = {/literal}{xlj t="Weight"}{literal} + ' (' + {/literal}{xlj t="lbs"}{literal} + ')';
-
-    elementsToValidate[1] = new Array();
-    elementsToValidate[1][0] = 'weight_input_metric';
-    elementsToValidate[1][1] = {/literal}{xlj t="Weight"}{literal} + ' (' + {/literal}{xlj t="kg"}{literal} + ')';
-
-    elementsToValidate[2] = new Array();
-    elementsToValidate[2][0] = 'height_input';
-    elementsToValidate[2][1] = {/literal}{xlj t="Height/Length"}{literal} + ' (' + {/literal}{xlj t="in"}{literal} + ')';
-
-    elementsToValidate[3] = new Array();
-    elementsToValidate[3][0] = 'height_input_metric';
-    elementsToValidate[3][1] = {/literal}{xlj t="Height/Length"}{literal} + ' (' + {/literal}{xlj t="cm"}{literal} + ')';
-
-    elementsToValidate[4] = new Array();
-    elementsToValidate[4][0] = 'bps_input';
-    elementsToValidate[4][1] = {/literal}{xlj t="BP Systolic"}{literal};
-
-    elementsToValidate[5] = new Array();
-    elementsToValidate[5][0] = 'bpd_input';
-    elementsToValidate[5][1] = {/literal}{xlj t="BP Diastolic"}{literal};
-
-    for (var i = 0; i < elementsToValidate.length; i++) {
-        var current_elem_id = elementsToValidate[i][0];
-        var tag_name = elementsToValidate[i][1];
-
-        document.getElementById(current_elem_id).classList.remove('error');
-
-        if (isNaN(document.getElementById(current_elem_id).value)) {
-            invalid += {/literal}{xlj t="The following field has an invalid value"}{literal} + ": " + tag_name + "\n";
-            document.getElementById(current_elem_id).className = document.getElementById(current_elem_id).className + " error";
-            document.getElementById(current_elem_id).focus();
-        }
-    }
-
-    if (invalid.length > 0) {
-        invalid += "\n" + {/literal}{xlj t="Please correct the value(s) before proceeding!"}{literal};
-        alert(invalid);
-
-        return false;
+    let vitalsTranslations = {
+        'weight_input': {/literal}{xlj t="Weight"}{literal} + ' (' + {/literal}{xlj t="lbs"}{literal} + ')'
+        ,'weight_input_metric': {/literal}{xlj t="Weight"}{literal} + ' (' + {/literal}{xlj t="kg"}{literal} + ')'
+        ,'height_input': {/literal}{xlj t="Height/Length"}{literal} + ' (' + {/literal}{xlj t="in"}{literal} + ')'
+        ,'height_input_metric': {/literal}{xlj t="Height/Length"}{literal} + ' (' + {/literal}{xlj t="cm"}{literal} + ')'
+        ,'bps_input': {/literal}{xlj t="BP Systolic"}{literal}
+        ,'bpd_input': {/literal}{xlj t="BP Diastolic"}{literal}
+        ,'validateFailed': {/literal}{xlj t="Please correct the value(s) before proceeding!"}{literal}
+        ,'invalidField': {/literal}{xlj t="The following field has an invalid value"}{literal}
+    };
+    if (window.vitalsForm) {
+        window.vitalsForm.init({/literal}{$webroot|js_url}{literal}, vitalsTranslations);
     } else {
-
-        return top.restoreSession();
+        console.error("Failed to find vitalsForm object to initialize javascript vitals form");
     }
-}
 </script>
-<style>
-    .title {
-        font-weight: bold;
-    }
-
-    .currentvalues {
-        padding-right: 5px;
-        text-align: left;
-        min-width: 10rem;
-    }
-
-    th.currentvalues,
-    th.historicalvalues {
-        background: var(--gray200);
-    }
-
-    .valuesunfocus {
-        padding-right: 5px;
-        background-color: var(--gray400);
-        text-align: left;
-    }
-
-    .unfocus {
-        background-color: var(--gray400);
-    }
-
-    .historicalvalues {
-        background-color: var(--gray400);
-        border-bottom: 1px solid var(--gray300);
-        border-right: 1px solid var(--gray300);
-        text-align: right;
-        background: var(--gray200);
-    }
-
-    table {
-        border-collapse: collapse;
-        font-weight: 600;
-    }
-
-    td,
-    th {
-        padding-right: 10px;
-        padding-left: 10px;
-    }
-
-    th {
-        font-weight: 800;
-    }
-
-    td {
-        padding-top: 0 !important;
-        padding-bottom: 0 !important;
-    }
-
-    input[type=text],
-    select {
-        margin: 1px !important;
-    }
-
-    .hide {
-        display: none;
-    }
-
-    .readonly {
-        display: none;
-    }
-
-    .error {
-        border: 2px solid var(--danger);
-    }
-</style>
 {/literal}
-
+</script>
+<!--Update the version (v flag) to cache bust if you modify this file -->
+<link rel="stylesheet" href="{$webroot|attr}/interface/forms/vitals/vitals.css?v=1" />
 <title>{xlt t='Vitals'}</title>
 </head>
 <body>
@@ -147,19 +42,20 @@ function vitalsFormSubmitted() {
     <div class="row">
         <h2>{xlt t="Vitals"}&nbsp;&nbsp;&nbsp;<a href="../summary/demographics.php" class="text-decoration-none" onclick="top.restoreSession()" title="{xla t='Back to patient dashboard'}"><i id="advanced-tooltip" class="readonly fas fa-arrow-circle-left fa-2x small" aria-hidden="true"></i> </a></h2>
         <div class="col-sm-12">
-            <form name="vitals" method="post" action="{$FORM_ACTION}/interface/forms/vitals/save.php" onSubmit="return vitalsFormSubmitted()">
+            <form id="vitalsForm" name="vitals" method="post" action="{$FORM_ACTION}/interface/forms/vitals/save.php">
                 <input type="hidden" name="csrf_token_form" value="{$CSRF_TOKEN_FORM|attr}" />
                 <div id="chart" class="chart-dygraphs" style="margin-left: -15px"></div>
                     <div class="table-responsive">
                         <table class="table">
-                            <thead>
+                            <thead class="table-head">
                                 <tr>
                                     <th class="text-left">{xlt t="Name"}</th>
                                     <th class="text-left">{xlt t="Unit"}</th>
                                     <th class='currentvalues p-2' title="{xla t='Date and time of this observation'}">
                                         <input type='text' size='14' class='form-control datetimepicker oe-patient-background' name='date' id='date' value='{$vitals->get_date()|date_format:"%Y-%m-%d %H:%M"|attr}' />
                                     </th>
-                                    <th class="currentvalues editonly">{xlt t="Abn"}</th>
+                                    <th class="editonly">{xlt t="Abn"}</th>
+                                    <th class="editonly">{xlt t="Actions"}</th>
                                     {foreach item=result from=$results}
                                         <th class='historicalvalues'>{$result->get_date()|date_format:"%Y-%m-%d %H:%M"|text}</th>
                                     {/foreach}
@@ -171,7 +67,6 @@ function vitalsFormSubmitted() {
                                     vitals=$vitals vitalsValue="get_weight" vitalsValueMetric="get_weight_metric"
                                     unit="lbs" unitMetric="kg" vitalsStringFormat="%.2f"
                                     vitalsValueUSAHelpTitle="Decimal pounds or pounds and ounces separated by #(e.g. 5#4)" }
-
                                 { include file="vitals_textbox_conversion.tpl" title="Height/Length" input="height"
                                     vitalsValue="get_height" vitalsValueMetric="get_height_metric" unit="in"
                                     unitMetric="cm" vitalsStringFormat="%.2f" }
@@ -217,9 +112,13 @@ function vitalsFormSubmitted() {
                                         <td class='currentvalues p-2'><input type="text" class="form-control" size='5'
                                             name='BMI' id='BMI_input' value="{if $vitals->get_BMI() != 0}{$vitals->get_BMI()|substr:0:5|attr}{/if}"/></td>
                                         <td class="editonly"></td>
+                                        <td class="editonly actions">
+                                            { include file='vitals_actions.tpl' input='BMI' }
+                                        </td>
                                         { include file='vitals_historical_values.tpl' vitals=$vitals useMetric=false
                                             vitalsValue='get_BMI' results=$results }
                                     </tr>
+                                    { include file='vitals_reason_row.tpl' input='BMI' vitalDetails=$vitals->get_details_for_column('BMI')  }
 
                                     <tr>
                                         <td>{xlt t="BMI Status"}</td><td>{xlt t="Type"}</td>
@@ -227,9 +126,13 @@ function vitalsFormSubmitted() {
                                             <input type="text" class="form-control" size='20'
                                                 name="BMI_status" id="BMI_status" value="{$vitals->get_BMI_status()|attr}"/></td>
                                         <td class="editonly"></td>
+                                        <td class="editonly actions">
+                                            { include file='vitals_actions.tpl' input='BMI_Status' }
+                                        </td>
                                         { include file='vitals_historical_values.tpl' vitals=$vitals useMetric=false
                                         vitalsValue='get_BMI_status' results=$results }
                                     </tr>
+                                    { include file='vitals_reason_row.tpl' input='BMI_Status' vitalDetails=$vitals->get_details_for_column('BMI_status')  }
 
                                 {if $patient_age <= 20 || (preg_match('/month/', $patient_age))}
                                     {include file="vitals_textbox.tpl" title="Pediatric Weight Height Percentile"
@@ -247,17 +150,15 @@ function vitalsFormSubmitted() {
                                 {/if}
 
                                 {include file="vitals_notes.tpl" title="Other Notes" unit="" input="note" vitalsValue=$vitals->get_note()}
-                                    <tr><td>&nbsp;</td></tr>
-
+                                {if $patient_age <= 20 || (preg_match('/month/', $patient_age))}
                                     <tr>
-                                        <td colspan='5' class="text-center">
-                                            {if $patient_age <= 20 || (preg_match('/month/', $patient_age))}
+                                        <td colspan='5' class="text-center pt-2">
                                             <!-- only show growth-chart button for patients < 20 years old -->
                                             <input type="button" class="btn btn-primary" id="pdfchart" value='{xla t="Growth-Chart"} ({xla t="PDF"})'>
                                             <input type="button" class="btn btn-primary" id="htmlchart" value='{xla t="Growth-Chart"} ({xla t="HTML"})'>
-                                            {/if}
                                         </td>
                                     </tr>
+                                {/if}
                             </tbody>
                         </table>
                     </div>
@@ -375,7 +276,5 @@ function ShowGrowthchart(doPDF) {
 }
         {/literal}
 </script>
-{include file='vitals_javascript_functions.tpl' }
-
 </body>
 </html>

--- a/interface/forms/vitals/templates/vitals/general_new.html
+++ b/interface/forms/vitals/templates/vitals/general_new.html
@@ -11,7 +11,7 @@
 <head>
 {headerTemplate assets='datetime-picker|reason-code-widget'}
 <!--Update the version (v flag) to cache bust if you modify this file -->
-<script src="{$webroot|attr}/interface/forms/vitals/vitals.js?v=1" type="text/javascript"></script>
+<script src="{$webroot|attr}/interface/forms/vitals/vitals.js?v={assetVersionNumber}" type="text/javascript"></script>
 {literal}
 <script>
     let vitalsTranslations = {
@@ -33,7 +33,7 @@
 {/literal}
 </script>
 <!--Update the version (v flag) to cache bust if you modify this file -->
-<link rel="stylesheet" href="{$webroot|attr}/interface/forms/vitals/vitals.css?v=1" />
+<link rel="stylesheet" href="{$webroot|attr}/interface/forms/vitals/vitals.css?v={assetVersionNumber}" />
 <title>{xlt t='Vitals'}</title>
 </head>
 <body>

--- a/interface/forms/vitals/templates/vitals/vitals_actions.tpl
+++ b/interface/forms/vitals/templates/vitals/vitals_actions.tpl
@@ -1,0 +1,1 @@
+<button class="btn btn-secondary reason-code-btn" data-toggle-container="{$input|attr}_reason_code"><i class="fa fa-asterisk"></i></button>

--- a/interface/forms/vitals/templates/vitals/vitals_notes.tpl
+++ b/interface/forms/vitals/templates/vitals/vitals_notes.tpl
@@ -11,6 +11,8 @@
     </td>
     <td class="editonly">
     </td>
+    <td class="editonly actions">
+    </td>
     {foreach item=result from=$results}
         <td  class='historicalvalues'>
             {if $result->get_note() != 0}

--- a/interface/forms/vitals/templates/vitals/vitals_reason_row.tpl
+++ b/interface/forms/vitals/templates/vitals/vitals_reason_row.tpl
@@ -16,15 +16,15 @@
                         <label>{xlt t="Reason Code"}</label>
                         {if isset($vitalDetails) && !empty($vitalDetails->get_reason_code())}
                         <input class="code-selector-popup form-control" placeholder="{xlt t="Select a reason code"}"
-                               name="reasonCode[{$input|attr}]" type="text" value="{$vitalDetails->get_reason_code()}" />
+                               name="reasonCode[{$input|attr}]" type="text" value="{$vitalDetails->get_reason_code()|attr}" />
                         {else}
                         <input class="code-selector-popup form-control" placeholder="{xlt t="Select a reason code"}"
                                name="reasonCode[{$input|attr}]" type="text" value="" />
                         {/if}
 
                         {if isset($vitalDetails) && !empty($vitalDetails->get_reason_description())}
-                            <p class="code-selector-text-display">{$vitalDetails->get_reason_description()}</p>
-                            <input type="hidden" name="reasonCodeText[{$input|attr}]" class="code-selector-text" value="{$vitalDetails->get_reason_description()}" />
+                            <p class="code-selector-text-display">{$vitalDetails->get_reason_description()|text}</p>
+                            <input type="hidden" name="reasonCodeText[{$input|attr}]" class="code-selector-text" value="{$vitalDetails->get_reason_description()|attr}" />
                         {else}
                             <p class="code-selector-text-display d-none"></p>
                             <input type="hidden" name="reasonCodeText[{$input|attr}]" class="code-selector-text" value="" />

--- a/interface/forms/vitals/templates/vitals/vitals_reason_row.tpl
+++ b/interface/forms/vitals/templates/vitals/vitals_reason_row.tpl
@@ -1,0 +1,53 @@
+<!-- Note if you change this id you need to change the vitals_actions.tpl and vitals.js to match -->
+<tr id="{$input|attr}_reason_code" class="reasonCodeContainer {if !($vitals->has_reason_for_column($input))}d-none{/if}">
+    <td colspan="5" class="border-top-0">
+        <div class="card mt-2 mb-4">
+            <div class="card-header">
+                {xlt t=$title} {xlt t="Reason Information"}
+            </div>
+            <div class="card-body">
+                <div class="row">
+                    <p class="col">
+                        {xlt t="When recording a reason for the value (or absence of a value) of an observation both the reason code and status of the reason are required"}
+                    </p>
+                </div>
+                <div class="row">
+                    <div class="col-md-6 form-group">
+                        <label>{xlt t="Reason Code"}</label>
+                        {if isset($vitalDetails) && !empty($vitalDetails->get_reason_code())}
+                        <input class="code-selector-popup form-control" placeholder="{xlt t="Select a reason code"}"
+                               name="reasonCode[{$input|attr}]" type="text" value="{$vitalDetails->get_reason_code()}" />
+                        {else}
+                        <input class="code-selector-popup form-control" placeholder="{xlt t="Select a reason code"}"
+                               name="reasonCode[{$input|attr}]" type="text" value="" />
+                        {/if}
+
+                        {if isset($vitalDetails) && !empty($vitalDetails->get_reason_description())}
+                            <p class="code-selector-text-display">{$vitalDetails->get_reason_description()}</p>
+                            <input type="hidden" name="reasonCodeText[{$input|attr}]" class="code-selector-text" value="{$vitalDetails->get_reason_description()}" />
+                        {else}
+                            <p class="code-selector-text-display d-none"></p>
+                            <input type="hidden" name="reasonCodeText[{$input|attr}]" class="code-selector-text" value="" />
+                        {/if}
+                    </div>
+                    <div class="col-md-6 form-group">
+                        <label>{xlt t="Reason Status"}</label>
+                        <select name="reasonCodeStatus[{$input|attr}]" class="form-control">
+                            {foreach item=codeDesc from=$reasonCodeStatii}
+                                <option value="{$codeDesc.code|attr}"
+                                    {if isset($vitalDetails) && $vitalDetails->get_reason_status() == $codeDesc.code}
+                                        selected
+                                    {/if}
+                                >{$codeDesc.description|text}</option>
+                            {/foreach}
+                        </select>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </td>
+
+    {foreach item=result from=$results}
+        <td class="historicalvalues"></td>
+    {/foreach}
+</tr>

--- a/interface/forms/vitals/templates/vitals/vitals_temp_method.tpl
+++ b/interface/forms/vitals/templates/vitals/vitals_temp_method.tpl
@@ -7,5 +7,10 @@
             <option value="Temporal Artery"   {if $vitals->get_temp_method() == "Temporal Artery" } selected{/if}>{xlt t="Temporal Artery"}
         </select></td>
     <td class="editonly"></td>
+    <td class="editonly actions">
+        { include file='vitals_actions.tpl' }
+    </td>
 
     { include file='vitals_historical_values.tpl' useMetric=false vitalsValue="get_temp_method" results=$results }
+</tr>
+{ include file='vitals_reason_row.tpl' input=$input title=$title vitalDetails=$vitals->get_details_for_column($input)  }

--- a/interface/forms/vitals/templates/vitals/vitals_textbox.tpl
+++ b/interface/forms/vitals/templates/vitals/vitals_textbox.tpl
@@ -19,7 +19,11 @@
     <td class="editonly">
         { include file='vitals_interpretation_selector.tpl' vitalDetails=$vitals->get_details_for_column($input) }
     </td>
+    <td class="editonly actions">
+        { include file='vitals_actions.tpl' }
+    </td>
 
     { include file='vitals_historical_values.tpl' useMetric=false vitalsValue=$vitalsValue results=$results
         vitalsStringFormat=$vitalsStringFormat }
 </tr>
+{ include file='vitals_reason_row.tpl' input=$input title=$title vitalDetails=$vitals->get_details_for_column($input)  }

--- a/interface/forms/vitals/templates/vitals/vitals_textbox_conversion.tpl
+++ b/interface/forms/vitals/templates/vitals/vitals_textbox_conversion.tpl
@@ -30,6 +30,9 @@
     <td class="editonly">
         { include file='vitals_interpretation_selector.tpl' vitalDetails=$vitals->get_details_for_column($input) }
     </td>
+    <td class="editonly actions">
+        { include file='vitals_actions.tpl' }
+    </td>
     { include file='vitals_historical_values.tpl' useMetric=false vitalsValue=$vitalsValue vitalsValueMetric=$vitalsValueMetric
             results=$results }
     </tr>
@@ -70,6 +73,13 @@
                 { include file='vitals_interpretation_selector.tpl' vitalDetails=$vitals->get_details_for_column($input) }
             {/if}
         </td>
+        <td class="editonly actions">
+            {if $units_of_measurement == $MEASUREMENT_METRIC_ONLY }
+                { include file='vitals_actions.tpl' }
+            {/if}
+        </td>
         { include file='vitals_historical_values.tpl' useMetric=true vitalsValue=$vitalsValue vitalsValueMetric=$vitalsValueMetric
         results=$results }
     </tr>
+
+{ include file='vitals_reason_row.tpl' input=$input title=$title vitalDetails=$vitals->get_details_for_column($input) }

--- a/interface/forms/vitals/vitals.css
+++ b/interface/forms/vitals/vitals.css
@@ -1,72 +1,74 @@
 .title {
-    font-weight: bold;
+  font-weight: bold;
 }
 
 .currentvalues {
-    padding-right: 5px;
-    text-align: left;
-    min-width: 10rem;
+  min-width: 10rem;
+  padding-right: 5px;
+  text-align: left;
 }
 
 th.currentvalues,
 th.historicalvalues {
-    background: var(--gray200);
+  background: var(--gray200);
 }
 
 .valuesunfocus {
-    padding-right: 5px;
-    background-color: var(--gray400);
-    text-align: left;
+  background-color: var(--gray400);
+  padding-right: 5px;
+  text-align: left;
 }
 
 .unfocus {
-    background-color: var(--gray400);
+  background-color: var(--gray400);
 }
 
 .historicalvalues {
-    background-color: var(--gray400);
-    border-bottom: 1px solid var(--gray300);
-    border-right: 1px solid var(--gray300);
-    text-align: right;
-    background: var(--gray200);
+  background: var(--gray200);
+  background-color: var(--gray400);
+  border-bottom: 1px solid var(--gray300);
+  border-right: 1px solid var(--gray300);
+  text-align: right;
 }
-.historicalvalues:nth-child(6), .reasonCodeContainer .historicalvalues:nth-child(2) {
-    border-left: 1px solid var(--gray300);
+
+.historicalvalues:nth-child(6),
+.reasonCodeContainer .historicalvalues:nth-child(2) {
+  border-left: 1px solid var(--gray300);
 }
 
 table {
-    border-collapse: collapse;
-    font-weight: 600;
+  border-collapse: collapse;
+  font-weight: 600;
 }
 
 td,
 th {
-    padding-right: 10px;
-    padding-left: 10px;
+  padding-left: 10px;
+  padding-right: 10px;
 }
 
 th {
-    font-weight: 800;
+  font-weight: 800;
 }
 
 td {
-    padding-top: 0 !important;
-    padding-bottom: 0 !important;
+  padding-bottom: 0 !important;
+  padding-top: 0 !important;
 }
 
 input[type=text],
 select {
-    margin: 1px !important;
+  margin: 1px !important;
 }
 
 .hide {
-    display: none;
+  display: none;
 }
 
 .readonly {
-    display: none;
+  display: none;
 }
 
 .error {
-    border: 2px solid var(--danger);
+  border: 2px solid var(--danger);
 }

--- a/interface/forms/vitals/vitals.css
+++ b/interface/forms/vitals/vitals.css
@@ -1,0 +1,72 @@
+.title {
+    font-weight: bold;
+}
+
+.currentvalues {
+    padding-right: 5px;
+    text-align: left;
+    min-width: 10rem;
+}
+
+th.currentvalues,
+th.historicalvalues {
+    background: var(--gray200);
+}
+
+.valuesunfocus {
+    padding-right: 5px;
+    background-color: var(--gray400);
+    text-align: left;
+}
+
+.unfocus {
+    background-color: var(--gray400);
+}
+
+.historicalvalues {
+    background-color: var(--gray400);
+    border-bottom: 1px solid var(--gray300);
+    border-right: 1px solid var(--gray300);
+    text-align: right;
+    background: var(--gray200);
+}
+.historicalvalues:nth-child(6), .reasonCodeContainer .historicalvalues:nth-child(2) {
+    border-left: 1px solid var(--gray300);
+}
+
+table {
+    border-collapse: collapse;
+    font-weight: 600;
+}
+
+td,
+th {
+    padding-right: 10px;
+    padding-left: 10px;
+}
+
+th {
+    font-weight: 800;
+}
+
+td {
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
+}
+
+input[type=text],
+select {
+    margin: 1px !important;
+}
+
+.hide {
+    display: none;
+}
+
+.readonly {
+    display: none;
+}
+
+.error {
+    border: 2px solid var(--danger);
+}

--- a/interface/forms/vitals/vitals.js
+++ b/interface/forms/vitals/vitals.js
@@ -1,5 +1,3 @@
-{literal}
-<script>
 /*
  * vitals_functions.js
  * @package openemr
@@ -9,6 +7,67 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+(function(window, oeUI) {
+
+    let translations = {};
+    let webroot = null;
+
+    function vitalsFormSubmitted() {
+        var invalid = "";
+
+        var elementsToValidate = ['weight_input', 'weight_input_metric', 'height_input', 'height_input_metric', 'bps_input', 'bpd_input'];
+
+        for (var i = 0; i < elementsToValidate.length; i++) {
+            var current_elem_id = elementsToValidate[i];
+            var tag_name = vitalsTranslations[current_elem_id] || "<unknown_tag_name>";
+
+            document.getElementById(current_elem_id).classList.remove('error');
+
+            if (isNaN(document.getElementById(current_elem_id).value)) {
+                invalid += vitalsTranslations['invalidField'] + ":" + vitalsTranslations[current_elem_id] + "\n";
+                document.getElementById(current_elem_id).className = document.getElementById(current_elem_id).className + " error";
+                document.getElementById(current_elem_id).focus();
+            }
+
+            if (invalid.length > 0) {
+                invalid += "\n" + vitalsTranslations['validateFailed'];
+                alert(invalid);
+                return false;
+            } else {
+                return top.restoreSession();
+            }
+        }
+    }
+
+    function initDOMEvents() {
+        let vitalsForm = document.getElementById('vitalsForm');
+        if (!vitalsForm) {
+            console.error("Failed to find vitalsForm DOM Node");
+            return;
+        }
+        vitalsForm.addEventListener('submit', vitalsFormSubmitted);
+
+        // we want to setup our reason code widgets
+        if (oeUI.reasonCodeWidget) {
+            oeUI.reasonCodeWidget.init(webroot);
+        } else {
+            console.error("Missing required dependency reason-code-widget");
+            return;
+        }
+    }
+    function init(webRootParam, vitalsTranslations) {
+        webroot = webRootParam;
+        translations = vitalsTranslations;
+        window.document.addEventListener("DOMContentLoaded", initDOMEvents);
+    }
+
+    let vitalsForm = {
+        "init": init
+    };
+    window.vitalsForm = vitalsForm;
+})(window, window.oeUI || {});
+
+// TODO: we need to move all of these functions into the anonymous function and connect the events via event listeners
 function convUnit(system, unit, name)
 {
     if (unit == 'kg' || unit == 'lbs')
@@ -182,5 +241,3 @@ function calculateBMI() {
         $("#BMI_input").val("");
     }
 }
-</script>
-{/literal}

--- a/library/dialog.js
+++ b/library/dialog.js
@@ -720,7 +720,7 @@ function dlgopen(url, winname, width, height, forceNewWindow, title, opts) {
                     console.log('Doing callBack:[' + opts.callBack.call + '|' + opts.callBack.args + ']');
                     if (opts.callBack.call === 'reload') {
                         window.location.reload();
-                    } else if (typeof opts.callBack == 'string') {
+                    } else if (typeof opts.callBack.call == 'string') {
                         window[opts.callBack.call](opts.callBack.args);
                     } else {
                         opts.callBack.call(opts.callBack.args);

--- a/library/dialog.js
+++ b/library/dialog.js
@@ -720,8 +720,10 @@ function dlgopen(url, winname, width, height, forceNewWindow, title, opts) {
                     console.log('Doing callBack:[' + opts.callBack.call + '|' + opts.callBack.args + ']');
                     if (opts.callBack.call === 'reload') {
                         window.location.reload();
-                    } else {
+                    } else if (typeof opts.callBack == 'string') {
                         window[opts.callBack.call](opts.callBack.args);
+                    } else {
+                        opts.callBack.call(opts.callBack.args);
                     }
                 }
 

--- a/library/js/reasonCodeWidget.js
+++ b/library/js/reasonCodeWidget.js
@@ -1,0 +1,263 @@
+/**
+ * reasonCodeWidget is used with observation,vitals, and procedures to toggle and select reason codes and their accompanying
+ * statii / text descriptions.  It requires a launch button to be present with the selector attribute of .reason-code-btn
+ *
+ * The launch button must have a data-toggle-container property with the id of the DOM node containing the reason window
+ * that you want to be displayed on the screen.  The widget will setup the code selector widget on the input that has
+ * a class of .code-selector-popup.  It will also populate the following fields if they are present in the DOM:
+ *
+ * .code-selector-popup -> text code that will be sent to the server.  In the format of CODE_SYSTEM:CODE
+ * .code-selector-text-display -> text description of the selected code or empty if code is deleted
+ * .code-selector-text -> text descriptoin of the selected code or empty (intended to be a hidden attribute to be sent to the server)
+ *
+ * If the reasonCodeWidget is toggled off it will clear all of the reason code values inside the container.
+ *
+ * Widgets can be instantiated by calling the init() method, cleanup is done via the destroy() method.  If you are manipulating
+ * the DOM (copying, moving, etc) and want to clear event handlers and reinstantiate you can call the reload() method.
+ *
+ * Note only one code selector window can be instantiated at a time.  The widget will override the default set_related callback
+ * in the document window and restore it once the find code popup window closes.
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2022 Discover and Change <snielson@discoverandchange.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+(function(window, oeUI) {
+
+    let widgetPtrs = [];
+    let previousSelCodeFunction = window.set_related || null;
+    let webroot = null;
+    let currentWindowOpenWidget = null;
+
+    function getNegationContainerFromWidget(widget) {
+        if (!(widget && widget.dataset)) {
+            window.console.error("Failed to find reason code button");
+            return false;
+        }
+        let containerId = widget.dataset['toggleContainer'];
+        if (!containerId) {
+            window.console.error("Missing data-toggle-container");
+            return false;
+        }
+        let node = document.getElementById(containerId);
+        return node;
+    }
+
+    function noop() {
+        // do nothing here.
+    }
+
+        /**
+         * Represents a single instance of a ReasonCode Widget.  Tracks the dom nodes and event callbacks associated
+         * with this instance.
+         * @param btnToggleNode
+         * @constructor
+         */
+    function Widget(btnToggleNode) {
+        var _this = this;
+
+        this.btnToggle = btnToggleNode;
+        this.reasonCodeContainer = getNegationContainerFromWidget(btnToggleNode);
+        this.reasonCodeInput = null;
+        this.reasonCodeText = null;
+        this.reasonCodeTextInput = null;
+        this.reasonStatusNode = null;
+
+        this.handleCodeSelected = function(codetype, code, selector, codedesc) {
+            // restore this first thing.
+            _this.restoreCallback(); // if there is any error we want to restore our window callback first thing.
+            if (typeof codetype != "string") {
+                // called externally so we have to check this
+                console.error("codetype was invalid data type");
+            }
+            if (typeof code != "string") {
+                console.error("code was invalid data type");
+            }
+            if (typeof codedesc != "string") {
+                console.error("codedesc was invalid data type");
+            }
+
+            if (_this.reasonCodeInput) {
+                if (codetype.trim() !== "") {
+                    _this.reasonCodeInput.value = (codetype + ":" + code);
+                } else {
+                    _this.reasonCodeInput.value = "";
+                }
+            }
+            if (_this.reasonCodeTextInput) {
+                _this.reasonCodeTextInput.value = (codedesc || "").trim();
+            }
+            // hide out our text if we arempty
+            if (_this.reasonCodeText) {
+                _this.reasonCodeText.innerText  = (codedesc || "").trim();
+                if (codedesc.trim() != "") {
+                    _this.reasonCodeText.classList.remove("d-none");
+                } else {
+                    _this.reasonCodeText.classList.add("d-none");
+                }
+            }
+        };
+
+        this.restoreCallback = function() {
+            // could be undefined but we need this for the code selector anyways
+            window.set_related = previousSelCodeFunction;
+        };
+
+        this.launchCodeSelector = function() {
+            let opts = {
+                callBack: {
+                    call: _this.restoreCallback
+                }
+            };
+            // we are going to replace our global function for the time, and it will get setback in the callback
+            previousSelCodeFunction = window.set_related;
+            window.set_related =  _this.handleCodeSelected;
+
+            window.dlgopen(webroot + "/interface/patient_file/encounter/find_code_popup.php?default=SNOMED-CT"
+                , '_blank', 700, 400, false, undefined, opts);
+        };
+
+        this.destroy = function() {
+            if (_this.reasonCodeInput) {
+                _this.reasonCodeInput.removeEventListener('click', _this.launchCodeSelector);
+            }
+            if (_this.btnToggle) {
+                _this.btnToggle.removeEventListener('click', toggleReasonCode);
+            }
+            _this.reasonCodeInput = null;
+            _this.reasonCodeText = null;
+            _this.reasonCodeTextInput = null;
+            _this.reasonStatusNode = null;
+            _this.btnToggle = null;
+            _this.reasonCodeContainer = null;
+        };
+
+        this.show = function() {
+            toggleDisplay(true);
+        };
+
+        this.hide = function() {
+            toggleDisplay(false);
+        };
+
+        function toggleDisplay(shouldDisplay) {
+            if (shouldDisplay) {
+                _this.reasonCodeContainer.classList.remove("d-none");
+            } else {
+                _this.reasonCodeContainer.classList.add("d-none");
+                resetValues();
+            }
+        }
+
+        function resetValues() {
+            // reset our values here
+            if (_this.reasonCodeInput) {
+                _this.reasonCodeInput.value = "";
+
+            }
+            if (_this.reasonCodeText) {
+                _this.reasonCodeText.innerText = "";
+                _this.reasonCodeText.classList.add("d-none");
+            }
+            if (_this.reasonCodeTextInput) {
+                _this.reasonCodeTextInput.value = "";
+            }
+            if (_this.reasonStatusNode) {
+                _this.reasonStatusNode.selectedIndex = 0;
+            }
+        }
+
+        function toggleReasonCode(event) {
+            event.preventDefault();
+            var target = event.currentTarget;
+            if (!(target && target.dataset)) {
+                window.console.error("Failed to find reason code button");
+                return false;
+            }
+            toggleDisplay(_this.reasonCodeContainer.classList.contains("d-none"))
+            return false;
+        }
+
+        function init() {
+
+            if (_this.reasonCodeContainer) {
+                _this.reasonCodeInput = _this.reasonCodeContainer.querySelector('.code-selector-popup');
+                if (_this.reasonCodeInput) {
+                    _this.reasonCodeInput.addEventListener('click', _this.launchCodeSelector);
+                } else {
+                    console.error("Failed to find input node with selector .code-selector-popup");
+                }
+                _this.reasonCodeText = _this.reasonCodeContainer.querySelector('.code-selector-text-display');
+                _this.reasonCodeTextInput = _this.reasonCodeContainer.querySelector('.code-selector-text');
+                _this.reasonStatusNode = _this.reasonCodeContainer.querySelector('select');
+            }
+
+            if (_this.btnToggle && btnToggleNode.addEventListener) {
+                _this.btnToggle.addEventListener('click', toggleReasonCode);
+            }
+            else {
+                window.console.error("Widget called to be setup but was null");
+            }
+
+        }
+        init();
+    }
+
+    function destroyWidget(widget) {
+        if (widget && widget.removeEventListener) {
+            widget.removeEventListener('click', toggleNegationRationale);
+        } else {
+            window.console.error("Widget called to be destroyed but was not a valid widget", widget);
+        }
+    }
+
+    function destroyWidgetList() {
+        if (widgetPtrs && widgetPtrs.length) {
+            widgetPtrs.forEach(function(widget) {
+                widget.destroy();
+            });
+        }
+        widgetPtrs = [];
+    }
+
+    function reload() {
+        destroy();
+        init(webroot); // make sure we keep the same webroot here.
+    }
+
+    function init(webRootValue) {
+        widgetPtrs = [];
+        // destroy if we have anything setup right now
+        widgetPtrNodes = document.querySelectorAll('.reason-code-btn');
+        if (!(widgetPtrNodes && widgetPtrNodes.forEach)) {
+            return; // nothing to do here
+        }
+        widgetPtrNodes.forEach(function(node) {
+            let widget = new Widget(node);
+            widgetPtrs.push(widget);
+        });
+        webroot = webRootValue;
+    }
+    function destroy() {
+        destroyWidgetList();
+    }
+
+    function getWidgetForNode(node) {
+        return widgetPtrs.filter(function(widget) {
+            return widget.btnToggle == node;
+        });
+    }
+
+    // any other functions can go here
+    oeUI.reasonCodeWidget = {
+        init: init
+        ,destroy: destroy
+        ,reload: reload
+        ,getWidget: getWidgetForNode
+    };
+    window.oeUI = oeUI;
+}
+// we wrap everything into an oeUI so we don't get namespace clashes.
+)(window, window.oeUI || {});

--- a/library/js/reasonCodeWidget.js
+++ b/library/js/reasonCodeWidget.js
@@ -114,7 +114,7 @@
             // we are going to replace our global function for the time, and it will get setback in the callback
             previousSelCodeFunction = window.set_related;
             window.set_related =  _this.handleCodeSelected;
-
+            window.top.restoreSession();
             window.dlgopen(webroot + "/interface/patient_file/encounter/find_code_popup.php?default=SNOMED-CT"
                 , '_blank', 700, 400, false, undefined, opts);
         };

--- a/library/smarty/plugins/function.assetVersionNumber.php
+++ b/library/smarty/plugins/function.assetVersionNumber.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Smarty plugin
+ * @package Smarty
+ * @subpackage plugins
+ * xl() version for smarty templates
+ *
+ * Copyright (C) 2007 Christian Navalici
+ * Copyright (C) 2019 Brady Miller <brady.g.miller@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+
+/**
+ * Smarty {xl} function plugin
+ *
+ * Type:     function<br />
+ * Name:     assetVersionNumber<br />
+ * Purpose:  Return the version number to be used in a script or style asset include ie script?v={jsVersionNumber}<br />
+ *
+ * Examples:
+ *
+ * {jsVersionNumber}
+ *
+ * @param array
+ * @param Smarty
+ */
+
+
+function smarty_function_assetVersionNumber($params, &$smarty)
+{
+    echo $GLOBALS['v_js_includes'] ?? 1; // if for some reason we don't have a version we just return one
+}

--- a/sql/6_1_0-to-7_0_0_upgrade.sql
+++ b/sql/6_1_0-to-7_0_0_upgrade.sql
@@ -549,5 +549,5 @@ UPDATE categories SET codes='LOINC:LP173394-0' WHERE name='Reviewed';
 #EndIf
 
 #IfMissingColumn form_vital_details reason_code
-ALTER TABLE `form_vital_details` ADD `reason_code` VARCHAR(31) DEFAULT NULL, ADD `reason_description` TEXT, ADD `reason_status` VARCHAR(31) NULL DEFAULT NULL;
+ALTER TABLE `form_vital_details` ADD `reason_code` VARCHAR(31) DEFAULT NULL COMMENT 'Medical code explaining reason of the vital observation value in form codesystem:codetype;...;', ADD `reason_description` TEXT COMMENT 'Human readable text description of the reason_code column', ADD `reason_status` VARCHAR(31) NULL DEFAULT NULL COMMENT 'The status of the reason ie completed, in progress, etc';
 #EndIf

--- a/sql/6_1_0-to-7_0_0_upgrade.sql
+++ b/sql/6_1_0-to-7_0_0_upgrade.sql
@@ -547,3 +547,7 @@ UPDATE categories SET codes='LOINC:LP173418-7' WHERE name='Advance Directive';
 UPDATE categories SET codes='LOINC:LP173421-1' WHERE name='FHIR Export Document';
 UPDATE categories SET codes='LOINC:LP173394-0' WHERE name='Reviewed';
 #EndIf
+
+#IfMissingColumn form_vital_details reason_code
+ALTER TABLE `form_vital_details` ADD `reason_code` VARCHAR(31) DEFAULT NULL, ADD `reason_description` TEXT, ADD `reason_status` VARCHAR(31) NULL DEFAULT NULL;
+#EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -12909,6 +12909,9 @@ CREATE TABLE `form_vital_details` (
 `interpretation_option_id` varchar(100) DEFAULT NULL COMMENT 'FK to list_options.option_id for observation_interpretation',
 `interpretation_codes` varchar(255) DEFAULT NULL COMMENT 'Archived original codes value from list_options observation_interpretation',
 `interpretation_title` varchar(255) DEFAULT NULL COMMENT 'Archived original title value from list_options observation_interpretation',
+`reason_code` VARCHAR(31) NULL DEFAULT NULL COMMENT 'Medical code explaining reason of the vital observation value in form codesystem:codetype;...;',
+`reason_description` TEXT COMMENT 'Human readable text description of the reason_code column',
+`reason_status` VARCHAR(31) NULL DEFAULT NULL COMMENT 'The status of the reason ie completed, in progress, etc',
 PRIMARY KEY (`id`),
 KEY `fk_form_id` (`form_id`),
 KEY `fk_list_options_id` (`interpretation_list_id`, `interpretation_option_id`)

--- a/src/Common/Forms/FormVitalDetails.php
+++ b/src/Common/Forms/FormVitalDetails.php
@@ -69,6 +69,12 @@ class FormVitalDetails extends ORDataObject
      */
     private $interpretation_codes;
 
+    private $reason_code;
+
+    private $reason_status;
+
+    private $reason_description;
+
     public function __construct()
     {
         parent::__construct(self::TABLE_NAME);
@@ -223,4 +229,68 @@ class FormVitalDetails extends ORDataObject
     {
         return $this->form_id;
     }
+
+    /**
+     * @return string
+     */
+    public function get_reason_code()
+    {
+        return $this->reason_code;
+    }
+
+    /**
+     * @param string $reason_code
+     * @return FormVitalDetails
+     */
+    public function set_reason_code($reason_code)
+    {
+        $this->reason_code = $reason_code;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function get_reason_status()
+    {
+        return $this->reason_status;
+    }
+
+    /**
+     * @param string $reason_status
+     * @return FormVitalDetails
+     */
+    public function set_reason_status($reason_status)
+    {
+        $this->reason_status = $reason_status;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function get_reason_description()
+    {
+        return $this->reason_description;
+    }
+
+    /**
+     * @param string $reason_status_code
+     * @return FormVitalDetails
+     */
+    public function set_reason_description($reason_description)
+    {
+        $this->reason_description = $reason_description;
+        return $this;
+    }
+
+    /**
+     * Removes all of the reason code, status, and text data
+     */
+    public function clear_reason() {
+        $this->reason_code = null;
+        $this->reason_status = null;
+        $this->reason_description = null;
+    }
+
 }

--- a/src/Common/Forms/FormVitalDetails.php
+++ b/src/Common/Forms/FormVitalDetails.php
@@ -287,10 +287,10 @@ class FormVitalDetails extends ORDataObject
     /**
      * Removes all of the reason code, status, and text data
      */
-    public function clear_reason() {
+    public function clear_reason()
+    {
         $this->reason_code = null;
         $this->reason_status = null;
         $this->reason_description = null;
     }
-
 }

--- a/src/Common/Forms/FormVitals.php
+++ b/src/Common/Forms/FormVitals.php
@@ -479,6 +479,13 @@ class FormVitals extends ORDataObject
         $this->_vitals_details[$column] = $details;
     }
 
+    public function has_reason_for_column($column) {
+        $details = $this->get_details_for_column($column);
+        if (isset($details)) {
+            return !empty($details->get_reason_code());
+        }
+    }
+
     public function persist()
     {
         if (empty($this->uuid)) {

--- a/src/Common/Forms/FormVitals.php
+++ b/src/Common/Forms/FormVitals.php
@@ -479,7 +479,8 @@ class FormVitals extends ORDataObject
         $this->_vitals_details[$column] = $details;
     }
 
-    public function has_reason_for_column($column) {
+    public function has_reason_for_column($column)
+    {
         $details = $this->get_details_for_column($column);
         if (isset($details)) {
             return !empty($details->get_reason_code());

--- a/src/Common/Forms/ReasonStatusCodes.php
+++ b/src/Common/Forms/ReasonStatusCodes.php
@@ -12,7 +12,6 @@
 
 namespace OpenEMR\Common\Forms;
 
-
 class ReasonStatusCodes
 {
     const COMPLETED = "completed";
@@ -20,13 +19,14 @@ class ReasonStatusCodes
     const PENDING = "pending";
     const EMPTY = "";
 
-    public static function getCodesWithDescriptions() {
+    public static function getCodesWithDescriptions()
+    {
         return [
-            self::EMPTY=> [
+            self::EMPTY => [
                 'code' => self::EMPTY
                 ,'description' => ""
             ]
-            ,self::PENDING=> [
+            ,self::PENDING => [
                 'code' => self::PENDING
                 ,'description' => xl("Pending")
             ]

--- a/src/Common/Forms/ReasonStatusCodes.php
+++ b/src/Common/Forms/ReasonStatusCodes.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * ReasonStatusCodes represents the statii that an observation,procedure, and other ccda/cql reportable item's reason code
+ * can be.
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2022 Discover and Change <snielson@discoverandchange.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Common\Forms;
+
+
+class ReasonStatusCodes
+{
+    const COMPLETED = "completed";
+    const NEGATED = "negated";
+    const PENDING = "pending";
+    const EMPTY = "";
+
+    public static function getCodesWithDescriptions() {
+        return [
+            self::EMPTY=> [
+                'code' => self::EMPTY
+                ,'description' => ""
+            ]
+            ,self::PENDING=> [
+                'code' => self::PENDING
+                ,'description' => xl("Pending")
+            ]
+            ,self::COMPLETED => [
+                'code' => self::COMPLETED
+                ,'description' => xl("Completed")
+            ]
+            ,self::NEGATED => [
+                'code' => self::NEGATED
+                ,'description' => xl("Negated")
+            ]
+        ];
+    }
+}

--- a/src/Core/Header.php
+++ b/src/Core/Header.php
@@ -8,6 +8,7 @@
 
 namespace OpenEMR\Core;
 
+use OpenEMR\Common\Logging\SystemLogger;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\Yaml\Exception\ParseException;
 
@@ -169,6 +170,7 @@ class Header
      */
     private static function parseConfigFile($map, $selectedAssets = array())
     {
+        $foundAssets = [];
         foreach ($map as $k => $opts) {
             $autoload = (isset($opts['autoload'])) ? $opts['autoload'] : false;
             $allowNoLoad = (isset($opts['allowNoLoad'])) ? $opts['allowNoLoad'] : false;
@@ -182,6 +184,7 @@ class Header
                         continue;
                     }
                 }
+                $foundAssets[] = $k;
 
                 $tmp = self::buildAsset($opts, $alreadyBuilt);
 
@@ -214,6 +217,10 @@ class Header
                     }
                 }
             }
+        }
+
+        if (count(array_diff($selectedAssets, $foundAssets)) > 0) {
+            (new SystemLogger())->error("Not all selected assets were included in header", ['selectedAssets' => $selectedAssets, 'foundAssets' => $foundAssets]);
         }
     }
 

--- a/src/Services/VitalsService.php
+++ b/src/Services/VitalsService.php
@@ -119,6 +119,9 @@ class VitalsService extends BaseService
                     ,details.interpretation_option_id
                     ,details.interpretation_codes
                     ,details.interpretation_title
+                    ,details.reason_code
+                    ,details.reason_status
+                    ,details.reason_description
                     ,details.vitals_column
                 FROM
                 (
@@ -175,6 +178,9 @@ class VitalsService extends BaseService
                         ,interpretation_option_id
                         ,interpretation_codes
                         ,interpretation_title
+                        ,reason_code
+                        ,reason_status
+                        ,reason_description
                         ,vitals_column
                     FROM
                         form_vital_details
@@ -273,7 +279,7 @@ class VitalsService extends BaseService
 
 
         $detailColumns = ['details_id', 'interpretation_codes', 'interpretation_title', 'vitals_column'
-            , 'interpretation_list_id', 'interpretation_option_id'];
+            , 'interpretation_list_id', 'interpretation_option_id', 'reason_code', 'reason_status', 'reason_description'];
 
 
         // we only set the details record if we actually have a details


### PR DESCRIPTION
Fixes #5255

Added support for reason code, reason_status, and reason_description for
the observation form as well as for the vitals_form.

Fixed the observation form to use a datetime selector instead of just a
regular date field.

Implemented a reason code widget script that allows us to implement the
code selector and hide/display of the reason container based upon the
launch button.

Refactored a lot of the javascript i the observation and vitals form
into separate javascript files to simplify debugging and to make it
easier to work with.

Added reason_code, reason_status, and reason_description to the
vital_form_details table.

Added a callback function parameter to the dialog so that you can pass a
callback that doesn't have to exist in the global document window.

Made it so if we attempt to include a header asset file that does not
exist in the config.yaml that it writes an error out to the log that the
includes did not match.