### PR TITLE
Fix templates and pdf to allow images and barcodes

### DIFF
--- a/portal/lib/download_template.php
+++ b/portal/lib/download_template.php
@@ -509,12 +509,23 @@ if ($encounter) {
         $encounter
     ));
 }
-$template = $templateService->fetchTemplate($form_id);
-$edata = $template['template_content'];
-
+// From database
+$template = $templateService->fetchTemplate($form_id)['template_content'];
+// snatch style tag content to replace after content purified. Ho-hum!
+$style_flag = preg_match('#<\s*?style\b[^>]*>(.*?)</style\b[^>]*>#s', $template, $style_matches);
+$style = str_replace('<style type="text/css">', '<style>', $style_matches);
 // purify html (and remove js)
-$edata = (new \HTMLPurifier(\HTMLPurifier_Config::createDefault()))->purify($edata);
-
+$config = \HTMLPurifier_Config::createDefault();
+$purify = new \HTMLPurifier($config);
+$edata = $purify->purify($template);
+// insert style tag from raw template content
+if ($style_flag && !empty($style[0] ?? '')) {
+    $edata = $style[0] . $edata;
+}
+// Purify escapes URIs.
+// Add back escaped directive delimiters so any directives in a URL will be parsed by our engine.
+$edata = str_replace('%7B', '{', $edata);
+$edata = str_replace('%7D', '}', $edata);
 // do the substitutions (ie. magic)
 $edata = doSubs($edata);
 


### PR DESCRIPTION
- add config items to HTML Purifier

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:
Document templates render images and style tag

#### Changes proposed in this pull request:
