### PR TITLE
Fixes #5429 Include patient documents in zip

### DIFF
--- a/interface/modules/zend_modules/module/Application/view/application/sendto/send.phtml
+++ b/interface/modules/zend_modules/module/Application/view/application/sendto/send.phtml
@@ -180,7 +180,7 @@ $download_format = $this->download_format;
             ?>
         </select>
     </div>
-    <div id="componentsForCCDA" style="height:300px !important;display:none;" class="ap-st-st-13">
+    <div id="componentsForCCDA" style="height:300px !important;display:none;" class="ap-st-st-13 components-for-ccda">
         <div style="display:inline-flex;width:100%;">
             <div style="width:35%">
                 <label><input class="ap-st-st-3" type="radio" name="downloadformat_type" id="downloadformat_toc" value="toc" checked>&nbsp;<?php echo $this->listenerObject->z_xlt('Transistion of Care') ?></label>
@@ -217,6 +217,12 @@ $download_format = $this->download_format;
                 $i++;
             }
         } ?>
+        <div style="display:inline-flex;width:100%;">
+            <input type="checkbox" id="patient_documents" name="patient_documents" value="1" />
+            <label for="patient_documents">
+                <?php echo $this->listenerObject->z_xlt('Include Patient Documents In Zip File'); ?>
+            </label>
+        </div>
     </div>
     <!--End Download All-->
     <div class="ap-st-st-6">

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncounterccdadispatchController.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncounterccdadispatchController.php
@@ -224,7 +224,7 @@ class EncounterccdadispatchController extends AbstractActionController
                     // TODO: this appears to be the only place this is used.  Looks at removing this action and bringing it into this controller
                     // no sense in having this forward piece at all...
                     $this->forward()->dispatch(EncountermanagerController::class, array('action' => 'downloadall', 'pids' => $pids
-                    , 'document_type' => $this->document_type));
+                    , 'document_type' => $this->document_type, 'patient_documents' => $this->params('patient_documents')));
                 } else {
                     die;
                 }

