### PR TITLE
Add medication dosage to the patient dashboard and reports (#5621 #5623)

### DIFF
--- a/interface/patient_file/summary/stats.php
+++ b/interface/patient_file/summary/stats.php
@@ -35,10 +35,21 @@ $t = $twigContainer->getTwig();
  */
 function getListData($pid, $type)
 {
-    $sqlArr = [
-        "SELECT * FROM lists WHERE pid = ? AND type = ? AND",
-        dateEmptySql('enddate')
-    ];
+    if ($type == "medication") {
+        $sqlArr = [
+            "SELECT lists.*, medications.list_id, medications.drug_dosage_instructions FROM lists",
+            "LEFT JOIN ( SELECT id AS lists_medication_id, list_id, drug_dosage_instructions FROM lists_medication )",
+            "medications ON medications.list_id = id",
+            "WHERE pid = ? AND type = ? AND",
+            dateEmptySql('enddate')
+        ];
+    } else {
+        $sqlArr = [
+            "SELECT * FROM lists WHERE pid = ? AND type = ? AND",
+            dateEmptySql('enddate')
+        ];
+    }
+
 
     if ($GLOBALS['erx_enable'] && $GLOBALS['erx_medication_display'] && $type == 'medication') {
         $sqlArr[] = "and erx_uploaded != '1'";

--- a/interface/patient_file/summary/stats.php
+++ b/interface/patient_file/summary/stats.php
@@ -213,11 +213,11 @@ foreach ($ISSUE_TYPES as $key => $arr) {
             $viewArgs['listTouched'] = (getListTouch($pid, $key)) ? true : false;
         }
 
-	if ($id == "medication_ps_expand") {
+        if ($id == "medication_ps_expand") {
             echo $t->render('patient/card/medication.html.twig', $viewArgs);
-	} else {
+        } else {
             echo $t->render('patient/card/medical_problems.html.twig', $viewArgs);
-	}
+        }
     }
 }
 

--- a/interface/patient_file/summary/stats.php
+++ b/interface/patient_file/summary/stats.php
@@ -213,7 +213,11 @@ foreach ($ISSUE_TYPES as $key => $arr) {
             $viewArgs['listTouched'] = (getListTouch($pid, $key)) ? true : false;
         }
 
-        echo $t->render('patient/card/medical_problems.html.twig', $viewArgs);
+	if ($id == "medication_ps_expand") {
+            echo $t->render('patient/card/medication.html.twig', $viewArgs);
+	} else {
+            echo $t->render('patient/card/medical_problems.html.twig', $viewArgs);
+	}
     }
 }
 

