### PR TITLE
Native form to patient portal form

### DIFF
--- a/interface/forms/LBF/new.php
+++ b/interface/forms/LBF/new.php
@@ -14,19 +14,14 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-$patientPortalSession = false;
-if (isset($_GET['isPortal']) && (int)$_GET['isPortal'] !== 0) {
-    require_once(__DIR__ . "/../../../src/Common/Session/SessionUtil.php");
-    OpenEMR\Common\Session\SessionUtil::portalSessionStart();
-    if (isset($_SESSION['pid']) && isset($_SESSION['patient_portal_onsite_two'])) {
-        $ignoreAuth_onsite_portal = true;
-    } else {
-        OpenEMR\Common\Session\SessionUtil::portalSessionCookieDestroy();
-        exit;
-    }
-    // flag to show patient portal session being used, which will use
-    //  below to bootrap the form id to the patient
-    $patientPortalSession = true;
+// since need this class before autoloader, need to manually include it and then set it in line below with use command
+require_once(__DIR__ . "/../../../src/Common/Forms/CoreFormToPortalUtility.php");
+use OpenEMR\Common\Forms\CoreFormToPortalUtility;
+
+// block of code to securely support use by the patient portal
+$patientPortalSession = CoreFormToPortalUtility::isPatientPortalSession($_GET);
+if ($patientPortalSession) {
+    $ignoreAuth_onsite_portal = true;
 }
 
 require_once("../../globals.php");

--- a/interface/forms/sdoh/new.php
+++ b/interface/forms/sdoh/new.php
@@ -10,17 +10,29 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+// block of code to securely support use by the patient portal
+//   since need this class before autoloader, need to manually include it and then set it in line below with use command
+require_once(__DIR__ . "/../../../src/Common/Forms/CoreFormToPortalUtility.php");
+use OpenEMR\Common\Forms\CoreFormToPortalUtility;
+
+// block of code to securely support use by the patient portal
+$patientPortalSession = CoreFormToPortalUtility::isPatientPortalSession($_GET);
+if ($patientPortalSession) {
+    $ignoreAuth_onsite_portal = true;
+}
+$patientPortalOther = CoreFormToPortalUtility::isPatientPortalOther($_GET);
+
 require_once(__DIR__ . "/../../globals.php");
 require_once("$srcdir/api.inc");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
 
-$returnurl = 'encounter_top.php';
-
 if (!empty($_GET['id'])) {
     $obj = formFetch("form_sdoh", $_GET["id"]);
     $mode = 'update';
+    // if running from patient portal, then below will ensure patient can only see their forms
+    CoreFormToPortalUtility::confirmFormBootstrapPatient($patientPortalSession, $_GET['id'], 'sdoh', $_SESSION['pid']);
 } else {
     $mode = 'new';
 }
@@ -156,6 +168,9 @@ if (!empty($_GET['id'])) {
             document.getElementById('totalscorerender').innerHTML = totalscore;
             document.getElementById('totalscore').value = totalscore;
         }
+
+        <?php echo CoreFormToPortalUtility::javascriptSupportPortal($patientPortalSession, $patientPortalOther, $mode, $_GET['id'] ?? null); ?>
+
     </script>
 
 </head>
@@ -166,9 +181,9 @@ if (!empty($_GET['id'])) {
             <div class="col-12">
                 <h2><?php echo xlt("Social Screening Tool");?></h2>
                 <?php if ($mode == "new") { ?>
-                    <form method="post" action="<?php echo $rootdir;?>/forms/sdoh/save.php?mode=new" name="my_form" onsubmit="return top.restoreSession()">
+                    <form method="post" action="<?php echo $rootdir;?>/forms/sdoh/save.php?mode=new<?php echo ($patientPortalSession) ? '&isPortal=1' : '' ?>" name="my_form" onsubmit="return top.restoreSession()">
                 <?php } else { // $mode == "update" ?>
-                    <form method="post" action="<?php echo $rootdir;?>/forms/sdoh/save.php?mode=update&id=<?php echo attr_url($_GET["id"]); ?>" name="my_form" onsubmit="return top.restoreSession()">
+                    <form method="post" action="<?php echo $rootdir;?>/forms/sdoh/save.php?mode=update&id=<?php echo attr_url($_GET["id"]); ?><?php echo ($patientPortalSession) ? '&isPortal=1' : '' ?>" name="my_form" onsubmit="return top.restoreSession()">
                 <?php } ?>
                     <input type="hidden" name="csrf_token_form" value="<?php echo attr(CsrfUtils::collectCsrfToken()); ?>" />
                     <fieldset>
@@ -1111,16 +1126,18 @@ if (!empty($_GET['id'])) {
                             </div>
                         </div>
                     </fieldset>
-                    <div class="form-group">
-                        <div class="row">
-                            <div class="col-12 position-override">
-                                <div class="btn-group" role="group">
-                                    <button type="submit" onclick="top.restoreSession()" class="btn btn-primary btn-save"><?php echo xlt('Save'); ?></button>
-                                    <button type="button" class="btn btn-secondary btn-cancel" onclick="top.restoreSession(); parent.closeTab(window.name, false);"><?php echo xlt('Cancel');?></button>
+                    <?php if (!$patientPortalSession && !$patientPortalOther) { ?>
+                        <div class="form-group">
+                            <div class="row">
+                                <div class="col-12 position-override">
+                                    <div class="btn-group" role="group">
+                                        <button type="submit" onclick="top.restoreSession()" class="btn btn-primary btn-save"><?php echo xlt('Save'); ?></button>
+                                        <button type="button" class="btn btn-secondary btn-cancel" onclick="top.restoreSession(); parent.closeTab(window.name, false);"><?php echo xlt('Cancel');?></button>
+                                    </div>
                                 </div>
                             </div>
                         </div>
-                    </div>
+                    <?php } ?>
                 </form>
             </div>
         </div>

--- a/interface/forms/sdoh/patient_portal.php
+++ b/interface/forms/sdoh/patient_portal.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * sdoh form
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Char Miller <charjmiller@gmail.com>
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2022 Char Miller <charjmiller@gmail.com>
+ * @copyright Copyright (c) 2022 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+require_once(__DIR__ . "/../../globals.php");
+require_once(__DIR__ . "/report.php");
+
+$formid = $_GET['formid'] ?? null;
+if (empty($formid)) {
+    exit;
+}
+
+$formMetaData = sqlQuery("SELECT `date` FROM `forms` WHERE `form_id` = ? AND `formdir` = ?", [$formid, 'sdoh']);
+
+ob_start();
+echo "<h2>" . xlt("Social Screening Tool") . "</h2>";
+echo text(oeFormatShortDate($formMetaData['date'])) . "<br><br>";
+sdoh_report('', '', '', $formid);
+echo json_encode(ob_get_clean());

--- a/interface/forms/sdoh/report.php
+++ b/interface/forms/sdoh/report.php
@@ -10,8 +10,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . '/../../globals.php');
-require_once($GLOBALS["srcdir"] . "/api.inc");
+require_once(dirname(__FILE__) . '/../../../library/api.inc');
 
 function sdoh_report($pid, $encounter, $cols, $id)
 {
@@ -28,10 +27,11 @@ function sdoh_report($pid, $encounter, $cols, $id)
             $sdohData[$key] = $value;
         }
 
+        // note that including the bold inline styling so it works when create pdf (when storing as pdf document from portal)
         if (empty($sdohData['totalscore'])) {
-            echo "<tr><td><span class=bold>" . xlt("No Social Screening Risks") . "</span></td></tr>";
+            echo "<tr><td><span class=bold style='font-weight: bold;'>" . xlt("No Social Screening Risks") . "</span></td></tr>";
         } else {
-            echo "<tr><td><span class=bold>" . xlt("Social Screening Risks") . ":" . "</span></td></tr>";
+            echo "<tr><td><span class=bold style='font-weight: bold;'>" . xlt("Social Screening Risks") . ":" . "</span></td></tr>";
 
             if (($sdohData['education'] ?? '') == 'lessthanhs') {
                 echo "<tr><td><span class=text>" . xlt("Less than High School Education") . "</span></td></tr>";
@@ -379,24 +379,24 @@ function sdoh_report($pid, $encounter, $cols, $id)
                 echo "<tr><td><span class=text>" . xlt("Discriminated in Other") . ": " . text($sdohData['displaceotherinput'] ?? '') . "</span></td></tr>";
             }
             if (($sdohData['contact'] ?? '') == 'contactphone') {
-                echo "<tr><td><span class=bold>" . xlt("Contact by Phone with Resources") . "</span></td></tr>";
+                echo "<tr><td><span class=bold style='font-weight: bold;'>" . xlt("Contact by Phone with Resources") . "</span></td></tr>";
             }
             if (($sdohData['contact'] ?? '') == 'contactemail') {
-                echo "<tr><td><span class=bold>" . xlt("Contact by Email with Resources") . "</span></td></tr>";
+                echo "<tr><td><span class=bold style='font-weight: bold;'>" . xlt("Contact by Email with Resources") . "</span></td></tr>";
             }
             if (($sdohData['contact'] ?? '') == 'contactportal') {
-                echo "<tr><td><span class=bold>" . xlt("Contact through Patient Portal with Resources") . "</span></td></tr>";
+                echo "<tr><td><span class=bold style='font-weight: bold;'>" . xlt("Contact through Patient Portal with Resources") . "</span></td></tr>";
             }
             if (($sdohData['contact'] ?? '') == 'contactno') {
-                echo "<tr><td><span class=bold>" . xlt("Do Not Contact With Resources") . "</span></td></tr>";
+                echo "<tr><td><span class=bold style='font-weight: bold;'>" . xlt("Do Not Contact With Resources") . "</span></td></tr>";
             }
             if (($sdohData['contact'] ?? '') == 'contactother') {
-                echo "<tr><td><span class=bold>" . xlt("Contact with Resources via Other") . ": " . text($sdohData['contactotherinput'] ?? '') . "</span></td></tr>";
+                echo "<tr><td><span class=bold style='font-weight: bold;'>" . xlt("Contact with Resources via Other") . ": " . text($sdohData['contactotherinput'] ?? '') . "</span></td></tr>";
             }
 
             echo "<tr><td><span class=text>" . xlt("Patient Score") . " = " . text($sdohData['totalscore'] ?? '') . "</span></td></tr>";
 
-            echo "<tr><td><span class=bold>" . xlt("Possible Diagnoses") . ":" . "</span></td></tr>";
+            echo "<tr><td><span class=bold style='font-weight: bold;'>" . xlt("Possible Diagnoses") . ":" . "</span></td></tr>";
 
             if (
                 ($sdohData['debtmedical'] ?? '') == 'on'

--- a/interface/forms_admin/forms_admin.php
+++ b/interface/forms_admin/forms_admin.php
@@ -15,6 +15,7 @@ require_once("$srcdir/registry.inc");
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Acl\AclExtended;
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Forms\CoreFormToPortalUtility;
 use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Core\Header;
 
@@ -47,7 +48,12 @@ if (!empty($_GET['method']) && ($_GET['method'] == "enable")) {
     if (!CsrfUtils::verifyCsrfToken($_GET["csrf_token_form"])) {
         CsrfUtils::csrfNotVerified();
     }
-    registerForm($_GET['name']) or $err = xl('error while registering form!');
+    $newRegisteredFormId = registerForm($_GET['name']) or $err = xl('error while registering form!');
+    if (empty($err)) {
+        // below block of code will insert the patient portal template (if it has not yet already been added) if the
+        //  form is patient portal compliant
+        CoreFormToPortalUtility::insertPatientPortalTemplate($newRegisteredFormId);
+    }
 }
 
 $bigdata = getRegistered("%") or $bigdata = false;
@@ -123,13 +129,19 @@ $bigdata = getRegistered("%") or $bigdata = false;
                                     "select priority, category, nickname, aco_spec from registry where id = ?",
                                     array($registry['id'])
                                 );
+                                $patientPortalCompliant = file_exists($GLOBALS['srcdir'] . "/../interface/forms/" . $registry['directory'] . "/patient_portal.php");
                                 ?>
                             <tr>
                                 <td>
                                     <span class='text'><?php echo text($registry['id']); ?></span>
                                 </td>
                                 <td>
-                                    <span class='font-weight-bold'><?php echo text(xl_form_title($registry['name'])); ?></span>
+                                    <span class='font-weight-bold'>
+                                        <?php
+                                        echo text(xl_form_title($registry['name']));
+                                        echo ($patientPortalCompliant) ? ' <i class="fas fa-cloud-arrow-up" title="' . xla('Patient Portal Compliant') . '"></i>' : '';
+                                        ?>
+                                    </span>
                                 </td>
                                 <?php
                                 if ($registry['sql_run'] == 0) {
@@ -217,14 +229,20 @@ $bigdata = getRegistered("%") or $bigdata = false;
                             <tr>
                                 <td colspan="2">
                                     <?php
-                                        $form_title_file = @file($GLOBALS['srcdir'] . "/../interface/forms/$fname/info.txt");
+                                    $form_title_file = @file($GLOBALS['srcdir'] . "/../interface/forms/$fname/info.txt");
                                     if ($form_title_file) {
                                             $form_title = $form_title_file[0];
                                     } else {
                                         $form_title = $fname;
                                     }
+                                    $patientPortalCompliant = file_exists($GLOBALS['srcdir'] . "/../interface/forms/" . $fname . "/patient_portal.php");
                                     ?>
-                                    <span class="font-weight-bold"><?php echo text(xl_form_title($form_title)); ?></span>
+                                    <span class="font-weight-bold">
+                                        <?php
+                                        echo text(xl_form_title($form_title));
+                                        echo ($patientPortalCompliant) ? ' <i class="fas fa-cloud-arrow-up" title="' . xla('Patient Portal Compliant') . '"></i>' : '';
+                                        ?>
+                                    </span>
                                 </td>
                                 <td>
                                     <?php

--- a/library/api.inc
+++ b/library/api.inc
@@ -109,7 +109,6 @@ function formFetch($tableName, $id, $cols = "*", $activity = "1")
     return sqlQuery("select " . escape_sql_column_name(process_cols_escape($cols), array($tableName)) . " from `" . escape_table_name($tableName) . "` where id=? and pid = ? and activity like ? order by date DESC LIMIT 0,1", array($id,$GLOBALS['pid'],$activity)) ;
 }
 
-
 function formDisappear($tableName, $id)
 {
         // Run through escape_table_name() function to support dynamic form names in addition to mitigate sql table casing issues.

--- a/library/registry.inc
+++ b/library/registry.inc
@@ -3,7 +3,6 @@
 //these are the functions used to access the forms registry database
 //
 
-
 function registerForm($directory, $sql_run = 0, $unpackaged = 1, $state = 0)
 {
     $check = sqlQuery("select state from registry where directory=?", array($directory));

--- a/portal/lib/download_template.php
+++ b/portal/lib/download_template.php
@@ -31,6 +31,14 @@ if ($is_module) {
     require_once(dirname(__file__) . '/../../interface/globals.php');
 } else {
     require_once(dirname(__file__) . "/../verify_session.php");
+    // ensure patient is bootstrapped (if sent)
+    if (!empty($_POST['pid'])) {
+        if ($_POST['pid'] != $_SESSION['pid']) {
+            echo xlt("illegal Action");
+            OpenEMR\Common\Session\SessionUtil::portalSessionCookieDestroy();
+            exit;
+        }
+    }
 }
 
 use OpenEMR\Services\DocumentTemplates\DocumentTemplateService;

--- a/portal/patient/libs/Controller/OnsitePortalActivityController.php
+++ b/portal/patient/libs/Controller/OnsitePortalActivityController.php
@@ -113,7 +113,7 @@ class OnsitePortalActivityController extends AppBasePortalController
             $onsiteportalactivity = $this->Phreezer->Get('OnsitePortalActivity', $pk);
             // only allow patient to update onsiteportalactivity about themself
             if (!empty($GLOBALS['bootstrap_pid'])) {
-                if ($GLOBALS['bootstrap_pid'] !== $onsiteportalactivity->PatientId) {
+                if ($GLOBALS['bootstrap_pid'] != $onsiteportalactivity->PatientId) {
                     $error = 'Unauthorized';
                     throw new Exception($error);
                 }

--- a/portal/patient/scripts/app/onsitedocuments.js
+++ b/portal/patient/scripts/app/onsitedocuments.js
@@ -233,11 +233,29 @@ var page = {
                             }
                             page.lbfFormId = e.originalEvent.data.formid;
                             page.onsiteDocument.set('encounter', page.lbfFormId);
-                            let url = webroot_url +
-                                "/interface/forms/LBF/printable.php?return_content=" +
-                                "&formname=" + encodeURIComponent(page.lbfFormName) +
-                                "&formid=" + encodeURIComponent(page.lbfFormId) +
-                                "&visitid=0&patientid=" + encodeURIComponent(cpid);
+                            let url = '';
+                            if (page.lbfFormName.startsWith('LBF')) {
+                                url = webroot_url +
+                                    "/interface/forms/LBF/printable.php?return_content=" +
+                                    "&formname=" + encodeURIComponent(page.lbfFormName) +
+                                    "&formid=" + encodeURIComponent(page.lbfFormId) +
+                                    "&visitid=0&patientid=" + encodeURIComponent(cpid);
+                            } else {
+                                // first, ensure form name is valid
+                                let formNameValid = false;
+                                for (let k=0; k < formNamesWhitelist.length; k++) {
+                                   if (formNamesWhitelist[k] == page.lbfFormName) {
+                                      formNameValid = true;
+                                   }
+                                }
+                                if (!formNameValid) {
+                                    signerAlertMsg("There is an issue loading form. Form does not exist.");
+                                    return false;
+                                }
+                                url = webroot_url +
+                                    "/interface/forms/" + encodeURIComponent(page.lbfFormName) + "/patient_portal.php" +
+                                    "?formid=" + encodeURIComponent(page.lbfFormId);
+                            }
                             fetch(url).then(response => {
                                 if (!response.ok) {
                                     throw new Error('Network Error.');
@@ -285,11 +303,29 @@ var page = {
                             }
                             page.lbfFormId = e.originalEvent.data.formid;
                             page.onsiteDocument.set('encounter', page.lbfFormId);
-                            let url = webroot_url +
-                                "/interface/forms/LBF/printable.php?return_content=" +
-                                "&formname=" + encodeURIComponent(page.lbfFormName) +
-                                "&formid=" + encodeURIComponent(page.lbfFormId) +
-                                "&visitid=0&patientid=" + encodeURIComponent(cpid);
+                            let url = '';
+                            if (page.lbfFormName.startsWith('LBF')) {
+                                url = webroot_url +
+                                    "/interface/forms/LBF/printable.php?return_content=" +
+                                    "&formname=" + encodeURIComponent(page.lbfFormName) +
+                                    "&formid=" + encodeURIComponent(page.lbfFormId) +
+                                    "&visitid=0&patientid=" + encodeURIComponent(cpid);
+                            } else {
+                                // first, ensure form name is valid
+                                let formNameValid = false;
+                                for (let k=0; k < formNamesWhitelist.length; k++) {
+                                   if (formNamesWhitelist[k] == page.lbfFormName) {
+                                      formNameValid = true;
+                                   }
+                                }
+                                if (!formNameValid) {
+                                    signerAlertMsg("There is an issue loading form. Form does not exist.");
+                                    return false;
+                                }
+                                url = webroot_url +
+                                    "/interface/forms/" + encodeURIComponent(page.lbfFormName) + "/patient_portal.php" +
+                                    "?formid=" + encodeURIComponent(page.lbfFormId);
+                            }
                             fetch(url).then(response => {
                                 if (!response.ok) {
                                     throw new Error('Network Error LBF Render.');
@@ -656,12 +692,31 @@ var page = {
                             if (page.isFrameForm) {
                                 // a layout form
                                 if (page.lbfFormName) {
-                                    // iframe from template directive {EncounterDocument:LBFxxxxx}
-                                    let url = webRoot + "/interface/forms/LBF/new.php" + "" +
-                                        "?isPortal=" + encodeURIComponent(isPortal ? 1 : 0) +
-                                        "&formOrigin=" + encodeURIComponent(page.formOrigin) +
-                                        "&formname=" + encodeURIComponent(page.lbfFormName) + "&id=0";
-
+                                    let url = '';
+                                    if (page.lbfFormName.startsWith('LBF')) {
+                                        // iframe from template directive {EncounterDocument:LBFxxxxx} for a LBF form
+                                        url = webRoot + "/interface/forms/LBF/new.php" + "" +
+                                            "?isPortal=" + encodeURIComponent(isPortal ? 1 : 0) +
+                                            "&formOrigin=" + encodeURIComponent(page.formOrigin) +
+                                            "&formname=" + encodeURIComponent(page.lbfFormName) + "&id=0";
+                                    } else {
+                                        // iframe from template directive {EncounterDocument:xxxxx} for a native form
+                                        // first, ensure form name is valid
+                                        let formNameValid = false;
+                                        for (let k=0; k < formNamesWhitelist.length; k++) {
+                                           if (formNamesWhitelist[k] == page.lbfFormName) {
+                                              formNameValid = true;
+                                           }
+                                        }
+                                        if (!formNameValid) {
+                                            signerAlertMsg("There is an issue loading form. Form does not exist.");
+                                            return false;
+                                        }
+                                        url = webRoot + "/interface/forms/" + encodeURIComponent(page.lbfFormName) + "/new.php" +
+                                            "?isPortal=" + encodeURIComponent(isPortal ? 1 : 0) +
+                                            "&formOrigin=" + encodeURIComponent(page.formOrigin) +
+                                            "&formname=" + encodeURIComponent(page.lbfFormName) + "&id=0";
+                                    }
                                     document.getElementById('lbfForm').src = url;
                                 }
                             }

--- a/portal/patient/templates/OnsiteDocumentListView.tpl.php
+++ b/portal/patient/templates/OnsiteDocumentListView.tpl.php
@@ -13,6 +13,7 @@
  */
 
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Forms\CoreFormToPortalUtility;
 use OpenEMR\Core\Header;
 use OpenEMR\Services\DocumentTemplates\DocumentTemplateService;
 
@@ -80,6 +81,8 @@ $templateService = new DocumentTemplateService();
     echo "<script>var alertMsg1='" . xlt("Saved to Patient Documents") . '->' . xlt("Category") . ": " . attr($catname) . "';</script>";
     echo "<script>var msgSuccess='" . xlt("Updates Successful") . "';</script>";
     echo "<script>var msgDelete='" . xlt("Delete Successful") . "';</script>";
+    // list of encounter form directories/names (that are patient portal compliant) that use for whitelisting (security)
+    echo "<script>var formNamesWhitelist=" . json_encode(CoreFormToPortalUtility::getListPortalCompliantEncounterForms()) . ";</script>";
 
     Header::setupHeader(['no_main-theme', 'patientportal-style', 'datetime-picker', 'jspdf']);
 

--- a/src/Common/Forms/CoreFormToPortalUtility.php
+++ b/src/Common/Forms/CoreFormToPortalUtility.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * CoreFormToPortalUtility class for supporting core form use in the patient portal.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2022 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Common\Forms;
+
+if (!class_exists('OpenEMR\Common\Session\SessionUtil')) {
+    // This CoreFormToPortalUtility class is sometimes used prior to autoloader,
+    //   so need to manually bring in the SessionUtil class if not autoloaded yet.
+    require_once(__DIR__ . "/../Session/SessionUtil.php");
+}
+
+use OpenEMR\Common\Session\SessionUtil;
+use OpenEMR\Services\DocumentTemplates\DocumentTemplateService;
+
+class CoreFormToPortalUtility
+{
+    public static function isPatientPortalSession(?array $get): bool
+    {
+        if (isset($get['isPortal']) && (int)$get['isPortal'] !== 0) {
+            SessionUtil::portalSessionStart();
+            if (isset($_SESSION['pid']) && isset($_SESSION['patient_portal_onsite_two'])) {
+                // patient portal session is authenticated
+                return true;
+            } else {
+                // user has claimed that is using patient portal, however patient portal session is not
+                // authenticated, so destroy the session/cookie and kill the script
+                SessionUtil::portalSessionCookieDestroy();
+                exit;
+            }
+        } else {
+            // not using patient portal (ie. using core OpenEMR)
+            return false;
+        }
+    }
+
+    public static function isPatientPortalOther(?array $get): bool
+    {
+        // $_GET['formOrigin']; not set is from core, 0 is from portal, 1 is from portal module, 2 is from portal dashboard
+        if (($get['formOrigin'] ?? 0) > 0) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public static function confirmFormBootstrapPatient(bool $patientPortalSession, int $formid, string $formdir, int $patientId): void
+    {
+        if ($patientPortalSession) {
+            $pidForm = sqlQuery("SELECT `pid` FROM `forms` WHERE `form_id` = ? AND `formdir` = ?", [$formid, $formdir])['pid'];
+            if (empty($pidForm) || ($pidForm != $patientId)) {
+                echo xlt("illegal Action");
+                SessionUtil::portalSessionCookieDestroy();
+                exit;
+            }
+        }
+    }
+
+    public static function javascriptSupportPortal(bool $patientPortalSession, bool $patientPortalOther, string $mode, ?int $formid): string
+    {
+        $ret = '';
+        if ($patientPortalSession || $patientPortalOther) {
+            // code to support form in the patient portal
+            $ret = '
+            $(function () {
+                window.addEventListener("message", (e) => {
+                    if (event.origin !== window.location.origin) {
+                        return false;
+                    }
+                    if (e.data.submitForm === true) {
+                        e.preventDefault();
+                        document.forms[0].submit();
+                    }
+            ';
+            if (($mode == "update") && $patientPortalOther && !empty($formid)) {
+                $ret .= 'parent.postMessage({formid:' . js_escape($formid) . '}, window.location.origin);';
+            }
+            $ret .= '
+                });
+            });
+            ';
+        }
+        return $ret;
+    }
+
+    public static function formPatientPortalPostSave(int $formid): string
+    {
+        $ret = "<html><head><script>";
+        $ret .= "parent.postMessage({formid:" . js_escape($formid) . "}, window.location.origin);";
+        $ret .= "</script></head><body></body></html>";
+        return $ret;
+    }
+
+    public static function insertPatientPortalTemplate(int $id): void
+    {
+        $infoNewRegisteredForm = sqlQuery("SELECT `name`, `directory` FROM `registry` WHERE `id` = ?", [$id]);
+        $patientPortalCompliant = file_exists($GLOBALS['srcdir'] . "/../interface/forms/" . $infoNewRegisteredForm['directory'] . "/patient_portal.php");
+        if ($patientPortalCompliant) {
+            $checkDocumentTemplate = sqlQuery("SELECT `id` FROM `document_templates` WHERE `template_name` = ?", [$infoNewRegisteredForm['name']]);
+            if (empty($checkDocumentTemplate)) {
+                $contentTemplate = '{EncounterForm:' . $infoNewRegisteredForm['directory'] . '}';
+                (new DocumentTemplateService())->insertTemplate(-1, '', $infoNewRegisteredForm['name'], $contentTemplate, 'text/plain');
+            }
+        }
+    }
+
+    public static function getListPortalCompliantEncounterForms(): array
+    {
+        // first get list of form directory names that are patient portal compliant
+        $dirFormNames = [];
+        $formDirs = scandir($GLOBALS['srcdir'] . "/../interface/forms/");
+        foreach ($formDirs as $formDir) {
+            if (
+                $formDir != "." &&
+                $formDir != ".." &&
+                $formDir != "LBF" &&
+                file_exists($GLOBALS['srcdir'] . "/../interface/forms/" . $formDir . "/patient_portal.php")
+            ) {
+                $dirFormNames[] = $formDir;
+            }
+        }
+
+        // then remove forms that are not yet registered
+        $list = [];
+        $res = sqlStatement("SELECT `directory` FROM `registry`");
+        while ($ret = sqlFetchArray($res)) {
+            if (!empty($ret['directory']) && in_array($ret['directory'], $dirFormNames)) {
+                $list[] = $ret['directory'];
+            }
+        }
+
+        return $list;
+    }
+}


### PR DESCRIPTION
@sjpadgett , Have the main plumbing in (can save the form and modify the form form the patient portal).  Plan:
1. Get it working well in portal and in the dashboard where it is saved to chart as pdf etc. **DONE**
2. Streamline the process of how a "patient portal compliant" form can be placed in template (will potentially do this from the Forms->Adminstration gui for forms that are "patient portal compliant") - **DONE - (patient portal compliant forms get a neat icon next to their names in the gui and the template is placed into the document_templates sql table when the form is registered)**
3. Encapsulate things as much as possible to make it as easy as possible for users to make their forms "patient portal compliant" **DONE**

btw, the first commit in this PR is security related bug fixes and then the second commit is where the magic is starting :)

Up For Grabs demo (includes the standard demo data) is at:
https://www.open-emr.org/wiki/index.php/Development_Demo#Epsilon_-_Up_For_Grabs_Demo