### PR TITLE
Openemr fix 5277 immunization reason codes

### DIFF
--- a/interface/modules/zend_modules/module/CodeTypes/src/CodeTypes/Listener/CodeTypeEventsSubscriber.php
+++ b/interface/modules/zend_modules/module/CodeTypes/src/CodeTypes/Listener/CodeTypeEventsSubscriber.php
@@ -37,34 +37,34 @@ class CodeTypeEventsSubscriber implements EventSubscriberInterface
         'religious_exemption' => '183945002',
         'patient_decision' => '105480006',
         'parental_decision' => '105480006', // patient and parental refuse are considered the same
-	    'financial_problem' => '160932005',
-	    'financial_circumstances_change' => '160934006',
-	    'alternative_treatment_requested' => '182890002',
-	    'patient_declined_procedure' => '105480006',
-	    'patient_declined_drug' => '182895007',
-	    'patient_declined_drug_effects' => '182897004',
-	    'patient_declined_drug_beliefs' => '182900006',
-	    'patient_declined_drug_cannot_pay' => '182902003',
-	    'patient_moved' => '184081006',
-	    'patient_dissatisfied_result' => '185479006',
-	    'patient_dissatisfied_doctor' => '185481008',
-	    'patient_variable_income' => '224187001',
-	    'patient_self_discharge' => '225928004',
-	    'drugs_not_completed' => '266710000',
-	    'family_illness' => '266966009',
-	    'follow_defaulted' => '275694009',
-	    'patient_noncompliance' => '275936005',
-	    'patient_noshow' => '281399006',
-	    'patient_further_opinion' => '310343007',
-	    'patient_treatment_delay' => '373787003',
-	    'patient_medication_declined' => '406149000',
-	    'patient_medication_forgot' => '408367005',
-	    'patient_non_compliant' => '413311005',
-	    'procedure_not_wanted' => '416432009',
-	    'income_insufficient' => '423656007',
-	    'income_necessities_only' => '424739004',
-	    'refused' => '443390004',
-	    'patient_procedure_discontinued' => '713247000'
+        'financial_problem' => '160932005',
+        'financial_circumstances_change' => '160934006',
+        'alternative_treatment_requested' => '182890002',
+        'patient_declined_procedure' => '105480006',
+        'patient_declined_drug' => '182895007',
+        'patient_declined_drug_effects' => '182897004',
+        'patient_declined_drug_beliefs' => '182900006',
+        'patient_declined_drug_cannot_pay' => '182902003',
+        'patient_moved' => '184081006',
+        'patient_dissatisfied_result' => '185479006',
+        'patient_dissatisfied_doctor' => '185481008',
+        'patient_variable_income' => '224187001',
+        'patient_self_discharge' => '225928004',
+        'drugs_not_completed' => '266710000',
+        'family_illness' => '266966009',
+        'follow_defaulted' => '275694009',
+        'patient_noncompliance' => '275936005',
+        'patient_noshow' => '281399006',
+        'patient_further_opinion' => '310343007',
+        'patient_treatment_delay' => '373787003',
+        'patient_medication_declined' => '406149000',
+        'patient_medication_forgot' => '408367005',
+        'patient_non_compliant' => '413311005',
+        'procedure_not_wanted' => '416432009',
+        'income_insufficient' => '423656007',
+        'income_necessities_only' => '424739004',
+        'refused' => '443390004',
+        'patient_procedure_discontinued' => '713247000'
     ];
 
     private const CODE_TYPE_SNOMED = "SNOMED";
@@ -185,15 +185,20 @@ class CodeTypeEventsSubscriber implements EventSubscriberInterface
             return true;
         }
 
-        if ($this->shouldUpdateListWithSnomedCodes(self::SNOMED_IMMUNIZATION_REFUSAL_REASON_MAPPINGS
-                , self::LIST_ID_IMMUNIZATION_REFUSAL)) {
+        if (
+            $this->shouldUpdateListWithSnomedCodes(
+                self::SNOMED_IMMUNIZATION_REFUSAL_REASON_MAPPINGS,
+                self::LIST_ID_IMMUNIZATION_REFUSAL
+            )
+        ) {
             return true;
         }
         // no upgrade needed
         return false;
     }
 
