### PR TITLE
Patient Finder Update

### DIFF
--- a/interface/main/finder/patient_data_ajax.php
+++ b/interface/main/finder/patient_data_ajax.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * patient_data_ajax.php
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    David Eschelbacher <psoas@tampabay.rr.com>
+ * @copyright Copyright (c) 2022 David Eschelbacher <psoas@tampabay.rr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+require_once(dirname(__FILE__) . "/../../globals.php");
+require_once($GLOBALS['srcdir'] . "/options.inc.php");
+require_once($GLOBALS['srcdir'] . "/column_views.inc.php");
+
+$pid = $_GET['pid'];
+
+$query = "SELECT * FROM patient_data WHERE pid = ?";
+$result = sqlStatement($query, array($pid));
+$out = array();
+
+$row = sqlFetchArray($result);
+
+foreach($row as $column_name => $value) {
+    $out[$column_name] = attr($value);
+}
+
+$out = array_merge($out, all_column_views($row));
+
+// Dump the output array as JSON.
+//
+// Encoding with options for escaping a special chars - JSON_HEX_TAG (<)(>), JSON_HEX_AMP(&), JSON_HEX_APOS('), JSON_HEX_QUOT(").
+//$json_out = json_encode($out, 15);
+//echo $json_out;
+
+$formType = "LBF_PATIENTLIST_DETAIL";
+ob_start();
+display_layout_tabs_data($formType, $out);
+$patient_detail_HTML = ob_get_clean();
+$json_patient_detail_HTML = json_encode($patient_detail_HTML, 15);
+
+echo $json_patient_detail_HTML;

--- a/interface/super/edit_list.php
+++ b/interface/super/edit_list.php
@@ -18,6 +18,7 @@ require_once("../globals.php");
 require_once("$srcdir/lists.inc");
 require_once("../../custom/code_types.inc.php");
 require_once("$srcdir/options.inc.php");
+require_once("$srcdir/column_views.inc.php");
 
 use OpenEMR\Common\Acl\AclExtended;
 use OpenEMR\Common\Acl\AclMain;
