### PR TITLE
Change Globals Page Name to User-Friendly Name

### DIFF
--- a/interface/main/tabs/menu/menus/standard.json
+++ b/interface/main/tabs/menu/menus/standard.json
@@ -724,7 +724,7 @@
     "menu_id": "admimg",
     "children": [
       {
-        "label": "Globals",
+        "label": "Config",
         "menu_id": "adm0",
         "target": "adm",
         "url": "/interface/super/edit_globals.php",

--- a/interface/super/edit_globals.php
+++ b/interface/super/edit_globals.php
@@ -44,7 +44,7 @@ if (!$userMode) {
   // Check authorization.
     $thisauth = AclMain::aclCheckCore('admin', 'super');
     if (!$thisauth) {
-        echo (new TwigContainer(null, $GLOBALS['kernel']))->getTwig()->render('core/unauthorized.html.twig', ['pageTitle' => xl("Global Settings")]);
+        echo (new TwigContainer(null, $GLOBALS['kernel']))->getTwig()->render('core/unauthorized.html.twig', ['pageTitle' => xl("Configuration")]);
         exit;
     }
 }
@@ -330,7 +330,7 @@ if (array_key_exists('form_save', $_POST) && $_POST['form_save'] && !$userMode) 
     echo "</script>";
 }
 
-$title = ($userMode) ? xlt("User Settings") : xlt("Global Settings");
+$title = ($userMode) ? xlt("User Settings") : xlt("Configuration");
 ?>
 <title><?php  echo $title; ?></title>
 <?php Header::setupHeader(['common','jscolor']); ?>
@@ -352,7 +352,7 @@ $title = ($userMode) ? xlt("User Settings") : xlt("Global Settings");
 }
 </style>
 <?php
-$heading_title = ($userMode) ? xl("Edit User Settings") : xl("Edit Global Settings");
+$heading_title = ($userMode) ? xl("Edit User Settings") : xl("Edit Configuration");
 
 $arrOeUiSettings = array(
     'heading_title' => $heading_title,
@@ -395,7 +395,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                         <div class="input-group col-sm-4 oe-pull-away">
                         <?php // mdsupport - Optional server based searching mechanism for large number of fields on this screen.
                         if (!$userMode) {
-                            $placeholder = xla('Search global settings');
+                            $placeholder = xla('Search configuration');
                         } else {
                             $placeholder = xla('Search user settings');
                         }

--- a/sites/default/documents/custom_menus/Custom.json
+++ b/sites/default/documents/custom_menus/Custom.json
@@ -724,7 +724,7 @@
     "menu_id": "admimg",
     "children": [
       {
-        "label": "Globals",
+        "label": "Config",
         "menu_id": "adm0",
         "target": "adm",
         "url": "/interface/super/edit_globals.php",


### PR DESCRIPTION
Fixes #5560 

#### Short description of what this resolves
Resolves the issue of the page name of "Globals" not having a meaningful name.

#### Changes proposed in this pull request:
I feel like the easiest name would be "Config" as "Globals" is a configuration area for the entire EMR. I have made "Config" the navigation bar name and "Configuration" the long version on the actual page.
