### PR TITLE
Fixes #5919 fix timezone code to handle DST/UTC

### DIFF
--- a/src/Services/FHIR/DiagnosticReport/FhirDiagnosticReportClinicalNotesService.php
+++ b/src/Services/FHIR/DiagnosticReport/FhirDiagnosticReportClinicalNotesService.php
@@ -87,7 +87,7 @@ class FhirDiagnosticReportClinicalNotesService extends FhirServiceBase
         $report = new FHIRDiagnosticReport();
         $meta = new FHIRMeta();
         $meta->setVersionId('1');
-        $meta->setLastUpdated(gmdate('c'));
+        $meta->setLastUpdated(UtilsService::getDateFormattedAsUTC());
         $report->setMeta($meta);
 
         $id = new FHIRId();
@@ -95,7 +95,7 @@ class FhirDiagnosticReportClinicalNotesService extends FhirServiceBase
         $report->setId($id);
 
         if (!empty($dataRecord['date'])) {
-            $date = gmdate('c', strtotime($dataRecord['date']));
+            $date = UtilsService::getLocalDateAsUTC($dataRecord['date']);
             $report->setEffectiveDateTime(new FHIRDateTime($date));
             $report->setIssued(new FHIRInstant($date));
         } else {

--- a/src/Services/FHIR/DiagnosticReport/FhirDiagnosticReportLaboratoryService.php
+++ b/src/Services/FHIR/DiagnosticReport/FhirDiagnosticReportLaboratoryService.php
@@ -93,7 +93,7 @@ class FhirDiagnosticReportLaboratoryService extends FhirServiceBase
         $report = new FHIRDiagnosticReport();
         $meta = new FHIRMeta();
         $meta->setVersionId('1');
-        $meta->setLastUpdated(gmdate('c'));
+        $meta->setLastUpdated(UtilsService::getDateFormattedAsUTC());
         $report->setMeta($meta);
 
 
@@ -105,9 +105,9 @@ class FhirDiagnosticReportLaboratoryService extends FhirServiceBase
         $report->setId($id);
 
         if (!empty($dataRecordReport['date'])) {
-            $date = gmdate('c', strtotime($dataRecordReport['date']));
-            $report->setEffectiveDateTime(new FHIRDateTime($date));
-            $report->setIssued(new FHIRInstant($date));
+            $utcDate = UtilsService::getLocalDateAsUTC($dataRecordReport['date']);
+            $report->setEffectiveDateTime(new FHIRDateTime($utcDate));
+            $report->setIssued(new FHIRInstant($utcDate));
         } else {
             $report->setDate(UtilsService::createDataMissingExtension());
         }

--- a/src/Services/FHIR/DocumentReference/FhirClinicalNotesService.php
+++ b/src/Services/FHIR/DocumentReference/FhirClinicalNotesService.php
@@ -93,7 +93,7 @@ class FhirClinicalNotesService extends FhirServiceBase
         $docReference = new FHIRDocumentReference();
         $meta = new FHIRMeta();
         $meta->setVersionId('1');
-        $meta->setLastUpdated(gmdate('c'));
+        $meta->setLastUpdated(UtilsService::getDateFormattedAsUTC());
         $docReference->setMeta($meta);
 
         $id = new FHIRId();
@@ -105,7 +105,7 @@ class FhirClinicalNotesService extends FhirServiceBase
         $docReference->addIdentifier($identifier);
 
         if (!empty($dataRecord['date'])) {
-            $docReference->setDate(gmdate('c', strtotime($dataRecord['date'])));
+            $docReference->setDate(UtilsService::getLocalDateAsUTC($dataRecord['date']));
         } else {
             $docReference->setDate(UtilsService::createDataMissingExtension());
         }
@@ -116,7 +116,7 @@ class FhirClinicalNotesService extends FhirServiceBase
             // we currently don't track anything dealing with start and end date for the context
             if (!empty($dataRecord['encounter_date'])) {
                 $period = new FHIRPeriod();
-                $period->setStart(gmdate('c', strtotime($dataRecord['encounter_date'])));
+                $period->setStart(UtilsService::getLocalDateAsUTC($dataRecord['encounter_date']));
                 $context->setPeriod($period);
             }
             $context->addEncounter(UtilsService::createRelativeReference('Encounter', $dataRecord['euuid']));

--- a/src/Services/FHIR/DocumentReference/FhirPatientDocumentReferenceService.php
+++ b/src/Services/FHIR/DocumentReference/FhirPatientDocumentReferenceService.php
@@ -101,7 +101,7 @@ class FhirPatientDocumentReferenceService extends FhirServiceBase
         $docReference = new FHIRDocumentReference();
         $meta = new FHIRMeta();
         $meta->setVersionId('1');
-        $meta->setLastUpdated(gmdate('c'));
+        $meta->setLastUpdated(UtilsService::getDateFormattedAsUTC());
         $docReference->setMeta($meta);
 
         $id = new FHIRId();
@@ -115,7 +115,7 @@ class FhirPatientDocumentReferenceService extends FhirServiceBase
         // TODO: @adunsulag need to support content.attachment.url
 
         if (!empty($dataRecord['date'])) {
-            $docReference->setDate(gmdate('c', strtotime($dataRecord['date'])));
+            $docReference->setDate(UtilsService::getLocalDateAsUTC($dataRecord['date']));
         } else {
             $docReference->setDate(UtilsService::createDataMissingExtension());
         }
@@ -126,7 +126,7 @@ class FhirPatientDocumentReferenceService extends FhirServiceBase
             // we currently don't track anything dealing with start and end date for the context
             if (!empty($dataRecord['encounter_date'])) {
                 $period = new FHIRPeriod();
-                $period->setStart(gmdate('c', strtotime($dataRecord['encounter_date'])));
+                $period->setStart(UtilsService::getLocalDateAsUTC($dataRecord['encounter_date']));
                 $context->setPeriod($period);
             }
             $context->addEncounter(UtilsService::createRelativeReference('Encounter', $dataRecord['euuid']));

--- a/src/Services/FHIR/FhirAllergyIntoleranceService.php
+++ b/src/Services/FHIR/FhirAllergyIntoleranceService.php
@@ -113,7 +113,7 @@ class FhirAllergyIntoleranceService extends FhirServiceBase implements IResource
         $allergyIntoleranceResource = new FHIRAllergyIntolerance();
         $fhirMeta = new FHIRMeta();
         $fhirMeta->setVersionId("1");
-        $fhirMeta->setLastUpdated(gmdate('c'));
+        $fhirMeta->setLastUpdated(UtilsService::getDateFormattedAsUTC());
         $allergyIntoleranceResource->setMeta($fhirMeta);
 
         $id = new FHIRId();

--- a/src/Services/FHIR/FhirAppointmentService.php
+++ b/src/Services/FHIR/FhirAppointmentService.php
@@ -75,7 +75,7 @@ class FhirAppointmentService extends FhirServiceBase implements IPatientCompartm
 
         $fhirMeta = new FHIRMeta();
         $fhirMeta->setVersionId("1");
-        $fhirMeta->setLastUpdated(gmdate('c'));
+        $fhirMeta->setLastUpdated(UtilsService::getDateFormattedAsUTC());
         $appt->setMeta($fhirMeta);
 
         $id = new FHIRId();
@@ -182,22 +182,22 @@ class FhirAppointmentService extends FhirServiceBase implements IPatientCompartm
         // start time
         if (!empty($dataRecord['pc_eventDate'])) {
             $concatenatedDate = $dataRecord['pc_eventDate'] . ' ' . $dataRecord['pc_startTime'];
-            $startInstant = gmdate('c', strtotime($concatenatedDate));
+            $startInstant = UtilsService::getLocalDateAsUTC($concatenatedDate);
             $appt->setStart(new FHIRInstant($startInstant));
         } else if ($dataRecord['pc_endDate'] != '0000-00-00' && !empty($dataRecord['pc_startTime'])) {
             $concatenatedDate = $dataRecord['pc_endDate'] . ' ' . $dataRecord['pc_startTime'];
-            $startInstant = gmdate('c', strtotime($concatenatedDate));
+            $startInstant = UtilsService::getLocalDateAsUTC($concatenatedDate);
             $appt->setStart(new FHIRInstant($startInstant));
         }
 
         // if we have a start date and and end time we will use that
         if (!empty($dataRecord['pc_eventDate']) && !empty($dataRecord['pc_endTime'])) {
             $concatenatedDate = $dataRecord['pc_eventDate'] . ' ' . $dataRecord['pc_endTime'];
-            $endInstant = gmdate('c', strtotime($concatenatedDate));
+            $endInstant = UtilsService::getLocalDateAsUTC($concatenatedDate);
             $appt->setEnd(new FHIRInstant($endInstant));
         } else if (!empty($dataRecord['pc_endDate']) && !empty($dataRecord['pc_endTime'])) {
             $concatenatedDate = $dataRecord['pc_endDate'] . ' ' . $dataRecord['pc_endTime'];
-            $endInstant = gmdate('c', strtotime($concatenatedDate));
+            $endInstant = UtilsService::getLocalDateAsUTC($concatenatedDate);
             $appt->setEnd(new FHIRInstant($endInstant));
         }
 

--- a/src/Services/FHIR/FhirCarePlanService.php
+++ b/src/Services/FHIR/FhirCarePlanService.php
@@ -73,7 +73,7 @@ class FhirCarePlanService extends FhirServiceBase implements IResourceUSCIGProfi
 
         $fhirMeta = new FHIRMeta();
         $fhirMeta->setVersionId('1');
-        $fhirMeta->setLastUpdated(gmdate('c'));
+        $fhirMeta->setLastUpdated(UtilsService::getDateFormattedAsUTC());
         $carePlanResource->setMeta($fhirMeta);
 
         $fhirId = new FHIRId();

--- a/src/Services/FHIR/FhirCareTeamService.php
+++ b/src/Services/FHIR/FhirCareTeamService.php
@@ -83,7 +83,7 @@ class FhirCareTeamService extends FhirServiceBase implements IResourceUSCIGProfi
 
         $fhirMeta = new FHIRMeta();
         $fhirMeta->setVersionId('1');
-        $fhirMeta->setLastUpdated(gmdate('c'));
+        $fhirMeta->setLastUpdated(UtilsService::getDateFormattedAsUTC());
         $careTeamResource->setMeta($fhirMeta);
 
         $id = new FHIRId();

--- a/src/Services/FHIR/FhirConditionService.php
+++ b/src/Services/FHIR/FhirConditionService.php
@@ -74,7 +74,7 @@ class FhirConditionService extends FhirServiceBase implements IResourceUSCIGProf
 
         $meta = new FHIRMeta();
         $meta->setVersionId('1');
-        $meta->setLastUpdated(gmdate('c'));
+        $meta->setLastUpdated(UtilsService::getDateFormattedAsUTC());
         $conditionResource->setMeta($meta);
 
         $id = new FHIRId();

--- a/src/Services/FHIR/FhirCoverageService.php
+++ b/src/Services/FHIR/FhirCoverageService.php
@@ -67,7 +67,7 @@ class FhirCoverageService extends FhirServiceBase implements IPatientCompartment
     public function parseOpenEMRRecord($dataRecord = array(), $encode = false)
     {
         $coverageResource = new FHIRCoverage();
-        $meta = array('versionId' => '1', 'lastUpdated' => gmdate('c'));
+        $meta = array('versionId' => '1', 'lastUpdated' => UtilsService::getDateFormattedAsUTC());
         $coverageResource->setMeta($meta);
 
         $id = new FHIRId();

--- a/src/Services/FHIR/FhirDeviceService.php
+++ b/src/Services/FHIR/FhirDeviceService.php
@@ -66,7 +66,7 @@ class FhirDeviceService extends FhirServiceBase implements IResourceUSCIGProfile
     {
         $device = new FHIRDevice();
 
-        $device->setMeta(UtilsService::createFhirMeta('1', gmdate('c')));
+        $device->setMeta(UtilsService::createFhirMeta('1', UtilsService::getDateFormattedAsUTC()));
 
         $id = new FHIRId();
         $id->setValue($dataRecord['uuid']);

--- a/src/Services/FHIR/FhirEncounterService.php
+++ b/src/Services/FHIR/FhirEncounterService.php
@@ -112,7 +112,7 @@ class FhirEncounterService extends FhirServiceBase implements
 
         $meta = new FHIRMeta();
         $meta->setVersionId('1');
-        $meta->setLastUpdated(gmdate('c'));
+        $meta->setLastUpdated(UtilsService::getDateFormattedAsUTC());
         $encounterResource->setMeta($meta);
 
         $id = new FhirId();
@@ -169,8 +169,7 @@ class FhirEncounterService extends FhirServiceBase implements
                 )
             );
             $period = new FHIRPeriod();
-            $period->setStart(DateTime::createFromFormat("Y-m-d H:i:s", $dataRecord['date'])->format('c'));
-            $period->setStart(gmdate('c', strtotime($dataRecord['date'])));
+            $period->setStart(UtilsService::getLocalDateAsUTC($dataRecord['date']));
             $participant->setPeriod($period);
 
             $participantType = UtilsService::createCodeableConcept([
@@ -195,8 +194,7 @@ class FhirEncounterService extends FhirServiceBase implements
                 )
             );
             $period = new FHIRPeriod();
-            $period->setStart(DateTime::createFromFormat("Y-m-d H:i:s", $dataRecord['date'])->format('c'));
-            $period->setStart(gmdate('c', strtotime($dataRecord['date'])));
+            $period->setStart(UtilsService::getLocalDateAsUTC($dataRecord['date']));
             $participant->setPeriod($period);
 
             $participantType = UtilsService::createCodeableConcept([
@@ -214,7 +212,7 @@ class FhirEncounterService extends FhirServiceBase implements
         // period - must support
         if (!empty($dataRecord['date'])) {
             $period = new FHIRPeriod();
-            $period->setStart(DateTime::createFromFormat("Y-m-d H:i:s", $dataRecord['date'])->format('c'));
+            $period->setStart(UtilsService::getLocalDateAsUTC($dataRecord['date']));
             $encounterResource->setPeriod($period);
         }
 

--- a/src/Services/FHIR/FhirGoalService.php
+++ b/src/Services/FHIR/FhirGoalService.php
@@ -75,7 +75,7 @@ class FhirGoalService extends FhirServiceBase implements IResourceUSCIGProfileSe
 
         $fhirMeta = new FHIRMeta();
         $fhirMeta->setVersionId('1');
-        $fhirMeta->setLastUpdated(gmdate('c'));
+        $fhirMeta->setLastUpdated(UtilsService::getDateFormattedAsUTC());
         $goal->setMeta($fhirMeta);
 
         $fhirId = new FHIRId();
@@ -110,7 +110,7 @@ class FhirGoalService extends FhirServiceBase implements IResourceUSCIGProfileSe
                 $fhirGoalTarget = new FHIRGoalTarget();
                 if (!empty($detail['date'])) {
                     $fhirDate = new FHIRDate();
-                    $parsedDateTime = \DateTime::createFromFormat("Y-m-d H:i:s", $detail['date']);
+                    $parsedDateTime = \DateTime::createFromFormat("Y-m-d H:i:s", $detail['date'], new \DateTimeZone(date('P')));
                     $fhirDate->setValue($parsedDateTime->format("Y-m-d"));
                     $fhirGoalTarget->setDueDate($fhirDate);
                 } else {

--- a/src/Services/FHIR/FhirImmunizationService.php
+++ b/src/Services/FHIR/FhirImmunizationService.php
@@ -78,7 +78,7 @@ class FhirImmunizationService extends FhirServiceBase implements IResourceUSCIGP
 
         $meta = new FHIRMeta();
         $meta->setVersionId('1');
-        $meta->setLastUpdated(gmdate('c'));
+        $meta->setLastUpdated(UtilsService::getDateFormattedAsUTC());
         $immunizationResource->setMeta($meta);
 
         $id = new FHIRId();

--- a/src/Services/FHIR/FhirLocationService.php
+++ b/src/Services/FHIR/FhirLocationService.php
@@ -76,7 +76,7 @@ class FhirLocationService extends FhirServiceBase implements IFhirExportableReso
 
         $meta = new FHIRMeta();
         $meta->setVersionId('1');
-        $meta->setLastUpdated(gmdate('c'));
+        $meta->setLastUpdated(UtilsService::getDateFormattedAsUTC());
         $locationResource->setMeta($meta);
 
         $id = new FHIRId();

--- a/src/Services/FHIR/FhirMedicationRequestService.php
+++ b/src/Services/FHIR/FhirMedicationRequestService.php
@@ -125,7 +125,7 @@ class FhirMedicationRequestService extends FhirServiceBase implements IResourceU
 
         $meta = new FHIRMeta();
         $meta->setVersionId('1');
-        $meta->setLastUpdated(gmdate('c'));
+        $meta->setLastUpdated(UtilsService::getDateFormattedAsUTC());
         $medRequestResource->setMeta($meta);
 
         $id = new FHIRId();
@@ -222,7 +222,7 @@ class FhirMedicationRequestService extends FhirServiceBase implements IResourceU
         // authoredOn must support
         if (!empty($dataRecord['date_added'])) {
             $authored_on = new FHIRDateTime();
-            $authored_on->setValue(gmdate('c', strtotime($dataRecord['date_added'])));
+            $authored_on->setValue(UtilsService::getLocalDateAsUTC($dataRecord['date_added']));
             $medRequestResource->setAuthoredOn($authored_on);
         }
 

--- a/src/Services/FHIR/FhirMedicationService.php
+++ b/src/Services/FHIR/FhirMedicationService.php
@@ -7,6 +7,7 @@ use OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRCoding;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRDateTime;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRId;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRMeta;
 use OpenEMR\FHIR\R4\FHIRResource\FHIRMedication\FHIRMedicationBatch;
 use OpenEMR\Services\DrugService;
 use OpenEMR\Services\FHIR\FhirServiceBase;
@@ -61,7 +62,9 @@ class FhirMedicationService extends FhirServiceBase implements IResourceUSCIGPro
     {
         $medicationResource = new FHIRMedication();
 
-        $meta = array('versionId' => '1', 'lastUpdated' => gmdate('c'));
+        $meta = new FHIRMeta();
+        $meta->setVersionId('1');
+        $meta->setLastUpdated(UtilsService::getDateFormattedAsUTC());
         $medicationResource->setMeta($meta);
 
         $id = new FHIRId();

--- a/src/Services/FHIR/FhirPatientService.php
+++ b/src/Services/FHIR/FhirPatientService.php
@@ -156,8 +156,10 @@ class FhirPatientService extends FhirServiceBase implements IFhirExportableResou
     {
         $patientResource = new FHIRPatient();
 
-        $meta = array('versionId' => '1', 'lastUpdated' => gmdate('c'));
-        $patientResource->setMeta(new FHIRMeta($meta));
+        $meta = new FHIRMeta();
+        $meta->setVersionId('1');
+        $meta->setLastUpdated(UtilsService::getDateFormattedAsUTC());
+        $patientResource->setMeta($meta);
 
         $patientResource->setActive(true);
         $id = new FHIRId();
@@ -259,7 +261,7 @@ class FhirPatientService extends FhirServiceBase implements IFhirExportableResou
                 }
                 if (!empty($prevName['previous_name_enddate'])) {
                     $fhirPeriod = new FHIRPeriod();
-                    $fhirPeriod->setEnd(gmdate('c', strtotime($prevName['previous_name_enddate'])));
+                    $fhirPeriod->setEnd(UtilsService::getLocalDateAsUTC($prevName['previous_name_enddate']));
                     $previousHumanName->setPeriod($fhirPeriod);
                 }
                 $patientResource->addName($previousHumanName);

--- a/src/Services/FHIR/FhirPersonService.php
+++ b/src/Services/FHIR/FhirPersonService.php
@@ -18,6 +18,7 @@ use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRPractitioner;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRId;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRHumanName;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRAddress;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRMeta;
 use OpenEMR\Services\FHIR\Traits\BulkExportSupportAllOperationsTrait;
 use OpenEMR\Services\FHIR\Traits\FhirBulkExportDomainResourceTrait;
 use OpenEMR\Services\Search\FhirSearchParameterDefinition;
@@ -82,7 +83,9 @@ class FhirPersonService extends FhirServiceBase implements IFhirExportableResour
     {
         $person = new FHIRPerson();
 
-        $meta = array('versionId' => '1', 'lastUpdated' => gmdate('c'));
+        $meta = new FHIRMeta();
+        $meta->setVersionId('1');
+        $meta->setLastUpdated(UtilsService::getDateFormattedAsUTC());
         $person->setMeta($meta);
 
         $person->setActive($dataRecord['active'] == "1" ? true : false);

--- a/src/Services/FHIR/FhirPractitionerRoleService.php
+++ b/src/Services/FHIR/FhirPractitionerRoleService.php
@@ -4,6 +4,7 @@ namespace OpenEMR\Services\FHIR;
 
 use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRPractitionerRole;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRMeta;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRReference;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRId;
 use OpenEMR\Services\PractitionerRoleService;
@@ -60,7 +61,9 @@ class FhirPractitionerRoleService extends FhirServiceBase implements IResourceUS
     {
         $practitionerRoleResource = new FHIRPractitionerRole();
 
-        $meta = array('versionId' => '1', 'lastUpdated' => gmdate('c'));
+        $meta = new FHIRMeta();
+        $meta->setVersionId('1');
+        $meta->setLastUpdated(UtilsService::getDateFormattedAsUTC());
         $practitionerRoleResource->setMeta($meta);
 
         $id = new FHIRId();

--- a/src/Services/FHIR/FhirPractitionerService.php
+++ b/src/Services/FHIR/FhirPractitionerService.php
@@ -82,7 +82,7 @@ class FhirPractitionerService extends FhirServiceBase implements IFhirExportable
 
         $meta = new FHIRMeta();
         $meta->setVersionId('1');
-        $meta->setLastUpdated(gmdate('c'));
+        $meta->setLastUpdated(UtilsService::getDateFormattedAsUTC());
         $practitionerResource->setMeta($meta);
 
         $practitionerResource->setActive($dataRecord['active'] == "1" ? true : false);

--- a/src/Services/FHIR/Group/FhirPatientProviderGroupService.php
+++ b/src/Services/FHIR/Group/FhirPatientProviderGroupService.php
@@ -56,7 +56,7 @@ class FhirPatientProviderGroupService extends FhirServiceBase
         $fhirGroup = new FHIRGroup();
         $fhirMeta = new FHIRMeta();
         $fhirMeta->setVersionId("1");
-        $fhirMeta->setLastUpdated(gmdate('c'));
+        $fhirMeta->setLastUpdated(UtilsService::getDateFormattedAsUTC());
         $fhirGroup->setMeta($fhirMeta);
 
         $fhirGroup->setId($dataRecord['uuid']);

--- a/src/Services/FHIR/Observation/FhirObservationLaboratoryService.php
+++ b/src/Services/FHIR/Observation/FhirObservationLaboratoryService.php
@@ -159,7 +159,7 @@ class FhirObservationLaboratoryService extends FhirServiceBase implements IPatie
         $observation = new FHIRObservation();
         $meta = new FHIRMeta();
         $meta->setVersionId('1');
-        $meta->setLastUpdated(gmdate('c'));
+        $meta->setLastUpdated(UtilsService::getDateFormattedAsUTC());
         $observation->setMeta($meta);
 
         $id = new FHIRId();
@@ -167,7 +167,7 @@ class FhirObservationLaboratoryService extends FhirServiceBase implements IPatie
         $observation->setId($id);
 
         if (!empty($dataRecord['report_date'])) {
-            $observation->setEffectiveDateTime(gmdate('c', strtotime($dataRecord['report_date'])));
+            $observation->setEffectiveDateTime(UtilsService::getLocalDateAsUTC($dataRecord['report_date']));
         } else {
             $observation->setEffectiveDateTime(UtilsService::createDataMissingExtension());
         }

--- a/src/Services/FHIR/Observation/FhirObservationSocialHistoryService.php
+++ b/src/Services/FHIR/Observation/FhirObservationSocialHistoryService.php
@@ -271,7 +271,7 @@ class FhirObservationSocialHistoryService extends FhirServiceBase implements IPa
         $observation = new FHIRObservation();
         $meta = new FHIRMeta();
         $meta->setVersionId('1');
-        $meta->setLastUpdated(gmdate('c'));
+        $meta->setLastUpdated(UtilsService::getDateFormattedAsUTC());
         $observation->setMeta($meta);
 
         $id = new FHIRId();
@@ -279,7 +279,7 @@ class FhirObservationSocialHistoryService extends FhirServiceBase implements IPa
         $observation->setId($id);
 
         if (!empty($dataRecord['date'])) {
-            $observation->setIssued(gmdate('c', strtotime($dataRecord['date'])));
+            $observation->setIssued(UtilsService::getLocalDateAsUTC($dataRecord['date']));
         } else {
             $observation->setIssued(UtilsService::createDataMissingExtension());
         }

--- a/src/Services/FHIR/Observation/FhirObservationVitalsService.php
+++ b/src/Services/FHIR/Observation/FhirObservationVitalsService.php
@@ -421,7 +421,7 @@ class FhirObservationVitalsService extends FhirServiceBase implements IPatientCo
         $observation = new FHIRObservation();
         $meta = new FHIRMeta();
         $meta->setVersionId('1');
-        $meta->setLastUpdated(gmdate('c'));
+        $meta->setLastUpdated(UtilsService::getDateFormattedAsUTC());
         $observation->setMeta($meta);
 
         $id = new FHIRId();
@@ -429,7 +429,7 @@ class FhirObservationVitalsService extends FhirServiceBase implements IPatientCo
         $observation->setId($id);
 
         if (!empty($dataRecord['date'])) {
-            $observation->setEffectiveDateTime(gmdate('c', strtotime($dataRecord['date'])));
+            $observation->setEffectiveDateTime(UtilsService::getLocalDateAsUTC($dataRecord['date']));
         } else {
             $observation->setEffectiveDateTime(UtilsService::createDataMissingExtension());
         }

--- a/src/Services/FHIR/Organization/FhirOrganizationFacilityService.php
+++ b/src/Services/FHIR/Organization/FhirOrganizationFacilityService.php
@@ -162,7 +162,7 @@ class FhirOrganizationFacilityService extends FhirServiceBase
 
         $fhirMeta = new FHIRMeta();
         $fhirMeta->setVersionId('1');
-        $fhirMeta->setLastUpdated(gmdate('c'));
+        $fhirMeta->setLastUpdated(UtilsService::getDateFormattedAsUTC());
         $organizationResource->setMeta($fhirMeta);
         // facilities have no active / inactive state
         $organizationResource->setActive(true);

--- a/src/Services/FHIR/Organization/FhirOrganizationInsuranceService.php
+++ b/src/Services/FHIR/Organization/FhirOrganizationInsuranceService.php
@@ -93,7 +93,7 @@ class FhirOrganizationInsuranceService extends FhirServiceBase
 
         $fhirMeta = new FHIRMeta();
         $fhirMeta->setVersionId('1');
-        $fhirMeta->setLastUpdated(gmdate('c'));
+        $meta->setLastUpdated(UtilsService::getDateFormattedAsUTC());
         $organizationResource->setMeta($fhirMeta);
         $organizationResource->setActive($dataRecord['inactive'] == '0');
 

--- a/src/Services/FHIR/Organization/FhirOrganizationProcedureProviderService.php
+++ b/src/Services/FHIR/Organization/FhirOrganizationProcedureProviderService.php
@@ -84,7 +84,7 @@ class FhirOrganizationProcedureProviderService extends FhirServiceBase
 
         $fhirMeta = new FHIRMeta();
         $fhirMeta->setVersionId('1');
-        $fhirMeta->setLastUpdated(gmdate('c'));
+        $fhirMeta->setLastUpdated(UtilsService::getDateFormattedAsUTC());
         $organizationResource->setMeta($fhirMeta);
         $organizationResource->setActive($dataRecord['active'] == '1');
 

--- a/src/Services/FHIR/Procedure/FhirProcedureOEProcedureService.php
+++ b/src/Services/FHIR/Procedure/FhirProcedureOEProcedureService.php
@@ -113,7 +113,7 @@ class FhirProcedureOEProcedureService extends FhirServiceBase
 
         $meta = new FHIRMeta();
         $meta->setVersionId('1');
-        $meta->setLastUpdated(gmdate('c'));
+        $meta->setLastUpdated(UtilsService::getDateFormattedAsUTC());
         $procedureResource->setMeta($meta);
 
         $report = array_pop($dataRecord['reports']);
@@ -204,7 +204,7 @@ class FhirProcedureOEProcedureService extends FhirServiceBase
 
 
         if (!empty($report['date'])) {
-            $procedureResource->setPerformedDateTime(gmdate('c', strtotime($report['date'])));
+            $procedureResource->setPerformedDateTime(UtilsService::getLocalDateAsUTC($report['date']));
         } else {
             $procedureResource->setPerformedDateTime(UtilsService::createDataMissingExtension());
         }

--- a/src/Services/FHIR/Procedure/FhirProcedureSurgeryService.php
+++ b/src/Services/FHIR/Procedure/FhirProcedureSurgeryService.php
@@ -85,7 +85,7 @@ class FhirProcedureSurgeryService extends FhirServiceBase
 
         $meta = new FHIRMeta();
         $meta->setVersionId('1');
-        $meta->setLastUpdated(gmdate('c'));
+        $meta->setLastUpdated(UtilsService::getDateFormattedAsUTC());
         $procedureResource->setMeta($meta);
 
         $id = new FHIRId();
@@ -125,7 +125,7 @@ class FhirProcedureSurgeryService extends FhirServiceBase
         }
 
         if (!empty($dataRecord['begdate'])) {
-            $procedureResource->setPerformedDateTime(gmdate('c', strtotime($dataRecord['begdate'])));
+            $procedureResource->setPerformedDateTime(UtilsService::getLocalDateAsUTC($dataRecord['begdate']));
         }
 
         if (!empty($dataRecord['comments'])) {

--- a/src/Services/FHIR/UtilsService.php
+++ b/src/Services/FHIR/UtilsService.php
@@ -135,7 +135,7 @@ class UtilsService
                     "Failed to format date record with date format ",
                     ['start' => $dataRecord['period_start'], 'contact_address_id' => ($dataRecord['contact_address_id'] ?? null)]
                 );
-                $date = new \DateTime();
+                $date = new \DateTime('now', new \DateTimeZone(date('P')));
             }
             $addressPeriod->setStart($date->format(\DateTime::RFC3339_EXTENDED));
         } else {
@@ -288,5 +288,24 @@ class UtilsService
         $narrative->setStatus($code);
         $narrative->setDiv($div);
         return $narrative;
+    }
+
+    public static function getDateFormattedAsUTC(): string
+    {
+        return (new \DateTime())->format(DATE_ATOM);
+    }
+
+    public static function getLocalDateAsUTC($date)
+    {
+        // make this assumption explicit that we are using the current timezone specified in PHP
+        // when we use strtotime or gmdate we get bad behavior when dealing with DST
+        // we really should be storing dates internally as UTC instead of local time... but until that happens we have
+        // to do this.
+        // note this is what we were using before
+        // $date = gmdate('c', strtotime($dataRecord['date']));
+        // w/ DST the date 2015-06-22 00:00:00 server time becomes 2015-06-22T04:00:00+00:00 w/o DST the server time becomes 2015-06-22T00:00:00-04:00
+        $date = new \DateTime($date, new \DateTimeZone(date('P')));
+        $utcDate = $date->format(DATE_ATOM);
+        return $utcDate;
     }
 }


### PR DESCRIPTION
We aren't handling timezones properly in what we return for read operations via FHIR.  We've been returning times as UTC as if the time was in the UTC/GMT timezone which is incorrect.  We've been needing to report the timezone information as a UTC time WITH the local offset expressed in the timezone.  Part of this problem is the fact that we don't store times in UTC internally.

This fixes #5919 hopefully for good.

I had to add two new functions to our utility class to create date times using the passed in DateTimeZone class.  We were using strtotime in a bunch of places but strtotime assumes the time passed in (IF there is no timezone component in the time string) is a UTC time.  I had to change this everywhere we were using gmdate and our strtotime pieces in the FHIR api.