### PR TITLE
Fixes #5933 Fhir Location Type invalid

### DIFF
--- a/src/Services/FHIR/FhirLocationService.php
+++ b/src/Services/FHIR/FhirLocationService.php
@@ -97,6 +97,9 @@ class FhirLocationService extends FhirServiceBase implements IFhirExportableReso
 
         // TODO: @brady.miller is this the right security ACL for a facilities organization?
         if ($this->shouldIncludeContactInformationForLocationType($dataRecord['type'], $dataRecord['uuid'])) {
+            // TODO: @adunsulag when we handle the contact,contact_address,and address tables we can grab those fields
+            // instead of overriding the type for the fhir.
+            $dataRecord['type'] = 'physical';
             $locationResource->setAddress(UtilsService::createAddressFromRecord($dataRecord));
 
             if (!empty($dataRecord['phone'])) {

--- a/src/Services/LocationService.php
+++ b/src/Services/LocationService.php
@@ -59,6 +59,7 @@ class LocationService extends BaseService
     {
         $sqlBindArray = array();
 
+        // TODO: @adunsulag we need to add the contact,contact_address,address records to this Location service which requires uuids in the tables
         $sql = 'SELECT location.*, uuid_mapping.uuid FROM
                 (SELECT
                     uuid as table_uuid,


### PR DESCRIPTION
We were using invalid types in the Location.type field which I've gone ahead and fixed.

Fixes #5933. 
I also call out for future work the fact that we need to support the multiple patient addresses (such as previous address) in FHIR for the Location work here.