### PR TITLE
ccda import fix

### DIFF
--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php
@@ -193,6 +193,9 @@ class CarecoordinationTable extends AbstractTableGateway
         // 10/27/2022 sjp Extended base reader Laminas XML class using provided interface class
         // Needed to add LIBXML_COMPACT | LIBXML_PARSEHUGE flags because large text node(>10MB) will fail.
         try {
+            // For unknown reasons, need to create a prior dummy XML() instance for the XMLExtended() instance to work.
+            //  Otherwise it fails silently in linux (notably, this is not needed for windows).
+            $dummyXml = new XML();
             $xmltoarray = new XmlExtended();
             $xml = $xmltoarray->fromString($xml_content_new);
         } catch (Exception $e) {

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php
@@ -193,9 +193,6 @@ class CarecoordinationTable extends AbstractTableGateway
         // 10/27/2022 sjp Extended base reader Laminas XML class using provided interface class
         // Needed to add LIBXML_COMPACT | LIBXML_PARSEHUGE flags because large text node(>10MB) will fail.
         try {
-            // For unknown reasons, need to create a prior dummy XML() instance for the XMLExtended() instance to work.
-            //  Otherwise it fails silently in linux (notably, this is not needed for windows).
-            $dummyXml = new XML();
             $xmltoarray = new XmlExtended();
             $xml = $xmltoarray->fromString($xml_content_new);
         } catch (Exception $e) {

--- a/src/Services/Cda/XmlExtended.php
+++ b/src/Services/Cda/XmlExtended.php
@@ -13,10 +13,10 @@
 namespace OpenEMR\Services\Cda;
 
 use Laminas\Config\Reader\ReaderInterface;
-use Laminas\Config\Reader\XML;
+use Laminas\Config\Reader\Xml;
 use XMLReader;
 
-class XmlExtended extends XML implements ReaderInterface
+class XmlExtended extends Xml implements ReaderInterface
 {
     /**
      * fromFile(): defined by Reader interface.


### PR DESCRIPTION
fixes #5903 

@sjpadgett , the silent fail was happening at the creation of the instance `$xmltoarray = new XmlExtended();`. No constructor is involved, so figured that the class it extended was bringing in something that XmlExtended didn't. So, if create a dummy Xml class `$dummyXml = new XML();` before creating the XmlExtended() class then it works (gui import of xml and zip with documents and the command line synthea import also works)
:)
I think something that XML brings in at https://github.com/laminas/laminas-config/blob/3.7.0/src/Reader/Xml.php#L5-L21 that is not brought in by XmlExtended is causing the fail, but even if I copy that into the XmlExtended class script, it still fails.