### PR TITLE
Fixes #5708 Add Appointment FHIR,Portal endpoints

### DIFF
--- a/apis/dispatch.php
+++ b/apis/dispatch.php
@@ -151,7 +151,7 @@ if (!empty($tokenId)) {
 
 
 // recollect this so the DEBUG global can be used if set
-$logger = new SystemLogger();
+    $logger = new SystemLogger();
 
 $gbl::$apisBaseFullUrl = $GLOBALS['site_addr_oath'] . $GLOBALS['webroot'] . "/apis/" . $gbl::$SITE;
 $restRequest->setApiBaseFullUrl($gbl::$apisBaseFullUrl);

--- a/sql/7_0_1-to-7_0_2_upgrade.sql
+++ b/sql/7_0_1-to-7_0_2_upgrade.sql
@@ -1,0 +1,110 @@
+--
+--  Comment Meta Language Constructs:
+--
+--  #IfNotTable
+--    argument: table_name
+--    behavior: if the table_name does not exist,  the block will be executed
+
+--  #IfTable
+--    argument: table_name
+--    behavior: if the table_name does exist, the block will be executed
+
+--  #IfColumn
+--    arguments: table_name colname
+--    behavior:  if the table and column exist,  the block will be executed
+
+--  #IfMissingColumn
+--    arguments: table_name colname
+--    behavior:  if the table exists but the column does not,  the block will be executed
+
+--  #IfNotColumnType
+--    arguments: table_name colname value
+--    behavior:  If the table table_name does not have a column colname with a data type equal to value, then the block will be executed
+
+--  #IfNotColumnTypeDefault
+--    arguments: table_name colname value value2
+--    behavior:  If the table table_name does not have a column colname with a data type equal to value and a default equal to value2, then the block will be executed
+
+--  #IfNotRow
+--    arguments: table_name colname value
+--    behavior:  If the table table_name does not have a row where colname = value, the block will be executed.
+
+--  #IfNotRow2D
+--    arguments: table_name colname value colname2 value2
+--    behavior:  If the table table_name does not have a row where colname = value AND colname2 = value2, the block will be executed.
+
+--  #IfNotRow3D
+--    arguments: table_name colname value colname2 value2 colname3 value3
+--    behavior:  If the table table_name does not have a row where colname = value AND colname2 = value2 AND colname3 = value3, the block will be executed.
+
+--  #IfNotRow4D
+--    arguments: table_name colname value colname2 value2 colname3 value3 colname4 value4
+--    behavior:  If the table table_name does not have a row where colname = value AND colname2 = value2 AND colname3 = value3 AND colname4 = value4, the block will be executed.
+
+--  #IfNotRow2Dx2
+--    desc:      This is a very specialized function to allow adding items to the list_options table to avoid both redundant option_id and title in each element.
+--    arguments: table_name colname value colname2 value2 colname3 value3
+--    behavior:  The block will be executed if both statements below are true:
+--               1) The table table_name does not have a row where colname = value AND colname2 = value2.
+--               2) The table table_name does not have a row where colname = value AND colname3 = value3.
+
+--  #IfRow
+--    arguments: table_name colname value
+--    behavior:  If the table table_name does have a row where colname = value, the block will be executed.
+
+--  #IfRow2D
+--    arguments: table_name colname value colname2 value2
+--    behavior:  If the table table_name does have a row where colname = value AND colname2 = value2, the block will be executed.
+
+--  #IfRow3D
+--        arguments: table_name colname value colname2 value2 colname3 value3
+--        behavior:  If the table table_name does have a row where colname = value AND colname2 = value2 AND colname3 = value3, the block will be executed.
+
+--  #IfRowIsNull
+--    arguments: table_name colname
+--    behavior:  If the table table_name does have a row where colname is null, the block will be executed.
+
+--  #IfIndex
+--    desc:      This function is most often used for dropping of indexes/keys.
+--    arguments: table_name colname
+--    behavior:  If the table and index exist the relevant statements are executed, otherwise not.
+
+--  #IfNotIndex
+--    desc:      This function will allow adding of indexes/keys.
+--    arguments: table_name colname
+--    behavior:  If the index does not exist, it will be created
+
+--  #EndIf
+--    all blocks are terminated with a #EndIf statement.
+
+--  #IfNotListReaction
+--    Custom function for creating Reaction List
+
+--  #IfNotListOccupation
+--    Custom function for creating Occupation List
+
+--  #IfTextNullFixNeeded
+--    desc: convert all text fields without default null to have default null.
+--    arguments: none
+
+--  #IfTableEngine
+--    desc:      Execute SQL if the table has been created with given engine specified.
+--    arguments: table_name engine
+--    behavior:  Use when engine conversion requires more than one ALTER TABLE
+
+--  #IfInnoDBMigrationNeeded
+--    desc: find all MyISAM tables and convert them to InnoDB.
+--    arguments: none
+--    behavior: can take a long time.
+
+--  #IfDocumentNamingNeeded
+--    desc: populate name field with document names.
+--    arguments: none
+
+--  #IfUpdateEditOptionsNeeded
+--    desc: Change Layout edit options.
+--    arguments: mode(add or remove) layout_form_id the_edit_option comma_separated_list_of_field_ids
+
+#IfMissingColumn openemr_postcalendar_events uuid
+ALTER TABLE `openemr_postcalendar_events` ADD `uuid` binary(16) DEFAULT NULL;
+#EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -7308,6 +7308,7 @@ CREATE TABLE `openemr_postcalendar_events` (
   `pc_sendalertemail` VARCHAR( 3 ) NOT NULL DEFAULT 'NO',
   `pc_billing_location` SMALLINT (6) NOT NULL DEFAULT '0',
   `pc_room` varchar(20) NOT NULL DEFAULT '',
