### PR TITLE
Fixes #5858 DocumentReference date search

### DIFF
--- a/src/Services/FHIR/DocumentReference/FhirClinicalNotesService.php
+++ b/src/Services/FHIR/DocumentReference/FhirClinicalNotesService.php
@@ -83,7 +83,7 @@ class FhirClinicalNotesService extends FhirServiceBase
             'patient' => $this->getPatientContextSearchField(),
             'type' => new FhirSearchParameterDefinition('type', SearchFieldType::TOKEN, ['code']),
             'category' => new FhirSearchParameterDefinition('category', SearchFieldType::TOKEN, ['category']),
-            'date' => new FhirSearchParameterDefinition('date', SearchFieldType::DATETIME, ['date']),
+            'date' => new FhirSearchParameterDefinition('date', SearchFieldType::DATE, ['date']),
             '_id' => new FhirSearchParameterDefinition('_id', SearchFieldType::TOKEN, [new ServiceField('uuid', ServiceField::TYPE_UUID)]),
         ];
     }


### PR DESCRIPTION
Make the date search work for document reference with onc inferno.

Fixes #5858 where the date search was not working.