### PR TITLE
Openemr fix 5508 ccd date ranges

### DIFF
--- a/API_README.md
+++ b/API_README.md
@@ -24,6 +24,7 @@
         - [System Export (in FHIR_README.md)](FHIR_README.md#bulk-fhir-exports)
         - [Patient Export (in FHIR_README.md)](FHIR_README.md#bulk-fhir-exports)
         - [Group Export (in FHIR_README.md)](FHIR_README.md#bulk-fhir-exports)
+    - [Carecoordination Summary of Care (CCD) Generation (in FHIR_README.md)](FHIR_README.md#carecoordination-summary-of-care-docref-operation)
 - [For Developers](API_README.md#for-developers)
 
 ## Overview

--- a/FHIR_README.md
+++ b/FHIR_README.md
@@ -226,7 +226,7 @@ It is recommended that native applications follow best practices for native clie
     
 - CCD is generated on demand, saved off in patient's record under the CCDA category
 - Requires following standard FHIR authorization
-- Requires <context>/DocumentReference.$docref scope, <context>/Document.read scope
+- Requires <context>/DocumentReference.$docref scope, <context>/DocumentReference.read, <context>/Document.read scope
 - Returns a DocumentReference search bundle per the IG spec.
 - XSL to view the document can be download at /<site>/interface/modules/zend_modules/public/xls/cda.xsl
 - Or xml file can be uploaded as a document into OpenEMR to view in a human readable format

--- a/FHIR_README.md
+++ b/FHIR_README.md
@@ -24,6 +24,7 @@
         - [Group Export](FHIR_README.md#bulk-fhir-exports)
 - [3rd Party SMART Apps](FHIR_README.md#3rd-party-smart-apps)
 - [Native Applications](FHIR_README.md#native-applications)
+- [Carecoordination Summary Of Care (CCD) Generation](FHIR_README.md#carecoordination-summary-of-care-docref-operation)
 - [For Developers](FHIR_README.md#for-developers)
 
 ## Overview
@@ -188,6 +189,49 @@ Interoperability requirements with OpenEMR for Native Applications
 - Native applications must use the Authorization Code grant flow in order to receive a refresh token.  
 
 It is recommended that native applications follow best practices for native client applications as outlined in RFC 8252 OAuth 2.0 for Native Apps.
+
+## Carecoordination Summary of Care Docref Operation
+
+- TODO: add documentation for POST /$doc-ref operation that meets 3.1.1 US Core standard
+- The $docref operation is used to request the server generates a document based on the specified
+  parameters. If no additional parameters are specified then a DocumentReference to the patient's most current Clinical
+  Summary of Care Document (CCD) is returned. The document itself is retrieved using the DocumentReference.content.attachment.url
+  element.  See <a href='http://hl7.org/fhir/us/core/OperationDefinition-docref.html' target='_blank'
+  rel='noopener'>http://hl7.org/fhir/us/core/OperationDefinition-docref.html</a> for more details.
+- Need to discuss that if the medical info is connected to an encounter and the encounter service date falls in the date range it will be included.
+- start and end date filter encounter related events for the following sections.
+    - History of Procedures
+    - Relevant DX Tests / LAB Data
+    - Functional Status
+    - Vital Signs
+    - Progress Notes
+    - Procedure Notes
+    - Laboratory Report Narrative
+    - Encounters
+    - Assessments
+    - Treatment Plan
+    - Goals
+    - Health Concerns Document
+    - Reason for Referral
+    - Mental Status
+  
+- The following sections have the entire medical record sent to ensure that medical professionals have medically necessary information to provide treatment of care
+    - Demographics
+    - Allergies, Adverse Reactions, Alerts
+    - History of Medication Use
+    - Problem List
+    - Immunizations
+    - Social History
+    - Medical Equipment
+    
+- CCD is generated on demand, saved off in patient's record under the CCDA category
+- Requires following standard FHIR authorization
+- Requires <context>/DocumentReference.$docref scope, <context>/Document.read scope
+- Returns a DocumentReference search bundle per the IG spec.
+- XSL to view the document can be download at /<site>/interface/modules/zend_modules/public/xls/cda.xsl
+- Or xml file can be uploaded as a document into OpenEMR to view in a human readable format
+- Due to browser security restrictions XSL file must be in same directory as ccd document to view.
+- link out to swagger location on where to build file
 
 ## For Developers
 

--- a/_rest_routes.inc.php
+++ b/_rest_routes.inc.php
@@ -8457,7 +8457,7 @@ RestConfig::$FHIR_ROUTE_MAP = array(
     },
 
     /**
-     *  @OA\Get(
+     *  @OA\POST(
      *      path="/fhir/DocumentReference/$docref",
      *      description="The $docref operation is used to request the server generates a document based on the specified parameters. If no additional parameters are specified then a DocumentReference to the patient's most current Clinical Summary of Care Document (CCD) is returned. The document itself is retrieved using the DocumentReference.content.attachment.url element.  See <a href='http://hl7.org/fhir/us/core/OperationDefinition-docref.html' target='_blank' rel='noopener'>http://hl7.org/fhir/us/core/OperationDefinition-docref.html</a> for more details",
      *      tags={"fhir"},
@@ -8512,7 +8512,7 @@ RestConfig::$FHIR_ROUTE_MAP = array(
      *      security={{"openemr_auth":{}}}
      *  )
      */
-    'GET /fhir/DocumentReference/$docref' => function (HttpRestRequest $request) {
+    'POST /fhir/DocumentReference/$docref' => function (HttpRestRequest $request) {
 
         // NOTE: The order of this route is IMPORTANT as it needs to come before the DocumentReference single request.
         if ($request->isPatientRequest()) {

--- a/_rest_routes.inc.php
+++ b/_rest_routes.inc.php
@@ -8459,8 +8459,9 @@ RestConfig::$FHIR_ROUTE_MAP = array(
     /**
      *  @OA\POST(
      *      path="/fhir/DocumentReference/$docref",
-     *      description="The $docref operation is used to request the server generates a document based on the specified parameters. If no additional parameters are specified then a DocumentReference to the patient's most current Clinical Summary of Care Document (CCD) is returned. The document itself is retrieved using the DocumentReference.content.attachment.url element.  See <a href='http://hl7.org/fhir/us/core/OperationDefinition-docref.html' target='_blank' rel='noopener'>http://hl7.org/fhir/us/core/OperationDefinition-docref.html</a> for more details",
+     *      description="The $docref operation is used to request the server generates a document based on the specified parameters. If no additional parameters are specified then a DocumentReference to the patient's most current Clinical Summary of Care Document (CCD) is returned. The document itself is retrieved using the DocumentReference.content.attachment.url element.  See <a href='http://hl7.org/fhir/us/core/OperationDefinition-docref.html' target='_blank' rel='noopener'>http://hl7.org/fhir/us/core/OperationDefinition-docref.html</a> for more details.",
      *      tags={"fhir"},
+     *      @OA\ExternalDocumentation(description="Detailed documentation on this operation", url="https://github.com/openemr/openemr/blob/master/FHIR_README.md#carecoordination-summary-of-care-docref-operation"),
      *      @OA\Parameter(
      *          name="patient",
      *          in="query",

--- a/ccdaservice/serveccda.js
+++ b/ccdaservice/serveccda.js
@@ -112,8 +112,13 @@ function isOne(who) {
     return 0;
 }
 
-function headReplace(content) {
-    let xslUrl = "cda.xsl";
+function headReplace(content, xslUrl="") {
+
+    let xsl = "cda.xsl";
+    if (typeof xslUrl == "string" && xslUrl.trim() != "") {
+        xsl = xslUrl;
+    }
+
     let r = '<?xml version="1.0" encoding="UTF-8"?>' + "\n" +
         '<?xml-stylesheet type="text/xsl" href="' + xslUrl + '"?>';
     r += "\n" + content.substr(content.search(/<ClinicalDocument/i));
@@ -1209,7 +1214,10 @@ function getPlanOfCare(pd) {
         }
     }
     if (one) {
-        let value = all.encounter_list.encounter.encounter_diagnosis || "";
+        let value = "";
+        if (all.encounter_list && all.encounter_list.encounter && all.encounter_list.encounter.encounter_diagnosis) {
+            value = all.encounter_list.encounter.encounter_diagnosis;
+        }
         name = value.text;
         code = cleanCode(value.code);
         code_system_name = value.code_type;
@@ -2221,6 +2229,14 @@ function populateHeader(pd) {
         docCode = "57133-1";
         docOid = "2.16.840.1.113883.10.20.22.1.14";
     }
+    let authorDateTime = pd.created_time_timezone;
+    if (all.encounter_list && all.encounter_list.encounter) {
+        if (isOne(all.encounter_list.encounter) === 1) {
+            authorDateTime = all.encounter_list.encounter.date_formatted;
+        } else {
+            authorDateTime = all.encounter_list.encounter[0].date_formatted;
+        }
+    }
     const head = {
         "identifiers": [
             {
@@ -2245,7 +2261,7 @@ function populateHeader(pd) {
         "author": {
             "date_time": {
                 "point": {
-                    "date": (isOne(all.encounter_list.encounter) === 1 ? all.encounter_list.encounter.date_formatted : all.encounter_list.encounter[0].date_formatted) || pd.created_time_timezone,
+                    "date": authorDateTime,
                     "precision": "day"
                 }
             },
@@ -2542,7 +2558,7 @@ function genCcda(pd) {
     let count = 0;
     let many = [];
     let theone = {};
-
+    authorDate = '';
     all = pd;
     npiProvider = all.primary_care_provider.provider.npi;
     oidFacility = all.encounter_provider.facility_oid ? all.encounter_provider.facility_oid : "2.16.840.1.113883.19.5.99999.1";
@@ -2550,10 +2566,16 @@ function genCcda(pd) {
     webRoot = all.serverRoot;
     documentLocation = all.document_location;
 
-    if (all.encounter_list.encounter.date) {
-        authorDate = all.encounter_list.encounter.date;
-    } else if (all.encounter_list.encounter[0].date) {
-        authorDate = all.encounter_list.encounter[0].date;
+    if (all.encounter_list && all.encounter_list.encounter) {
+        if (all.encounter_list.encounter.date) {
+            authorDate = all.encounter_list.encounter.date;
+        } else if (all.encounter_list.encounter[0].date) {
+            authorDate = all.encounter_list.encounter[0].date;
+        }
+    }
+    if (!authorDate) {
+        // when is there ever a situation where a patient doesn't have an encounter?
+        authorDate = pd.created_time_timezone;
     }
 // Demographics
     let demographic = populateDemographic(pd.patient, pd.guardian, pd);
@@ -2998,6 +3020,7 @@ function processConnection(connection) {
         if (xml.toString().match(/<\/CCDA>$/g)) {
             // ---------------------start--------------------------------
             let doc = "";
+            let xslUrl = "";
             xml_complete = xml_complete.replace(/\t\s+/g, ' ').trim();
             // convert xml data set for document to json array
             to_json(xml_complete, function (error, data) {
@@ -3008,9 +3031,12 @@ function processConnection(connection) {
                 }
                 // create document
                 doc = genCcda(data.CCDA);
+                if (data.CCDA.xslUrl) {
+                    xslUrl = data.CCDA.xslUrl;
+                }
             });
 
-            doc = headReplace(doc);
+            doc = headReplace(doc, xslUrl);
             doc = doc.toString().replace(/(\u000b|\u001c|\r)/gm, "").trim();
             //console.log(doc);
             let chunk = "";

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Listener/CCDAEventsSubscriber.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Listener/CCDAEventsSubscriber.php
@@ -62,6 +62,16 @@ class CCDAEventsSubscriber implements EventSubscriberInterface
      */
     public function onCCDACreateEvent(PatientDocumentCreateCCDAEvent $event)
     {
+        $dates = [];
+        if (!empty($event->getDateFrom())) {
+            $dates['date_start'] = $event->getDateFrom()->format("Y-m-d H:i:s");
+            $dates['filter_content'] = true;
+        }
+
+        if (!empty($event->getDateTo())) {
+            $dates['date_end'] = $event->getDateTo()->format("Y-m-d H:i:s");
+            $dates['filter_content'] = true;
+        }
 
         try {
             $result = $this->generator->generate(
@@ -74,9 +84,11 @@ class CCDAEventsSubscriber implements EventSubscriberInterface
                 $event->getComponentsAsString(),
                 $event->getSectionsAsString(),
                 '',
-                [],
+                [], // params appears to be used for the informationRecipient pieces, so we leaves this alone
                 'xml',
                 ''
+                ,$dates
+                ,true // not sure I like how many parameters we are adding on and on, may need to introduce a configuration object
             );
 
             // the generator just returns the content...

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Listener/CCDAEventsSubscriber.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Listener/CCDAEventsSubscriber.php
@@ -88,7 +88,6 @@ class CCDAEventsSubscriber implements EventSubscriberInterface
                 'xml',
                 ''
                 ,$dates
-                ,true // not sure I like how many parameters we are adding on and on, may need to introduce a configuration object
             );
 
             // the generator just returns the content...

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Listener/CCDAEventsSubscriber.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Listener/CCDAEventsSubscriber.php
@@ -86,8 +86,8 @@ class CCDAEventsSubscriber implements EventSubscriberInterface
                 '',
                 [], // params appears to be used for the informationRecipient pieces, so we leaves this alone
                 'xml',
-                ''
-                ,$dates
+                '',
+                $dates
             );
 
             // the generator just returns the content...

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaGenerator.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaGenerator.php
@@ -58,6 +58,8 @@ class CcdaGenerator
      * @param $recipients
      * @param $params
      * @param $document_type
+     * @param $referral_reason
+     * @param $date_options has the format of ['date_start' => 'YYYY-MM-DD HH:mm:ss', 'date_end' => 'YYYY-MM-DD HH:mm:ss', 'filter_content' => boolean]
      * @return GeneratedCcdaResult
      * @throws \Exception
      */
@@ -74,7 +76,8 @@ class CcdaGenerator
         $params,
         $document_type,
         $referral_reason,
-        $date_options = []
+        $date_options = [],
+        $useAbsoluteXsl = false
     ): GeneratedCcdaResult {
 
         // we need to make sure we don't accidently stuff in the debug logs any PHI so we'll only report on the presence of certain variables
@@ -83,7 +86,8 @@ class CcdaGenerator
                 , 'send' => $send, 'view' => $view, 'emr_transfer' => $emr_transfer, 'components' => $components
                 , 'sections' => $sections, 'recipients' => !empty($recipients) ? "Recipients count " . count($recipients) : "No recipients"
                 , 'params' => $params, 'document_type' => $document_type
-                , 'referral_reason' => (empty($referral_reason) ? "No referral reason" : "Has referral reason"), 'date_options' => $date_options]);
+                , 'referral_reason' => (empty($referral_reason) ? "No referral reason" : "Has referral reason")
+                , 'date_options' => $date_options, 'useAbsoluteXsl' => $useAbsoluteXsl]);
         if ($sent_by != '') {
             $_SESSION['authUserID'] = $sent_by;
         }
@@ -115,7 +119,8 @@ class CcdaGenerator
             }
             $components = $str1;
         }
-        $data = $this->create_data($patient_id, $encounter_id, $sections, $components, $recipients, $params, $document_type, $referral_reason, $send, $date_options);
+        $data = $this->create_data($patient_id, $encounter_id, $sections, $components, $recipients, $params
+                    , $document_type, $referral_reason, $send, $date_options, $useAbsoluteXsl);
         $content = $this->socket_get($data);
         $content = trim($content);
         $generatedResult = $this->getEncounterccdadispatchTable()->logCCDA(
@@ -141,10 +146,12 @@ class CcdaGenerator
     }
 
 
-    public function create_data($pid, $encounter, $sections, $components, $recipients, $params, $document_type, $referral_reason = null, $send = null, $date_options = [])
+    public function create_data($pid, $encounter, $sections, $components, $recipients, $params, $document_type
+        , $referral_reason = null, $send = null, $date_options = [], $useAbsoluteXsl = false)
     {
         $modelGenerator = new CcdaServiceRequestModelGenerator($this->getEncounterccdadispatchTable());
-        $modelGenerator->create_data($pid, $encounter, $sections, $components, $recipients, $params, $document_type, $referral_reason, $send, $date_options);
+        $modelGenerator->create_data($pid, $encounter, $sections, $components, $recipients, $params, $document_type
+                            , $referral_reason, $send, $date_options, $useAbsoluteXsl);
         $this->createdtime = $modelGenerator->getCreatedTime();
         $this->data = $modelGenerator->getData();
         return $this->data;

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaGenerator.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaGenerator.php
@@ -76,8 +76,7 @@ class CcdaGenerator
         $params,
         $document_type,
         $referral_reason,
-        $date_options = [],
-        $useAbsoluteXsl = false
+        $date_options = []
     ): GeneratedCcdaResult {
 
         // we need to make sure we don't accidently stuff in the debug logs any PHI so we'll only report on the presence of certain variables
@@ -87,7 +86,7 @@ class CcdaGenerator
                 , 'sections' => $sections, 'recipients' => !empty($recipients) ? "Recipients count " . count($recipients) : "No recipients"
                 , 'params' => $params, 'document_type' => $document_type
                 , 'referral_reason' => (empty($referral_reason) ? "No referral reason" : "Has referral reason")
-                , 'date_options' => $date_options, 'useAbsoluteXsl' => $useAbsoluteXsl]);
+                , 'date_options' => $date_options]);
         if ($sent_by != '') {
             $_SESSION['authUserID'] = $sent_by;
         }
@@ -120,7 +119,7 @@ class CcdaGenerator
             $components = $str1;
         }
         $data = $this->create_data($patient_id, $encounter_id, $sections, $components, $recipients, $params
-                    , $document_type, $referral_reason, $send, $date_options, $useAbsoluteXsl);
+                    , $document_type, $referral_reason, $send, $date_options);
         $content = $this->socket_get($data);
         $content = trim($content);
         $generatedResult = $this->getEncounterccdadispatchTable()->logCCDA(
@@ -147,11 +146,11 @@ class CcdaGenerator
 
 
     public function create_data($pid, $encounter, $sections, $components, $recipients, $params, $document_type
-        , $referral_reason = null, $send = null, $date_options = [], $useAbsoluteXsl = false)
+        , $referral_reason = null, $send = null, $date_options = [])
     {
         $modelGenerator = new CcdaServiceRequestModelGenerator($this->getEncounterccdadispatchTable());
         $modelGenerator->create_data($pid, $encounter, $sections, $components, $recipients, $params, $document_type
-                            , $referral_reason, $send, $date_options, $useAbsoluteXsl);
+                            , $referral_reason, $send, $date_options);
         $this->createdtime = $modelGenerator->getCreatedTime();
         $this->data = $modelGenerator->getData();
         return $this->data;

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaGenerator.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaGenerator.php
@@ -118,8 +118,18 @@ class CcdaGenerator
             }
             $components = $str1;
         }
-        $data = $this->create_data($patient_id, $encounter_id, $sections, $components, $recipients, $params
-                    , $document_type, $referral_reason, $send, $date_options);
+        $data = $this->create_data(
+            $patient_id,
+            $encounter_id,
+            $sections,
+            $components,
+            $recipients,
+            $params,
+            $document_type,
+            $referral_reason,
+            $send,
+            $date_options
+        );
         $content = $this->socket_get($data);
         $content = trim($content);
         $generatedResult = $this->getEncounterccdadispatchTable()->logCCDA(
@@ -145,12 +155,21 @@ class CcdaGenerator
     }
 
 
-    public function create_data($pid, $encounter, $sections, $components, $recipients, $params, $document_type
-        , $referral_reason = null, $send = null, $date_options = [])
+    public function create_data($pid, $encounter, $sections, $components, $recipients, $params, $document_type, $referral_reason = null, $send = null, $date_options = [])
     {
         $modelGenerator = new CcdaServiceRequestModelGenerator($this->getEncounterccdadispatchTable());
-        $modelGenerator->create_data($pid, $encounter, $sections, $components, $recipients, $params, $document_type
-                            , $referral_reason, $send, $date_options);
+        $modelGenerator->create_data(
+            $pid,
+            $encounter,
+            $sections,
+            $components,
+            $recipients,
+            $params,
+            $document_type,
+            $referral_reason,
+            $send,
+            $date_options
+        );
         $this->createdtime = $modelGenerator->getCreatedTime();
         $this->data = $modelGenerator->getData();
         return $this->data;

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaGenerator.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaGenerator.php
@@ -83,7 +83,7 @@ class CcdaGenerator
         (new SystemLogger())->debug("CcdaGenerator->generate() called ", ['patient_id' => $patient_id
                 , 'encounter_id' => $encounter_id, 'sent_by' => (!empty($sent_by) ? "sent_by not empty" : "sent_by is empty")
                 , 'send' => $send, 'view' => $view, 'emr_transfer' => $emr_transfer, 'components' => $components
-                , 'sections' => $sections, 'recipients' => !empty($recipients) ? "Recipients count " . count($recipients) : "No recipients"
+                , 'sections' => $sections, 'recipients' => !empty($recipients) ? "Recipients count " . (is_array($recipients) ? count($recipients) : "1") : "No recipients"
                 , 'params' => $params, 'document_type' => $document_type
                 , 'referral_reason' => (empty($referral_reason) ? "No referral reason" : "Has referral reason")
                 , 'date_options' => $date_options]);

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaServiceDocumentRequestor.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaServiceDocumentRequestor.php
@@ -106,6 +106,9 @@ class CcdaServiceDocumentRequestor
         if ($output == "Authentication Failure") {
             throw new CcdaServiceConnectionException("Authentication Failure");
         }
+        if (empty(trim($output))) {
+            throw new CcdaServiceConnectionException("Ccda document generated was empty.  Check node service logs.");
+        }
         return $output;
     }
 }

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaServiceRequestModelGenerator.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaServiceRequestModelGenerator.php
@@ -48,8 +48,7 @@ class CcdaServiceRequestModelGenerator
         return $this->createdtime;
     }
 
