### PR TITLE
switch on PKCE support in swagger

### DIFF
--- a/swagger/index.html
+++ b/swagger/index.html
@@ -48,6 +48,9 @@
         ],
         defaultModelsExpandDepth: -1
       });
+      ui.initOAuth({
+        usePkceWithAuthorizationCodeGrant: true
+      });
       // End Swagger UI call region
 
       window.ui = ui;


### PR DESCRIPTION
This works with @adunsulag 's ongoing PR at: #5706

Works for both testing of private (works with or without this change) and public (only works with this change) apps.

Note that the not very smart swagger feature that hides the client secret appears to not be in the current version that is used in OpenEMR (using 3.50.2 in OpenEMR where it looks like that change is in the 4.4.0 https://github.com/swagger-api/swagger-ui/releases/tag/v4.4.0 release ).
