### PR TITLE
feat: new prescription endpoints

### DIFF
--- a/_rest_routes.inc.php
+++ b/_rest_routes.inc.php
@@ -140,6 +140,7 @@
  *              "user/practitioner.read": "Read practitioners the user has access to (api:oemr)",
  *              "user/practitioner.write": "Write practitioners the user has access to (api:oemr)",
  *              "user/prescription.read": "Read prescriptions the user has access to (api:oemr)",
+ *              "user/prescription.write": "Write prescriptions the user has access to (api:oemr)",
  *              "user/procedure.read": "Read procedures the user has access to (api:oemr)",
  *              "user/soap_note.read": "Read soap notes the user has access to (api:oemr)",
  *              "user/soap_note.write": "Write soap notes the user has access to (api:oemr)",
@@ -302,6 +303,7 @@ use OpenEMR\RestControllers\MessageRestController;
 use OpenEMR\RestControllers\PrescriptionRestController;
 use OpenEMR\RestControllers\ProcedureRestController;
 use OpenEMR\RestControllers\TransactionRestController;
+use OpenEMR\RestControllers\CodeTypesRestController;
 
 // Note some Http clients may not send auth as json so a function
 // is implemented to determine and parse encoding on auth route's.
@@ -7029,6 +7031,60 @@ RestConfig::$ROUTE_MAP = array(
     },
 
     /**
+     *  @OA\POST(
+     *      path="/api/prescription",
+     *      description="Creates a new prescription",
+     *      tags={"standard"},
+     *      @OA\Response(
+     *          response="200",
+     *          ref="#/components/responses/standard"
+     *      ),
+     *      @OA\Response(
+     *          response="400",
+     *          ref="#/components/responses/badrequest"
+     *      ),
+     *      @OA\Response(
+     *          response="401",
+     *          ref="#/components/responses/unauthorized"
+     *      ),
+     *      security={{"openemr_auth":{}}}
+     *  )
+     */
+    "POST /api/prescription" => function () {
+        $data = (array) (json_decode(file_get_contents("php://input")));
+        $return = (new PrescriptionRestController())->post($data);
+        RestConfig::apiLog($return, $data);
+        return $return;
+    },
+
+    /**
+     *  @OA\Get(
+     *      path="/api/patient/{puuid}/prescription",
+     *      description="Retrieves a list of all prescriptions for the patient",
+     *      tags={"standard"},
+     *      @OA\Response(
+     *          response="200",
+     *          ref="#/components/responses/standard"
+     *      ),
+     *      @OA\Response(
+     *          response="400",
+     *          ref="#/components/responses/badrequest"
+     *      ),
+     *      @OA\Response(
+     *          response="401",
+     *          ref="#/components/responses/unauthorized"
+     *      ),
+     *      security={{"openemr_auth":{}}}
+     *  )
+     */
+    "GET /api/patient/:puuid/prescription" => function ($puuid) {
+        RestConfig::authorization_check("patients", "med");
+        $return = (new PrescriptionRestController())->getAll(['puuid' => $puuid]);
+        RestConfig::apiLog($return);
+        return $return;
+    },
+
+    /**
      *  @OA\Get(
      *      path="/api/prescription/{uuid}",
      *      description="Retrieves a prescription",
@@ -7062,7 +7118,42 @@ RestConfig::$ROUTE_MAP = array(
         $return = (new PrescriptionRestController())->getOne($uuid);
         RestConfig::apiLog($return);
         return $return;
-    }
+    },
+
+    /**
+     *  @OA\Delete(
+     *      path="/api/prescription/{id}",
+     *      description="Delete a prescription",
+     *      tags={"standard"},
+     *      @OA\Parameter(
+     *          name="id",
+     *          in="path",
+     *          description="The id for the prescription.",
+     *          required=true,
+     *          @OA\Schema(
+     *              type="string"
+     *          )
+     *      ),
+     *      @OA\Response(
+     *          response="200",
+     *          ref="#/components/responses/standard"
+     *      ),
+     *      @OA\Response(
+     *          response="400",
+     *          ref="#/components/responses/badrequest"
+     *      ),
+     *      @OA\Response(
+     *          response="401",
+     *          ref="#/components/responses/unauthorized"
+     *      ),
+     *      security={{"openemr_auth":{}}}
+     *  )
+     */
+    "DELETE /api/prescription/:id" => function ($id) {
+        $return = (new PrescriptionRestController())->delete($id);
+        RestConfig::apiLog($return);
+        return $return;
+    },
 );
 
 use OpenEMR\Common\Http\StatusCode;