-    public function create_data($pid, $encounter, $sections, $components, $recipients, $params, $document_type, $referral_reason
-        , int $send = null, $date_options = [])
+    public function create_data($pid, $encounter, $sections, $components, $recipients, $params, $document_type, $referral_reason, int $send = null, $date_options = [])
     {
         global $assignedEntity;
         global $representedOrganization;

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaServiceRequestModelGenerator.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaServiceRequestModelGenerator.php
@@ -49,12 +49,12 @@ class CcdaServiceRequestModelGenerator
     }
 
     public function create_data($pid, $encounter, $sections, $components, $recipients, $params, $document_type, $referral_reason
-        , int $send = null, $date_options = [], $useAbsoluteXsl = false)
+        , int $send = null, $date_options = [])
     {
         global $assignedEntity;
         global $representedOrganization;
 
-        $this->getEncounterccdadispatchTable()->setOptions($date_options);
+        $this->getEncounterccdadispatchTable()->setOptions($pid, $encounter, $date_options);
 
         if (!$send) {
             $send = 0;
@@ -65,10 +65,6 @@ class CcdaServiceRequestModelGenerator
         $this->data .= "<CCDA>";
         $this->data .= "<serverRoot>" . $GLOBALS['webroot'] . "</serverRoot>";
         $this->data .= "<document_location>" . $GLOBALS['OE_SITE_DIR'] . "</document_location>";
-        if ($useAbsoluteXsl) {
-            // if we are generating a document to be passed around w/o our zip file we need to specify an absolute xsl
-            $this->data .= "<xslUrl>" . $GLOBALS['qualified_site_addr'] . '/interface/modules/zend_modules/public/xsl/cda.xsl' . "</xslUrl>";
-        }
         $this->data .= "<username></username>";
         $this->data .= "<password></password>";
         $this->data .= "<hie>MyHealth</hie>";
@@ -113,11 +109,11 @@ class CcdaServiceRequestModelGenerator
 
         /***************CCDA Body Information***************/
         if (in_array('encounters', $components_list)) {
-            $this->data .= $this->getEncounterccdadispatchTable()->getEncounterHistory($pid, $encounter);
+            $this->data .= $this->getEncounterccdadispatchTable()->getEncounterHistory($pid);
         }
 
         if (in_array('continuity_care_document', $sections_list)) {
-            $this->data .= $this->getContinuityCareDocument($pid, $encounter, $components_list);
+            $this->data .= $this->getContinuityCareDocument($pid, $components_list);
         }
 
         // we're sending everything anyway. document type will tell engine what to include in cda.
@@ -156,51 +152,51 @@ class CcdaServiceRequestModelGenerator
         $this->data .= "</CCDA>";
     }
 
-    public function getContinuityCareDocument($pid, $encounter, $components_list)
+    public function getContinuityCareDocument($pid, $components_list)
     {
         $ccd = '';
         if (in_array('allergies', $components_list)) {
-            $ccd .= $this->getEncounterccdadispatchTable()->getAllergies($pid, $encounter);
+            $ccd .= $this->getEncounterccdadispatchTable()->getAllergies($pid);
         }
 
         if (in_array('medications', $components_list)) {
-            $ccd .= $this->getEncounterccdadispatchTable()->getMedications($pid, $encounter);
+            $ccd .= $this->getEncounterccdadispatchTable()->getMedications($pid);
         }
 
         if (in_array('problems', $components_list)) {
-            $ccd .= $this->getEncounterccdadispatchTable()->getProblemList($pid, $encounter);
+            $ccd .= $this->getEncounterccdadispatchTable()->getProblemList($pid);
         }
 
         if (in_array('procedures', $components_list)) {
-            $ccd .= $this->getEncounterccdadispatchTable()->getProcedures($pid, $encounter);
+            $ccd .= $this->getEncounterccdadispatchTable()->getProcedures($pid);
         }
 
         if (in_array('results', $components_list)) {
-            $ccd .= $this->getEncounterccdadispatchTable()->getResults($pid, $encounter);
+            $ccd .= $this->getEncounterccdadispatchTable()->getResults($pid);
         }
 
         if (in_array('immunizations', $components_list)) {
-            $ccd .= $this->getEncounterccdadispatchTable()->getImmunization($pid, $encounter);
+            $ccd .= $this->getEncounterccdadispatchTable()->getImmunization($pid);
         }
 
         if (in_array('plan_of_care', $components_list)) {
-            $ccd .= $this->getEncounterccdadispatchTable()->getPlanOfCare($pid, $encounter);
+            $ccd .= $this->getEncounterccdadispatchTable()->getPlanOfCare($pid);
         }
 
         if (in_array('functional_status', $components_list)) {
-            $ccd .= $this->getEncounterccdadispatchTable()->getFunctionalCognitiveStatus($pid, $encounter);
+            $ccd .= $this->getEncounterccdadispatchTable()->getFunctionalCognitiveStatus($pid);
         }
 
         if (in_array('instructions', $components_list)) {
-            $ccd .= $this->getEncounterccdadispatchTable()->getClinicalInstructions($pid, $encounter);
+            $ccd .= $this->getEncounterccdadispatchTable()->getClinicalInstructions($pid);
         }
 
         if (in_array('medical_devices', $components_list)) {
-            $ccd .= $this->getEncounterccdadispatchTable()->getMedicalDeviceList($pid, $encounter);
+            $ccd .= $this->getEncounterccdadispatchTable()->getMedicalDeviceList($pid);
         }
 
         if (in_array('referral', $components_list)) {
-            $ccd .= $this->getEncounterccdadispatchTable()->getReferrals($pid, $encounter);
+            $ccd .= $this->getEncounterccdadispatchTable()->getReferrals($pid);
         }
         return $ccd;
     }
@@ -328,11 +324,11 @@ class CcdaServiceRequestModelGenerator
         $history_and_physical_notes .= $this->getEncounterccdadispatchTable()->getHistoryOfPastIllness($pid, $encounter);
         $history_and_physical_notes .= $this->getEncounterccdadispatchTable()->getReviewOfSystems($pid, $encounter);
         if (in_array('vitals', $components_list)) {
-            $history_and_physical_notes .= $this->getEncounterccdadispatchTable()->getVitals($pid, $encounter);
+            $history_and_physical_notes .= $this->getEncounterccdadispatchTable()->getVitals($pid);
         }
 
         if (in_array('social_history', $components_list)) {
-            $history_and_physical_notes .= $this->getEncounterccdadispatchTable()->getSocialHistory($pid, $encounter);
+            $history_and_physical_notes .= $this->getEncounterccdadispatchTable()->getSocialHistory($pid);
         }
 
         $history_and_physical_notes .= "</history_physical>";

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaServiceRequestModelGenerator.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaServiceRequestModelGenerator.php
@@ -48,7 +48,8 @@ class CcdaServiceRequestModelGenerator
         return $this->createdtime;
     }
 