--- a/library/classes/Prescription.class.php
+++ b/library/classes/Prescription.class.php
@@ -448,13 +448,13 @@ class Prescription extends ORDataObject
             if (!isset($dataRow['id'])) {
                 //add the record to the medication list
                 sqlStatement("insert into lists(date,begdate,type,activity,pid,user,groupname,title) values (now(),cast(now() as date),'medication',1,'" . add_escape_custom($this->patient->id) . "','" . add_escape_custom($_SESSION['authUser']) . "','" . add_escape_custom($_SESSION['authProvider']) . "','" . add_escape_custom($this->drug) . "')");
-		$medListId = sqlQuery("select id from lists where type = 'medication' and (enddate is null or cast(now() as date) < enddate) and upper(trim(title)) = upper(trim('" . add_escape_custom($this->drug) . "')) and pid = '" . add_escape_custom($this->patient->id) . "' limit 1");
-		$this->gen_lists_medication($medListId["id"], $dosageInstructions);
+                $medListId = sqlQuery("select id from lists where type = 'medication' and (enddate is null or cast(now() as date) < enddate) and upper(trim(title)) = upper(trim('" . add_escape_custom($this->drug) . "')) and pid = '" . add_escape_custom($this->patient->id) . "' limit 1");
+                $this->gen_lists_medication($medListId["id"], $dosageInstructions);
             } else {
                 $dataRow = sqlQuery('update lists set activity = 1'
                             . " ,user = '" . add_escape_custom($_SESSION['authUser'])
                             . "', groupname = '" . add_escape_custom($_SESSION['authProvider']) . "' where id = '" . add_escape_custom($dataRow['id']) . "'");
-		$this->gen_lists_medication($dataRow["id"]);
+                $this->gen_lists_medication($dataRow["id"]);
             }
         } elseif (!$med && isset($dataRow['id'])) {
             //remove the drug from the medication list if it exists

--- a/library/classes/Prescription.class.php
+++ b/library/classes/Prescription.class.php
@@ -412,7 +412,7 @@ class Prescription extends ORDataObject
     }
     function gen_lists_medication($id)
     {
-        $instructions = $this->size . $this->unit_array[$this->unit] . "\t" . $this->get_dosage_display();
+        $instructions = $this->size . $this->unit_array[$this->unit] . "\t\t" . $this->get_dosage_display();
         if (!empty($id)) {
             $medId = sqlQuery("select list_id from lists_medication where list_id = '" . add_escape_custom($id) . "' limit 1");
             if (isset($medId["list_id"])) {

--- a/library/classes/Prescription.class.php
+++ b/library/classes/Prescription.class.php
@@ -442,7 +442,6 @@ class Prescription extends ORDataObject
                 $dataRow = sqlQuery('update lists set activity = 1'
                             . " ,user = '" . add_escape_custom($_SESSION['authUser'])
                             . "', groupname = '" . add_escape_custom($_SESSION['authProvider']) . "' where id = '" . add_escape_custom($dataRow['id']) . "'");
-
             }
         } elseif (!$med && isset($dataRow['id'])) {
             //remove the drug from the medication list if it exists

--- a/library/classes/Prescription.class.php
+++ b/library/classes/Prescription.class.php
@@ -412,7 +412,6 @@ class Prescription extends ORDataObject
     }
     function gen_lists_medication($id)
     {
-        //$instructions = $this->dosage . " in " . $this->form_array[$this->form] . " form " . $this->interval_array[$this->interval] . "(" . $this->size . " " . $this->unit_array[$this->unit] . ")";
         $instructions = $this->size . $this->unit_array[$this->unit] . "\t" . $this->get_dosage_display();
         if (!empty($id)) {
             $medId = sqlQuery("select list_id from lists_medication where list_id = '" . add_escape_custom($id) . "' limit 1");
@@ -439,8 +438,6 @@ class Prescription extends ORDataObject
 
         //check if this drug is on the medication list
         $dataRow = sqlQuery("select id from lists where type = 'medication' and activity = 1 and (enddate is null or cast(now() as date) < enddate) and upper(trim(title)) = upper(trim('" . add_escape_custom($this->drug) . "')) and pid = '" . add_escape_custom($this->patient->id) . "' limit 1");
-        //Get dosage instructions
-        $dosageInstructions = $this->dosage . " in " . $this->form_array[$this->form] . " form " . $this->interval_array[$this->interval] . "(" . $this->size . " " . $this->unit_array[$this->unit] . ")";
 
         if ($med && !isset($dataRow['id'])) {
             $dataRow = sqlQuery("select id from lists where type = 'medication' and activity = 0 and (enddate is null or cast(now() as date) < enddate) and upper(trim(title)) = upper(trim('" . add_escape_custom($this->drug) . "')) and pid = '" . add_escape_custom($this->patient->id) . "' limit 1");

--- a/library/classes/Prescription.class.php
+++ b/library/classes/Prescription.class.php
@@ -642,6 +642,18 @@ class Prescription extends ORDataObject
 
     function set_drug($drug)
     {
+        // If the medication already exists in the list and the drug name is being changed, update the title there as well
+        if (!empty($this->drug) && $this->medication) {
+            $dataRow = sqlQuery("select id from lists where type = 'medication' and (enddate is null or cast(now() as date) < enddate) and upper(trim(title)) = upper(trim('" . add_escape_custom($this->drug) . "')) and pid = '" . add_escape_custom($this->patient->id) . "' limit 1");
+            if (isset($dataRow['id'])) {
+                $dataRow = sqlQuery('update lists set activity = 1'
+                            . " ,user = '" . add_escape_custom($_SESSION['authUser'])
+                           . "', groupname = '" . add_escape_custom($_SESSION['authProvider'])
+                           . "', title = '" . add_escape_custom($drug)
+                           . "' where id = '" . add_escape_custom($dataRow['id']) . "'");
+            }
+        }
+
         $this->drug = $drug;
     }
     function get_drug()

--- a/library/classes/Prescription.class.php
+++ b/library/classes/Prescription.class.php
@@ -410,6 +410,19 @@ class Prescription extends ORDataObject
     {
         $this->erx_source = $erx_source;
     }
+    function gen_lists_medication($id)
+    {
+        //$instructions = $this->dosage . " in " . $this->form_array[$this->form] . " form " . $this->interval_array[$this->interval] . "(" . $this->size . " " . $this->unit_array[$this->unit] . ")";
+        $instructions = $this->size . $this->unit_array[$this->unit] . "\t" . $this->get_dosage_display();
+        if (!empty($id)) {
+            $medId = sqlQuery("select list_id from lists_medication where list_id = '" . add_escape_custom($id) . "' limit 1");
+            if (isset($medId["list_id"])) {
+                $medId = sqlQuery("update lists_medication set drug_dosage_instructions = '" . add_escape_custom($instructions) . "' where list_id = '" . add_escape_custom($id) . "'");
+            } else {
+                sqlStatement("insert into lists_medication(list_id, drug_dosage_instructions) values ('" . add_escape_custom($id) . "', '" . add_escape_custom($instructions) . "')");
+            }
+        }
+    }
     function set_medication($med)
     {
         global $ISSUE_TYPES;
@@ -435,13 +448,13 @@ class Prescription extends ORDataObject
             if (!isset($dataRow['id'])) {
                 //add the record to the medication list
                 sqlStatement("insert into lists(date,begdate,type,activity,pid,user,groupname,title) values (now(),cast(now() as date),'medication',1,'" . add_escape_custom($this->patient->id) . "','" . add_escape_custom($_SESSION['authUser']) . "','" . add_escape_custom($_SESSION['authProvider']) . "','" . add_escape_custom($this->drug) . "')");
-                // Also ensure it gets added to lists_medication
-                $medListId = sqlQuery("select id from lists where type = 'medication' and (enddate is null or cast(now() as date) < enddate) and upper(trim(title)) = upper(trim('" . add_escape_custom($this->drug) . "')) and pid = '" . add_escape_custom($this->patient->id) . "' limit 1");
-                sqlStatement("insert into lists_medication(list_id, drug_dosage_instructions) values ('" . add_escape_custom($medListId["id"]) . "', '" . add_escape_custom($dosageInstructions) . "')");
+		$medListId = sqlQuery("select id from lists where type = 'medication' and (enddate is null or cast(now() as date) < enddate) and upper(trim(title)) = upper(trim('" . add_escape_custom($this->drug) . "')) and pid = '" . add_escape_custom($this->patient->id) . "' limit 1");
+		$this->gen_lists_medication($medListId["id"], $dosageInstructions);
             } else {
                 $dataRow = sqlQuery('update lists set activity = 1'
                             . " ,user = '" . add_escape_custom($_SESSION['authUser'])
                             . "', groupname = '" . add_escape_custom($_SESSION['authProvider']) . "' where id = '" . add_escape_custom($dataRow['id']) . "'");
+		$this->gen_lists_medication($dataRow["id"]);
             }
         } elseif (!$med && isset($dataRow['id'])) {
             //remove the drug from the medication list if it exists
@@ -449,7 +462,7 @@ class Prescription extends ORDataObject
                             . " ,user = '" . add_escape_custom($_SESSION['authUser'])
                             . "', groupname = '" . add_escape_custom($_SESSION['authProvider']) . "' where id = '" . add_escape_custom($dataRow['id']) . "'");
         } elseif ($med && isset($dataRow['id'])) {
-            $medDataRow = sqlQuery("update lists_medication set drug_dosage_instructions = '" . add_escape_custom($dosageInstructions) . "' where list_id = '" . add_escape_custom($dataRow['id']) . "'");
+            $this->gen_lists_medication($dataRow["id"]);
         }
     }
 
@@ -651,6 +664,7 @@ class Prescription extends ORDataObject
                            . "', groupname = '" . add_escape_custom($_SESSION['authProvider'])
                            . "', title = '" . add_escape_custom($drug)
                            . "' where id = '" . add_escape_custom($dataRow['id']) . "'");
+                $this->gen_lists_medication($dataRow["id"]);
             }
         }
 

