### PR TITLE
Encounter type field in encounter form.  Fixes #5260

### DIFF
--- a/interface/forms/newpatient/common.php
+++ b/interface/forms/newpatient/common.php
@@ -581,6 +581,14 @@ $ires = sqlStatement("SELECT id, type, title, begdate FROM lists WHERE " .
                             <?php echo generate_select_list('class_code', '_ActEncounterCode', $viewmode ? $result['class_code'] : '', '', ''); ?>
                         </div>
                     </div>
+                    <div class="form-row align-items-center mt-2">
+                        <div class="col-sm-2">
+                            <label for='encounter_type' class="text-right"><?php echo xlt('Type'); ?>:</label>
+                        </div>
+                        <div class="col-sm">
+                            <?php echo generate_select_list('encounter_type', 'encounter-types', $viewmode ? $result['encounter_type'] : '', '', ''); ?>
+                        </div>
+                    </div>
                     <?php if ($GLOBALS['set_pos_code_encounter']) { ?>
                     <div class="form-row align-items-center mt-2">
                         <div class="col-sm-2">

--- a/interface/forms/newpatient/common.php
+++ b/interface/forms/newpatient/common.php
@@ -586,7 +586,22 @@ $ires = sqlStatement("SELECT id, type, title, begdate FROM lists WHERE " .
                             <label for='encounter_type' class="text-right"><?php echo xlt('Type'); ?>:</label>
                         </div>
                         <div class="col-sm">
-                            <?php echo generate_select_list('encounter_type', 'encounter-types', $viewmode ? $result['encounter_type'] : '', '', ''); ?>
+                            <?php
+                            // we need to convert from our selected code if we have one to our list type
+                            $encounter_type_option = $result['encounter_type_code'] ?? '';
+                            if (!empty($encounter_type_option)) {
+                                $listService = new ListService();
+                                $codes = $listService->getOptionsByListName('encounter-types', ['codes' => $result['encounter_type_code']]);
+                                if (empty($codes[0])) {
+                                    // we may not have code types installed, in that case we will just use the option-id so we can remember the data
+                                    $option = $listService->getListOption('encounter-types', $encounter_type_option);
+                                    $encounter_type_option = $option['option_id'] ?? '';
+                                } else {
+                                    $encounter_type_option = $codes[0]['option_id'];
+                                }
+                            }
+                            ?>
+                            <?php echo generate_select_list('encounter_type', 'encounter-types', $viewmode ? $encounter_type_option : '', '', '--' . xl('Select One') . '--'); ?>
                         </div>
                     </div>
                     <?php if ($GLOBALS['set_pos_code_encounter']) { ?>

--- a/interface/forms/newpatient/save.php
+++ b/interface/forms/newpatient/save.php
@@ -18,8 +18,10 @@ require_once("$srcdir/encounter.inc");
 
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Services\CodeTypesService;
 use OpenEMR\Services\EncounterService;
 use OpenEMR\Services\FacilityService;
+use OpenEMR\Services\ListService;
 
 if (!CsrfUtils::verifyCsrfToken($_POST["csrf_token_form"])) {
     CsrfUtils::csrfNotVerified();
@@ -57,6 +59,24 @@ $nexturl = $normalurl;
 $provider_id = $_SESSION['authUserID'] ? $_SESSION['authUserID'] : 0;
 $provider_id = $encounter_provider ? $encounter_provider : $provider_id;
 
+$encounter_type = $_POST['encounter_type'] ?? '';
+$encounter_type_code = null;
+$encounter_type_description = null;
+// we need to lookup the codetype and the description from this if we have one
+if (!empty($encounter_type)) {
+    $listService = new ListService();
+    $option = $listService->getListOption('encounter-types', $encounter_type);
+    $encounter_type_code = $option['codes'] ?? null;
+    if (!empty($encounter_type_code)) {
+        $codeService = new CodeTypesService();
+        $encounter_type_description = $codeService->lookup_code_description($encounter_type_code) ?? null;
+    } else {
+        // we don't have any codes installed here so we will just use the encounter_type
+        $encounter_type_code = $encounter_type;
+        $encounter_type_description = $option['title'];
+    }
+}
+
 if ($mode == 'new') {
     $encounter = generate_id();
     addForm(
@@ -81,7 +101,9 @@ if ($mode == 'new') {
                 parent_encounter_id = ?,
                 provider_id = ?,
                 discharge_disposition = ?,
-                referring_provider_id = ?",
+                referring_provider_id = ?,
+                encounter_type_code = ?,
+                encounter_type_description = ?",
             [
                 $date,
                 $onset_date,
@@ -100,7 +122,9 @@ if ($mode == 'new') {
                 $parent_enc_id,
                 $provider_id,
                 $discharge_disposition,
-                $referring_provider_id
+                $referring_provider_id,
+                $encounter_type_code,
+                $encounter_type_description
             ]
         ),
         "newpatient",
@@ -138,6 +162,8 @@ if ($mode == 'new') {
         $pos_code,
         $discharge_disposition,
         $referring_provider_id,
+        $encounter_type_code,
+        $encounter_type_description,
         $id
     );
     sqlStatement(
@@ -155,7 +181,10 @@ if ($mode == 'new') {
             class_code = ?,
             pos_code = ?,
             discharge_disposition = ?,
-            referring_provider_id = ? WHERE id = ?",
+            referring_provider_id = ?,
+            encounter_type_code = ?,
+            encounter_type_description = ?
+            WHERE id = ?",
         $sqlBindArray
     );
 } else {

--- a/interface/modules/zend_modules/config/application.config.php
+++ b/interface/modules/zend_modules/config/application.config.php
@@ -18,6 +18,7 @@ $core_modules = [
     'Installer', // Handles the dynamic adding / removing of modules in the system.
     'Acl', // Handles all of the permission checks in the system.
     'FHIR', // Handles FHIR mapped uuid population and other FHIR utility functions
+    'CodeTypes', // Handles CodeType mappings and anything else to do with the system of dealing with code types
     'PatientFlowBoard', // Handle any functionality needed for the patient flow board
 ];
 

--- a/interface/modules/zend_modules/module/CodeTypes/Module.php
+++ b/interface/modules/zend_modules/module/CodeTypes/Module.php
@@ -1,14 +1,14 @@
 <?php
 
 /**
- * FHIR/Module  Handles the module instantiation for the FHIR module.  Note that because of the way laminas loads the
- * modules the namespace for this module is 'FHIR'.  However to avoid namespace clashes we have defined the namespace
- * to be under the OpenEMR namespace as seen in the getAutoloaderConfig method.
+ * CodeTypes/Module  Handles the mapping of code systems to our list options and any other code type processing that
+ * we need to take care of in the system based on system events.
  *
  * @package   OpenEMR
- * @link      https://www.open-emr.org
- * @author Stephen Nielson <stephen@nielson.org>
- * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @link      http://www.open-emr.org
+ *
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2022 Discover and Change, Inc. <snielson@discoverandchange.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 

--- a/interface/modules/zend_modules/module/CodeTypes/config/module.config.php
+++ b/interface/modules/zend_modules/module/CodeTypes/config/module.config.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Handles class, routing, views, and other configuration properties for the module.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\ZendModules\CodeTypes;
+
+use Laminas\ServiceManager\Factory\InvokableFactory;
+use OpenEMR\ZendModules\CodeTypes\Listener\CodeTypeEventsSubscriber;
+
+return array(
+    'service_manager' => array(
+        'factories' => array(
+            CodeTypeEventsSubscriber::class => InvokableFactory::class
+        )
+    )
+);

--- a/interface/modules/zend_modules/module/CodeTypes/src/CodeTypes/Listener/CodeTypeEventsSubscriber.php
+++ b/interface/modules/zend_modules/module/CodeTypes/src/CodeTypes/Listener/CodeTypeEventsSubscriber.php
@@ -1,0 +1,96 @@
+<?php
+
+
+namespace OpenEMR\ZendModules\CodeTypes\Listener;
+
+
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Events\Core\CodeTypeInstalledEvent;
+use OpenEMR\Events\Core\SQLUpgradeEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class CodeTypeEventsSubscriber  implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return [
+            SQLUpgradeEvent::EVENT_UPGRADE_POST => 'onSqlUpgradeEvent'
+            ,CodeTypeInstalledEvent::EVENT_INSTALLED_POST
+        ];
+    }
+
+    public function onSqlUpgradeEvent(SQLUpgradeEvent $event) {
+        // grab our currently installed code types, check for SNOMED-CT AND CPT4 and then update accordingly.
+        // SELECT * FROM code_types WHERE ct_active=1 ORDER BY ct_seq, ct_key
+    }
+
+    public function onCodeTypeInstalledEvent(CodeTypeInstalledEvent $event) {
+        if ($event->getCodeType() == "SNOMED") {
+            // check if we have SNOMED codes installed and update our list options
+            $this->updateSNOMEDCTMappings();
+        }
+        else if ($event->getCodeType() == "CPT4") {
+            // check if we have CPT4 codes installed and update our list options
+            $this->updateCPT4Mappings();
+        }
+    }
+    private function updateSNOMEDCTMappings() {
+        // update our list options
+        $mappings = [
+            'visit-after-hours' => '185463005',
+            'visit-after-hours-not-night' => '185464004',
+            'weekend-visit' => '185465003',
+            'office-visit' => '30346009',
+            'established-patient' => '3391000175108',
+            'new-patient' => '37894004',
+            'postoperative-follow-up' => '439740005'
+        ];
+
+        try {
+            \sqlBeginTrans();
+            foreach ($mappings as $option_id => $code_id) {
+                $sql = "UPDATE list_options SET codes=CONCAT('SNOMED-CT:', ?) WHERE list_id='encounter-types' AND option_id=?";
+                QueryUtils::sqlStatementThrowException($sql, [$option_id, $code_id]);
+            }
+            \sqlCommitTrans();
+        }
+        catch (\Exception $exception) {
+            (new SystemLogger())->errorLogCaller($exception->getMessage(), ['trace' => $exception->getTraceAsString()]);
+            \sqlRollbackTrans();
+        }
+    }
+
+    private function updateCPT4Mappings() {
+        // update our list options
+        $mappings = [
+            'new-patient-10' => 'New Patient (Brief)'
+            ,'new-patient-15-29' => 'New Patient (Limited)'
+            ,'new-patient-30-44' => 'Level 3, New Patient, Office Visit'
+            , 'new-patient-45-59' => 'Extended Physical Exam'
+            , 'new-patient-60-74' => 'New Exam (Comprehensive)'
+            , 'established-patient-10-19' => 'Established Patient (Limited)'
+            , 'established-patient-20-29' => 'Established Patient (Detailed)'
+            , 'established-patient-30-39' => 'Established Patient (Extended)'
+            , 'established-patient-40-54' => 'Established Patient (Comprehensive)'
+        ];
+
+        try {
+            \sqlBeginTrans();
+            foreach ($mappings as $option_id => $code_text) {
+                $code_id = QueryUtils::fetchSingleValue("SELECT `code` FROM codes_cpt WHERE code_text =?", 'code', [$code_text]);
+                if (empty($code_id)) {
+                    (new SystemLogger())->debug("Failed to find code in codes_cpt with code_text. Skipping option_id"
+                        , ['code_text' => $code_text, 'option_id' => $option_id]);
+                }
+                $sql = "UPDATE list_options SET codes=CONCAT('CPT4:', ?) WHERE list_id='encounter-types' AND option_id=?";
+                QueryUtils::sqlStatementThrowException($sql, [$option_id, $code_id]);
+            }
+            \sqlCommitTrans();
+        }
+        catch (\Exception $exception) {
+            (new SystemLogger())->errorLogCaller($exception->getMessage(), ['trace' => $exception->getTraceAsString()]);
+            \sqlRollbackTrans();
+        }
+    }
+}

--- a/interface/modules/zend_modules/module/CodeTypes/src/CodeTypes/Listener/CodeTypeEventsSubscriber.php
+++ b/interface/modules/zend_modules/module/CodeTypes/src/CodeTypes/Listener/CodeTypeEventsSubscriber.php
@@ -1,94 +1,205 @@
 <?php
 
+/**
+ * CodeTypeEventsSubscriber  Handles the mapping of code systems to our list options.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ *
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2022 Discover and Change, Inc. <snielson@discoverandchange.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
 
 namespace OpenEMR\ZendModules\CodeTypes\Listener;
 
-
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Logging\SystemLogger;
-use OpenEMR\Events\Core\CodeTypeInstalledEvent;
+use OpenEMR\Events\Codes\CodeTypeInstalledEvent;
 use OpenEMR\Events\Core\SQLUpgradeEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class CodeTypeEventsSubscriber  implements EventSubscriberInterface
+class CodeTypeEventsSubscriber implements EventSubscriberInterface
 {
+    private const SNOMED_ENCOUNTER_TYPE_MAPPINGS = [
+        'visit-after-hours' => '185463005',
+        'visit-after-hours-not-night' => '185464004',
+        'weekend-visit' => '185465003',
+        'office-visit' => '30346009',
+        'established-patient' => '3391000175108',
+        'new-patient' => '37894004',
+        'postoperative-follow-up' => '439740005'
+    ];
+
+    private const CODE_TYPE_SNOMED = "SNOMED";
+    private const CODE_TYPE_SNOMED_CT = "SNOMED-CT";
+    private const CODE_TYPE_SNOMED_PR = "SNOMED-PR";
+    private const CODE_TYPE_CPT4 = "CPT4";
+
+    private const CPT4_ENCOUNTER_TYPE_MAPPINGS = [
+        'new-patient-10' => 'New Patient (Brief)'
+        ,'new-patient-15-29' => 'New Patient (Limited)'
+        ,'new-patient-30-44' => 'Level 3, New Patient, Office Visit'
+        , 'new-patient-45-59' => 'Extended Physical Exam'
+        , 'new-patient-60-74' => 'New Exam (Comprehensive)'
+        , 'established-patient-10-19' => 'Established Patient (Limited)'
+        , 'established-patient-20-29' => 'Established Patient (Detailed)'
+        , 'established-patient-30-39' => 'Established Patient (Extended)'
+        , 'established-patient-40-54' => 'Established Patient (Comprehensive)'
+    ];
+
     public static function getSubscribedEvents()
     {
         return [
             SQLUpgradeEvent::EVENT_UPGRADE_POST => 'onSqlUpgradeEvent'
-            ,CodeTypeInstalledEvent::EVENT_INSTALLED_POST
+            ,CodeTypeInstalledEvent::EVENT_INSTALLED_POST => 'onCodeTypeInstalledEvent'
         ];
     }
 
-    public function onSqlUpgradeEvent(SQLUpgradeEvent $event) {
+    public function onSqlUpgradeEvent(SQLUpgradeEvent $event)
+    {
         // grab our currently installed code types, check for SNOMED-CT AND CPT4 and then update accordingly.
         // SELECT * FROM code_types WHERE ct_active=1 ORDER BY ct_seq, ct_key
+        $activatedCodeTypes = QueryUtils::fetchRecords("SELECT ct_key FROM code_types WHERE ct_active=1 ORDER BY ct_seq, ct_key");
+        if (empty($activatedCodeTypes)) {
+            return;
+        }
+        // we want to push out to the system that we are making changes...
+        $logger = function ($message) use ($event) {
+            // make sure we escape this here.
+            $event->getSqlUpgradeService()->flush_echo(text($message) . "<br />");
+        };
+
+        foreach ($activatedCodeTypes as $record) {
+            if ($record['ct_key'] == self::CODE_TYPE_CPT4) {
+                if ($this->shouldUpdateCPT4Mappings()) {
+                    $logger("Updating " . $record['ct_key'] . " Mappings");
+                    $this->updateCPT4Mappings($logger);
+                } else {
+                    $logger("Skipping Section #updateCPT4Mappings");
+                }
+            } else if ($this->isSnomedCodeType($record['ct_key'])) {
+                if ($this->shouldUpdateSNOMEDMappings()) {
+                    $logger("Updating " . $record['ct_key'] . " Mappings");
+                    $this->updateSNOMEDCTMappings($logger);
+                } else {
+                    $logger("Skipping Section #updateSNOMEDMappings type=" . $record['ct_key']);
+                }
+            }
+        }
     }
 
-    public function onCodeTypeInstalledEvent(CodeTypeInstalledEvent $event) {
+    public function onCodeTypeInstalledPreEvent(CodeTypeInstalledEvent $event)
+    {
+        error_log("Got here in pre installed event");
+    }
+
+    public function onCodeTypeInstalledEvent(CodeTypeInstalledEvent $event)
+    {
         if ($event->getCodeType() == "SNOMED") {
             // check if we have SNOMED codes installed and update our list options
             $this->updateSNOMEDCTMappings();
-        }
-        else if ($event->getCodeType() == "CPT4") {
+        } else if ($event->getCodeType() == "CPT4" && $this->shouldUpdateCPT4Mappings()) {
             // check if we have CPT4 codes installed and update our list options
             $this->updateCPT4Mappings();
         }
     }
-    private function updateSNOMEDCTMappings() {
-        // update our list options
-        $mappings = [
-            'visit-after-hours' => '185463005',
-            'visit-after-hours-not-night' => '185464004',
-            'weekend-visit' => '185465003',
-            'office-visit' => '30346009',
-            'established-patient' => '3391000175108',
-            'new-patient' => '37894004',
-            'postoperative-follow-up' => '439740005'
-        ];
 
+    private function isSnomedCodeType($codeType)
+    {
+        return in_array($codeType, [self::CODE_TYPE_SNOMED, self::CODE_TYPE_SNOMED_CT, self::CODE_TYPE_SNOMED_PR]);
+    }
+
+    private function exists_code_table($tableName)
+    {
+        // make sure our table is installed
+        $table_records = QueryUtils::fetchRecords("SHOW TABLES LIKE ?", [$tableName]);
+        if (empty($table_records)) {
+            (new SystemLogger())->debug("table for code_type does not exist", ['tableName' => $tableName]);
+        }
+        return !empty($table_records);
+    }
+
+    private function shouldUpdateCPT4Mappings()
+    {
+        if (!$this->exists_code_table('codes_cpt')) {
+            // no codes installed so we aren't updating anything.
+            return false;
+        }
+
+        foreach (self::CPT4_ENCOUNTER_TYPE_MAPPINGS as $option_id => $code_text) {
+            $code_id = QueryUtils::fetchSingleValue("SELECT `code` FROM codes_cpt WHERE code_text =?", 'code', [$code_text]);
+            if (empty($code_id)) {
+                (new SystemLogger())->debug(
+                    "Failed to find code in codes_cpt with code_text. Skipping option_id",
+                    ['code_text' => $code_text, 'option_id' => $option_id]
+                );
+            }
+            $sql = "SELECT codes FROM list_options WHERE list_id='encounter-types' AND option_id=?";
+            $codes = QueryUtils::fetchSingleValue($sql, 'codes', [$option_id]);
+            if ($codes != "CPT4:" . $code_id) {
+                return true;
+            }
+        }
+        // no upgrade needed
+        return false;
+    }
+
+    private function shouldUpdateSNOMEDMappings()
+    {
+        foreach (self::SNOMED_ENCOUNTER_TYPE_MAPPINGS as $option_id => $code_id) {
+            $sql = "SELECT codes FROM list_options WHERE list_id='encounter-types' AND option_id=?";
+            $codes = QueryUtils::fetchSingleValue($sql, 'codes', [$option_id]);
+            if ($codes != self::CODE_TYPE_SNOMED_CT . ":" . $code_id) {
+                return true;
+            }
+        }
+        // no upgrade needed
+        return false;
+    }
+
+    private function updateSNOMEDCTMappings($logger = null)
+    {
+        // update our list options
         try {
             \sqlBeginTrans();
-            foreach ($mappings as $option_id => $code_id) {
+            foreach (self::SNOMED_ENCOUNTER_TYPE_MAPPINGS as $option_id => $code_id) {
                 $sql = "UPDATE list_options SET codes=CONCAT('SNOMED-CT:', ?) WHERE list_id='encounter-types' AND option_id=?";
-                QueryUtils::sqlStatementThrowException($sql, [$option_id, $code_id]);
+                $values = [$code_id, $option_id];
+                if (!empty($logger) && is_callable($logger)) {
+                    $logger('(sql=`"' . $sql . '`, values=`' . var_export($values, true) . "`)");
+                }
+                QueryUtils::sqlStatementThrowException($sql, $values);
             }
             \sqlCommitTrans();
-        }
-        catch (\Exception $exception) {
+        } catch (\Exception $exception) {
             (new SystemLogger())->errorLogCaller($exception->getMessage(), ['trace' => $exception->getTraceAsString()]);
             \sqlRollbackTrans();
         }
     }
 
-    private function updateCPT4Mappings() {
+    private function updateCPT4Mappings($logger = null)
+    {
         // update our list options
-        $mappings = [
-            'new-patient-10' => 'New Patient (Brief)'
-            ,'new-patient-15-29' => 'New Patient (Limited)'
-            ,'new-patient-30-44' => 'Level 3, New Patient, Office Visit'
-            , 'new-patient-45-59' => 'Extended Physical Exam'
-            , 'new-patient-60-74' => 'New Exam (Comprehensive)'
-            , 'established-patient-10-19' => 'Established Patient (Limited)'
-            , 'established-patient-20-29' => 'Established Patient (Detailed)'
-            , 'established-patient-30-39' => 'Established Patient (Extended)'
-            , 'established-patient-40-54' => 'Established Patient (Comprehensive)'
-        ];
-
         try {
             \sqlBeginTrans();
-            foreach ($mappings as $option_id => $code_text) {
+            foreach (self::CPT4_ENCOUNTER_TYPE_MAPPINGS as $option_id => $code_text) {
                 $code_id = QueryUtils::fetchSingleValue("SELECT `code` FROM codes_cpt WHERE code_text =?", 'code', [$code_text]);
                 if (empty($code_id)) {
-                    (new SystemLogger())->debug("Failed to find code in codes_cpt with code_text. Skipping option_id"
-                        , ['code_text' => $code_text, 'option_id' => $option_id]);
+                    (new SystemLogger())->debug(
+                        "Failed to find code in codes_cpt with code_text. Skipping option_id",
+                        ['code_text' => $code_text, 'option_id' => $option_id]
+                    );
                 }
                 $sql = "UPDATE list_options SET codes=CONCAT('CPT4:', ?) WHERE list_id='encounter-types' AND option_id=?";
-                QueryUtils::sqlStatementThrowException($sql, [$option_id, $code_id]);
+                $values = [$code_id, $option_id];
+                if (!empty($logger) && is_callable($logger)) {
+                    $logger('(sql=`"' . $sql . '`, values=`' . var_export($values, true) . "`)");
+                }
+                QueryUtils::sqlStatementThrowException($sql, $values);
             }
             \sqlCommitTrans();
-        }
-        catch (\Exception $exception) {
+        } catch (\Exception $exception) {
             (new SystemLogger())->errorLogCaller($exception->getMessage(), ['trace' => $exception->getTraceAsString()]);
             \sqlRollbackTrans();
         }

--- a/interface/modules/zend_modules/module/CodeTypes/src/Module.php
+++ b/interface/modules/zend_modules/module/CodeTypes/src/Module.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * FHIR/Module  Handles the module instantiation for the FHIR module.  Note that because of the way laminas loads the
+ * modules the namespace for this module is 'FHIR'.  However to avoid namespace clashes we have defined the namespace
+ * to be under the OpenEMR namespace as seen in the getAutoloaderConfig method.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace CodeTypes;
+
+use Laminas\Mvc\ModuleRouteListener;
+use Laminas\Mvc\MvcEvent;
+use OpenEMR\ZendModules\CodeTypes\Listener\CodeTypeEventsSubscriber;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class Module
+{
+    const NAMESPACE_NAME = 'CodeTypes';
+
+    public function getAutoloaderConfig()
+    {
+        // TODO: verify that we need this namespace autoloader... it should be on by default...
+        return array(
+            'Laminas\Loader\StandardAutoloader' => array(
+                'namespaces' => array(
+                    'OpenEMR\\ZendModules\\' . __NAMESPACE__ => __DIR__ . '/src/' . self::NAMESPACE_NAME,
+                ),
+            ),
+        );
+    }
+
+    public function onBootstrap(MvcEvent $e)
+    {
+        // we grab the OpenEMR event listener (which is injected as Laminas has its own dispatcher)
+        $serviceManager = $e->getApplication()->getServiceManager();
+        $oemrDispatcher = $serviceManager->get(EventDispatcherInterface::class);
+
+        // now we can listen to our module events
+        $subscriber = $serviceManager->get(CodeTypeEventsSubscriber::class);
+        $oemrDispatcher->addSubscriber($subscriber);
+    }
+
+    public function getServiceConfig()
+    {
+        return array();
+    }
+
+    public function getConfig()
+    {
+        return include __DIR__ . '/config/module.config.php';
+    }
+}

--- a/library/standard_tables_capture.inc
+++ b/library/standard_tables_capture.inc
@@ -17,6 +17,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+use OpenEMR\Events\Core\CodeTypeInstalledEvent;
+
 // Function to copy a package to temp
 // $type (RXNORM, SNOMED etc.)
 function temp_copy($filename, $type)
@@ -80,7 +82,12 @@ function temp_unarchive($filename, $type)
 // $is_windows_flag - pass the IS_WINDOWS constant
 function rxnorm_import($is_windows_flag)
 {
-
+    // let's fire off an event so people can listen if needed and handle any module upgrading, version checks,
+    // or any manual processing that needs to occur.
+    if (!empty($GLOBALS['kernel'])) {
+        $codeTypeInstalledEvent = new CodeTypeInstalledEvent('RXNORM', ['is_windows_flag' => $is_windows_flag]);
+        $GLOBALS['kernel']->getEventDispatcher()->dispatch($codeTypeInstalledEvent, CodeTypeInstalledEvent::EVENT_INSTALLED_PRE);
+    }
     // set paths
     $dirScripts = $GLOBALS['temporary_files_dir'] . "/RXNORM/scripts/mysql";
     $dir = $GLOBALS['temporary_files_dir'] . "/RXNORM/rrf";
@@ -150,12 +157,25 @@ function rxnorm_import($is_windows_flag)
     sqlStatementNoLog("COMMIT");
     sqlStatementNoLog("SET autocommit=1");
 
+    // let's fire off an event so people can listen if needed and handle any module upgrading, version checks,
+    // or any manual processing that needs to occur.
+    if (!empty($GLOBALS['kernel'])) {
+        $codeTypeInstalledEvent = new CodeTypeInstalledEvent('RXNORM', ['is_windows_flag' => $is_windows_flag]);
+        $GLOBALS['kernel']->getEventDispatcher()->dispatch($codeTypeInstalledEvent, CodeTypeInstalledEvent::EVENT_INSTALLED_POST);
+    }
+
     return true;
 }
 
 // Function to import SNOMED tables
 function snomed_import($us_extension = false)
 {
+    // let's fire off an event so people can listen if needed and handle any module upgrading, version checks,
+    // or any manual processing that needs to occur.
+    if (!empty($GLOBALS['kernel'])) {
+        $codeTypeInstalledEvent = new CodeTypeInstalledEvent('SNOMED', ['us_extension' => $us_extension]);
+        $GLOBALS['kernel']->getEventDispatcher()->dispatch($codeTypeInstalledEvent, CodeTypeInstalledEvent::EVENT_INSTALLED_POST);
+    }
 
     // set up array
     $table_array_for_snomed = array(
@@ -251,6 +271,13 @@ function snomed_import($us_extension = false)
         closedir($handle);
     }
 
+    // let's fire off an event so people can listen if needed and handle any module upgrading, version checks,
+    // or any manual processing that needs to occur.
+    if (!empty($GLOBALS['kernel'])) {
+        $codeTypeInstalledEvent = new CodeTypeInstalledEvent('SNOMED', ['us_extension' => $us_extension]);
+        $GLOBALS['kernel']->getEventDispatcher()->dispatch($codeTypeInstalledEvent, CodeTypeInstalledEvent::EVENT_INSTALLED_POST);
+    }
+
     return true;
 }
 
@@ -301,6 +328,12 @@ function chg_ct_external_torf2()
 
 function snomedRF2_import()
 {
+    // let's fire off an event so people can listen if needed and handle any module upgrading, version checks,
+    // or any manual processing that needs to occur.
+    if (!empty($GLOBALS['kernel'])) {
+        $codeTypeInstalledEvent = new CodeTypeInstalledEvent('SNOMED', []);
+        $GLOBALS['kernel']->getEventDispatcher()->dispatch($codeTypeInstalledEvent, CodeTypeInstalledEvent::EVENT_INSTALLED_PRE);
+    }
 
     // set up array
     $table_array_for_snomed = array(
@@ -437,6 +470,14 @@ function snomedRF2_import()
         }
         closedir($handle);
     }
+
+    // let's fire off an event so people can listen if needed and handle any module upgrading, version checks,
+    // or any manual processing that needs to occur.
+    if (!empty($GLOBALS['kernel'])) {
+        $codeTypeInstalledEvent = new CodeTypeInstalledEvent('SNOMED', []);
+        $GLOBALS['kernel']->getEventDispatcher()->dispatch($codeTypeInstalledEvent, CodeTypeInstalledEvent::EVENT_INSTALLED_POST);
+    }
+
     return true;
 }
 
@@ -444,6 +485,13 @@ function snomedRF2_import()
 //
 function icd_import($type)
 {
+    // let's fire off an event so people can listen if needed and handle any module upgrading, version checks,
+    // or any manual processing that needs to occur.
+    if (!empty($GLOBALS['kernel'])) {
+        $codeTypeInstalledEvent = new CodeTypeInstalledEvent('ICD', ['type' => $type]);
+        $GLOBALS['kernel']->getEventDispatcher()->dispatch($codeTypeInstalledEvent, CodeTypeInstalledEvent::EVENT_INSTALLED_PRE);
+    }
+
     // set up paths
     $dir_icd = $GLOBALS['temporary_files_dir'] . "/" . $type . "/";
     $dir = str_replace('\\', '/', $dir_icd);
@@ -591,11 +639,25 @@ function icd_import($type)
         sqlStatement("update `icd10_dx_order_code` SET formatted_dx_code = concat(concat(left(dx_code, 3), '.'), substr(dx_code, 4)) WHERE LENGTH(dx_code) > 3");
     }
 
+    // let's fire off an event so people can listen if needed and handle any module upgrading, version checks,
+    // or any manual processing that needs to occur.
+    if (!empty($GLOBALS['kernel'])) {
+        $codeTypeInstalledEvent = new CodeTypeInstalledEvent('ICD', ['type' => $type]);
+        $GLOBALS['kernel']->getEventDispatcher()->dispatch($codeTypeInstalledEvent, CodeTypeInstalledEvent::EVENT_INSTALLED_POST);
+    }
+
     return true;
 }
 
 function valueset_import($type)
 {
+    // let's fire off an event so people can listen if needed and handle any module upgrading, version checks,
+    // or any manual processing that needs to occur.
+    if (!empty($GLOBALS['kernel'])) {
+        $codeTypeInstalledEvent = new CodeTypeInstalledEvent('CQM_VALUESET', ['type' => $type]);
+        $GLOBALS['kernel']->getEventDispatcher()->dispatch($codeTypeInstalledEvent, CodeTypeInstalledEvent::EVENT_INSTALLED_PRE);
+    }
+
     $dir_valueset = $GLOBALS['temporary_files_dir'] . "/" . $type . "/";
         $dir = str_replace('\\', '/', $dir_valueset);
 
@@ -630,6 +692,13 @@ function valueset_import($type)
     // Settings to drastically speed up import with InnoDB
     sqlStatementNoLog("COMMIT");
     sqlStatementNoLog("SET autocommit=1");
+
+    // let's fire off an event so people can listen if needed and handle any module upgrading, version checks,
+    // or any manual processing that needs to occur.
+    if (!empty($GLOBALS['kernel'])) {
+        $codeTypeInstalledEvent = new CodeTypeInstalledEvent('CQM_VALUESET', ['type' => $type]);
+        $GLOBALS['kernel']->getEventDispatcher()->dispatch($codeTypeInstalledEvent, CodeTypeInstalledEvent::EVENT_INSTALLED_POST);
+    }
         return true;
 }
 

--- a/library/standard_tables_capture.inc
+++ b/library/standard_tables_capture.inc
@@ -17,7 +17,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-use OpenEMR\Events\Core\CodeTypeInstalledEvent;
+use OpenEMR\Events\Codes\CodeTypeInstalledEvent;
 
 // Function to copy a package to temp
 // $type (RXNORM, SNOMED etc.)

--- a/sql/6_1_0-to-7_0_0_upgrade.sql
+++ b/sql/6_1_0-to-7_0_0_upgrade.sql
@@ -554,9 +554,9 @@ ALTER TABLE `form_vital_details` ADD `reason_code` VARCHAR(31) DEFAULT NULL COMM
 
 #IfNotRow2D list_options list_id lists option_id encounter-types
 INSERT INTO list_options (list_id,option_id,title, seq, is_default, option_value) VALUES ('lists','encounter-types','Encounter Types',0, 1, 0);
-INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','visit-after-hours','Visit out of hours',10,1,1);
-INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-type','visit-after-hours-not-night','Out of Hours visit (Not Night)',20,0,1);
-INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-type','weekend-visit','Weekend Visit',30,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','visit-after-hours','Visit out of hours',10,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','visit-after-hours-not-night','Out of Hours visit (Not Night)',20,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','weekend-visit','Weekend Visit',30,0,1);
 INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','office-visit','Office visit for pediatric care and assessment',40,0,1);
 INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','established-patient','Evaluation and management of established patient in office or outpatient facility',50,0,1);
 INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','new-patient','Evaluation and management of new patient in office or outpatient facility',60,0,1);

--- a/sql/6_1_0-to-7_0_0_upgrade.sql
+++ b/sql/6_1_0-to-7_0_0_upgrade.sql
@@ -551,3 +551,23 @@ UPDATE categories SET codes='LOINC:LP173394-0' WHERE name='Reviewed';
 #IfMissingColumn form_vital_details reason_code
 ALTER TABLE `form_vital_details` ADD `reason_code` VARCHAR(31) DEFAULT NULL COMMENT 'Medical code explaining reason of the vital observation value in form codesystem:codetype;...;', ADD `reason_description` TEXT COMMENT 'Human readable text description of the reason_code column', ADD `reason_status` VARCHAR(31) NULL DEFAULT NULL COMMENT 'The status of the reason ie completed, in progress, etc';
 #EndIf
+
+#IfNotRow2D list_options list_id lists option_id encounter-types
+INSERT INTO list_options (list_id,option_id,title, seq, is_default, option_value) VALUES ('lists','encounter-types','Encounter Types',0, 1, 0);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','visit-after-hours','Visit out of hours',10,1,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-type','visit-after-hours-not-night','Out of Hours visit (Not Night)',20,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-type','weekend-visit','Weekend Visit',30,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','office-visit','Office visit for pediatric care and assessment',40,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','established-patient','Evaluation and management of established patient in office or outpatient facility',50,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','new-patient','Evaluation and management of new patient in office or outpatient facility',60,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','postoperative-follow-up','Postoperative follow-up visit',70,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','new-patient-10','New Patient - 10 Minutes',80,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','new-patient-15-29','New Patient - 15-29 Minutes',90,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','new-patient-30-44','New Patient - 30-44 Minutes',100,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','new-patient-45-59','New Patient - 45-59 Minutes',110,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','new-patient-60-74','New Patient - 60-74 Minutes',120,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','established-patient-10-19','Established Patient - 10-19 Minutes',130,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','established-patient-20-29','Established Patient - 20-29 Minutes',140,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','established-patient-30-39','Established Patient - 30-39 Minutes',140,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','established-patient-40-54','Established Patient - 40-54 Minutes',150,0,1);
+#EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -11129,6 +11129,25 @@ INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`) 
 INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`) VALUES ('ecqm_2022_reporting','CMS75v10','Children Who Have Dental Decay or Cavities',450,0);
 INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`) VALUES ('ecqm_2022_reporting','CMS771v3','Urinary Symptom Score Change 6-12 Months After Diagnosis of Benign Prostatic Hyperplasia',460,0);
 INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`) VALUES ('ecqm_2022_reporting','CMS90v11','Functional Status Assessments for Congestive Heart Failure',470,0);
+
+-- Insert encounter_type list
+INSERT INTO list_options (list_id,option_id,title, seq, is_default, option_value) VALUES ('lists','encounter-types','Encounter Types',0, 1, 0);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','visit-after-hours','Visit out of hours',10,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','visit-after-hours-not-night','Out of Hours visit (Not Night)',20,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','weekend-visit','Weekend Visit',30,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','office-visit','Office visit for pediatric care and assessment',40,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','established-patient','Evaluation and management of established patient in office or outpatient facility',50,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','new-patient','Evaluation and management of new patient in office or outpatient facility',60,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','postoperative-follow-up','Postoperative follow-up visit',70,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','new-patient-10','New Patient - 10 Minutes',80,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','new-patient-15-29','New Patient - 15-29 Minutes',90,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','new-patient-30-44','New Patient - 30-44 Minutes',100,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','new-patient-45-59','New Patient - 45-59 Minutes',110,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','new-patient-60-74','New Patient - 60-74 Minutes',120,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','established-patient-10-19','Established Patient - 10-19 Minutes',130,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','established-patient-20-29','Established Patient - 20-29 Minutes',140,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','established-patient-30-39','Established Patient - 30-39 Minutes',140,0,1);
+INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','established-patient-40-54','Established Patient - 40-54 Minutes',150,0,1);
 -- --------------------------------------------------------
 
 --

--- a/src/Events/Codes/CodeTypeInstalledEvent.php
+++ b/src/Events/Codes/CodeTypeInstalledEvent.php
@@ -1,9 +1,9 @@
 <?php
 
 /**
- * SQLUpgradeEvent class is fired the SQLUpgradeService when a SQL upgrade file has completed upgrading.  Note if there
- * are multiple upgrade files that must be processed this event will fire multiple times.  Consumers of this event
- * need to handle this use case.
+ * CodeTypeInstalledEvent class is fired when a code type has been installed in the OpenEMR system. Currently it is fired
+ * during the External Data Load process for code types found in standard_tables_capture.inc  Consumers can hook into
+ * the pre install event and post install event.
  *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
@@ -13,10 +13,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-namespace OpenEMR\Events\Core;
-
-
-use OpenEMR\Services\Utils\SQLUpgradeService;
+namespace OpenEMR\Events\Codes;
 
 class CodeTypeInstalledEvent
 {

--- a/src/Events/Codes/CodeTypeInstalledEvent.php
+++ b/src/Events/Codes/CodeTypeInstalledEvent.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * SQLUpgradeEvent class is fired the SQLUpgradeService when a SQL upgrade file has completed upgrading.  Note if there
+ * are multiple upgrade files that must be processed this event will fire multiple times.  Consumers of this event
+ * need to handle this use case.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ *
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2022 Discover and Change, Inc. <snielson@discoverandchange.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\Core;
+
+
+use OpenEMR\Services\Utils\SQLUpgradeService;
+
+class CodeTypeInstalledEvent
+{
+    /**
+     * This event is triggered before the code system is installed
+     */
+    const EVENT_INSTALLED_PRE = 'external_codes.installed.pre';
+
+    /**
+     * This event is triggered after the code system is installed
+     */
+    const EVENT_INSTALLED_POST = 'external_codes.installed.post';
+
+    /**
+     * @var string The code type system that was installed
+     */
+    private $code_type;
+
+    /**
+     * @var array Additional details for the specific code type that was installed.
+     */
+    private $details;
+
+    public function __construct($code_type, $details)
+    {
+        $this->code_type = $code_type;
+        $this->details = $details;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCodeType(): string
+    {
+        return $this->code_type;
+    }
+
+    /**
+     * @param string $code_type
+     * @return CodeTypeInstalledEvent
+     */
+    public function setCodeType(string $code_type): CodeTypeInstalledEvent
+    {
+        $this->code_type = $code_type;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getDetails(): array
+    {
+        return $this->details;
+    }
+
+    /**
+     * @param array $details
+     * @return CodeTypeInstalledEvent
+     */
+    public function setDetails(array $details): CodeTypeInstalledEvent
+    {
+        $this->details = $details;
+        return $this;
+    }
+}

--- a/src/Events/Core/SQLUpgradeEvent.php
+++ b/src/Events/Core/SQLUpgradeEvent.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * SQLUpgradeEvent class is fired the SQLUpgradeService when a SQL upgrade file has completed upgrading.  Note if there
+ * are multiple upgrade files that must be processed this event will fire multiple times.  Consumers of this event
+ * need to handle this use case.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ *
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2022 Discover and Change, Inc. <snielson@discoverandchange.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\Core;
+
+
+use OpenEMR\Services\Utils\SQLUpgradeService;
+
+class SQLUpgradeEvent
+{
+    /**
+     * This event is triggered just before the upgrade starts processing the upgrade file
+     */
+    const EVENT_UPGRADE_PRE = 'core.upgrade.sql.pre';
+
+    /**
+     * This event is triggered after the upgrade has finished completing processing the sql upgrade file.
+     */
+    const EVENT_UPGRADE_POST = 'core.upgrade.sql.post';
+
+    /**
+     * @var string The filename that was executed to upgrade the database
+     */
+    private $filename;
+
+    /**
+     * @var string The path to the filename that was executed.
+     */
+    private $path;
+
+    /**
+     * @var SQLUpgradeService The sql upgrade service object
+     */
+    private $sqlUpgradeService;
+
+    public function __construct($filename, $path, SQLUpgradeService $upgradeService)
+    {
+        $this->filename = $filename;
+        $this->path = $path;
+        $this->sqlUpgradeService = $upgradeService;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFilename(): string
+    {
+        return $this->filename;
+    }
+
+    /**
+     * @param string $filename
+     * @return SQLUpgradeEvent
+     */
+    public function setFilename(string $filename): SQLUpgradeEvent
+    {
+        $this->filename = $filename;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    /**
+     * @param string $path
+     * @return SQLUpgradeEvent
+     */
+    public function setPath(string $path): SQLUpgradeEvent
+    {
+        $this->path = $path;
+        return $this;
+    }
+
+    /**
+     * @return SQLUpgradeService
+     */
+    public function getSqlUpgradeService(): SQLUpgradeService
+    {
+        return $this->sqlUpgradeService;
+    }
+
+    /**
+     * @param SQLUpgradeService $sqlUpgradeService
+     * @return SQLUpgradeEvent
+     */
+    public function setSqlUpgradeService(SQLUpgradeService $sqlUpgradeService): SQLUpgradeEvent
+    {
+        $this->sqlUpgradeService = $sqlUpgradeService;
+        return $this;
+    }
+}

--- a/src/Events/Core/SQLUpgradeEvent.php
+++ b/src/Events/Core/SQLUpgradeEvent.php
@@ -15,7 +15,6 @@
 
 namespace OpenEMR\Events\Core;
 
-
 use OpenEMR\Services\Utils\SQLUpgradeService;
 
 class SQLUpgradeEvent


### PR DESCRIPTION
This eventually will fix #5260.  I'm putting this out as a draft PR so people can see what I'm doing here.

Since we can't bundle certain codes like CPT4 or even SNOMED in
non-member countries we want to only install the codes property for
the Encounter Type list options if we have the right code systems
installed.  So we have added a CodeTypes event subscriber that listens
to newly installed coded types as well as the SQL Upgrade script process
to update the Encounter Type codes property.

This is WIP and is not finalized.  I've still got to add the codes the database.sql file and do some testing on the events to make sure this is all working properly.