### PR TITLE
Fixes #5549 ccda documentation

### DIFF
--- a/FHIR_README.md
+++ b/FHIR_README.md
@@ -203,7 +203,6 @@ It is recommended that native applications follow best practices for native clie
     - History of Procedures
     - Relevant DX Tests / LAB Data
     - Functional Status
-    - Vital Signs
     - Progress Notes
     - Procedure Notes
     - Laboratory Report Narrative
@@ -223,6 +222,7 @@ It is recommended that native applications follow best practices for native clie
     - Immunizations
     - Social History
     - Medical Equipment
+    - Vital Signs (shows the latest vitals recorded for the patient)
     
 - CCD is generated on demand, saved off in patient's record under the CCDA category
 - Requires following standard FHIR authorization
@@ -232,6 +232,11 @@ It is recommended that native applications follow best practices for native clie
 - Or xml file can be uploaded as a document into OpenEMR to view in a human readable format
 - Due to browser security restrictions XSL file must be in same directory as ccd document to view.
 - link out to swagger location on where to build file
+- If no start date is provided it will retrieve all records in the patient history up to the end date
+- If no end date is provided it will retrieve all records connected to encounters starting from
+the start date
+- If a records for a specific service date are desired, make the start date and end date the same day in YYYY-MM-DD format. 
+- Dates must be specified in least specifity to most specifity for wildcard like operations IE YYYY for the beginning of the year for start date or ending of the year for end date, YYYY-MM for the beginning of the month for start date and end of the month for end date, etc.
 
 ## For Developers
 

--- a/_rest_routes.inc.php
+++ b/_rest_routes.inc.php
@@ -8642,7 +8642,7 @@ RestConfig::$FHIR_ROUTE_MAP = array(
     /**
      *  @OA\Get(
      *      path="/fhir/Document/{id}/Binary",
-     *      description="The BULK FHIR Exports documentation can be found at <a href='https://www.open-emr.org/wiki/index.php/OpenEMR_Wiki_Home_Page#API' target='_blank' rel='noopener'>https://www.open-emr.org/wiki/index.php/OpenEMR_Wiki_Home_Page#API</a>",
+     *      description="Used for downloading binary documents generated either with BULK FHIR Export or with the $docref CCD export operation.  Documentation can be found at <a href='https://www.open-emr.org/wiki/index.php/OpenEMR_Wiki_Home_Page#API' target='_blank' rel='noopener'>https://www.open-emr.org/wiki/index.php/OpenEMR_Wiki_Home_Page#API</a>",
      *      tags={"fhir"},
      *      @OA\Parameter(
      *          name="id",
@@ -8655,7 +8655,7 @@ RestConfig::$FHIR_ROUTE_MAP = array(
      *      ),
      *      @OA\Response(
      *          response="200",
-     *          description="The BULK FHIR Exports documentation can be found at <a href='https://www.open-emr.org/wiki/index.php/OpenEMR_Wiki_Home_Page#API' target='_blank' rel='noopener'>https://www.open-emr.org/wiki/index.php/OpenEMR_Wiki_Home_Page#API</a>"
+     *          description="The documentation for working with BULK FHIR or $docref document exports can be found at <a href='https://www.open-emr.org/wiki/index.php/OpenEMR_Wiki_Home_Page#API' target='_blank' rel='noopener'>https://www.open-emr.org/wiki/index.php/OpenEMR_Wiki_Home_Page#API</a>"
      *      ),
      *      @OA\Response(
      *          response="400",

--- a/swagger/openemr-api.yaml
+++ b/swagger/openemr-api.yaml
@@ -4300,7 +4300,7 @@ paths:
     get:
       tags:
         - fhir
-      description: 'The BULK FHIR Exports documentation can be found at <a href=''https://www.open-emr.org/wiki/index.php/OpenEMR_Wiki_Home_Page#API'' target=''_blank'' rel=''noopener''>https://www.open-emr.org/wiki/index.php/OpenEMR_Wiki_Home_Page#API</a>'
+      description: 'Used for downloading binary documents generated either with BULK FHIR Export or with the $docref CCD export operation.  Documentation can be found at <a href=''https://www.open-emr.org/wiki/index.php/OpenEMR_Wiki_Home_Page#API'' target=''_blank'' rel=''noopener''>https://www.open-emr.org/wiki/index.php/OpenEMR_Wiki_Home_Page#API</a>'
       parameters:
         -
           name: id
@@ -4311,7 +4311,7 @@ paths:
             type: string
       responses:
         '200':
-          description: 'The BULK FHIR Exports documentation can be found at <a href=''https://www.open-emr.org/wiki/index.php/OpenEMR_Wiki_Home_Page#API'' target=''_blank'' rel=''noopener''>https://www.open-emr.org/wiki/index.php/OpenEMR_Wiki_Home_Page#API</a>'
+          description: 'The documentation for working with BULK FHIR or $docref document exports can be found at <a href=''https://www.open-emr.org/wiki/index.php/OpenEMR_Wiki_Home_Page#API'' target=''_blank'' rel=''noopener''>https://www.open-emr.org/wiki/index.php/OpenEMR_Wiki_Home_Page#API</a>'
         '400':
           $ref: '#/components/responses/badrequest'
         '401':


### PR DESCRIPTION
Wanted to make sure I get this in before I forget it since I've had it
stashed for a while.  Updating the ccda documentation for g9.
Fixes #5549 @bradymiller this is just a minor fix.  Hopefully it doesn't mess  up anything you've been doing on the g9 documentation.  Big thing is we dropped filtering on vitals as I found out vitals always just returns the most recent vitals in ccda.  Will be quite a bit of work to change so I'm leaving it be.