### PR TITLE
Fix Drugs dispensing in Charges Panel

### DIFF
--- a/interface/drugs/dispense_drug.php
+++ b/interface/drugs/dispense_drug.php
@@ -46,6 +46,7 @@ $prescription_id = $_REQUEST['prescription'];
 $quantity        = $_REQUEST['quantity'];
 $fee             = $_REQUEST['fee'];
 $user            = $_SESSION['authUser'];
+$encounter       = $_SESSION['encounter']
 
 if (!AclMain::aclCheckCore('admin', 'drugs')) {
     echo (new TwigContainer(null, $GLOBALS['kernel']))->getTwig()->render('core/unauthorized.html.twig', ['pageTitle' => xl("Dispense Drug")]);
@@ -78,7 +79,7 @@ if (! $sale_id) {
   // Post the order and update inventory, deal with errors.
   //
     if ($drug_id) {
-        $sale_id = sellDrug($drug_id, $quantity, $fee, $pid, 0, $prescription_id, $today, $user);
+        $sale_id = sellDrug($drug_id, $quantity, $fee, $pid, $encounter, $prescription_id, $today, $user);
         if (!$sale_id) {
             die(xlt('Inventory is not available for this order.'));
         }

--- a/interface/drugs/dispense_drug.php
+++ b/interface/drugs/dispense_drug.php
@@ -46,7 +46,7 @@ $prescription_id = $_REQUEST['prescription'];
 $quantity        = $_REQUEST['quantity'];
 $fee             = $_REQUEST['fee'];
 $user            = $_SESSION['authUser'];
-$encounter       = $_SESSION['encounter'] :: 0;
+$encounter       = $_SESSION['encounter'] ?? 0;
 
 if (!AclMain::aclCheckCore('admin', 'drugs')) {
     echo (new TwigContainer(null, $GLOBALS['kernel']))->getTwig()->render('core/unauthorized.html.twig', ['pageTitle' => xl("Dispense Drug")]);

--- a/interface/drugs/dispense_drug.php
+++ b/interface/drugs/dispense_drug.php
@@ -46,7 +46,7 @@ $prescription_id = $_REQUEST['prescription'];
 $quantity        = $_REQUEST['quantity'];
 $fee             = $_REQUEST['fee'];
 $user            = $_SESSION['authUser'];
-$encounter       = $_SESSION['encounter']
+$encounter       = $_SESSION['encounter'] :: 0;
 
 if (!AclMain::aclCheckCore('admin', 'drugs')) {
     echo (new TwigContainer(null, $GLOBALS['kernel']))->getTwig()->render('core/unauthorized.html.twig', ['pageTitle' => xl("Dispense Drug")]);


### PR DESCRIPTION
The current encounter was not used in dispensing drugs. Default encounter value of 0 was used. So we take the encounter from the session and use it accordingly.

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #5712

#### Short description of what this resolves:
Internal error: the referenced encounter no longer exists. 1 0


#### Changes proposed in this pull request:
Get the current encounter and use this in dispensing a drug via the charges panel