+  `uuid` binary(16) DEFAULT NULL,
   PRIMARY KEY  (`pc_eid`),
   KEY `basic_event` (`pc_catid`,`pc_aid`,`pc_eventDate`,`pc_endDate`,`pc_eventstatus`,`pc_sharing`,`pc_topic`),
   KEY `pc_eventDate` (`pc_eventDate`)

--- a/sql/patch.sql
+++ b/sql/patch.sql
@@ -47,3 +47,7 @@
 
 --  #EndIf
 --    all blocks are terminated with and #EndIf statement.
+
+#IfMissingColumn openemr_postcalendar_events uuid
+ALTER TABLE `openemr_postcalendar_events` ADD `uuid` binary(16) DEFAULT NULL;
+#EndIf

--- a/src/Common/Auth/OpenIDConnect/Repositories/ScopeRepository.php
+++ b/src/Common/Auth/OpenIDConnect/Repositories/ScopeRepository.php
@@ -332,7 +332,7 @@ class ScopeRepository implements ScopeRepositoryInterface
 //            "patient/Account.read",
             "patient/AllergyIntolerance.read",
 //            "patient/AllergyIntolerance.write",
-//            "patient/Appointment.read",
+            "patient/Appointment.read",
 //            "patient/Appointment.write",
             "patient/CarePlan.read",
             "patient/CareTeam.read",