--- a/templates/patient/card/medical_problems.html.twig
+++ b/templates/patient/card/medical_problems.html.twig
@@ -22,19 +22,19 @@
         {% if l.critical is defined %}
             {% set classes = "bg-danger text-light font-weight-bold" %}
         {% endif %}
-            <div class="list-group-item p-1 {{ classes|attr }}">
-                <div class="d-flex w-100 justify-content-between">
-                    <div class="flex-fill">
-                        {{ l.title|text }}
-                        {% if id == "allergy_ps_expand" %}
-                            <small class="d-block">{{ l.reactionTitle|text }}</small>
-                        {% endif %}
-                    </div>
+        <div class="list-group-item p-1 {{ classes|attr }}">
+            <div class="d-flex w-100 justify-content-between">
+                <div class="flex-fill">
+                    {{ l.title|text }}
                     {% if id == "allergy_ps_expand" %}
-                        <div class="flex-fill text-right">{{ l.severity|text }}</div>
+                        <small class="d-block">{{ l.reactionTitle|text }}</small>
                     {% endif %}
                 </div>
+                {% if id == "allergy_ps_expand" %}
+                    <div class="flex-fill text-right">{{ l.severity|text }}</div>
+                {% endif %}
             </div>
+        </div>
     {% endfor %}
 {% endif %}
 </div>

