### PR TITLE
Clinic notes duplicate notes on fetch

### DIFF
--- a/interface/patient_file/history/encounters.php
+++ b/interface/patient_file/history/encounters.php
@@ -885,13 +885,13 @@ $(function () {
             return fetchedReport;
         },
         selector: '[data-toggle="PopOverReport"]',
-        boundary: "scrollParent",
-        animation: true,
+        boundary: "window",
+        animation: false,
         placement: "auto",
         trigger: "hover focus",
         html: true,
-        delay: {"show": 500, "hide": 30000},
-        template: '<div class="container-fluid"><div class="popover" style="max-width:90%;max-height:100vh;" role="tooltip"><div class="arrow"></div><h3 class="popover-header bg-dark text-light"></h3><div class="popover-body"></div></div></div>'
+        delay: {"show": 300, "hide": 30000},
+        template: '<div class="container"><div class="popover" style="max-width:fit-content;max-height:fit-content;" role="tooltip"><div class="arrow"></div><h3 class="popover-header bg-dark text-light"></h3><div class="popover-body bg-light text-dark"></div></div></div>'
     });
     // Report tooltip where popover will stay open for 30 seconds
     // or mouse leaves popover or user clicks anywhere in popover.

--- a/src/Services/ClinicalNotesService.php
+++ b/src/Services/ClinicalNotesService.php
@@ -313,12 +313,10 @@ class ClinicalNotesService extends BaseService
             throw new \InvalidArgumentException("formid, and pid must all be populated");
         }
 
-        $sql = "SELECT fcn.*
-                        ,lo_category.title AS category_title
-                        ,lo_category.notes AS category_code
+        $sql = "SELECT fcn.*, lo_category.title AS category_title, lo_category.notes AS category_code
                 FROM `form_clinical_notes` fcn
-                LEFT JOIN list_options lo_category ON lo_category.option_id = fcn.clinical_notes_category
-                LEFT JOIN list_options lo_type ON lo_type.option_id = fcn.clinical_notes_type
+                LEFT JOIN list_options lo_category ON lo_category.list_id = `Clinical_Notes_Category` AND lo_category.option_id = fcn.clinical_notes_category
+                LEFT JOIN list_options lo_type ON lo_type.list_id = `Clinical_Notes_Type` AND lo_type.option_id = fcn.clinical_notes_type
                 WHERE fcn.`form_id`=? AND fcn.`pid` = ? AND fcn.`encounter` = ?";
         return QueryUtils::fetchRecords($sql, array($formid, $pid, $encounter));
     }


### PR DESCRIPTION
- fix query to qualify the list that option ids for a note are selected from.

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #5949

#### Short description of what this resolves:
Notes fetch query was fetching notes category and note type using the option_id only which caused duplicates.
The reason is that the same option_id happens to be in another list resulting in the join including result.

#### Changes proposed in this pull request:
Qualify the option_id to the correct list by including list_id in join.