### PR TITLE
make oe-schematron-service production ready

### DIFF
--- a/ccdaservice/package-lock.json
+++ b/ccdaservice/package-lock.json
@@ -13,8 +13,8 @@
                 "libxmljs2": "0.29.0",
                 "lodash": "4.17.21",
                 "net": "1.0.2",
-                "oe-cqm-service": "6.0.0",
-                "oe-schematron-service": "1.0.0",
+                "oe-cqm-service": "^6.0.0",
+                "oe-schematron-service": "^1.0.0",
                 "uuid": "8.3.2",
                 "xmljson": "0.2.0"
             }
@@ -28,10 +28,11 @@
             }
         },
         "node_modules/@lhncbc/ucum-lhc": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/@lhncbc/ucum-lhc/-/ucum-lhc-4.1.4.tgz",
-            "integrity": "sha512-ErlXJv6lrerZbthxc33SWTKrZv4KjMIaCN2lNxsNrGZW4PqyVFEKDie6lok//SvC6QeEoAC1mWN8xD87r72qPQ==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@lhncbc/ucum-lhc/-/ucum-lhc-4.1.5.tgz",
+            "integrity": "sha512-w1SxajHhCXyWd9aHLmX4W2qAljwvcqA0BJGmy7LOLW4Cs4Xj0TlrQ1yeAftOQzjH5qU8wWwUlsfaxlIaneSHqw==",
             "dependencies": {
+                "coffeescript": "^2.7.0",
                 "csv-parse": "^4.4.6",
                 "csv-stringify": "^1.0.4",
                 "escape-html": "^1.0.3",
@@ -80,9 +81,9 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "17.0.33",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.33.tgz",
-            "integrity": "sha512-miWq2m2FiQZmaHfdZNcbpp9PuXg34W5JZ5CrJ/BaS70VuhoJENBEQybeiYSaPBRNq6KQGnjfEnc/F3PN++D+XQ=="
+            "version": "17.0.35",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
+            "integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg=="
         },
         "node_modules/abbrev": {
             "version": "1.1.1",
@@ -276,6 +277,18 @@
                 "node": ">=10"
             }
         },
+        "node_modules/coffeescript": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.7.0.tgz",
+            "integrity": "sha512-hzWp6TUE2d/jCcN67LrW1eh5b/rSDKQK6oD6VMLlggYVUUFexgTH9z3dNYihzX4RMhze5FTUsUmOXViJKFQR/A==",
+            "bin": {
+                "cake": "bin/cake",
+                "coffee": "bin/coffee"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/color": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
@@ -296,7 +309,7 @@
         "node_modules/color-name": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
         },
         "node_modules/color-string": {
             "version": "1.9.1",
@@ -318,7 +331,7 @@
         "node_modules/colornames": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
-            "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y="
+            "integrity": "sha512-/pyV40IrsdulWv+wFPmERh9k/mjsPZ64yUMDmWrtj/k1nmgrzzIENWKdaVKyBbvFdQWqkcaRxr+polCo3VMe7A=="
         },
         "node_modules/colors": {
             "version": "1.4.0",
@@ -381,7 +394,7 @@
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
         },
         "node_modules/console-control-strings": {
             "version": "1.1.0",
@@ -1366,9 +1379,9 @@
             }
         },
         "node_modules/oe-schematron-service": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/oe-schematron-service/-/oe-schematron-service-1.0.0.tgz",