-    private function shouldUpdateListWithSnomedCodes($mappings, $list_id) {
+    private function shouldUpdateListWithSnomedCodes($mappings, $list_id)
+    {
         foreach ($mappings as $option_id => $code_id) {
             $sql = "SELECT codes FROM list_options WHERE list_id=? AND option_id=?";
             $codes = QueryUtils::fetchSingleValue($sql, 'codes', [$list_id, $option_id]);
@@ -206,13 +211,20 @@ class CodeTypeEventsSubscriber implements EventSubscriberInterface
 
     private function updateSNOMEDCTMappings($logger = null)
     {
-       $this->updateSNOMEDCTMappingsForList(self::SNOMED_ENCOUNTER_TYPE_MAPPINGS
-           , self::LIST_ID_ENCOUNTER_TYPES, $logger);
-       $this->updateSNOMEDCTMappingsForList(self::SNOMED_IMMUNIZATION_REFUSAL_REASON_MAPPINGS
-           , self::LIST_ID_IMMUNIZATION_REFUSAL, $logger);
+        $this->updateSNOMEDCTMappingsForList(
+            self::SNOMED_ENCOUNTER_TYPE_MAPPINGS,
+            self::LIST_ID_ENCOUNTER_TYPES,
+            $logger
+        );
+        $this->updateSNOMEDCTMappingsForList(
+            self::SNOMED_IMMUNIZATION_REFUSAL_REASON_MAPPINGS,
+            self::LIST_ID_IMMUNIZATION_REFUSAL,
+            $logger
+        );
     }
 
-    private function updateSNOMEDCTMappingsForList($mappings, $list_id, $logger = null) {
+    private function updateSNOMEDCTMappingsForList($mappings, $list_id, $logger = null)
+    {
         // update our list options
         try {
             \sqlBeginTrans();

--- a/interface/modules/zend_modules/module/CodeTypes/src/CodeTypes/Listener/CodeTypeEventsSubscriber.php
+++ b/interface/modules/zend_modules/module/CodeTypes/src/CodeTypes/Listener/CodeTypeEventsSubscriber.php
@@ -31,6 +31,42 @@ class CodeTypeEventsSubscriber implements EventSubscriberInterface
         'postoperative-follow-up' => '439740005'
     ];
 
+    private const SNOMED_IMMUNIZATION_REFUSAL_REASON_MAPPINGS = [
+        // note only thing not mapped here is 'other' as we don't know what that goes here
+        // note valueset OID is: 2.16.840.1.113883.3.526.3.1008
+        'religious_exemption' => '183945002',
+        'patient_decision' => '105480006',
+        'parental_decision' => '105480006', // patient and parental refuse are considered the same
+	    'financial_problem' => '160932005',
+	    'financial_circumstances_change' => '160934006',
+	    'alternative_treatment_requested' => '182890002',
+	    'patient_declined_procedure' => '105480006',
+	    'patient_declined_drug' => '182895007',
+	    'patient_declined_drug_effects' => '182897004',
+	    'patient_declined_drug_beliefs' => '182900006',
+	    'patient_declined_drug_cannot_pay' => '182902003',
+	    'patient_moved' => '184081006',
+	    'patient_dissatisfied_result' => '185479006',
+	    'patient_dissatisfied_doctor' => '185481008',
+	    'patient_variable_income' => '224187001',
+	    'patient_self_discharge' => '225928004',
+	    'drugs_not_completed' => '266710000',
+	    'family_illness' => '266966009',
+	    'follow_defaulted' => '275694009',
+	    'patient_noncompliance' => '275936005',
+	    'patient_noshow' => '281399006',
+	    'patient_further_opinion' => '310343007',
+	    'patient_treatment_delay' => '373787003',
+	    'patient_medication_declined' => '406149000',
+	    'patient_medication_forgot' => '408367005',
+	    'patient_non_compliant' => '413311005',
+	    'procedure_not_wanted' => '416432009',
+	    'income_insufficient' => '423656007',
+	    'income_necessities_only' => '424739004',
+	    'refused' => '443390004',
+	    'patient_procedure_discontinued' => '713247000'
+    ];
+
     private const CODE_TYPE_SNOMED = "SNOMED";
     private const CODE_TYPE_SNOMED_CT = "SNOMED-CT";
     private const CODE_TYPE_SNOMED_PR = "SNOMED-PR";
@@ -47,6 +83,9 @@ class CodeTypeEventsSubscriber implements EventSubscriberInterface
         , 'established-patient-30-39' => 'Established Patient (Extended)'
         , 'established-patient-40-54' => 'Established Patient (Comprehensive)'
     ];
+
+    private const LIST_ID_ENCOUNTER_TYPES = 'encounter-types';
+    private const LIST_ID_IMMUNIZATION_REFUSAL = 'immunization_refusal_reason';
 
     public static function getSubscribedEvents()
     {
@@ -130,8 +169,8 @@ class CodeTypeEventsSubscriber implements EventSubscriberInterface
                     ['code_text' => $code_text, 'option_id' => $option_id]
                 );
             }
-            $sql = "SELECT codes FROM list_options WHERE list_id='encounter-types' AND option_id=?";
-            $codes = QueryUtils::fetchSingleValue($sql, 'codes', [$option_id]);
+            $sql = "SELECT codes FROM list_options WHERE list_id=? AND option_id=?";
+            $codes = QueryUtils::fetchSingleValue($sql, 'codes', [self::LIST_ID_ENCOUNTER_TYPES, $option_id]);
             if ($codes != "CPT4:" . $code_id) {
                 return true;
             }
@@ -142,33 +181,55 @@ class CodeTypeEventsSubscriber implements EventSubscriberInterface
 
     private function shouldUpdateSNOMEDMappings()
     {
-        foreach (self::SNOMED_ENCOUNTER_TYPE_MAPPINGS as $option_id => $code_id) {
-            $sql = "SELECT codes FROM list_options WHERE list_id='encounter-types' AND option_id=?";
-            $codes = QueryUtils::fetchSingleValue($sql, 'codes', [$option_id]);
-            if ($codes != self::CODE_TYPE_SNOMED_CT . ":" . $code_id) {
-                return true;
-            }
+        if ($this->shouldUpdateListWithSnomedCodes(self::SNOMED_ENCOUNTER_TYPE_MAPPINGS, self::LIST_ID_ENCOUNTER_TYPES)) {
+            return true;
+        }
+
+        if ($this->shouldUpdateListWithSnomedCodes(self::SNOMED_IMMUNIZATION_REFUSAL_REASON_MAPPINGS
+                , self::LIST_ID_IMMUNIZATION_REFUSAL)) {
+            return true;
         }
         // no upgrade needed
         return false;
     }
 
+    private function shouldUpdateListWithSnomedCodes($mappings, $list_id) {
+        foreach ($mappings as $option_id => $code_id) {
+            $sql = "SELECT codes FROM list_options WHERE list_id=? AND option_id=?";
+            $codes = QueryUtils::fetchSingleValue($sql, 'codes', [$list_id, $option_id]);
+            if ($codes != self::CODE_TYPE_SNOMED_CT . ":" . $code_id) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private function updateSNOMEDCTMappings($logger = null)
     {
+       $this->updateSNOMEDCTMappingsForList(self::SNOMED_ENCOUNTER_TYPE_MAPPINGS
+           , self::LIST_ID_ENCOUNTER_TYPES, $logger);
+       $this->updateSNOMEDCTMappingsForList(self::SNOMED_IMMUNIZATION_REFUSAL_REASON_MAPPINGS
+           , self::LIST_ID_IMMUNIZATION_REFUSAL, $logger);
+    }
+
+    private function updateSNOMEDCTMappingsForList($mappings, $list_id, $logger = null) {
         // update our list options
         try {
             \sqlBeginTrans();
-            foreach (self::SNOMED_ENCOUNTER_TYPE_MAPPINGS as $option_id => $code_id) {
-                $sql = "UPDATE list_options SET codes=CONCAT('SNOMED-CT:', ?) WHERE list_id='encounter-types' AND option_id=?";
-                $values = [$code_id, $option_id];
-                if (!empty($logger) && is_callable($logger)) {
-                    $logger('(sql=`"' . $sql . '`, values=`' . var_export($values, true) . "`)");
-                }
+            foreach ($mappings as $option_id => $code_id) {
+                $sql = "UPDATE list_options SET codes=CONCAT('SNOMED-CT:', ?) WHERE list_id=? AND option_id=?";
+                $values = [$code_id, $list_id, $option_id];
                 QueryUtils::sqlStatementThrowException($sql, $values);
+                if (!empty($logger) && is_callable($logger)) {
+                    $logger(xl('Success') . ' - (sql=`"' . $sql . '`, values=`' . var_export($values, true) . "`)");
+                }
             }
             \sqlCommitTrans();
         } catch (\Exception $exception) {
             (new SystemLogger())->errorLogCaller($exception->getMessage(), ['trace' => $exception->getTraceAsString()]);
+            if (!empty($logger) && is_callable($logger)) {
+                $logger(xl('Failed') . ' - (sql=`"' . $sql . '`, values=`' . var_export($values, true) . "`)");
+            }
             \sqlRollbackTrans();
         }
     }
@@ -186,8 +247,8 @@ class CodeTypeEventsSubscriber implements EventSubscriberInterface
                         ['code_text' => $code_text, 'option_id' => $option_id]
                     );
                 }
-                $sql = "UPDATE list_options SET codes=CONCAT('CPT4:', ?) WHERE list_id='encounter-types' AND option_id=?";
-                $values = [$code_id, $option_id];
+                $sql = "UPDATE list_options SET codes=CONCAT('CPT4:', ?) WHERE list_id=? AND option_id=?";
+                $values = [$code_id, self::LIST_ID_ENCOUNTER_TYPES, $option_id];
                 if (!empty($logger) && is_callable($logger)) {
                     $logger('(sql=`"' . $sql . '`, values=`' . var_export($values, true) . "`)");
                 }

--- a/interface/patient_file/summary/immunizations.php
+++ b/interface/patient_file/summary/immunizations.php
@@ -979,7 +979,7 @@ function del_related(s) {
 // This invokes the find-code popup.
 function sel_cvxcode(e) {
  current_sel_name = e.name;
- dlgopen('../encounter/find_code_dynamic.php?codetype=CVX', '_blank', 900, 600);
+ dlgopen('../encounter/find_code_dynamic.php?codetype=CVX,VALUESET', '_blank', 900, 600);
 }
 
 // This ensures the cvx centric entry is filled.

--- a/interface/patient_file/summary/immunizations.php
+++ b/interface/patient_file/summary/immunizations.php
@@ -57,6 +57,8 @@ if (isset($_GET['mode'])) {
             completion_status = ?,
             information_source = ?,
             refusal_reason = ?,
+            reason_code = ?,
+            reason_description = ?,
             ordering_provider = ?";
         $sqlBindArray = array(
             trim($_GET['id']),
@@ -82,6 +84,8 @@ if (isset($_GET['mode'])) {
             trim($_GET['immuniz_completion_status']),
             trim($_GET['immunization_informationsource']),
             trim($_GET['immunization_refusal_reason']),
+            trim($_GET['reason_code']),
+            trim($_GET['reason_description']),
             trim($_GET['ordered_by_id'])
         );
         $newid = sqlInsert($sql, $sqlBindArray);
@@ -123,6 +127,8 @@ if (isset($_GET['mode'])) {
         $drugunitselecteditem = $result['amount_administered_unit'];
         $immunization_id = $result['immunization_id'];
         $immuniz_exp_date = $result['expiration_date'];
+        $reason_code = trim($result['reason_code'] ?? '');
+        $reason_code_text = trim($result['reason_description'] ?? "");
 
         $cvx_code = $result['cvx_code'];
         $code_text = '';
@@ -490,6 +496,15 @@ tr.selected {
                         <?php echo generate_select_list('immunization_refusal_reason', 'immunization_refusal_reason', ($immuniz_refusal_reason ?? ''), 'Select Refusal Reason', ' ');?>
                     </div>
                     <div class="form-group mt-3">
+                        <label><?php echo xlt('Reason Code'); ?></label>
+                        <input class="code-selector-popup form-control immunizationReasonCode"
+                               name="reason_code" type="text" value="<?php echo attr($reason_code); ?>"
+                               placeholder="<?php echo xlt("Select a reason code"); ?>"
+                        />
+                        <input type="hidden" name="reason_code_text" value="<?php echo $reason_code_text; ?>" />
+                        <p class="reason_code_text d-inline float-right p-1 ml-2 <?php echo empty($reason_code_text) ? "" : "d-none"; ?>"></p>
+                    </div>
+                    <div class="form-group mt-3">
                         <label><?php echo xlt('Immunization Ordering Provider'); ?></label>
                         <select class="form-control" name="ordered_by_id" id='ordered_by_id'>
                             <option value=""></option>
@@ -854,6 +869,7 @@ $(function () {
             $("#cvx_code").trigger("change");
         }
     });
+    $(".immunizationReasonCode").click(sel_reasonCode);
 
   $('.datepicker').datetimepicker({
     <?php $datetimepicker_timepicker = false; ?>
@@ -912,6 +928,7 @@ var ErrorImm = function(imm) {
 //This is for callback by the find-code popup.
 //Appends to or erases the current list of diagnoses.
 function set_related(codetype, code, selector, codedesc) {
+
     if(codetype == 'CVX') {
     var f = document.forms[0][current_sel_name];
         if(!f.length) {
@@ -958,6 +975,53 @@ function set_related(codetype, code, selector, codedesc) {
         $("#codetext_" + checkId).val(codedesc);
         $("#displaytext_" + checkId).html(codedesc);
     }
+}
+function sel_reasonCode(e) {
+    let target = e.currentTarget;
+    if (!(target && target.name)) {
+        console.error("Could not find DOMNode name for event target");
+        return;
+    }
+    current_sel_name = e.currentTarget.name;
+
+    let previousSelCodeFunction = window.set_related;
+    let restoreCallback = function() {
+        window.set_related = previousSelCodeFunction;
+    };
+
+    let set_relatedReasonCode = function(codetype, code, selector, codedesc) {
+
+        let field = document.forms[0][current_sel_name];
+        let field_text = document.forms[0][current_sel_name + "_text"];
+        let text = document.querySelector("." + current_sel_name + "_text");
+        if (typeof code == 'string' && code.trim() != '') {
+            field.value = codetype + ":" + code;
+            if (field_text && text) {
+                field_text.value = codedesc;
+                text.classList.remove("d-none"); // remove anything hiding the attribute.
+                text.innerText = codedesc;
+            }
+        } else {
+            field.value = "";
+            if (field_text && text) {
+                field_text.value = "";
+                text.classList.add("d-none");
+                text.innerText = "";
+            }
+        }
+    };
+
+    let opts = {
+        callBack: {
+            call: restoreCallback
+        }
+    };
+    // we are going to replace our global function for the time, and it will get setback in the callback
+
+    window.set_related = set_relatedReasonCode;
+    window.top.restoreSession();
+    window.dlgopen("../encounter/find_code_popup.php?default=SNOMED-CT"
+        , '_blank', 700, 400, false, undefined, opts);
 }
 
 // This is for callback by the find-code popup.

--- a/interface/patient_file/summary/immunizations.php
+++ b/interface/patient_file/summary/immunizations.php
@@ -499,9 +499,9 @@ tr.selected {
                         <label><?php echo xlt('Reason Code'); ?></label>
                         <input class="code-selector-popup form-control immunizationReasonCode"
                                name="reason_code" type="text" value="<?php echo attr($reason_code); ?>"
-                               placeholder="<?php echo xlt("Select a reason code"); ?>"
+                               placeholder="<?php echo xla("Select a reason code"); ?>"
                         />
-                        <input type="hidden" name="reason_code_text" value="<?php echo $reason_code_text; ?>" />
+                        <input type="hidden" name="reason_code_text" value="<?php echo attr($reason_code_text); ?>" />
                         <p class="reason_code_text d-inline float-right p-1 ml-2 <?php echo empty($reason_code_text) ? "" : "d-none"; ?>"></p>
                     </div>
                     <div class="form-group mt-3">

--- a/sql/6_1_0-to-7_0_0_upgrade.sql
+++ b/sql/6_1_0-to-7_0_0_upgrade.sql
@@ -537,8 +537,6 @@ ALTER TABLE `procedure_order` CHANGE `date_ordered` `date_ordered` DATETIME DEFA
 #IfMissingColumn immunizations reason_code
 ALTER TABLE `immunizations` CHANGE `cvx_code` `cvx_code` VARCHAR(64) DEFAULT NULL;
 ALTER TABLE `immunizations` ADD `reason_code` varchar(31) DEFAULT NULL;
-ALTER TABLE `immunizations` ADD `reason_description` text;
-ALTER TABLE `immunizations` ADD `reason_status` varchar(31) DEFAULT NULL;
 #EndIf
 
 #IfMissingColumn categories codes
@@ -570,4 +568,36 @@ INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUE
 INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','established-patient-20-29','Established Patient - 20-29 Minutes',140,0,1);
 INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','established-patient-30-39','Established Patient - 30-39 Minutes',140,0,1);
 INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','established-patient-40-54','Established Patient - 40-54 Minutes',150,0,1);
+#EndIf
+
+#IfNotRow2d list_options list_id immunization_refusal_reason option_id financial_problem
+-- Note we map all of these list options onto CDC NIP002 00=parental decision,01=religious exemption,02=other,03=patient decision
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','financial_problem','Financial Problem',50,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','financial_circumstances_change','Financial circumstances change',60,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','alternative_treatment_requested','Alternative Treatment Requested',70,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_declined_procedure','Patient declined procedure',80,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_declined_drug','Patient declined drug',90,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_declined_drug_effects','Patient declined drug - side effects',100,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_declined_drug_beliefs','Patient declined drug - patient beliefs',110,1, "01");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_declined_drug_cannot_pay','Patient declined drug - cannot pay script',120,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_moved','Patient moved',130,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_dissatisfied_result','Patient dissatisfied with result',140,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_dissatisfied_doctor','Patient dissatisfied with doctor',150,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_variable_income','Variable income',160,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_self_discharge','Patient self-discharge against medical advice',170,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','drugs_not_completed','Drugs not taken/completed',180,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','family_illness','Family illness',190,1, "02");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','follow_defaulted','Patient defaulted from follow-up',200,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_noncompliance','Patient noncompliance - general',210,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_noshow','Patient did not attend',220,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_further_opinion','Further opinion sought',230,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_treatment_delay','Treatment delay - patient choice',240,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_medication_declined','Medication declined',250,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_medication_forgot','Patient forgets to take medication',260,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_non_compliant','Patient non-compliant declined intervention/support',270,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','procedure_not_wanted','Procedure not wanted',280,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','income_insufficient','Income insufficient to buy necessities',290,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','income_necessities_only','Income sufficient to buy only necessities',300,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','refused','Refused',310,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_procedure_discontinued','Procedure discontinued by patient',320,1, "03");
 #EndIf

--- a/sql/6_1_0-to-7_0_0_upgrade.sql
+++ b/sql/6_1_0-to-7_0_0_upgrade.sql
@@ -570,8 +570,7 @@ INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUE
 INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('encounter-types','established-patient-40-54','Established Patient - 40-54 Minutes',150,0,1);
 #EndIf
 
-#IfNotRow2d list_options list_id immunization_refusal_reason option_id financial_problem
--- Note we map all of these list options onto CDC NIP002 00=parental decision,01=religious exemption,02=other,03=patient decision
+#IfNotRow2D list_options list_id immunization_refusal_reason option_id financial_problem
 INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','financial_problem','Financial Problem',50,1, "03");
 INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','financial_circumstances_change','Financial circumstances change',60,1, "03");
 INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','alternative_treatment_requested','Alternative Treatment Requested',70,1, "03");

--- a/sql/6_1_0-to-7_0_0_upgrade.sql
+++ b/sql/6_1_0-to-7_0_0_upgrade.sql
@@ -536,7 +536,8 @@ ALTER TABLE `procedure_order` CHANGE `date_ordered` `date_ordered` DATETIME DEFA
 
 #IfMissingColumn immunizations reason_code
 ALTER TABLE `immunizations` CHANGE `cvx_code` `cvx_code` VARCHAR(64) DEFAULT NULL;
-ALTER TABLE `immunizations` ADD `reason_code` varchar(31) DEFAULT NULL;
+ALTER TABLE `immunizations` ADD `reason_code` varchar(31) DEFAULT NULL COMMENT 'Medical code explaining reason of the vital observation value in form codesystem:codetype;...;';
+ALTER TABLE `immunizations` ADD `reason_description` TEXT COMMENT 'Human readable text description of the reason_code column';
 #EndIf
 
 #IfMissingColumn categories codes

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -3050,7 +3050,6 @@ CREATE TABLE `immunizations` (
   `ordering_provider` INT(11) DEFAULT NULL,
   `reason_code` varchar(31) DEFAULT NULL,
   `reason_description` text,
-  `reason_status` varchar(31) DEFAULT NULL,
   PRIMARY KEY  (`id`),
   KEY `patient_id` (`patient_id`),
   UNIQUE KEY `uuid` (`uuid`)
@@ -5272,6 +5271,34 @@ INSERT INTO list_options (list_id, option_id, title, notes, seq) VALUES ('immuni
 INSERT INTO list_options (list_id, option_id, title, notes, seq) VALUES ('immunization_refusal_reason','religious_exemption','Religious exemption','01', '20');
 INSERT INTO list_options (list_id, option_id, title, notes, seq) VALUES ('immunization_refusal_reason','other','Other','02', '30');
 INSERT INTO list_options (list_id, option_id, title, notes, seq) VALUES ('immunization_refusal_reason','patient_decision','Patient decision','03', '40');
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','financial_problem','Financial Problem',50,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','financial_circumstances_change','Financial circumstances change',60,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','alternative_treatment_requested','Alternative Treatment Requested',70,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_declined_procedure','Patient declined procedure',80,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_declined_drug','Patient declined drug',90,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_declined_drug_effects','Patient declined drug - side effects',100,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_declined_drug_beliefs','Patient declined drug - patient beliefs',110,1, "01");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_declined_drug_cannot_pay','Patient declined drug - cannot pay script',120,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_moved','Patient moved',130,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_dissatisfied_result','Patient dissatisfied with result',140,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_dissatisfied_doctor','Patient dissatisfied with doctor',150,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_variable_income','Variable income',160,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_self_discharge','Patient self-discharge against medical advice',170,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','drugs_not_completed','Drugs not taken/completed',180,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','family_illness','Family illness',190,1, "02");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','follow_defaulted','Patient defaulted from follow-up',200,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_noncompliance','Patient noncompliance - general',210,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_noshow','Patient did not attend',220,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_further_opinion','Further opinion sought',230,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_treatment_delay','Treatment delay - patient choice',240,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_medication_declined','Medication declined',250,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_medication_forgot','Patient forgets to take medication',260,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_non_compliant','Patient non-compliant declined intervention/support',270,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','procedure_not_wanted','Procedure not wanted',280,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','income_insufficient','Income insufficient to buy necessities',290,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','income_necessities_only','Income sufficient to buy only necessities',300,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','refused','Refused',310,1, "03");
+INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `activity`, `notes`) VALUES ('immunization_refusal_reason','patient_procedure_discontinued','Procedure discontinued by patient',320,1, "03");
 
 -- Immunization Information Source
 

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -3048,8 +3048,8 @@ CREATE TABLE `immunizations` (
   `information_source` VARCHAR(31) DEFAULT NULL,
   `refusal_reason` VARCHAR(31) DEFAULT NULL,
   `ordering_provider` INT(11) DEFAULT NULL,
-  `reason_code` varchar(31) DEFAULT NULL,
-  `reason_description` text,
+  `reason_code` varchar(31) DEFAULT NULL COMMENT 'Medical code explaining reason of the vital observation value in form codesystem:codetype;...;',
+  `reason_description` text COMMENT 'Human readable text description of the reason_code column',
   PRIMARY KEY  (`id`),
   KEY `patient_id` (`patient_id`),
   UNIQUE KEY `uuid` (`uuid`)

--- a/src/Services/FHIR/FhirImmunizationService.php
+++ b/src/Services/FHIR/FhirImmunizationService.php
@@ -102,19 +102,18 @@ class FhirImmunizationService extends FhirServiceBase implements IResourceUSCIGP
 
                 // we are leaving these here just to document these values as PATOBJ corresponds to both patient or
                 // guardian objection.  Other doesn't have a correspondance, and patient decision is already handled.
-                switch ($dataRecord['refusal_reason_cdc_nip_code'])
-                {
+                switch ($dataRecord['refusal_reason_cdc_nip_code']) {
                     case '00': // Parental exemption
-                    break;
+                        break;
                     case '01': // Religious exemption
                         $code = "RELIG";
-                        $display = 	"religious objection";
-                    break;
+                        $display =  "religious objection";
+                        break;
                     case '02': // other
-                    break;
+                        break;
                     case '03': // patient decision
                     default:
-                    break;
+                        break;
                 }
             }
             $statusReason = new FHIRCodeableConcept();

--- a/src/Services/FHIR/FhirImmunizationService.php
+++ b/src/Services/FHIR/FhirImmunizationService.php
@@ -93,11 +93,35 @@ class FhirImmunizationService extends FhirServiceBase implements IResourceUSCIGP
         } else {
             $status->setValue("not-done");
 
+            // TODO: @adunsulag we need to update these codes here as we need to map better from NIP002
+            // to these status codes here: https://terminology.hl7.org/3.1.0/CodeSystem-v3-ActReason.html
+            //
+            if (!empty($dataRecord['refusal_reason_cdc_nip_code'])) {
+                $code = "PATOBJ";
+                $display = "patient objection";
+
+                // we are leaving these here just to document these values as PATOBJ corresponds to both patient or
+                // guardian objection.  Other doesn't have a correspondance, and patient decision is already handled.
+                switch ($dataRecord['refusal_reason_cdc_nip_code'])
+                {
+                    case '00': // Parental exemption
+                    break;
+                    case '01': // Religious exemption
+                        $code = "RELIG";
+                        $display = 	"religious objection";
+                    break;
+                    case '02': // other
+                    break;
+                    case '03': // patient decision
+                    default:
+                    break;
+                }
+            }
             $statusReason = new FHIRCodeableConcept();
             $statusReasonCoding = new FHIRCoding();
             $statusReasonCoding->setSystem(FhirCodeSystemConstants::IMMUNIZATION_OBJECTION_REASON);
-            $statusReasonCoding->setCode("PATOBJ");
-            $statusReasonCoding->setDisplay("patient objection");
+            $statusReasonCoding->setCode($code);
+            $statusReasonCoding->setDisplay($display);
             $statusReason->addCoding($statusReasonCoding);
             $immunizationResource->setStatusReason($statusReason);
         }

--- a/src/Services/ImmunizationService.php
+++ b/src/Services/ImmunizationService.php
@@ -84,7 +84,11 @@ class ImmunizationService extends BaseService
                 site.title as site_display,
                 site.notes as site_code,
                 completion_status,
-                refusal_reason,
+                immunizations.reason_codes,
+                immunizations.refusal_reason,
+                refusal_reasons.refusal_reason_codes,
+                refusal_reasons.refusal_reason_cdc_nip_code,
+                refusal_reasons.refusal_reason_description,
                 providers.provider_uuid,
                 providers.provider_npi,
                 providers.provider_username,
@@ -123,7 +127,15 @@ class ImmunizationService extends BaseService
                         ,id AS provider_id
                     FROM
                         users
-                ) providers ON immunizations.administered_by_id = providers.provider_id";
+                ) providers ON immunizations.administered_by_id = providers.provider_id
+                LEFT JOIN (
+                    SELECT option_id as refusal_reason_id,
+                           notes AS refusal_reason_cdc_nip_code,
+                           codes AS refusal_reason_codes,
+                           title AS refusal_reason_description
+                   FROM list_options 
+                   WHERE list_id = 'immunization_refusal_reason'
+               ) refusal_reasons ON immunizations.refusal_reason = refusal_reasons.refusal_reason_id";
 
         $whereClause = FhirSearchWhereClauseBuilder::build($search, $isAndCondition);
 

--- a/src/Services/Qdm/Services/ImmunizationAdministeredService.php
+++ b/src/Services/Qdm/Services/ImmunizationAdministeredService.php
@@ -13,6 +13,7 @@ namespace OpenEMR\Services\Qdm\Services;
 use OpenEMR\Cqm\Qdm\BaseTypes\Code;
 use OpenEMR\Cqm\Qdm\BaseTypes\DateTime;
 use OpenEMR\Cqm\Qdm\ImmunizationAdministered;
+use OpenEMR\Services\ListService;
 use OpenEMR\Services\Qdm\Interfaces\QdmServiceInterface;
 use OpenEMR\Services\Qdm\QdmRecord;
 
@@ -25,7 +26,7 @@ class ImmunizationAdministeredService extends AbstractQdmService implements QdmS
 
     public function getSqlStatement()
     {
-        $sql = "SELECT patient_id, patient_id AS pid, administered_date, cvx_code, reason_code, reason_status
+        $sql = "SELECT patient_id, patient_id AS pid, administered_date, cvx_code, refusal_reason, reason_code
                 FROM immunizations";
         return $sql;
     }
@@ -42,12 +43,20 @@ class ImmunizationAdministeredService extends AbstractQdmService implements QdmS
             ]),
         ]);
 
-        // If the reason status is "negated" then add the code to negation rationale, otherwise add to reason
+        // if we have a reason code we add that in.  Its unlikely there is a reason and a refusal_reason but
+        // we handle both as the QDM measure does support the possibility.
         if (!empty($record['reason_code'])) {
-            if ($record['reason_status'] == parent::NEGATED) {
-                $model->negationRationale = $this->makeQdmCode($record['reason_code']);
-            } else {
-                $model->reason = $this->makeQdmCode($record['reason_code']);
+            $model->reason = $this->makeQdmModel($record['reason_code']);
+        }
+
+        // we add in a negation rationale if there is a refusal reason provided
+        // @see https://ecqi.healthit.gov/mcw/2022/qdm-dataelement/immunizationadministered.html
+        if (!empty($record['refusal_reason']))
+        {
+            $listService = new ListService();
+            $option = $listService->getListOption('immunization_refusal_reason', $record['refusal_reason']);
+            if (!empty($option)) {
+                $model->negationRationale = $this->makeQdmCode($option['codes']);
             }
         }
 

--- a/src/Services/Qdm/Services/ImmunizationAdministeredService.php
+++ b/src/Services/Qdm/Services/ImmunizationAdministeredService.php
@@ -51,8 +51,7 @@ class ImmunizationAdministeredService extends AbstractQdmService implements QdmS
 
         // we add in a negation rationale if there is a refusal reason provided
         // @see https://ecqi.healthit.gov/mcw/2022/qdm-dataelement/immunizationadministered.html
-        if (!empty($record['refusal_reason']))
-        {
+        if (!empty($record['refusal_reason'])) {
             $listService = new ListService();
             $option = $listService->getListOption('immunization_refusal_reason', $record['refusal_reason']);
             if (!empty($option)) {


### PR DESCRIPTION
Fixes #5277 

Added additional value options for the Immunization Refusal Reason so we can report it in Clinical Quality Measures.  I made sure to map the values to the USA CDC's NIP0002 valueset so reporting to immunization registries will still function.

Fixed up the QDM services to use the refusal reason codes.  Since the Immunization QDM model supports both a reason and a negationRationale I added the reason_code and support both fields.  

Implemented code type mappings for when SNOMED is installed to map SNOMED codes to the immunization refusal reason code.  

Implemented a popup selector for the immunization reason code.