-    public function create_data($pid, $encounter, $sections, $components, $recipients, $params, $document_type, $referral_reason, int $send = null, $date_options = [])
+    public function create_data($pid, $encounter, $sections, $components, $recipients, $params, $document_type, $referral_reason
+        , int $send = null, $date_options = [], $useAbsoluteXsl = false)
     {
         global $assignedEntity;
         global $representedOrganization;
@@ -64,6 +65,10 @@ class CcdaServiceRequestModelGenerator
         $this->data .= "<CCDA>";
         $this->data .= "<serverRoot>" . $GLOBALS['webroot'] . "</serverRoot>";
         $this->data .= "<document_location>" . $GLOBALS['OE_SITE_DIR'] . "</document_location>";
+        if ($useAbsoluteXsl) {
+            // if we are generating a document to be passed around w/o our zip file we need to specify an absolute xsl
+            $this->data .= "<xslUrl>" . $GLOBALS['qualified_site_addr'] . '/interface/modules/zend_modules/public/xsl/cda.xsl' . "</xslUrl>";
+        }
         $this->data .= "<username></username>";
         $this->data .= "<password></password>";
         $this->data .= "<hie>MyHealth</hie>";

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncounterccdadispatchTable.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncounterccdadispatchTable.php
@@ -83,7 +83,6 @@ class EncounterccdadispatchTable extends AbstractTableGateway
             if ($dateStart !== false) {
                 $this->searchFromDate = $searchFromDate;
                 $dateValues[] = SearchComparator::GREATER_THAN_OR_EQUAL_TO . $dateStart;
-
             } else {
                 // TODO: do we want to log the invalid format
             }
@@ -113,19 +112,18 @@ class EncounterccdadispatchTable extends AbstractTableGateway
             }
             $this->searchFiltered = false;
         }