-            "integrity": "sha512-RPrJzYE3l4+0nAcyez0eEzwoSxzNyawyb+TivxtfWpDBLSKMIXyZMjfUJuQUy3SyVK57gdcrPwJD9J3QUETmpw==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/oe-schematron-service/-/oe-schematron-service-1.0.1.tgz",
+            "integrity": "sha512-DtO5g++GNjKkEyoAQYYoSUtXw0w+Ugk4NmjMv5HsSxIM6M6WKD1P2k4+bzzbjPBsT5JzvgR0qaVZgKcflifxSg==",
             "dependencies": {
                 "body-parser": "^1.16.0",
                 "express": "^4.14.0",
@@ -1385,7 +1398,7 @@
         "node_modules/oe-schematron-service/node_modules/colors": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-            "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+            "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
             "engines": {
                 "node": ">=0.1.90"
             }
@@ -2069,6 +2082,7 @@
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "oe-blue-button-generate": {
+            "name": "oe-blue-button-generate",
             "version": "1.5.10",
             "bundleDependencies": [
                 "libxmljs2",
@@ -2094,10 +2108,11 @@
             "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
         },
         "@lhncbc/ucum-lhc": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/@lhncbc/ucum-lhc/-/ucum-lhc-4.1.4.tgz",
-            "integrity": "sha512-ErlXJv6lrerZbthxc33SWTKrZv4KjMIaCN2lNxsNrGZW4PqyVFEKDie6lok//SvC6QeEoAC1mWN8xD87r72qPQ==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@lhncbc/ucum-lhc/-/ucum-lhc-4.1.5.tgz",
+            "integrity": "sha512-w1SxajHhCXyWd9aHLmX4W2qAljwvcqA0BJGmy7LOLW4Cs4Xj0TlrQ1yeAftOQzjH5qU8wWwUlsfaxlIaneSHqw==",
             "requires": {
+                "coffeescript": "^2.7.0",
                 "csv-parse": "^4.4.6",
                 "csv-stringify": "^1.0.4",
                 "escape-html": "^1.0.3",
@@ -2143,9 +2158,9 @@
             }
         },
         "@types/node": {
-            "version": "17.0.33",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.33.tgz",
-            "integrity": "sha512-miWq2m2FiQZmaHfdZNcbpp9PuXg34W5JZ5CrJ/BaS70VuhoJENBEQybeiYSaPBRNq6KQGnjfEnc/F3PN++D+XQ=="
+            "version": "17.0.35",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
+            "integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg=="
         },
         "abbrev": {
             "version": "1.1.1",
@@ -2316,6 +2331,11 @@
             "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
             "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
         },
+        "coffeescript": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.7.0.tgz",
+            "integrity": "sha512-hzWp6TUE2d/jCcN67LrW1eh5b/rSDKQK6oD6VMLlggYVUUFexgTH9z3dNYihzX4RMhze5FTUsUmOXViJKFQR/A=="
+        },
         "color": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
@@ -2336,7 +2356,7 @@
         "color-name": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
         },
         "color-string": {
             "version": "1.9.1",
@@ -2355,7 +2375,7 @@
         "colornames": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
-            "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y="
+            "integrity": "sha512-/pyV40IrsdulWv+wFPmERh9k/mjsPZ64yUMDmWrtj/k1nmgrzzIENWKdaVKyBbvFdQWqkcaRxr+polCo3VMe7A=="
         },
         "colors": {
             "version": "1.4.0",
@@ -2411,7 +2431,7 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
         },
         "console-control-strings": {
             "version": "1.1.0",
@@ -3190,9 +3210,9 @@
             }
         },
         "oe-schematron-service": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/oe-schematron-service/-/oe-schematron-service-1.0.0.tgz",
-            "integrity": "sha512-RPrJzYE3l4+0nAcyez0eEzwoSxzNyawyb+TivxtfWpDBLSKMIXyZMjfUJuQUy3SyVK57gdcrPwJD9J3QUETmpw==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/oe-schematron-service/-/oe-schematron-service-1.0.1.tgz",
+            "integrity": "sha512-DtO5g++GNjKkEyoAQYYoSUtXw0w+Ugk4NmjMv5HsSxIM6M6WKD1P2k4+bzzbjPBsT5JzvgR0qaVZgKcflifxSg==",
             "requires": {
                 "body-parser": "^1.16.0",
                 "express": "^4.14.0",
@@ -3209,7 +3229,7 @@
                 "colors": {
                     "version": "1.0.3",
                     "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-                    "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+                    "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw=="
                 },
                 "winston": {
                     "version": "2.4.6",

--- a/ccdaservice/package.json
+++ b/ccdaservice/package.json
@@ -13,7 +13,7 @@
         "net": "1.0.2",
         "uuid": "8.3.2",
         "xmljson": "0.2.0",
-        "oe-schematron-service": "1.0.0",
-        "oe-cqm-service": "6.0.0"
+        "oe-schematron-service": "^1.0.0",
+        "oe-cqm-service": "^6.0.0"
     }
 }


### PR DESCRIPTION
bump install version to allow for all future minor and patch level version changes.

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:
change package to include minor and patch level version bumps to our NPM managed packages so we aren't needing to change core lock and json for minor changes to services. 