@@ -7094,7 +7185,6 @@ use OpenEMR\RestControllers\FHIR\FhirProvenanceRestController;
 use OpenEMR\RestControllers\FHIR\FhirMetaDataRestController;
 use OpenEMR\RestControllers\FHIR\Operations\FhirOperationExportRestController;
 use OpenEMR\RestControllers\FHIR\Operations\FhirOperationDocRefRestController;
-use OpenEMR\RestControllers\FHIR\Operations\FhirOperationDefinitionRestController;
 
 // Note that the fhir route includes both user role and patient role
 //  (there is a mechanism in place to ensure patient role is binded

--- a/src/RestControllers/PrescriptionRestController.php
+++ b/src/RestControllers/PrescriptionRestController.php
@@ -25,6 +25,17 @@ class PrescriptionRestController
     }
 
     /**
+     * Process a HTTP POST request used to create a prescription record.
+     * @param $data - array of prescription fields.
+     * @return a 201/Created status code and the prescription identifier if successful.
+     */
+    public function post($data)
+    {
+        $processingResult = $this->prescriptionService->insert($data);
+        return RestControllerHelper::handleProcessingResult($processingResult, 201);
+    }
+
+    /**
      * Fetches a single prescription resource by id.
      * @param $uuid- The prescription uuid identifier in string format.
      */
@@ -46,5 +57,11 @@ class PrescriptionRestController
     {
         $processingResult = $this->prescriptionService->getAll($search);
         return RestControllerHelper::handleProcessingResult($processingResult, 200, true);
+    }
+
+    public function delete($id)
+    {
+        $serviceResult = $this->prescriptionService->delete($id);
+        return RestControllerHelper::responseHandler($serviceResult, null, 200);
     }
 }