--- a/interface/modules/zend_modules/public/js/application/sendTo.js
+++ b/interface/modules/zend_modules/public/js/application/sendTo.js
@@ -171,34 +171,34 @@ $(function () {
     $(".export-document").click(function (event) {
         let qrda = $("input[name='downloadformat']:checked").val();
         if (qrda == 'qrda') {
-            $("#componentsForCCDA").hide('slow');
+            $(".components-for-ccda").hide('slow');
             $("#componentsForQRDA3").hide('slow');
             $("#componentsForQRDA").show('slow');
         } else if (qrda == 'qrda3') {
-            $("#componentsForCCDA").hide('slow');
+            $(".components-for-ccda").hide('slow');
             $("#componentsForQRDA").hide('slow');
             $("#componentsForQRDA3").show('slow');
         } else {
             $("#componentsForQRDA").hide('slow');
             $("#componentsForQRDA3").hide('slow');
-            $("#componentsForCCDA").show('slow');
+            $(".components-for-ccda").show('slow');
         }
     });
 
     $(".showcomponentsForCCDA-div").click(function () {
         let qrda = $("input[name='downloadformat']:checked").val();
         if (qrda === 'qrda') {
-            $("#componentsForCCDA").hide('slow');
+            $(".components-for-ccda").hide('slow');
             $("#componentsForQRDA3").hide('slow');
             $("#componentsForQRDA").toggle('slow');
         } else if (qrda === 'qrda3') {
-            $("#componentsForCCDA").hide('slow');
+            $(".components-for-ccda").hide('slow');
             $("#componentsForQRDA").hide('slow');
             $("#componentsForQRDA3").toggle('slow');
         } else {
             $("#componentsForQRDA").hide('slow');
             $("#componentsForQRDA3").hide('slow');
-            $("#componentsForCCDA").toggle('slow');
+            $(".components-for-ccda").toggle('slow');
         }
     });
 
@@ -372,6 +372,15 @@ function getComponentsString() {
     return comp;
 }
 
+function shouldIncludePatientDocuments() {
+    let node = document.querySelector("#patient_documents");
+    if (!node) {
+        console.error("Failed to find DOM node #patient_documents");
+        return false;
+    }
+    return node.checked === true;
+}
+
 function sendToDownloadAll() {
     var i;
     var count = 0;
@@ -379,6 +388,7 @@ function sendToDownloadAll() {
     var pid;
     var latest_ccda = getLatestCcda();
     var comp = getComponentsString();
+    var patient_documents = shouldIncludePatientDocuments() ? 1 : 0;
 
     if ($('#ccda_pid').val()) {
         pids = $('#ccda_pid').val();
@@ -403,7 +413,10 @@ function sendToDownloadAll() {
         var download_format = $('input:radio[name="downloadformat"]:checked').val();
         if (download_format == 'ccda') {
             if ($('#ccda_pid').val()) {
-                window.location.assign(WEB_ROOT + "/interface/modules/zend_modules/public/encountermanager/index?pid_ccda=" + pid + "&downloadccda=download_ccda&components=" + comp + "&latest_ccda=" + latest_ccda);
+                window.location.assign(WEB_ROOT + "/interface/modules/zend_modules/public/encountermanager/index?pid_ccda="
+                    + pid + "&downloadccda=download_ccda&components=" + comp + "&latest_ccda=" + latest_ccda
+                    + "&includePatientDocuments=" + includePatientDocuments
+                );
             } else {
                 $('#components').val(comp);
                 $("#latestccda").val(latest_ccda);
@@ -426,14 +439,16 @@ function sendToDownloadAll() {
             }
         } else if (download_format == 'ccr') {
             if ($('#ccda_pid').val()) {
-                window.location.assign(WEB_ROOT + "/interface/modules/zend_modules/public/encountermanager/index?pid_ccr=" + pid + "&downloadccr=download_ccr");
+                window.location.assign(WEB_ROOT + "/interface/modules/zend_modules/public/encountermanager/index?pid_ccr=" + pid + "&downloadccr=download_ccr"
+                    + "&includePatientDocuments=" + includePatientDocuments);
             } else {
                 $('#download_ccr').trigger("click");
                 $(".check_pid").prop("checked", false);
             }
         } else if (download_format == 'ccd') {
             if ($('#ccda_pid').val()) {
-                window.location.assign(WEB_ROOT + "/interface/modules/zend_modules/public/encountermanager/index?pid_ccd=" + pid + "&downloadccd=download_ccd");
+                window.location.assign(WEB_ROOT + "/interface/modules/zend_modules/public/encountermanager/index?pid_ccd=" + pid + "&downloadccd=download_ccd"
+                    + "&includePatientDocuments=" + includePatientDocuments);
             } else {
                 $('#download_ccd').trigger("click");
                 $(".check_pid").prop("checked", false);

--- a/library/classes/Document.class.php
+++ b/library/classes/Document.class.php
@@ -432,7 +432,7 @@ class Document extends ORDataObject
     /**
      * Returns all of the documents for a specific patient
      * @param int $patient_id
-     * @return array
+     * @return Document[]
      */
     public static function getDocumentsForPatient(int $patient_id)
     {

--- a/src/Services/Cda/CdaTemplateImportDispose.php
+++ b/src/Services/Cda/CdaTemplateImportDispose.php
@@ -253,8 +253,8 @@ class CdaTemplateImportDispose
         foreach ($proc_array as $key => $value) {
             $procedure_date_value = null;
             if (!empty($value['date']) && ($revapprove == 0 || $revapprove == 1)) {
-                $procedure_date_value = $value['date'] ? date("Y-m-d H:i:s", strtotime($value['date'])) : null;
-                $end_date = $value['end_date'] ? date("Y-m-d H:i:s", strtotime($value['end_date'])) : null;
+                $procedure_date_value = !empty($value['date']) ? date("Y-m-d H:i:s", strtotime($value['date'])) : null;
+                $end_date = !empty($value['end_date']) ? date("Y-m-d H:i:s", strtotime($value['end_date'])) : null;
             }
             //facility1
             if (empty($value['represented_organization1'])) {


### PR DESCRIPTION
Made it so there is an option as part of care coordination to include
the patient documents in the zip export for each patient.  This checks
agains the current user's ACLs.

Had this in a stashed commit and don't want to leave it.  Going to leave it as a WIP until I can come back and vet this is all working properly.  However, others can see what I am doing here to include the documents.