--- a/templates/patient/card/medical_problems.html.twig
+++ b/templates/patient/card/medical_problems.html.twig
@@ -18,24 +18,47 @@
     </div>
     {% endif %}
 {% else %}
+    {% if id == "medication_ps_expand" %}
+        <div class="table-responsive">
+            <table class="table table-sm table-striped">
+                <thead>
+                    <tr>
+                        <th>{{ "Dosage"|xlt }}</th>
+                        <th>{{ "Details"|xlt }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+    {% endif %}
     {% for l in list %}
         {% if l.critical is defined %}
             {% set classes = "bg-danger text-light font-weight-bold" %}
         {% endif %}
-        <div class="list-group-item p-1 {{ classes|attr }}">
-            <div class="d-flex w-100 justify-content-between">
-                <div class="flex-fill">
-                    {{ l.title|text }}
+        {% if id == "medication_ps_expand" %}
+                        <tr>
+                            <td class="{{ classes|attr }}">{{ l.title|text }}</td>
+                            <td class="{{ classes|attr }}">{{ l.drug_dosage_instructions|text }}</td>
+                        </tr>
+        {% else %}
+            <div class="list-group-item p-1 {{ classes|attr }}">
+                <div class="d-flex w-100 justify-content-between">
+                    <div class="flex-fill">
+                        {{ l.title|text }}
+                        {% if id == "allergy_ps_expand" %}
+                            <small class="d-block">{{ l.reactionTitle|text }}</small>
+                        {% endif %}
+                    </div>
                     {% if id == "allergy_ps_expand" %}
-                        <small class="d-block">{{ l.reactionTitle|text }}</small>
+                        <div class="flex-fill text-right">{{ l.severity|text }}</div>
                     {% endif %}
                 </div>
-                {% if id == "allergy_ps_expand" %}
-                    <div class="flex-fill text-right">{{ l.severity|text }}</div>
-                {% endif %}
             </div>
-        </div>
+        {% endif %}
     {% endfor %}
+    {% if id == "medication_ps_expand" %}
+                </tbody>
+            </table>
+        </div>
+    {% endif %}
 {% endif %}
 </div>
 {% endblock %}

--- a/templates/patient/card/medication.html.twig
+++ b/templates/patient/card/medication.html.twig
@@ -18,24 +18,27 @@
     </div>
     {% endif %}
 {% else %}
+        <div class="table-responsive">
+            <table class="table table-sm table-striped">
+                <thead>
+                    <tr>
+                        <th>{{ "Dosage"|xlt }}</th>
+                        <th>{{ "Details"|xlt }}</th>
+                    </tr>
+                </thead>
+                <tbody>
     {% for l in list %}
         {% if l.critical is defined %}
             {% set classes = "bg-danger text-light font-weight-bold" %}
         {% endif %}
-            <div class="list-group-item p-1 {{ classes|attr }}">
-                <div class="d-flex w-100 justify-content-between">
-                    <div class="flex-fill">
-                        {{ l.title|text }}
-                        {% if id == "allergy_ps_expand" %}
-                            <small class="d-block">{{ l.reactionTitle|text }}</small>
-                        {% endif %}
-                    </div>
-                    {% if id == "allergy_ps_expand" %}
-                        <div class="flex-fill text-right">{{ l.severity|text }}</div>
-                    {% endif %}
-                </div>
-            </div>
+                        <tr>
+                            <td class="{{ classes|attr }}">{{ l.title|text }}</td>
+                            <td class="{{ classes|attr }}">{{ l.drug_dosage_instructions|text }}</td>
+                        </tr>
     {% endfor %}
+                </tbody>
+            </table>
+        </div>
 {% endif %}
 </div>
 {% endblock %}


### PR DESCRIPTION
Previously, on the patient dashboard, medication would only be listed and it would not have any useful information. Fixes #5621, #5623.

I still need one more part to this change, as described in the issue. Feel free to merge this change individually, or wait for the last part.

I have a feeling I put a few too many conditionals in here and perhaps should just split it out into a separate `.html.twig` page. Thoughts?

(Originally wrote for 6.1.0, rebased onto 7.0 automatically. Tested on Ubuntu 22.04 LTS, which ships PHP 8.1.2.)