-
     }
 
-    private function getDateQueryClauseForColumn($column) : SearchQueryFragment {
-
+    private function getDateQueryClauseForColumn($column): SearchQueryFragment
+    {
         $searchField = $this->convertDateSearchFieldForColumn($this->searchDateField, $column);
-
 
         $queryClause = SearchFieldStatementResolver::resolveDateField($searchField);
         return $queryClause;
     }
 
-    private function convertDateSearchFieldForColumn(DateSearchField $searchField, $column) {
+    private function convertDateSearchFieldForColumn(DateSearchField $searchField, $column)
+    {
         return new DateSearchField($column, $searchField->getValues(), $searchField->getDateType(), $searchField->isAnd());
     }
 
@@ -1079,7 +1077,7 @@ class EncounterccdadispatchTable extends AbstractTableGateway
         $sqlBindArray = [];
         if (!empty($this->encounterFilterList)) {
             $wherCon .= " b.encounter IN (" . implode(",", array_map('intval', $this->encounterFilterList)) . ") AND ";
-        } else if ($this->searchFiltered) {
+        } elseif ($this->searchFiltered) {
             // if we are filtering our results, if there is no connected procedures to an encounter that fits within our
             // date range then we want to return an empty procedures list
             return "<procedures></procedures>";
@@ -1146,7 +1144,7 @@ class EncounterccdadispatchTable extends AbstractTableGateway
         $sqlBindArray = [];
         if (!empty($this->encounterFilterList)) {
             $wherCon .= " po.encounter_id IN (" . implode(",", array_map('intval', $this->encounterFilterList)) . ") AND ";
-        } else if ($this->searchFiltered) {
+        } elseif ($this->searchFiltered) {
             // if we are filtering our results, if there is no connected procedures to an encounter that fits within our
             // date range then we want to return an empty procedures list
             return "<results></results>";
@@ -1252,7 +1250,7 @@ class EncounterccdadispatchTable extends AbstractTableGateway
         $sqlBindArray = [];
         if (!empty($this->encounterFilterList)) {
             $wherCon .= " fe.encounter IN (" . implode(",", array_map('intval', $this->encounterFilterList)) . ") AND ";
-        } else if ($this->searchFiltered) {
+        } elseif ($this->searchFiltered) {
             // if we are filtering our results, if there is no connected procedures to an encounter that fits within our
             // date range then we want to return an empty procedures list
             return "<encounter_list></encounter_list>";
@@ -1976,7 +1974,7 @@ class EncounterccdadispatchTable extends AbstractTableGateway
         $wherCon = '';
         if (!empty($this->encounterFilterList)) {
             $wherCon .= " fe.encounter IN (" . implode(",", array_map('intval', $this->encounterFilterList)) . ") AND ";
-        } else if ($this->searchFiltered) {
+        } elseif ($this->searchFiltered) {
             // if we are filtering our results, if there is no connected procedures to an encounter that fits within our
             // date range then we want to return an empty procedures list
             return "<vitals_list></vitals_list>";
@@ -2988,7 +2986,7 @@ class EncounterccdadispatchTable extends AbstractTableGateway
 
         if (!empty($this->encounterFilterList)) {
             $wherCon = " AND f.encounter IN (" . implode(",", array_map("intval", $this->encounterFilterList)) . ")";
-        } else if ($this->searchFiltered) {
+        } elseif ($this->searchFiltered) {
             // there are no encounters to filter on in the form and we are filtering the data...
             return "<planofcare></planofcare><goals></goals><health_concerns></health_concerns>";
         }
@@ -3018,9 +3016,10 @@ class EncounterccdadispatchTable extends AbstractTableGateway
             if ($this->searchFiltered) {
                 $rowDate = strtotime($row['date']);
                 // if we can't format the date and we are filtering then we exclude it,
-                if ($rowDate === false ||
+                if (
+                    $rowDate === false
                     // we have a from date so we filter by it
-                    (isset($this->searchFromDate) && $rowDate < $this->searchFromDate)
+                    || (isset($this->searchFromDate) && $rowDate < $this->searchFromDate)
                     // we have a to date so we filter by it
                     || (isset($this->searchToDate) && $rowDate > $this->searchToDate)
                 ) {
@@ -3117,7 +3116,7 @@ class EncounterccdadispatchTable extends AbstractTableGateway
 
         if (!empty($this->encounterFilterList)) {
             $wherCon .= " f.encounter IN (" . implode(",", array_map('intval', $this->encounterFilterList)) . ") AND ";
-        } else if ($this->searchFiltered) {
+        } elseif ($this->searchFiltered) {
             // if we are filtering our results, if there is no connected procedures to an encounter that fits within our
             // date range then we want to return an empty procedures list
             return "<functional_status></functional_status><mental_status></mental_status>";
@@ -3176,7 +3175,7 @@ class EncounterccdadispatchTable extends AbstractTableGateway
             } else {
                 $wherCon .= " f.encounter IN (" . implode(",", array_map('intval', $this->encounterFilterList)) . ") AND ";
             }
-        } else if ($encounter) {
+        } elseif ($encounter) {
             $wherCon = " f.encounter = ? AND ";
             $sqlBindArray[] = $encounter;
         }
@@ -3246,7 +3245,7 @@ class EncounterccdadispatchTable extends AbstractTableGateway
         $sqlBindArray = [];
         if (!empty($this->encounterFilterList)) {
             $wherCon .= " f.encounter IN (" . implode(",", array_map('intval', $this->encounterFilterList)) . ") AND ";
-        } else if ($this->searchFiltered) {
+        } elseif ($this->searchFiltered) {
             // if we are filtering our results, if there is no connected procedures to an encounter that fits within our
             // date range then we want to return an empty procedures list
             return "<clinical_instruction></clinical_instruction>";

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncounterccdadispatchTable.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncounterccdadispatchTable.php
@@ -18,25 +18,18 @@ namespace Carecoordination\Model;
 use Application\Listener\Listener;
 use Application\Model\ApplicationTable;
 use Carecoordination\Model\CarecoordinationTable;
-use Couchbase\SearchQuery;
-use CouchDB;
 use Laminas\Db\Adapter\Driver\Pdo\Result;
 use Laminas\Db\TableGateway\AbstractTableGateway;
 use Matrix\Exception;
-use OpenEMR\Common\Crypto\CryptoGen;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Common\ORDataObject\ContactAddress;
 use OpenEMR\Common\Uuid\UuidRegistry;
-use OpenEMR\FHIR\Export\ExportException;
 use OpenEMR\Services\ContactService;
 use OpenEMR\Services\PatientService;
-use OpenEMR\Services\Search\BasicSearchField;
 use OpenEMR\Services\Search\DateSearchField;
-use OpenEMR\Services\Search\FhirSearchWhereClauseBuilder;
 use OpenEMR\Services\Search\SearchComparator;
 use OpenEMR\Services\Search\SearchFieldStatementResolver;
-use OpenEMR\Services\Search\SearchModifier;
 use OpenEMR\Services\Search\SearchQueryFragment;
 
 require_once(__DIR__ . "/../../../../../../../../custom/code_types.inc.php");
@@ -1973,7 +1966,7 @@ class EncounterccdadispatchTable extends AbstractTableGateway
     {
         $wherCon = '';
         if (!empty($this->encounterFilterList)) {
-            $wherCon .= " fe.encounter IN (" . implode(",", array_map('intval', $this->encounterFilterList)) . ") AND ";
+            $wherCon .= " AND fe.encounter IN (" . implode(",", array_map('intval', $this->encounterFilterList)) . ") ";
         } elseif ($this->searchFiltered) {
             // if we are filtering our results, if there is no connected procedures to an encounter that fits within our
             // date range then we want to return an empty procedures list

--- a/src/Common/ORDataObject/ORDataObject.php
+++ b/src/Common/ORDataObject/ORDataObject.php
@@ -81,7 +81,10 @@ class ORDataObject
                 // false/true, we should change this but we will need to heavily test it.
                 if (!empty($val)) {
                     if ($val instanceof \DateTime) {
-                        $val = $val->format(DATE_ISO8601);
+                        // we are storing up to the second in precision, if we need to store fractional seconds
+                        // that will be more complicated as the mysql datetime needs to specify the decimal seconds
+                        // that can be stored
+                        $val = $val->format("Y-m-d H:i:s");
                     }
                     //echo "s: $field to: $val <br />";
 

--- a/src/Events/PatientDocuments/PatientDocumentCreateCCDAEvent.php
+++ b/src/Events/PatientDocuments/PatientDocumentCreateCCDAEvent.php
@@ -12,6 +12,9 @@
 
 namespace OpenEMR\Events\PatientDocuments;
 
+use OpenEMR\Services\Search\DateSearchField;
+use \DateTime;
+
 class PatientDocumentCreateCCDAEvent
 {
     const EVENT_NAME_CCDA_CREATE = "patient.ccda.create";
@@ -53,12 +56,18 @@ class PatientDocumentCreateCCDAEvent
     private $fileUrl;
 
     /**
-     * @var \DateTime The start date from which to include clinically relevant data for the generated CCDA.  Null if all data from the start of the system is relevant.
+     * @var DateTime The start date from which to include clinically relevant data for the generated CCDA.  Null if all data from the start of the system is relevant.
      */
     private $dateFrom;
 
     /**
-     * @var \DateTime The end date to include clinically relevant data for the generated CCDA.  Null if there is no end date.
+     * If a dateFromSearchField is populated it will take precedence over the dateFrom field
+     * @var DateSearchField Complex date search field - The start date from which to include clinically relevant data for the generated CCDA.  Null if all data from the start of the system is relevant.
+     */
+    private $dateFromSearchField;
+
+    /**
+     * @var DateTime The end date to include clinically relevant data for the generated CCDA.  Null if there is no end date.
      */
     private $dateTo;
 
@@ -189,36 +198,36 @@ class PatientDocumentCreateCCDAEvent
     }
 
     /**
-     * @return \DateTime
+     * @return DateTime|null
      */
-    public function getDateFrom(): \DateTime
+    public function getDateFrom(): ?DateTime
     {
         return $this->dateFrom;
     }
 
     /**
-     * @param \DateTime $dateFrom
+     * @param DateTime $dateFrom
      * @return PatientDocumentCreateCCDAEvent
      */
-    public function setDateFrom(\DateTime $dateFrom): PatientDocumentCreateCCDAEvent
+    public function setDateFrom(?DateTime $dateFrom): PatientDocumentCreateCCDAEvent
     {
         $this->dateFrom = $dateFrom;
         return $this;
     }
 
     /**
-     * @return \DateTime
+     * @return DateTime|null
      */
-    public function getDateTo(): \DateTime
+    public function getDateTo(): ?DateTime
     {
         return $this->dateTo;
     }
 
     /**
-     * @param \DateTime $dateTo
+     * @param DateTime|null $dateTo
      * @return PatientDocumentCreateCCDAEvent
      */
-    public function setDateTo(\DateTime $dateTo): PatientDocumentCreateCCDAEvent
+    public function setDateTo(?DateTime $dateTo): PatientDocumentCreateCCDAEvent
     {
         $this->dateTo = $dateTo;
         return $this;

--- a/src/Events/PatientDocuments/PatientDocumentCreateCCDAEvent.php
+++ b/src/Events/PatientDocuments/PatientDocumentCreateCCDAEvent.php
@@ -13,7 +13,7 @@
 namespace OpenEMR\Events\PatientDocuments;
 
 use OpenEMR\Services\Search\DateSearchField;
-use \DateTime;
+use DateTime;
 
 class PatientDocumentCreateCCDAEvent
 {

--- a/src/Services/FHIR/FhirDocRefService.php
+++ b/src/Services/FHIR/FhirDocRefService.php
@@ -30,6 +30,7 @@ use OpenEMR\Services\FHIR\DocumentReference\FhirPatientDocumentReferenceService;
 use OpenEMR\Services\FHIR\Traits\PatientSearchTrait;
 use OpenEMR\Services\FHIR\Traits\ResourceServiceSearchTrait;
 use OpenEMR\Services\PatientService;
+use OpenEMR\Services\Search\DateSearchField;
 use OpenEMR\Services\Search\FHIRSearchFieldFactory;
 use OpenEMR\Services\Search\FhirSearchParameterDefinition;
 use OpenEMR\Services\Search\FhirSearchWhereClauseBuilder;
@@ -66,8 +67,8 @@ class FhirDocRefService
     {
         return  [
             'patient' => $this->getPatientContextSearchField(),
-            'start' => new FhirSearchParameterDefinition('start', SearchFieldType::DATETIME, ['start_datetime']),
-            'end' => new FhirSearchParameterDefinition('end', SearchFieldType::DATETIME, ['end_datetime']),
+            'start' => new FhirSearchParameterDefinition('start', SearchFieldType::DATETIME, ['start']),
+            'end' => new FhirSearchParameterDefinition('end', SearchFieldType::DATETIME, ['end']),
             'type' => new FhirSearchParameterDefinition('type', SearchFieldType::TOKEN, ['type']),
         ];
     }
@@ -92,8 +93,8 @@ class FhirDocRefService
         }
 
         // if no start & end, return current CCD
-        if ($this->shouldReturnMostRecentCCD($oeSearchParameters)) {
-            $documentReference = $this->getMostRecentCCDReference($oeSearchParameters, $fhirSearchResult);
+        if ($this->shouldReturnMostCurrentCCD($oeSearchParameters)) {
+            $documentReference = $this->getMostCurrentCCDReference($oeSearchParameters, $fhirSearchResult);
         } else {
             // else
             // generate CCD using start & end
@@ -117,10 +118,10 @@ class FhirDocRefService
         return false;
     }
 
-    private function shouldReturnMostRecentCCD($oeSearchparameters): bool
+    private function shouldReturnMostCurrentCCD($oeSearchparameters): bool
     {
-        // attempt to grab our CCD from our
-        return empty($oeSearchparameters['start']) || empty($oeSearchparameters['end']);
+        // if start and end date is empty then we return the most current ccd
+        return empty($oeSearchparameters['start']) && empty($oeSearchparameters['end']);
     }
 
     private function getPatientRecordForSearchParameters($oeSearchParameters): array
@@ -128,14 +129,20 @@ class FhirDocRefService
         $mappedField = reset($this->getPatientContextSearchField()->getMappedFields()); // grab the first one
         $searchPatient = $oeSearchParameters[$mappedField->getField()];
 
+        // we only allow one patient CCD to be generated at a time.
+        if (empty($searchPatient->getValues()) || count($searchPatient->getValues()) > 1) {
+            throw new SearchFieldException($mappedField->getField(), "Field is required and cardinality is 1..1");
+        }
+
         $fhirPatientService = new FhirPatientService();
 
         $field = current($fhirPatientService->getPatientContextSearchField()->getMappedFields())->getField();
         $newSearchField = new ReferenceSearchField($field, $searchPatient->getValues(), true);
+
         $patientService = new PatientService();
         $patient = $patientService->search([$field => $newSearchField])->getData() ?? null;
         if (empty($patient)) {
-            // TODO: do we have a not found exception anywhere?
+            (new SystemLogger())->errorLogCaller("Failed to find patient with uuid", ['uuids' => $searchPatient->getValues()]);
             throw new SearchFieldException($field, "Invalid argument");
         } else {
             $patient = $patient[0];
@@ -143,9 +150,15 @@ class FhirDocRefService
         return $patient;
     }
 
-    private function getMostRecentCCDReference($oeSearchParameters): FHIRDocumentReference
+    /**
+     * At some point we could return an already generated CCD, but we generate a CCD that covers the patient's entire
+     * medical history as their most current
+     * @param $oeSearchParameters
+     * @return FHIRDocumentReference
+     * @throws \Exception
+     */
+    private function getMostCurrentCCDReference($oeSearchParameters): FHIRDocumentReference
     {
-
         // let's grab our patient
         // while these are right now 100% the same field names, the underlying data models can change so we have to handle that.
         $patient = $this->getPatientRecordForSearchParameters($oeSearchParameters);
@@ -153,14 +166,51 @@ class FhirDocRefService
         // document create event
         $event = new PatientDocumentCreateCCDAEvent($patient['pid']);
 
-        // apparently the PHP CCDA just sends over every single section/component regardless of whether its used or not
+        // apparently the PHP download CCDA just sends over every single section/component regardless of whether its used or not
         // the node server on the backend is what distinguishes between what sections to include / exclude based on the
-        // document type that is sent.  Bizarre.
+        // document type that is sent.
         // TODO: if we ever decide to actually put the filtering on the PHP side we will need to adjust this.
 //        $event->addSection("continuity_care_document"); // make it a CCD
 //        $event->addComponent("vitals");
 //        $event->addComponent("social_history");
+        return $this->getDocumentReferenceForCCDAEvent($event);
+    }
 
+    private function generateCCD($oeSearchParameters): FHIRDocumentReference
+    {
+        $patient = $this->getPatientRecordForSearchParameters($oeSearchParameters);
+        $event = new PatientDocumentCreateCCDAEvent($patient['pid']);
+
+        if (!empty($oeSearchParameters['start'])) {
+            $dateFrom = $oeSearchParameters['start'];
+            if (!($dateFrom instanceof DateSearchField)) {
+                throw new SearchFieldException("start", "start parameter could not be parsed as a valid date");
+            }
+            if (empty($dateFrom->getValues())) {
+                throw new SearchFieldException("start", "start parameter could not be parsed as a valid date");
+            }
+            // getValue() returns a DatePeriod object
+            // TODO: if we implement FHIR support for dates we will pass this along
+            $startDate = current($dateFrom->getValues())->getValue()->getStartDate();
+            $event->setDateFrom($startDate);
+        }
+
+        if (!empty($oeSearchParameters['end'])) {
+            $dateTo = $oeSearchParameters['end'];
+            if (!($dateTo instanceof DateSearchField)) {
+                throw new SearchFieldException("start", "start parameter could not be parsed as a valid date");
+            }
+            if (empty($dateTo->getValues())) {
+                throw new SearchFieldException("start", "start parameter could not be parsed as a valid date");
+            }
+            // TODO: if we implement FHIR support for dates we will pass this along
+            $endDate = current($dateTo->getValues())->getValue()->getEndDate();
+            $event->setDateTo($endDate);
+        }
+        return $this->getDocumentReferenceForCCDAEvent($event);
+    }
+
+    private function getDocumentReferenceForCCDAEvent(PatientDocumentCreateCCDAEvent $event) {
         // this creates our CCDA
         $createdEvent = $GLOBALS['kernel']->getEventDispatcher()->dispatch($event, PatientDocumentCreateCCDAEvent::EVENT_NAME_CCDA_CREATE);
         if (empty($createdEvent->getCcdaId())) {
@@ -185,10 +235,5 @@ class FhirDocRefService
             throw new \Exception("Fhir DocumentReference resource could not be found for uuid");
         }
         return $result->getData()[0];
-    }
-
-    private function generateCCD($oeSearchParameters): FHIRDocumentReference
-    {
-        return new FHIRDocumentReference();
     }
 }

--- a/src/Services/FHIR/FhirDocRefService.php
+++ b/src/Services/FHIR/FhirDocRefService.php
@@ -210,7 +210,8 @@ class FhirDocRefService
         return $this->getDocumentReferenceForCCDAEvent($event);
     }
 
-    private function getDocumentReferenceForCCDAEvent(PatientDocumentCreateCCDAEvent $event) {
+    private function getDocumentReferenceForCCDAEvent(PatientDocumentCreateCCDAEvent $event)
+    {
         // this creates our CCDA
         $createdEvent = $GLOBALS['kernel']->getEventDispatcher()->dispatch($event, PatientDocumentCreateCCDAEvent::EVENT_NAME_CCDA_CREATE);
         if (empty($createdEvent->getCcdaId())) {

--- a/src/Services/FHIR/FhirProvenanceService.php
+++ b/src/Services/FHIR/FhirProvenanceService.php
@@ -417,7 +417,8 @@ class FhirProvenanceService extends FhirServiceBase implements IResourceUSCIGPro
                 ['resource' => $resource->getId(), 'type' => $resource->get_fhirElementName()]
             );
         } else {
-            $lastUpdated = \DateTime::createFromFormat(DATE_ISO8601, $resource->getMeta()->getLastUpdated());
+            // we use DATE_ATOM to get an ISO8601 compatible date as DATE_ISO8601 does not actually conform to an ISO8601 date for php legacy purposes
+            $lastUpdated = \DateTime::createFromFormat(DATE_ATOM, $resource->getMeta()->getLastUpdated());
 
             if ($lastUpdated !== false && $lastUpdated->getTimestamp() < self::V2_TIMESTAMP) {
                 $separator = self::SURROGATE_KEY_SEPARATOR_V1;

--- a/src/Services/PatientService.php
+++ b/src/Services/PatientService.php
@@ -419,8 +419,10 @@ class PatientService extends BaseService
             }, $uuidResults)) . ")";
             $statementResults = QueryUtils::sqlStatementThrowException($sqlSelectData . $sql . $whereClause, $uuidResults);
             $processingResult = $this->hydrateSearchResultsFromQueryResource($statementResults);
+            return $processingResult;
+        } else {
+            return new ProcessingResult();
         }
-        return $processingResult;
     }
 
     private function hydrateSearchResultsFromQueryResource($queryResource)

--- a/src/Services/Search/BasicSearchField.php
+++ b/src/Services/Search/BasicSearchField.php
@@ -140,6 +140,22 @@ class BasicSearchField implements ISearchField
         return $this;
     }
 
+
+    public function __clone() {
+        if (!empty($this->values)) {
+            $values = $this->values;
+            $newValues = [];
+            foreach ($values as $value) {
+                if (is_object($value)) {
+                    $newValues[] = clone $value;
+                } else {
+                    $newValues[] = $value;
+                }
+            }
+            $this->values = $values;
+        }
+    }
+
     /**
      * Useful for debugging, you can echo the object to see its values.
      * @return string

--- a/src/Services/Search/BasicSearchField.php
+++ b/src/Services/Search/BasicSearchField.php
@@ -141,7 +141,8 @@ class BasicSearchField implements ISearchField
     }
 
 
-    public function __clone() {
+    public function __clone()
+    {
         if (!empty($this->values)) {
             $values = $this->values;
             $newValues = [];

--- a/src/Services/Search/DateSearchField.php
+++ b/src/Services/Search/DateSearchField.php
@@ -44,7 +44,7 @@ class DateSearchField extends BasicSearchField
     const DATE_TYPES = [self::DATE_TYPE_DATE, self::DATE_TYPE_DATETIME];
 
     /**
-     * @var Tracks the type of search date this is.  Must be a value contined in the DATE_TYPES constant
+     * @var Tracks the type of search date this is.  Must be a value contained in the DATE_TYPES constant
      */
     private $dateType;
 
@@ -55,12 +55,13 @@ class DateSearchField extends BasicSearchField
      * @param $values
      * @param bool $isAnd
      */
-    public function __construct($field, $values, $dateType = self::DATE_TYPE_DATETIME)
+    public function __construct($field, $values, $dateType = self::DATE_TYPE_DATETIME, $isAnd = false)
     {
         $this->setDateType($dateType);
 
         $modifier = null;
         parent::__construct($field, SearchFieldType::DATE, $field, $values, $modifier);
+        $this->setIsAnd($isAnd);
     }
 
     public function getDateType()

--- a/src/Services/Search/SearchFieldComparableValue.php
+++ b/src/Services/Search/SearchFieldComparableValue.php
@@ -63,4 +63,11 @@ class SearchFieldComparableValue
         }
         return "(value=" . $value . ",comparator=" . $this->getComparator() ?? "" . ")";
     }
+
+    public function __clone()
+    {
+        if (!empty($this->value) && is_object($this->value)) {
+            $this->value = clone $this->value;
+        }
+    }
 }

--- a/swagger/openemr-api.yaml
+++ b/swagger/openemr-api.yaml
@@ -4210,7 +4210,10 @@ paths:
     post:
       tags:
         - fhir
-      description: 'The $docref operation is used to request the server generates a document based on the specified parameters. If no additional parameters are specified then a DocumentReference to the patient''s most current Clinical Summary of Care Document (CCD) is returned. The document itself is retrieved using the DocumentReference.content.attachment.url element.  See <a href=''http://hl7.org/fhir/us/core/OperationDefinition-docref.html'' target=''_blank'' rel=''noopener''>http://hl7.org/fhir/us/core/OperationDefinition-docref.html</a> for more details'
+      description: 'The $docref operation is used to request the server generates a document based on the specified parameters. If no additional parameters are specified then a DocumentReference to the patient''s most current Clinical Summary of Care Document (CCD) is returned. The document itself is retrieved using the DocumentReference.content.attachment.url element.  See <a href=''http://hl7.org/fhir/us/core/OperationDefinition-docref.html'' target=''_blank'' rel=''noopener''>http://hl7.org/fhir/us/core/OperationDefinition-docref.html</a> for more details.'
+      externalDocs:
+        description: 'Detailed documentation on this operation'
+        url: 'https://github.com/openemr/openemr/blob/master/FHIR_README.md#carecoordination-summary-of-care-docref-operation'
       parameters:
         -
           name: patient

--- a/swagger/openemr-api.yaml
+++ b/swagger/openemr-api.yaml
@@ -4207,7 +4207,7 @@ paths:
         -
           openemr_auth: []
   /fhir/DocumentReference/$docref:
-    get:
+    post:
       tags:
         - fhir
       description: 'The $docref operation is used to request the server generates a document based on the specified parameters. If no additional parameters are specified then a DocumentReference to the patient''s most current Clinical Summary of Care Document (CCD) is returned. The document itself is retrieved using the DocumentReference.content.attachment.url element.  See <a href=''http://hl7.org/fhir/us/core/OperationDefinition-docref.html'' target=''_blank'' rel=''noopener''>http://hl7.org/fhir/us/core/OperationDefinition-docref.html</a> for more details'


### PR DESCRIPTION
Fixes #5508 
Fixes #5517

Changes g9 $docref to be a POST api since we generate a new document
every time.

Fixes ISO8601 date problems with php since php's date constant is
incorrect.  Switch to ATOM constant.

Fixed the ORDataObject saving incorrectly on some database instance
types due to the timezone and microsecond formatting.

Added __clone helper methods to the search field classes so we can copy
them and modify properties w/o modifying the references.

Added brief, terse documentation for g9 generation with docref.  Needs
to be fleshed out in the fhir readme file.

Updated the swagger file to point to the g9 documentation.

Removed the remote xsl stuff as I found out chrome actively blocks
remote xsl's from rendering unless everything is in the same folder,
port, origin, and schema.

Changed up the filtering as careplan was still breaking due to its
requirement on an encounter.  Changed up the filtering to be encounter
based so that any of the sections related to an encounter are filtered
for the CCD.  I left non-ccd document types alone since g9 only requires
the ccd filtering.

Removed unused referral pieces in the care plan section as they were all
being skipped due to the missing required codes in the transactions
table.  node side was skipping it as well so I left it off.