### PR TITLE
Edit User page bootstrap

### DIFF
--- a/interface/usergroup/user_admin.php
+++ b/interface/usergroup/user_admin.php
@@ -59,7 +59,7 @@ $iter = $result[0];
 <html>
 <head>
 
-<?php Header::setupHeader(['common','opener', 'erx']); ?>
+<?php Header::setupHeader(['common','opener', 'erx', 'select2']); ?>
 
 <script src="checkpwd_validation.js"></script>
 
@@ -229,14 +229,7 @@ function toggle_password() {
   }
 }
 </script>
-<style>
-  .physician_type_class{
-    width: 150px !important;
-  }
-  #main_menu_role {
-    width: 120px !important;
-  }
-</style>
+<title><?php echo xlt('Edit User'); ?>&nbsp;<?php echo $iter['fname'] . " " . $iter['lname']; ?></title>
 </head>
 <body class="body_top">
 
@@ -261,340 +254,153 @@ function toggle_password() {
     }
     $disabled_save = !$is_super_user && $selected_user_is_superuser ? 'disabled' : '';
     ?>
-<table><tr><td>
-<span class="title"><?php echo xlt('Edit User'); ?></span>&nbsp;
-</td><td>
-    <a class="btn btn-secondary btn-save" name='form_save' id='form_save' href='#' onclick='return submitform()' <?php echo $disabled_save; ?>> <span><?php echo xlt('Save');?></span> </a>
-    <a class="btn btn-link btn-cancel" id='cancel' href='#'><span><?php echo xlt('Cancel');?></span></a>
-</td></tr>
-</table>
-<br />
-<FORM NAME="user_form" id="user_form" METHOD="POST" ACTION="usergroup_admin.php">
+<div class="d-flex justify-content-space">
+    <div class="flex-grow-1 ">
+        <h4 class="py-2"><?php echo xlt('Edit User'); ?>&nbsp;<?php echo $iter['fname'] . " " . $iter['lname']; ?></h4>
+    </div>
+    <div>
+        <a href="usergroup_admin.php" class="btn btn-text btn-lg"><i class="fa fa-arrow-left"></i>&nbsp;<?php echo xlt("Back to User List"); ?></a>
+    </div>
+</div>
+<form name="user_form" id="user_form" method="POST" action="usergroup_admin.php">
 <input type="hidden" name="csrf_token_form" value="<?php echo attr(CsrfUtils::collectCsrfToken()); ?>" />
-
 <input type=hidden name="pre_active" value="<?php echo attr($iter["active"]); ?>" >
 <input type=hidden name="get_admin_id" value="<?php echo attr($GLOBALS['Emergency_Login_email']); ?>" >
 <input type=hidden name="admin_id" value="<?php echo attr($GLOBALS['Emergency_Login_email_id']); ?>" >
 <input type=hidden name="check_acl" value="">
 <input type=hidden name="user_type" value="<?php echo attr($bg_name); ?>" >
-
-<TABLE border=0 cellpadding=0 cellspacing=0>
-<tr>
-    <td colspan="4">
-        <?php
-        // TODO: we eventually want to move to a responsive layout and not use tables here.  So we are going to give
-        // module writers the ability to inject divs, tables, or whatever inside the cell instead of having them
-        // generate additional rows / table columns which locks us into that format.
-        $preRenderEvent = new UserEditRenderEvent('user_admin.php', $_GET['id']);
-        $GLOBALS['kernel']->getEventDispatcher()->dispatch($preRenderEvent, UserEditRenderEvent::EVENT_USER_EDIT_RENDER_BEFORE);
-        ?>
-    </td>
-</tr>
-<TR>
-    <TD style="width:180px;"><span class=text><?php echo xlt('Username'); ?>: </span></TD>
-    <TD style="width:270px;"><input type="text" name=username style="width:150px;" class="form-control" value="<?php echo attr($iter["username"]); ?>" disabled></td>
-<?php if (empty($GLOBALS['gbl_ldap_enabled']) || empty($GLOBALS['gbl_ldap_exclusions'])) { ?>
-        <TD style="width:200px;"><span class=text>*<?php echo xlt('Your Password'); ?>*: </span></TD>
-        <TD class='text' style="width:280px;"><input type='password' name=adminPass style="width:150px;"  class="form-control" value="" autocomplete='off'><font class="mandatory"></font></TD>
-<?php } ?>
-</TR>
-<?php if (empty($GLOBALS['gbl_ldap_enabled']) || empty($GLOBALS['gbl_ldap_exclusions'])) { ?>
-<TR>
-    <TD style="width:180px;"><span class=text></span></TD>
-    <TD style="width:270px;"></td>
-    <TD style="width:200px;"><span class=text><?php echo xlt('User\'s New Password'); ?>: </span></TD>
-    <TD class='text' style="width:280px;">
-        <input type='password' id=clearPass name=clearPass style="width:150px;"  class="form-control" value="">
-        <input type="checkbox" id="togglePass" name="togglePass" onclick="toggle_password()" style="margin: .5rem 0 1rem;">
-        <label for="togglePass"><?php echo xlt('Show Password'); ?></label>
-        <font class="mandatory"></font>
-    </td>
-</TR>
-<?php } ?>
-
-<TR height="30" style="valign:middle;">
-<td class='text'>
-<?php echo xlt('Clear 2FA'); ?>:
-</td>
-<td title='<?php echo xla('Remove multi-factor authentications for this person.'); ?>'>
-<input type="checkbox" name="clear_2fa" value='1' />
-</td>
-<td colspan="2"><span class=text><?php echo xlt('Provider'); ?>:
-<input type="checkbox" name="authorized" onclick="authorized_clicked()"<?php
-if ($iter["authorized"]) {
-    echo " checked";
-} ?> /></span>
-<span class='text'><?php echo xlt('Calendar'); ?>:
-<input type="checkbox" name="calendar"<?php
-if ($iter["calendar"]) {
-    echo " checked";
-}
-if (!$iter["authorized"]) {
-    echo " disabled";
-} ?> /></span>
-<span class=text><?php echo xlt('Portal'); ?>:
-<input type="checkbox" name="portal_user" <?php
-if ($iter["portal_user"]) {
-    echo " checked";
-} ?> /></span>
-<span class='text'><?php echo xlt('Active'); ?>:
-    <input type="checkbox" name="active"<?php echo ($iter["active"]) ? " checked" : ""; ?>/></span>
-</TD>
-</TR>
-
-<TR>
-<TD><span class=text><?php echo xlt('First Name'); ?>: </span></TD>
-<TD><input type="text" name=fname id=fname style="width:150px;" class="form-control" value="<?php echo attr($iter["fname"]); ?>"><span class="mandatory"></span></td>
-<td><span class=text><?php echo xlt('Middle Name'); ?>: </span></TD><td><input type="text" name=mname style="width:150px;"  value="<?php echo attr($iter["mname"]); ?>"></td>
-</TR>
-
-<TR>
-<td><span class=text><?php echo xlt('Last Name'); ?>: </span></td><td><input type="text" name=lname id=lname style="width:150px;"  class="form-control" value="<?php echo attr($iter["lname"]); ?>"><span class="mandatory"></span></td>
-<td><span class=text><?php echo xlt('Default Facility'); ?>: </span></td><td><select name=facility_id style="width:150px;" class="form-control">
 <?php
