### PR TITLE
Revert adodb-php version to 5.22.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=7.4.0",
         "academe/omnipay-authorizenetapi": "3.1.2",
-        "adodb/adodb-php": "5.22.2",
+        "adodb/adodb-php": "5.22.0",
         "aranyasen/hl7": "2.1.6",
         "digitickets/lalit": "3.3.0",
         "dompdf/dompdf": "1.2.2",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=7.4.0",
         "academe/omnipay-authorizenetapi": "3.1.2",
-        "adodb/adodb-php": "5.22.0",
+        "adodb/adodb-php": "5.21.4",
         "aranyasen/hl7": "2.1.6",
         "digitickets/lalit": "3.3.0",
         "dompdf/dompdf": "1.2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "137e464217415a1730b8453de042b956",
+    "content-hash": "6f094d96251531ed6dceee4c0e1bb1d0",
     "packages": [
         {
             "name": "academe/authorizenet-objects",
@@ -132,16 +132,16 @@
         },
         {
             "name": "adodb/adodb-php",
-            "version": "v5.22.2",
+            "version": "v5.22.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ADOdb/ADOdb.git",
-                "reference": "876bc2287171ea96a571f84c23845e44a759d9a0"
+                "reference": "d99127b8811a9f949c00ab425065e380dce6bdc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ADOdb/ADOdb/zipball/876bc2287171ea96a571f84c23845e44a759d9a0",
-                "reference": "876bc2287171ea96a571f84c23845e44a759d9a0",
+                "url": "https://api.github.com/repos/ADOdb/ADOdb/zipball/d99127b8811a9f949c00ab425065e380dce6bdc1",
+                "reference": "d99127b8811a9f949c00ab425065e380dce6bdc1",
                 "shasum": ""
             },
             "require": {
@@ -189,7 +189,7 @@
                 "issues": "https://github.com/ADOdb/ADOdb/issues",
                 "source": "https://github.com/ADOdb/ADOdb"
             },
-            "time": "2022-05-08T10:01:41+00:00"
+            "time": "2022-02-07T23:42:42+00:00"
         },
         {
             "name": "aranyasen/hl7",
@@ -12656,5 +12656,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6f094d96251531ed6dceee4c0e1bb1d0",
+    "content-hash": "73d55df0c48cfdd66c39f96ae098b868",
     "packages": [
         {
             "name": "academe/authorizenet-objects",
@@ -132,20 +132,20 @@
         },
         {
             "name": "adodb/adodb-php",
-            "version": "v5.22.0",
+            "version": "v5.21.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ADOdb/ADOdb.git",
-                "reference": "d99127b8811a9f949c00ab425065e380dce6bdc1"
+                "reference": "c3e6a3661c60beebb7b2cd819bcf76446d69e41a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ADOdb/ADOdb/zipball/d99127b8811a9f949c00ab425065e380dce6bdc1",
-                "reference": "d99127b8811a9f949c00ab425065e380dce6bdc1",
+                "url": "https://api.github.com/repos/ADOdb/ADOdb/zipball/c3e6a3661c60beebb7b2cd819bcf76446d69e41a",
+                "reference": "c3e6a3661c60beebb7b2cd819bcf76446d69e41a",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0 || ^8.0"
+                "php": "^5.5.9 || ^7.0 || ^8.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^8.5"
@@ -189,7 +189,7 @@
                 "issues": "https://github.com/ADOdb/ADOdb/issues",
                 "source": "https://github.com/ADOdb/ADOdb"
             },
-            "time": "2022-02-07T23:42:42+00:00"
+            "time": "2022-01-22T22:56:43+00:00"
         },
         {
             "name": "aranyasen/hl7",


### PR DESCRIPTION
- breaks on windows 5.22.1+
5.22.2 okay on linux!
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #5571
