### PR TITLE
Fixes #5539 Toggle Messages Received Confirmation

### DIFF
--- a/interface/main/messages/trusted-messages-ajax.php
+++ b/interface/main/messages/trusted-messages-ajax.php
@@ -28,6 +28,7 @@ $mimeTypeMappings = [
 ];
 
 $csrf = $_REQUEST['csrf_token_form'] ?? null;
+$verifyMessageReceived = false;
 if (!CsrfUtils::verifyCsrfToken($csrf)) {
     $result['errorCode'] = 'invalidCsrf';
     $isValid = false;
@@ -71,6 +72,7 @@ if (!CsrfUtils::verifyCsrfToken($csrf)) {
                 throw new AccessDeniedException("patients", "demo", "Access to patient data is denied");
             }
         }
+        $verifyMessageReceived = intval($_REQUEST['verifyMessageReceived'] ?? 0) == 1;
         $isValid = true;
     } catch (AccessDeniedException $exception) {
         http_response_code(401);
@@ -87,7 +89,7 @@ if (!CsrfUtils::verifyCsrfToken($csrf)) {
 if ($isValid) {
     try {
         if (empty($document)) {
-            $transmitResult = transmitMessage($message, $recipient);
+            $transmitResult = transmitMessage($message, $recipient, $verifyMessageReceived);
         } else {
             $mimeType = $document->get_mimetype();
             $formatType = 'xml';
@@ -103,7 +105,7 @@ if ($isValid) {
             // use the filename that exists in the document for what is sent
             $fileName = $document->get_name();
 
-            $transmitResult = transmitCCD($pid, $dataToSend, $recipient, $requested_by, $xmlType, $formatType, $message, $fileName);
+            $transmitResult = transmitCCD($pid, $dataToSend, $recipient, $requested_by, $xmlType, $formatType, $message, $fileName, $verifyMessageReceived);
         }
         if ($transmitResult !== "SUCCESS") {
             $result['errorCode'] = 'directError';

--- a/interface/main/messages/trusted-messages.php
+++ b/interface/main/messages/trusted-messages.php
@@ -40,6 +40,11 @@ if (!empty($_SESSION['pid'])) {
     }
 }
 
+if ($GLOBALS['phimail_verifyrecipientreceived_enable'] == '1') {
+    $verifyMessageReceivedChecked = "checked";
+} else {
+    $verifyMessageReceivedChecked = '';
+}
 ?>
 <!DOCTYPE html>
 <html>
@@ -182,6 +187,22 @@ if (!empty($_SESSION['pid'])) {
                                         <input id="documentId" type="hidden" name="documentId" value="" />
                                         <input id="documentName" class="form-control" type="textbox" name="documentName" value="" placeholder="<?php echo xla('Choose a document to attach'); ?>" />
                                         <p class="alert alert-info mt-2"><?php echo xlt("CCD/CCR/CCDA Documents must be in a xml or pdf format in order to send via Direct"); ?></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-12 oe-custom-line">
+                                <div class="row">
+                                    <div class="col-3">
+                                        <div class="form-check">
+                                            <input class="form-check-input" type="checkbox" name="verifyMessageReceived" id="verifyMessageReceived" value="1" <?php echo $verifyMessageReceivedChecked; ?>>
+                                            <label for="verifyMessageReceived" class="form-check-label"><?php echo xlt("Verify Message Received"); ?></label>
+                                        </div>
+
+                                    </div>
+                                    <div class="col-9">
+                                        <p class="alert alert-warning mt-2"><?php echo xlt("Forcing confirmation that recipient received a message could fail to send if the recipient's system does not support or has disabled receipt confirmation."); ?></p>
                                     </div>
                                 </div>
                             </div>

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncountermanagerTable.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncountermanagerTable.php
@@ -251,6 +251,12 @@ class EncountermanagerTable extends AbstractTableGateway
             return ("$config_err " . ErrorConstants::ERROR_CODE_MESSAGING_DISABLED);
         }
 
+        if ($GLOBALS['phimail_verifyrecipientreceived_enable'] == '1') {
+            $verifyMessageReceivedChecked = true;
+        } else {
+            $verifyMessageReceivedChecked = false;
+        }
+
         try {
             foreach ($rec_arr as $recipient) {
                 $elec_sent = array();
@@ -296,7 +302,7 @@ class EncountermanagerTable extends AbstractTableGateway
 
                     // there is no way currently to specify this came from the patient so we force to clinician.
                     // Default xml type is CCD  (ie Continuity of Care Document)
-                    $result = transmitCCD($value, $ccda_file, $recipient, 'clinician', "CCD", $xml_type, '', $fileName);
+                    $result = transmitCCD($value, $ccda_file, $recipient, 'clinician', "CCD", $xml_type, '', $fileName, $verifyMessageReceivedChecked);
                     if ($result !== "SUCCESS") {
                         $d_Address .= ' ' . $recipient . "(" . $result . ")";
                     }

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -3425,6 +3425,12 @@ $GLOBALS_METADATA = array(
             '0',
             xl('When you are ready to run phiMail in production mode. Turn on this flag.')
         ),
+        'phimail_verifyrecipientreceived_enable' => array(
+            xl("phiMail default force message receipt confirmation to on"),
+            'bool',
+            '0',
+            xl("Marks a message as succesful only if recipient confirms they received the message.  This can fail messages that otherwise would have been received if the recipient's system does not support confirmation receipt")
+        ),
 
         'phimail_server_address' => array(
             xl('phiMail Server Address'),

--- a/src/Common/DirectMessaging/ErrorConstants.php
+++ b/src/Common/DirectMessaging/ErrorConstants.php
@@ -58,4 +58,6 @@ class ErrorConstants
     // We sent the file to Direct and we got back an unexpected response other than ERROR or QUEUED
     // xl("There was a problem sending the message.")
     const ERROR_MESSAGE_UNEXPECTED_RESPONSE = "There was a problem sending the message.";
+
+    const ERROR_MESSAGE_SET_DISPOSITION_NOTIFICATION_FAILED = "There was a problem in setting the server flag for receiving a message recieved disposition notification";
 }


### PR DESCRIPTION
Fixes #5539 

We were not supporting the message disposition notification check with EMRDirect.  This is an ONC requirement in order to support immediate confirmation that a recipient received the message.  I added a globals setting and a flag on the messages page to support this use.

I changed up the transmitCCD and transmitMessages function to use SET FINAL flag for EMR Direct to trigger the message disposition notification check.

The carecoordination will use whatever the globals setting is set to.

@lcmaas you may be interested in reviewing this to make sure we are handling everything your company needs.

From my testing this passes the ONC 2015 (b)(1) MT 46 Disposition Notification Options test.