-$fres = $facilityService->getAllServiceLocations();
-if ($fres) {
-    for ($iter2 = 0; $iter2 < sizeof($fres); $iter2++) {
-                $result[$iter2] = $fres[$iter2];
-    }
-
-    foreach ($result as $iter2) {
-        ?>
-          <option value="<?php echo attr($iter2['id']); ?>" <?php if ($iter['facility_id'] == $iter2['id']) {
-                echo "selected";
-                         } ?>><?php echo text($iter2['name']); ?></option>
-        <?php
-    }
-}
+// TODO: we eventually want to move to a responsive layout and not use tables here.  So we are going to give
+// module writers the ability to inject divs, tables, or whatever inside the cell instead of having them
+// generate additional rows / table columns which locks us into that format.
+$preRenderEvent = new UserEditRenderEvent('user_admin.php', $_GET['id']);
+$GLOBALS['kernel']->getEventDispatcher()->dispatch($preRenderEvent, UserEditRenderEvent::EVENT_USER_EDIT_RENDER_BEFORE);
 ?>
-</select></td>
-</tr>
-
-<?php if ($GLOBALS['restrict_user_facility']) { ?>
-<tr>
- <td colspan=2>&nbsp;</td>
- <td><span class=text><?php echo xlt('Schedule Facilities:');?></td>
- <td>
-  <select name="schedule_facility[]" multiple style="width:150px;" class="form-control">
-    <?php
-    $userFacilities = getUserFacilities($_GET['id']);
-    $ufid = array();
-    foreach ($userFacilities as $uf) {
-        $ufid[] = $uf['id'];
-    }
-
-    $fres = $facilityService->getAllServiceLocations();
-    if ($fres) {
-        foreach ($fres as $frow) :
-            ?>
-   <option <?php echo in_array($frow['id'], $ufid) || $frow['id'] == $iter['facility_id'] ? "selected" : null ?>
-           class="form-control" value="<?php echo attr($frow['id']); ?>"><?php echo text($frow['name']) ?></option>
+<div class="form-row">
+    <div class="form-group col-sm-12 col-md-3">
+        <label for="username"><?php echo xlt("Username");?></label>
+        <input type="text" name="username" class="form-control" value="<?php echo attr($iter["username"]); ?>" readonly>
+    </div>
+    <div class="form-group col-sm-12 col-md-3">
+        <label for="clearPass"><?php echo xlt("New Password"); ?></label>
+        <input type='password' id="clearPass" name="clearPass" class="form-control" value="" placeholder="<?php echo xlt("New Password") ?>">
+    </div>
+    <div class="form-group col-sm-12 col-md-2 pt-3">
+        <div class="custom-control custom-switch">
+            <input type="checkbox" id="togglePass" name="togglePass" onclick="toggle_password()" class="custom-control-input">
+            <label for="togglePass" class="custom-control-label"><?php echo xlt('Show Password'); ?></label>
+        </div>
+        <div class="custom-control custom-switch">
+            <input type="checkbox" name="clear_2fa" id="clear_2fa" class="custom-control-input" value="">
+            <label for="clear_2fa" class="custom-control-label" title="<?php echo xla('Remove multi-factor authentications for this person.'); ?>"><?php echo xlt('Clear 2FA'); ?></label>
+        </div>
+    </div>
+    <div class="form-group col-sm-12 col-md-2 pt-3">
+        <div class="custom-control custom-switch">
+            <input type="checkbox" name="authorized" id="authorized" class="custom-control-input" onclick="authorized_clicked()" <?php echo ($iter["authorized"] ? "checked" : "");?>>
+            <label for="authorized" class="custom-control-label"><?php echo xlt("Provider");?></label>
+        </div>
+        <div class="custom-control custom-switch">
+            <input type="checkbox" name="calendar" id="calendar" class="custom-control-input" <?php echo ($iter["calendar"] ? "checked" : "");?> <?php echo (!$iter["calendar"]) ? "disabled" : ""; ?> >
+            <label for="calendar" class="custom-control-label"><?php echo xlt("Calendar");?></label>
+        </div>
+    </div>
+    <div class="form-group col-sm-12 col-md-2 pt-3">
+        <div class="custom-control custom-switch">
+            <input type="checkbox" name="portal_user" id="portal_user" class="custom-control-input" <?php echo ($iter["portal_user"] ? "checked" : "");?>>
+            <label for="portal_user" class="custom-control-label"><?php echo xlt("Portal");?></label>
+        </div>
+        <div class="custom-control custom-switch">
+            <input type="checkbox" name="active" id="active" class="custom-control-input" <?php echo ($iter["active"] ? "checked" : "");?>>
+            <label for="active" class="custom-control-label"><?php echo xlt("Active");?></label>
+        </div>
+    </div>
+</div>
+<div class="form-row">
+    <div class="form-group col-sm-12 col-md-4">
+        <label for="fname"><?php echo xlt("First Name"); ?></label>
+        <input type="text" name="fname" id="fname" class="form-control" value="<?php echo attr($iter["fname"]); ?>" placeholder="First Name" required><span class="mandatory"></span>
+    </div>
+    <div class="form-group col-sm-12 col-md-4">
+        <label for="fname"><?php echo xlt("Middle Name"); ?></label>
+        <input type="text" name="mname" id="mname" class="form-control" value="<?php echo attr($iter["mname"]); ?>" placeholder="Middle Name">
+    </div>
+    <div class="form-group col-sm-12 col-md-4">
+        <label for="fname"><?php echo xlt("Last Name"); ?></label>
+        <input type="text" name="lname" id="lname" class="form-control" value="<?php echo attr($iter["lname"]); ?>" placeholder="Last Name" required><span class="mandatory"></span></td>
+    </div>
+</div>
+<div class="form-row">
+    <div class="form-group col-sm-12 col-md-2">
+        <label for="taxonomy"><?php echo xlt("Taxonomy"); ?></label>
+        <input type="text" name="taxonomy" class="form-control" value="<?php echo attr($iter["taxonomy"]); ?>">
+    </div>
+    <div class="form-group col-sm-12 col-md-2">
+        <label for="state_license_number"><?php echo xlt("State License Number"); ?></label>
+        <input type="text" name="state_license_number" class="form-control" value="<?php echo attr($iter["state_license_number"]); ?>">
+    </div>
+    <div class="form-group col-sm-12 col-md-2 d-none" data-specificity="provider">
+        <label for="taxid"><?php echo xlt("Federal Tax ID");?></label>
+        <input type="text" name="taxid" class="form-control" value="<?php echo attr($iter["federaltaxid"]); ?>">
+    </div>
+    <div class="form-group col-sm-12 col-md-2 d-none" data-specificity="provider">
+        <label for="drugid"><?php echo xlt("DEA Number"); ?></label>
+        <input type="text" name="drugid" class="form-control" value="<?php echo attr($iter["federaldrugid"]); ?>">
+    </div>
+    <div class="form-group col-sm-12 col-md-2 d-none" data-specificity="provider">
+        <label for="upin"><?php echo xlt("UPIN"); ?></label>
+        <input type="text" name="upin" class="form-control" value="<?php echo attr($iter["upin"]); ?>">
+    </div>
+    <div class="form-group col-sm-12 col-md-2 d-none" data-specificity="provider">
+        <label for="npi"><?php echo xlt("NPI"); ?></label>
+        <input type="text" name="npi" class="form-control" value="<?php echo attr($iter["npi"]); ?>">
+    </div>
+</div>
+<div class="form-row connectors">
+    <?php if ($GLOBALS['erx_enable']) : ?>
+    <div class="form-group col-sm-12 col-md-4">
+        <label for="newcrop_erx_role"><?php echo xlt("NewCrop eRX Role"); ?></label>
+        <?php echo generate_select_list("erxrole", "newcrop_erx_role", $iter['newcrop_user_role'], '', xl('Select Role'), '', '', '', []); ?>
+    </div>
+    <?php endif; ?>
+    <?php if ($GLOBALS['weno_rx_enable']) : ?>
+    <div class="form-group col-sm-12 col-md-4">
+        <label for="erxprid"><?php echo xlt('Weno Provider ID'); ?></label>
+        <input type="text" name="erxprid" class="form-control" value="<?php echo attr($iter["weno_prov_id"]); ?>">
+    </div>
+    <?php endif; ?>
+    <?php if ($GLOBALS['google_signin_enabled']) : ?>
+    <div class="form-group col-sm-12 col-md-4">
+        <label for="google_signin_email"><?php echo xlt('Google Email for Login'); ?></label>
+        <input type="text" name="google_signin_email" class="form-control" value="<?php echo attr($iter["google_signin_email"]); ?>">
+    </div>
+    <?php endif; ?>
+</div>
+<div class="form-row">
+    <div class="form-group col-sm-12 col-md-4">
+        <label for="facility_id"><?php echo xlt('Default Facility'); ?></label>
+        <select name="facility_id" class="form-control">
             <?php
-        endforeach;
-    }
-    ?>
-  </select>
- </td>
-</tr>
-<?php } ?>
+            $fres = $facilityService->getAllServiceLocations();
+            if ($fres) {
+                for ($iter2 = 0; $iter2 < sizeof($fres); $iter2++) {
+                            $result[$iter2] = $fres[$iter2];
+                }
 
-<TR>
-<TD><span class=text><?php echo xlt('Federal Tax ID'); ?>: </span></TD><TD><input type=text name=taxid style="width:150px;"  class="form-control" value="<?php echo attr($iter["federaltaxid"]); ?>"></td>
-<TD><span class=text><?php echo xlt('DEA Number'); ?>: </span></TD><TD><input type=text name=drugid style="width:150px;"  class="form-control" value="<?php echo attr($iter["federaldrugid"]); ?>"></td>
-</TR>
-
-<tr>
-<td><span class="text"><?php echo xlt('UPIN'); ?>: </span></td><td><input type="text" name="upin" style="width:150px;" class="form-control" value="<?php echo attr($iter["upin"]); ?>"></td>
-<td class='text'><?php echo xlt('See Authorizations'); ?>: </td>
-<td><select name="see_auth" style="width:150px;" class="form-control" >
-<?php
-foreach (array(1 => xl('None{{Authorization}}'), 2 => xl('Only Mine'), 3 => xl('All')) as $key => $value) {
-    echo " <option value='" . attr($key) . "'";
-    if ($key == $iter['see_auth']) {
-        echo " selected";
-    }
-
-    echo ">" . text($value) . "</option>\n";
-}
-?>
-</select></td>
-</tr>
-
-<tr>
-<td><span class="text"><?php echo xlt('NPI'); ?>: </span></td><td><input type="text" name="npi" style="width:150px;" class="form-control" value="<?php echo attr($iter["npi"]); ?>"></td>
-<td><span class="text"><?php echo xlt('Job Description'); ?>: </span></td><td><input type="text" name="job" style="width:150px;" class="form-control" value="<?php echo attr($iter["specialty"]); ?>"></td>
-</tr>
-
-<tr>
-<td><span class="text"><?php echo xlt('Taxonomy'); ?>: </span></td>
-<td><input type="text" name="taxonomy" style="width:150px;" class="form-control" value="<?php echo attr($iter["taxonomy"]); ?>"></td>
-<td><span class="text"><?php echo xlt('Supervisor'); ?>: </span></td>
-<td>
-    <select name="supervisor_id" style="width:150px;" class="form-control">
-        <option value=""><?php echo xlt("Select Supervisor") ?></option>
-        <?php
-        $userService = new UserService();
-        $users = $userService->getActiveUsers();
-        foreach ($users as $activeUser) {
-            $p_id = (int)$activeUser['id'];
-            if ($activeUser['authorized'] != 1) {
-                continue;
-            }
-            echo "<option value='" . attr($p_id) . "'";
-            if ((int)$iter["supervisor_id"] === $p_id) {
-                echo " selected";
-            }
-            echo ">" . text($activeUser['lname']) . ' ' .
-                text($activeUser['fname']) . ' ' . text($activeUser['mname']) . "</option>\n";
-        }
-        ?>
-    </select>
-</td>
-</tr>
-
-<tr>
-<td><span class="text"><?php echo xlt('State License Number'); ?>: </span></td>
-<td><input type="text" name="state_license_number" style="width:150px;" class="form-control" value="<?php echo attr($iter["state_license_number"]); ?>"></td>
-<td class='text'><?php echo xlt('NewCrop eRX Role'); ?>:</td>
-<td>
-    <?php echo generate_select_list("erxrole", "newcrop_erx_role", $iter['newcrop_user_role'], '', xl('Select Role'), '', '', '', array('style' => 'width:150px')); ?>
-</td>
-</tr>
-<tr>
-<td><span class="text"><?php echo xlt('Weno Provider ID'); ?>: </span></td><td><input type="text" name="erxprid" style="width:150px;" class="form-control" value="<?php echo attr($iter["weno_prov_id"]); ?>"></td>
-<td><span class="text"><?php echo xlt('Google Email for Login'); ?>: </span></td><td><input type="text" name="google_signin_email" style="width:150px;" class="form-control" value="<?php echo attr($iter["google_signin_email"]); ?>"></td>
-</tr>
-
-<tr>
-  <td><span class="text"><?php echo xlt('Provider Type'); ?>: </span></td>
-  <td><?php echo generate_select_list("physician_type", "physician_type", $iter['physician_type'], '', xl('Select Type'), 'physician_type_class', '', '', ''); ?></td>
-</tr>
-<tr>
-  <td>
-    <span class="text"><?php echo xlt('Main Menu Role'); ?>: </span>
-  </td>
-  <td>
-    <?php
-    $menuMain = new MainMenuRole($GLOBALS['kernel']->getEventDispatcher());
-    echo $menuMain->displayMenuRoleSelector($iter["main_menu_role"]);
-    ?>
-  </td>
-  <td>
-    <span class="text"><?php echo xlt('Patient Menu Role'); ?>: </span>
-  </td>
-  <td>
-    <?php
-    $menuPatient = new PatientMenuRole();
-    echo $menuPatient->displayMenuRoleSelector($iter["patient_menu_role"]);
-    ?>
-  </td>
-
-</tr>
-<?php if (!empty($GLOBALS['inhouse_pharmacy'])) { ?>
-<tr>
- <td class="text"><?php echo xlt('Default Warehouse'); ?>: </td>
- <td class='text'>
-    <?php
-    echo generate_select_list(
-        'default_warehouse',
-        'warehouse',
-        $iter['default_warehouse'],
-        ''
-    );
-    ?>
- </td>
-
-    <?php if (!empty($GLOBALS['inhouse_pharmacy'])) { ?>
- <td class="text"><?php echo xlt('Invoice Refno Pool'); ?>: </td>
- <td class='text'>
-        <?php
-        echo generate_select_list(
-            'irnpool',
-            'irnpool',
-            $iter['irnpool'],
-            xl('Invoice reference number pool, if used')
-        );
-        ?>
- </td>
-    <?php } else { ?>
-  <td class="text" colspan="2">&nbsp;</td>
-    <?php } ?>
-
-</tr>
-<?php } ?>
-
-<!-- facility and warehouse restrictions, optional -->
-<?php if (!empty($GLOBALS['gbl_fac_warehouse_restrictions']) || !empty($GLOBALS['restrict_user_facility'])) { ?>
- <tr title="<?php echo xla('If nothing is selected here then all are permitted.'); ?>">
-  <td class="text"><?php echo !empty($GLOBALS['gbl_fac_warehouse_restrictions']) ?
-    xlt('Facility and warehouse permissions') : xlt('Facility permissions'); ?>:</td>
-  <td colspan="3">
-   <select name="schedule_facility[]" multiple style="width:490px;">
-    <?php
-    $userFacilities = getUserFacilities($_GET['id'], 'id', $GLOBALS['gbl_fac_warehouse_restrictions']);
-    $ufid = array();
-    foreach ($userFacilities as $uf) {
-        $ufid[] = $uf['id'];
-    }
-    $fres = sqlStatement("select * from facility order by name");
-    if ($fres) {
-        while ($frow = sqlFetchArray($fres)) {
-            // Get the warehouses that are linked to this user and facility.
-            $whids = getUserFacWH($_GET['id'], $frow['id']); // from calendar.inc.php
-            // Generate an option for just the facility with no warehouse restriction.
-            echo "    <option";
-            if (empty($whids) && in_array($frow['id'], $ufid)) {
-                echo ' selected';
-            }
-            echo " value='" . attr($frow['id']) . "'>" . text($frow['name']) . "</option>\n";
-            // Then generate an option for each of the facility's warehouses.
-            // Does not apply if the site does not use warehouse restrictions.
-            if (!empty($GLOBALS['gbl_fac_warehouse_restrictions'])) {
-                $lres = sqlStatement(
-                    "SELECT option_id, title FROM list_options WHERE " .
-                    "list_id = ? AND option_value = ? ORDER BY seq, title",
-                    array('warehouse', $frow['id'])
-                );
-                while ($lrow = sqlFetchArray($lres)) {
-                    echo "    <option";
-                    if (in_array($lrow['option_id'], $whids)) {
-                        echo ' selected';
-                    }
-                    echo " value='" . attr($frow['id']) . "/" . attr($lrow['option_id']) . "'>&nbsp;&nbsp;&nbsp;" .
-                        text(xl_list_label($lrow['title'])) . "</option>\n";
+                foreach ($result as $iter2) {
+                    ?>
+                    <option value="<?php echo attr($iter2['id']); ?>" <?php if ($iter['facility_id'] == $iter2['id']) {
+                            echo "selected";
+                                    } ?>><?php echo text($iter2['name']); ?></option>
+                    <?php
                 }
             }
-        }
-    }
-    ?>
-   </select>
-  </td>
- </tr>
-<?php } ?>
-
- <tr>
-<td class='text'><?php echo xlt('Access Control'); ?>:</td>
- <td><select id="access_group_id" name="access_group[]" multiple style="width:150px;" class="form-control">
-<?php
-// Collect the access control group of user
-$list_acl_groups = AclExtended::aclGetGroupTitleList($is_super_user || $selected_user_is_superuser);
-$username_acl_groups = AclExtended::aclGetGroupTitles($iter["username"]);
-foreach ($list_acl_groups as $value) {
-    // Disable groups that have any permissions that the logged-in user does not have.
-    $tmp = AclExtended::iHaveGroupPermissions($value) ? '' : 'disabled ';
-    if ($username_acl_groups && in_array($value, $username_acl_groups)) {
-        $tmp .= 'selected ';
-    }
-    echo " <option value='" . attr($value) . "' $tmp>" . text(xl_gacl_group($value)) . "</option>\n";
-}
-?>
-  </select></td>
-  <td><span class=text><?php echo xlt('Additional Info'); ?>:</span></td>
-  <td><textarea style="width:150px;" name="comments" wrap=auto rows=4 cols=25 class="form-control"><?php echo text($iter["info"]); ?></textarea></td>
-
-  </tr>
-    <tr>
-        <td><span class=text><?php echo xlt('Default Billing Facility'); ?>: </span></td><td><select name="billing_facility_id" style="width:150px;" class="form-control">
+            ?>
+        </select>
+    </div>
+    <div class="form-group col-sm-12 col-md-4">
+        <label for="billing_facility_id"><?php echo xlt('Default Billing Facility'); ?></label>
+        <select name="billing_facility_id" class="form-control">
             <?php
             $fres = $facilityService->getAllBillingLocations();
             if ($fres) {
@@ -612,57 +418,237 @@ foreach ($list_acl_groups as $value) {
                 }
             }
             ?>
-        </select></td>
-        <td>
-
-        </td>
-    </tr>
-    <tr>
-        <td colspan="4">
+        </select>
+    </div>
+    <?php if (!$GLOBALS['restrict_user_facility']) : ?>
+    <div class="form-group col-sm-12 col-md-4">
+        <label for="schedule_facility[]"><?php echo xlt('Schedule Facilities:');?></label>
+        <select name="schedule_facility[]" multiple="multiple" class="form-control select2">
             <?php
-            // TODO: we eventually want to move to a responsive layout and not use tables here.  So we are going to give
-            // module writers the ability to inject divs, tables, or whatever inside the cell instead of having them
-            // generate additional rows / table columns which locks us into that format.
-            $postRenderEvent = new UserEditRenderEvent('user_admin.php', $_GET['id']);
-            $GLOBALS['kernel']->getEventDispatcher()->dispatch($postRenderEvent, UserEditRenderEvent::EVENT_USER_EDIT_RENDER_AFTER);
+            $userFacilities = getUserFacilities($_GET['id']);
+            $ufid = array();
+            foreach ($userFacilities as $uf) {
+                $ufid[] = $uf['id'];
+            }
+
+            $fres = $facilityService->getAllServiceLocations();
+            if ($fres) {
+                foreach ($fres as $frow) :
+                    ?>
+        <option <?php echo in_array($frow['id'], $ufid) || $frow['id'] == $iter['facility_id'] ? "selected" : null ?>
+                class="form-control" value="<?php echo attr($frow['id']); ?>"><?php echo text($frow['name']) ?></option>
+                    <?php
+                endforeach;
+            }
             ?>
-        </td>
-    </tr>
+        </select>
+    </div>
+    <?php endif; ?>
+</div>
+<div class="form-row">
+    <div class="form-group col-sm-12 col-md-4">
+        <label for="see_auth"><?php echo xlt('See Authorizations'); ?></label>
+        <select name="see_auth" class="form-control" >
+            <?php
+            foreach (array(1 => xl('None{{Authorization}}'), 2 => xl('Only Mine'), 3 => xl('All')) as $key => $value) {
+                echo " <option value='" . attr($key) . "'";
+                if ($key == $iter['see_auth']) {
+                    echo " selected";
+                }
 
-  <tr height="20" valign="bottom">
-  <td colspan="4" class="text">
-      <p>*<?php echo xlt('You must enter your own password to change user passwords. Leave blank to keep password unchanged.'); ?></p>
-    <?php
-    if (!$is_super_user && $selected_user_is_superuser) {
-        echo '<p class="redtext">*' . xlt('View mode - only administrator can edit another administrator user') . '.</p>';
-    }
-    ?>
-<!--
-Display red alert if entered password matched one of last three passwords/Display red alert if user password is expired
--->
-  <div class="redtext" id="error_message">&nbsp;</div>
-  </td>
-  </tr>
-
-</table>
-
-<INPUT TYPE="HIDDEN" NAME="id" VALUE="<?php echo attr($_GET["id"]); ?>">
-<INPUT TYPE="HIDDEN" NAME="mode" VALUE="update">
-<INPUT TYPE="HIDDEN" NAME="privatemode" VALUE="user_admin">
-
-<INPUT TYPE="HIDDEN" NAME="secure_pwd" VALUE="<?php echo attr($GLOBALS['secure_password']); ?>">
-</FORM>
+                echo ">" . text($value) . "</option>\n";
+            }
+            ?>
+        </select>
+    </div>
+    <div class="form-group col-sm-12 col-md-4">
+        <label for="supervisor_id"><?php echo xlt('Supervisor'); ?></label>
+        <select name="supervisor_id" class="form-control">
+            <option value=""><?php echo xlt("Select Supervisor") ?></option>
+            <?php
+            $userService = new UserService();
+            $users = $userService->getActiveUsers();
+            foreach ($users as $activeUser) {
+                $p_id = (int)$activeUser['id'];
+                if ($activeUser['authorized'] != 1) {
+                    continue;
+                }
+                echo "<option value='" . attr($p_id) . "'";
+                if ((int)$iter["supervisor_id"] === $p_id) {
+                    echo " selected";
+                }
+                echo ">" . text($activeUser['lname']) . ' ' .
+                    text($activeUser['fname']) . ' ' . text($activeUser['mname']) . "</option>\n";
+            }
+            ?>
+        </select>
+    </div>
+    <div class="form-group col-sm-12 col-md-4">
+        <label for="physician_type"><?php echo xlt('Provider Type'); ?></label>
+        <?php echo generate_select_list("physician_type", "physician_type", $iter['physician_type'], '', xl('Select Type'), 'physician_type_class', '', '', ''); ?>
+    </div>
+</div>
+<div class="form-row">
+    <div class="form-group col-sm-12 col-md-4">
+        <label for="main_menu_role"><?php echo xlt('Main Menu Role'); ?></label>
+        <?php
+        $menuMain = new MainMenuRole($GLOBALS['kernel']->getEventDispatcher());
+        echo $menuMain->displayMenuRoleSelector($iter["main_menu_role"]);
+        ?>
+    </div>
+    <div class="form-group col-sm-12 col-md-4">
+        <label for="patient_menu_role"><?php echo xlt('Patient Menu Role'); ?></label>
+        <?php
+        $menuPatient = new PatientMenuRole();
+        echo $menuPatient->displayMenuRoleSelector($iter["patient_menu_role"]);
+        ?>
+    </div>
+    <div class="form-group col-sm-12 col-md-4">
+        <label for="access_group_id"><?php echo xlt('Access Control'); ?></label>
+        <select id="access_group_id" name="access_group[]" multiple="multiple" class="form-control select2">
+            <?php
+            // Collect the access control group of user
+            $list_acl_groups = AclExtended::aclGetGroupTitleList($is_super_user || $selected_user_is_superuser);
+            $username_acl_groups = AclExtended::aclGetGroupTitles($iter["username"]);
+            foreach ($list_acl_groups as $value) {
+                // Disable groups that have any permissions that the logged-in user does not have.
+                $tmp = AclExtended::iHaveGroupPermissions($value) ? '' : 'disabled ';
+                if ($username_acl_groups && in_array($value, $username_acl_groups)) {
+                    $tmp .= 'selected ';
+                }
+                echo " <option value='" . attr($value) . "' $tmp>" . text(xl_gacl_group($value)) . "</option>\n";
+            }
+            ?>
+        </select>
+    </div>
+</div>
+<div class="form-row">
+    <div class="form-group col-sm-12 col-md-3">
+        <label for="job"><?php echo xlt('Job Description'); ?></label>
+        <input type="text" name="job" class="form-control" value="<?php echo attr($iter["specialty"]); ?>">
+    </div>
+    <?php if (!empty($GLOBALS['inhouse_pharmacy'])) : ?>
+    <div class="form-group col-sm-12 col-md-3">
+        <label><?php echo xlt('Default Warehouse'); ?></label>
+        <?php echo generate_select_list('default_warehouse', 'warehouse', $iter['default_warehouse'], '');?>
+    </div>
+    <div class="form-group col-sm-12 col-md-3">
+        <label for="irnpool"><?php echo xlt('Invoice Refno Pool'); ?></label>
+        <?php echo generate_select_list('irnpool', 'irnpool', $iter['irnpool'], xl('Invoice reference number pool, if used')); ?>
+    </div>
+    <?php endif; ?>
+    <?php if (!empty($GLOBALS['gbl_fac_warehouse_restrictions']) || !empty($GLOBALS['restrict_user_facility'])) : ?>
+    <div class="form-group col-sm-12 col-md-3">
+        <label for="schedule_facility" title="<?php echo xla('If nothing is selected here then all are permitted.'); ?>"><?php echo !empty($GLOBALS['gbl_fac_warehouse_restrictions']) ? xlt('Facility and warehouse permissions') : xlt('Facility permissions'); ?></label>
+        <select name="schedule_facility[]" multiple="multiple" class="form-control select2">
+        <?php
+        $userFacilities = getUserFacilities($_GET['id'], 'id', $GLOBALS['gbl_fac_warehouse_restrictions']);
+        $ufid = array();
+        foreach ($userFacilities as $uf) {
+            $ufid[] = $uf['id'];
+        }
+        $fres = sqlStatement("select * from facility order by name");
+        if ($fres) {
+            while ($frow = sqlFetchArray($fres)) {
+                // Get the warehouses that are linked to this user and facility.
+                $whids = getUserFacWH($_GET['id'], $frow['id']); // from calendar.inc.php
+                // Generate an option for just the facility with no warehouse restriction.
+                echo "    <option";
+                if (empty($whids) && in_array($frow['id'], $ufid)) {
+                    echo ' selected';
+                }
+                echo " value='" . attr($frow['id']) . "'>" . text($frow['name']) . "</option>\n";
+                // Then generate an option for each of the facility's warehouses.
+                // Does not apply if the site does not use warehouse restrictions.
+                if (!empty($GLOBALS['gbl_fac_warehouse_restrictions'])) {
+                    $lres = sqlStatement(
+                        "SELECT option_id, title FROM list_options WHERE " .
+                        "list_id = ? AND option_value = ? ORDER BY seq, title",
+                        array('warehouse', $frow['id'])
+                    );
+                    while ($lrow = sqlFetchArray($lres)) {
+                        echo "    <option";
+                        if (in_array($lrow['option_id'], $whids)) {
+                            echo ' selected';
+                        }
+                        echo " value='" . attr($frow['id']) . "/" . attr($lrow['option_id']) . "'>&nbsp;&nbsp;&nbsp;" .
+                            text(xl_list_label($lrow['title'])) . "</option>\n";
+                    }
+                }
+            }
+        }
+        ?>
+        </select>
+    </div>
+    <?php endif; ?>
+</div>
+<div class="form-row">
+    <div class="form-group col-sm-12 col-md-12">
+        <label for="additional_info"><?php echo xlt('Additional Info'); ?></label>
+        <textarea name="comments" wrap="auto" rows="" class="form-control"><?php echo text($iter["info"]); ?></textarea>
+    </div>
+</div>
+<?php
+// TODO: we eventually want to move to a responsive layout and not use tables here.  So we are going to give
+// module writers the ability to inject divs, tables, or whatever inside the cell instead of having them
+// generate additional rows / table columns which locks us into that format.
+$postRenderEvent = new UserEditRenderEvent('user_admin.php', $_GET['id']);
+$GLOBALS['kernel']->getEventDispatcher()->dispatch($postRenderEvent, UserEditRenderEvent::EVENT_USER_EDIT_RENDER_AFTER);
+?>
+<div class="d-flex">
+    <div class="flex-grow-1 pr-2">
+        <p>
+            <?php echo xlt('You must enter your own password to change user passwords. Leave blank to keep password unchanged.'); ?>
+            <?php if (!$is_super_user && $selected_user_is_superuser) : ?>
+                <br><?php echo xlt('View mode - only administrator can edit another administrator user'); ?>
+            <?php endif; ?>
+            <!-- Display red alert if entered password matched one of last three passwords/Display red alert if user password is expired -->
+            <div class="redtext" id="error_message">&nbsp;</div>
+        </p>
+    </div>
+    <div>
+        <?php if (empty($GLOBALS['gbl_ldap_enabled']) || empty($GLOBALS['gbl_ldap_exclusions'])) : ?>
+            <label for="adminPass"><?php echo xlt('Your Password'); ?></label>
+            <input type='password' name="adminPass" class="form-control" value="" autocomplete='off'>
+        <?php endif; ?>
+    </div>
+    <div>
+        <a class="btn btn-link btn-cancel" id='cancel' href='#'><span><?php echo xlt('Cancel');?></span></a>
+        <a class="btn btn-secondary btn-save" name='form_save' id='form_save' href='#' onclick='return submitform()' <?php echo $disabled_save; ?>> <span><?php echo xlt('Save');?></span> </a>
+    </div>
+</div>
+<input type="hidden" name="id" value="<?php echo attr($_GET["id"]); ?>">
+<input type="hidden" name="mode" value="update">
+<input type="hidden" name="privatemode" value="user_admin">
+<input type="hidden" name="secure_pwd" value="<?php echo attr($GLOBALS['secure_password']); ?>">
+</form>
 <script>
 $(function () {
     $("#cancel").click(function() {
-          dlgclose();
-     });
-
+        dlgclose();
+    });
+    renderProviderSpecificAttributes();
+    $(".select2").select2();
 });
