### PR TITLE
fix: Quietly report an error if logo cannot be located

### DIFF
--- a/src/Services/LogoService.php
+++ b/src/Services/LogoService.php
@@ -65,11 +65,23 @@ class LogoService
     public function getLogo(string $type): string
     {
         $siteDir = "{$GLOBALS['OE_SITE_DIR']}/images/logos/{$type}/";
-        $paths[] = "{$GLOBALS['images_static_absolute']}/logos/{$type}/";
+        $publicDir = "{$GLOBALS['images_static_absolute']}/logos/{$type}/";
+        $paths = [];
+
+        if ($this->fs->exists($publicDir)) {
+            // Only look in public directory if the structure exists
+            $paths[] = $publicDir;
+        }
 
         if ($this->fs->exists($siteDir)) {
             // Only look in sites if the sites structure exists, ensures upgrades continue to work
             array_unshift($paths, $siteDir);
+        }
+
+        if (count($paths) === 0) {
+            // The logo directory couldn't not be found, log an error, return an empty string as this should be a non-breaking error
+            error_log("No logo found in primary or backup location.");
+            return "";
         }
 
         $logo = $this->findLogo($paths);


### PR DESCRIPTION
Now start with an empty paths array - only add `public` if the proper structure exists. If not, `error_log()` the problem and return an empty string. This ensures the rendering can continue (albeit, with no logo).

Fixes #6147