### PR TITLE
Bug Fixes Amendments

### DIFF
--- a/interface/forms/CAMOS/new.php
+++ b/interface/forms/CAMOS/new.php
@@ -53,10 +53,10 @@ $quote_search = array("\r","\n");
 $quote_replace = array("\\r","\\n");
 $quote_search_content = array("\r","\n");
 $quote_replace_content = array("\\r","\\n");
-$category = str_replace($quote_search, $quote_replace, $_POST['change_category']);
-$subcategory = str_replace($quote_search, $quote_replace, $_POST['change_subcategory']);
-$item = str_replace($quote_search, $quote_replace, $_POST['change_item']);
-$content = str_replace($quote_search_content, $quote_replace_content, $_POST['textarea_content']);
+$category = str_replace($quote_search, $quote_replace, $_POST['change_category'] ?? '');
+$subcategory = str_replace($quote_search, $quote_replace, $_POST['change_subcategory'] ?? '');
+$item = str_replace($quote_search, $quote_replace, $_POST['change_item'] ?? '');
+$content = str_replace($quote_search_content, $quote_replace_content, $_POST['textarea_content'] ?? '');
 if ($_POST['hidden_category']) {
     $preselect_category = $_POST['hidden_category'];
 }
@@ -70,7 +70,7 @@ if ($_POST['hidden_item']) {
 }
 
 //handle changes to database
