### PR TITLE
ci: add minimum GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/manual-build-php-fpm-dockers.yml
+++ b/.github/workflows/manual-build-php-fpm-dockers.yml
@@ -3,6 +3,9 @@ name: Manual Build php-fpm Dockers
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
 
   build_7_3:

--- a/.github/workflows/styling.yml
+++ b/.github/workflows/styling.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
 
   php_styling:

--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build_apache_74_106:


### PR DESCRIPTION
### Description
This PR adds minimum token permissions for the GITHUB_TOKEN in GitHub Actions workflows using [secure-workflows](https://github.com/step-security/secure-workflows).

The GitHub Actions workflow has a GITHUB_TOKEN with write access to multiple scopes. Here is an example of the permissions in one of the workflow runs:
https://github.com/openemr/openemr/actions/runs/3166984505/jobs/5157123174#step:1:19

After this change, the scopes will be reduced to the minimum needed for the following workflows:

- manual-build-php-fpm-dockers.yml
- styling.yml
- syntax.yml
- test.yml


### Motivation and Context

- This is a security best practice, so if the GITHUB_TOKEN is compromised due to a vulnerability or compromised Action, the damage will be reduced.
- [GitHub recommends](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) defining minimum GITHUB_TOKEN permissions.
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. This change will help increase the Scorecard score for this repository.

Signed-off-by: Ashish Kurmi <akurmi@stepsecurity.io>