### PR TITLE
Rel 700 bring in #5643 #5681 #5683 #5685

### DIFF
--- a/interface/main/calendar/modules/PostCalendar/pnuserapi.php
+++ b/interface/main/calendar/modules/PostCalendar/pnuserapi.php
@@ -326,13 +326,14 @@ function postcalendar_userapi_buildView($args)
 
                 //==================================
                 //FACILITY FILTERING (CHEMED)
+        $userService = new UserService();
         if ($_SESSION['pc_facility']) {
-            $provinfo = getProviderInfo('%', true, $_SESSION['pc_facility']);
+            $provinfo = $userService->getUsersForCalendar($_SESSION['pc_facility']);
             if (!$provinfo) {
-                $provinfo = getProviderInfo($_SESSION['authUserID'], 'any', '');
+                $provinfo = $userService->getUserForCalendar($_SESSION['authUserID']);
             }
         } else {
-            $provinfo = getProviderInfo();
+            $provinfo = $userService->getUsersForCalendar();
         }
 
                 //EOS FACILITY FILTERING (CHEMED)

--- a/interface/usergroup/user_admin.php
+++ b/interface/usergroup/user_admin.php
@@ -30,6 +30,7 @@ use OpenEMR\Menu\MainMenuRole;
 use OpenEMR\Menu\PatientMenuRole;
 use OpenEMR\Services\FacilityService;
 use OpenEMR\Services\UserService;
