### PR TITLE
Fixes #5455 Document Type Display Order

### DIFF
--- a/ccr/display.php
+++ b/ccr/display.php
@@ -8,6 +8,7 @@
  * @author    Ajil P.M <ajilpm@zhservices.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
  * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @deprecated 7.0.0 People should use the /interface/modules/zend_modules/public/encountermanager/previewDocument?docId=<id> REST action instead of this file
  * @copyright Copyright (c) 2011 Z&H Consultancy Services Private Limited <ajilpm@zhservices.com>
  * @copyright Copyright (c) 2013 Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2022 Discover and Change <snielson@discoverandchange.com>

--- a/controllers/C_Document.class.php
+++ b/controllers/C_Document.class.php
@@ -19,6 +19,7 @@ use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Services\FacilityService;
 use OpenEMR\Services\PatientService;
+use OpenEMR\Events\PatientDocuments\PatientDocumentTreeViewFilterEvent;
 
 class C_Document extends Controller
 {
@@ -543,7 +544,7 @@ class C_Document extends Controller
         $menu  = new HTML_TreeMenu();
 
         //pass an empty array because we don't want the documents for each category showing up in this list box
-        $rnode = $this->array_recurse($this->tree->tree, array());
+        $rnode = $this->array_recurse($this->tree->tree, $patient_id, array());
         $menu->addItem($rnode);
         $treeMenu_listbox  = new HTML_TreeMenu_Listbox($menu, array("promoText" => xl('Move Document to Category:')));
 
@@ -1053,7 +1054,7 @@ class C_Document extends Controller
         //print_r($categories_list);
 
         $menu  = new HTML_TreeMenu();
-        $rnode = $this->array_recurse($this->tree->tree, $categories_list);
+        $rnode = $this->array_recurse($this->tree->tree, $patient_id, $categories_list);
         $menu->addItem($rnode);
         $treeMenu = new HTML_TreeMenu_DHTML($menu, array('images' => 'public/images', 'defaultClass' => 'treeMenuDefault'));
         $treeMenu_listbox  = new HTML_TreeMenu_Listbox($menu, array('linkTarget' => '_self'));
@@ -1084,7 +1085,7 @@ class C_Document extends Controller
         return $this->fetch($GLOBALS['template_dir'] . "documents/" . $this->template_mod . "_list.html");
     }
 
