### PR TITLE
Fixes #5464 AMC - pass not defaulted to 0

### DIFF
--- a/library/classes/rulesets/Amc/library/AbstractAmcReport.php
+++ b/library/classes/rulesets/Amc/library/AbstractAmcReport.php
@@ -198,6 +198,7 @@ abstract class AbstractAmcReport implements RsReportIF
         $denominatorObjects = 0;
 
         foreach ($this->_amcPopulation as $patient) {
+            $pass = 0;
             $numeratorResultItemDetails = new AmcItemizedActionData();
             $denominatorResultItemDetails = new AmcItemizedActionData();
 


### PR DESCRIPTION
AMC was breaking if a numerator test did not pass with the patient fhir credentials being missing.