### PR TITLE
Insurance card information adjustments 2

### DIFF
--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -1048,8 +1048,11 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                         $patientbalance = get_patient_balance($pid, false);
                         $insurancebalance = get_patient_balance($pid, true) - $patientbalance;
                         $totalbalance = $patientbalance + $insurancebalance;
+                        $unallocated_amt = get_unallocated_patient_balance($pid); //ALB Added this
+
                         $id = "billing_ps_expand";
                         $dispatchResult = $ed->dispatch(CardRenderEvent::EVENT_HANDLE, new CardRenderEvent('billing'));
+                        //ALB Added unallocated amount below
                         $viewArgs = [
                             'title' => xl('Billing'),
                             'id' => $id,
@@ -1058,6 +1061,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                             'patientBalance' => $patientbalance,
                             'insuranceBalance' => $insurancebalance,
                             'totalBalance' => $totalbalance,
+                            'unallocated' => $unallocated_amt,
                             'forceAlwaysOpen' => $forceBillingExpandAlways,
                             'prependedInjection' => $dispatchResult->getPrependedInjection(),
                             'appendedInjection' => $dispatchResult->getAppendedInjection(),
@@ -1111,6 +1115,8 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                         $params = array_merge($params, $insurance_array);
                         $res = sqlStatement($sql, $params);
                         $prior_ins_type = '';
+                        $prev_eff_date = 'Present'; //ALB Needed to keep track of effective dates
+                     
 
                         while ($row = sqlFetchArray($res)) {
                             if ($row['provider']) {
@@ -1134,9 +1140,41 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                 $row['dispFromDate'] = $row['date'] ? true : false;
                                 $mname = ($row['subscriber_mname'] != "") ? $row['subscriber_mname'] : "";
                                 $row['subscriber_full_name'] = str_replace("%mname%", $mname, "{$row['subscriber_fname']} %mname% {$row['subscriber_lname']}");
+                                if ($row['isOld']) { //ALB Added all this
+                                    $row['until_date'] = date_create($prev_eff_date)->modify('-1 days')->format('Y-m-d'); 
+                                } else {
+                                    $row['until_date'] = 'Present';
+                                }
                                 $insArr[] = $row;
+                                $prev_eff_date = $row['date']; //ALB Update previous effective date
                                 $prior_ins_type = $row['type'];
-                            }
+                            } else { //ALB All below is needed for self-pay patients
+                                $row['isOld'] = (strcmp($row['type'], $prior_ins_type) == 0) ? true : false;
+                                $row['dispFromDate'] = $row['date'] ? true : false;
+                                $row['insco'] = [
+                                    'name' => 'Self-Pay',
+                                    'address' => [
+                                        'line1' => '',
+                                        'line2' => '',
+                                        'city' => '',
+                                        'state' => '',
+                                        'postal' => '',
+                                        'country' => ''
+                                    ],
+                                ];
+                                $row['policy_type'] = false;
+                                $mname = ''; //($row['subscriber_mname'] != "") ? $row['subscriber_mname'] : "";
+                                $row['subscriber_full_name'] = ' '; // str_replace("%mname%", $mname, "{$row['subscriber_fname']} %mname% {$row['subscriber_lname']}");
+                                if ($row['isOld']) { //ALB
+                                    $row['until_date'] = date_create($prev_eff_date)->modify('-1 days')->format('Y-m-d'); 
+                                } else {
+                                    $row['until_date'] = 'Present';
+                                }
+                                $prev_eff_date = $row['date']; //ALB Added all this
+                                $prior_ins_type = $row['type'];
+                                if ($row['type'] != 'primary') continue; //ALB No Self-pay for secondary or tertiary insurance, so do not render card
+                                $insArr[] = $row;
+                            }    
                         }
 
                         if ($GLOBALS["enable_oa"]) {
@@ -1644,6 +1682,8 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                             if ($row['pc_hometext'] != "") {
                                 $etitle = xl('Comments') . ": " . ($row['pc_hometext']) . "\r\n" . $etitle;
                             }
+                             
+                            $row['etitle'] = $etitle; //ALB Added this
 
                             if ($extraApptDate && $count > $firstApptIndx) {
                                 $apptStyle = $apptStyle2;
@@ -1658,6 +1698,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
 
                             $row['pc_eventTime'] = sprintf("%02d", $disphour) . ":{$dispmin}";
                             $row['pc_status'] = generate_display_field(array('data_type' => '1', 'list_id' => 'apptstat'), $row['pc_apptstatus']);
+                            if ($row['pc_status'] == 'None') $row['pc_status'] = 'Scheduled'; //ALB Added this
 
                             if (in_array($row['pc_catid'], $therapyGroupCategories)) {
                                 $row['groupName'] = getGroup($row['pc_gid'])['group_name'];
@@ -1735,7 +1776,8 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
 
                     if (isset($pid) && !$GLOBALS['disable_calendar'] && $showpast > 0 && AclMain::aclCheckCore('patients', 'appt')) {
                         $displayPastAppts = true;
-                        $query = "SELECT e.pc_eid, e.pc_aid, e.pc_title, e.pc_eventDate, e.pc_startTime, e.pc_hometext, u.fname, u.lname, u.mname, c.pc_catname, e.pc_apptstatus
+                        //ALB Added pc_facility below
+                        $query = "SELECT e.pc_eid, e.pc_aid, e.pc_title, e.pc_eventDate, e.pc_startTime, e.pc_hometext, u.fname, u.lname, u.mname, c.pc_catname, e.pc_apptstatus, e.pc_facility 
                             FROM openemr_postcalendar_events AS e,
                                 users AS u,
                                 openemr_postcalendar_categories AS c
@@ -1752,7 +1794,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                         while ($row = sqlFetchArray($pres)) {
                             $count++;
                             $dayname = date("D", strtotime($row['pc_eventDate']));
-                            $displayMeridiem = "am";
+                            $displayMeridiem = ($GLOBALS['time_display_format'] == 0) ? "" : "am"; //ALB Changed this
                             $disphour = substr($row['pc_startTime'], 0, 2) + 0;
                             $dispmin = substr($row['pc_startTime'], 3, 2);
                             if ($disphour >= 12) {
@@ -1766,9 +1808,13 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                             if ($row['pc_hometext'] != "") {
                                 $petitle = xl('Comments') . ": " . ($row['pc_hometext']) . "\r\n" . $petitle;
                             }
+                            $row['etitle'] = $petitle; //ALB Added this
 
                             $row['pc_status'] = generate_display_field(array('data_type' => '1', 'list_id' => 'apptstat'), $row['pc_apptstatus']);
+                            if ($row['pc_status'] == 'None') $row['pc_status'] = 'Scheduled'; //ALB Added this
+       
                             $row['dayName'] = $dayname;
+                            $row['displayMeridiem'] = $displayMeridiem; //ALB Added this
                             $row['pc_eventTime'] = sprintf("%02d", $disphour) . ":{$dispmin}";
                             $row['uname'] = text($row['fname'] . " " . $row['lname']);
                             $row['jsEvent'] = attr_js(preg_replace("/-/", "", $row['pc_eventDate'])) . ', ' . attr_js($row['pc_eid']);

--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -1683,7 +1683,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                             if ($row['pc_hometext'] != "") {
                                 $etitle = xl('Comments') . ": " . ($row['pc_hometext']) . "\r\n" . $etitle;
                             }
-                             
+
                             $row['etitle'] = $etitle; //ALB Added this
 
                             if ($extraApptDate && $count > $firstApptIndx) {
@@ -1817,7 +1817,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                             if ($row['pc_status'] == 'None') {
                                 $row['pc_status'] = 'Scheduled';
                             } //ALB Added this
-       
+
                             $row['dayName'] = $dayname;
                             $row['displayMeridiem'] = $displayMeridiem; //ALB Added this
                             $row['pc_eventTime'] = sprintf("%02d", $disphour) . ":{$dispmin}";

--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -1139,11 +1139,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                 $row['dispFromDate'] = $row['date'] ? true : false;
                                 $mname = ($row['subscriber_mname'] != "") ? $row['subscriber_mname'] : "";
                                 $row['subscriber_full_name'] = str_replace("%mname%", $mname, "{$row['subscriber_fname']} %mname% {$row['subscriber_lname']}");
-                                if ($row['isOld']) { //ALB Added all this
-                                    $row['until_date'] = date_create($prev_eff_date)->modify('-1 days')->format('Y-m-d');
-                                } else {
-                                    $row['until_date'] = 'Present';
-                                }
+                                $row['until_date'] = ($row['isOld']) ? date_create($prev_eff_date)->modify('-1 days')->format('Y-m-d') : xlt('Present');
                                 $insArr[] = $row;
                                 $prev_eff_date = $row['date']; //ALB Update previous effective date
                                 $prior_ins_type = $row['type'];
@@ -1164,11 +1160,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                 $row['policy_type'] = false;
                                 $mname = ''; //($row['subscriber_mname'] != "") ? $row['subscriber_mname'] : "";
                                 $row['subscriber_full_name'] = ' '; // str_replace("%mname%", $mname, "{$row['subscriber_fname']} %mname% {$row['subscriber_lname']}");
-                                if ($row['isOld']) { //ALB
-                                    $row['until_date'] = date_create($prev_eff_date)->modify('-1 days')->format('Y-m-d');
-                                } else {
-                                    $row['until_date'] = 'Present';
-                                }
+                                $row['until_date'] = ($row['isOld']) ? date_create($prev_eff_date)->modify('-1 days')->format('Y-m-d') : xlt("Present");
                                 $prev_eff_date = $row['date']; //ALB Added all this
                                 $prior_ins_type = $row['type'];
                                 if ($row['type'] != 'primary') {
@@ -1780,7 +1772,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                     if (isset($pid) && !$GLOBALS['disable_calendar'] && $showpast > 0 && AclMain::aclCheckCore('patients', 'appt')) {
                         $displayPastAppts = true;
                         //ALB Added pc_facility below
-                        $query = "SELECT e.pc_eid, e.pc_aid, e.pc_title, e.pc_eventDate, e.pc_startTime, e.pc_hometext, u.fname, u.lname, u.mname, c.pc_catname, e.pc_apptstatus, e.pc_facility 
+                        $query = "SELECT e.pc_eid, e.pc_aid, e.pc_title, e.pc_eventDate, e.pc_startTime, e.pc_hometext, u.fname, u.lname, u.mname, c.pc_catname, e.pc_apptstatus, e.pc_facility
                             FROM openemr_postcalendar_events AS e,
                                 users AS u,
                                 openemr_postcalendar_categories AS c
@@ -1814,9 +1806,6 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                             $row['etitle'] = $petitle; //ALB Added this
 
                             $row['pc_status'] = generate_display_field(array('data_type' => '1', 'list_id' => 'apptstat'), $row['pc_apptstatus']);
-                            if ($row['pc_status'] == 'None') {
-                                $row['pc_status'] = 'Scheduled';
-                            } //ALB Added this
 
                             $row['dayName'] = $dayname;
                             $row['displayMeridiem'] = $displayMeridiem; //ALB Added this

--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -1116,7 +1116,6 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                         $res = sqlStatement($sql, $params);
                         $prior_ins_type = '';
                         $prev_eff_date = 'Present'; //ALB Needed to keep track of effective dates
-                     
 
                         while ($row = sqlFetchArray($res)) {
                             if ($row['provider']) {
@@ -1141,7 +1140,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                 $mname = ($row['subscriber_mname'] != "") ? $row['subscriber_mname'] : "";
                                 $row['subscriber_full_name'] = str_replace("%mname%", $mname, "{$row['subscriber_fname']} %mname% {$row['subscriber_lname']}");
                                 if ($row['isOld']) { //ALB Added all this
-                                    $row['until_date'] = date_create($prev_eff_date)->modify('-1 days')->format('Y-m-d'); 
+                                    $row['until_date'] = date_create($prev_eff_date)->modify('-1 days')->format('Y-m-d');
                                 } else {
                                     $row['until_date'] = 'Present';
                                 }
@@ -1166,15 +1165,17 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                 $mname = ''; //($row['subscriber_mname'] != "") ? $row['subscriber_mname'] : "";
                                 $row['subscriber_full_name'] = ' '; // str_replace("%mname%", $mname, "{$row['subscriber_fname']} %mname% {$row['subscriber_lname']}");
                                 if ($row['isOld']) { //ALB
-                                    $row['until_date'] = date_create($prev_eff_date)->modify('-1 days')->format('Y-m-d'); 
+                                    $row['until_date'] = date_create($prev_eff_date)->modify('-1 days')->format('Y-m-d');
                                 } else {
                                     $row['until_date'] = 'Present';
                                 }
                                 $prev_eff_date = $row['date']; //ALB Added all this
                                 $prior_ins_type = $row['type'];
-                                if ($row['type'] != 'primary') continue; //ALB No Self-pay for secondary or tertiary insurance, so do not render card
+                                if ($row['type'] != 'primary') {
+                                    continue;
+                                } //ALB No Self-pay for secondary or tertiary insurance, so do not render card
                                 $insArr[] = $row;
-                            }    
+                            }
                         }
 
                         if ($GLOBALS["enable_oa"]) {
@@ -1698,7 +1699,9 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
 
                             $row['pc_eventTime'] = sprintf("%02d", $disphour) . ":{$dispmin}";
                             $row['pc_status'] = generate_display_field(array('data_type' => '1', 'list_id' => 'apptstat'), $row['pc_apptstatus']);
-                            if ($row['pc_status'] == 'None') $row['pc_status'] = 'Scheduled'; //ALB Added this
+                            if ($row['pc_status'] == 'None') {
+                                $row['pc_status'] = 'Scheduled';
+                            } //ALB Added this
 
                             if (in_array($row['pc_catid'], $therapyGroupCategories)) {
                                 $row['groupName'] = getGroup($row['pc_gid'])['group_name'];
@@ -1811,7 +1814,9 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                             $row['etitle'] = $petitle; //ALB Added this
 
                             $row['pc_status'] = generate_display_field(array('data_type' => '1', 'list_id' => 'apptstat'), $row['pc_apptstatus']);
-                            if ($row['pc_status'] == 'None') $row['pc_status'] = 'Scheduled'; //ALB Added this
+                            if ($row['pc_status'] == 'None') {
+                                $row['pc_status'] = 'Scheduled';
+                            } //ALB Added this
        
                             $row['dayName'] = $dayname;
                             $row['displayMeridiem'] = $displayMeridiem; //ALB Added this

--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -1048,11 +1048,11 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                         $patientbalance = get_patient_balance($pid, false);
                         $insurancebalance = get_patient_balance($pid, true) - $patientbalance;
                         $totalbalance = $patientbalance + $insurancebalance;
-                        $unallocated_amt = get_unallocated_patient_balance($pid); //ALB Added this
+                        $unallocated_amt = get_unallocated_patient_balance($pid);
 
                         $id = "billing_ps_expand";
-                        $dispatchResult = $ed->dispatch(CardRenderEvent::EVENT_HANDLE, new CardRenderEvent('billing'));
-                        //ALB Added unallocated amount below
+                        $dispatchResult = $ed->dispatch(new CardRenderEvent('billing'), CardRenderEvent::EVENT_HANDLE);
+
                         $viewArgs = [
                             'title' => xl('Billing'),
                             'id' => $id,
@@ -1115,7 +1115,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                         $params = array_merge($params, $insurance_array);
                         $res = sqlStatement($sql, $params);
                         $prior_ins_type = '';
-                        $prev_eff_date = 'Present'; //ALB Needed to keep track of effective dates
+                        $prev_eff_date = 'Present';
 
                         while ($row = sqlFetchArray($res)) {
                             if ($row['provider']) {
@@ -1141,9 +1141,9 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                 $row['subscriber_full_name'] = str_replace("%mname%", $mname, "{$row['subscriber_fname']} %mname% {$row['subscriber_lname']}");
                                 $row['until_date'] = ($row['isOld']) ? date_create($prev_eff_date)->modify('-1 days')->format('Y-m-d') : xlt('Present');
                                 $insArr[] = $row;
-                                $prev_eff_date = $row['date']; //ALB Update previous effective date
+                                $prev_eff_date = $row['date'];
                                 $prior_ins_type = $row['type'];
-                            } else { //ALB All below is needed for self-pay patients
+                            } else {
                                 $row['isOld'] = (strcmp($row['type'], $prior_ins_type) == 0) ? true : false;
                                 $row['dispFromDate'] = $row['date'] ? true : false;
                                 $row['insco'] = [
@@ -1161,11 +1161,11 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                 $mname = ''; //($row['subscriber_mname'] != "") ? $row['subscriber_mname'] : "";
                                 $row['subscriber_full_name'] = ' '; // str_replace("%mname%", $mname, "{$row['subscriber_fname']} %mname% {$row['subscriber_lname']}");
                                 $row['until_date'] = ($row['isOld']) ? date_create($prev_eff_date)->modify('-1 days')->format('Y-m-d') : xlt("Present");
-                                $prev_eff_date = $row['date']; //ALB Added all this
+                                $prev_eff_date = $row['date'];
                                 $prior_ins_type = $row['type'];
                                 if ($row['type'] != 'primary') {
                                     continue;
-                                } //ALB No Self-pay for secondary or tertiary insurance, so do not render card
+                                }
                                 $insArr[] = $row;
                             }
                         }
@@ -1676,7 +1676,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                 $etitle = xl('Comments') . ": " . ($row['pc_hometext']) . "\r\n" . $etitle;
                             }
 
-                            $row['etitle'] = $etitle; //ALB Added this
+                            $row['etitle'] = $etitle;
 
                             if ($extraApptDate && $count > $firstApptIndx) {
                                 $apptStyle = $apptStyle2;
@@ -1693,7 +1693,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                             $row['pc_status'] = generate_display_field(array('data_type' => '1', 'list_id' => 'apptstat'), $row['pc_apptstatus']);
                             if ($row['pc_status'] == 'None') {
                                 $row['pc_status'] = 'Scheduled';
-                            } //ALB Added this
+                            }
 
                             if (in_array($row['pc_catid'], $therapyGroupCategories)) {
                                 $row['groupName'] = getGroup($row['pc_gid'])['group_name'];
@@ -1771,7 +1771,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
 
                     if (isset($pid) && !$GLOBALS['disable_calendar'] && $showpast > 0 && AclMain::aclCheckCore('patients', 'appt')) {
                         $displayPastAppts = true;
-                        //ALB Added pc_facility below
+
                         $query = "SELECT e.pc_eid, e.pc_aid, e.pc_title, e.pc_eventDate, e.pc_startTime, e.pc_hometext, u.fname, u.lname, u.mname, c.pc_catname, e.pc_apptstatus, e.pc_facility
                             FROM openemr_postcalendar_events AS e,
                                 users AS u,
@@ -1789,7 +1789,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                         while ($row = sqlFetchArray($pres)) {
                             $count++;
                             $dayname = date("D", strtotime($row['pc_eventDate']));
-                            $displayMeridiem = ($GLOBALS['time_display_format'] == 0) ? "" : "am"; //ALB Changed this
+                            $displayMeridiem = ($GLOBALS['time_display_format'] == 0) ? "" : "am";
                             $disphour = substr($row['pc_startTime'], 0, 2) + 0;
                             $dispmin = substr($row['pc_startTime'], 3, 2);
                             if ($disphour >= 12) {
@@ -1803,12 +1803,12 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                             if ($row['pc_hometext'] != "") {
                                 $petitle = xl('Comments') . ": " . ($row['pc_hometext']) . "\r\n" . $petitle;
                             }
-                            $row['etitle'] = $petitle; //ALB Added this
+                            $row['etitle'] = $petitle;
 
                             $row['pc_status'] = generate_display_field(array('data_type' => '1', 'list_id' => 'apptstat'), $row['pc_apptstatus']);
 
                             $row['dayName'] = $dayname;
-                            $row['displayMeridiem'] = $displayMeridiem; //ALB Added this
+                            $row['displayMeridiem'] = $displayMeridiem;
                             $row['pc_eventTime'] = sprintf("%02d", $disphour) . ":{$dispmin}";
                             $row['uname'] = text($row['fname'] . " " . $row['lname']);
                             $row['jsEvent'] = attr_js(preg_replace("/-/", "", $row['pc_eventDate'])) . ', ' . attr_js($row['pc_eid']);

--- a/library/patient.inc.php
+++ b/library/patient.inc.php
@@ -402,7 +402,6 @@ function getInsuranceDataByDate(
     return sqlQuery($sql, array($pid,$date,$type));
 }
 
-//ALB Calculates unallocated patient balance (pre-payments)
 function get_unallocated_patient_balance($pid)
 {
     $unallocated = '';
@@ -420,7 +419,6 @@ function get_unallocated_patient_balance($pid)
     return sprintf('%01.2f', $unallocated);
 }
 
-//ALB Added this function
 function getInsuranceNameByDate(
     $pid,
     $date,

--- a/library/patient.inc.php
+++ b/library/patient.inc.php
@@ -444,7 +444,7 @@ function getInsuranceNameByDate(
 // it needs to be escaped via whitelisting prior to using this function.
 function getEmployerData($pid, $given = "*")
 {
-    $sql = "select $given from employer_data where pid=? order by date DESC limit 0,1";
+    $sql = "select $given from employer_data where pid = ? order by date DESC limit 0,1";
     return sqlQuery($sql, array($pid));
 }
 
@@ -668,7 +668,7 @@ function getPatientId($pid = "%", $given = "pid, id, lname, fname, mname, provid
 function getByPatientDemographics($searchTerm = "%", $given = "pid, id, lname, fname, mname, providerID, DATE_FORMAT(DOB,'%m/%d/%Y') as DOB_TS", $orderby = "lname ASC, fname ASC", $limit = "all", $start = "0")
 {
     $layoutCols = sqlStatement(
-        "SELECT field_id FROM layout_options WHERE form_id = 'DEM' AND field_id not like ? AND uor !=0",
+        "SELECT field_id FROM layout_options WHERE form_id = 'DEM' AND field_id not like ? AND uor ! = 0",
         array('em\_%')
     );
 

--- a/library/patient.inc.php
+++ b/library/patient.inc.php
@@ -403,7 +403,8 @@ function getInsuranceDataByDate(
 }
 
 //ALB Calculates unallocated patient balance (pre-payments)
-function get_unallocated_patient_balance($pid) {
+function get_unallocated_patient_balance($pid)
+{
     $unallocated = '';
     $query = "SELECT a.session_id, a.pay_total, a.global_amount " .
         "FROM ar_session AS a " .
@@ -412,7 +413,7 @@ function get_unallocated_patient_balance($pid) {
     $res = sqlStatement($query, array($pid));
     while ($row = sqlFetchArray($res)) {
         $total_amt = $row['pay_total'] - $row['global_amount'];
-        $rs= sqlQuery("SELECT sum(pay_amount) AS total_pay_amt FROM ar_activity WHERE session_id= ? AND pid = ? AND deleted IS NULL", array($row['session_id'], $pid));
+        $rs= sqlQuery("SELECT sum(pay_amount) AS total_pay_amt FROM ar_activity WHERE session_id = ? AND pid = ? AND deleted IS NULL", array($row['session_id'], $pid));
         $pay_amount = $rs['total_pay_amt'];
         $unallocated += ($total_amt - $pay_amount);
     }

--- a/library/patient.inc.php
+++ b/library/patient.inc.php
@@ -413,7 +413,7 @@ function get_unallocated_patient_balance($pid)
     $res = sqlStatement($query, array($pid));
     while ($row = sqlFetchArray($res)) {
         $total_amt = $row['pay_total'] - $row['global_amount'];
-        $rs= sqlQuery("SELECT sum(pay_amount) AS total_pay_amt FROM ar_activity WHERE session_id = ? AND pid = ? AND deleted IS NULL", array($row['session_id'], $pid));
+        $rs = sqlQuery("SELECT sum(pay_amount) AS total_pay_amt FROM ar_activity WHERE session_id = ? AND pid = ? AND deleted IS NULL", array($row['session_id'], $pid));
         $pay_amount = $rs['total_pay_amt'];
         $unallocated += ($total_amt - $pay_amount);
     }

--- a/library/patient.inc.php
+++ b/library/patient.inc.php
@@ -668,7 +668,7 @@ function getPatientId($pid = "%", $given = "pid, id, lname, fname, mname, provid
 function getByPatientDemographics($searchTerm = "%", $given = "pid, id, lname, fname, mname, providerID, DATE_FORMAT(DOB,'%m/%d/%Y') as DOB_TS", $orderby = "lname ASC, fname ASC", $limit = "all", $start = "0")
 {
     $layoutCols = sqlStatement(
-        "SELECT field_id FROM layout_options WHERE form_id = 'DEM' AND field_id not like ? AND uor ! = 0",
+        "SELECT field_id FROM layout_options WHERE form_id = 'DEM' AND field_id not like ? AND uor != 0",
         array('em\_%')
     );
 

--- a/templates/patient/card/billing.html.twig
+++ b/templates/patient/card/billing.html.twig
@@ -2,46 +2,46 @@
 
 {% block content %}
 <div class="container">
-    <div class="row"> <!--ALB Changed this to red and bold -->
-        <div class="col-4 font-weight-bold"><font color='red'>{{ "Patient Balance Due"|xlt }}</font></div>
-        <div class="col font-weight-bold"><font color='red'>{{ patientBalance|money|text }}</font></div>
+    <div class="row">
+        <div class="col-4">{{ "Patient Balance Due"|xlt }}</div>
+        <div class="col">{{ patientBalance|money|text }}</div>
     </div>
     <div class="row">
         <div class="col-4">{{ "Insurance Balance Due"|xlt }}</div>
         <div class="col">{{ insuranceBalance|money|text }}</div>
     </div>
     <div class="row">
-        <div class="col-4 font-weight-bold">{{ "Total Balance Due"|xlt }}</div>
-        <div class="col font-weight-bold">{{ totalBalance|money|text }}</div>
+        <div class="col-4">{{ "Total Balance Due"|xlt }}</div>
+        <div class="col">{{ totalBalance|money|text }}</div>
     </div>
 
     {% if unallocated > 0 %}{# ALB Show unallocated amount, if present #}
     <div class="row">
-        <div class="col-4 font-weight-bold"><font color='#ee6600'>{{ "Unallocated Patient Pre-Payment"|xlt }}</div>
-        <div class="col font-weight-bold">{{ unallocated|money|text }}</font></div>
+        <div class="col-4"><font color='#ee6600'>{{ "Unallocated Patient Pre-Payment"|xlt }}</div>
+        <div class="col">{{ unallocated|money|text }}</font></div>
     </div>
     {% endif %}
 
     {% if billingNote %}
     <div class="row"> <!--ALB Made all bold -->
-        <div class="col-4 font-weight-bold">{{ "Billing Note"|xlt }}</div>
-        <div class="col font-weight-bold">{{ billingNote|text }}</div>
+        <div class="col-4">{{ "Billing Note"|xlt }}</div>
+        <div class="col">{{ billingNote|text }}</div>
     </div>
     {% endif %}
     {% if provider %}
     <div class="row">
-        <div class="col-4 font-weight-bold">{{ "Primary Insurance"|xlt }}</div>
-        <div class="col font-weight-bold">{{ insName|text }}</div>
+        <div class="col-4">{{ "Primary Insurance"|xlt }}</div>
+        <div class="col">{{ insName|text }}</div>
     </div>
         {% if copay %}
         <div class="row">
-            <div class="col-4 font-weight-bold">{{ "Copay"|xlt }}</div>
-            <div class="col font-weight-bold">{{ copay|text }}</div>
+            <div class="col-4">{{ "Copay"|xlt }}</div>
+            <div class="col">{{ copay|text }}</div>
         </div>
         {% endif %}
     <div class="row">
-        <div class="col-4 font-weight-bold">{{ "Effective Date"|xlt }}</div>
-        <div class="col font-weight-bold">{{ effDate|shortDate|text }}</div>
+        <div class="col-4">{{ "Effective Date"|xlt }}</div>
+        <div class="col">{{ effDate|shortDate|text }}</div>
     </div>
     {% endif %}
 

--- a/templates/patient/card/billing.html.twig
+++ b/templates/patient/card/billing.html.twig
@@ -15,7 +15,7 @@
         <div class="col">{{ totalBalance|money|text }}</div>
     </div>
 
-    {% if unallocated > 0 %}{# ALB Show unallocated amount, if present #}
+    {% if unallocated > 0 %}
     <div class="row">
         <div class="col-4">{{ "Unallocated Patient Pre-Payment"|xlt }}</div>
         <div class="col">{{ unallocated|money|text }}</font></div>
@@ -23,7 +23,7 @@
     {% endif %}
 
     {% if billingNote %}
-    <div class="row"> <!--ALB Made all bold -->
+    <div class="row">
         <div class="col-4">{{ "Billing Note"|xlt }}</div>
         <div class="col">{{ billingNote|text }}</div>
     </div>

--- a/templates/patient/card/billing.html.twig
+++ b/templates/patient/card/billing.html.twig
@@ -2,9 +2,9 @@
 
 {% block content %}
 <div class="container">
-    <div class="row">
-        <div class="col-4">{{ "Patient Balance Due"|xlt }}</div>
-        <div class="col">{{ patientBalance|money|text }}</div>
+    <div class="row"> <!--ALB Changed this to red and bold -->
+        <div class="col-4 font-weight-bold"><font color='red'>{{ "Patient Balance Due"|xlt }}</font></div>
+        <div class="col font-weight-bold"><font color='red'>{{ patientBalance|money|text }}</font></div>
     </div>
     <div class="row">
         <div class="col-4">{{ "Insurance Balance Due"|xlt }}</div>
@@ -14,26 +14,34 @@
         <div class="col-4 font-weight-bold">{{ "Total Balance Due"|xlt }}</div>
         <div class="col font-weight-bold">{{ totalBalance|money|text }}</div>
     </div>
-    {% if billingNote %}
+
+    {% if unallocated > 0 %}{# ALB Show unallocated amount, if present #}
     <div class="row">
-        <div class="col-4">{{ "Billing Note"|xlt }}</div>
-        <div class="col">{{ billingNote|text }}</div>
+        <div class="col-4 font-weight-bold"><font color='#ee6600'>{{ "Unallocated Patient Pre-Payment"|xlt }}</div>
+        <div class="col font-weight-bold">{{ unallocated|money|text }}</font></div>
+    </div>
+    {% endif %}
+
+    {% if billingNote %}
+    <div class="row"> <!--ALB Made all bold -->
+        <div class="col-4 font-weight-bold">{{ "Billing Note"|xlt }}</div>
+        <div class="col font-weight-bold">{{ billingNote|text }}</div>
     </div>
     {% endif %}
     {% if provider %}
     <div class="row">
-        <div class="col-4">{{ "Primary Insurance"|xlt }}</div>
-        <div class="col">{{ insName|text }}</div>
+        <div class="col-4 font-weight-bold">{{ "Primary Insurance"|xlt }}</div>
+        <div class="col font-weight-bold">{{ insName|text }}</div>
     </div>
         {% if copay %}
         <div class="row">
-            <div class="col-4">{{ "Copay"|xlt }}</div>
-            <div class="col">{{ copay|text }}</div>
+            <div class="col-4 font-weight-bold">{{ "Copay"|xlt }}</div>
+            <div class="col font-weight-bold">{{ copay|text }}</div>
         </div>
         {% endif %}
     <div class="row">
-        <div class="col-4">{{ "Effective Date"|xlt }}</div>
-        <div class="col">{{ effDate|shortDate|text }}</div>
+        <div class="col-4 font-weight-bold">{{ "Effective Date"|xlt }}</div>
+        <div class="col font-weight-bold">{{ effDate|shortDate|text }}</div>
     </div>
     {% endif %}
 

--- a/templates/patient/card/billing.html.twig
+++ b/templates/patient/card/billing.html.twig
@@ -17,7 +17,7 @@
 
     {% if unallocated > 0 %}{# ALB Show unallocated amount, if present #}
     <div class="row">
-        <div class="col-4"><font color='#ee6600'>{{ "Unallocated Patient Pre-Payment"|xlt }}</div>
+        <div class="col-4">{{ "Unallocated Patient Pre-Payment"|xlt }}</div>
         <div class="col">{{ unallocated|money|text }}</font></div>
     </div>
     {% endif %}


### PR DESCRIPTION
Fixes #5954 

Short description of what this resolves:
From Dr Alexander Berlin, TX
Another important bug fix. In the new system, they got the insurance card wrong, with all insurances, including old insurances showing "until Present".

Here's the fix and it also introduces the concept of Self-Pay display for those times when a patient did not have insurance, both currently and in the past.

But wait there is more.
Unallocated amount. We have the ability to take a pre-payment on the front_payment screen, but it just doesn't show anywhere obvious, so that it could be applied to the account!

Changes proposed in this pull request:
Go to patient chart, put in a couple of insurances (primary and secondary) with an effective date of let’s say a year ago. Then add another primary insurance (as a separate test, set to Unassigned for primary) with an effective date of a month ago and set secondary to Unassigned for the same effective date a month ago.
Then refresh patient demographics by clicking on the patient name above. See what you see for insurances and their effective dates (insurance tab on top - Insurance from… until …).
