### PR TITLE
Fixes Left and Right Login Layout Color Not Fully Showing

### DIFF
--- a/interface/login/login.php
+++ b/interface/login/login.php
@@ -98,7 +98,7 @@ if (count($emr_app)) {
 // This code allows configurable positioning in the login page
 $logoarea = "py-2 px-2 py-md-3 px-md-5 order-1 bg-primary";
 $formarea = "py-3 px-2 p-sm-5 bg-white order-2";
-$loginrow = "row login-row bg-white shadow-lg align-items-center my-sm-5";
+$loginrow = "row login-row bg-primary shadow-lg align-items-center m-0 my-sm-5";
 
 // Apply these classes to the logo area if the login page is left or right
 $lrArr = ['left', 'right'];


### PR DESCRIPTION
Fixes #5759 

#### Short description of what this resolves:

Fixes the right and left login layout not fully showing up as explained in the issue.

NOTE: This also needs to be merged in as a patch to version 7.0.0 and version 6.1.0 as it is affected by this bug. Login layouts will look distorted if this fix isn't implemented.