### PR TITLE
Fixes #5681 Header events for js/css

### DIFF
--- a/src/Core/Header.php
+++ b/src/Core/Header.php
@@ -9,6 +9,8 @@
 namespace OpenEMR\Core;
 
 use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Events\Core\ScriptFilterEvent;
+use OpenEMR\Events\Core\StyleFilterEvent;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\Yaml\Exception\ParseException;
 
@@ -87,6 +89,38 @@ class Header
         // Favicon
         $output .= "<link rel=\"shortcut icon\" href=\"" . $GLOBALS['images_static_relative'] . "/favicon.ico\" />\n";
         $output .= self::setupAssets($assets, true, false);
+
+        // we need to grab the script
+        $scriptName = $_SERVER['SCRIPT_NAME'];
+
+        // we fire off events to grab any additional module scripts or css files that desire to adjust the currently executed script
+        $scriptFilterEvent = new ScriptFilterEvent(basename($scriptName));
+        $scriptFilterEvent->setContextArgument(ScriptFilterEvent::CONTEXT_ARGUMENT_SCRIPT_NAME, $scriptName);
+        $apptScripts = $GLOBALS['kernel']->getEventDispatcher()->dispatch($scriptFilterEvent, ScriptFilterEvent::EVENT_NAME);
+
+        $styleFilterEvent = new StyleFilterEvent($scriptName);
+        $styleFilterEvent->setContextArgument(StyleFilterEvent::CONTEXT_ARGUMENT_SCRIPT_NAME, $scriptName);
+        $apptStyles = $GLOBALS['kernel']->getEventDispatcher()->dispatch($styleFilterEvent, StyleFilterEvent::EVENT_NAME);
+        // note these scripts have been filtered to be in the same origin as the current site in pnadmin.php & pnuserapi.php {
+
+        if (!empty($apptScripts->getScripts())) {
+            $output .= "<!-- Module Scripts Started -->";
+            foreach ($apptScripts->getScripts() as $script) {
+                // we want versions appended
+                $output .= Header::createElement($script, 'script', false);
+            }
+            $output .= "<!-- Module Scripts Ended -->";
+        }
+
+        if (!empty($apptStyles->getStyles())) {
+            $output .= "<!-- Module Styles Started -->";
+            foreach ($apptStyles->getStyles() as $cssSrc) {
+                // we want version appended
+                $output .= Header::createElement($cssSrc, 'style', false);
+            }
+            $output .= "<!-- Module Styles Ended -->";
+        }
+
         if ($echoOutput) {
             echo $output;
         } else {

--- a/src/Events/Core/TemplatePageEvent.php
+++ b/src/Events/Core/TemplatePageEvent.php
@@ -16,6 +16,7 @@ namespace OpenEMR\Events\Core;
 
 class TemplatePageEvent
 {
+    const CONTEXT_ARGUMENT_SCRIPT_NAME = "script_name";
     /**
      * Context variables used for filtering the event
      * @var array


### PR DESCRIPTION
Fixes #5681 
Added the ability to inject javascript or css into any page inside
OpenEMR using the Header class specifically the setupHeader method which
is used in smarty, twig, and our regular php files all over the place to
bring in javascript and css assets.  This allows module / event writers
to inject content on every page or on specific pages based on the script
name / page name.