-    public function &array_recurse($array, $categories = array())
+    public function &array_recurse($array, $patient_id, $categories = array())
     {
         if (!is_array($array)) {
             $array = array();
@@ -1107,7 +1108,7 @@ class C_Document extends Controller
                     $current_node = &$this->_last_node;
                 }
 
-                $this->array_recurse($ar, $categories);
+                $this->array_recurse($ar, $patient_id, $categories);
             } else {
                 if ($id === 0 && !empty($ar)) {
                     $info = $this->tree->get_node_info($id);
@@ -1133,29 +1134,30 @@ class C_Document extends Controller
                     if (!AclMain::aclCheckAcoSpec($doc['aco_spec'])) {
                         $link = '';
                     }
-                    if ($this->tree->get_node_name($id) == "CCR") {
-                        $current_node->addItem(new HTML_TreeNode(array(
-                            'text' => oeFormatShortDate($doc['docdate']) . ' ' . $doc['document_name'] . '-' . $doc['document_id'],
-                            'link' => $link,
-                            'icon' => $icon,
-                            'expandedIcon' => $expandedIcon,
-                            'events' => array('Onclick' => "javascript:newwindow=window.open('ccr/display.php?type=CCR&doc_id=" . attr_url($doc['document_id']) . "','_blank');")
-                        )));
-                    } elseif ($this->tree->get_node_name($id) == "CCD") {
-                        $current_node->addItem(new HTML_TreeNode(array(
-                            'text' => oeFormatShortDate($doc['docdate']) . ' ' . $doc['document_name'] . '-' . $doc['document_id'],
-                            'link' => $link,
-                            'icon' => $icon,
-                            'expandedIcon' => $expandedIcon,
-                            'events' => array('Onclick' => "javascript:newwindow=window.open('ccr/display.php?type=CCD&doc_id=" . attr_url($doc['document_id']) . "','_blank');")
-                        )));
+                    // CCD view
+                    $nodeInfo = $this->tree->get_node_info($id);
+                    $treeViewFilterEvent = new PatientDocumentTreeViewFilterEvent();
+                    $treeViewFilterEvent->setCategoryTreeNode($this->tree);
+                    $treeViewFilterEvent->setDocumentId($doc['document_id']);
+                    $treeViewFilterEvent->setDocumentName($doc['document_name']);
+                    $treeViewFilterEvent->setCategoryId($id);
+                    $treeViewFilterEvent->setCategoryInfo($nodeInfo);
+                    $treeViewFilterEvent->setPid($patient_id);
+
+                    $htmlNode = new HTML_TreeNode(array(
+                        'text' => oeFormatShortDate($doc['docdate']) . ' ' . $doc['document_name'] . '-' . $doc['document_id'],
+                        'link' => $link,
+                        'icon' => $icon,
+                        'expandedIcon' => $expandedIcon
+                    ));
+
+                    $treeViewFilterEvent->setHtmlTreeNode($htmlNode);
+                    $filteredEvent = $GLOBALS['kernel']->getEventDispatcher()->dispatch($treeViewFilterEvent, PatientDocumentTreeViewFilterEvent::EVENT_NAME);
+                    if ($filteredEvent->getHtmlTreeNode() != null) {
+                        $current_node->addItem($filteredEvent->getHtmlTreeNode());
                     } else {
-                        $current_node->addItem(new HTML_TreeNode(array(
-                            'text' => oeFormatShortDate($doc['docdate']) . ' ' . $doc['document_name'] . '-' . $doc['document_id'],
-                            'link' => $link,
-                            'icon' => $icon,
-                            'expandedIcon' => $expandedIcon
-                        )));
+                        // add the original node if we got back nothing from the server
+                        $current_node->addItem($htmlNode);
                     }
                 }
             }

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaDocumentTemplateOids.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaDocumentTemplateOids.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * CcdaDocumentTemplateOids contains all of the CCD-A oids for the document template types we support in OpenEMR.
+ *
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2022 Discover and Change <snielson@discoverandchange.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace Carecoordination\Model;
+
+// @see http://www.hl7.org/ccdasearch/ for a listing of this oids (Last accessed on June 14th 2022)
+class CcdaDocumentTemplateOids
+{
+    const CCD = "2.16.840.1.113883.10.20.22.1.2";
+    const REFERRAL = "2.16.840.1.113883.10.20.22.1.14";
+    const TRANSFER_SUMMARY = "2.16.840.1.113883.10.20.22.1.13";
+    const CAREPLAN  = "2.16.840.1.113883.10.20.22.1.15";
+    const CCDA_DOCUMENT_TEMPLATE_OIDS = [self::CCD, self::REFERRAL, self::TRANSFER_SUMMARY, self::CAREPLAN];
+
+    public static function isValidDocumentTemplateOid($oid)
+    {
+        return in_array($oid, self::CCDA_DOCUMENT_TEMPLATE_OIDS);
+    }
+}

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaGlobalsConfiguration.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaGlobalsConfiguration.php
@@ -23,7 +23,17 @@ class CcdaGlobalsConfiguration
     const GLOBAL_SECTION_NAME = 'Carecoordination';
 
     const GLOBAL_KEY_CCDA_MAX_SECTIONS = 'ccda_view_max_sections';
-    const GLOBAL_KEY_CCDA_SORT_ORDER = 'ccda_section_sort_order';
+
+    // these are based on the four document types we allow
+    const GLOBAL_KEY_CCDA_CCD_SORT_ORDER = 'ccda_ccd_section_sort_order';
+    const GLOBAL_KEY_CCDA_REFERRAL_SORT_ORDER = 'ccda_referral_section_sort_order';
+    const GLOBAL_KEY_CCDA_TOC_SORT_ORDER = 'ccda_toc_section_sort_order';
+    const GLOBAL_KEY_CCDA_CAREPLAN_SORT_ORDER = 'ccda_careplan_section_sort_order';
+
+    /**
+     * @var array in memory cache of the ccda list options in the database
+     */
+    private $ccdaSections;
 
     public function setupGlobalSections(GlobalsService $service)
     {
@@ -38,15 +48,24 @@ class CcdaGlobalsConfiguration
         $service->appendToSection(self::GLOBAL_SECTION_NAME, self::GLOBAL_KEY_CCDA_MAX_SECTIONS, $setting);
 
 
-        $setting = new GlobalSetting(
-            xl('Section Display Order'),
-            GlobalSetting::DATA_TYPE_MULTI_SORTED_LIST_SELECTOR,
-            '',
-            xl('The order of clinical information sections to display when viewing a CCD-A document'),
-            true
-        );
-        $setting->addFieldOption(GlobalSetting::DATA_TYPE_OPTION_LIST_ID, 'ccda-sections');
-        $service->appendToSection(self::GLOBAL_SECTION_NAME, self::GLOBAL_KEY_CCDA_SORT_ORDER, $setting);
+        $docTypeSortOrderSections = [
+            xl("CCD Section Display Order") => self::GLOBAL_KEY_CCDA_CCD_SORT_ORDER
+            ,xl("Referral Section Display Order") => self::GLOBAL_KEY_CCDA_REFERRAL_SORT_ORDER
+            ,xl("Transition of Care Section Display Order") => self::GLOBAL_KEY_CCDA_TOC_SORT_ORDER
+            ,xl("Careplan Section Display Order") => self::GLOBAL_KEY_CCDA_CAREPLAN_SORT_ORDER
+            ,xl("Referral Section Display Order") => self::GLOBAL_KEY_CCDA_REFERRAL_SORT_ORDER
+        ];
+        foreach ($docTypeSortOrderSections as $name => $globalKey) {
+            $setting = new GlobalSetting(
+                $name,
+                GlobalSetting::DATA_TYPE_MULTI_SORTED_LIST_SELECTOR,
+                '',
+                xl('The order of clinical information sections to display when viewing a CCD-A document'),
+                true
+            );
+            $setting->addFieldOption(GlobalSetting::DATA_TYPE_OPTION_LIST_ID, 'ccda-sections');
+            $service->appendToSection(self::GLOBAL_SECTION_NAME, $globalKey, $setting);
+        }
     }
 
     public function getMaxSections(): int
@@ -54,21 +73,41 @@ class CcdaGlobalsConfiguration
         return intval($GLOBALS[self::GLOBAL_KEY_CCDA_MAX_SECTIONS] ?? 0);
     }
 
