### PR TITLE
fix for  insertEncounter, always creates an encounter with the curren…

### DIFF
--- a/src/Services/EncounterService.php
+++ b/src/Services/EncounterService.php
@@ -307,7 +307,7 @@ class EncounterService extends BaseService
         $encounter = generate_id();
         $data['encounter'] = $encounter;
         $data['uuid'] = UuidRegistry::getRegistryForTable(self::ENCOUNTER_TABLE)->createUuid();
-        $data['date'] = date("Y-m-d");
+        // $data['date'] = date("Y-m-d");
         $puuidBytes = UuidRegistry::uuidToBytes($puuid);
         $data['pid'] = $this->getIdByUuid($puuidBytes, self::PATIENT_TABLE, "pid");
         $query = $this->buildInsertColumns($data);


### PR DESCRIPTION
Issue:[Encounter Post API - Date is saving as current date instead of data passed](https://community.open-emr.org/t/encounter-post-api-date-is-saving-as-current-date-instead-of-data-passed/18550)

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #5872

#### Short description of what this resolves:
this will replace the current date with the date that is being transferred via API

#### Changes proposed in this pull request:
