### PR TITLE
Handle route ids with string values.

### DIFF
--- a/library/classes/Prescription.class.php
+++ b/library/classes/Prescription.class.php
@@ -376,9 +376,7 @@ class Prescription extends ORDataObject
 
     function set_route($route)
     {
-        if (is_numeric($route)) {
-            $this->route = $route;
-        }
+        $this->route = $route;
     }
     function get_route()
     {
@@ -656,7 +654,7 @@ class Prescription extends ORDataObject
         if (!empty($this->drug) && $this->medication) {
             $dataRow = sqlQuery("select id from lists where type = 'medication' and (enddate is null or cast(now() as date) < enddate) and upper(trim(title)) = upper(trim('" . add_escape_custom($this->drug) . "')) and pid = '" . add_escape_custom($this->patient->id) . "' limit 1");
             if (isset($dataRow['id'])) {
-                $dataRow = sqlQuery('update lists set activity = 1'
+                $updateRow = sqlQuery('update lists set activity = 1'
                             . " ,user = '" . add_escape_custom($_SESSION['authUser'])
                            . "', groupname = '" . add_escape_custom($_SESSION['authProvider'])
                            . "', title = '" . add_escape_custom($drug)

--- a/sql/7_0_0-to-7_0_1_upgrade.sql
+++ b/sql/7_0_0-to-7_0_1_upgrade.sql
@@ -197,3 +197,7 @@ CREATE UNIQUE INDEX `uuid` ON `openemr_postcalendar_events` (`uuid`);
 #IfNotRow2D list_options list_id drug_route option_id bymouth
 INSERT INTO `list_options` (`list_id`, `option_id`, `title`, `seq`, `is_default`, `notes`, `codes`) VALUES ('drug_route', 'bymouth', 'By Mouth', 1, 0, 'PO', 'NCI-CONCEPT-ID:C38288');
 #EndIf
+
+#IfNotColumnType prescriptions route VARCHAR(100)
+ALTER TABLE `prescriptions` CHANGE `route` `route` VARCHAR(100) NULL DEFAULT NULL Comment 'Max size 100 characters is same max as immunizations';
+#EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -7716,7 +7716,7 @@ CREATE TABLE `prescriptions` (
   `quantity` varchar(31) default NULL,
   `size` varchar(25) DEFAULT NULL,
   `unit` int(11) default NULL,
-  `route` int(11) default NULL,
+  `route` varchar(100) default NULL COMMENT 'Max size 100 characters is same max as immunizations',
   `interval` int(11) default NULL,
   `substitute` int(11) default NULL,
   `refills` int(11) default NULL,

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@ $v_realpatch = '0';
 // is a database change in the course of development.  It is used
 // internally to determine when a database upgrade is needed.
 //
-$v_database = 473;
+$v_database = 474;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #5743


#### Short description of what this resolves:
Allow string option_id from drug_route list

#### Changes proposed in this pull request:
Modify Prescription class and change table column from int to varchar