### PR TITLE
Contact ID Fix 2

### DIFF
--- a/src/Common/ORDataObject/Contact.php
+++ b/src/Common/ORDataObject/Contact.php
@@ -37,7 +37,7 @@ class Contact extends ORDataObject
     const CONTACT_TYPE_PATIENT = 'Patient';
     const CONTACT_TYPES = [self::CONTACT_TYPE_PATIENT];
 
-    public function __construct($id = "")
+    public function __construct($id)
     {
         parent::__construct("contact");
         $this->id = $id;

--- a/src/Common/ORDataObject/Contact.php
+++ b/src/Common/ORDataObject/Contact.php
@@ -37,21 +37,20 @@ class Contact extends ORDataObject
     const CONTACT_TYPE_PATIENT = 'Patient';
     const CONTACT_TYPES = [self::CONTACT_TYPE_PATIENT];
 
-    public function __construct($id)
+    public function __construct($id = "")
     {
         parent::__construct("contact");
-        $this->_id = $id;
+        $this->id = $id;
 
         if (!empty($id)) {
             $this->populate();
         }
     }
-
-    public function setPatientPid($pid)
+    public function setContactRecord(string $foreign_table_name, int $foreign_id): void
     {
         // we set our type to be patient_id and our table type here.
-        $this->foreign_table_name = 'patient_data';
-        $this->foreign_id = $pid;
+        $this->foreign_table_name = $foreign_table_name;
+        $this->foreign_id = $foreign_id;
     }
 
     /**

--- a/src/Common/ORDataObject/ContactAddress.php
+++ b/src/Common/ORDataObject/ContactAddress.php
@@ -239,7 +239,7 @@ class ContactAddress extends ORDataObject implements \JsonSerializable
     /**
      * @return int
      */
-    public function get_contact_id(): int
+    public function get_contact_id(): ?int
     {
         return $this->contact_id;
     }

--- a/src/Services/ContactService.php
+++ b/src/Services/ContactService.php
@@ -160,13 +160,13 @@ class ContactService extends BaseService
             // using the id stored in the variable ContractAddress->contact_id.
             // If the id in ContractAddress->contact_id is null, it creates
             // a class with Contact->id = null.
-            
+
             $contact = $contactAddress->getContact();
-            
+
             // If ContractAddress->contact_id already had an id,
             // then instantiating the Contact class already populated
             // the Contact record and there is no need to setContactRecord.
-            
+
             $contact_id = $contact->get_id();
             if (is_null($contact_id)) {
                 $contact->setContactRecord('patient_data', $pid);

--- a/src/Services/ContactService.php
+++ b/src/Services/ContactService.php
@@ -172,6 +172,11 @@ class ContactService extends BaseService
                 $contact->setContactRecord('patient_data', $pid);
             }
 
+            // here we can handle all of our data actions
+            if ($contactData['data_action'][$i] == 'INACTIVATE') {
+                $contactAddress->deactivate();
+            }
+
             // now we fill in any of our ContactAddress information if we have it
             $records[] = $contactAddress;
         }

--- a/src/Services/ContactService.php
+++ b/src/Services/ContactService.php
@@ -145,9 +145,19 @@ class ContactService extends BaseService
             $address->set_postalcode($contactData['postalcode'][$i] ?? '');
             $address->set_foreign_id(null);
 
+            $contact_id = $contactAddress->get_contact_id();
+            if (is_null($contact_id)) {
+                $contact_id = $this->getContact_Id('patient_data', $pid);
+                if (!is_null($contact_id)) {
+                    $contactAddress->set_contact_id($contact_id);
+                }
+            }
+
             $contact = $contactAddress->getContact();
-            // then we will create our contacts record as well
-            $contact->setPatientPid($pid);
+            $contact_id = $contact->get_id();
+            if (is_null($contact_id)) {
+                $contact->setContactRecord('patient_data', $pid);
+            }
 
             // here we can handle all of our data actions
             if ($contactData['data_action'][$i] == 'INACTIVATE') {
@@ -189,5 +199,14 @@ class ContactService extends BaseService
             $resultSet[] = $arrAddress;
         }
         return $resultSet;
+    }
+    private function getContact_Id($foreign_table_name, $foreign_id): ?int
+    {
+        $id = sqlQuery("SELECT `id` FROM `contact` WHERE `foreign_table_name` = ? AND `foreign_id` = ?", [$foreign_table_name, $foreign_id])['id'] ?? null;
+        if (!empty($id)) {
+            return $id;
+        } else {
+            return null;
+        }
     }
 }

--- a/src/Services/ContactService.php
+++ b/src/Services/ContactService.php
@@ -147,21 +147,29 @@ class ContactService extends BaseService
 
             $contact_id = $contactAddress->get_contact_id();
             if (is_null($contact_id)) {
+                // If the address is new, ContactAddress->contact_id will be null.
+                // We need to find out if a contact table entry already exists for the patient
+                // and put it in ContactAddress->contact_id.
                 $contact_id = $this->getContact_Id('patient_data', $pid);
                 if (!is_null($contact_id)) {
                     $contactAddress->set_contact_id($contact_id);
                 }
             }
 
+            // ContactAddress->getContact instantiates the class Contact
+            // using the id stored in the variable ContractAddress->contact_id.
+            // If the id in ContractAddress->contact_id is null, it creates
+            // a class with Contact->id = null.
+            
             $contact = $contactAddress->getContact();
+            
+            // If ContractAddress->contact_id already had an id,
+            // then instantiating the Contact class already populated
+            // the Contact record and there is no need to setContactRecord.
+            
             $contact_id = $contact->get_id();
             if (is_null($contact_id)) {
                 $contact->setContactRecord('patient_data', $pid);
-            }
-
-            // here we can handle all of our data actions
-            if ($contactData['data_action'][$i] == 'INACTIVATE') {
-                $contactAddress->deactivate();
             }
 
             // now we fill in any of our ContactAddress information if we have it


### PR DESCRIPTION
Fixes Contact Table Not Being Updated Correctly #5609.

Fixes bug where every time an address was modified or added for a patient, a new contact table row was added.  There is supposed to be only one contact table row per patient.

This fix is an evolution of Brady's fix.

My understanding of ORDataObject is that it is not supposed to have queries in it.  That goes against its purpose and design.  The queries should be in Services--in this case ContactService.  My fix moves the query that Brady created to ContactService.

I thoroughly tested this solution and traced it with XDebug.