+
+let provSpec = document.querySelectorAll("[data-specificity=provider]");
+let isProvider = document.getElementById("authorized");
+
+isProvider.addEventListener('change', (e) => {
+    renderProviderSpecificAttributes();
+});
+
+function renderProviderSpecificAttributes()
+{
+    provSpec.forEach((elm) => {
+        if (isProvider.checked) {
+            elm.classList.remove('d-none');
+        } else {
+            elm.classList.add('d-none');
+        }
+    });
+}
+
 </script>
-
-<div class="container">
-
-</BODY>
-
-</HTML>
+</body>
+</html>

--- a/interface/usergroup/usergroup_admin.php
+++ b/interface/usergroup/usergroup_admin.php
@@ -540,17 +540,7 @@ $form_inactive = empty($_POST['form_inactive']) ? false : true;
 <script>
 
 $(function () {
-
     tabbify();
-
-    $(".medium_modal").on('click', function(e) {
-        e.preventDefault();e.stopPropagation();
-        dlgopen('', '', 'modal-mlg', 450, '', '', {
-            type: 'iframe',
-            url: $(this).attr('href')
-        });
-    });
-
 });
 
 function authorized_clicked() {
@@ -665,7 +655,7 @@ function authorized_clicked() {
 
                             print "<tr>
                                 <td><a href='user_admin.php?id=" . attr_url($iter["id"]) . "&csrf_token_form=" . attr_url(CsrfUtils::collectCsrfToken()) .
-                                "' class='medium_modal' onclick='top.restoreSession()'>" . text($iter["username"]) . "</a>" . "</td>
+                                "' onclick='top.restoreSession()'>" . text($iter["username"]) . "</a>" . "</td>
                                 <td>" . text($iter["fname"]) . ' ' . text($iter["lname"]) . "&nbsp;</td>
                                 <td>" . text($iter["info"]) . "&nbsp;</td>
                                 <td align='left'><span>" . text($iter["authorized"]) . "</td>


### PR DESCRIPTION
Exchange the edit user page's table-based layout in favor of bootstrap. Not introducing twig at this time, would rather do it in pieces. Edit users page now is a tab, not a dialog. Still in progress, need to tidy up a couple of things but it is >80% complete at this point.

Some notes, I hide several inputs that are provider-specific and added conditional rendering for Newcrop, Weno, and Google sign-in input fields.

![image](https://user-images.githubusercontent.com/1381170/209751042-761ccbff-0fcb-4844-8016-6a6790955cfb.png)