@@ -35,7 +36,7 @@ if (!empty($_POST)) {
 // Below allows the list to default to the first item on the list
 //   when list_id is blank.
 $blank_list_id = '';
-if (empty($_REQUEST['list_id'] ?? null) && empty($_REQUEST['list_id_container'] ?? null)) {
+if (empty($_REQUEST['list_id'])) {
     $list_id = 'language';
     $blank_list_id = true;
 } else {
@@ -382,8 +383,28 @@ function writeOptionLine($option_id, $title, $seq, $default, $value, $mapping = 
     //New line for hidden input, for update items
     echo "<input type='hidden' name='opt[" . attr($opt_line_no) . "][real_id]' value='" .
         attr($option_id) . "' size='12' maxlength='127' class='optin form-control form-control-sm' />";
-    echo "<input type='text' name='opt[" . attr($opt_line_no) . "][id]' value='" .
-        attr($option_id) . "' size='12' maxlength='127' class='optin form-control form-control-sm' />";
+
+    if ($list_id == 'ptlistcols') {
+        $query = "SELECT COLUMN_NAME FROM information_schema.COLUMNS WHERE TABLE_NAME = 'patient_data'";
+        $res = sqlStatement($query);
+        $patient_data_column_names = array();
+        while ($row = sqlFetchArray($res)) {
+            $patient_data_column_names[] = $row['COLUMN_NAME'];
+        }
+        $patient_data_column_names[] = '';
+        $patient_data_column_names = array_merge($patient_data_column_names, column_views_list());
+        sort($patient_data_column_names);
+
+        echo "<select name='opt[" . attr($opt_line_no) . "][id]' class='form-control form-control-sm select2-patient_data_column_names option'>";
+        foreach ($patient_data_column_names as $column_name) {
+            $selected = ($option_id == $column_name) ? " selected=''" : "";
+            echo "    <option value='".attr($column_name)."'".$selected.">".attr($column_name)."</option>";
+        }
+        echo "</select>";
+    } else {
+        echo "<input type='text' name='opt[" . attr($opt_line_no) . "][id]' value='" .
+            attr($option_id) . "' size='12' maxlength='127' class='optin form-control form-control-sm' />";
+    }
     echo "</td>\n";
     echo "  <td>";
     echo "<input type='text' name='opt[" . attr($opt_line_no) . "][title]' value='" .
@@ -501,7 +522,11 @@ function writeOptionLine($option_id, $title, $seq, $default, $value, $mapping = 
         echo "</td>\n";
     } elseif ($list_id == 'ptlistcols') {
         echo "  <td>";
-        echo generate_select_list("opt[$opt_line_no][toggle_setting_1]", 'Sort_Direction', $tog1, 'Sort Direction', null, 'option');
+        echo generate_select_list("opt[$opt_line_no][toggle_setting_1]", 'Sort_Direction_Full', $tog1, 'Sort Direction', null, 'form-control-sm option');
+        echo "</td>\n";
+        echo "  <td>";
+        echo "<input type='text' name='opt[" . attr($opt_line_no) . "][subtype]' value='" .
+            attr($subtype) . "' size='8' maxlength='15' class='optin form-control form-control-sm' />";
         echo "</td>\n";
     }
 
@@ -874,6 +899,20 @@ function writeITLine($it_array)
         $(document).on('select2:open', () => {
             document.querySelector('.select2-search__field').focus();
         });
+
+        <?php 
+            if ($list_id == 'ptlistcols') {
+        ?>
+                $(function () {             
+                    $(".select2-patient_data_column_names").select2({ 
+                        <?php require($GLOBALS['srcdir'] . '/js/xl/select2.js.php'); ?>
+                    });
+                    $('.select2-patient_data_column_names').next()
+                        .css("width","100%")
+                        .css("font-size","small")
+                });
+        <?php } ?>
+
         // Keeping track of code picker requests.
         var current_lino = 0;
         var current_sel_name = '';
@@ -1312,7 +1351,8 @@ function writeITLine($it_array)
             <?php } elseif ($list_id == 'immunizations') { ?>
                 <th>&nbsp;&nbsp;&nbsp;&nbsp;<?php echo xlt('CVX Code Mapping'); ?></th>
             <?php } elseif ($list_id == 'ptlistcols') { ?>
-                <th>&nbsp;&nbsp;&nbsp;&nbsp;<?php echo xlt('Default Sort Direction'); ?></th>
+                <th>&nbsp;<?php echo xlt('Default Sort'); ?></th>
+                <th><?php echo xlt('Width (%,px,or rem)'); ?>&nbsp;&nbsp;</th>
             <?php }
             if ($GLOBALS['ippf_specific']) { ?>
                 <th><?php echo xlt('Global ID'); ?></th>

--- a/interface/themes/default-variables.scss
+++ b/interface/themes/default-variables.scss
@@ -50,7 +50,16 @@ $theme-colors: (
   dark: $dark,
   ovr-dark: $ovr-dark,
   ovr-light: $ovr-light,
-  body-color: $body-color
+  body-color: $body-color,
+  gray100: $gray-100,
+  gray200: $gray-200,
+  gray300: $gray-300,
+  gray400: $gray-400,
+  gray500: $gray-500,
+  gray600: $gray-600,
+  gray700: $gray-700,
+  gray800: $gray-800,
+  gray900: $gray-900
 );
 
 /* Array of random colors that can be added to */

--- a/interface/themes/oe-styles/style_light.scss
+++ b/interface/themes/oe-styles/style_light.scss
@@ -3,7 +3,10 @@
 $black: #222;
 $close-color: $black;
 $close-text-shadow: 0 1 0 $black;
-$gray: #cdcdcd;
+$gray: #6c757d;
+$secondary-color: #6c757d;
+
+@import "../default-variables";
 
 // Import Bootstrap 4 SCSS Files before doing anything
 // This gets replaced in gulp now -- do not touch

--- a/library/column_views.inc.php
+++ b/library/column_views.inc.php
@@ -1,0 +1,226 @@
+<?php
+/**
+ * column_views.inc.php
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    David Eschelbacher <psoas@tampabay.rr.com>
+ * @copyright Copyright (c) 2022 David Eschelbacher <psoas@tampabay.rr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+$column_views = array(
+    "name" => array(
+        "function" => "column_view_name",
+        "require" => "lname, fname, mname"
+    ),
+    "name_first_last" => array(
+        "function" => "column_view_name_first_last",
+        "require" => "lname, fname"
+    ),
+    "name_first_last_middle" => array(
+        "function" => "column_view_name_first_last_middle",
+        "require" => "lname, fname, mname"
+    ),
+    "city_state" => array(
+        "function" => "column_view_city_state",
+        "require" => "city, state"
+    ),
+    "address_full" => array(
+        "function" => "column_view_address_full",
+        "require" => "street, street_line_2, city, state, postal_code"
+    ),
+    "address_full_country" => array(
+        "function" => "column_view_address_full_country",
+        "require" => "street, street_line_2, city, state, postal_code, country_code"
+    ),
+    "next_appointment" => array(
+        "function" => "column_view_next_appointment",
+        "require" => ""
+    ),
+    "last_appointment" => array(
+        "function" => "column_view_last_appointment",
+        "require" => ""
+    ),
+    "insurance_primary_provider_name" => array(
+        "function" => "column_view_insurance_primary_provider_name",
+        "require" => ""
+    ),
+    "insurance_primary_policy" => array(
+        "function" => "column_view_insurance_primary_policy_number",
+        "require" => ""
+    ),
+    "age" => array(
+        "function" => "column_view_age",
+        "require" => ""
+    ),
+
+
+);
+
+function is_column_view($name) {
+    global $column_views;
+    return array_key_exists($name, $column_views);
+}
+
+function column_views_list() {
+    global $column_views;
+    $column_view_list = array();
+    foreach($column_views as $name => $column_view) {
+        $column_view_list[] = attr($name);
+    }
+    return $column_view_list;
+}
+
+function all_column_views($row) {
+    global $column_views;
+    $column_view_array = array();
+    foreach($column_views as $name => $column_view) {
+        $column_view_array[$name] = attr($column_view["function"]($row));
+    }
+    return $column_view_array;
+}
+
+function column_view($name, $row) {
+    global $column_views;
+    return attr($column_views[$name]["function"]($row));
+}
+
+function column_view_select_list($name) {
+    global $column_views;
+    return $column_views[$name]["require"];
+}
+
+function column_view_name($row) {
+    $name = $row['lname'];
+    if ($name && ($row['fname'] || $row['mname'])) {
+        $name .= ', ';
+    }
+    if ($row['fname']) {
+        $name .= $row['fname'];
+    }
+    if ($row['mname'] && $row['fname']) {
+        $name .= ' ';
+    }
+    $name .= $row['mname'];
+    return attr($name);
+}
+
+function column_view_name_first_last($row) {
+    $name_first_last = $row['fname'];
+    if ($name_first_last && $row['lname']) {
+        $name_first_last .= ' ';
+    }
+    $name_first_last .= $row['lname'];
+    return attr($name_first_last);
+}
+
+function column_view_name_first_last_middle($row) {
+    $name_first_last_middle = $row['fname'];
+    if ($name_first_last_middle && $row['mname']) {
+        $name_first_last_middle .= ' ';
+    }
+    $name_first_last_middle .= $row['mname'];
+    if ($name_first_last_middle && $row['lname']) {
+        $name_first_last_middle .= ' ';
+    }
+    $name_first_last_middle .= $row['lname'];
+    return attr($name_first_last_middle);
+}
+
+function column_view_city_state($row) {
+    $city_state = $row['city'];
+    if ($city_state && $row['state']) {
+        $city_state .= ', ';
+    }
+    $city_state .= $row['state'];
+    return attr($city_state);    
+}
+//street, street_line_2, city, state, postal_code, country_code
+function column_view_address_full($row) {
+    $address_full =  $row['street'];
+    if ($address_full && $row['street_line_2']) {
+        $address_full .= ', ';
+    }
+    $address_full .= $row['street_line_2'];
+    if ($address_full && $row['city']) {
+        $address_full .= ', ';
+    }
+    $address_full .= $row['city']; 
+    if ($address_full && $row['state']) {
+        $address_full .= ', ';
+    }
+    $address_full .= $row['state'];
+    if ($address_full && $row['postal_code'] && $row['state']) {
+        $address_full .= '  ';
+    } elseif ($address_full && $row['postal_code']) {
+        $address_full .= ', ';        
+    }
+    $address_full .= $row['postal_code'];
+    return attr($address_full);    
+}
+
+
+function column_view_address_full_country($row) {
+    $address_full_country = column_view_address_full($row);
+    if ($address_full_country && $row['country_code']) {
+        $address_full_country .= ', ';
+    }
+    $address_full_country .= $row['country_code'];    
+    return attr($address_full_country);     
+}
+
+function column_view_next_appointment($row) {
+    $pid = $row['pid'];
+    $query = "SELECT
+                pc_eventDate, 
+                pc_startTime
+                FROM `openemr_postcalendar_events` AS e
+                WHERE (ADDTIME(CONVERT(pc_eventDate, DATETIME), pc_startTime)) > now() AND pc_pid = ?
+                ORDER BY pc_eventDate, pc_startTime ASC
+                LIMIT 1";
+    $result = sqlStatement($query, array($pid)); 
+    $row = sqlFetchArray($result);
+    $event_date = $row['pc_eventDate'];
+    $event_time = $row['pc_startTime'];
+    if ($event_date && $event_time) {
+    $next_appointment_datetime  = new DateTime($event_date." ".$event_time);
+    $next_appointment = $next_appointment_datetime->format("D, M j, Y, g:i A");
+    } else {
+    $next_appointment = "";
+    } 
+    return $next_appointment;
+}
+
+function column_view_last_appointment($row) {
+    $pid = $row['pid'];
+    $query = "SELECT
+                pc_eventDate, 
+                pc_startTime
+                FROM `openemr_postcalendar_events` AS e
+                WHERE (ADDTIME(CONVERT(pc_eventDate, DATETIME), pc_startTime)) < now() AND pc_pid = ?
+                ORDER BY pc_eventDate, pc_startTime DESC
+                LIMIT 1";
+    $result = sqlStatement($query, array($pid)); 
+    $row = sqlFetchArray($result);
+    $event_date = $row['pc_eventDate'];
+    $event_time = $row['pc_startTime'];
+    $last_appointment_datetime  = new DateTime($event_date." ".$event_time);
+    $last_appointment = "";
+    $last_appointment = $last_appointment_datetime->format("D, M j, Y, g:i A");
+    return $last_appointment;
+}
+
+function column_view_insurance_primary_provider_name($row) {
+
+}
+
+function column_view_insurance_primary_policy_number($row) {
+
+    }
+
+function column_view_age($row) {
+    $dob = $row['DOB'];
+    $age = date_diff(date_create($dob), date_create('now'))->y;
+    return $age;
+}

--- a/src/OeUI/OemrUI.php
+++ b/src/OeUI/OemrUI.php
@@ -341,6 +341,7 @@ JQD;
                     $(this).toggleClass('fa-expand fa-compress');
                     $(this).toggleClass('oe-expand oe-center');
                     $('#container_div').toggleClass('container container-fluid');
+                    $('#pt_table').removeClass('w-auto');
                     if ($(arrFiles).length) {
                         $.each(arrFiles, function (index, value) {
 
@@ -359,6 +360,7 @@ JQD;
                     $(this).toggleClass('fa-compress fa-expand');
                     $(this).toggleClass('oe-center oe-expand');
                     $('#container_div').toggleClass('container-fluid container');
+                    $('#pt_table').addClass('w-auto');
                     if ($(arrFiles).length) {
                         $.each(arrFiles, function (index, value) {
                             $.post(


### PR DESCRIPTION
Issue:   Patient Finder Appearance #5616 

This update contains multiple improvements to patient finder.

Changes completed:

--Changed color to match color of demographic tab.

--Decreased the height of each row so that more patients can fit on one screen.

--Removed the heading at the top the says "Patient Finder".  
The heading was redundant because the name Patient Finder is in the tab. Also, the heading used up real estate that could show more useful information, i.e. more patient names. 

--Minor adjustments to padding and input box sizes.

--Introduced variable width columns.  
Different columns can now have different widths. For example, column for DOB does not need to be as wide as Full Name.  Column widths are specified in the List Editor (Admin->Forms->Lists, List = "Patient List Columns")

--Introduced custom columns.  
These are essentially "views" of the table "patient_data".  These views are created in PHP code.  They are not views created in SQL.  We probably need to discuss whether or not to create SQL views.  

Custom views are created in a way that they can be easily used in other areas of OpenEMR.

The custom columns (views) created thus far are:
- name
- name_first_last
- name_first_last_middle
- city_state
- address_full
- address_full_country
- next_appointment
- last_appointment
- insurance_primary_provider_name
- insurance_primary_policy
- age

--Introduced Child Rows.
Added a "+" button to insert a child row showing more patient detail.  
Similar to the following feature in DataTables:
[DataTables Example - Child Rows (Show Extra / Detailed Information)](https://datatables.net/examples/api/row_details.html)

The content of the child row is defined by an LBF form titled "Patient List Detail".
Also, the custom views can be used in the LBF form fields.

--Updated List Editor to allow more options in the list "Patient List Columns".
The changes are:
- Created a Select2 popup menu to select content of each patient finder column.  In this popup menu are all of the patient_data table fields PLUS the custom views.
- Added a column width option.


below added by bradymiller:
Up For Grabs demo (includes the standard demo data) for this PR is at: https://www.open-emr.org/wiki/index.php/Development_Demo#Zeta_-_Up_For_Grabs_Demo