### PR TITLE
Fixes #5565 referral fallback, style fixes

### DIFF
--- a/ccdaservice/oe-blue-button-generate/lib/headerLevel.js
+++ b/ccdaservice/oe-blue-button-generate/lib/headerLevel.js
@@ -187,51 +187,12 @@ var provider = exports.provider = [{
                 attributes: leafLevel.code,
                 content: [{key: "originalText", text: "Care Team Member"}],
                 dataKey: "type"
-            }, {
-                key: "addr",
-                attributes: {
-                    use: leafLevel.use("use")
-                },
-                content: [{
-                    key: "country",
-                    text: leafLevel.inputProperty("country")
-                }, {
-                    key: "state",
-                    text: leafLevel.inputProperty("state")
-                }, {
-                    key: "city",
-                    text: leafLevel.inputProperty("city")
-                }, {
-                    key: "postalCode",
-                    text: leafLevel.inputProperty("zip")
-                }, {
-                    key: "streetAddressLine",
-                    text: leafLevel.input,
-                    dataKey: "street_lines"
-                }],
-                dataKey: "address"
-            }, {
-                key: "telecom",
-                attributes: [{
-                    use: "WP",
-                    value: function (input) {
-                        return input.value.number;
-                    }
-                }],
-                dataKey: "phone"
-            }, {
+            },
+            ,fieldLevel.usRealmAddress
+            ,fieldLevel.telecom
+            ,{
                 key: "assignedPerson",
-                content: [{
-                    key: "name",
-                    content: [{
-                        key: "given",
-                        text: leafLevel.inputProperty("first")
-                    }, {
-                        key: "family",
-                        text: leafLevel.inputProperty("last")
-                    }],
-                    dataKey: "name"
-                }]
+                content: fieldLevel.usRealmName
             }
             ]
         }
@@ -624,7 +585,10 @@ var headerComponentOf = exports.headerComponentOf = {
                         attributes: {
                             root: leafLevel.inputProperty("root")
                         }
-                    }, {
+                    }
+                    ,fieldLevel.usRealmAddress
+                    ,fieldLevel.telecom
+                    ,{
                         key: "assignedPerson",
                         content: fieldLevel.usRealmName
                     }]

--- a/ccdaservice/serveccda.js
+++ b/ccdaservice/serveccda.js
@@ -138,6 +138,7 @@ function isOne(who) {
                 || who.hasOwnProperty('id')
                 || who.hasOwnProperty('date')
                 || who.hasOwnProperty('use')
+                || who.hasOwnProperty('type')
             ) ? 1 : Object.keys(who).length;
         }
     } catch (e) {
@@ -393,13 +394,10 @@ function populateProvider(provider) {
                 "country": all.encounter_provider.facility_country_code || "US"
             }
         ],
-        "phone": [
-            {
-                "value": {
-                    "number": all.encounter_provider.facility_phone || "",
-                }
-            }
-        ]
+
+        "phone": [{
+            "number": all.encounter_provider.facility_phone || ""
+        }]
     }
 }
 
@@ -479,11 +477,12 @@ function populateCareTeamMember(provider) {
             "zip": provider.zip,
             "country": all.encounter_provider.facility_country_code || "US"
         },
-        "phone": [{
-            "value": {
-                "number": provider.phone || "",
+        "phone": [
+            {
+                "number": provider.telecom,
+                "type": "work place"
             }
-        }]
+        ]
     }
 }
 
@@ -2384,16 +2383,12 @@ function populateParticipant(participant) {
 function populateHeader(pd) {
     // default doc type ToC CCD
     let name = "Summarization of Episode Note";
-    let isEpisodicDocumentType = false;
     let docCode = "34133-9";
     let docOid = "2.16.840.1.113883.10.20.22.1.2";
     if (pd.doc_type == 'referral') {
         name = "Referral Note";
         docCode = "57133-1";
         docOid = "2.16.840.1.113883.10.20.22.1.14";
-        isEpisodicDocumentType = true;
-    } else if (pd.doc_type == 'careplan') {
-        isEpisodicDocumentType = true;
     }
 
     const head = {
@@ -2553,8 +2548,7 @@ function populateHeader(pd) {
     }
 
 
-    if (isEpisodicDocumentType
-        && isOne(all.encounter_list.encounter) === 1) {
+    if (isOne(all.encounter_list.encounter) === 1) {
         head.component_of = {
             "identifiers": [
                 {
@@ -2590,6 +2584,24 @@ function populateHeader(pd) {
                     "last": pd.primary_care_provider.provider.lname || "",
                     "first": pd.primary_care_provider.provider.fname || ""
                 },
+                "address": [
+                    {
+                        "street_lines": [
+                            pd.encounter_provider.facility_street
+                        ],
+                        "city": pd.encounter_provider.facility_city,
+                        "state": pd.encounter_provider.facility_state,
+                        "zip": pd.encounter_provider.facility_postal_code,
+                        "country": pd.encounter_provider.facility_country_code || "US",
+                        "use": "work place"
+                    }
+                ],
+                "phone": [
+                    {
+                        "number": pd.encounter_provider.facility_phone,
+                        "type": "work primary"
+                    }
+                ]
             }
         }
     }


### PR DESCRIPTION
Implemented the referral fallback by using the encompassing encounter provider information if we have one in the displayed CCDA, or falling back to the Primary Care Provider (PP) or the Primary Care Physician (PCP) if we have one.

In order to grab the phone and contact information I had to fix up some issues in the care team and provider templates.  Those are still displaying properly in the documentationOf and in the Care Team sections.

Everything is passing in the ETT validator and looking at the xml it looks like everything is populating correctly for care team and the documentationOf.

Fixed up a number of style issues in the cda to make the format a bit more condensed while still preserving readability.  Did this by moving address info all into one line.  Found a couple of places where headers were being pushed onto two lines that I tidied up.