+use OpenEMR\Events\User\UserEditRenderEvent;
 
 if (!empty($_GET)) {
     if (!CsrfUtils::verifyCsrfToken($_GET["csrf_token_form"])) {
@@ -279,6 +280,17 @@ function toggle_password() {
 <input type=hidden name="user_type" value="<?php echo attr($bg_name); ?>" >
 
 <TABLE border=0 cellpadding=0 cellspacing=0>
+<tr>
+    <td colspan="4">
+        <?php
+        // TODO: we eventually want to move to a responsive layout and not use tables here.  So we are going to give
+        // module writers the ability to inject divs, tables, or whatever inside the cell instead of having them
+        // generate additional rows / table columns which locks us into that format.
+        $preRenderEvent = new UserEditRenderEvent('user_admin.php', $_GET['id']);
+        $GLOBALS['kernel']->getEventDispatcher()->dispatch($preRenderEvent, UserEditRenderEvent::EVENT_USER_EDIT_RENDER_BEFORE);
+        ?>
+    </td>
+</tr>
 <TR>
     <TD style="width:180px;"><span class=text><?php echo xlt('Username'); ?>: </span></TD>
     <TD style="width:270px;"><input type="text" name=username style="width:150px;" class="form-control" value="<?php echo attr($iter["username"]); ?>" disabled></td>
@@ -606,6 +618,18 @@ foreach ($list_acl_groups as $value) {
 
         </td>
     </tr>
+    <tr>
+        <td colspan="4">
+            <?php
+            // TODO: we eventually want to move to a responsive layout and not use tables here.  So we are going to give
+            // module writers the ability to inject divs, tables, or whatever inside the cell instead of having them
+            // generate additional rows / table columns which locks us into that format.
+            $postRenderEvent = new UserEditRenderEvent('user_admin.php', $_GET['id']);
+            $GLOBALS['kernel']->getEventDispatcher()->dispatch($postRenderEvent, UserEditRenderEvent::EVENT_USER_EDIT_RENDER_AFTER);
+            ?>
+        </td>
+    </tr>
+
   <tr height="20" valign="bottom">
   <td colspan="4" class="text">
       <p>*<?php echo xlt('You must enter your own password to change user passwords. Leave blank to keep password unchanged.'); ?></p>

--- a/interface/usergroup/usergroup_admin_add.php
+++ b/interface/usergroup/usergroup_admin_add.php
@@ -21,6 +21,7 @@ use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Core\Header;
+use OpenEMR\Events\User\UserEditRenderEvent;
 use OpenEMR\Menu\MainMenuRole;
 use OpenEMR\Menu\PatientMenuRole;
 use OpenEMR\Services\FacilityService;
@@ -223,6 +224,17 @@ function authorized_clicked() {
 
 <span class="font-weight-bold">&nbsp;</span>
 <table class="border-0" cellpadding='0' cellspacing='0' style="width:600px;">
+<tr>
+    <td colspan="4">
+        <?php
+        // TODO: we eventually want to move to a responsive layout and not use tables here.  So we are going to give
+        // module writers the ability to inject divs, tables, or whatever inside the cell instead of having them
+        // generate additional rows / table columns which locks us into that format.
+        $preRenderEvent = new UserEditRenderEvent('usergroup_admin_add');
+        $GLOBALS['kernel']->getEventDispatcher()->dispatch($preRenderEvent, UserEditRenderEvent::EVENT_USER_EDIT_RENDER_BEFORE);
+        ?>
+    </td>
+</tr>
 <tr>
 <td style="width:150px;"><span class="text"><?php echo xlt('Username'); ?>: </span></td><td style="width:220px;"><input type="text" name="rumple" style="width:120px;" class="form-control"><span class="mandatory"></span></td>
 <?php if (empty($GLOBALS['gbl_ldap_enabled']) || empty($GLOBALS['gbl_ldap_exclusions'])) { ?>
@@ -495,6 +507,17 @@ foreach ($list_acl_groups as $value) {
         </td>
         <td></td>
     </tr>
+    <tr>
+        <td colspan="4">
+            <?php
+            // TODO: we eventually want to move to a responsive layout and not use tables here.  So we are going to give
+            // module writers the ability to inject divs, tables, or whatever inside the cell instead of having them
+            // generate additional rows / table columns which locks us into that format.
+            $preRenderEvent = new UserEditRenderEvent('usergroup_admin_add.php');
+            $GLOBALS['kernel']->getEventDispatcher()->dispatch($preRenderEvent, UserEditRenderEvent::EVENT_USER_EDIT_RENDER_AFTER);
+            ?>
+        </td>
+    </tr>
   <tr height="25"><td colspan="4">&nbsp;</td></tr>
 
 </table>
@@ -538,7 +561,6 @@ foreach ($result as $iter) {
 </td>
 
 </tr>
-
 <tr<?php echo ($GLOBALS['disable_non_default_groups']) ? " style='display:none'" : ""; ?>>
 
 <td valign='top'>

--- a/src/Core/Header.php
+++ b/src/Core/Header.php
@@ -9,6 +9,8 @@
 namespace OpenEMR\Core;
 
 use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Events\Core\ScriptFilterEvent;
+use OpenEMR\Events\Core\StyleFilterEvent;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\Yaml\Exception\ParseException;
 
@@ -87,6 +89,38 @@ class Header
         // Favicon
         $output .= "<link rel=\"shortcut icon\" href=\"" . $GLOBALS['images_static_relative'] . "/favicon.ico\" />\n";
         $output .= self::setupAssets($assets, true, false);
+
+        // we need to grab the script
+        $scriptName = $_SERVER['SCRIPT_NAME'];
+
+        // we fire off events to grab any additional module scripts or css files that desire to adjust the currently executed script
+        $scriptFilterEvent = new ScriptFilterEvent(basename($scriptName));
+        $scriptFilterEvent->setContextArgument(ScriptFilterEvent::CONTEXT_ARGUMENT_SCRIPT_NAME, $scriptName);
+        $apptScripts = $GLOBALS['kernel']->getEventDispatcher()->dispatch($scriptFilterEvent, ScriptFilterEvent::EVENT_NAME);
+
+        $styleFilterEvent = new StyleFilterEvent($scriptName);
+        $styleFilterEvent->setContextArgument(StyleFilterEvent::CONTEXT_ARGUMENT_SCRIPT_NAME, $scriptName);
+        $apptStyles = $GLOBALS['kernel']->getEventDispatcher()->dispatch($styleFilterEvent, StyleFilterEvent::EVENT_NAME);
+        // note these scripts have been filtered to be in the same origin as the current site in pnadmin.php & pnuserapi.php {
+
+        if (!empty($apptScripts->getScripts())) {
+            $output .= "<!-- Module Scripts Started -->";
+            foreach ($apptScripts->getScripts() as $script) {
+                // we want versions appended
+                $output .= Header::createElement($script, 'script', false);
+            }
+            $output .= "<!-- Module Scripts Ended -->";
+        }
+
+        if (!empty($apptStyles->getStyles())) {
+            $output .= "<!-- Module Styles Started -->";
+            foreach ($apptStyles->getStyles() as $cssSrc) {
+                // we want version appended
+                $output .= Header::createElement($cssSrc, 'style', false);
+            }
+            $output .= "<!-- Module Styles Ended -->";
+        }
+
         if ($echoOutput) {
             echo $output;
         } else {

--- a/src/Core/ModulesClassLoader.php
+++ b/src/Core/ModulesClassLoader.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * ModulesClassLoader is made available in every custom_module's openemr.bootstrap.php file as the variable $classLoader.
+ * Modules can use the ModulesClassLoader to register their namespace in order to auto load their classes.  This facilitates
+ * modules being dropped into the filesystem without having to go through a composer install / dumping of the autoloader.
+ *
+ * The class loader will check to make sure a namespace has not already been registered in case the module is installed
+ * via composer and is already in the namespace heirarchy.  Note this means each module needs to have its own DISTINCT
+ * namespace and should not share a namespace as the very first module that registers with the namespace is the one
+ * made available to OpenEMR.
+ *
+ * For performance reasons, if a module writer wishes to avoid hitting the filesystem for class discovery, they can use
+ * the registerClassmap function to optimize their runtime performance.
+ *
+ * An example use in an openemr.bootstrap.php file is as follows:
+ * <example>
+ * // openemr.bootstrap.php
+ * namespace Acme\OpenEMR\Modules\MyUniqueModule;
+ * use OpenEMR\Core\ModulesClassLoader;
+ * // @global ModulesClassLoader $classLoader
+ * $classLoader->registerNamespaceIfNotExists('Acme\\OpenEMR\\Modules\\MyUniqueModule\\', __DIR__ . DIRECTORY_SEPARATOR . 'src');
+ * // run any other custom module code needed here.
+ * </example>
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ *
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2019 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Core;
+
+use Composer\Autoload\ClassLoader;
+
+class ModulesClassLoader
+{
+    /**
+     * @var ClassLoader
+     */
+    private $classLoader;
+
+    public function __construct($webRootPath)
+    {
+        $this->classLoader = require $webRootPath . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
+    }
+
+    /**
+     * Registers a set of PSR-4 directories for a given namespace.  If the namespace already exists it skips registering
+     * the namespace (such as if the module has been installed via the main composer.json file)
+     *
+     * @param string          $prefix  The prefix/namespace, with trailing '\\'
+     * @param string[]|string $paths   The PSR-4 base directories to
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return void
+     */
+    public function registerNamespaceIfNotExists($namespace, $paths)
+    {
+        $prefixes = $this->classLoader->getPrefixesPsr4();
+        if (empty($prefixes[$namespace])) {
+            $this->classLoader->addPsr4($namespace, $paths);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @param string[] $classMap Class to filename map
+     * @psalm-param array<string, string> $classMap
+     *
+     * @return void
+     */
+    public function registerClassmap($classMap)
+    {
+        $this->classLoader->addClassMap($classMap);
+    }
+}

--- a/src/Events/Core/TemplatePageEvent.php
+++ b/src/Events/Core/TemplatePageEvent.php
@@ -16,6 +16,7 @@ namespace OpenEMR\Events\Core;
 
 class TemplatePageEvent
 {
+    const CONTEXT_ARGUMENT_SCRIPT_NAME = "script_name";
     /**
      * Context variables used for filtering the event
      * @var array

--- a/src/Events/User/UserEditRenderEvent.php
+++ b/src/Events/User/UserEditRenderEvent.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * UserEditRenderEvent class is fired from the interface/usergroup/user_admin.php and interface/usergroup/usergroup_admin_add.php
+ * pages inside OpenEMR and allows event listeners to render content before or after the form fields for the user.  Content
+ * will be contained inside a div.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ *
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2022 Discover and Change, Inc. <snielson@discoverandchange.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\User;
+
+use OpenEMR\Events\Core\TemplatePageEvent;
+
+class UserEditRenderEvent extends TemplatePageEvent
+{
+    const EVENT_USER_EDIT_RENDER_BEFORE = 'user.edit.render.before';
+
+
+    const EVENT_USER_EDIT_RENDER_AFTER = 'user.edit.render.after';
+
+    private $userId;
+
+    /**
+     * UserEditRenderEvent constructor.
+     * @param string $pageName
+     * @param int|null $userId The userid that is being edited, null if this is a brand new user
+     * @param array $context
+     */
+    public function __construct(string $pageName, ?int $userId = null, $context = array())
+    {
+        parent::__construct($pageName, $context);
+        $this->setUserId($userId);
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getUserId()
+    {
+        return $this->userId;
+    }
+
+    /**
+     * @param int|null $userId
+     * @return UserEditRenderEvent
+     */
+    public function setUserId($userId)
+    {
+        $this->userId = $userId;
+        return $this;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/openemr/openemr/issues/5643 ModulesClassLoader

Implemented a modules class loader that allow module writers to register a namespace if its not already been registered. This makes it so the ModuleWriter doesn't have to use requires everywhere and a module can be just dropped into the filesystem and execute once its been registered and installed from the Manage Modules interface.

Style fixes

Fixes https://github.com/openemr/openemr/issues/5681 Added the ability to inject javascript or css into any page inside OpenEMR using the Header class specifically the setupHeader method which is used in smarty, twig, and our regular php files all over the place to bring in javascript and css assets. This allows module / event writers to inject content on every page or on specific pages based on the script name / page name.

Fixes https://github.com/openemr/openemr/issues/5685 add provider calendar methods

Fix spelling, improve sql escaping
Fixes https://github.com/openemr/openemr/issues/5683 user admin events

Fixes https://github.com/openemr/openemr/issues/5683 adds events to user_admin and usergroup_admin_add page in order to be able to render content on those pages from a module.

Remove debug line