### PR TITLE
Fixes #6144 Postmaster throw exceptions

### DIFF
--- a/library/classes/postmaster.php
+++ b/library/classes/postmaster.php
@@ -24,8 +24,11 @@ class MyMailer extends PHPMailer
     var $Port;
     var $CharSet;
 
-    function __construct()
+    function __construct($throwExceptions = false)
     {
+        // make sure we initiate our constructor here...
+        parent::__construct($throwExceptions);
+
         $this->emailMethod();
     }
 


### PR DESCRIPTION
Make it so the postmaster throws exceptions by calling the constructor on the parent class.

Fixes #6144 