### PR TITLE
Mu3 3 author local cherry pick

### DIFF
--- a/ccdaservice/oe-blue-button-generate/lib/entryLevel/socialHistoryEntryLevel.js
+++ b/ccdaservice/oe-blue-button-generate/lib/entryLevel/socialHistoryEntryLevel.js
@@ -97,7 +97,7 @@ exports.genderStatusObservation = {
             required: true,
             dataKey: "gender"
         }
-        ,fieldLevel.author
+        ,[fieldLevel.author, contentModifier.dataKey("gender_author")]
     ],
     existsWhen: function (input) {
         return input && input.gender;

--- a/ccdaservice/serveccda.js
+++ b/ccdaservice/serveccda.js
@@ -1919,44 +1919,7 @@ function getMentalStatus(pd) {
 function getAssessments(pd) {
     return {
         "description": cleanText(pd.description),
-        "author": {
-            "code": {
-                "name": all.author.physician_type || '',
-                "code": all.author.physician_type_code || '',
-                "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
-            },
-            "date_time": {
-                "point": {
-                    "date": authorDateTime,
-                    "precision": "tz"
-                }
-            },
-            "identifiers": [
-                {
-                    "identifier": all.author.npi ? "2.16.840.1.113883.4.6" : all.author.id,
-                    "extension": all.author.npi ? all.author.npi : ''
-                }
-            ],
-            "name": [
-                {
-                    "last": all.author.lname,
-                    "first": all.author.fname
-                }
-            ],
-            "organization": [
-                {
-                    "identity": [
-                        {
-                            "root": oidFacility || "2.16.840.1.113883.4.6",
-                            "extension": npiFacility || ""
-                        }
-                    ],
-                    "name": [
-                        all.encounter_provider.facility_name
-                    ]
-                }
-            ]
-        }
+        "author": populateAuthorFromAuthorContainer(pd)
     };
 }
 
@@ -3224,30 +3187,7 @@ function populateNote(pd) {
             code: cleanCode(pd.code),
             name: pd.code_text || ""
         },
-        "author": {
-            "identifiers": [{
-                "identifier": "2.16.840.1.113883.4.6",
-                "extension": pd.author_npi || "123456789"
-            }],
-            "date_time": {
-                "point": {
-                    "date": fDate(authorDateTime),
-                    "precision": "tz"
-                }
-            },
-            "name": {
-                "prefix": pd.author_title,
-                "last": pd.author_last,
-                "first": pd.author_first,
-            },
-            "author_full_name": pd.author_title + " " + pd.author_first + " " + pd.author_last,
-            "organization": [{
-                "identity": {
-                    "root": pd.facility_oid || oidFacility || "",
-                },
-                "name": [pd.facility_name]
-            }]
-        },
+        "author": populateAuthorFromAuthorContainer(pd),
         "note": cleanText(pd.description),
     };
 }

