### PR TITLE
Fixes #5875 portal module extensions

### DIFF
--- a/interface/patient_file/summary/create_portallogin.php
+++ b/interface/patient_file/summary/create_portallogin.php
@@ -10,9 +10,11 @@
  * @author    Paul Simon <paul@zhservices.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
  * @author    Tyler Wrenn <tyler@tylerwrenn.com>
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
  * @copyright Copyright (c) 2011 Z&H Consultancy Services Private Limited <sam@zhservices.com>
  * @copyright Copyright (c) 2018-2019 Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2020 Tyler Wrenn <tyler@tylerwrenn.com>
+ * @copyright Copyright (c) 2022 Discover and Change, Inc <snielson@discoverandchange.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -23,6 +25,8 @@ use OpenEMR\Common\Auth\AuthHash;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Common\Utils\RandomGenUtils;
+use OpenEMR\Events\Patient\Summary\PortalCredentialsTemplateDataFilterEvent;
+use OpenEMR\Events\Patient\Summary\PortalCredentialsUpdatedEvent;
 use OpenEMR\FHIR\Config\ServerConfig;
 use Twig\Environment;
 
@@ -107,6 +111,38 @@ function displayLogin($patient_id, $message, $emailFlag)
     return $message;
 }
 
+/**
+ * Takes in a twig template and data for a given patient pid and notifies module listeners that we are about to
+ * render a twig template and let them modify the data.   Note we do NOT allow the module writer to change the template
+ * name here.
+ * @param $twig
+ * @param $pid
+ * @param $templateName
+ * @param $data
+ * @return mixed The rendered twig output
+ */
+function filterTwigTemplateData($twig, $pid, $templateName, $data)
+{
+
+    $filterEvent = new PortalCredentialsTemplateDataFilterEvent($twig, $data);
+    $filterEvent->setPid($pid);
+    $filterEvent->setData($data);
+    $filterEvent->setTemplateName($templateName);
+    /**
+     * @var \OpenEMR\Core\Kernel
+     */
+    $kernel = $GLOBALS['kernel'] ?? null;
+    if (!empty($kernel)) {
+        $filterEvent = $GLOBALS['kernel']->getEventDispatcher()->dispatch($filterEvent, PortalCredentialsTemplateDataFilterEvent::EVENT_HANDLE);
+    }
+    $paramData = $filterEvent->getData();
+    if (!is_array($paramData)) {
+        $paramData = []; // safety
+    }
+
+    return $twig->render($templateName, $paramData);
+};
+
 if (isset($_POST['form_save']) && $_POST['form_save'] == 'submit') {
     if (!CsrfUtils::verifyCsrfToken($_POST["csrf_token_form"])) {
         CsrfUtils::csrfNotVerified();
@@ -115,7 +151,14 @@ if (isset($_POST['form_save']) && $_POST['form_save'] == 'submit') {
     $clear_pass = $_POST['pwd'];
 
     $res = sqlStatement("SELECT * FROM patient_access_onsite WHERE pid=?", array($pid));
-    $query_parameters = array($_POST['uname'],$_POST['login_uname']);
+    // we let module writers know we are about to update the patient portal credentials in case any additional stuff needs to happen
+    // such as MFA update, other data tied to the portal credentials etc.
+    $preUpdateEvent = new PortalCredentialsUpdatedEvent($pid);
+    $preUpdateEvent->setUsername($_POST['uname'] ?? '')
+        ->setLoginUsername($_POST['login_uname'] ?? '');
+
+    $updatedEvent = $GLOBALS['kernel']->getEventDispatcher()->dispatch($preUpdateEvent, PortalCredentialsUpdatedEvent::EVENT_UPDATE_PRE) ?? $preUpdateEvent;
+    $query_parameters = array($updatedEvent->getUsername(),$updatedEvent->getLoginUsername());
     $hash = (new AuthHash('auth'))->passwordHash($clear_pass);
     if (empty($hash)) {
         // Something is seriously wrong
@@ -132,22 +175,31 @@ if (isset($_POST['form_save']) && $_POST['form_save'] == 'submit') {
     } else {
         sqlStatementNoLog("INSERT INTO patient_access_onsite SET portal_username=?,portal_login_username=?,portal_pwd=?,portal_pwd_status=0,pid=?", $query_parameters);
     }
+    $postUpdateEvent = new PortalCredentialsUpdatedEvent($pid);
+    $postUpdateEvent->setUsername($updatedEvent->getUsername())
+        ->setLoginUsername($updatedEvent->getLoginUsername());
+
+    // we let module writers know we have updated the patient portal credentials in case any additional stuff needs to happen
+    // such as MFA update, other data tied to the portal credentials etc.
+    $updatedEvent = $GLOBALS['kernel']->getEventDispatcher()->dispatch($preUpdateEvent, PortalCredentialsUpdatedEvent::EVENT_UPDATE_POST) ?? $preUpdateEvent;
 
     // Create the message
     $fhirServerConfig = new ServerConfig();
     $data = [
         'portal_onsite_two_address' => $GLOBALS['portal_onsite_two_address']
         ,'enforce_signin_email' => $GLOBALS['enforce_signin_email']
-        ,'uname' => $_POST['uname']
-        ,'login_uname' => $_POST['login_uname']
+        ,'uname' => $updatedEvent->getUsername()
+        ,'login_uname' => $updatedEvent->getLoginUsername()
         ,'pwd' => $clear_pass
         ,'email_direct' => trim($trustedEmail['email_direct'])
         ,'fhir_address' => $fhirServerConfig->getFhirUrl()
         ,'fhir_requirements_address' => $fhirServerConfig->getFhir3rdPartyAppRequirementsDocument()
     ];
 
-    $htmlMessage = $twig->render('emails/patient/portal_login/message.html.twig', $data);
-    $plainMessage = $twig->render('emails/patient/portal_login/message.text.twig', $data);
+    // we run the twigs through this filterTwigTemplateData function as we want module writers to be able to modify the passed
+    // in $data value.  The rendered twig output ($twig->render) is returned from this function.
+    $htmlMessage = filterTwigTemplateData($twig, $pid, 'emails/patient/portal_login/message.html.twig', $data);
+    $plainMessage = filterTwigTemplateData($twig, $pid, 'emails/patient/portal_login/message.text.twig', $data);
 
     // Email and display/print the message
     if (emailLogin($pid, $htmlMessage, $plainMessage, $twig)) {
@@ -162,7 +214,7 @@ if (isset($_POST['form_save']) && $_POST['form_save'] == 'submit') {
     $credMessage = '';
 }
 
-echo $twig->render('patient/portal_login/print.html.twig', [
+echo filterTwigTemplateData($twig, $pid, 'patient/portal_login/print.html.twig', [
         'credMessage' => $credMessage
         , 'csrfToken' => CsrfUtils::collectCsrfToken()
         , 'fname' => $row['fname']
@@ -173,4 +225,10 @@ echo $twig->render('patient/portal_login/print.html.twig', [
         , 'pwd' => RandomGenUtils::generatePortalPassword()
         , 'enforce_signin_email' => $GLOBALS['enforce_signin_email']
         , 'email_direct' => trim($trustedEmail['email_direct'])
+        // if someone wants to add additional data fields they can add this in as a
+        // key => [...] property where the key is the template filename
+        // which must exist inside a twig directory path of 'patient/partials/' and end with the '.html.twig' extension
+        // the mapped value is the data array that will be passed to the twig template.
+        , 'extensionsFormFields' => []
+        , 'extensionsJavascript' => []
 ]);

--- a/src/Events/Patient/Summary/PortalCredentialsTemplateDataFilterEvent.php
+++ b/src/Events/Patient/Summary/PortalCredentialsTemplateDataFilterEvent.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * PortalCredentialsTemplateDataFilterEvent is intended to be used and dispatched when a template is about to be rendered
+ * for the create_portallogin.php process.  It allows template authors to add to / modify the data that is passed to the
+ * template.
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) Discover and Change, Inc <snielson@discoverandchange.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\Patient\Summary;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+class PortalCredentialsTemplateDataFilterEvent extends Event
+{
+    const EVENT_HANDLE = 'patient.portal-credentials.filter';
+
+    /**
+     * @var int
+     */
+    private $pid;
+
+    /**
+     * @var string The name of the twig template being rendered
+     */
+    private $templateName;
+
+    /**
+     * @var array The data that is being passed to the twig array
+     */
+    private $data;
+
+    public function __construct()
+    {
+    }
+
+    /**
+     * @return int
+     */
+    public function getPid(): int
+    {
+        return $this->pid;
+    }
+
+    /**
+     * @param int $pid
+     * @return PortalCredentialsTemplateDataFilterEvent
+     */
+    public function setPid(int $pid): PortalCredentialsTemplateDataFilterEvent
+    {
+        $this->pid = $pid;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTemplateName(): string
+    {
+        return $this->templateName;
+    }
+
+    /**
+     * @param string $templateName
+     * @return PortalCredentialsTemplateDataFilterEvent
+     */
+    public function setTemplateName(string $templateName): PortalCredentialsTemplateDataFilterEvent
+    {
+        $this->templateName = $templateName;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    /**
+     * @param array $data
+     * @return PortalCredentialsTemplateDataFilterEvent
+     */
+    public function setData(array $data): PortalCredentialsTemplateDataFilterEvent
+    {
+        $this->data = $data;
+        return $this;
+    }
+}

--- a/src/Events/Patient/Summary/PortalCredentialsUpdatedEvent.php
+++ b/src/Events/Patient/Summary/PortalCredentialsUpdatedEvent.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * PortalCredentialsUpdatedEvent is intended to be used and dispatched when a patient's portal credentials have been
+ * updated.  For now it only fires from the admin page.  Future updates would be to add this to the patient change
+ * password page so that event listeners can connect to that as well.  For security reasons we do NOT pass the patient
+ * password as part of this event.  Only the fact that their credentials are about to change and that their credentials
+ * have changed.
+ *
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) Discover and Change, Inc <snielson@discoverandchange.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\Patient\Summary;
+
+class PortalCredentialsUpdatedEvent
+{
+    const EVENT_UPDATE_PRE = 'patient.portal-credentials.update.pre';
+    const EVENT_UPDATE_POST  = 'patient.portal-credentials.update.post';
+
+    /**
+     * @var int
+     */
+    private $pid;
+
+    // TODO: do we want to expose the patient password credentials to module listeners?
+
+    /**
+     * @var string The username for the patient
+     */
+    private $username;
+
+    /**
+     * @var string The username the patient will use to login
+     */
+    private $loginUsername;
+
+    public function __construct(int $pid)
+    {
+        $this->pid = $pid;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPid(): int
+    {
+        return $this->pid;
+    }
+
+    /**
+     * @param int $pid
+     * @return PortalCredentialsUpdatedEvent
+     */
+    public function setPid(int $pid): PortalCredentialsUpdatedEvent
+    {
+        $this->pid = $pid;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUsername(): string
+    {
+        return $this->username;
+    }
+
+    /**
+     * @param string $username
+     * @return PortalCredentialsUpdatedEvent
+     */
+    public function setUsername(string $username): PortalCredentialsUpdatedEvent
+    {
+        $this->username = $username;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLoginUsername(): string
+    {
+        return $this->loginUsername;
+    }
+
+    /**
+     * @param string $loginUsername
+     * @return PortalCredentialsUpdatedEvent
+     */
+    public function setLoginUsername(string $loginUsername): PortalCredentialsUpdatedEvent
+    {
+        $this->loginUsername = $loginUsername;
+        return $this;
+    }
+}

--- a/templates/patient/portal_login/print.html.twig
+++ b/templates/patient/portal_login/print.html.twig
@@ -40,6 +40,12 @@
             });
         {% endif %}
         // <?php } ?>
+        {% if extensionsJavascript is not empty %}
+            {% for file, data in extensionsJavascript %}
+                {# Extension writers can overload the patient/partials in their module and include their own data #}
+                {% include 'patient/partials/' ~ file ~ '.js.twig' with data %}
+            {% endfor %}
+        {% endif %}
     </script>
 </head>
 <body class="body_top">
@@ -82,6 +88,12 @@
         </div>
         {% endif %}
         <hr />
+        {% if extensionsFormFields is not empty %}
+            {% for file, data in extensionsFormFields %}
+                {# Extension writers can overload the patient/partials in their module and include their own data #}
+                {% include 'patient/partials/' ~ file ~ '.html.twig' with data %}
+            {% endfor %}
+        {% endif %}
         <input type="hidden" name="form_save" id="form_save" />
         <a href="#" class="btn btn-primary" onclick="return transmit()">{{ 'Save'|xlt }}</a>
         <input type="hidden" name="form_cancel" id="form_cancel" />


### PR DESCRIPTION
Add twig and event extensions that can be used by module writers to extend to create_portallogin dialog.

I introduce two new events, one for extending the data sent to the twig templates in the create_portallogin.php and one for triggering when the portal credentials have been updated. Also utilized a new technique that can be used to add a 0..* extension of twig files to add content to an existing twig.  I had to go this route as my module wanted to replace SOME of the twig files but I needed the twig data with some additional field data added.  The fireEvent in twig would not have accomplished this mechanism as I couldn't re-arrange the output in the existing twig file.

Fixes #5875. 