### PR TITLE
fix: easy development docker environment - allow development and testing in public folder

### DIFF
--- a/docker/development-easy-arm32/docker-compose.yml
+++ b/docker/development-easy-arm32/docker-compose.yml
@@ -23,7 +23,8 @@ services:
     volumes:
     - ../..:/openemr:ro
     - ../..:/var/www/localhost/htdocs/openemr:rw
-    - publicvolume:/var/www/localhost/htdocs/openemr/public:rw
+    - assetvolume:/var/www/localhost/htdocs/openemr/public/assets:rw
+    - themevolume:/var/www/localhost/htdocs/openemr/public/themes:rw
     - sitesvolume:/var/www/localhost/htdocs/openemr/sites:rw
     - nodemodules:/var/www/localhost/htdocs/openemr/node_modules:rw
     - vendordir:/var/www/localhost/htdocs/openemr/vendor:rw
@@ -80,7 +81,8 @@ services:
       LDAP_TLS_KEY_FILENAME: server-key.pem
 volumes:
   databasevolume: {}
-  publicvolume: {}
+  assetvolume: {}
+  themevolume: {}
   sitesvolume: {}
   nodemodules: {}
   vendordir: {}

--- a/docker/development-easy-arm64/docker-compose.yml
+++ b/docker/development-easy-arm64/docker-compose.yml
@@ -22,7 +22,8 @@ services:
     volumes:
     - ../..:/openemr:ro
     - ../..:/var/www/localhost/htdocs/openemr:rw
-    - publicvolume:/var/www/localhost/htdocs/openemr/public:rw
+    - assetvolume:/var/www/localhost/htdocs/openemr/public/assets:rw
+    - themevolume:/var/www/localhost/htdocs/openemr/public/themes:rw
     - sitesvolume:/var/www/localhost/htdocs/openemr/sites:rw
     - nodemodules:/var/www/localhost/htdocs/openemr/node_modules:rw
     - vendordir:/var/www/localhost/htdocs/openemr/vendor:rw
@@ -101,7 +102,8 @@ services:
       LDAP_TLS_KEY_FILENAME: server-key.pem
 volumes:
   databasevolume: {}
-  publicvolume: {}
+  assetvolume: {}
+  themevolume: {}
   sitesvolume: {}
   nodemodules: {}
   vendordir: {}

--- a/docker/development-easy-light/docker-compose.yml
+++ b/docker/development-easy-light/docker-compose.yml
@@ -22,7 +22,8 @@ services:
     volumes:
     - ../..:/openemr:ro
     - ../..:/var/www/localhost/htdocs/openemr:rw
-    - publicvolume:/var/www/localhost/htdocs/openemr/public:rw
+    - assetvolume:/var/www/localhost/htdocs/openemr/public/assets:rw
+    - themevolume:/var/www/localhost/htdocs/openemr/public/themes:rw
     - sitesvolume:/var/www/localhost/htdocs/openemr/sites:rw
     - nodemodules:/var/www/localhost/htdocs/openemr/node_modules:rw
     - vendordir:/var/www/localhost/htdocs/openemr/vendor:rw
@@ -67,7 +68,8 @@ services:
       PMA_HOSTS: mysql
 volumes:
   databasevolume: {}
-  publicvolume: {}
+  assetvolume: {}
+  themevolume: {}
   sitesvolume: {}
   nodemodules: {}
   vendordir: {}

--- a/docker/development-easy/docker-compose.yml
+++ b/docker/development-easy/docker-compose.yml
@@ -22,7 +22,8 @@ services:
     volumes:
     - ../..:/openemr:ro
     - ../..:/var/www/localhost/htdocs/openemr:rw
-    - publicvolume:/var/www/localhost/htdocs/openemr/public:rw
+    - assetvolume:/var/www/localhost/htdocs/openemr/public/assets:rw
+    - themevolume:/var/www/localhost/htdocs/openemr/public/themes:rw
     - sitesvolume:/var/www/localhost/htdocs/openemr/sites:rw
     - nodemodules:/var/www/localhost/htdocs/openemr/node_modules:rw
     - vendordir:/var/www/localhost/htdocs/openemr/vendor:rw
@@ -99,7 +100,8 @@ services:
       LDAP_TLS_KEY_FILENAME: server-key.pem
 volumes:
   databasevolume: {}
-  publicvolume: {}
+  assetvolume: {}
+  themevolume: {}
   sitesvolume: {}
   nodemodules: {}
   vendordir: {}


### PR DESCRIPTION
fixes #6147

For the easy development docker environment, allow development/testing in the public folder