+    /**
+     * Retrieves an mapped array of sorted section oids where each key in the map is the oid of a document template in CCD-A
+     * that we support inside of OpenEMR.  This will retrieve the global settings that users have configured for their
+     * carecoordination document types.
+     * @return array
+     */
     public function getSectionDisplayOrder(): array
+    {
+        return [
+            CcdaDocumentTemplateOids::CCD => $this->getSectionDisplayOrderForType(self::GLOBAL_KEY_CCDA_CCD_SORT_ORDER)
+            ,CcdaDocumentTemplateOids::CAREPLAN => $this->getSectionDisplayOrderForType(self::GLOBAL_KEY_CCDA_CAREPLAN_SORT_ORDER)
+            ,CcdaDocumentTemplateOids::TRANSFER_SUMMARY => $this->getSectionDisplayOrderForType(self::GLOBAL_KEY_CCDA_TOC_SORT_ORDER)
+            ,CcdaDocumentTemplateOids::REFERRAL => $this->getSectionDisplayOrderForType(self::GLOBAL_KEY_CCDA_REFERRAL_SORT_ORDER)
+        ];
+    }
+
+    /**
+     * Retrieves an array of sorted section oids for the given global key we want to retrieve.
+     * @param string $key
+     * @return array
+     */
+    private function getSectionDisplayOrderForType($key = self::GLOBAL_KEY_CCDA_CCD_SORT_ORDER)
     {
         $codeService = new CodeTypesService();
         $sortOrder = array();
         $sortOrderIndexesByKeys = [];
-        if (!empty($GLOBALS[self::GLOBAL_KEY_CCDA_SORT_ORDER])) {
-            $sortString = $GLOBALS[self::GLOBAL_KEY_CCDA_SORT_ORDER] ?? "";
+        if (!empty($GLOBALS[$key])) {
+            $sortString = $GLOBALS[$key] ?? "";
             $sortOrder = explode(";", $sortString);
             $sortOrderIndexesByKeys = array_combine($sortOrder, array_keys($sortOrder));
         }
         if (!empty($sortOrder)) {
             // now we are going to grab our keys from the list service
-            $listService = new ListService();
             // should be less than 50 items, better to just use memory than try to hit the db off a search
-            $sections = $listService->getOptionsByListName('ccda-sections');
+            $sections = $this->getCcdaSections();
             foreach ($sections as $section) {
                 $option_id = $section['option_id'] ?? 'undefined';
                 if (isset($sortOrderIndexesByKeys[$option_id])) {
@@ -80,5 +119,14 @@ class CcdaGlobalsConfiguration
             }
         }
         return $sortOrder;
+    }
+
+    private function getCcdaSections()
+    {
+        if (empty($this->ccdaSections)) {
+            $listService = new ListService();
+            $this->ccdaSections = $listService->getOptionsByListName('ccda-sections');
+        }
+        return $this->ccdaSections;
     }
 }

--- a/src/Events/PatientDocuments/PatientDocumentTreeViewFilterEvent.php
+++ b/src/Events/PatientDocuments/PatientDocumentTreeViewFilterEvent.php
@@ -1,0 +1,188 @@
+<?php
+
+/**
+ * PatientDocumentTreeViewFilterEvent is fired when patient documents are rendered in the html tree view widget.  It
+ * enables event listeners to modify the html element that is displayed for each patient document.
+ * @see Carecoordination\Listener\CCDAEventsSubscriber::onPatientDocumentTreeViewFilter for an example.
+ *
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2022 Discover and Change <snielson@discoverandchange.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\PatientDocuments;
+
+use HTML_TreeNode;
+use CategoryTree;
+
+class PatientDocumentTreeViewFilterEvent
+{
+    const EVENT_NAME = "patient.document.tree.view.filter";
+
+    /**
+     * @var CategoryTree
+     */
+    private $categoryTreeNode;
+
+    /**
+     * @var \HTML_TreeNode
+     */
+    private $htmlTreeNode;
+
+    /**
+     * @var ?string
+     */
+    private $documentId;
+
+    /**
+     * @var ?string
+     */
+    private $documentName;
+
+    /**
+     * @var ?string
+     */
+    private $categoryId;
+
+    /**
+     * @var array
+     */
+    private $categoryInfo;
+
+    /**
+     * @var ?int
+     */
+    private $pid;
+
+    public function __construct()
+    {
+    }
+
+    /**
+     * @return CategoryTree
+     */
+    public function getCategoryTreeNode(): CategoryTree
+    {
+        return $this->categoryTreeNode;
+    }
+
+    /**
+     * @param CategoryTree $categoryTreeNode
+     * @return PatientDocumentTreeViewFilterEvent
+     */
+    public function setCategoryTreeNode(CategoryTree $categoryTreeNode): PatientDocumentTreeViewFilterEvent
+    {
+        $this->categoryTreeNode = $categoryTreeNode;
+        return $this;
+    }
+
+    /**
+     * @return HTML_TreeNode
+     */
+    public function getHtmlTreeNode(): HTML_TreeNode
+    {
+        return $this->htmlTreeNode;
+    }
+
+    /**
+     * @param HTML_TreeNode $htmlTreeNode
+     * @return PatientDocumentTreeViewFilterEvent
+     */
+    public function setHtmlTreeNode(HTML_TreeNode $htmlTreeNode): PatientDocumentTreeViewFilterEvent
+    {
+        $this->htmlTreeNode = $htmlTreeNode;
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getPid()
+    {
+        return $this->pid;
+    }
+
+    /**
+     * @param mixed $pid
+     * @return PatientDocumentTreeViewFilterEvent
+     */
+    public function setPid($pid)
+    {
+        $this->pid = $pid;
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getDocumentId()
+    {
+        return $this->documentId;
+    }
+
+    /**
+     * @param mixed $documentId
+     * @return PatientDocumentTreeViewFilterEvent
+     */
+    public function setDocumentId($documentId)
+    {
+        $this->documentId = $documentId;
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getDocumentName()
+    {
+        return $this->documentName;
+    }
+
+    /**
+     * @param mixed $documentName
+     * @return PatientDocumentTreeViewFilterEvent
+     */
+    public function setDocumentName($documentName)
+    {
+        $this->documentName = $documentName;
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getCategoryId()
+    {
+        return $this->categoryId;
+    }
+
+    /**
+     * @param mixed $categoryId
+     * @return PatientDocumentTreeViewFilterEvent
+     */
+    public function setCategoryId($categoryId)
+    {
+        $this->categoryId = $categoryId;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getCategoryInfo(): array
+    {
+        return $this->categoryInfo;
+    }
+
+    /**
+     * @param array $categoryInfo
+     * @return PatientDocumentTreeViewFilterEvent
+     */
+    public function setCategoryInfo(array $categoryInfo): PatientDocumentTreeViewFilterEvent
+    {
+        $this->categoryInfo = $categoryInfo;
+        return $this;
+    }
+}


### PR DESCRIPTION
Fixes #5455 
After talking this over with @sjpadgett we decided to implement this by having multiple sort order sections for the four document types we support in CCD-A.  Its not ideal, but the alternative will take quite a bit of time to architect.  

I wrote a new preview option for CCD-A that examines the XML document to figure out the correct CCDA Template document type so we can know what sort order to use to display for the correct document.

Added a deprecation notice to the ccr/display.php in case anyone is using it.  We no longer reference it from the documents pages so we can probably remove it at some point.

I also added a new filter event to the patient document tree viewer so people can modify / update the html tree rendering on the documents if they so choose.  This made it easy to loosely couple the tree with the Carecoordination module.

One thing I did was leave in place where we give the CCDA preview only to documents that are in the CCR/CCD/CCDA category folders.  Another option would be to key off the LOINC codes of any category.  That way people could have whatever categories they want... but I don't know if people would really use that and if it just makes more sense to go with the defaults.  The downside is if anyone deletes those categories then the CCDA previewers will stop working.

Another option would be just to have the preview on pretty much any XML document but I'm not sure we want to do that either.  If you have any thoughts here, let me know.