### PR TITLE
Openemr fix #5496 vital form bugs

### DIFF
--- a/interface/forms/vitals/report.php
+++ b/interface/forms/vitals/report.php
@@ -87,6 +87,7 @@ function vitals_report($pid, $encounter, $cols, $id, $print = true)
                     continue;
                 }
             } elseif ($key == "Weight") {
+                $value = floatval($value);
                 $convValue = number_format($value * 0.45359237, 2);
                 $vitals .= "<td><div class='font-weight-bold d-inline-block'>" . xlt($key) . ": </div></td><td><div class='text' style='display:inline-block'>";
                 // show appropriate units
@@ -103,6 +104,7 @@ function vitals_report($pid, $encounter, $cols, $id, $print = true)
 
                 $vitals .= "</div></td>";
             } elseif ($key == "Height" || $key == "Waist Circ"  || $key == "Head Circ") {
+                $value = floatval($value);
                 $convValue = round(number_format($value * 2.54, 2), 1);
                 // show appropriate units
                 if ($GLOBALS['units_of_measurement'] == 2) {
@@ -115,6 +117,7 @@ function vitals_report($pid, $encounter, $cols, $id, $print = true)
                     $vitals .= "<td><div class='font-weight-bold d-inline-block'>" . xlt($key) . ": </div></td><td><div class='text' style='display:inline-block'>" . text($value) . " " . xlt('in') . " (" . text($convValue) . " " . xlt('cm')  . ")</div></td>";
                 }
             } elseif ($key == "Temperature") {
+                $value = floatval($value);
                 $convValue = number_format((($value - 32) * 0.5556), 2);
                 // show appropriate units
                 if ($GLOBALS['units_of_measurement'] == 2) {
@@ -127,6 +130,7 @@ function vitals_report($pid, $encounter, $cols, $id, $print = true)
                     $vitals .= "<td><div class='font-weight-bold d-inline-block'>" . xlt($key) . ": </div></td><td><div class='text' style='display:inline-block'>" . text($value) . " " . xlt('F') . " (" . text($convValue) . " " . xlt('C')  . ")</div></td>";
                 }
             } elseif ($key == "Pulse" || $key == "Respiration"  || $key == "Oxygen Saturation" || $key == "BMI" || $key == "Oxygen Flow Rate") {
+                $value = floatval($value);
                 $c_value = number_format($value, 0);
                 if ($key == "Oxygen Saturation") {
                     $vitals .= "<td><div class='font-weight-bold d-inline-block'>" . xlt($key) . ": </div></td><td><div class='text' style='display:inline-block'>" . text($c_value) . " " . xlt('%') . "</div></td>";
@@ -139,6 +143,7 @@ function vitals_report($pid, $encounter, $cols, $id, $print = true)
                     $vitals .= "<td><div class='font-weight-bold d-inline-block'>" . xlt($key) . ": </div></td><td><div class='text' style='display:inline-block'>" . text($c_value) . " " . xlt('per min') . "</div></td>";
                 }
             } elseif ($key == "Ped Weight Height" || $key == 'Ped Bmi' || $key == 'Ped Head Circ') {
+                $value = floatval($value);
                 if ($is_pediatric_patient) {
                     $c_value = number_format($value, 0);
                     if ($key == "Ped Weight Height") {

--- a/interface/forms/vitals/templates/vitals/general_new.html
+++ b/interface/forms/vitals/templates/vitals/general_new.html
@@ -132,7 +132,7 @@
                                     <tr>
                                         <td>{xlt t="BMI Status"}</td><td>{xlt t="Type"}</td>
                                         <td class='currentvalues p-2'>
-                                            <input type="text" class="form-control" size='20'
+                                            <input type="text" class="form-control skip-template-editor" size='20'
                                                 name="BMI_status" id="BMI_status" value="{$vitals->get_BMI_status()|attr}"/></td>
                                         <td class="editonly"></td>
                                         <td class="editonly actions">

--- a/interface/forms/vitals/templates/vitals/vitals_textbox.tpl
+++ b/interface/forms/vitals/templates/vitals/vitals_textbox.tpl
@@ -8,10 +8,10 @@
 
     <td class='currentvalues p-2'>
         {if isset($vitalsStringFormat) }
-        <input type="text" class="form-control" size='5' name='{$input|attr}' id='{$input|attr}_input'
+        <input type="text" class="form-control skip-template-editor" size='5' name='{$input|attr}' id='{$input|attr}_input'
                value="{if is_numeric($vitals->$vitalsValue()) }{$vitals->$vitalsValue()|string_format:$vitalsStringFormat|attr}{/if}"/>
         {else}
-        <input type="text" class="form-control" size='5' name='{$input|attr}' id='{$input|attr}_input'
+        <input type="text" class="form-control skip-template-editor" size='5' name='{$input|attr}' id='{$input|attr}_input'
                value="{if is_numeric($vitals->$vitalsValue())}{$vitals->$vitalsValue()|attr}{/if}"/>
         {/if}
 

--- a/interface/forms/vitals/templates/vitals/vitals_textbox_conversion.tpl
+++ b/interface/forms/vitals/templates/vitals/vitals_textbox_conversion.tpl
@@ -34,7 +34,7 @@
     {else}
         <td class='currentvalues p-2'>
     {/if}
-            <input type="text" class="form-control vitals-conv-unit" size='5' id='{$input|attr}_input_usa'
+            <input type="text" class="form-control vitals-conv-unit skip-template-editor" size='5' id='{$input|attr}_input_usa'
                    value="{if is_numeric($vitals->$vitalsValue()) }{$vitals->$vitalsValue()|string_format:$vitalsStringFormat|attr}{/if}"
                    data-system="usa" data-unit="{$unit|attr}" data-target-input="{$input|attr}_input"
                    data-target-input-conv="{$input|attr}_input_metric"
@@ -76,7 +76,7 @@
         <td class='currentvalues p-2'>
     {/if}
             <!-- Note we intentionally use vitalsValue not vitalValuesMetric because of how data is stored internally -->
-            <input type="text" class="form-control vitals-conv-unit" size='5' id='{$input|attr}_input_metric'
+            <input type="text" class="form-control vitals-conv-unit skip-template-editor" size='5' id='{$input|attr}_input_metric'
                    value="{if is_numeric($vitals->$vitalsValue()) }{$vitals->$vitalsValueMetric()|string_format:$vitalsStringFormat|attr}{/if}"
                    data-system="metric" data-unit="{$unit|attr}" data-target-input="{$input|attr}_input"
                    data-target-input-conv="{$input|attr}_input_usa" />

--- a/interface/forms/vitals/vitals.js
+++ b/interface/forms/vitals/vitals.js
@@ -69,14 +69,19 @@
         if (value != "") {
             let convValue = convUnit(system, unit, value);
             if (!isNaN(convValue)) {
-                inputSave.value = convValue;
                 inputConv.value = convValue.toFixed(precision);
+                // all values are saved in usa system units
+                if (system !== "usa") {
+                    inputSave.value = inputSave.value = convValue;
+                } else {
+                    inputSave.value = value;
+                }
             } else {
                 console.error("Failed to get valid number for input with id ", node.id, " with value ", value);
             }
         } else {
-            targetSaveUnit.value = "";
-            targetInputConv.value = "";
+            inputSave.value = "";
+            inputConv.value = "";
         }
 
         if (targetSaveUnit == "weight_input" || targetSaveUnit == "height_input") {
@@ -180,7 +185,6 @@ function convLbtoKg(value) {
     }
     else if (lb == parseFloat(lb)) {
         kg = lb*0.45359237;
-        kg = kg.toFixed(6);
         return kg;
     }
     else {

--- a/interface/forms/vitals/vitals.js
+++ b/interface/forms/vitals/vitals.js
@@ -277,12 +277,12 @@ function calculateBMI() {
     let precision = vitalsGetPrecision(bmiNode, 2);
 
     let heightNode = document.getElementById("height_input");
-    if (!bmiNode) {
+    if (!heightNode) {
         console.error("Failed to find node with id height_input");
         return;
     }
     let weightNode = document.getElementById("weight_input");
-    if (!bmiNode) {
+    if (!weightNode) {
         console.error("Failed to find node with id weight_input");
         return;
     }

--- a/library/js/CustomTemplateApi.js
+++ b/library/js/CustomTemplateApi.js
@@ -28,7 +28,7 @@ function doTemplateEditor(_this, event, oContext = '') {
 }
 
 const bindTextArea = function () {
-    const teventElement = document.querySelectorAll("textarea, input[type='text']");
+    const teventElement = document.querySelectorAll("textarea, input[type='text']:not(.skip-template-editor)");
     if (typeof teventElement === 'undefined' || teventElement === null) {
         return false;
     }


### PR DESCRIPTION
Fixes #5496 
Fixes #5500 

kg to lb was throwing an error as we tried calling a Number method on a
string.

Vitals were saving in metric if you had metric set as the main unit and
entered in data that way.

Setting a vitals value to be empty was not emptying out the
corresponding conversion field and the saved input.

I haven't been able to reproduce this typecast error on my version of php but on
some versions of php this was throwing a type conversion error.  We
parse as floats the values before we put them through number_format to
fix the type conversion problem.

Made it so double clicking the vitals form doesn't popup the dialog
template editor.