@@ -931,6 +931,9 @@ class ScopeRepository implements ScopeRepositoryInterface
         switch ($resource) {
             case 'AllergyIntolerance':
                 $description .= xl("allergies/adverse reactions");
+                break;
+            case 'Appointment':
+                $description .= xl("appointments");
                 break;
             case 'Observation':
                 $description .= xl("observations including laboratory,vitals, and social history records");

--- a/src/Common/Uuid/UuidRegistry.php
+++ b/src/Common/Uuid/UuidRegistry.php
@@ -38,6 +38,7 @@ class UuidRegistry
 {
     const UUID_MAX_BATCH_COUNT = 1000;
     const UUID_TABLE_DEFINITIONS = [
+
         'ccda' => ['table_name' => 'ccda'],
         'documents' => ['table_name' => 'documents'],
         'drugs' => ['table_name' => 'drugs', 'table_id' => 'drug_id'],
@@ -51,6 +52,7 @@ class UuidRegistry
         'insurance_companies' => ['table_name' => 'insurance_companies'],
         'insurance_data' => ['table_name' => 'insurance_data'],
         'lists' => ['table_name' => 'lists'],
+        'openemr_postcalendar_events' => ['table_name' => 'openemr_postcalendar_events', 'table_id' => 'pc_eid'],
         'patient_data' => ['table_name' => 'patient_data'],
         'patient_history' => ['table_name' => 'patient_history'],
         'prescriptions' => ['table_name' => 'prescriptions'],

--- a/src/RestControllers/AppointmentRestController.php
+++ b/src/RestControllers/AppointmentRestController.php
@@ -13,8 +13,10 @@
 namespace OpenEMR\RestControllers;
 
 use OpenEMR\Common\Logging\SystemLogger;
-use OpenEMR\Services\AppointmentService;
 use OpenEMR\RestControllers\RestControllerHelper;
+use OpenEMR\Services\AppointmentService;
+use OpenEMR\Services\PatientService;
+use OpenEMR\Validators\ProcessingResult;
 
 class AppointmentRestController
 {
@@ -31,9 +33,29 @@ class AppointmentRestController
         return RestControllerHelper::responseHandler($serviceResult, null, 200);
     }
 
+    public function getOneForPatient($auuid, $patientUuid)
+    {
+        $serviceResult = $this->appointmentService->search(['puuid' => $patientUuid, 'pc_uuid' => $auuid]);
+        $data = ProcessingResult::extractDataArray($serviceResult);
+        return RestControllerHelper::responseHandler($data[0] ?? [], null, 200);
+    }
+
     public function getAll()
     {
         $serviceResult = $this->appointmentService->getAppointmentsForPatient(null);
+        return RestControllerHelper::responseHandler($serviceResult, null, 200);
+    }
+
+    public function getAllForPatientByUuid($puuid)
+    {
+        $patientService = new PatientService();
+        $result = ProcessingResult::extractDataArray($patientService->getOne($puuid));
+        if (!empty($result)) {
+            $serviceResult = $this->appointmentService->getAppointmentsForPatient($result[0]['pid']);
+        } else {
+            $serviceResult = [];
+        }
+
         return RestControllerHelper::responseHandler($serviceResult, null, 200);
     }
 

--- a/src/RestControllers/FHIR/FhirAppointmentRestController.php
+++ b/src/RestControllers/FHIR/FhirAppointmentRestController.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * FhirAppointmentRestController handles the REST conversion for retrieving FHIR appointment resources.
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2022 Discover and Change, Inc. <snielson@discoverandchange.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\RestControllers\FHIR;
+
+use OpenEMR\Common\Http\HttpRestRequest;
+use OpenEMR\FHIR\R4\FHIRResource\FHIRBundle\FHIRBundleEntry;
+use OpenEMR\RestControllers\RestControllerHelper;
+use OpenEMR\Services\FHIR\FhirAppointmentService;
+use OpenEMR\Services\FHIR\FhirResourcesService;
+
+class FhirAppointmentRestController
+{
+    public function __construct(HttpRestRequest $request)
+    {
+        $this->fhirAppointmentService = new FhirAppointmentService($request->getApiBaseFullUrl());
+        $this->fhirService = new FhirResourcesService();
+    }
+
+    /**
+     * Queries for a single FHIR appointment resource by FHIR id
+     * @param $fhirId The FHIR appointment resource id (uuid)
+     * @param $puuidBind - Optional variable to only allow visibility of the patient with this puuid.
+     * @returns 200 if the operation completes successfully
+     */
+    public function getOne($fhirId, $puuidBind = null)
+    {
+        $processingResult = $this->fhirAppointmentService->getOne($fhirId, $puuidBind);
+        return RestControllerHelper::handleFhirProcessingResult($processingResult, 200);
+    }
+
+    /**
+     * Queries for FHIR appointment resources using various search parameters.
+     * Search parameters include:
+     * - patient (puuid)
+     * @param $puuidBind - Optional variable to only allow visibility of the patient with this puuid.
+     * @return FHIR bundle with query results, if found
+     */
+    public function getAll($searchParams, $puuidBind = null)
+    {
+        $processingResult = $this->fhirAppointmentService->getAll($searchParams, $puuidBind);
+        $bundleEntries = array();
+        foreach ($processingResult->getData() as $index => $searchResult) {
+            $bundleEntry = [
+                'fullUrl' =>  $GLOBALS['site_addr_oath'] . ($_SERVER['REDIRECT_URL'] ?? '') . '/' . $searchResult->getId(),
+                'resource' => $searchResult
+            ];
+            $fhirBundleEntry = new FHIRBundleEntry($bundleEntry);
+            array_push($bundleEntries, $fhirBundleEntry);
+        }
+        $bundleSearchResult = $this->fhirService->createBundle('Appointment', $bundleEntries, false);
+        $searchResponseBody = RestControllerHelper::responseHandler($bundleSearchResult, null, 200);
+        return $searchResponseBody;
+    }
+}

--- a/src/Services/FHIR/FhirAppointmentService.php
+++ b/src/Services/FHIR/FhirAppointmentService.php
@@ -1,0 +1,244 @@
+<?php
+
+/**
+ * FhirAppointmentService handles the mapping of data from the OpenEMR appointment service into FHIR resources.
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2022 Discover and Change, Inc. <snielson@discoverandchange.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Services\FHIR;
+
+use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRAppointment;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRAppointmentStatus;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRId;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRInstant;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRMeta;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRParticipationStatus;
+use OpenEMR\FHIR\R4\FHIRResource\FHIRAppointment\FHIRAppointmentParticipant;
+use OpenEMR\Services\AppointmentService;
+use OpenEMR\Services\FHIR\Traits\BulkExportSupportAllOperationsTrait;
+use OpenEMR\Services\FHIR\Traits\FhirBulkExportDomainResourceTrait;
+use OpenEMR\Services\FHIR\Traits\FhirServiceBaseEmptyTrait;
+use OpenEMR\Services\FHIR\Traits\PatientSearchTrait;
+use OpenEMR\Services\Search\FhirSearchParameterDefinition;
+use OpenEMR\Services\Search\SearchFieldType;
+use OpenEMR\Services\Search\ServiceField;
+use OpenEMR\Validators\ProcessingResult;
+
+class FhirAppointmentService extends FhirServiceBase implements IPatientCompartmentResourceService, IFhirExportableResourceService
+{
+    use FhirServiceBaseEmptyTrait;
+    use BulkExportSupportAllOperationsTrait;
+    use FhirBulkExportDomainResourceTrait;
+    use PatientSearchTrait;
+
+    const PARTICIPANT_TYPE_PARTICIPANT = "PART";
+    const PARTICIPANT_TYPE_PRIMARY_PERFORMER = "PPRF";
+    const PARTICIPANT_TYPE_PRIMARY_PERFORMER_TEXT = "Primary Performer";
+    const PARTICIPANT_TYPE_PARTICIPANT_TEXT = "Participant";
+
+    /**
+     * @var AppointmentService
+     */
+    private $appointmentService;
+
+    public function __construct($fhirApiURL = null)
+    {
+        parent::__construct($fhirApiURL);
+        $this->appointmentService = new AppointmentService();
+    }
+
+    /**
+     * Returns an array mapping FHIR Resource search parameters to OpenEMR search parameters
+     */
+    protected function loadSearchParameters()
+    {
+        return  [
+            'patient' => $this->getPatientContextSearchField(),
+            '_id' => new FhirSearchParameterDefinition('_id', SearchFieldType::TOKEN, [new ServiceField('pc_uuid', ServiceField::TYPE_UUID)]),
+        ];
+    }
+
+    /**
+     * Parses an OpenEMR data record, returning the equivalent FHIR Resource
+     *
+     * @param $dataRecord The source OpenEMR data record
+     * @param $encode Indicates if the returned resource is encoded into a string. Defaults to True.
+     * @return the FHIR Resource. Returned format is defined using $encode parameter.
+     */
+    public function parseOpenEMRRecord($dataRecord = array(), $encode = false)
+    {
+        $appt = new FHIRAppointment();
+
+        $fhirMeta = new FHIRMeta();
+        $fhirMeta->setVersionId("1");
+        $fhirMeta->setLastUpdated(gmdate('c'));
+        $appt->setMeta($fhirMeta);
+
+        $id = new FHIRId();
+        $id->setValue($dataRecord['pc_uuid']);
+        $appt->setId($id);
+
+        // now we need to parse out our status
+        $statusCode = 'pending'; // there can be a lot of different status and we will default to pending
+        switch ($dataRecord['pc_apptstatus']) {
+            case '-': // none
+                // None of the participant(s) have finalized their acceptance of the appointment request, and the start/end time might not be set yet.
+                $statusCode = 'proposed';
+                break;
+            case '#': // insurance / financial issue
+            case '^': // pending
+                // Some or all of the participant(s) have not finalized their acceptance of the appointment request.
+                $statusCode = 'pending';
+                break;
+            case '>': // checked out
+            case '$': // coding done
+                $statusCode = 'fulfilled';
+                break;
+            case 'AVM': // AVM confirmed
+            case 'SMS': // SMS confirmed
+            case 'EMAIL': // Email confirmed
+            case '*': // reminder done
+                // All participant(s) have been considered and the appointment is confirmed to go ahead at the date/times specified.
+                $statusCode = 'booked';
+                break;
+            case '%': // Cancelled < 24h
+            case '!': // left w/o visit
+            case 'x':
+                // The appointment has been cancelled.
+                $statusCode = 'cancelled';
+                break;
+            case '?':
+                // Some or all of the participant(s) have not/did not appear for the appointment (usually the patient).
+                $statusCode = 'noshow';
+                break;
+            case '~': // arrived late
+            case '@':
+                $statusCode = 'arrived';
+                break;
+            case '<': // in exam room
+            case '+': // chart pulled
+                // When checked in, all pre-encounter administrative work is complete, and the encounter may begin. (where multiple patients are involved, they are all present).
+                $statusCode = 'checked-in';
+                break;
+            case 'CALL': // Callback requested
+                $statusCode = 'waitlist';
+                //  The appointment has been placed on a waitlist, to be scheduled/confirmed in the future when a slot/service is available. A specific time might or might not be pre-allocated.
+                break;
+        }
+        // TODO: add an event here allowing people to update / configure the FHIR status
+        $apptStatus = new FHIRAppointmentStatus();
+        $apptStatus->setValue($statusCode);
+        $appt->setStatus($apptStatus);
+        // now parse out the participants
+        // patient first
+        if (!empty($dataRecord['puuid'])) {
+            $patient = new FHIRAppointmentParticipant();
+            $participantType = UtilsService::createCodeableConcept([
+                self::PARTICIPANT_TYPE_PARTICIPANT =>
+                    [
+                        'code' => self::PARTICIPANT_TYPE_PARTICIPANT
+                        ,'description' => self::PARTICIPANT_TYPE_PARTICIPANT_TEXT
+                        ,'system' => FhirCodeSystemConstants::HL7_PARTICIPATION_TYPE
+                    ]
+            ]);
+            $patient->addType($participantType);
+            $patient->setActor(UtilsService::createRelativeReference('Patient', $dataRecord['puuid']));
+            $status = new FHIRParticipationStatus();
+            $status->setValue('accepted'); // we don't really track any other field right now in FHIR
+            $patient->setStatus($status);
+            $appt->addParticipant($patient);
+        }
+
+        // now provider
+        if (!empty($dataRecord['pce_aid_uuid'])) {
+            $provider = new FHIRAppointmentParticipant();
+            $providerType = UtilsService::createCodeableConcept([
+                self::PARTICIPANT_TYPE_PRIMARY_PERFORMER =>
+                    [
+                        'code' => self::PARTICIPANT_TYPE_PRIMARY_PERFORMER
+                        ,'description' => self::PARTICIPANT_TYPE_PRIMARY_PERFORMER_TEXT
+                        ,'system' => FhirCodeSystemConstants::HL7_PARTICIPATION_TYPE
+                    ]
+            ]);
+            $provider->addType($providerType);
+            // we can only provide the provider if they have an NPI, otherwise they are a person
+            if (!empty($dataRecord['pce_aid_npi'])) {
+                $provider->setActor(UtilsService::createRelativeReference('Practitioner', $dataRecord['pce_aid_uuid']));
+            } else {
+                $provider->setActor(UtilsService::createRelativeReference('Person', $dataRecord['pce_aid_uuid']));
+            }
+            $status = new FHIRParticipationStatus();
+            $status->setValue('accepted'); // we don't really track any other field right now in FHIR
+            $provider->setStatus($status);
+            $appt->addParticipant($provider);
+        }
+
+        // now let's get start and end dates
+
+        // start time
+        if (!empty($dataRecord['pc_eventDate'])) {
+            $concatenatedDate = $dataRecord['pc_eventDate'] . ' ' . $dataRecord['pc_startTime'];
+            $startInstant = gmdate('c', strtotime($concatenatedDate));
+            $appt->setStart(new FHIRInstant($startInstant));
+        } else if ($dataRecord['pc_endDate'] != '0000-00-00' && !empty($dataRecord['pc_startTime'])) {
+            $concatenatedDate = $dataRecord['pc_endDate'] . ' ' . $dataRecord['pc_startTime'];
+            $startInstant = gmdate('c', strtotime($concatenatedDate));
+            $appt->setStart(new FHIRInstant($startInstant));
+        }
+
+        // if we have a start date and and end time we will use that
+        if (!empty($dataRecord['pc_eventDate']) && !empty($dataRecord['pc_endTime'])) {
+            $concatenatedDate = $dataRecord['pc_eventDate'] . ' ' . $dataRecord['pc_endTime'];
+            $endInstant = gmdate('c', strtotime($concatenatedDate));
+            $appt->setEnd(new FHIRInstant($endInstant));
+        } else if (!empty($dataRecord['pc_endDate']) && !empty($dataRecord['pc_endTime'])) {
+            $concatenatedDate = $dataRecord['pc_endDate'] . ' ' . $dataRecord['pc_endTime'];
+            $endInstant = gmdate('c', strtotime($concatenatedDate));
+            $appt->setEnd(new FHIRInstant($endInstant));
+        }
+
+        if (!empty($dataRecord['pc_hometext'])) {
+            $appt->setComment($dataRecord['pc_hometext']);
+        }
+
+        return $appt;
+    }
+
+
+    /**
+     * Searches for OpenEMR records using OpenEMR search parameters
+     * @param openEMRSearchParameters OpenEMR search fields
+     * @param $puuidBind - Optional variable to only allow visibility of the patient with this puuid.
+     * @return OpenEMR records
+     */
+    protected function searchForOpenEMRRecords($openEMRSearchParameters, $puuidBind = null): ProcessingResult
+    {
+        return $this->appointmentService->search($openEMRSearchParameters, true, $puuidBind);
+    }
+
+    /**
+     * Creates the Provenance resource  for the equivalent FHIR Resource
+     *
+     * @param $dataRecord The source OpenEMR data record
+     * @param $encode Indicates if the returned resource is encoded into a string. Defaults to True.
+     * @return the FHIR Resource. Returned format is defined using $encode parameter.
+     */
+    public function createProvenanceResource($dataRecord, $encode = false)
+    {
+        if (!($dataRecord instanceof FHIRAppointment)) {
+            throw new \BadMethodCallException("Data record should be correct instance class");
+        }
+        $fhirProvenanceService = new FhirProvenanceService();
+        // we don't have an individual authorship right now for appointments so we default to billing organization
+        $fhirProvenance = $fhirProvenanceService->createProvenanceForDomainResource($dataRecord);
+        if ($encode) {
+            return json_encode($fhirProvenance);
+        } else {
+            return $fhirProvenance;
+        }
+    }
+}

--- a/swagger/openemr-api.yaml
+++ b/swagger/openemr-api.yaml
@@ -3605,6 +3605,80 @@ paths:
       security:
         -
           openemr_auth: []
+  /fhir/Appointment:
+    get:
+      tags:
+        - fhir
+      description: 'Returns a list of Appointment resources.'
+      parameters:
+        -
+          name: _id
+          in: query
+          description: 'The uuid for the Appointment resource.'
+          required: false
+          schema:
+            type: string
+        -
+          name: patient
+          in: query
+          description: 'The uuid for the patient.'
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'Standard Response'
+          content:
+            application/json:
+              schema:
+                properties:
+                  'json object': { description: 'FHIR Json object.', type: object }
+                type: object
+                example:
+                  meta: { lastUpdated: '2021-09-14T09:13:51' }
+                  resourceType: Bundle
+                  type: collection
+                  total: 0
+                  link: [{ relation: self, url: 'https://localhost:9300/apis/default/fhir/AllergyIntolerance' }]
+        '400':
+          $ref: '#/components/responses/badrequest'
+        '401':
+          $ref: '#/components/responses/unauthorized'
+      security:
+        -
+          openemr_auth: []
+  '/fhir/Appointment/{uuid}':
+    get:
+      tags:
+        - fhir
+      description: 'Returns a single Appointment resource.'
+      parameters:
+        -
+          name: uuid
+          in: path
+          description: 'The uuid for the Appointment resource.'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'Standard Response'
+          content:
+            application/json:
+              schema:
+                properties:
+                  'json object': { description: 'FHIR Json object.', type: object }
+                type: object
+                example: []
+        '400':
+          $ref: '#/components/responses/badrequest'
+        '401':
+          $ref: '#/components/responses/unauthorized'
+        '404':
+          $ref: '#/components/responses/uuidnotfound'
+      security:
+        -
+          openemr_auth: []
   /fhir/CarePlan:
     get:
       tags:
@@ -6343,6 +6417,44 @@ paths:
       security:
         -
           openemr_auth: []
+  /portal/patient/appointment:
+    get:
+      tags:
+        - standard-patient
+      description: 'Retrieves all appointments for a patient'
+      responses:
+        '200':
+          $ref: '#/components/responses/standard'
+        '400':
+          $ref: '#/components/responses/badrequest'
+        '401':
+          $ref: '#/components/responses/unauthorized'
+      security:
+        -
+          openemr_auth: []
+  '/portal/patient/appointment/{auuid}':
+    get:
+      tags:
+        - standard-patient
+      description: 'Returns a selected appointment by its uuid.'
+      parameters:
+        -
+          name: auuid
+          in: path
+          description: 'The uuid for the appointment.'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/standard'
+        '400':
+          $ref: '#/components/responses/badrequest'
+        '401':
+          $ref: '#/components/responses/unauthorized'
+      security:
+        -
+          openemr_auth: []
 components:
   schemas:
     api_patient_request:
@@ -7296,6 +7408,7 @@ components:
             launch/patient: 'Will provide a patient selector when logging in as an OpenEMR user (required for testing patient/* scopes in swagger if not logging in as a patient)'
             'api:fhir': 'FHIR R4 API'
             patient/AllergyIntolerance.read: 'Read allergy intolerance resources for the current patient (api:fhir)'
+            patient/Appointment.read: 'Read appointment resources for the current patient (api:fhir)'
             patient/CarePlan.read: 'Read care plan resources for the current patient (api:fhir)'
             patient/CareTeam.read: 'Read care team resources for the current patient (api:fhir)'
             patient/Condition.read: 'Read condition resources for the current patient (api:fhir)'
@@ -7413,6 +7526,7 @@ components:
             'api:port': 'Standard Patient Portal OpenEMR API'
             patient/encounter.read: 'Read encounters the patient has access to (api:port)'
             patient/patient.read: 'Write encounters the patient has access to (api:port)'
+            patient/appointment.read: 'Read appointments the patient has access to (api:port)'
 tags:
   -
     name: fhir


### PR DESCRIPTION
Fixes #5708 

This adds the following endpoints

- /fhir/Appointment
- /fhir/Appointment/{uuid}
- /portal/patient/Appointment
- /portal/patient/Appointment/{auuid}

Implemented a very basic version of the FHIR R4 Appointment resource.  I had to map OpenEMR appointment statii to FHIR appointment statii.  If anyone has modified the list's it will mark all of those as pending as we don't right now have a way of handling it.  We may need to have a mapping list or something if people customize these values a lot.

Opened up the appointment resources for patient standalone apps with the patient portal if people want to consume direct appointment resources from the api.