### PR TITLE
fix: #6097 uuid failing on ccda generation

### DIFF
--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncounterccdadispatchTable.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncounterccdadispatchTable.php
@@ -728,7 +728,17 @@ class EncounterccdadispatchTable extends AbstractTableGateway
         if (empty($details)) {
             return '';
         } else {
-            $organization_uuid = UuidRegistry::uuidToString($details['facility_uuid']);
+            if (!empty($details['facility_uuid'])) {
+                $organization_uuid = UuidRegistry::uuidToString($details['facility_uuid']);
+            } else {
+                $organization_uuid = ''; // leave it an empty string as we don't even know if we have a connected organization.
+                (new SystemLogger())->errorLogCaller(
+                    "Failed to find facility uuid for Carecoordination hie_office_contact, uuid is either missing or office contact has no connected organization",
+                    ['fname' => $details['fname'], 'lname' => $details['lname'], 'organization' => $details['organization']
+                    ,
+                    'npi' => $details['facility_npi']]
+                );
+            }
         }
 
         $time = $this->getAuthorDate($pid, $encounter);


### PR DESCRIPTION
Fixes #6097 

Makes it so we don't blow up the ccda generation when the uuid doesn't generate.  This only happens when you specify an office contact and the organization uuid is missing or the organization for the office contact is missing.