-if (substr($_POST['hidden_mode'], 0, 3) == 'add') {
+if (substr($_POST['hidden_mode'] ?? '', 0, 3) == 'add') {
     if ($_POST['hidden_selection'] == 'change_category') {
         $preselect_category_override = $_POST['change_category'];
         $query = "INSERT INTO " . mitigateSqlTableUpperCase("form_CAMOS_category") . " (user, category) values (?, ?)";
@@ -246,7 +246,7 @@ var special_select_end = 0;
 
 <?php
 
-if (substr($_POST['hidden_mode'], 0, 5) == 'clone') {
+if (substr($_POST['hidden_mode'] ?? '', 0, 5) == 'clone') {
     echo "clone_mode = true;\n";
 }
 ?>
@@ -479,7 +479,7 @@ if (1) { //we are hiding the clone buttons and still need 'search others' so thi
     $clone_data1 = '';
     $clone_data2 = '';
     $clone_data_array = array();
-    if (substr($_POST['hidden_mode'], 0, 5) == 'clone') {
+    if (substr($_POST['hidden_mode'] ?? '', 0, 5) == 'clone') {
         $clone_category = $_POST['category'] ? $_POST['category'] : '';
         $clone_category_term = '';
         if ($clone_category != '') {
@@ -517,7 +517,7 @@ if (1) { //we are hiding the clone buttons and still need 'search others' so thi
         }
 
         $clone_search_term = '';
-        if ($clone_search != '') {
+        if (!empty($clone_search)) {
             $clone_search =  preg_replace('/\s+/', '%', $clone_search);
             if (substr($clone_search, 0, 1) == "`") {
                 $clone_subcategory_term = '';
@@ -528,7 +528,7 @@ if (1) { //we are hiding the clone buttons and still need 'search others' so thi
             $clone_search_term = " and content like '%" . add_escape_custom($clone_search) . "%'";
         }
 
-        if (substr($_POST['hidden_mode'], 0, 12) == 'clone others') {
+        if (substr($_POST['hidden_mode'] ?? '', 0, 12) == 'clone others') {
             if (preg_match('/^(export)(.*)/', $clone_search, $matches)) {
                 $query1 = "select id, category from " . mitigateSqlTableUpperCase("form_CAMOS_category");
                 $statement1 = sqlStatement($query1);
@@ -746,7 +746,7 @@ if ($preselect_category_override != '') {
   }
 <?php
 
-if (substr($_POST['hidden_mode'], 0, 5) == 'clone') {
+if (substr($_POST['hidden_mode'] ?? '', 0, 5) == 'clone') {
     echo "f2.textarea_content.value = '';\n";
 //  echo "f2.textarea_content.value += '/* count = ".count($clone_data_array)."*/\\n$break\\n';";
     echo "f2.textarea_content.value += '/* count = " . count($clone_data_array) . "*/\\n$break\\n';";

--- a/interface/forms/CAMOS/save.php
+++ b/interface/forms/CAMOS/save.php
@@ -38,7 +38,7 @@ if ($_GET["mode"] == "delete") {
                 //   before being submitted to the database. Will also continue to support placeholder conversion on report
                 //   views to support notes within database that still contain placeholders (ie. notes that were created previous to
                 //   version 4.0).
-                $content = $_POST['textarea_' . ${id}];
+                $content = $_POST['textarea_' . $id];
                 $content = replace($pid, $encounter, $content);
                 sqlStatement("update " . mitigateSqlTableUpperCase("form_CAMOS") . " set content=? where id=?", array($content, $id));
             }

--- a/interface/forms/newpatient/report.php
+++ b/interface/forms/newpatient/report.php
@@ -31,7 +31,7 @@ function newpatient_report($pid, $encounter, $cols, $id)
             print "<span class=bold>" . xlt('Reason') . ": </span><span class=text>" . nl2br(text($result["reason"])) . "</span><br />\n";
             print "<span>" . xlt('Provider') . ": </span><span class=text>" . text($provider['lname'] . ", " . $provider['fname']) . "</span><br />\n";
             print "<span>" . xlt('Referring Provider') . ": </span><span class=text>" . text(($referringProvider['lname'] ?? '') . ", " . ($referringProvider['fname'] ?? '')) . "</span><br />\n";
-            print "<span>" . xlt('POS Code') . ": </span><span class=text>" . text(sprintf('%02d', trim($result['pos_code']))) . "</span><br />\n";
+            print "<span>" . xlt('POS Code') . ": </span><span class=text>" . text(sprintf('%02d', trim($result['pos_code'] ?? ''))) . "</span><br />\n";
         }
     }
 

--- a/interface/patient_file/encounter/forms.php
+++ b/interface/patient_file/encounter/forms.php
@@ -544,7 +544,7 @@ $eventDispatcher->addListener(EncounterMenuEvent::MENU_RENDER, function (Encount
 
         $_cat = trim($item['category']);
         $_cat = ($_cat == '') ? xl("Miscellaneous") : xl($_cat);
-        $item['displayText'] = (trim($item['nickname']) != '') ? trim($item['nickname']) : trim($item['name']);
+        $item['displayText'] = (trim($item['nickname'] ?? '') != '') ? trim($item['nickname'] ?? '') : trim($item['name'] ?? '');
         unset($item['category']);
         unset($item['name']);
         unset($item['nickname']);

--- a/interface/patient_file/summary/add_edit_amendments.php
+++ b/interface/patient_file/summary/add_edit_amendments.php
@@ -113,7 +113,9 @@ $customAttributes = ( $onlyRead ) ? array("disabled" => "true") : null;
 <html>
 <head>
 
-<?php Header::setupHeader('datetime-picker'); ?>
+<?php Header::setupHeader('datetime-picker');
+echo "<title>" . xlt('Amendments') . "</title>";
+?>
 
 <script>
 

--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -1202,7 +1202,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                             'initiallyCollapsed' => (getUserSetting($id) == 0) ? false : true,
                             'btnLabel' => 'Edit',
                             'btnLink' => $GLOBALS['webroot'] . "/interface/patient_file/summary/list_amendments.php?id=" . attr_url($pid),
-                            'btnCLass' => 'rx_modal',
+                            'btnCLass' => '',
                             'linkMethod' => 'html',
                             'bodyClass' => 'notab collapse show',
                             'auth' => AclMain::aclCheckCore('patients', 'amendment', '', 'write'),

--- a/interface/patient_file/summary/list_amendments.php
+++ b/interface/patient_file/summary/list_amendments.php
@@ -22,7 +22,9 @@ use OpenEMR\Core\Header;
 <html>
 <head>
 
-<?php Header::setupHeader(); ?>
+<?php Header::setupHeader();
+echo "<title>" . xlt('Amendment List') . "</title>";
+?>
 
 <script>
     function checkForAmendments() {
@@ -48,12 +50,10 @@ use OpenEMR\Core\Header;
         });
     }
     var AddAmendment = function () {
-        var iam = top.frames.editAmendments;
-        iam.location.href = "<?php echo $GLOBALS['webroot']?>/interface/patient_file/summary/add_edit_amendments.php"
+        window.location.href = "<?php echo $GLOBALS['webroot']?>/interface/patient_file/summary/add_edit_amendments.php"
     };
     var ListAmendments = function () {
-        var iam = top.frames.editAmendments;
-        iam.location.href = "<?php echo $GLOBALS['webroot']?>/interface/patient_file/summary/list_amendments.php"
+        window.location.href = "<?php echo $GLOBALS['webroot']?>/interface/patient_file/summary/list_amendments.php"
     };
 </script>
 </head>
@@ -77,6 +77,7 @@ use OpenEMR\Core\Header;
                                     <a href="javascript:AddAmendment();" class="btn btn-primary btn-add"><?php echo xlt("Add"); ?></a>
                                     <a href="javascript:checkForAmendments();" class="btn btn-primary btn-print"><?php echo xlt("Print Amendments"); ?></a>
                                     <a href="javascript:ListAmendments();" class="btn btn-primary"><?php echo xlt("List"); ?></a>
+                                    <a href="demographics.php" class="btn btn-secondary"><?php echo xlt("Return Dashboard"); ?></a>
                                 </td>
                                 <td class="text-right">
                                     <a href="#" class="small" onClick="checkUncheck(1);"><?php echo xlt('Check All');?></a> |

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -424,7 +424,7 @@ $GLOBALS_METADATA = array(
         'right_justify_labels_demographics' => array(
             xl('Right Justify Labels in Demographics'),
             'bool',                           // data type
-            '1',                              // default = true
+            '0',                              // default = false
             xl('Right justify labels in Demographics for easier readability.')
         ),
 

--- a/library/patient.inc
+++ b/library/patient.inc
@@ -783,8 +783,11 @@ function getPatientName($pid)
  * @var $pid int The Patient ID
  * @returns string The Full Name
  */
-function getPatientFullNameAsString(int $pid): string
+function getPatientFullNameAsString($pid): string
 {
+    if (empty($pid)) {
+        return '';
+    }
     $ptData = getPatientPID(["pid" => $pid]);
     $pt = $ptData[0];
 

--- a/src/Core/Header.php
+++ b/src/Core/Header.php
@@ -171,6 +171,7 @@ class Header
     private static function parseConfigFile($map, $selectedAssets = array())
     {
         $foundAssets = [];
+        $excludedCount = 0;
         foreach ($map as $k => $opts) {
             $autoload = (isset($opts['autoload'])) ? $opts['autoload'] : false;
             $allowNoLoad = (isset($opts['allowNoLoad'])) ? $opts['allowNoLoad'] : false;
@@ -181,6 +182,7 @@ class Header
             if ((self::$isHeader === true && $autoload === true) || in_array($k, $selectedAssets) || ($loadInFile && $loadInFile === self::getCurrentFile())) {
                 if ($allowNoLoad === true) {
                     if (in_array("no_" . $k, $selectedAssets)) {
+                        $excludedCount++;
                         continue;
                     }
                 }
@@ -219,9 +221,10 @@ class Header
             }
         }
 
-        if (count(array_diff($selectedAssets, $foundAssets)) > 0) {
-            (new SystemLogger())->error("Not all selected assets were included in header", ['selectedAssets' => $selectedAssets, 'foundAssets' => $foundAssets]);
-        }
+        if (($thisCnt = count(array_diff($selectedAssets, $foundAssets))) > 0) {
+            if ($thisCnt !== $excludedCount) {
+                (new SystemLogger())->error("Not all selected assets were included in header", ['selectedAssets' => $selectedAssets, 'foundAssets' => $foundAssets]);
+            }}
     }
 
     /**

--- a/src/Menu/MainMenuRole.php
+++ b/src/Menu/MainMenuRole.php
@@ -131,7 +131,7 @@ class MainMenuRole extends MenuRole
         $regrows = getFormsByCategory('1', false);
         foreach ($regrows as $entry) {
             $option_id = $entry['directory'];
-            $title = trim($entry['nickname']);
+            $title = trim($entry['nickname'] ?? '');
             if (empty($title)) {
                 $title = $entry['name'];
             }
@@ -182,7 +182,7 @@ class MainMenuRole extends MenuRole
         $regrows = getFormsByCategory('1', true);
         foreach ($regrows as $entry) {
             $option_id = $entry['directory'];
-            $title = trim($entry['nickname']);
+            $title = trim($entry['nickname'] ?? '');
             if (empty($title)) {
                 $title = $entry['name'];
             }


### PR DESCRIPTION
- converted to render in tab instead of dialog.
- remove rx_modal class reference in widget

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #5581
Fixes #5597 
Fixes #5601


#### Short description of what this resolves:
Originally Amendments were a dialog. After twig conversion the class event reference to call modal wasn't in scope any longer.
Converted to render in tab as other widget do.