### PR TITLE
Fix encounter history hover tooltips

### DIFF
--- a/interface/patient_file/history/encounters.php
+++ b/interface/patient_file/history/encounters.php
@@ -583,7 +583,7 @@ window.onload = function() {
                             if (hasFormPermission($enc['formdir'])) {
                                 $formDiv .= "data-toggle='PopOverReport' data-formpid='$formPid' data-formdir='$formDir' data-formenc='$formEnc' data-formid='$formId' ";
                             }
-                            $formDiv .= "title='" . text(xl_form_title($enc['form_name'])) . " <small>" . xla("Click or change focus to dismiss") . "</small>'>";
+                            $formDiv .= "data-original-title='" . text(xl_form_title($enc['form_name'])) . " <i>" . xla("Click or change focus to dismiss") . "</i>'>";
                             $formDiv .= text(xl_form_title($enc['form_name']));
                             $formDiv .= "</div>";
                             echo $formDiv;
@@ -891,7 +891,7 @@ $(function () {
         trigger: "hover focus",
         html: true,
         delay: {"show": 500, "hide": 30000},
-        template: '<div class="container-fluid"><div class="popover" style="max-width:90%;max-height:100vh;" role="tooltip"><div class="arrow"></div><h3 class="popover-header bg-dark text-light"></h3><div class="popover-body bg-light text-dark"></div></div></div>'
+        template: '<div class="container-fluid"><div class="popover" style="max-width:90%;max-height:100vh;" role="tooltip"><div class="arrow"></div><h3 class="popover-header bg-dark text-light"></h3><div class="popover-body"></div></div></div>'
     });
     // Report tooltip where popover will stay open for 30 seconds
     // or mouse leaves popover or user clicks anywhere in popover.

--- a/interface/patient_file/history/encounters.php
+++ b/interface/patient_file/history/encounters.php
@@ -890,9 +890,11 @@ $(function () {
         placement: "auto",
         trigger: "hover focus",
         html: true,
-        delay: {"show": 500, "hide": 30000},
+        delay: {"show": 1000, "hide": 30000},
         template: '<div id="report_id" class="container-fluid"><div class="popover" style="max-width:90%;max-height:100vh;" role="tooltip"><div class="arrow"></div><h3 class="popover-header bg-dark text-light"></h3><div class="popover-body bg-light text-dark"></div></div></div>'
     });
+    // Report tooltip where popover will stay open for 30 seconds
+    // or mouse leaves popover or user clicks anywhere in popover.
     // this will allow user to enter popover report view and scroll if report
     // height is overflowed. Poporver will eiter close when mouse leaves view
     // or user clicks anywhere in view.

--- a/interface/patient_file/history/encounters.php
+++ b/interface/patient_file/history/encounters.php
@@ -581,9 +581,9 @@ window.onload = function() {
                             $formId = attr($enc['form_id']);
                             $formPid = attr($pid);
                             if (hasFormPermission($enc['formdir'])) {
-                                $formDiv .= "data-toggle='PopOverReport' data-formpid='$formPid' data-formdir='$formDir' data-formenc='$formEnc' data-formid='$formId'";
+                                $formDiv .= "data-toggle='PopOverReport' data-formpid='$formPid' data-formdir='$formDir' data-formenc='$formEnc' data-formid='$formId' ";
                             }
-                            $formDiv .= ">";
+                            $formDiv .= "title='" . text(xl_form_title($enc['form_name'])) . " <small>" . xla("Click or change focus to dismiss") . "</small>'>";
                             $formDiv .= text(xl_form_title($enc['form_name']));
                             $formDiv .= "</div>";
                             echo $formDiv;
@@ -890,19 +890,33 @@ $(function () {
         placement: "auto",
         trigger: "hover focus",
         html: true,
-        delay: {"show": 1000, "hide": 30000},
-        template: '<div id="report_id" class="container-fluid"><div class="popover" style="max-width:90%;max-height:100vh;" role="tooltip"><div class="arrow"></div><h3 class="popover-header bg-dark text-light"></h3><div class="popover-body bg-light text-dark"></div></div></div>'
+        delay: {"show": 500, "hide": 30000},
+        template: '<div class="container-fluid"><div class="popover" style="max-width:90%;max-height:100vh;" role="tooltip"><div class="arrow"></div><h3 class="popover-header bg-dark text-light"></h3><div class="popover-body bg-light text-dark"></div></div></div>'
     });
     // Report tooltip where popover will stay open for 30 seconds
     // or mouse leaves popover or user clicks anywhere in popover.
     // this will allow user to enter popover report view and scroll if report
     // height is overflowed. Poporver will eiter close when mouse leaves view
     // or user clicks anywhere in view.
+    $('[data-toggle="PopOverReport"]').on('show.bs.popover', function () {
+        let elements = $('[aria-describedby^="popover"]');
+        let thisOne = this.dataset.formid;
+        let thisTitle = this.dataset.formdir;
+        for (i = 0; i < elements.length; ++i) {
+            if (thisOne === elements[i].dataset.formid && thisTitle === elements[i].dataset.formdir) {
+                continue;
+            }
+            $(elements[i]).popover('hide');
+        }
+    });
+
     $('[data-toggle="PopOverReport"]').on('shown.bs.popover', function () {
-        $('.popover').click(function(e) {
+
+        // set event listeners
+        $('.popover').click(function (e) {
             $('[data-toggle="PopOverReport"]').popover('hide');
-        }).mouseleave(function(e) {
-            timeoutObj = setTimeout(function(){
+        }).mouseleave(function (e) {
+            timeoutObj = setTimeout(function () {
                 $('[data-toggle="PopOverReport"]').popover('hide');
             }, 100);
         });

--- a/interface/patient_file/history/encounters.php
+++ b/interface/patient_file/history/encounters.php
@@ -223,21 +223,10 @@ function changePageSize() {
 window.onload = function() {
     $("#selPagesize").on("change", changePageSize);
 }
-
-// Mouseover handler for encounter form names. Brings up a custom tooltip
-// to display the form's contents.
-function efmouseover(elem, ptid, encid, formname, formid) {
- ttMouseOver(elem, "encounters_ajax.php?ptid=" + encodeURIComponent(ptid) + "&encid=" + encodeURIComponent(encid) +
-  "&formname=" + encodeURIComponent(formname) + "&formid=" + encodeURIComponent(formid) + "&csrf_token_form=" + <?php echo js_url(CsrfUtils::collectCsrfToken()); ?>);
-}
-
 </script>
-
 </head>
-
 <body>
 <div class="container-fluid mt-3" id="encounters"> <!-- large outer DIV -->
-
     <span class='title'>
         <?php
         if ($issue) {
@@ -252,8 +241,6 @@ function efmouseover(elem, ptid, encid, formname, formid) {
     </span>
     <?php
     // Setup the GET string to append when switching between billing and clinical views.
-
-
     if (!($auth_notes_a || $auth_notes || $auth_coding_a || $auth_coding || $auth_med || $auth_relaxed) || ($is_group && !$glog_view_write)) {
         echo "<body>\n<html>\n";
         echo "<p>(" . xlt('Encounters not authorized') . ")</p>\n";
@@ -589,12 +576,12 @@ function efmouseover(elem, ptid, encid, formname, formid) {
                             echo "</div>";
                         } else {
                             $formDiv = "<div ";
+                            $formDir = attr($formdir);
+                            $formEnc = attr($result4['encounter']);
+                            $formId = attr($enc['form_id']);
+                            $formPid = attr($pid);
                             if (hasFormPermission($enc['formdir'])) {
-                                $formDiv .= "onmouseover='efmouseover(this," . attr_js($pid) . ","
-                                . attr_js($result4['encounter']) .
-                                "," . attr_js($formdir) . "," . attr_js($enc['form_id'])
-                                . ")' " .
-                                "onmouseout='ttMouseOut()'";
+                                $formDiv .= "data-toggle='PopOverReport' data-formpid='$formPid' data-formdir='$formDir' data-formenc='$formEnc' data-formid='$formId'";
                             }
                             $formDiv .= ">";
                             $formDiv .= text(xl_form_title($enc['form_name']));
@@ -817,12 +804,11 @@ function efmouseover(elem, ptid, encid, formname, formid) {
 
                 if ($GLOBALS['enable_follow_up_encounters']) {
                     $encounterId = ( !empty($result4['parent_encounter_id']) ) ? $result4['parent_encounter_id'] : $result4['id'];
-                    echo "<td> <div style='z-index: 9999'>  <a href='#' class='btn btn-primary' onclick='createFollowUpEncounter(event," . attr_js($encounterId) . ")'><span>" . xlt('Create follow-up encounter') . "</span></a> </div></td>\n";
+                    echo "<td> <div style='z-index: 9999'>  <a href='#' class='btn btn-sm btn-primary' onclick='createFollowUpEncounter(event," . attr_js($encounterId) . ")'><span>" . xlt('Create follow-up encounter') . "</span></a> </div></td>\n";
                 }
 
                     echo "</tr>\n";
             } // end while
-
 
             // Dump remaining document lines if count not exceeded.
             while ($drow /* && $count <= $N */) {
@@ -835,8 +821,6 @@ function efmouseover(elem, ptid, encid, formname, formid) {
     </div>
 
 </div> <!-- end 'encounters' large outer DIV -->
-
-<span class='position-absolute border border-danger w-auto jumbotron p-1 ml-4' id='tooltipdiv' style='max-width: 75%; visibility: hidden;'></span>
 
 <script>
 // jQuery stuff to make the page a little easier to use
@@ -871,8 +855,57 @@ $(function () {
 
 $(function () {
     $('[data-toggle="tooltip"]').tooltip();
+    // Report tooltip where popover will stay open for 30 seconds
+    // or mouse leaves popover or user clicks anywhere in popover.
+    $('body').popover({
+        sanitize: false,
+        title: function () {
+            return this.innerHTML;
+        },
+        content: function () {
+            let el = this;
+            if (typeof el.dataset == 'undefined') {
+                return xl("Report Unavailable");
+            }
+            let url = "encounters_ajax.php?ptid=" + encodeURIComponent(el.dataset.formpid) +
+                "&encid=" + encodeURIComponent(el.dataset.formenc) +
+                "&formname=" + encodeURIComponent(el.dataset.formdir) +
+                "&formid=" + encodeURIComponent(el.dataset.formid) +
+                "&csrf_token_form=" + <?php echo js_url(CsrfUtils::collectCsrfToken()); ?>;
+            let fetchedReport;
+            $.ajax({
+                url: url,
+                method: "GET",
+                async: false,
+                beforeSend: top.restoreSession,
+                success: function (report) {
+                    fetchedReport = report;
+                }
+            });
+            return fetchedReport;
+        },
+        selector: '[data-toggle="PopOverReport"]',
+        boundary: "scrollParent",
+        animation: true,
+        placement: "auto",
+        trigger: "hover focus",
+        html: true,
+        delay: {"show": 500, "hide": 30000},
+        template: '<div id="report_id" class="container-fluid"><div class="popover" style="max-width:90%;max-height:100vh;" role="tooltip"><div class="arrow"></div><h3 class="popover-header bg-dark text-light"></h3><div class="popover-body bg-light text-dark"></div></div></div>'
+    });
+    // this will allow user to enter popover report view and scroll if report
+    // height is overflowed. Poporver will eiter close when mouse leaves view
+    // or user clicks anywhere in view.
+    $('[data-toggle="PopOverReport"]').on('shown.bs.popover', function () {
+        $('.popover').click(function(e) {
+            $('[data-toggle="PopOverReport"]').popover('hide');
+        }).mouseleave(function(e) {
+            timeoutObj = setTimeout(function(){
+                $('[data-toggle="PopOverReport"]').popover('hide');
+            }, 100);
+        });
+    });
 });
-
 </script>
 </body>
 </html>


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #5926 

#### Short description of what this resolves:
Tooltips currently are not useful.

#### Changes proposed in this pull request:
Make the darn thing useful:)
The report tooltip now popover where popover will stay open for 30 seconds             
or if the mouse leaves popover or if the user clicks anywhere in popover.            
This will allow user to enter popover report view and scroll if report 
height is overflowed. Popover will either close when mouse leaves view 
or user clicks anywhere in view. 
Multiple popovers may be opened on hover/focus but closing any one of them, closes all.   
Kind of a nifty solution.                                   