### PR TITLE
Lab results match patient query change

### DIFF
--- a/interface/orders/receive_hl7_results.inc.php
+++ b/interface/orders/receive_hl7_results.inc.php
@@ -463,7 +463,8 @@ function match_patient($ptarr)
         $patient_id = intval($tmp['pid']);
     } else {
         // No match good enough, figure out if there's enough ambiguity to ask the user.
-        $tmp = sqlQuery("SELECT pid FROM patient_data WHERE MATCH(lname) " .
+        $tmp = sqlQuery(
+            "SELECT pid FROM patient_data WHERE MATCH(lname) " .
             " AGAINST(? IN BOOLEAN MODE) AND fname = ? AND DOB = ? AND sex = ?",
             array($in_lname, $in_fname, $in_dob, $in_sex)
         );

--- a/sql/6_1_0-to-7_0_0_upgrade.sql
+++ b/sql/6_1_0-to-7_0_0_upgrade.sql
@@ -551,3 +551,7 @@ UPDATE categories SET codes='LOINC:LP173394-0' WHERE name='Reviewed';
 #IfMissingColumn form_vital_details reason_code
 ALTER TABLE `form_vital_details` ADD `reason_code` VARCHAR(31) DEFAULT NULL COMMENT 'Medical code explaining reason of the vital observation value in form codesystem:codetype;...;', ADD `reason_description` TEXT COMMENT 'Human readable text description of the reason_code column', ADD `reason_status` VARCHAR(31) NULL DEFAULT NULL COMMENT 'The status of the reason ie completed, in progress, etc';
 #EndIf
+
+#IfNotIndex patient_data lname
+ALTER TABLE `patient_data` ADD FULLTEXT INDEX(`lname`);
+#EndIf


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->
In the practice, I am working with. They have a high number of last names that are not a single. They have a high number of hyphenated names. We were getting a lot of orphan results because of this. 

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #
The ability for the query to match a name that is hyphenated or unhyphenated last name. 

#### Short description of what this resolves:
Matching patient lab results to the correct patient when there are two last names or a hyphenated last name. 

#### Changes proposed in this pull request:
Do a full text Index of the last name in the patient_data table 

https://github.com/openemr/openemr/issues/5282