--- a/ccdaservice/serveccda.js
+++ b/ccdaservice/serveccda.js
@@ -1896,44 +1896,7 @@ function getHealthConcerns(pd) {
 function getReferralReason(pd) {
     return {
         "reason": cleanText(pd.text),
-        "author": {
-            "code": {
-                "name": all.author.physician_type || '',
-                "code": all.author.physician_type_code || '',
-                "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
-            },
-            "date_time": {
-                "point": {
-                    "date": authorDateTime,
-                    "precision": "tz"
-                }
-            },
-            "identifiers": [
-                {
-                    "identifier": all.author.npi ? "2.16.840.1.113883.4.6" : all.author.id,
-                    "extension": all.author.npi ? all.author.npi : ''
-                }
-            ],
-            "name": [
-                {
-                    "last": all.author.lname,
-                    "first": all.author.fname
-                }
-            ],
-            "organization": [
-                {
-                    "identity": [
-                        {
-                            "root": oidFacility || "2.16.840.1.113883.4.6",
-                            "extension": npiFacility || ""
-                        }
-                    ],
-                    "name": [
-                        all.encounter_provider.facility_name
-                    ]
-                }
-            ]
-        }
+        "author": populateAuthorFromAuthorContainer(pd)
     };
 }
 

--- a/ccdaservice/serveccda.js
+++ b/ccdaservice/serveccda.js
@@ -1971,44 +1971,7 @@ function populateVital(pd) {
             "interpretations": ["Normal"],
             "value": parseFloat(pd.bps) || pd.bps,
             "unit": "mm[Hg]",
-            "author": {
-                "code": {
-                    "name": all.author.physician_type || '',
-                    "code": all.author.physician_type_code || '',
-                    "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
-                },
-                "date_time": {
-                    "point": {
-                        "date": authorDateTime,
-                        "precision": "tz"
-                    }
-                },
-                "identifiers": [
-                    {
-                        "identifier": all.author.npi ? "2.16.840.1.113883.4.6" : all.author.id,
-                        "extension": all.author.npi ? all.author.npi : ''
-                    }
-                ],
-                "name": [
-                    {
-                        "last": all.author.lname,
-                        "first": all.author.fname
-                    }
-                ],
-                "organization": [
-                    {
-                        "identity": [
-                            {
-                                "root": oidFacility || "2.16.840.1.113883.4.6",
-                                "extension": npiFacility || ""
-                            }
-                        ],
-                        "name": [
-                            all.encounter_provider.facility_name
-                        ]
-                    }
-                ]
-            },
+            "author": populateAuthorFromAuthorContainer(pd),
         }, {
             "identifiers": [{
                 "identifier": pd.sha_extension,
@@ -2029,44 +1992,7 @@ function populateVital(pd) {
             "interpretations": ["Normal"],
             "value": parseFloat(pd.bpd) || pd.bpd,
             "unit": "mm[Hg]",
-            "author": {
-                "code": {
-                    "name": all.author.physician_type || '',
-                    "code": all.author.physician_type_code || '',
-                    "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
-                },
-                "date_time": {
-                    "point": {
-                        "date": authorDateTime,
-                        "precision": "tz"
-                    }
-                },
-                "identifiers": [
-                    {
-                        "identifier": all.author.npi ? "2.16.840.1.113883.4.6" : all.author.id,
-                        "extension": all.author.npi ? all.author.npi : ''
-                    }
-                ],
-                "name": [
-                    {
-                        "last": all.author.lname,
-                        "first": all.author.fname
-                    }
-                ],
-                "organization": [
-                    {
-                        "identity": [
-                            {
-                                "root": oidFacility || "2.16.840.1.113883.4.6",
-                                "extension": npiFacility || ""
-                            }
-                        ],
-                        "name": [
-                            all.encounter_provider.facility_name
-                        ]
-                    }
-                ]
-            },
+            "author": populateAuthorFromAuthorContainer(pd),
         }, {
             "identifiers": [{
                 "identifier": pd.sha_extension,
@@ -2087,44 +2013,7 @@ function populateVital(pd) {
             "interpretations": ["Normal"],
             "value": parseFloat(pd.height) || pd.height,
             "unit": pd.unit_height,
-            "author": {
-                "code": {
-                    "name": all.author.physician_type || '',
-                    "code": all.author.physician_type_code || '',
-                    "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
-                },
-                "date_time": {
-                    "point": {
-                        "date": authorDateTime,
-                        "precision": "tz"
-                    }
-                },
-                "identifiers": [
-                    {
-                        "identifier": all.author.npi ? "2.16.840.1.113883.4.6" : all.author.id,
-                        "extension": all.author.npi ? all.author.npi : ''
-                    }
-                ],
-                "name": [
-                    {
-                        "last": all.author.lname,
-                        "first": all.author.fname
-                    }
-                ],
-                "organization": [
-                    {
-                        "identity": [
-                            {
-                                "root": oidFacility || "2.16.840.1.113883.4.6",
-                                "extension": npiFacility || ""
-                            }
-                        ],
-                        "name": [
-                            all.encounter_provider.facility_name
-                        ]
-                    }
-                ]
-            },
+            "author": populateAuthorFromAuthorContainer(pd),
         }, {
             "identifiers": [{
                 "identifier": pd.sha_extension,
@@ -2145,44 +2034,7 @@ function populateVital(pd) {
             "interpretations": ["Normal"],
             "value": parseFloat(pd.weight) || "",
             "unit": pd.unit_weight,
-            "author": {
-                "code": {
-                    "name": all.author.physician_type || '',
-                    "code": all.author.physician_type_code || '',
-                    "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
-                },
-                "date_time": {
-                    "point": {
-                        "date": authorDateTime,
-                        "precision": "tz"
-                    }
-                },
-                "identifiers": [
-                    {
-                        "identifier": all.author.npi ? "2.16.840.1.113883.4.6" : all.author.id,
-                        "extension": all.author.npi ? all.author.npi : ''
-                    }
-                ],
-                "name": [
-                    {
-                        "last": all.author.lname,
-                        "first": all.author.fname
-                    }
-                ],
-                "organization": [
-                    {
-                        "identity": [
-                            {
-                                "root": oidFacility || "2.16.840.1.113883.4.6",
-                                "extension": npiFacility || ""
-                            }
-                        ],
-                        "name": [
-                            all.encounter_provider.facility_name
-                        ]
-                    }
-                ]
-            },
+            "author": populateAuthorFromAuthorContainer(pd),
         }, {
             "identifiers": [{
                 "identifier": pd.sha_extension,
@@ -2203,44 +2055,7 @@ function populateVital(pd) {
             "interpretations": [pd.BMI_status == 'Overweight' ? 'High' : pd.BMI_status == 'Overweight' ? 'Low' : 'Normal'],
             "value": parseFloat(pd.BMI) || "",
             "unit": "kg/m2",
-            "author": {
-                "code": {
-                    "name": all.author.physician_type || '',
-                    "code": all.author.physician_type_code || '',
-                    "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
-                },
-                "date_time": {
-                    "point": {
-                        "date": authorDateTime,
-                        "precision": "tz"
-                    }
-                },
-                "identifiers": [
-                    {
-                        "identifier": all.author.npi ? "2.16.840.1.113883.4.6" : all.author.id,
-                        "extension": all.author.npi ? all.author.npi : ''
-                    }
-                ],
-                "name": [
-                    {
-                        "last": all.author.lname,
-                        "first": all.author.fname
-                    }
-                ],
-                "organization": [
-                    {
-                        "identity": [
-                            {
-                                "root": oidFacility || "2.16.840.1.113883.4.6",
-                                "extension": npiFacility || ""
-                            }
-                        ],
-                        "name": [
-                            all.encounter_provider.facility_name
-                        ]
-                    }
-                ]
-            },
+            "author": populateAuthorFromAuthorContainer(pd),
         }, {
             "identifiers": [{
                 "identifier": pd.sha_extension,
@@ -2261,44 +2076,7 @@ function populateVital(pd) {
             "interpretations": ["Normal"],
             "value": parseFloat(pd.pulse) || "",
             "unit": "/min",
-            "author": {
-                "code": {
-                    "name": all.author.physician_type || '',
-                    "code": all.author.physician_type_code || '',
-                    "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
-                },
-                "date_time": {
-                    "point": {
-                        "date": authorDateTime,
-                        "precision": "tz"
-                    }
-                },
-                "identifiers": [
-                    {
-                        "identifier": all.author.npi ? "2.16.840.1.113883.4.6" : all.author.id,
-                        "extension": all.author.npi ? all.author.npi : ''
-                    }
-                ],
-                "name": [
-                    {
-                        "last": all.author.lname,
-                        "first": all.author.fname
-                    }
-                ],
-                "organization": [
-                    {
-                        "identity": [
-                            {
-                                "root": oidFacility || "2.16.840.1.113883.4.6",
-                                "extension": npiFacility || ""
-                            }
-                        ],
-                        "name": [
-                            all.encounter_provider.facility_name
-                        ]
-                    }
-                ]
-            },
+            "author": populateAuthorFromAuthorContainer(pd),
         }, {
             "identifiers": [{
                 "identifier": "2.16.840.1.113883.3.140.1.0.6.10.14.2",
@@ -2319,44 +2097,7 @@ function populateVital(pd) {
             "interpretations": ["Normal"],
             "value": parseFloat(pd.breath) || "",
             "unit": "/min",
-            "author": {
-                "code": {
-                    "name": all.author.physician_type || '',
-                    "code": all.author.physician_type_code || '',
-                    "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
-                },
-                "date_time": {
-                    "point": {
-                        "date": authorDateTime,
-                        "precision": "tz"
-                    }
-                },
-                "identifiers": [
-                    {
-                        "identifier": all.author.npi ? "2.16.840.1.113883.4.6" : all.author.id,
-                        "extension": all.author.npi ? all.author.npi : ''
-                    }
-                ],
-                "name": [
-                    {
-                        "last": all.author.lname,
-                        "first": all.author.fname
-                    }
-                ],
-                "organization": [
-                    {
-                        "identity": [
-                            {
-                                "root": oidFacility || "2.16.840.1.113883.4.6",
-                                "extension": npiFacility || ""
-                            }
-                        ],
-                        "name": [
-                            all.encounter_provider.facility_name
-                        ]
-                    }
-                ]
-            },
+            "author": populateAuthorFromAuthorContainer(pd),
         }, {
             "identifiers": [{
                 "identifier": "2.16.840.1.113883.3.140.1.0.6.10.14.3",
@@ -2377,44 +2118,7 @@ function populateVital(pd) {
             "interpretations": ["Normal"],
             "value": parseFloat(pd.temperature) || "",
             "unit": pd.unit_temperature,
-            "author": {
-                "code": {
-                    "name": all.author.physician_type || '',
-                    "code": all.author.physician_type_code || '',
-                    "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
-                },
-                "date_time": {
-                    "point": {
-                        "date": authorDateTime,
-                        "precision": "tz"
-                    }
-                },
-                "identifiers": [
-                    {
-                        "identifier": all.author.npi ? "2.16.840.1.113883.4.6" : all.author.id,
-                        "extension": all.author.npi ? all.author.npi : ''
-                    }
-                ],
-                "name": [
-                    {
-                        "last": all.author.lname,
-                        "first": all.author.fname
-                    }
-                ],
-                "organization": [
-                    {
-                        "identity": [
-                            {
-                                "root": oidFacility || "2.16.840.1.113883.4.6",
-                                "extension": npiFacility || ""
-                            }
-                        ],
-                        "name": [
-                            all.encounter_provider.facility_name
-                        ]
-                    }
-                ]
-            },
+            "author": populateAuthorFromAuthorContainer(pd),
         }, {
             "identifiers": [{
                 "identifier": pd.sha_extension,
@@ -2435,44 +2139,7 @@ function populateVital(pd) {
             "interpretations": ["Normal"],
             "value": parseFloat(pd.oxygen_saturation) || "",
             "unit": "%",
-            "author": {
-                "code": {
-                    "name": all.author.physician_type || '',
-                    "code": all.author.physician_type_code || '',
-                    "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
-                },
-                "date_time": {
-                    "point": {
-                        "date": authorDateTime,
-                        "precision": "tz"
-                    }
-                },
-                "identifiers": [
-                    {
-                        "identifier": all.author.npi ? "2.16.840.1.113883.4.6" : all.author.id,
-                        "extension": all.author.npi ? all.author.npi : ''
-                    }
-                ],
-                "name": [
-                    {
-                        "last": all.author.lname,
-                        "first": all.author.fname
-                    }
-                ],
-                "organization": [
-                    {
-                        "identity": [
-                            {
-                                "root": oidFacility || "2.16.840.1.113883.4.6",
-                                "extension": npiFacility || ""
-                            }
-                        ],
-                        "name": [
-                            all.encounter_provider.facility_name
-                        ]
-                    }
-                ]
-            },
+            "author": populateAuthorFromAuthorContainer(pd),
         }, {
             "identifiers": [{
                 "identifier": pd.sha_extension,
@@ -2493,44 +2160,7 @@ function populateVital(pd) {
             "interpretations": ["Normal"],
             "value": parseFloat(pd.ped_weight_height) || "",
             "unit": "%",
-            "author": {
-                "code": {
-                    "name": all.author.physician_type || '',
-                    "code": all.author.physician_type_code || '',
-                    "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
-                },
-                "date_time": {
-                    "point": {
-                        "date": authorDateTime,
-                        "precision": "tz"
-                    }
-                },
-                "identifiers": [
-                    {
-                        "identifier": all.author.npi ? "2.16.840.1.113883.4.6" : all.author.id,
-                        "extension": all.author.npi ? all.author.npi : ''
-                    }
-                ],
-                "name": [
-                    {
-                        "last": all.author.lname,
-                        "first": all.author.fname
-                    }
-                ],
-                "organization": [
-                    {
-                        "identity": [
-                            {
-                                "root": oidFacility || "2.16.840.1.113883.4.6",
-                                "extension": npiFacility || ""
-                            }
-                        ],
-                        "name": [
-                            all.encounter_provider.facility_name
-                        ]
-                    }
-                ]
-            },
+            "author": populateAuthorFromAuthorContainer(pd),
         }, {
             "identifiers": [{
                 "identifier": pd.sha_extension,
@@ -2551,44 +2181,7 @@ function populateVital(pd) {
             "interpretations": ["Normal"],
             "value": parseFloat(pd.inhaled_oxygen_concentration) || "",
             "unit": "%",
-            "author": {
-                "code": {
-                    "name": all.author.physician_type || '',
-                    "code": all.author.physician_type_code || '',
-                    "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
-                },
-                "date_time": {
-                    "point": {
-                        "date": authorDateTime,
-                        "precision": "tz"
-                    }
-                },
-                "identifiers": [
-                    {
-                        "identifier": all.author.npi ? "2.16.840.1.113883.4.6" : all.author.id,
-                        "extension": all.author.npi ? all.author.npi : ''
-                    }
-                ],
-                "name": [
-                    {
-                        "last": all.author.lname,
-                        "first": all.author.fname
-                    }
-                ],
-                "organization": [
-                    {
-                        "identity": [
-                            {
-                                "root": oidFacility || "2.16.840.1.113883.4.6",
-                                "extension": npiFacility || ""
-                            }
-                        ],
-                        "name": [
-                            all.encounter_provider.facility_name
-                        ]
-                    }
-                ]
-            },
+            "author": populateAuthorFromAuthorContainer(pd),
         }, {
             "identifiers": [{
                 "identifier": pd.sha_extension,
@@ -2609,44 +2202,7 @@ function populateVital(pd) {
             "interpretations": ["Normal"],
             "value": parseFloat(pd.ped_bmi) || "",
             "unit": "%",
-            "author": {
-                "code": {
-                    "name": all.author.physician_type || '',
-                    "code": all.author.physician_type_code || '',
-                    "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
-                },
-                "date_time": {
-                    "point": {
-                        "date": authorDateTime,
-                        "precision": "tz"
-                    }
-                },
-                "identifiers": [
-                    {
-                        "identifier": all.author.npi ? "2.16.840.1.113883.4.6" : all.author.id,
-                        "extension": all.author.npi ? all.author.npi : ''
-                    }
-                ],
-                "name": [
-                    {
-                        "last": all.author.lname,
-                        "first": all.author.fname
-                    }
-                ],
-                "organization": [
-                    {
-                        "identity": [
-                            {
-                                "root": oidFacility || "2.16.840.1.113883.4.6",
-                                "extension": npiFacility || ""
-                            }
-                        ],
-                        "name": [
-                            all.encounter_provider.facility_name
-                        ]
-                    }
-                ]
-            },
+            "author": populateAuthorFromAuthorContainer(pd),
         }, {
             "identifiers": [{
                 "identifier": pd.sha_extension,
@@ -2667,44 +2223,7 @@ function populateVital(pd) {
             "interpretations": ["Normal"],
             "value": parseFloat(pd.ped_head_circ) || "",
             "unit": "%",
-            "author": {
-                "code": {
-                    "name": all.author.physician_type || '',
-                    "code": all.author.physician_type_code || '',
-                    "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
-                },
-                "date_time": {
-                    "point": {
-                        "date": authorDateTime,
-                        "precision": "tz"
-                    }
-                },
-                "identifiers": [
-                    {
-                        "identifier": all.author.npi ? "2.16.840.1.113883.4.6" : all.author.id,
-                        "extension": all.author.npi ? all.author.npi : ''
-                    }
-                ],
-                "name": [
-                    {
-                        "last": all.author.lname,
-                        "first": all.author.fname
-                    }
-                ],
-                "organization": [
-                    {
-                        "identity": [
-                            {
-                                "root": oidFacility || "2.16.840.1.113883.4.6",
-                                "extension": npiFacility || ""
-                            }
-                        ],
-                        "name": [
-                            all.encounter_provider.facility_name
-                        ]
-                    }
-                ]
-            },
+            "author": populateAuthorFromAuthorContainer(pd),
         }
         ]
     }

--- a/ccdaservice/serveccda.js
+++ b/ccdaservice/serveccda.js
@@ -596,38 +596,38 @@ function populateMedication(pd) {
         },
         "author": {
             "code": {
-                "name": all.author.physician_type || '',
-                "code": all.author.physician_type_code || '',
-                "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
+                "name": pd.author.physician_type || '',
+                "code": pd.author.physician_type_code || '',
+                "code_system": pd.author.physician_type_system, "code_system_name": pd.author.physician_type_system_name
             },
             "date_time": {
                 "point": {
-                    "date": authorDateTime,
+                    "date": fDate(pd.author.time),
                     "precision": "tz"
                 }
             },
             "identifiers": [
                 {
-                    "identifier": all.author.npi ? "2.16.840.1.113883.4.6" : all.author.id,
-                    "extension": all.author.npi ? all.author.npi : ''
+                    "identifier": pd.author.npi ? "2.16.840.1.113883.4.6" : pd.author.id,
+                    "extension": pd.author.npi ? pd.author.npi : ''
                 }
             ],
             "name": [
                 {
-                    "last": all.author.lname,
-                    "first": all.author.fname
+                    "last": pd.author.lname,
+                    "first": pd.author.fname
                 }
             ],
             "organization": [
                 {
                     "identity": [
                         {
-                            "root": oidFacility || "2.16.840.1.113883.4.6",
-                            "extension": npiFacility || ""
+                            "root": pd.author.facility_oid || "2.16.840.1.113883.4.6",
+                            "extension": pd.author.facility_npi || ""
                         }
                     ],
                     "name": [
-                        all.encounter_provider.facility_name
+                        pd.author.facility_name
                     ]
                 }
             ]

--- a/ccdaservice/serveccda.js
+++ b/ccdaservice/serveccda.js
@@ -486,6 +486,47 @@ function populateCareTeamMember(provider) {
     }
 }
 
+function populateAuthorFromAuthorContainer(pd) {
+    return {
+        "code": {
+            "name": pd.author.physician_type || '',
+            "code": pd.author.physician_type_code || '',
+            "code_system": pd.author.physician_type_system, "code_system_name": pd.author.physician_type_system_name
+        },
+        "date_time": {
+            "point": {
+                "date": fDate(pd.author.time),
+                "precision": "tz"
+            }
+        },
+        "identifiers": [
+            {
+                "identifier": pd.author.npi ? "2.16.840.1.113883.4.6" : pd.author.id,
+                "extension": pd.author.npi ? pd.author.npi : ''
+            }
+        ],
+        "name": [
+            {
+                "last": pd.author.lname,
+                "first": pd.author.fname
+            }
+        ],
+        "organization": [
+            {
+                "identity": [
+                    {
+                        "root": pd.author.facility_oid || "2.16.840.1.113883.4.6",
+                        "extension": pd.author.facility_npi || ""
+                    }
+                ],
+                "name": [
+                    pd.author.facility_name
+                ]
+            }
+        ]
+    };
+}
+
 function populateCareTeamMembers(pd) {
     let providerArray = [];
     // primary provider
@@ -516,44 +557,8 @@ function populateCareTeamMembers(pd) {
                 "precision": "tz"
             }
         },
-        "author": {
-            "code": {
-                "name": all.author.physician_type || '',
-                "code": all.author.physician_type_code || '',
-                "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
-            },
-            "date_time": {
-                "point": {
-                    "date": authorDateTime,
-                    "precision": "tz"
-                }
-            },
-            "identifiers": [
-                {
-                    "identifier": all.author.npi ? "2.16.840.1.113883.4.6" : all.author.id,
-                    "extension": all.author.npi ? all.author.npi : ''
-                }
-            ],
-            "name": [
-                {
-                    "last": all.author.lname,
-                    "first": all.author.fname
-                }
-            ],
-            "organization": [
-                {
-                    "identity": [
-                        {
-                            "root": oidFacility || "2.16.840.1.113883.4.6",
-                            "extension": npiFacility || ""
-                        }
-                    ],
-                    "name": [
-                        all.encounter_provider.facility_name
-                    ]
-                }
-            ]
-        }
+        // we treat this author a bit differently since we are working at the main pd object instead of the sub pd.care_team
+        "author": populateAuthorFromAuthorContainer(pd.care_team)
     }
 }
 

--- a/ccdaservice/serveccda.js
+++ b/ccdaservice/serveccda.js
@@ -2870,38 +2870,76 @@ function populateSocialHistory(pd) {
         "gender": all.patient.gender,
         "author": {
             "code": {
-                "name": all.author.physician_type || '',
-                "code": all.author.physician_type_code || '',
-                "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
+                "name": pd.author.physician_type || '',
+                "code": pd.author.physician_type_code || '',
+                "code_system": pd.author.physician_type_system, "code_system_name": pd.author.physician_type_system_name
             },
             "date_time": {
                 "point": {
-                    "date": authorDateTime,
+                    "date": fDate(pd.author.time),
                     "precision": "tz"
                 }
             },
             "identifiers": [
                 {
-                    "identifier": all.author.npi ? "2.16.840.1.113883.4.6" : all.author.id,
-                    "extension": all.author.npi ? all.author.npi : ''
+                    "identifier": pd.author.npi ? "2.16.840.1.113883.4.6" : pd.author.id,
+                    "extension": pd.author.npi ? pd.author.npi : ''
                 }
             ],
             "name": [
                 {
-                    "last": all.author.lname,
-                    "first": all.author.fname
+                    "last": pd.author.lname,
+                    "first": pd.author.fname
                 }
             ],
             "organization": [
                 {
                     "identity": [
                         {
-                            "root": oidFacility || "2.16.840.1.113883.4.6",
-                            "extension": npiFacility || ""
+                            "root": pd.author.facility_oid || "2.16.840.1.113883.4.6",
+                            "extension": pd.author.facility_npi || ""
                         }
                     ],
                     "name": [
-                        all.encounter_provider.facility_name
+                        pd.author.facility_name
+                    ]
+                }
+            ]
+        }
+        ,"gender_author": {
+            "code": {
+                "name": all.patient.author.physician_type || '',
+                "code": all.patient.author.physician_type_code || '',
+                "code_system": all.patient.author.physician_type_system, "code_system_name": all.patient.author.physician_type_system_name
+            },
+            "date_time": {
+                "point": {
+                    "date": fDate(all.patient.author.time),
+                    "precision": "tz"
+                }
+            },
+            "identifiers": [
+                {
+                    "identifier": all.patient.author.npi ? "2.16.840.1.113883.4.6" : all.patient.author.id,
+                    "extension": all.patient.author.npi ? all.patient.author.npi : ''
+                }
+            ],
+            "name": [
+                {
+                    "last": all.patient.author.lname,
+                    "first": all.patient.author.fname
+                }
+            ],
+            "organization": [
+                {
+                    "identity": [
+                        {
+                            "root": all.patient.author.facility_oid || "2.16.840.1.113883.4.6",
+                            "extension": all.patient.author.facility_npi || ""
+                        }
+                    ],
+                    "name": [
+                        all.patient.author.facility_name
                     ]
                 }
             ]

--- a/ccdaservice/serveccda.js
+++ b/ccdaservice/serveccda.js
@@ -1624,44 +1624,7 @@ function getPlanOfCare(pd) {
         "status": {
             "code": cleanCode(pd.status)
         },
-        "author": {
-            "code": {
-                "name": all.author.physician_type || '',
-                "code": all.author.physician_type_code || '',
-                "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
-            },
-            "date_time": {
-                "point": {
-                    "date": authorDateTime,
-                    "precision": "tz"
-                }
-            },
-            "identifiers": [
-                {
-                    "identifier": all.author.npi ? "2.16.840.1.113883.4.6" : all.author.id,
-                    "extension": all.author.npi ? all.author.npi : ''
-                }
-            ],
-            "name": [
-                {
-                    "last": all.author.lname,
-                    "first": all.author.fname
-                }
-            ],
-            "organization": [
-                {
-                    "identity": [
-                        {
-                            "root": oidFacility || "2.16.840.1.113883.4.6",
-                            "extension": npiFacility || ""
-                        }
-                    ],
-                    "name": [
-                        all.encounter_provider.facility_name
-                    ]
-                }
-            ]
-        },
+        "author": populateAuthorFromAuthorContainer(pd),
         "performers": [{
             "identifiers": [{
                 "identifier": "2.16.840.1.113883.4.6",
@@ -1750,44 +1713,7 @@ function getGoals(pd) {
         "status": {
             "code": "active", //cleanCode(pd.status)
         },
-        "author": {
-            "code": {
-                "name": all.author.physician_type || '',
-                "code": all.author.physician_type_code || '',
-                "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
-            },
-            "date_time": {
-                "point": {
-                    "date": authorDateTime,
-                    "precision": "tz"
-                }
-            },
-            "identifiers": [
-                {
-                    "identifier": all.author.npi ? "2.16.840.1.113883.4.6" : all.author.id,
-                    "extension": all.author.npi ? all.author.npi : ''
-                }
-            ],
-            "name": [
-                {
-                    "last": all.author.lname,
-                    "first": all.author.fname
-                }
-            ],
-            "organization": [
-                {
-                    "identity": [
-                        {
-                            "root": oidFacility || "2.16.840.1.113883.4.6",
-                            "extension": npiFacility || ""
-                        }
-                    ],
-                    "name": [
-                        all.encounter_provider.facility_name
-                    ]
-                }
-            ]
-        },
+        "author": populateAuthorFromAuthorContainer(pd),
         "name": pd.description
     };
 }
@@ -1959,44 +1885,7 @@ function getHealthConcerns(pd) {
             "code": cleanCode(pd.code) || "",
             "code_system_name": pd.code_type || "SNOMED CT"
         },
-        "author": {
-            "code": {
-                "name": all.author.physician_type || '',
-                "code": all.author.physician_type_code || '',
-                "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
-            },
-            "date_time": {
-                "point": {
-                    "date": authorDateTime,
-                    "precision": "tz"
-                }
-            },
-            "identifiers": [
-                {
-                    "identifier": all.author.npi ? "2.16.840.1.113883.4.6" : all.author.id,
-                    "extension": all.author.npi ? all.author.npi : ''
-                }
-            ],
-            "name": [
-                {
-                    "last": all.author.lname,
-                    "first": all.author.fname
-                }
-            ],
-            "organization": [
-                {
-                    "identity": [
-                        {
-                            "root": oidFacility || "2.16.840.1.113883.4.6",
-                            "extension": npiFacility || ""
-                        }
-                    ],
-                    "name": [
-                        all.encounter_provider.facility_name
-                    ]
-                }
-            ]
-        },
+        "author": populateAuthorFromAuthorContainer(pd),
         "identifiers": [{
             "identifier": pd.sha_extension
         }],

--- a/ccdaservice/serveccda.js
+++ b/ccdaservice/serveccda.js
@@ -2981,38 +2981,38 @@ function populateImmunization(pd) {
         },
         "author": {
             "code": {
-                "name": all.author.physician_type || '',
-                "code": all.author.physician_type_code || '',
-                "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
+                "name": pd.author.physician_type || '',
+                "code": pd.author.physician_type_code || '',
+                "code_system": pd.author.physician_type_system, "code_system_name": pd.author.physician_type_system_name
             },
             "date_time": {
                 "point": {
-                    "date": authorDateTime,
+                    "date": fDate(pd.author.time),
                     "precision": "tz"
                 }
             },
             "identifiers": [
                 {
-                    "identifier": all.author.npi ? "2.16.840.1.113883.4.6" : all.author.id,
-                    "extension": all.author.npi ? all.author.npi : ''
+                    "identifier": pd.author.npi ? "2.16.840.1.113883.4.6" : pd.author.id,
+                    "extension": pd.author.npi ? pd.author.npi : ''
                 }
             ],
             "name": [
                 {
-                    "last": all.author.lname,
-                    "first": all.author.fname
+                    "last": pd.author.lname,
+                    "first": pd.author.fname
                 }
             ],
             "organization": [
                 {
                     "identity": [
                         {
-                            "root": oidFacility || "2.16.840.1.113883.4.6",
-                            "extension": npiFacility || ""
+                            "root": pd.author.facility_oid || "2.16.840.1.113883.4.6",
+                            "extension": pd.author.facility_npi || ""
                         }
                     ],
                     "name": [
-                        all.encounter_provider.facility_name
+                        pd.author.facility_name
                     ]
                 }
             ]

--- a/ccdaservice/serveccda.js
+++ b/ccdaservice/serveccda.js
@@ -972,6 +972,45 @@ function populateEncounter(pd) {
 }
 
 function populateAllergy(pd) {
+    let allergyAuthor = {
+        "code": {
+            "name": pd.author.physician_type || '',
+            "code": pd.author.physician_type_code || '',
+            "code_system": pd.author.physician_type_system, "code_system_name": pd.author.physician_type_system_name
+        },
+        "date_time": {
+            "point": {
+                "date": fDate(pd.author.time),
+                "precision": "tz"
+            }
+        },
+        "identifiers": [
+            {
+                "identifier": pd.author.npi ? "2.16.840.1.113883.4.6" : pd.author.id,
+                "extension": pd.author.npi ? pd.author.npi : ''
+            }
+        ],
+        "name": [
+            {
+                "last": pd.author.lname,
+                "first": pd.author.fname
+            }
+        ],
+        "organization": [
+            {
+                "identity": [
+                    {
+                        "root": pd.author.facility_oid || "2.16.840.1.113883.4.6",
+                        "extension": pd.author.facility_npi || ""
+                    }
+                ],
+                "name": [
+                    pd.author.facility_name
+                ]
+            }
+        ]
+    };
+
     if (!pd) {
         return {
             "no_know_allergies": "No Known Allergies",
@@ -990,87 +1029,13 @@ function populateAllergy(pd) {
             "low": templateDate(pd.startdate, "day"),
             //"high": templateDate(pd.enddate, "day")
         },
-        "author": {
-            "code": {
-                "name": all.author.physician_type || '',
-                "code": all.author.physician_type_code || '',
-                "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
-            },
-            "date_time": {
-                "point": {
-                    "date": authorDateTime,
-                    "precision": "tz"
-                }
-            },
-            "identifiers": [
-                {
-                    "identifier": all.author.npi ? "2.16.840.1.113883.4.6" : all.author.id,
-                    "extension": all.author.npi ? all.author.npi : ''
-                }
-            ],
-            "name": [
-                {
-                    "last": all.author.lname,
-                    "first": all.author.fname
-                }
-            ],
-            "organization": [
-                {
-                    "identity": [
-                        {
-                            "root": oidFacility || "2.16.840.1.113883.4.6",
-                            "extension": npiFacility || ""
-                        }
-                    ],
-                    "name": [
-                        all.encounter_provider.facility_name
-                    ]
-                }
-            ]
-        },
+        "author": allergyAuthor,
         "observation": {
             "identifiers": [{
                 "identifier": pd.sha_extension || "2a620155-9d11-439e-92b3-5d9815ff4ee8",
                 "extension": pd.id + 1 || ""
             }],
-            "author": {
-                "code": {
-                    "name": all.author.physician_type || '',
-                    "code": all.author.physician_type_code || '',
-                    "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
-                },
-                "date_time": {
-                    "point": {
-                        "date": authorDateTime,
-                        "precision": "tz"
-                    }
-                },
-                "identifiers": [
-                    {
-                        "identifier": all.author.npi ? "2.16.840.1.113883.4.6" : all.author.id,
-                        "extension": all.author.npi ? all.author.npi : ''
-                    }
-                ],
-                "name": [
-                    {
-                        "last": all.author.lname,
-                        "first": all.author.fname
-                    }
-                ],
-                "organization": [
-                    {
-                        "identity": [
-                            {
-                                "root": oidFacility || "2.16.840.1.113883.4.6",
-                                "extension": npiFacility || ""
-                            }
-                        ],
-                        "name": [
-                            all.encounter_provider.facility_name
-                        ]
-                    }
-                ]
-            },
+            "author": allergyAuthor,
             "allergen": {
                 "name": pd.title || "",
                 "code": pd.rxnorm_code_text ? cleanCode(pd.rxnorm_code) : pd.snomed_code_text ? cleanCode(pd.snomed_code) : cleanCode(""),
@@ -1386,38 +1351,38 @@ function populateMedicalDevice(pd) {
         },
         "author": {
             "code": {
-                "name": all.author.physician_type || '',
-                "code": all.author.physician_type_code || '',
-                "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
+                "name": pd.author.physician_type || '',
+                "code": pd.author.physician_type_code || '',
+                "code_system": pd.author.physician_type_system, "code_system_name": pd.author.physician_type_system_name
             },
             "date_time": {
                 "point": {
-                    "date": authorDateTime,
+                    "date": fDate(pd.author.time),
                     "precision": "tz"
                 }
             },
             "identifiers": [
                 {
-                    "identifier": all.author.npi ? "2.16.840.1.113883.4.6" : all.author.id,
-                    "extension": all.author.npi ? all.author.npi : ''
+                    "identifier": pd.author.npi ? "2.16.840.1.113883.4.6" : pd.author.id,
+                    "extension": pd.author.npi ? pd.author.npi : ''
                 }
             ],
             "name": [
                 {
-                    "last": all.author.lname,
-                    "first": all.author.fname
+                    "last": pd.author.lname,
+                    "first": pd.author.fname
                 }
             ],
             "organization": [
                 {
                     "identity": [
                         {
-                            "root": oidFacility || "2.16.840.1.113883.4.6",
-                            "extension": npiFacility || ""
+                            "root": pd.author.facility_oid || "2.16.840.1.113883.4.6",
+                            "extension": pd.author.facility_npi || ""
                         }
                     ],
                     "name": [
-                        all.encounter_provider.facility_name
+                        pd.author.facility_name
                     ]
                 }
             ]

--- a/ccdaservice/serveccda.js
+++ b/ccdaservice/serveccda.js
@@ -520,7 +520,7 @@ function populateCareTeamMembers(pd) {
             "code": {
                 "name": all.author.physician_type || '',
                 "code": all.author.physician_type_code || '',
-                "code_system_name": "SNOMED CT"
+                "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
             },
             "date_time": {
                 "point": {
@@ -598,7 +598,7 @@ function populateMedication(pd) {
             "code": {
                 "name": all.author.physician_type || '',
                 "code": all.author.physician_type_code || '',
-                "code_system_name": "SNOMED CT"
+                "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
             },
             "date_time": {
                 "point": {
@@ -667,7 +667,7 @@ function populateMedication(pd) {
                 "code": {
                     "name": all.author.physician_type || '',
                     "code": all.author.physician_type_code || '',
-                    "code_system_name": "SNOMED CT"
+                    "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
                 },
                 "date_time": {
                     "point": {
@@ -933,7 +933,7 @@ function populateEncounter(pd) {
                 "code": {
                     "name": all.author.physician_type || '',
                     "code": all.author.physician_type_code || '',
-                    "code_system_name": "SNOMED CT"
+                    "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
                 },
                 "date_time": {
                     "point": {
@@ -994,7 +994,7 @@ function populateAllergy(pd) {
             "code": {
                 "name": all.author.physician_type || '',
                 "code": all.author.physician_type_code || '',
-                "code_system_name": "SNOMED CT"
+                "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
             },
             "date_time": {
                 "point": {
@@ -1037,7 +1037,7 @@ function populateAllergy(pd) {
                 "code": {
                     "name": all.author.physician_type || '',
                     "code": all.author.physician_type_code || '',
-                    "code_system_name": "SNOMED CT"
+                    "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
                 },
                 "date_time": {
                     "point": {
@@ -1166,7 +1166,7 @@ function populateProblem(pd) {
             "code": {
                 "name": all.author.physician_type || '',
                 "code": all.author.physician_type_code || '',
-                "code_system_name": "SNOMED CT"
+                "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
             },
             "date_time": {
                 "point": {
@@ -1313,7 +1313,7 @@ function populateProcedure(pd) {
             "code": {
                 "name": all.author.physician_type || '',
                 "code": all.author.physician_type_code || '',
-                "code_system_name": "SNOMED CT"
+                "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
             },
             "date_time": {
                 "point": {
@@ -1388,7 +1388,7 @@ function populateMedicalDevice(pd) {
             "code": {
                 "name": all.author.physician_type || '',
                 "code": all.author.physician_type_code || '',
-                "code_system_name": "SNOMED CT"
+                "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
             },
             "date_time": {
                 "point": {
@@ -1497,7 +1497,7 @@ function getResultSet(results) {
             "code": {
                 "name": all.author.physician_type || '',
                 "code": all.author.physician_type_code || '',
-                "code_system_name": "SNOMED CT"
+                "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
             },
             "date_time": {
                 "point": {
@@ -1657,7 +1657,7 @@ function getPlanOfCare(pd) {
             "code": {
                 "name": all.author.physician_type || '',
                 "code": all.author.physician_type_code || '',
-                "code_system_name": "SNOMED CT"
+                "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
             },
             "date_time": {
                 "point": {
@@ -1783,7 +1783,7 @@ function getGoals(pd) {
             "code": {
                 "name": all.author.physician_type || '',
                 "code": all.author.physician_type_code || '',
-                "code_system_name": "SNOMED CT"
+                "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
             },
             "date_time": {
                 "point": {
@@ -1826,7 +1826,7 @@ function getFunctionalStatus(pd) {
         "code": {
             "name": all.author.physician_type || '',
                 "code": all.author.physician_type_code || '',
-                "code_system_name": "SNOMED CT"
+                "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
         },
         "date_time": {
             "point": {
@@ -1908,7 +1908,7 @@ function getMentalStatus(pd) {
             "code": {
                 "name": all.author.physician_type || '',
                 "code": all.author.physician_type_code || '',
-                "code_system_name": "SNOMED CT"
+                "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
             },
             "date_time": {
                 "point": {
@@ -1952,7 +1952,7 @@ function getAssessments(pd) {
             "code": {
                 "name": all.author.physician_type || '',
                 "code": all.author.physician_type_code || '',
-                "code_system_name": "SNOMED CT"
+                "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
             },
             "date_time": {
                 "point": {
@@ -2029,7 +2029,7 @@ function getHealthConcerns(pd) {
             "code": {
                 "name": all.author.physician_type || '',
                 "code": all.author.physician_type_code || '',
-                "code_system_name": "SNOMED CT"
+                "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
             },
             "date_time": {
                 "point": {
@@ -2077,7 +2077,7 @@ function getReferralReason(pd) {
             "code": {
                 "name": all.author.physician_type || '',
                 "code": all.author.physician_type_code || '',
-                "code_system_name": "SNOMED CT"
+                "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
             },
             "date_time": {
                 "point": {
@@ -2152,7 +2152,7 @@ function populateVital(pd) {
                 "code": {
                     "name": all.author.physician_type || '',
                     "code": all.author.physician_type_code || '',
-                    "code_system_name": "SNOMED CT"
+                    "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
                 },
                 "date_time": {
                     "point": {
@@ -2210,7 +2210,7 @@ function populateVital(pd) {
                 "code": {
                     "name": all.author.physician_type || '',
                     "code": all.author.physician_type_code || '',
-                    "code_system_name": "SNOMED CT"
+                    "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
                 },
                 "date_time": {
                     "point": {
@@ -2268,7 +2268,7 @@ function populateVital(pd) {
                 "code": {
                     "name": all.author.physician_type || '',
                     "code": all.author.physician_type_code || '',
-                    "code_system_name": "SNOMED CT"
+                    "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
                 },
                 "date_time": {
                     "point": {
@@ -2326,7 +2326,7 @@ function populateVital(pd) {
                 "code": {
                     "name": all.author.physician_type || '',
                     "code": all.author.physician_type_code || '',
-                    "code_system_name": "SNOMED CT"
+                    "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
                 },
                 "date_time": {
                     "point": {
@@ -2384,7 +2384,7 @@ function populateVital(pd) {
                 "code": {
                     "name": all.author.physician_type || '',
                     "code": all.author.physician_type_code || '',
-                    "code_system_name": "SNOMED CT"
+                    "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
                 },
                 "date_time": {
                     "point": {
@@ -2442,7 +2442,7 @@ function populateVital(pd) {
                 "code": {
                     "name": all.author.physician_type || '',
                     "code": all.author.physician_type_code || '',
-                    "code_system_name": "SNOMED CT"
+                    "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
                 },
                 "date_time": {
                     "point": {
@@ -2500,7 +2500,7 @@ function populateVital(pd) {
                 "code": {
                     "name": all.author.physician_type || '',
                     "code": all.author.physician_type_code || '',
-                    "code_system_name": "SNOMED CT"
+                    "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
                 },
                 "date_time": {
                     "point": {
@@ -2558,7 +2558,7 @@ function populateVital(pd) {
                 "code": {
                     "name": all.author.physician_type || '',
                     "code": all.author.physician_type_code || '',
-                    "code_system_name": "SNOMED CT"
+                    "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
                 },
                 "date_time": {
                     "point": {
@@ -2616,7 +2616,7 @@ function populateVital(pd) {
                 "code": {
                     "name": all.author.physician_type || '',
                     "code": all.author.physician_type_code || '',
-                    "code_system_name": "SNOMED CT"
+                    "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
                 },
                 "date_time": {
                     "point": {
@@ -2674,7 +2674,7 @@ function populateVital(pd) {
                 "code": {
                     "name": all.author.physician_type || '',
                     "code": all.author.physician_type_code || '',
-                    "code_system_name": "SNOMED CT"
+                    "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
                 },
                 "date_time": {
                     "point": {
@@ -2732,7 +2732,7 @@ function populateVital(pd) {
                 "code": {
                     "name": all.author.physician_type || '',
                     "code": all.author.physician_type_code || '',
-                    "code_system_name": "SNOMED CT"
+                    "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
                 },
                 "date_time": {
                     "point": {
@@ -2790,7 +2790,7 @@ function populateVital(pd) {
                 "code": {
                     "name": all.author.physician_type || '',
                     "code": all.author.physician_type_code || '',
-                    "code_system_name": "SNOMED CT"
+                    "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
                 },
                 "date_time": {
                     "point": {
@@ -2848,7 +2848,7 @@ function populateVital(pd) {
                 "code": {
                     "name": all.author.physician_type || '',
                     "code": all.author.physician_type_code || '',
-                    "code_system_name": "SNOMED CT"
+                    "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
                 },
                 "date_time": {
                     "point": {
@@ -2907,7 +2907,7 @@ function populateSocialHistory(pd) {
             "code": {
                 "name": all.author.physician_type || '',
                 "code": all.author.physician_type_code || '',
-                "code_system_name": "SNOMED CT"
+                "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
             },
             "date_time": {
                 "point": {
@@ -3018,7 +3018,7 @@ function populateImmunization(pd) {
             "code": {
                 "name": all.author.physician_type || '',
                 "code": all.author.physician_type_code || '',
-                "code_system_name": "SNOMED CT"
+                "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
             },
             "date_time": {
                 "point": {
@@ -3329,7 +3329,7 @@ function populateHeader(pd) {
             "code": {
                 "name": all.author.physician_type || '',
                 "code": all.author.physician_type_code || '',
-                "code_system_name": "SNOMED CT"
+                "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
             },
             "date_time": {
                 "point": {

--- a/ccdaservice/serveccda.js
+++ b/ccdaservice/serveccda.js
@@ -977,6 +977,16 @@ function populateEncounter(pd) {
 }
 
 function populateAllergy(pd) {
+    
+    if (!pd) {
+        return {
+            "no_know_allergies": "No Known Allergies",
+            "date_time": {
+                "low": templateDate("", "day"),
+                //"high": templateDate(pd.enddate, "day")
+            }
+        }
+    }
     let allergyAuthor = {
         "code": {
             "name": pd.author.physician_type || '',
@@ -1016,15 +1026,6 @@ function populateAllergy(pd) {
         ]
     };
 
-    if (!pd) {
-        return {
-            "no_know_allergies": "No Known Allergies",
-            "date_time": {
-                "low": templateDate("", "day"),
-                //"high": templateDate(pd.enddate, "day")
-            }
-        }
-    }
     return {
         "identifiers": [{
             "identifier": pd.sha_id,

--- a/ccdaservice/serveccda.js
+++ b/ccdaservice/serveccda.js
@@ -1164,38 +1164,38 @@ function populateProblem(pd) {
         },
         "author": {
             "code": {
-                "name": all.author.physician_type || '',
-                "code": all.author.physician_type_code || '',
-                "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
+                "name": pd.author.physician_type || '',
+                "code": pd.author.physician_type_code || '',
+                "code_system": pd.author.physician_type_system, "code_system_name": pd.author.physician_type_system_name
             },
             "date_time": {
                 "point": {
-                    "date": authorDateTime,
+                    "date": fDate(pd.author.time),
                     "precision": "tz"
                 }
             },
             "identifiers": [
                 {
-                    "identifier": all.author.npi ? "2.16.840.1.113883.4.6" : all.author.id,
-                    "extension": all.author.npi ? all.author.npi : ''
+                    "identifier": pd.author.npi ? "2.16.840.1.113883.4.6" : pd.author.id,
+                    "extension": pd.author.npi ? pd.author.npi : ''
                 }
             ],
             "name": [
                 {
-                    "last": all.author.lname,
-                    "first": all.author.fname
+                    "last": pd.author.lname,
+                    "first": pd.author.fname
                 }
             ],
             "organization": [
                 {
                     "identity": [
                         {
-                            "root": oidFacility || "2.16.840.1.113883.4.6",
-                            "extension": npiFacility || ""
+                            "root": pd.author.facility_oid || "2.16.840.1.113883.4.6",
+                            "extension": pd.author.facility_npi || ""
                         }
                     ],
                     "name": [
-                        all.encounter_provider.facility_name
+                        pd.author.facility_name
                     ]
                 }
             ]

--- a/ccdaservice/serveccda.js
+++ b/ccdaservice/serveccda.js
@@ -1420,50 +1420,14 @@ function getResultSet(results) {
 
     if (!results) return '';
 
+    // not sure if the result set should be grouped better on the backend as the author information needs to be more nuanced here
     let tResult = results.result[0] || results.result;
     var resultSet = {
         "identifiers": [{
             "identifier": tResult.root,
             "extension": tResult.extension
         }],
-        "author": [{
-            "code": {
-                "name": all.author.physician_type || '',
-                "code": all.author.physician_type_code || '',
-                "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
-            },
-            "date_time": {
-                "point": {
-                    "date": authorDateTime,
-                    "precision": "tz"
-                }
-            },
-            "identifiers": [
-                {
-                    "identifier": all.author.npi ? "2.16.840.1.113883.4.6" : all.author.id,
-                    "extension": all.author.npi ? all.author.npi : ''
-                }
-            ],
-            "name": [
-                {
-                    "last": all.author.lname,
-                    "first": all.author.fname
-                }
-            ],
-            "organization": [
-                {
-                    "identity": [
-                        {
-                            "root": oidFacility || "2.16.840.1.113883.4.6",
-                            "extension": npiFacility || ""
-                        }
-                    ],
-                    "name": [
-                        all.encounter_provider.facility_name
-                    ]
-                }
-            ]
-        }],
+        "author": populateAuthorFromAuthorContainer(tResult),
         "result_set": {
             "name": tResult.test_name,
             "code": cleanCode(tResult.test_code),

--- a/ccdaservice/serveccda.js
+++ b/ccdaservice/serveccda.js
@@ -1279,45 +1279,7 @@ function populateProcedure(pd) {
                 }]
             }]
         }],
-        // TODO: how do we handle external organization references?
-        "author": {
-            "code": {
-                "name": all.author.physician_type || '',
-                "code": all.author.physician_type_code || '',
-                "code_system": all.author.physician_type_system, "code_system_name": all.author.physician_type_system_name
-            },
-            "date_time": {
-                "point": {
-                    "date": authorDateTime,
-                    "precision": "tz"
-                }
-            },
-            "identifiers": [
-                {
-                    "identifier": all.author.npi ? "2.16.840.1.113883.4.6" : all.author.id,
-                    "extension": all.author.npi ? all.author.npi : ''
-                }
-            ],
-            "name": [
-                {
-                    "last": all.author.lname,
-                    "first": all.author.fname
-                }
-            ],
-            "organization": [
-                {
-                    "identity": [
-                        {
-                            "root": oidFacility || "2.16.840.1.113883.4.6",
-                            "extension": npiFacility || ""
-                        }
-                    ],
-                    "name": [
-                        all.encounter_provider.facility_name
-                    ]
-                }
-            ]
-        },
+        "author": populateAuthorFromAuthorContainer(pd),
         "procedure_type": "procedure"
     };
 }

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaServiceRequestModelGenerator.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaServiceRequestModelGenerator.php
@@ -248,7 +248,7 @@ class CcdaServiceRequestModelGenerator
         }
 
         if (in_array('plan_of_care', $components_list)) {
-            $ccd .= $this->getEncounterccdadispatchTable()->getPlanOfCare($pid);
+            $ccd .= $this->getEncounterccdadispatchTable()->getPlanOfCare($pid, $encounter);
         }
 
         if (in_array('functional_status', $components_list)) {

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaServiceRequestModelGenerator.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaServiceRequestModelGenerator.php
@@ -181,7 +181,7 @@ class CcdaServiceRequestModelGenerator
         }
 
         if (in_array('continuity_care_document', $sections_list)) {
-            $this->data .= $this->getContinuityCareDocument($pid, $components_list);
+            $this->data .= $this->getContinuityCareDocument($pid, $components_list, $encounter);
         }
 
         // we're sending everything anyway. document type will tell engine what to include in cda.
@@ -236,7 +236,7 @@ class CcdaServiceRequestModelGenerator
         }
 
         if (in_array('procedures', $components_list)) {
-            $ccd .= $this->getEncounterccdadispatchTable()->getProcedures($pid);
+            $ccd .= $this->getEncounterccdadispatchTable()->getProcedures($pid, $encounter);
         }
 
         if (in_array('results', $components_list)) {

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaServiceRequestModelGenerator.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaServiceRequestModelGenerator.php
@@ -220,7 +220,7 @@ class CcdaServiceRequestModelGenerator
         $this->data .= "</CCDA>";
     }
 
-    public function getContinuityCareDocument($pid, $components_list)
+    public function getContinuityCareDocument($pid, $components_list, $encounter)
     {
         $ccd = '';
         if (in_array('allergies', $components_list)) {
@@ -240,7 +240,7 @@ class CcdaServiceRequestModelGenerator
         }
 
         if (in_array('results', $components_list)) {
-            $ccd .= $this->getEncounterccdadispatchTable()->getResults($pid);
+            $ccd .= $this->getEncounterccdadispatchTable()->getResults($pid, $encounter);
         }
 
         if (in_array('immunizations', $components_list)) {

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncounterccdadispatchTable.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncounterccdadispatchTable.php
@@ -1292,6 +1292,7 @@ class EncounterccdadispatchTable extends AbstractTableGateway
             DATE_FORMAT(administered_date,'%Y%m%d') AS administered_formatted, lo.title as route_of_administration,
             u.title, u.fname, u.mname, u.lname, u.npi, u.street, u.streetb, u.city, u.state, u.zip, u.phonew1,
             f.name, f.phone, SUBSTRING(lo.codes, LOCATE(':',lo.codes)+1, LENGTH(lo.codes)) AS route_code
+            , im.updated_by AS provenance_updated_by, im.update_date
             FROM immunizations AS im
             LEFT JOIN codes AS cd ON cd.code = im.cvx_code
             JOIN code_types AS ctype ON ctype.ct_key = 'CVX' AND ctype.ct_id=cd.code_type
@@ -1304,8 +1305,14 @@ class EncounterccdadispatchTable extends AbstractTableGateway
 
         $immunizations .= '<immunizations>';
         foreach ($res as $row) {
+            $provenanceRecord = [
+                'author_id' => $row['provenance_updated_by']
+                ,'time' => $row['update_date']
+            ];
+            $provenanceXml = $this->getAuthorXmlForRecord($provenanceRecord, $pid, null);
+
             $immunizations .= "
-        <immunization>
+        <immunization>" . $provenanceXml . "
         <extension>" . xmlEscape(base64_encode($_SESSION['site_id'] . $row['id'])) . "</extension>
         <sha_extension>" . xmlEscape("e6f1ba43-c0ed-4b9b-9f12-f435d8ad8f92") . "</sha_extension>
         <id>" . xmlEscape($row['id']) . "</id>

--- a/interface/modules/zend_modules/module/Installer/src/Installer/Model/InstModuleTable.php
+++ b/interface/modules/zend_modules/module/Installer/src/Installer/Model/InstModuleTable.php
@@ -213,23 +213,28 @@ class InstModuleTable
             $fieldName,
             $moduleId,
         );
+        $createdBy = $_SESSION['authUserID'];
+        $updatedBy = $_SESSION['authUserID'];
         $result = $this->applicationTable->zQuery($sql, $params);
         if ($result->count() > 0) {
-            $sql = "UPDATE module_configuration SET field_value = ?
+            $sql = "UPDATE module_configuration SET field_value = ?, updated_by = ?
                                           WHERE module_id = ?
                                           AND field_name = ?";
             $params = array(
                 $fieldValue,
+                $updatedBy,
                 $moduleId,
                 $fieldName,
             );
             $result = $this->applicationTable->zQuery($sql, $params);
         } else {
-            $sql = "INSERT INTO module_configuration SET field_name = ?, field_value = ?, module_id = ?";
+            $sql = "INSERT INTO module_configuration SET field_name = ?, field_value = ?, module_id = ?, updated_by = ?, created_by = ?, date_created=NOW()";
             $params = array(
                 $fieldName,
                 $fieldValue,
                 $moduleId,
+                $updatedBy,
+                $createdBy
             );
             $result = $this->applicationTable->zQuery($sql, $params);
         }

--- a/library/classes/Prescription.class.php
+++ b/library/classes/Prescription.class.php
@@ -145,6 +145,10 @@ class Prescription extends ORDataObject
 
     var $encounter;
 
+    var $created_by;
+
+    var $updated_by;
+
     /**
     * Constructor sets all Prescription attributes to their default value
     */
@@ -178,11 +182,14 @@ class Prescription extends ORDataObject
             $this->_table = "prescriptions";
             $this->pharmacy = new Pharmacy();
             $this->pharmacist = new Person();
+            // default provider is the current user
             $this->provider = new Provider($_SESSION['authUserID']);
             $this->patient = new Patient();
             $this->start_date = date("Y-m-d");
-            $this->date_added = date("Y-m-d");
-            $this->date_modified = date("Y-m-d");
+            $this->date_added = date("Y-m-d H:i:s");
+            $this->date_modified = date("Y-m-d H:i:s");
+            $this->created_by = $_SESSION['authUserID'];
+            $this->updated_by = $_SESSION['authUserID'];
             $this->per_refill = 0;
             $this->note = "";
 
@@ -202,9 +209,9 @@ class Prescription extends ORDataObject
 
     function persist()
     {
-        $this->date_modified = date("Y-m-d");
+        $this->date_modified = date("Y-m-d H:i:s");
         if ($this->id == "") {
-            $this->date_added = date("Y-m-d");
+            $this->date_added = date("Y-m-d H:i:s");
         }
 
         if (parent::persist()) {
@@ -214,6 +221,13 @@ class Prescription extends ORDataObject
     function populate()
     {
         parent::populate();
+        // for old historical data we are going to populate our created_by and updated_by
+        if (empty($this->created_by)) {
+            $this->created_by = $this->get_provider_id();
+        }
+        if (empty($this->updated_by)) {
+            $this->updated_by = $this->get_provider_id();
+        }
     }
 
     function toString($html = false)
@@ -468,6 +482,28 @@ class Prescription extends ORDataObject
     function get_provider_id()
     {
         return $this->provider->id;
+    }
+
+    function set_created_by($id)
+    {
+        if (is_numeric($id)) {
+            $this->created_by = $id;
+        }
+    }
+    function get_created_by()
+    {
+        return $this->created_by;
+    }
+
+    function set_updated_by($id)
+    {
+        if (is_numeric($id)) {
+            $this->updated_by = $id;
+        }
+    }
+    function get_updated_by()
+    {
+        return $this->updated_by;
     }
 
     function set_provider($pobj)

--- a/sql/6_1_0-to-7_0_0_upgrade.sql
+++ b/sql/6_1_0-to-7_0_0_upgrade.sql
@@ -983,3 +983,13 @@ ALTER TABLE prescriptions ADD COLUMN created_by BIGINT(20) DEFAULT NULL COMMENT 
 #IfMissingColumn prescriptions updated_by
 ALTER TABLE prescriptions ADD COLUMN updated_by BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that last modified this record';
 #EndIf
+
+#IfMissingColumn module_configuration created_by
+ALTER TABLE module_configuration ADD COLUMN created_by BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that first created this record';
+ALTER TABLE `module_configuration` ADD COLUMN `date_added` DATETIME DEFAULT NULL COMMENT 'Datetime the record was initially created';
+#EndIf
+
+#IfMissingColumn module_configuration updated_by
+ALTER TABLE module_configuration ADD COLUMN updated_by BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that last modified this record';
+ALTER TABLE `module_configuration` ADD COLUMN `date_modified` DATETIME DEFAULT CURRENT_TIMESTAMP COMMENT 'Datetime the record was last modified';
+#EndIf

--- a/sql/6_1_0-to-7_0_0_upgrade.sql
+++ b/sql/6_1_0-to-7_0_0_upgrade.sql
@@ -967,3 +967,19 @@ ALTER TABLE patient_data ADD COLUMN updated_by BIGINT(20) DEFAULT NULL COMMENT '
 #IfMissingColumn patient_history created_by
 ALTER TABLE patient_history ADD COLUMN created_by BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that first created this record';
 #EndIf
+
+#IfNotColumnType prescriptions date_modified DATETIME
+ALTER TABLE `prescriptions` CHANGE COLUMN `date_modified` `date_modified` DATETIME DEFAULT NULL COMMENT 'Datetime the prescriptions was last modified';
+#EndIf
+
+#IfNotColumnType prescriptions date_added DATETIME
+ALTER TABLE `prescriptions` CHANGE COLUMN `date_added` `date_added` DATETIME DEFAULT NULL COMMENT 'Datetime the prescriptions was initially created';
+#EndIf
+
+#IfMissingColumn prescriptions created_by
+ALTER TABLE prescriptions ADD COLUMN created_by BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that first created this record';
+#EndIf
+
+#IfMissingColumn prescriptions updated_by
+ALTER TABLE prescriptions ADD COLUMN updated_by BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that last modified this record';
+#EndIf

--- a/sql/6_1_0-to-7_0_0_upgrade.sql
+++ b/sql/6_1_0-to-7_0_0_upgrade.sql
@@ -947,3 +947,23 @@ UPDATE list_options SET option_id='20' WHERE list_id='drug_interval' AND option_
 INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('drug_interval','19','Weekly',19,0,1);
 INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUES ('drug_interval','20','Monthly',20,0,1);
 #EndIf
+
+#IfMissingColumn history_data created_by
+ALTER TABLE history_data ADD COLUMN created_by BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that first created this record';
+#EndIf
+
+#IfMissingColumn patient_data created_by
+ALTER TABLE patient_data ADD COLUMN created_by BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that first created this record';
+#EndIf
+
+#IfNotColumnType patient_data regdate DATETIME
+ALTER TABLE `patient_data` CHANGE COLUMN `regdate` `regdate` DATETIME DEFAULT NULL COMMENT 'Registration Date';
+#EndIf
+
+#IfMissingColumn patient_data updated_by
+ALTER TABLE patient_data ADD COLUMN updated_by BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that last modified this record';
+#EndIf
+
+#IfMissingColumn patient_history created_by
+ALTER TABLE patient_history ADD COLUMN created_by BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that first created this record';
+#EndIf

--- a/sql/6_1_0-to-7_0_0_upgrade.sql
+++ b/sql/6_1_0-to-7_0_0_upgrade.sql
@@ -949,11 +949,11 @@ INSERT INTO list_options (list_id,option_id,title,seq,is_default,activity) VALUE
 #EndIf
 
 #IfMissingColumn history_data created_by
-ALTER TABLE history_data ADD COLUMN created_by BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that first created this record';
+ALTER TABLE history_data ADD COLUMN `created_by` BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that first created this record';
 #EndIf
 
 #IfMissingColumn patient_data created_by
-ALTER TABLE patient_data ADD COLUMN created_by BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that first created this record';
+ALTER TABLE patient_data ADD COLUMN `created_by` BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that first created this record';
 #EndIf
 
 #IfNotColumnType patient_data regdate DATETIME
@@ -961,11 +961,11 @@ ALTER TABLE `patient_data` CHANGE COLUMN `regdate` `regdate` DATETIME DEFAULT NU
 #EndIf
 
 #IfMissingColumn patient_data updated_by
-ALTER TABLE patient_data ADD COLUMN updated_by BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that last modified this record';
+ALTER TABLE patient_data ADD COLUMN `updated_by` BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that last modified this record';
 #EndIf
 
 #IfMissingColumn patient_history created_by
-ALTER TABLE patient_history ADD COLUMN created_by BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that first created this record';
+ALTER TABLE patient_history ADD COLUMN `created_by` BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that first created this record';
 #EndIf
 
 #IfNotColumnType prescriptions date_modified DATETIME
@@ -977,19 +977,19 @@ ALTER TABLE `prescriptions` CHANGE COLUMN `date_added` `date_added` DATETIME DEF
 #EndIf
 
 #IfMissingColumn prescriptions created_by
-ALTER TABLE prescriptions ADD COLUMN created_by BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that first created this record';
+ALTER TABLE prescriptions ADD COLUMN `created_by` BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that first created this record';
 #EndIf
 
 #IfMissingColumn prescriptions updated_by
-ALTER TABLE prescriptions ADD COLUMN updated_by BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that last modified this record';
+ALTER TABLE prescriptions ADD COLUMN `updated_by` BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that last modified this record';
 #EndIf
 
 #IfMissingColumn module_configuration created_by
-ALTER TABLE module_configuration ADD COLUMN created_by BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that first created this record';
+ALTER TABLE module_configuration ADD COLUMN `created_by` BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that first created this record';
 ALTER TABLE `module_configuration` ADD COLUMN `date_added` DATETIME DEFAULT NULL COMMENT 'Datetime the record was initially created';
 #EndIf
 
 #IfMissingColumn module_configuration updated_by
-ALTER TABLE module_configuration ADD COLUMN updated_by BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that last modified this record';
+ALTER TABLE module_configuration ADD COLUMN `updated_by` BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that last modified this record';
 ALTER TABLE `module_configuration` ADD COLUMN `date_modified` DATETIME DEFAULT CURRENT_TIMESTAMP COMMENT 'Datetime the record was last modified';
 #EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -2829,6 +2829,7 @@ CREATE TABLE `history_data` (
   `userdate15` date DEFAULT NULL,
   `userarea11` text,
   `userarea12` text,
+  `created_by` BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that first created this record',
   PRIMARY KEY  (`id`),
   KEY `pid` (`pid`),
   UNIQUE KEY `uuid` (`uuid`)
@@ -6913,6 +6914,10 @@ CREATE TABLE `module_configuration` (
   `module_id` int(10) unsigned NOT NULL,
   `field_name` varchar(45) NOT NULL,
   `field_value` varchar(255) NOT NULL,
+  `created_by` BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that first created this record',
+  `date_added` DATETIME DEFAULT NULL COMMENT 'Datetime the record was initially created',
+  `updated_by` BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that last modified this record',
+  `date_modified` DATETIME DEFAULT CURRENT_TIMESTAMP COMMENT 'Datetime the record was last modified',
   PRIMARY KEY (`module_config_id`)
 ) ENGINE=InnoDB;
 
@@ -7410,7 +7415,7 @@ CREATE TABLE `patient_data` (
   `userlist6` varchar(255) NOT NULL DEFAULT '',
   `userlist7` varchar(255) NOT NULL DEFAULT '',
   `pricelevel` varchar(255) NOT NULL default 'standard',
-  `regdate`     date DEFAULT NULL COMMENT 'Registration Date',
+  `regdate`     DATETIME DEFAULT NULL COMMENT 'Registration Date',
   `contrastart` date DEFAULT NULL COMMENT 'Date contraceptives initially used',
   `completed_ad` VARCHAR(3) NOT NULL DEFAULT 'NO',
   `ad_reviewed` date DEFAULT NULL,
@@ -7458,6 +7463,8 @@ CREATE TABLE `patient_data` (
   `patient_groups` TEXT,
   `prevent_portal_apps` TEXT,
   `provider_since_date` TINYTEXT,
+  `created_by` BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that first created this record',
+  `updated_by` BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that last modified this record',
   UNIQUE KEY `pid` (`pid`),
   UNIQUE KEY `uuid` (`uuid`),
   KEY `id` (`id`)
@@ -7481,6 +7488,7 @@ CREATE TABLE `patient_history` (
     , `previous_name_last` TEXT
     , `previous_name_suffix` TEXT
     , `previous_name_enddate` date DEFAULT NULL
+    ,`created_by` BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that first created this record'
     , PRIMARY KEY (`id`)
     , UNIQUE `uuid` (`uuid`)
     , KEY `pid_idx` (`pid`)
@@ -7692,8 +7700,8 @@ CREATE TABLE `prescriptions` (
   `patient_id` bigint(20) default NULL,
   `filled_by_id` int(11) default NULL,
   `pharmacy_id` int(11) default NULL,
-  `date_added` date default NULL,
-  `date_modified` date default NULL,
+  `date_added` DATETIME DEFAULT NULL COMMENT 'Datetime the prescriptions was initially created',
+  `date_modified` DATETIME DEFAULT NULL COMMENT 'Datetime the prescriptions was last modified',
   `provider_id` int(11) default NULL,
   `encounter` int(11) default NULL,
   `start_date` date default NULL,
@@ -7733,6 +7741,8 @@ CREATE TABLE `prescriptions` (
   `request_intent` VARCHAR(100) NULL COMMENT 'option_id in list_options.list_id=medication-request-intent',
   `request_intent_title` VARCHAR(255) NOT NULL COMMENT 'title in list_options.list_id=medication-request-intent',
   `drug_dosage_instructions` longtext COMMENT 'Medication dosage instructions',
+  `created_by` BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that first created this record',
+  `updated_by` BIGINT(20) DEFAULT NULL COMMENT 'users.id the user that last modified this record',
   PRIMARY KEY  (`id`),
   KEY `patient_id` (`patient_id`),
   UNIQUE INDEX `uuid` (`uuid`)

--- a/src/Services/CareTeamService.php
+++ b/src/Services/CareTeamService.php
@@ -235,9 +235,13 @@ class CareTeamService extends BaseService
 
     public function createCareTeamHistory($pid, $oldProviders, $oldFacilities)
     {
+        // we should never be null here but for legacy reasons we are going to default to this
+        $createdBy = $_SESSION['authUserID'] ?? null; // we don't let anyone else but the current user be the createdBy
+
         $insertData = [
             'pid' => $pid, 'care_team_provider' => $oldProviders, 'care_team_facility' => $oldFacilities,
             'history_type_key' => 'care_team_history',
+            'created_by' => $createdBy,
             'uuid' => UuidRegistry::getRegistryForTable(self::PATIENT_HISTORY_TABLE)->createUuid()
         ];
         $insert = $this->buildInsertColumns($insertData);

--- a/src/Services/CodeTypesService.php
+++ b/src/Services/CodeTypesService.php
@@ -33,6 +33,7 @@ class CodeTypesService
     const CODE_TYPE_ICD10PCS = 'ICD10PCS';
     const CODE_TYPE_CPT = 'CPT';
     const CODE_TYPE_CVX = 'CVX';
+    const CODE_TYPE_OID_HEALTHCARE_PROVIDER_TAXONOMY = "2.16.840.1.114222.4.11.1066";
     const CODE_TYPE_OID = array(
         '2.16.840.1.113883.6.96' => self::CODE_TYPE_SNOMED_CT,
         '2.16.840.1.113883.6.12' => self::CODE_TYPE_CPT4,
@@ -66,7 +67,8 @@ class CodeTypesService
         '2.16.840.1.113883.3.221.5' => "Source of Payment Typology",
         '2.16.840.1.113883.6.13' => 'CDT',
         '2.16.840.1.113883.18.2' => 'AdministrativeSex',
-        '2.16.840.1.113883.5.1' => 'AdministrativeGender'
+        '2.16.840.1.113883.5.1' => 'AdministrativeGender',
+        self::CODE_TYPE_OID_HEALTHCARE_PROVIDER_TAXONOMY => 'HealthCareProviderTaxonomy'
     );
     /**
      * @var array

--- a/src/Services/PatientService.php
+++ b/src/Services/PatientService.php
@@ -134,6 +134,10 @@ class PatientService extends BaseService
         // so set both to the current datetime.
         $data['date'] = date("Y-m-d H:i:s");
         $data['regdate'] = date("Y-m-d H:i:s");
+        // we should never be null here but for legacy reasons we are going to default to this
+        $createdBy = $_SESSION['authUserID'] ?? null; // we don't let anyone else but the current user be the createdBy
+        $data['created_by'] = $createdBy;
+        $data['updated_by'] = $createdBy; // for an insert this is the same
         if (empty($data['pubpid'])) {
             $data['pubpid'] = $freshPid;
         }
@@ -212,6 +216,9 @@ class PatientService extends BaseService
 
         // The `date` column is treated as an updated_date
         $data['date'] = date("Y-m-d H:i:s");
+        // we should never be null here but for legacy reasons we are going to default to this
+        $updatedBy = $_SESSION['authUserID'] ?? null; // we don't let anyone else but the current user be the updatedBy
+        $data['updated_by'] = $updatedBy; // for an insert this is the same
         $table = PatientService::TABLE_NAME;
 
         // Fire the "before patient updated" event so listeners can do extra processing before data is updated
@@ -356,6 +363,7 @@ class PatientService extends BaseService
                     patient_data.*
                     ,patient_history_uuid
                     ,patient_history_type_key
+                    ,patient_history_created_by
                     ,previous_name_first
                     ,previous_name_prefix
                     ,previous_name_first
@@ -371,6 +379,7 @@ class PatientService extends BaseService
                     SELECT
                     pid AS patient_history_pid
                     ,history_type_key AS patient_history_type_key
+                    ,created_by AS patient_history_created_by
                     ,previous_name_prefix
                     ,previous_name_first
                     ,previous_name_middle
@@ -658,8 +667,12 @@ class PatientService extends BaseService
      */
     public function createPatientNameHistory($pid, $record)
     {
+        // we should never be null here but for legacy reasons we are going to default to this
+        $createdBy = $_SESSION['authUserID'] ?? null; // we don't let anyone else but the current user be the createdBy
+
         $insertData = [
             'pid' => $pid,
+            'created_by' => $createdBy,
             'history_type_key' => 'name_history',
             'previous_name_prefix' => $record['previous_name_prefix'],
             'previous_name_first' => $record['previous_name_first'],


### PR DESCRIPTION
Was having all kinds of weird merge issues with my prior PR on the mu3-3 branch.  I decided to create a new branch off of the latest master, cherry-picked these commits and it is all working much nicer.  I've tested against ETT with our latest mu3 demo data as well as with a blank database.

- Add created_by and updated_by columns to patient_history, patient_data, and history_data as well as modify dates and created dates so we can at least track the last user who modified a piece of information and the user that created a piece of information for provenance purposes. A more detailed history can then be derived from the audit table log as we'll be able to see what user modified the data on each patient record.
- Change author role code to be the ccda recommended
- Added in support to populate medical problems with the provenance information from the lists table.
- Made the medical device and allergies provenance information come from the lists table with the last modifydate and username being the provenance information.
- Made it so the prescriptions table keeps track of the user that created the prescription and the user that last modified the prescription.
- Updated provenance information to use the last modified date and the last user that modified the prescription for the provenance information. For historical data the assigned provider id is treated as the provenance author.
- Left the new table columns as nullable so we don't break any legacy application use.
- Made the ccda use the provenance information from the immunizations table instead of the encounter date.
- Made the birth sex social history provenance information point to the patient_data table which is where gender is being pulled from.
- Made the social history smoking, alcohol records pull from the history_data table instead of from the encounters.
- Made it so provenance care team populates from the patient_data table if the primary care provider is set, or if the care coordination primary provider is being overridden the care team is populated from the module config settings.
- Fix allergy error for no known allergies
- Make the assessment and clinical notes templates use the provenance information from the form, and form_clinical_notes tables.
- Made goals, health concerns and care plan use the local provenance information from the form_care_plan form.
- Made the provenance information for the vitals come from the form_vitals instead of the encounter
- Made procedures use provenance from billing table instead of encounters
- Made the provenance for lab results local instead of encounter
- Add provenance db changes to new database sql, also escaped the column names in the upgrade file
- Fix ccda crashes w/ missing primary care provider.  If the primary care provider was missing the ccda crashes.  This was breaking on a new database install with a new patient who didn't have the PCP set.
- Fixed undefined array key errors.  Fixed a number of issues in the ccda generator where undefined array keys were being thrown.  Re-tested on ETT and that all is working.