--- a/src/Services/PrescriptionService.php
+++ b/src/Services/PrescriptionService.php
@@ -54,17 +54,17 @@ class PrescriptionService extends BaseService
     {
         $sqlBindArray = array();
 
-        if (isset($search['patient.uuid'])) {
+        if (isset($search['puuid'])) {
             $isValidPatient = $this->patientValidator->validateId(
                 'uuid',
                 self::PATIENT_TABLE,
-                $search['patient.uuid'],
+                $search['puuid'],
                 true
             );
             if ($isValidPatient != true) {
                 return $isValidPatient;
             }
-            $search['patient.uuid'] = UuidRegistry::uuidToBytes($search['patient.uuid']);
+            $search['puuid'] = UuidRegistry::uuidToBytes($search['puuid']);
         }
 
         if (!empty($puuidBind)) {
@@ -100,6 +100,9 @@ class PrescriptionService extends BaseService
                 ,combined_prescriptions.note
                 ,combined_prescriptions.status
                 ,combined_prescriptions.drug_dosage_instructions
+                ,combined_prescriptions.indication
+                ,combined_prescriptions.substitute
+                ,combined_prescriptions.quantity
                 ,patient.puuid
                 ,encounter.euuid
                 ,practitioner.pruuid
@@ -124,6 +127,9 @@ class PrescriptionService extends BaseService
                             ,prescriptions.drug
                             ,prescriptions.active
                             ,prescriptions.end_date
+                            ,prescriptions.indication
+                            ,prescriptions.substitute
+                            ,prescriptions.quantity
                             ,'order' AS intent
                             ,'Order' AS intent_title
                             ,'community' AS category
@@ -135,7 +141,7 @@ class PrescriptionService extends BaseService
                             ,date_added
                             ,COALESCE(prescriptions.unit,drugs.unit) AS unit
                             ,prescriptions.`interval`
-                            ,COALESCE(prescriptions.`route`,drugs.`route`) AS 'route'
+                            ,prescriptions.`route` AS 'route'
                             ,prescriptions.`note`
                             ,patient_id
                             ,encounter
@@ -153,50 +159,6 @@ class PrescriptionService extends BaseService
                     LEFT JOIN
                         -- @brady.miller so drug_id in my databases appears to always be 0 so I'm not sure I can grab anything here.. I know WENO doesn't populate this value...
                         drugs ON prescriptions.drug_id = drugs.drug_id
-                    UNION
-                    SELECT
-                        lists.uuid
-                        ,'lists' AS 'source_table'
-                        ,lists.title AS drug
-                        ,activity AS active
-                        ,lists.enddate AS end_date
-                        ,lists_medication.request_intent AS intent
-                        ,lists_medication.request_intent_title AS intent_title
-                        ,lists_medication.usage_category AS category
-                        ,lists_medication.usage_category_title AS category_title
-                        ,lists.diagnosis AS rxnorm_drugcode
-                        ,`date` AS date_added
-                        ,NULL as unit
-                        ,NULL as 'interval'
-                        ,NULL as `route`
-                        ,lists.comments as 'note'
-                        ,pid AS patient_id
-                        ,issues_encounter.issues_encounter_encounter as encounter
-                        ,users.id AS provider_id
-                        ,NULL as drug_uuid
-                        ,lists_medication.drug_dosage_instructions
-                        ,CASE 
-                                WHEN lists.enddate IS NOT NULL AND lists.activity = 1 THEN 'completed'
-                                WHEN lists.activity = 1 THEN 'active'
-                                ELSE 'stopped'
-                        END as 'status'
-                    FROM
-                        lists
-                    LEFT JOIN 
-                            users ON users.username = lists.user
-                    LEFT JOIN
-                        lists_medication ON lists_medication.list_id = lists.id
-                    LEFT JOIN
-                    (
-                       select 
-                              pid AS issues_encounter_pid
-                            , list_id AS issues_encounter_list_id
-                            -- lists have a 0..* relationship with issue_encounters which is a problem as FHIR treats medications as a 0.1
-                            -- we take the very first encounter that the issue was tied to.
-                            , min(encounter) AS issues_encounter_encounter FROM issue_encounter GROUP BY pid,list_id
-                    ) issues_encounter ON lists.pid = issues_encounter.issues_encounter_pid AND lists.id = issues_encounter.issues_encounter_list_id
-                    WHERE
-                        type = 'medication'
                 ) combined_prescriptions
                 LEFT JOIN
                 (
@@ -296,5 +258,45 @@ class PrescriptionService extends BaseService
     public function getOne($uuid, $puuidBind = null)
     {
         return $this->getAll(['_id' => $uuid], $puuidBind);
+    }
+
+    /**
+     * Inserts a new prescription record.
+     *
+     * @param $data The prescription fields (array) to insert.
+     * @return ProcessingResult which contains validation messages, internal error messages, and the data
+     * payload.
+     */
+    public function insert($data)
+    {
+        $processingResult = new ProcessingResult();
+
+        $data['uuid'] = UuidRegistry::getRegistryForTable(self::PRESCRIPTION_TABLE)->createUuid();
+
+        $query = $this->buildInsertColumns($data);
+        $sql = " INSERT INTO prescriptions SET ";
+        $sql .= $query['set'];
+
+        $results = sqlInsert(
+            $sql,
+            $query['bind']
+        );
+
+        if ($results) {
+            $processingResult->addData(array(
+                'id' => $results,
+                'uuid' => UuidRegistry::uuidToString($data['uuid'])
+            ));
+        } else {
+            $processingResult->addInternalError("error processing SQL Insert");
+        }
+
+        return $processingResult;
+    }
+
+    public function delete($id)
+    {
+        QueryUtils::sqlStatementThrowException("DELETE FROM prescriptions WHERE id = ?", $id);
+        return ['message' => 'record deleted'];
     }
 }


### PR DESCRIPTION
#### Short description of what this resolves:
Dear Community,  I am representing the project of a Digital health platform developed by Cardo Health AB ( [www.cardohealth.com](http://www.cardohealth.com/)),  through the support of my current employer ( NearForm ). We are pleased to contribute some fixes in OpenEMR on behalf of Cardo Health and look forward to continuing to do so in the future.

This PR adds POST and DELETE API endpoints for `prescriptions`, so we can use REST API not just to fetch prescriptions but also to update them. Thanks!

#### Changes proposed in this pull request:
