### PR TITLE
move esign data integrity warning to log

### DIFF
--- a/_rest_config.php
+++ b/_rest_config.php
@@ -524,8 +524,8 @@ class RestConfig
                 $restRequest->setPatientUuidString($patientUuid);
             }
         } else {
-            (new SystemLogger())->error(("OpenEMR Error: api had patient launch scope but no patient was set in the "
-            . " session cache.  Resources restricted with patient scopes will not return results"));
+            (new SystemLogger())->error("OpenEMR Error: api had patient launch scope but no patient was set in the "
+            . " session cache.  Resources restricted with patient scopes will not return results");
         }
         return $restRequest;
     }

--- a/library/ESign/views/default/esign_signature_log.php
+++ b/library/ESign/views/default/esign_signature_log.php
@@ -22,17 +22,24 @@
  * @link    http://www.open-emr.org
  **/
 
+use OpenEMR\Common\Logging\EventAuditLogger;
+
 ?>
 <div id='esign-signature-log-<?php echo attr($this->logId); ?>' class='esign-signature-log-container'>
     <div class="esign-signature-log-table">
     
         <div class="esign-log-row header"><?php echo xlt('eSign Log'); ?></div>
         
-        <?php if (!$this->verified) { ?>
-        <div class="esign-log-row">
-            <div class="text-center text-danger"><?php echo xlt('The data integrity test failed for this form'); ?></div>
-        </div>
-        <?php } ?>
+        <?php if (!$this->verified) {
+            EventAuditLogger::instance()->newEvent(
+                "esign",
+                $_SESSION['authUser'],
+                $_SESSION['authProvider'],
+                0,
+                'Esign data integrity test failed for a form in encounter ' . $_SESSION['encounter'],
+                $_SESSION['pid']
+            );
+        } ?>
         
         <?php foreach ($this->signatures as $count => $signature) { ?>
         <div class="esign-log-row esign-log-row-container <?php echo text($signature->getClass()); ?>">


### PR DESCRIPTION
Fixes #5531 

#### Short description of what this resolves:
remove warning from displaying to user

#### Changes proposed in this pull request:
move to log

eventually can follow @bradymiller's advice
>having an esign admin gui that checks the hashes and allows some flexibility towards fixing hashes