### PR TITLE
Insert a page break after each entry

### DIFF
--- a/sites/default/statement.inc.php
+++ b/sites/default/statement.inc.php
@@ -154,7 +154,7 @@ function create_HTML_statement($stmt)
     $remit_csz = "{$row['city']}, {$row['state']}, {$row['postal_code']}";
 
     ob_start();
-    ?><div style="padding-left:25px;">
+    ?><div style="padding-left:25px; page-break-after:always;">
     <?php
     $find_provider = sqlQuery("SELECT * FROM form_encounter " .
         "WHERE pid = ? AND encounter = ? " .


### PR DESCRIPTION
This saves hours when printing invoices at the end of the month, so they don't have to be printed one-by-one (otherwise they overlap).