### PR TITLE
couple optimizations for the node services

### DIFF
--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -2888,13 +2888,6 @@ $GLOBALS_METADATA = array(
             xl('Full path to directory containing Perl executables.')
         ),
 
-        'node_binary' => array(
-            xl('Absolute path to node binary'),
-            'text',                           // data type
-            'node',                           // default
-            xl('Full path to your node executable for starting external node.js processes.')
-        ),
-
         'temporary_files_dir' => array(
             xl('Path to Temporary Files'),
             'text',                           // data type

--- a/src/Cqm/CqmClient.php
+++ b/src/Cqm/CqmClient.php
@@ -26,12 +26,7 @@ class CqmClient extends HttpClient
     {
         $port = $this->port;
 
-        // The default node binary is 'node', but if the user want's to override it in Globals, they can.
-        // We also set the node binary here to 'node' in case there is no globals option (which also defaults to 'node')
         $node = 'node';
-        if (!empty($GLOBALS['node_binary'])) {
-            $node = $GLOBALS['node_binary'];
-        }
         $cmd = $this->servicePath;
 
         if (IS_WINDOWS) {
@@ -40,14 +35,11 @@ class CqmClient extends HttpClient
         } else {
             $command = $node;
             $system = new System();
-            if (
-                !file_exists($node) &&
-                !$system->command_exists($node)
-            ) {
+            if (!$system->command_exists($node)) {
                 if ($system->command_exists('nodejs')) {
                     $command = 'nodejs';
                 } else {
-                    error_log("Connection failed. Node does not appear to be installed on the system or OpenEMR cannot find it. You may set the path in Globals > Miscellaneous.");
+                    error_log("Connection failed. Node does not appear to be installed on the system.");
                     throw new Exception('Connection Failed.');
                 }
             }

--- a/src/Services/Cda/CdaValidateDocuments.php
+++ b/src/Services/Cda/CdaValidateDocuments.php
@@ -61,7 +61,7 @@ class CdaValidateDocuments
                 $cmd = $system->escapeshellcmd("$command " . $path . "/app.js");
                 exec($cmd . " > /dev/null &");
             }
-
+            sleep(2); // give cpu a rest
             $serverActive = socket_connect($socket, "localhost", $port);
             if ($serverActive === false) {
                 error_log("Failed to start and connect to local schematron service server on port 6662");

--- a/src/Services/Qrda/QrdaReportService.php
+++ b/src/Services/Qrda/QrdaReportService.php
@@ -33,19 +33,22 @@ class QrdaReportService
 
     public function __construct()
     {
-        // first thing, start node service.
+        // first thing, ensure have a node service.
         $this->client = CqmServiceManager::makeCqmClient();
-        $this->client->start();
+        if (empty($this->client->getHealth()['uptime'] ?? null)) {
+            $this->client->start();
+            sleep(2); // give cpu a rest
+        }
+        if (empty($this->client->getHealth()['uptime'] ?? null)) {
+            $msg = xlt("Can not complete report request. Node Service is not running.");
+            throw new \RuntimeException($msg);
+        }
         $this->builder = new QdmBuilder();
         $this->calculator = new CqmCalculator();
         $this->measuresPath = MeasureService::fetchMeasuresPath();
         $this->patientJson = "";
         $this->effectiveDate = trim($GLOBALS['cqm_performance_period'] ?? '2022') . '-01-01 00:00:00';
         $this->effectiveDateEnd = trim($GLOBALS['cqm_performance_period'] ?? '2022') . '-12-31 23:59:59';
-        if (empty($this->client->getHealth()['uptime'] ?? null)) {
-            $msg = xlt("Can not complete report request. Node Service is not running.");
-            throw new \RuntimeException($msg);
-        }
     }
 
     /**

--- a/tests/Tests/ECQM/MeasureResultsTest.php
+++ b/tests/Tests/ECQM/MeasureResultsTest.php
@@ -33,6 +33,11 @@ class MeasureResultsTest extends TestCase
         $serviceHealth = $this->client->getHealth();
         if ($serviceHealth['uptime'] <= 0) {
             $this->client->start();
+            sleep(2); // give cpu a rest
+        }
+        if ($serviceHealth['uptime'] <= 0) {
+            $msg = xlt("Can not complete measure results test. Node Service is not running.");
+            throw new \Exception($msg);
         }
 
         $this->measureOptions = MeasureService::fetchMeasureOptions();


### PR DESCRIPTION
fixes #5340

also removed node_binary global since not used in most service and is a security issue.

TODO (for me):
make it so that it only breaks when the service is needed (for example, Care Coordination module does not need it for import of ccda)
(I am going to work on this TODO in future after get more acquainted with the node services)