### PR TITLE
Fix for insertEncounter where creating an encounter always use current date

### DIFF
--- a/src/Services/EncounterService.php
+++ b/src/Services/EncounterService.php
@@ -359,7 +359,9 @@ class EncounterService extends BaseService
         $encounter = generate_id();
         $data['encounter'] = $encounter;
         $data['uuid'] = UuidRegistry::getRegistryForTable(self::ENCOUNTER_TABLE)->createUuid();
-        if($data['date'] == NULL) $data['date'] = date("Y-m-d");
+        if (empty($data['date'])) {
+            $data['date'] = date("Y-m-d");
+        }
         $puuidBytes = UuidRegistry::uuidToBytes($puuid);
         $data['pid'] = $this->getIdByUuid($puuidBytes, self::PATIENT_TABLE, "pid");
         $query = $this->buildInsertColumns($data);

--- a/src/Services/EncounterService.php
+++ b/src/Services/EncounterService.php
@@ -359,7 +359,7 @@ class EncounterService extends BaseService
         $encounter = generate_id();
         $data['encounter'] = $encounter;
         $data['uuid'] = UuidRegistry::getRegistryForTable(self::ENCOUNTER_TABLE)->createUuid();
-        $data['date'] = date("Y-m-d");
+        if($data['date'] == NULL) $data['date'] = date("Y-m-d");
         $puuidBytes = UuidRegistry::uuidToBytes($puuid);
         $data['pid'] = $this->getIdByUuid($puuidBytes, self::PATIENT_TABLE, "pid");
         $query = $this->buildInsertColumns($data);


### PR DESCRIPTION


<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->
There was already a pull request for this issue (#5873) but was never merged.

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #5872

#### Short description of what this resolves:
This allows to put the date of the encounter when creating it instead of needing to update it after

#### Changes proposed in this pull request:
