### PR TITLE
Openemr fix 5943 patient context launch scope

### DIFF
--- a/_rest_config.php
+++ b/_rest_config.php
@@ -528,6 +528,9 @@ class RestConfig
             // we only set the bound patient access if the underlying user can still access the patient
             if ($this->checkUserHasAccessToPatient($restRequest->getRequestUserId(), $patientUuid)) {
                 $restRequest->setPatientUuidString($patientUuid);
+            } else {
+                (new SystemLogger())->error("OpenEMR Error: api had patient launch scope but user did not have access to patient uuid."
+                . " Resources restricted with patient scopes will not return results");
             }
         } else {
             (new SystemLogger())->error("OpenEMR Error: api had patient launch scope but no patient was set in the "
@@ -562,7 +565,7 @@ class RestConfig
     private function checkUserHasAccessToPatient($userId, $patientUuid)
     {
         // TODO: the session should never be populated with the pid from the access token unless the user had access to
-        // it.  However, if we wanted an additional check or if we anted to fire off any kind of event that does
+        // it.  However, if we wanted an additional check or if we wanted to fire off any kind of event that does
         // patient filtering by provider / clinic we would handle that here.
         return true;
     }

--- a/apis/dispatch.php
+++ b/apis/dispatch.php
@@ -271,7 +271,10 @@ if ($isLocalApi) {
             http_response_code(401);
             exit();
         }
-        if ($restRequest->requestHasScope(SmartLaunchController::CLIENT_APP_STANDALONE_LAUNCH_SCOPE)) {
+        $logger->debug("dispatch.php request setup for user role", ['authUserID' => $user['id'], 'authUser' => $user['username']]);
+        if ($restRequest->requestHasScope(SmartLaunchController::CLIENT_APP_STANDALONE_LAUNCH_SCOPE)
+            || $restRequest->requestHasScope(SmartLaunchController::CLIENT_APP_REQUIRED_LAUNCH_SCOPE)) {
+            $logger->debug("dispatch.php api is userRole populating token context for request due to smart launch scope");
             $restRequest = $gbl->populateTokenContextForRequest($restRequest);
         }
     } elseif ($userRole == 'patient') {
@@ -287,6 +290,7 @@ if ($isLocalApi) {
         }
         $restRequest->setPatientRequest(true);
         $restRequest->setPatientUuidString($puuidStringCheck);
+        $logger->debug("dispatch.php request setup for patient role", ['patient' => $puuidStringCheck]);
     } else if ($userRole === 'system') {
         $_SESSION['authUser'] = $user["username"] ?? null;
         $_SESSION['authUserID'] = $user["id"] ?? null;

--- a/apis/dispatch.php
+++ b/apis/dispatch.php
@@ -272,8 +272,10 @@ if ($isLocalApi) {
             exit();
         }
         $logger->debug("dispatch.php request setup for user role", ['authUserID' => $user['id'], 'authUser' => $user['username']]);
-        if ($restRequest->requestHasScope(SmartLaunchController::CLIENT_APP_STANDALONE_LAUNCH_SCOPE)
-            || $restRequest->requestHasScope(SmartLaunchController::CLIENT_APP_REQUIRED_LAUNCH_SCOPE)) {
+        if (
+            $restRequest->requestHasScope(SmartLaunchController::CLIENT_APP_STANDALONE_LAUNCH_SCOPE)
+            || $restRequest->requestHasScope(SmartLaunchController::CLIENT_APP_REQUIRED_LAUNCH_SCOPE)
+        ) {
             $logger->debug("dispatch.php api is userRole populating token context for request due to smart launch scope");
             $restRequest = $gbl->populateTokenContextForRequest($restRequest);
         }

--- a/src/Common/Auth/OpenIDConnect/SMARTSessionTokenContextBuilder.php
+++ b/src/Common/Auth/OpenIDConnect/SMARTSessionTokenContextBuilder.php
@@ -41,8 +41,10 @@ class SMARTSessionTokenContextBuilder
             // tampered with?  Not sure that it matters as the ACL's will verify that the app only has access
             // to the data the currently authorized oauth2 user can access.
             $launchToken = SMARTLaunchToken::deserializeToken($launch);
-            $this->logger->debug("SMARTSessionTokenContextBuilder->getEHRLaunchContext() decoded launch context is",
-                ['patient' => $launchToken->getPatient(), 'encounter' => $launchToken->getEncounter(), 'intent' => $launchToken->getIntent()]);
+            $this->logger->debug(
+                "SMARTSessionTokenContextBuilder->getEHRLaunchContext() decoded launch context is",
+                ['patient' => $launchToken->getPatient(), 'encounter' => $launchToken->getEncounter(), 'intent' => $launchToken->getIntent()]
+            );
 
             // we assume that if a patient is provided we are already displaying the patient
             // we may in the future need to adjust the need_patient_banner depending on the 'intent' chosen.

--- a/src/Common/Auth/OpenIDConnect/SMARTSessionTokenContextBuilder.php
+++ b/src/Common/Auth/OpenIDConnect/SMARTSessionTokenContextBuilder.php
@@ -41,7 +41,8 @@ class SMARTSessionTokenContextBuilder
             // tampered with?  Not sure that it matters as the ACL's will verify that the app only has access
             // to the data the currently authorized oauth2 user can access.
             $launchToken = SMARTLaunchToken::deserializeToken($launch);
-            $this->logger->debug("SMARTSessionTokenContextBuilder->getEHRLaunchContext() decoded launch context is", ['context' => $launchToken]);
+            $this->logger->debug("SMARTSessionTokenContextBuilder->getEHRLaunchContext() decoded launch context is",
+                ['patient' => $launchToken->getPatient(), 'encounter' => $launchToken->getEncounter(), 'intent' => $launchToken->getIntent()]);
 
             // we assume that if a patient is provided we are already displaying the patient
             // we may in the future need to adjust the need_patient_banner depending on the 'intent' chosen.
@@ -60,6 +61,7 @@ class SMARTSessionTokenContextBuilder
             $this->logger->error("SMARTSessionTokenContextBuilder->getAccessTokenContextParameters() Failed to decode launch context parameter", ['error' => $ex->getMessage()]);
             throw new OAuthServerException("Invalid launch parameter", 0, 'invalid_launch_context');
         }
+        $this->logger->debug("SMARTSessionTokenContextBuilder->getEHRLaunchContext() ehr launch context is ", $context);
         return $context;
     }
 

--- a/src/FHIR/SMART/SMARTLaunchToken.php
+++ b/src/FHIR/SMART/SMARTLaunchToken.php
@@ -13,6 +13,7 @@
 namespace OpenEMR\FHIR\SMART;
 
 use OpenEMR\Common\Crypto\CryptoGen;
+use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Common\Uuid\UuidRegistry;
 
 class SMARTLaunchToken
@@ -105,6 +106,7 @@ class SMARTLaunchToken
         // return to system
         $cryptoGen = new CryptoGen();
         $jsonEncoded = json_encode($context);
+        (new SystemLogger())->debug(self::class . "->serialize() Context before encryption", ['context' => $context, 'json' => $jsonEncoded]);
         $launchParams = $cryptoGen->encryptStandard($jsonEncoded);
         return $launchParams;
     }
@@ -126,6 +128,7 @@ class SMARTLaunchToken
 
         // invalid json let it throw here
         $context = json_decode($jsonEncoded, true, 512, JSON_THROW_ON_ERROR);
+        (new SystemLogger())->debug(self::class . "->deserialize() Decoded context is ", $context);
         if (!empty($context['p'])) {
             $this->setPatient($context['p']);
         }


### PR DESCRIPTION
Fixes #5943 by allowing the **launch** scope context to establish request context information. 