### PR TITLE
Allow Form Templates to improve documentation efficienty

### DIFF
--- a/interface/modules/custom_modules/oe-form-templates/CHANGELOG.md
+++ b/interface/modules/custom_modules/oe-form-templates/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Form Templating Changelog
+
+
+
+## Version 0.1.0
+
+* Initial support

--- a/interface/modules/custom_modules/oe-form-templates/Readme.md
+++ b/interface/modules/custom_modules/oe-form-templates/Readme.md
@@ -1,0 +1,28 @@
+### Form Templates
+
+This modules provides Form Templates to streamline the process of standardized form processing.
+
+## Activating Your Module
+You can activate your module in OpenEMR by doing the following as a logged in administrator:
+
+1. Go to Modules --> Manage Modules
+2. Selected Unregstered
+3. _Register_ the Form Templates module.
+4. _Install_ the Form Templates module.
+5. _Enable_ the Form Templates module.
+6. Logout and login to refresh main menu.
+
+## Configuring Form Templates
+
+The Form Templates modules can be configured by Administrators using settings found under Admin --> Form Templates.
+
+## Using Form Templates
+
+End users interact with the Form Templates module by clicking on the Template Buttons placed during configuration.
+
+### Example
+
+1. A user has the Medical Records Dashboard page loaded for patient Phil Bedford.
+2. The Form Templates module has been configured to display a QuickPick Button on this page for a "Annual Physical Visit" New Encounter Form.
+3. User clicks "Annual Physical Visit" button and is redirected to the Encounter Summary screen for the newly created encounter.
+

--- a/interface/modules/custom_modules/oe-form-templates/index.php
+++ b/interface/modules/custom_modules/oe-form-templates/index.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ *
+ */
+
+use Google\Service\Books;
+use OpenEMR\Common\Acl\AclMain;
+use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\Modules\FormTemplates\Bootstrap;
+use OpenEMR\Modules\FormTemplates\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Twig\Extension\DebugExtension;
+
+require_once "../../../globals.php";
+require_once "../../../../library/registry.inc.php";
+
+// Control access
+if (!AclMain::aclCheckCore('patients', 'demo')) {
+    echo xlt('Not Authorized');
+    exit;
+}
+
+$templateDir = Bootstrap::getTemplatePath();
+$twigContainer = new TwigContainer($templateDir);
+$twig = $twigContainer->getTwig();
+$twig->addExtension(new DebugExtension());
+$twig->enableDebug();
+
+$request = Request::createFromGlobals();
+
+$r_controller = $request->get('controller', 'default');
+$r_action = $request->get('action', 'index');
+
+$routes = [
+    'default'       => 'OpenEMR\Modules\FormTemplates\Controller\ConfigurationController',
+    'configuration' => 'OpenEMR\Modules\FormTemplates\Controller\ConfigurationController',
+];
+
+if (array_key_exists($r_controller, $routes) == true) {
+    $reflection = new ReflectionClass($routes[$r_controller]);
+
+    if ($reflection->hasMethod($r_action)) {
+        /**
+         * @var Controller
+         */
+        $instance = $reflection->newInstance();
+        $results = call_user_func([$instance, $r_action]);
+        $results['mod_index'] = Bootstrap::MODULE_INSTALLATION_PATH . Bootstrap::MODULE_MACHINE_NAME . '/index.php';
+        echo $twig->render($instance->getTemplateName(), $results);
+    }
+
+}

--- a/interface/modules/custom_modules/oe-form-templates/info.txt
+++ b/interface/modules/custom_modules/oe-form-templates/info.txt
@@ -1,0 +1,1 @@
+Form Templates

--- a/interface/modules/custom_modules/oe-form-templates/openemr.bootstrap.php
+++ b/interface/modules/custom_modules/oe-form-templates/openemr.bootstrap.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Bootstrap for the Form Template module.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Robert Down <robertdown@live.com>
+ * @copyright Copyright (c) 2022-2023 Robert Down <robertdown@live.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Modules\FormTemplates;
+
+use OpenEMR\Core\ModulesClassLoader;
+
+/**
+ * @global OpenEMR\Core\ModulesClassLoader $classLoader
+ */
+$classLoader->registerNamespaceIfNotExists('OpenEMR\\Modules\\FormTemplates\\', __DIR__ . DIRECTORY_SEPARATOR . 'src');
+
+/**
+ * @global EventDispatcher $eventDispatcher Injected by the OpenEMR module loader;
+ */
+
+$bootstrap = new Bootstrap($eventDispatcher, $GLOBALS['kernel']);
+$bootstrap->subscribeToEvents();

--- a/interface/modules/custom_modules/oe-form-templates/phpunit.xml
+++ b/interface/modules/custom_modules/oe-form-templates/phpunit.xml
@@ -1,0 +1,7 @@
+<phpunit bootstrap="tests/bootstrap.php">
+  <testsuites>
+    <testsuite name="Unit">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/interface/modules/custom_modules/oe-form-templates/public/assets/css/telehealth.css
+++ b/interface/modules/custom_modules/oe-form-templates/public/assets/css/telehealth.css
@@ -1,0 +1,120 @@
+.event_telehealth .telehealth-launch-btn {
+  content: "\f03d";
+  display: inline-block;
+  font-family: "Font Awesome 5 Free";
+  font-size: 1.5rem;
+  font-style: normal;
+  font-variant: normal;
+  font-weight: 900;
+  line-height: 1;
+  padding-left: 10px;
+  padding-right: 10px;
+  text-rendering: auto;
+}
+
+.event_telehealth.event_condensed {
+  font-size: 0.75rem;
+  line-height: 0.75rem;
+}
+
+.event_telehealth .show-appointment {
+  display: none;
+}
+
+.event_telehealth.event_condensed .btn-sm {
+  font-size: 0.5rem;
+  margin-top: 2px;
+  padding-bottom: 0.2rem;
+  padding-top: 0.2rem;
+}
+
+#local-video-container {
+  position: relative;
+}
+
+.telehealth-button-bar {
+  background-color: transparent;
+  bottom: 0;
+  font-size: 1.25rem;
+  position: absolute;
+  text-align: center;
+  width: 100%;
+}
+
+.telehealth-button-bar .telehealth-btn {
+  font-size: 2rem;
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+}
+
+.telehealth-user-icon {
+  font-size: 5rem;
+}
+
+#minimized-telehealth-video {
+  background-color: #000;
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  z-index: 1050;
+}
+
+#minimized-telehealth-video #remote-video {
+  width: 100%;
+}
+
+#minimized-telehealth-video .telehealth-button-bar .telehealth-btn {
+  font-size: 1.25rem;
+  margin-left: 0;
+  margin-right: 0;
+  padding: 0.25rem;
+}
+
+/** stylesheet tries to shrink this all.
+ */
+#telehealth-container > .modal-dialog {
+  max-width: 100%;
+}
+
+#telehealth-container > .modal-dialog > .modal-content {
+  min-height: 90vh;
+}
+
+#telehealth-container > .modal-dialog > .modal-content > .modal-body {
+  /** We hide the overflow due to the way the dlgopen dialog window is setup **/
+  overflow-x: hidden !important;
+  padding-bottom: 0;
+  padding-left: 0.9rem;
+  padding-right: 0.9rem;
+  padding-top: 0;
+}
+
+
+.conference-room {
+  background-color: #000;
+  flex-grow: 1;
+  position: relative;
+}
+
+.conference-room .telehealth-button-bar {
+  bottom: 1.25rem;
+}
+
+.conference-room #local-video-container {
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
+.conference-room .remote-video {
+  height: 100%;
+}
+
+.conference-room #local-video {
+  width: 100%;
+}
+
+.telehealth-btn-hangup .fa-phone {
+  filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=1)";
+  transform: rotate(225deg);
+}

--- a/interface/modules/custom_modules/oe-form-templates/public/assets/js/cvb.min.js
+++ b/interface/modules/custom_modules/oe-form-templates/public/assets/js/cvb.min.js
@@ -1,0 +1,539 @@
+function t(t, i) {
+    if (!t) throw new Error(i)
+}
+
+class i {
+    static invokeAndIgnoreExceptions(t) {
+        try {
+            t()
+        } catch (t) {
+            console.log("Ignoring exception in user callback: " + t)
+        }
+    }
+}
+
+class s {
+    constructor(t) {
+        this.t = t, this.i = "", this.h = new TextDecoder("utf-8"), this.o = !1
+    }
+
+    cancel() {
+        this.t.cancel()
+    }
+
+    eof() {
+        return this.o
+    }
+
+    l() {
+        const t = this.i.indexOf("\r\n");
+        if (-1 == t) return null;
+        const i = this.i.substr(0, t);
+        return this.i = this.i.substr(t + 2), i
+    }
+
+    u() {
+        return this.t.read().then(t => {
+            if (t.done) return this.o = !0, Promise.resolve(this.i);
+            this.i += this.h.decode(t.value);
+            const i = this.l();
+            return i ? Promise.resolve(i) : this.u()
+        })
+    }
+
+    readEvent() {
+        if (this.o) return Promise.reject();
+        const t = this.l();
+        return t ? Promise.resolve(t) : this.u()
+    }
+}
+
+class e {
+    constructor(t) {
+        this._ = t
+    }
+
+    p(t, i) {
+        return fetch(this._ + t, {
+            method: "POST",
+            cache: "no-cache",
+            headers: {"Content-Type": "application/json"},
+            body: JSON.stringify(i)
+        }).then(t => t.ok ? t.json() : Promise.reject(t.status))
+    }
+
+    v(t, i) {
+        return fetch(this._ + t, {
+            method: "POST",
+            cache: "no-cache",
+            headers: {"Content-Type": "application/json"},
+            body: JSON.stringify(i)
+        })
+    }
+
+    createBridge(t, i, s) {
+        const e = {userId: t, passwordHash: i, type: s};
+        return fetch(this._ + "/client/createBridge", {
+            method: "POST",
+            cache: "no-cache",
+            headers: {"Content-Type": "application/json"},
+            body: JSON.stringify(e)
+        })
+    }
+
+    invite(t) {
+        return this.v("/client/invite", {callId: t})
+    }
+
+    call(t, i, s) {
+        return this.p("/client/call", {callerId: t, calleeId: i, isScreenSharing: s})
+    }
+
+    accept(t, i) {
+        return this.v("/client/accept", {callId: t, token: i})
+    }
+
+    reject(t, i) {
+        return this.v("/client/reject", {callId: t, token: i})
+    }
+
+    offer(t, i, s) {
+        return this.v("/client/offer", {callId: t, sdp: s, token: i})
+    }
+
+    answer(t, i, s) {
+        return this.v("/client/answer", {callId: t, sdp: s, token: i})
+    }
+
+    ice(t, i, s) {
+        return this.v("/client/ice", {callId: t, candidate: i, token: s})
+    }
+
+    end(t, i) {
+        return this.v("/client/end", {callId: t, token: i})
+    }
+}
+
+const h = new class {
+    constructor() {
+        this.g = [], this.I = 0, this.m = -1
+    }
+
+    C() {
+        this.g.forEach(t => t.func())
+    }
+
+    k() {
+        this.m = setInterval(() => this.C(), 1e3)
+    }
+
+    S() {
+        clearInterval(this.m), this.m = -1
+    }
+
+    addTask(t) {
+        const i = this.I++, s = {id: i, func: t};
+        return this.g.push(s), 1 == this.g.length && this.k(), i
+    }
+
+    removeTask(t) {
+        const i = this.g.findIndex(i => i.id == t);
+        -1 != i && (this.g.splice(i, 1), 0 == this.g.length && this.S())
+    }
+}, n = new class {
+    newAudioContext() {
+        return new (window.AudioContext || window.webkitAudioContext)
+    }
+};
+
+class r {
+    constructor() {
+        this.P = -1, this.V = n.newAudioContext(), this.T = this.V.createAnalyser(), this.T.fftSize = 2048, this.A = new Uint8Array(this.T.frequencyBinCount), this.L = null, this.db = 0, this.ondbthresholdexceeded = t => {
+        }, this.dbthreshold = 65
+    }
+
+    connect(t) {
+        -1 == this.P && (this.P = h.addTask(() => this.j())), this.L && this.L.disconnect(), this.L = this.V.createMediaStreamSource(t), this.L.connect(this.T)
+    }
+
+    disconnect() {
+        -1 != this.P && (h.removeTask(this.P), this.L.disconnect(), this.L = null, this.P = -1)
+    }
+
+    j() {
+        const t = this.A.length;
+        let s = 0;
+        this.T.getByteTimeDomainData(this.A);
+        for (let i = 0; i < t; i++) {
+            const t = .0078125 * (this.A[i] - 128);
+            s += t * t
+        }
+        this.db = 10 * Math.log10(s / t), console.log("db=" + this.db), this.db >= this.dbthreshold && i.invokeAndIgnoreExceptions(() => this.ondbthresholdexceeded(this))
+    }
+}
+
+class a {
+    constructor(t) {
+        this.B = t.isInbound, this.O = t.isScreenSharing, this.U = t.remotePartyId, this.R = t.bridge, this.M = t.callId, this.N = t.config, this.D = t.token, this.J = null, this.H = null, this.K = null, this.t = null, this.F = null, this.G = null, this.W = [], t.isInbound ? this.q = 1 : this.q = 0, this.oncallstarted = t => this.X("Unhandled event: call started: " + t.M), this.oncallrejected = t => this.X("Unhandled event: call rejected: " + t.M), this.oncallended = t => this.X("Unhandled event: call ended: " + t.M), this.onstreamupdated = (t, i) => this.X("Unhandled event: stream updated: " + t.M), this.onparticipantlistupdated = (t, i) => this.X("Unhandled event: participant list updated: " + t.M), this.onviewportlayoutupdated = (t, i) => this.X("Unahndled event: viewport layout updated: " + i), this.onfacialrecognizerresults = (t, i) => this.X("Unhandled event: facial recognizer results: " + i)
+    }
+
+    Y(t) {
+        console.log("VC/" + this.M + ": " + t)
+    }
+
+    Z(t) {
+        console.error("VC/" + this.M + ": " + t)
+    }
+
+    X(t) {
+        console.warn("VC/" + this.M + ": " + t)
+    }
+
+    $() {
+        return this.J = new RTCPeerConnection(this.N), this.J.onicecandidate = t => this.tt(t), this.J.ontrack = t => this.it(t), this.O ? this.B ? Promise.resolve(this) : this.st() : this.et()
+    }
+
+    et() {
+        return this.R.getLocalMediaStream().then(t => {
+            t.getTracks().forEach(i => this.J.addTrack(i, t))
+        })
+    }
+
+    st() {
+        return navigator.mediaDevices.getDisplayMedia({video: {cursor: "always"}, audio: !0}).then(t => {
+            t.getTracks().forEach(i => this.J.addTrack(i, t))
+        })
+    }
+
+    ht() {
+        this.K && (this.K.disconnect(), this.K = null), this.q = 6, this.R.nt(this), this.J.close()
+    }
+
+    rt(i) {
+        switch (t("CALL" == i.type, 'Bad event type. "CALL" expected.'), i.name) {
+            case"accept":
+                this.at();
+                break;
+            case"end":
+                this.ot();
+                break;
+            case"reject":
+                this.ct();
+                break;
+            case"sdp":
+                this.lt(i.sdp, i.action);
+                break;
+            case"ice":
+                this.dt(i.iceCandidate);
+                break;
+            case"participants":
+                this.ut(i.userIds);
+                break;
+            case"viewportLayout":
+                this._t({frameWidth: i.frameWidth, frameHeight: i.frameHeight, viewports: i.viewports});
+                break;
+            case"facialRecognition":
+                this.vt({callId: i.tagCallId, tag: i.tag, confidence: i.confidence});
+                break;
+            default:
+                throw new Error("Bad call state")
+        }
+    }
+
+    ut(t) {
+        this.F = t, i.invokeAndIgnoreExceptions(() => this.onparticipantlistupdated(this, this.F))
+    }
+
+    _t(t) {
+        this.G = t, i.invokeAndIgnoreExceptions(() => this.onviewportlayoutupdated(this, this.G))
+    }
+
+    vt(t) {
+        i.invokeAndIgnoreExceptions(() => this.onfacialrecognizerresults(this, t))
+    }
+
+    dt(t) {
+        this.J.remoteDescription ? this.J.addIceCandidate(t) : this.W.push(t)
+    }
+
+    it(t) {
+        this.t = t.streams[0], this.K && this.K.connect(this.t), i.invokeAndIgnoreExceptions(() => this.onstreamupdated(this, this.t))
+    }
+
+    ot() {
+        i.invokeAndIgnoreExceptions(() => this.oncallended(this)), this.ht()
+    }
+
+    at() {
+        this.J.createOffer({
+            offerToReceiveVideo: !0,
+            offerToReceiveAudio: !0
+        }).then(t => this.J.setLocalDescription(t)).then(() => this.R.gt.offer(this.M, this.D, this.J.localDescription.sdp)).catch(t => {
+            throw this.bt(t), t
+        }), i.invokeAndIgnoreExceptions(() => this.oncallstarted(this))
+    }
+
+    ct() {
+        this.R.nt(this), this.q = 4, i.invokeAndIgnoreExceptions(() => this.oncallrejected(this))
+    }
+
+    lt(t, i) {
+        const s = new RTCSessionDescription({type: i, sdp: t});
+        "offer" == i ? this.J.setRemoteDescription(s).then(() => (this.ft(), this.J.createAnswer())).then(t => this.J.setLocalDescription(t)).then(() => this.R.gt.answer(this.M, this.D, this.J.localDescription.sdp)).then(t => (this.q = 3, t)).catch(t => {
+            throw this.bt(t), t
+        }) : "answer" == i && this.J.setRemoteDescription(s).then(() => {
+            this.ft(), this.q = 3
+        }).catch(t => {
+            throw this.bt(t), t
+        })
+    }
+
+    ft() {
+        this.W.forEach(t => {
+            this.J.addIceCandidate(t)
+        }), this.W = []
+    }
+
+    tt(t) {
+        if (t.candidate) try {
+            this.R.gt.ice(this.M, t.candidate, this.D)
+        } catch (t) {
+            this.X("failed to transmit ICE candidate")
+        }
+    }
+
+    bt(t) {
+        this.q = 4, this.Z("panic: " + t.message)
+    }
+
+    getParticipantList() {
+        return this.F
+    }
+
+    getViewportLayout() {
+        return this.G
+    }
+
+    getCallId() {
+        return this.M
+    }
+
+    getVideoBridge() {
+        return this.R
+    }
+
+    getRemotePartyId() {
+        return this.U
+    }
+
+    isInbound() {
+        return this.B
+    }
+
+    setUserData(t) {
+        this.H = t
+    }
+
+    getUserData() {
+        return this.H
+    }
+
+    attachActivityMonitor(s, e) {
+        t(null == this.K, "Activity notifier already attached"), t(null != e, "Activity monitor callback not defined"), this.K = new r, this.K.dbtheshold = s, this.K.ondbthresholdexceeded = t => i.invokeAndIgnoreExceptions(() => e(this)), this.t && this.K.connect(this.t)
+    }
+
+    getSoundLevel() {
+        return this.K || this.K.db
+    }
+
+    start() {
+        return t(0 == this.q, "Call already initialized"), this.q = 1, this.Y("starting"), this.R.gt.call(this.R.getUserId(), this.U, this.O).then(t => (this.M = t.callId, this.N = t.config, this.D = t.token, this.$())).then(() => this.R.gt.invite(this.M)).then(() => (this.q = 2, this.R.wt(this), this)).catch(t => {
+            throw this.bt(t), t
+        })
+    }
+
+    accept() {
+        return t(1 == this.q, "Invalid call state"), this.Y("accepting"), this.$().then(() => this.R.gt.accept(this.M, this.D)).then(t => (this.q = 2, this)).catch(t => {
+            throw this.bt(t), t
+        })
+    }
+
+    reject() {
+        return t(1 == this.q, "Invalid call state"), this.Y("rejecting"), this.R.gt.reject(this.M, this.D).then(t => (this.q = 5, this.R.nt(this), this)).catch(t => {
+            throw this.bt(t), t
+        })
+    }
+
+    stop() {
+        return 6 != this.q && 4 != this.q ? (this.ht(), this.R.gt.end(this.M, this.D).then(() => this)) : Promise.resolve(this)
+    }
+
+    muteRemoteAudio(i) {
+        t("boolean" == typeof i, "Expected a boolean value"), this.J.getReceivers().forEach(t => {
+            "audio" == t.track.kind && (t.track.enabled = i)
+        })
+    }
+}
+
+class o {
+    constructor(t) {
+        this.It = t.userId, this.yt = t.type, this.Ct = t.passwordHash, this.gt = new e(t.serviceUrl || ""), this.kt = !1, this.St = {}, this.Et = !1, this.Pt = !1, this.Vt = null, this.Tt = null, this.onbridgeactive = t => console.log("onbridgeactive event not handled"), this.onbridgeinactive = t => console.log("onbridgeinactive event not handled"), this.onbridgefailure = t => console.log("onbridgefailure event not handled"), this.onincomingcall = t => {
+            console.log("Inbound call event not handled; call rejected."), t.reject()
+        }
+    }
+
+    bt(t) {
+        console.log("Catastrophic bridge failure: " + t), i.invokeAndIgnoreExceptions(() => this.onbridgefailure(this)), this.shutdown()
+    }
+
+    At() {
+        this.kt ? this.bt(new Error("Event stream closed unexpectedly")) : (i.invokeAndIgnoreExceptions(() => this.onbridgeinactive(this)), this.shutdown())
+    }
+
+    Lt() {
+        this.Vt.readEvent().then(t => {
+            if (this.Vt.eof()) this.At(); else {
+                try {
+                    const i = JSON.parse(t);
+                    this.rt(i)
+                } catch (t) {
+                    return void this.bt(t)
+                }
+                this.Lt()
+            }
+        })
+    }
+
+    jt(t) {
+        const i = this.St[t.callId];
+        i ? i.rt(t) : console.log("Invalid call identifier in the event stream: " + t.callId)
+    }
+
+    Bt(t) {
+        const s = new a({
+            bridge: this,
+            callId: t.callId,
+            isInbound: !0,
+            isScreenSharing: t.isScreenSharing,
+            remotePartyId: t.callerId,
+            config: t.config,
+            token: t.token
+        });
+        this.wt(s), i.invokeAndIgnoreExceptions(() => this.onincomingcall(s))
+    }
+
+    Ot(t) {
+        this.kt || (this.kt = !0, i.invokeAndIgnoreExceptions(() => this.onbridgeactive(this)))
+    }
+
+    rt(t) {
+        switch (console.log(t), t.type) {
+            case"INCOMING":
+                this.Bt(t);
+                break;
+            case"KEEPALIVE":
+                this.Ot(t);
+                break;
+            case"CALL":
+                this.jt(t);
+                break;
+            default:
+                this.bt(new Error("Bad event type: " + t.type + ". Corrupt stream?"))
+        }
+    }
+
+    Ut() {
+        Object.values(this.St).forEach(t => t.ht()), this.St = {}
+    }
+
+    wt(t) {
+        this.St[t.getCallId()] = t
+    }
+
+    nt(t) {
+        const i = t.getCallId();
+        this.St.hasOwnProperty(i) && delete this.St[i]
+    }
+
+    getUserId() {
+        return this.It
+    }
+
+    getCalls() {
+        return Object.values(this.St)
+    }
+
+    hasCamera() {
+        return this.Et
+    }
+
+    hasMicrophone() {
+        return this.Pt
+    }
+
+    getCallById(t) {
+        return this.St[t]
+    }
+
+    isActive() {
+        return this.kt
+    }
+
+    getLocalMediaStream() {
+        return t(this.kt, "VideoBridge not active"), this.Tt ? Promise.resolve(this.Tt) : navigator.mediaDevices.enumerateDevices().then(t => {
+            var i = {};
+            return null != t.find(t => "videoinput" == t.kind) && (this.Et = !0, i.video = {
+                width: 800,
+                height: 600
+            }), null != t.find(t => "audioinput" == t.kind) && (this.Pt = !0, i.audio = {channels: 1}), navigator.mediaDevices.getUserMedia(i)
+        }).then(t => (this.Tt = t, t))
+    }
+
+    closeLocalMediaStream() {
+        t(this.kt, "VideoBridge not active"), this.Tt && (this.Tt.getTracks().forEach(t => t.stop()), this.Tt = null, this.Pt = !1, this.Et = !1)
+    }
+
+    enableCamera(i) {
+        t(this.kt, "Video bridge not active"), t("boolean" == typeof i, "Expected a boolean value"), this.Et && this.Tt.getTracks().forEach(t => {
+            "live" == t.readyState && "video" === t.kind && (t.enabled = i)
+        })
+    }
+
+    enableMicrophone(i) {
+        t(this.kt, "Video bridge not active"), t("boolean" == typeof i, "Expected a boolean value"), this.Pt && this.Tt.getTracks().forEach(t => {
+            "live" == t.readyState && "audio" === t.kind && (t.enabled = i)
+        })
+    }
+
+    start() {
+        t(!this.kt, "Video bridge already active"), this.gt.createBridge(this.It, this.Ct, this.yt).then(t => t.body).then(t => {
+            this.Vt = new s(t.getReader()), this.Lt()
+        }).catch(t => {
+            console.error("Video bridge creation failure: " + t), i.invokeAndIgnoreExceptions(() => this.onbridgefailure(this)), this.bt(t)
+        })
+    }
+
+    shutdown() {
+        t(this.kt, "Video bridge not active"), Object.values(this.St).forEach(t => t.stop()), this.St = {}, this.Vt.cancel(), this.closeLocalMediaStream(), this.kt = !1
+    }
+
+    createVideoCall(i) {
+        return t(this.kt, "Video bridge not active"), new a({
+            bridge: this,
+            isInbound: !1,
+            isScreenSharing: !1,
+            remotePartyId: i
+        })
+    }
+
+    createScreenSharingCall(i) {
+        return t(this.kt, "Video bridge not activbe"), new a({
+            bridge: this,
+            isInboud: !1,
+            isScreenSharing: !0,
+            remotePartyId: i
+        })
+    }
+}
+
+export {o as VideoBridge, a as VideoCall};

--- a/interface/modules/custom_modules/oe-form-templates/public/assets/js/telehealth-appointment.js
+++ b/interface/modules/custom_modules/oe-form-templates/public/assets/js/telehealth-appointment.js
@@ -1,0 +1,118 @@
+/**
+ * Appointment TeleHealth javascript library for interacting with the appointment dialog window.
+ *
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2022 Comlink Inc <https://comlinkinc.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+(function(window, comlink) {
+
+    /**
+     * @type {string} The path of where the module is installed at.  In a multisite we pull this from the server configuration, otherwise we default here
+     */
+    let moduleLocation = comlink.settings.modulePath || '/interface/modules/custom_modules/oe-module-comlink-telehealth/';
+
+    let defaultTranslations = {
+    };
+
+    function getProviderSelectNode() {
+        let node = window.document.querySelector("#provd");
+        if (!node) {
+            console.error("Failed to find node with selector #provd");
+            return;
+        }
+        return node;
+    }
+
+    function hideInvalidTelehealthProviders(telehealthProviders) {
+        telehealthProviders = telehealthProviders || [];
+        let ids = telehealthProviders.map(p => +p).filter(p => !isNaN(p));
+        ids.sort();
+
+       let providerSelector = getProviderSelectNode();
+        if (!providerSelector) {
+            console.error("Failed to find provider select node");
+            return;
+        }
+
+        let options = providerSelector.options;
+        let selectedValues = [];
+        for (var index = 0; index < options.length; index++) {
+            let value = +(options[index].value || 0);
+            console.log("options are ", options[index]);
+            // we could do a binary search here if we need to for the amount of data... should be fairly small though for 3-4000 providers.
+            if (ids.indexOf(value) === -1) {
+                if (options[index].selected) {
+                    selectedValues.push(options[index]);
+                }
+                options[index].selected = false;
+                options[index].classList.add("d-none");
+            } else {
+                console.log("options are ", options[index]);
+                options[index].classList.remove("d-none");
+            }
+        }
+        if (selectedValues.length > 0) {
+            providerSelector.selectedIndex = -1; // if nothing is visible is selected we should remove all selected items
+        }
+    }
+
+    function displayAllProviders() {
+        let providerSelector = getProviderSelectNode();
+        if (!providerSelector) {
+            console.error("Failed to find provider select node");
+            return;
+        }
+
+        let options = providerSelector.options;
+        for (var index = 0; index < options.length; index++) {
+            options[index].classList.remove("d-none");
+        }
+    }
+
+    function updateAppointmentScreenForCategory(category, telehealthProviders, telehealthCategories) {
+
+        let node = window.document.querySelector("#form_category");
+        if (!node) {
+            console.error("Failed to find node with selector #form_category");
+            return;
+        }
+
+        // setup the change order
+        // if the current category has an id of one of the telehealth categories
+        // grab the select options and set their display option to be hidden if the provider is not in the
+        // telehealth provider lists
+        // Note this will probably max out at a few thousand providers... so if an OpenEMR install is larger than that
+        // this will need to be adjusted.
+        let value = +(node.value || 0);
+        if (value > 0 && telehealthCategories.indexOf(value) !== -1) {
+            // now let's hide our providers
+            hideInvalidTelehealthProviders(telehealthProviders);
+        } else {
+            displayAllProviders();
+        }
+    }
+
+    function initAppointmentWithTelehealth(telehealthProviders, telehealthCategories) {
+        let node = window.document.querySelector("#form_category");
+        if (!node) {
+            console.error("Failed to find node with selector #form_category");
+            return;
+        }
+
+        node.addEventListener('change', function(evt) {
+            let select = evt.currentTarget;
+            updateAppointmentScreenForCategory(select.value, telehealthProviders, telehealthCategories);
+        });
+
+        // go with the initial value
+        updateAppointmentScreenForCategory(node.value, telehealthProviders, telehealthCategories);
+    }
+
+    comlink.initAppointmentWithTelehealth = initAppointmentWithTelehealth;
+
+    let translations = comlink.translations || defaultTranslations;
+    window.comlink = comlink;
+})(window, window.comlink || {});

--- a/interface/modules/custom_modules/oe-form-templates/public/assets/js/telehealth-calendar.js
+++ b/interface/modules/custom_modules/oe-form-templates/public/assets/js/telehealth-calendar.js
@@ -1,0 +1,257 @@
+/**
+ * Calendar TeleHealth javascript library for interacting with the OpenEMR calendar tab.
+ *
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2022 Comlink Inc <https://comlinkinc.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+(function(window, comlink) {
+
+    /**
+     * @type {string} The path of where the module is installed at.  In a multisite we pull this from the server configuration, otherwise we default here
+     */
+    let moduleLocation = comlink.settings.modulePath || '/interface/modules/custom_modules/oe-module-comlink-telehealth/';
+
+    let defaultTranslations = {
+        'SESSION_LAUNCH_FAILED': "There was an error in launching your telehealth session.  Please try again or contact support",
+        'PROVIDER_SESSION_START_PROMPT': "Would you like to start a telehealth session with this patient (This will create an encounter if one does not exist)?",
+        "PROVIDER_SESSION_CLONE_START_PROMPT": "This appointment belongs to a different provider. Would you still like to start a telehealth session (this will copy the appointment to your calendar and create an encounter if needed)?",
+        "PROVIDER_SESSION_TELEHEALTH_UNENROLLED": "This is a Telehealth session appointment.  If you would like to provide telehealth sessions to your clients contact your administrator to enroll today.",
+        "CALENDAR_EVENT_DISABLED": "TeleHealth Sessions can only be launched within two hours of the current appointment time.",
+        "CALENDAR_EVENT_COMPLETE": "This TeleHealth appointment has been completed."
+    };
+    let translations = comlink.translations || defaultTranslations;
+
+    function closeDialogAndLaunchTelehealthSession(evt)
+    {
+        sendToEncounter(evt)
+        .then(() => {
+            if (window.dlgclose) {
+                window.dlgclose();
+            }
+        })
+        .catch(error => {
+            console.error(error);
+            alert(translations.SESSION_LAUNCH_FAILED);
+        });
+    }
+    function setCurrentEncounterForAppointment(pid, appointmentId)
+    {
+        window.top.restoreSession();
+        return window.fetch(moduleLocation + 'public/index.php?action=set_current_appt_encounter&pc_eid=' + encodeURIComponent(appointmentId), {redirect: "manual"})
+            .then(response => {
+                if (!response.ok)
+                {
+                    throw new Error("Failed to retrieve encounter settings");
+                }
+                return response.json();
+            });
+    }
+
+    function apptCompleteAlert(evt)
+    {
+        evt.stopPropagation();
+        evt.preventDefault();
+        alert(translations.CALENDAR_EVENT_COMPLETE);
+    }
+
+    function apptTelehealthUnenrolled(evt)
+    {
+        evt.stopPropagation();
+        evt.preventDefault();
+        alert(translations.PROVIDER_SESSION_TELEHEALTH_UNENROLLED);
+    }
+
+    function apptDisabledAlert(evt)
+    {
+        evt.stopPropagation();
+        evt.preventDefault();
+        alert(translations.CALENDAR_EVENT_DISABLED);
+    }
+
+    function switchProvidersAndSendToTeleHealthSession(evt)
+    {
+        if (!evt.target)
+        {
+            console.error("target invalid");
+            return;
+        }
+        let pid = evt.target.dataset["pid"];
+        let pc_eid = evt.target.dataset["eid"];
+        if (confirm(translations.PROVIDER_SESSION_CLONE_START_PROMPT))
+        {
+            console.log("Starting telehealth session");
+            // need to grab the encounter (// create the encounter as needed
+            return setCurrentEncounterForAppointment(pid, pc_eid)
+                .then(encounterData => {
+                    loadEncounterFromEncounterData(encounterData, pid, pc_eid);
+                    if (window.ChangeProviders && encounterData.user && encounterData.user.username)
+                    {
+                        // set our encounter
+                        // we need to clear off every option
+                        let calendarUsername = window.document.querySelector("#pc_username");
+                        if (calendarUsername && calendarUsername.options)
+                        {
+                            calendarUsername.selectedIndex = -1;
+                            for (let i = 0;i < calendarUsername.options.length; i++)
+                            {
+                                if (calendarUsername.options[i].value == encounterData.user.username)
+                                {
+                                    calendarUsername.selectedIndex = i;
+                                    break;
+                                }
+                            }
+                        }
+                        window.ChangeProviders();
+                    }
+                })
+                .catch(error => {
+                    alert(translations.SESSION_LAUNCH_FAILED);
+                    console.error(error);
+                });
+        }
+    }
+
+    function sendToEncounter(evt)
+    {
+        if (!evt.target)
+        {
+            console.error("target invalid");
+            return;
+        }
+        let pid = evt.target.dataset["pid"];
+        let pc_eid = evt.target.dataset["eid"];
+
+        evt.stopPropagation();
+        evt.preventDefault();
+        if (confirm(translations.PROVIDER_SESSION_START_PROMPT))
+        {
+            console.log("Starting telehealth session");
+            // need to grab the encounter (// create the encounter as needed
+            return setCurrentEncounterForAppointment(pid, pc_eid)
+            .then(encounterData => {
+                loadEncounterFromEncounterData(encounterData, pid, pc_eid);
+            })
+            .catch(error => {
+                alert(translations.SESSION_LAUNCH_FAILED);
+                console.error(error);
+            });
+        }
+    }
+
+    function loadEncounterFromEncounterData(encounterData, pid, pc_eid)
+    {
+        if (!(encounterData.encounterList && encounterData.patient && encounterData.selectedEncounter))
+        {
+            throw new Error("Missing encounter information in order to start telehealth appointment");
+        }
+        console.log("grabbed encounter ", encounterData);
+        window.top.restoreSession();
+        // the order here is pretty critical.  First we have to setPatient to populate the initial patient
+        // then we populate the patient's encounter lists with setPatientEncounter
+        // and finally we set the currently open / selected encounter w/ setEncounter
+        window.top.left_nav.setPatient(encounterData.patient.fullName,encounterData.patient.pid,encounterData.patient.pubpid,'',encounterData.patient.dob_str);
+        /**
+         * If we've created a new encounter than we need to populate the encounter list array for the top navigation
+         */
+        window.top.window.parent.left_nav.setPatientEncounter(encounterData.encounterList.ids, encounterData.encounterList.dates, encounterData.encounterList.categories);
+        window.top.left_nav.setEncounter(encounterData.selectedEncounter.dateStr, encounterData.selectedEncounter.id, "");
+        window.top.RTop.location = '../../patient_file/encounter/encounter_top.php?set_pid=' + encodeURIComponent(pid)
+            + '&set_encounter=' + encodeURIComponent(encounterData.selectedEncounter.id) + '&launch_telehealth=1';
+        if (window.top.comlink && window.top.comlink.telehealth && window.top.comlink.telehealth.launchProviderVideoMessage) {
+            window.top.comlink.telehealth.launchProviderVideoMessage({
+                pc_eid: pc_eid
+            });
+        } else {
+            console.error("launchProviderVideoMessage was not found in top window object");
+            alert(translations.SESSION_LAUNCH_FAILED);
+        }
+    }
+
+    function init()
+    {
+        // now we have the dom we can add our event listeners to everything
+        var telehealthNodes = document.querySelectorAll(".event_telehealth");
+        if (telehealthNodes && telehealthNodes.length)
+        {
+            var count = telehealthNodes.length;
+            for (let i = 0; i < count; i++)
+            {
+                if (telehealthNodes[i].clientHeight <= 20)
+                {
+                    // we need to shrink the button even more
+                    telehealthNodes[i].classList.add("event_condensed");
+                }
+                let linkTitle = telehealthNodes[i].querySelector('.link_title');
+                var btn = window.document.createElement("i");
+                btn.className = "fa fa-video btn-telehealth-calendar-launch btn btn-sm mr-1 ml-1";
+                btn.dataset["pid"] = linkTitle.dataset['pid'];
+                btn.dataset['eid'] = telehealthNodes[i].dataset['eid'];
+                if (telehealthNodes[i].classList.contains('event_telehealth_active'))
+                {
+                    if (telehealthNodes[i].classList.contains('event_user_different'))
+                    {
+                        btn.dataset['providerDifferent'] = 1;
+                        btn.addEventListener('click', switchProvidersAndSendToTeleHealthSession);
+                    }
+                    else
+                    {
+                        btn.dataset['providerDifferent'] = 0;
+                        btn.addEventListener('click', sendToEncounter);
+                    }
+                    btn.classList.add('btn-primary');
+
+                } else if (telehealthNodes[i].classList.contains('event_telehealth_completed')) {
+                    btn.addEventListener('click', apptCompleteAlert);
+                    btn.classList.add('btn-success');
+                    btn.disabled = true;
+                } else if (telehealthNodes[i].classList.contains('event_telehealth_unenrolled')) {
+                    btn.addEventListener('click', apptTelehealthUnenrolled);
+                    btn.classList.add('btn-warning');
+                    btn.disabled = true;
+                } else {
+                    btn.addEventListener('click', apptDisabledAlert);
+                    btn.classList.add('btn-dark');
+                    btn.disabled = true;
+                }
+                // img is used on monthly, .fas.fa-user on weekly & daily
+                let userPictureIcon = linkTitle.querySelector('.fas.fa-user,img');
+                if (userPictureIcon)
+                {
+                    userPictureIcon.parentNode.replaceChild(btn, userPictureIcon);
+                }
+                else {
+                    // if we can't find the icon we will put the btn here instead.
+                    linkTitle.parentNode.appendChild(btn);
+                }
+            }
+        }
+
+        // if we are on the add-edit-event form we can take action on initiating our appointment work
+        if (document.querySelector('body.add-edit-event'))
+        {
+            // we need to hide our launch button if they change the patient...
+            var oldSetPatient = window.setpatient || function() {};
+            var btn = document.querySelector('.btn-add-edit-appointment-launch-telehealth');
+            window.setpatient = function(pid, lname, fname, dob) {
+
+                if (btn)
+                {
+                    btn.classList.add('d-none');
+                }
+                oldSetPatient(pid, lname, fname, dob);
+            };
+            if (btn) {
+                // now let's add our event listener here
+                btn.addEventListener('click', closeDialogAndLaunchTelehealthSession);
+            }
+        }
+
+
+    }
+
+    window.addEventListener('DOMContentLoaded', init);
+    // if we are in an outer window we use that one, otherwise we grab the topmost comlink for our translation files
+})(window, window.comlink || window.top.comlink || {});

--- a/interface/modules/custom_modules/oe-form-templates/public/assets/js/telehealth-patient.js
+++ b/interface/modules/custom_modules/oe-form-templates/public/assets/js/telehealth-patient.js
@@ -1,0 +1,48 @@
+/**
+ * Patient TeleHealth methods for launching telehealth sessions from the patient portal.
+ *
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2022 Comlink Inc <https://comlinkinc.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+(function(window, comlink) {
+    let telehealth = comlink.telehealth || {};
+    let translations = comlink.translations || {};
+
+    function launchDialog(evt)
+    {
+        let target = evt.currentTarget;
+        try {
+            var appointmentEventId = target.dataset['pc_eid'] || null;
+            if (!appointmentEventId) {
+                throw new Error("No appointmentEventId id found, cannot start session");
+            }
+            if (telehealth.showPatientPortalDialog)
+            {
+                window.comlink.telehealth.showPatientPortalDialog(appointmentEventId)
+            } else {
+                throw new Error("Could not launch session, missing library");
+            }
+        }
+        catch (error) {
+            alert(translations.SESSION_LAUNCH_FAILED);
+            console.error(error);
+        }
+    }
+
+    function init() {
+        let launchButtons = document.querySelectorAll(".btn-comlink-telehealth-launch");
+        for (let i = 0; i < launchButtons.length; i++)
+        {
+            launchButtons[i].addEventListener('click', launchDialog);
+        }
+        telehealth.launchRegistrationChecker(true);
+    }
+
+    if (telehealth && telehealth.launchRegistrationChecker)
+    {
+        window.addEventListener('load', init);
+    }
+})(window, window.comlink || {});

--- a/interface/modules/custom_modules/oe-form-templates/public/assets/js/telehealth-provider.js
+++ b/interface/modules/custom_modules/oe-form-templates/public/assets/js/telehealth-provider.js
@@ -1,0 +1,19 @@
+/**
+ * Handles the checking of a provider's telehealth registration when they login.
+ *
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2022 Comlink Inc <https://comlinkinc.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+(function(window, comlink) {
+    let telehealth = comlink.telehealth || {};
+
+    if (telehealth && telehealth.launchRegistrationChecker)
+    {
+        window.addEventListener('load', function() {
+            telehealth.launchRegistrationChecker(false);
+        });
+    }
+})(window, window.comlink || {});

--- a/interface/modules/custom_modules/oe-form-templates/public/assets/js/telehealth.js
+++ b/interface/modules/custom_modules/oe-form-templates/public/assets/js/telehealth.js
@@ -1,0 +1,1550 @@
+/**
+ * Core TeleHealth javascript library for communicating with OpenEMR to start and stop TeleHealth sessions.
+ *
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2022 Comlink Inc <https://comlinkinc.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+(function(window, comlink, bootstrap, jQuery) {
+
+
+
+    let cvb = null;
+    /**
+     *
+     * @type {ConferenceRoom}
+     */
+    let conferenceRoom = false;
+
+    /**
+     * @type {string} The path of where the module is installed at.  In a multisite we pull this from the server configuration, otherwise we default here
+     */
+    let moduleLocation = comlink.settings.modulePath || '/interface/modules/custom_modules/oe-module-comlink-telehealth/';
+
+    /**
+     * @var VideoBar
+     */
+    let videoBar = null;
+
+    /**
+     * Handler from setInterval used as polling handle that checks to see if the provider has entered into the
+     * conference room and is ready to chat with the patient.
+     * @type number
+     */
+    let checkProviderReadyForPatientInterval = null;
+
+    /**
+     *
+     * @type {RegistrationChecker}
+     */
+    let checker = null;
+
+    let telehealthRegistrationInterval = null;
+
+    let registrationSettings;
+
+    let defaultTranslations = {
+        'CALL_CONNECT_FAILED': "Failed to connect the call.",
+        'SESSION_LAUNCH_FAILED': "There was an error in launching your telehealth session.  Please try again or contact support",
+        'APPOINTMENT_STATUS_UPDATE_FAILED': 'There was an error in saving the telehealth appointment status.  Please contact support or update the appointment manually in the calendar',
+        'DUPLICATE_SESSION': "You are already in a conference session.  Please hangup the current call to start a new telehealth session",
+        'HOST_LEFT': "Host left the call",
+        "CONFIRM_SESSION_CLOSE": "Are you sure you want to close this session?",
+        "TELEHEALTH_MODAL_TITLE": "TeleHealth Session",
+        "TELEHEALTH_MODAL_CONFIRM_TITLE": "Confirm Session Close",
+        "UPDATE_APPOINTMENT_STATUS" : "Update appointment status",
+        "STATUS_NO_SHOW" : "No Show",
+        "STATUS_CANCELED" : "Canceled",
+        "STATUS_CHECKED_OUT" : "Checked Out",
+        "STATUS_SKIP_UPDATE": "Skip Update",
+        "CONFIRM" : "Confirm",
+        "STATUS_NO_UPDATE": "No Change",
+        "STATUS_OTHER": "Other"
+    };
+    let translations = comlink.translations || defaultTranslations;
+
+    /**
+     * Returns the API endpoint to call for a patient or a provider for telehealth communication
+     * @param forPatient
+     */
+    function getTeleHealthScriptLocation(forPatient)
+    {
+        if (forPatient === true)
+        {
+            return moduleLocation + 'public/index-portal.php';
+        } else {
+            return moduleLocation + 'public/index.php';
+        }
+    }
+
+    function RegistrationChecker(isPatient)
+    {
+        var checker = this;
+        var timeoutId;
+        var settings;
+        var currentCheckCount = 0;
+        var maxCheck = 10;
+
+        this.checkRegistration = function()
+        {
+            if (currentCheckCount++ > maxCheck)
+            {
+                console.error("Failed to get a valid telehealth registration for user");
+                return;
+            }
+
+            let location = getTeleHealthScriptLocation(isPatient) + '?action=check_registration';
+
+            window.top.restoreSession();
+            window.fetch(location)
+            .then(result => {
+                if (!result.ok)
+                {
+                    throw new Error("Registration check failed");
+                }
+                return result.json();
+            })
+            .then(registrationSettings => {
+                if (registrationSettings && registrationSettings.hasOwnProperty('errorCode')) {
+                    if (registrationSettings.errorCode == 402) {
+                        // user is not enrolled and so we will skip trying to register the user
+                        checker.settings = {};
+                    }
+                }
+                checker.settings = registrationSettings;
+            })
+            .catch(error => {
+                console.error("Failed to execute check_registration action", error);
+                timeoutId = setTimeout(checker.checkRegistration.bind(checker), 2000);
+            });
+        };
+        return this;
+    }
+
+    // only 91% browser support for import... asian browsers like Baidu don't support this... according to conversations
+    // with Comlink, modern Chrome, Firefox, and Safari browsers are expected support.
+    import ('./cvb.min.js').then((module) => {
+        cvb = module;
+    });
+
+    function ATSlot(index, onhangup) {
+        /** @private */
+        this.__call = null;
+
+        /** @private */
+        this.__video = document.getElementById('remote-video');
+        if (!this.__video)
+        {
+            throw new Error("Failed to find #remote-video element");
+        }
+
+        this.isAvailable = function() {
+            return this.__call == null;
+        };
+
+
+        this.attach = function(call, stream) {
+            this.__call = call;
+            if (call == null || stream == null)
+            {
+                console.error("Call or stream were null.  Cannot proceed", {call: call, stream: stream});
+                throw new Error("call and stream cannot be null");
+            }
+            this.__call.setUserData(this);
+            this.__video.srcObject = stream;
+            this.__video.play();
+        };
+
+        this.detach = function() {
+            this.__call.setUserData(null);
+            this.__call = null;
+            this.__video.srcObject = null;
+        };
+    }
+
+    // TODO: @adunsulag eventually we can merge this into our conference room app.
+    function ATApp(conferenceRoom, params)
+    {
+        this.__hasLocalPermisions = false;
+        /** @private */
+        this.__bridge = null;
+
+        /** @pprivate */
+        this.__userId = params.userId;
+
+        /** @private */
+        this.__passwordHash = params.password;
+
+        /** @private */
+        this.__localVideoElement = document.getElementById('local-video');
+        this.__localVideoElement.muted = true;
+
+        /** @private */
+        this.__slots = [];
+
+        /**
+         * @private
+         */
+        this.__serviceUrl = params.serviceUrl;
+
+        this.__remoteCallSlot = null;
+
+        this.__isShutdown = true;
+
+        this.allocateSlot = function(call, stream) {
+            // as we can get multiple events we only want to allocate on the call if we don't have any stream data setup.
+            if (!call.getUserData()) {
+                // we are leaving this in place in case we want to extend things and add additional callers to the call
+                // in the future
+                if (this.__remoteCallSlot) {
+                    // detatch the old call and initiate the new one
+                    this.freeSlot(this.__remoteCallSlot);
+                }
+                this.__remoteCallSlot = new ATSlot(0, function () {
+                });
+                this.__remoteCallSlot.attach(call, stream);
+            }
+        };
+
+        this.freeSlot = function(slot) {
+            if (slot !== null && slot.__call == null)
+            {
+                console.error("freeSlot called with null slot ", {slot: slot});
+                return;
+            }
+            slot.__call.stop();
+            slot.detach();
+            // trying to leave code open in case we add more callers... but we add this in to clear our variables
+            if (slot == this.__remoteCallSlot)
+            {
+                this.__remoteCallSlot = null;
+            }
+        };
+
+        this.restartMediaStream = function() {
+            if (this.__localVideoElement.srcObject) {
+                this.__bridge.closeLocalMediaStream();
+            }
+
+            return this.__bridge.getLocalMediaStream()
+                .then(stream => this.handleLocalMediaStreamStarted(stream))
+                .catch(error => this.handleLocalMediaStreamFailed(error));
+        };
+        this.handleLocalMediaStreamStarted = function(stream) {
+            this.__localVideoElement.srcObject = stream;
+            this.__localVideoElement.play();
+            this.__hasLocalPermisions = true;
+            conferenceRoom.toggleJoinButton(conferenceRoom.shouldEnableJoinButton());
+            conferenceRoom.togglePermissionBox(false);
+            return this.__hasLocalPermisions;
+        };
+        this.handleLocalMediaStreamFailed = function(error) {
+            console.error(error);
+            this.__hasLocalPermisions = false;
+            conferenceRoom.toggleJoinButton(conferenceRoom.shouldEnableJoinButton());
+            conferenceRoom.togglePermissionBox(true);
+            return this.__hasLocalPermisions;
+        };
+
+        this.start = function() {
+            // Create the bridge instance
+            this.__bridge = new cvb.VideoBridge({
+                userId: this.__userId,
+                passwordHash: this.__passwordHash,
+                type: 'normal',
+                serviceUrl: this.__serviceUrl // 'https://sandbox.mvoipctsi.com:22528'
+            });
+            console.log("Instantiated bridge "  + this.__userId);
+
+            // Callback: incoming call
+            //
+            // When a new call comes in we'll ask the user if they want to accept or
+            // reject it.
+            this.__bridge.onincomingcall = (call) => {
+                console.log("Receiving call from " + call.getRemotePartyId() + " for "  + this.__userId);
+
+                conferenceRoom.handleIncomingCall(call);
+            };
+
+            // Callback: bridge active
+            //
+            // When the bridge becomes active we'll ask it for the local media stream
+            // which we will then play in the local video element.
+            this.__bridge.onbridgeactive = (bridge) => {
+                this.__bridge.getLocalMediaStream()
+                    .then(stream => this.handleLocalMediaStreamStarted(stream))
+                    .catch(error => this.handleLocalMediaStreamFailed(error));
+
+                console.log("The bridge is active " + this.__userId);
+            };
+
+            // Callback: bridge inactive
+            //
+            // When the bridge becomes inactive we'll stop the local stream video
+            // element.
+            this.__bridge.onbridgeinactive = (bridge) => {
+                if (this.__localVideoElement && this.__localVideoElement.stop) {
+                    this.__localVideoElement.stop();
+                    this.__localVideoElement.srcObject = null;
+                }
+
+                console.log("The bridge is inactive " + this.__userId);
+            };
+
+            // Callback: bridge failure
+            //
+            // Similarly, if the bridge suffers a catastrophic failure we'll stop the
+            // local stream video element.
+            this.__bridge.onbridgefailure = (bridge) => {
+                this.__localVideoElement.stop();
+                this.__localVideoElement.srcObject = null;
+
+                console.error("The bridge failed " + this.__userId);
+            };
+
+            // Finally spin up the bridge.
+            this.__bridge.start();
+            console.log("Started bridge "  + this.__userId);
+            this.__isShutdown = false;
+        };
+
+        this.shutdown = function()
+        {
+            if (this.__isShutdown)
+            {
+                return;
+            }
+
+            this.__bridge.shutdown();
+            this.__localVideoElement.srcObject = null;
+            console.log("Shutting down " +  this.__userId)
+            this.__isShutdown = true;
+        };
+
+        this.setCallHandlers = function(call) {
+            // Callback: streams updated
+            //
+            call.oncallstarted = (call) => {
+                conferenceRoom.handleCallStartedEvent(call);
+            };
+            // Once we have the remote stream we'll allocate a video slot.
+            call.onstreamupdated =
+                (call, stream) => {
+                    console.log("onstreamupdated " + this.__userId);
+                    this.allocateSlot(call, stream);
+                };
+
+            // Callback: call ended
+            //
+            // When the call ends we free the video slot.
+            call.oncallended = (call) => {
+                this.freeSlot(call.getUserData());
+                conferenceRoom.handleCallEndedEvent(call);
+            };
+        };
+
+        this.makeCall = function(calleeId) {
+            const call = this.__bridge.createVideoCall(calleeId);
+
+            this.setCallHandlers(call);
+
+            // Callback: outbound call rejected
+            //
+            // If the call is rejected we do nothing. We know that in that case the
+            // stream will not have been created and, consequently, we will not have
+            // created the video element.
+            call.oncallrejected = (call) => {
+                console.log(call);
+                console.log("oncallrejected " + this.__userId);
+                // if the call is rejected the provider dropped off before we connected so we go back to the conference
+                // room
+                conferenceRoom.handleCallEndedEvent(call);
+            };
+
+            // Finally, start the call
+            call.start().catch((e) => {
+                alert(translations.CALL_CONNECT_FAILED);
+                console.log("call exception " + this.__userId);
+                console.error(e);
+                conferenceRoom.handleCallEndedEvent(call);
+            });
+        };
+
+        this.enableMicrophone = function(flag) {
+            this.__bridge.enableMicrophone(flag);
+        };
+
+        this.enableCamera = function(flag) {
+            this.__bridge.enableCamera(flag);
+        };
+
+        this.hasLocalPermissionsEnabled = function()
+        {
+            return this.__hasLocalPermisions;
+        };
+
+        return this;
+    }
+
+    function ConferenceRoom()
+    {
+        let conf = this;
+
+        this.waitingRoomTemplate = null;
+        this.conferenceRoomTemplate = null;
+        this.callerSettings = null;
+        this.telehealthSessionData = null;
+        this.videoBar = null;
+        this.ROOM_TYPE_WAITING = 'waiting';
+        this.ROOM_TYPE_CONFERENCE = 'conference';
+
+        this.buttonSettings = {
+            microphoneEnabled: true
+            ,cameraEnabled: true
+        };
+
+        /**
+         * Milliseconds to update the session information
+         * @type {number}
+         */
+        this.sessionUpdatePollingTime = 5000;
+
+        /**
+         * What type of room this conference room is
+         * @see ROOM_TYPE_WAITING
+         * @see ROOM_TYPE_CONFERENCE
+         * @type string
+         */
+        this.room = null;
+        // TODO: @adunsulag rename this variable to be roomModal
+        this.waitingRoomModal = null;
+
+        /**
+         * Are we currently in the conference room session
+         * @type {boolean}
+         */
+        this.inSession = false;
+
+        /**
+         * Is the conference room currently  minimized
+         * @type {boolean}
+         */
+        this.isMinimized = false;
+
+        /**
+         * Tracking interval for the conference room session polling
+         * @type {number}
+         */
+        this.sessionUpdateInterval = null;
+
+        /**
+         * Checks to make sure that the user with the given calleeId is allowed to talk to the current conference room caller
+         * @param call The call that we are going to verify
+         * @returns {Promise<boolean>}
+         */
+        this.canReceiveCall = function(call)
+        {
+            let callerId = call.getRemotePartyId();
+            // TODO: @adunsulag check to make sure we don't need to hit the server... we already have the calleeUuid which we got
+            // from the server... we can double check again by hitting the server and verifying the session has started and accept
+            // the call, but that seems pretty paranoid to double check that...
+            if (callerId === conf.callerSettings.calleeUuid)
+            {
+                return Promise.resolve({call: call, canCall: true});
+            }
+            else
+            {
+                return Promise.resolve({call: call, canCall: false});
+            }
+        };
+
+        this.getRemoteScriptLocation = function()
+        {
+            return getTeleHealthScriptLocation(false);
+        };
+
+        this.getTelehealthLaunchData = function(data)
+        {
+            var scriptLocation = this.getRemoteScriptLocation() + '?action=get_telehealth_launch_data&eid=' + encodeURIComponent(data.pc_eid);
+            window.top.restoreSession();
+            return window.fetch(scriptLocation, {redirect: "manual"});
+        };
+
+        this.setupProviderWaitingRoom = function()
+        {
+            let modal = this.createModalWithContent(conf.waitingRoomTemplate);
+            // // now we will attach all of our event listeners here onto the document content.
+            let container = document.getElementById('telehealth-container');
+            conf.initWaitingRoomEvents(container);
+            conf.waitingRoomModal = modal;
+            conf.waitingRoomModal.show();
+        };
+
+        this.setupWaitingRoom = function()
+        {
+            conf.setupProviderWaitingRoom();
+        };
+
+        this.handleIncomingCall = function(call)
+        {
+
+            // we will hit the server to verify that the caller can actually make this call
+            this.canReceiveCall(call)
+                .then((result) => {
+                    if (result.canCall)
+                    {
+                        conf.app.setCallHandlers(result.call);
+                        result.call.accept();
+                        console.log("Call accepted from " + result.call.getRemotePartyId() + " for "  + conf.callerSettings.callerUuid);
+                        // NOTE that result.call.accept does NOT fire the oncallstarted event for the call stream... so we have to
+                        // toggle our remote video here instead.
+                        conf.toggleRemoteVideo(true);
+                    }
+                    else
+                    {
+                        result.call.reject();
+                        console.log("Call from " + result.call.getRemotePartyId() + " not authorized by server for "  + conf.callerSettings.callerUuid);
+                    }
+                })
+                .catch(error => {
+                    call.reject();
+                });
+        };
+
+        this.init = function(data)
+        {
+            if (!data.pc_eid)
+            {
+                alert(translations.SESSION_LAUNCH_FAILED);
+                return;
+            }
+
+            conf.telehealthSessionData = data;
+            // we grab everything up front as anything dealing with video playback needs to be triggered by a button on iOS devices
+            // so we have to make sure we grab everything here.
+
+            // we could also make sure we create users when we update... that would resolve the issue as well.
+            let getLaunchData = conf.getTelehealthLaunchData(data);
+
+            getLaunchData
+                .then(function(result) {
+                    if (!(result.ok && result.status == 200)) {
+                        throw new Error("Failed to fetch data");
+                    }
+
+                    return result.json();
+                })
+                .then(launchData => {
+                    conf.inSession = true;
+                    conf.callerSettings = launchData.callerSettings;
+                    conf.waitingRoomTemplate = launchData.waitingRoom;
+                    conf.conferenceRoomTemplate = launchData.conferenceRoom;
+                    conf.setupWaitingRoom();
+                    conf.app = new ATApp(conf, {
+                        userId: conf.callerSettings.callerUuid,
+                        password: conf.callerSettings.apiKey,
+                        serviceUrl: conf.callerSettings.serviceUrl
+                    });
+                    conf.app.start();
+                    conf.room = conf.ROOM_TYPE_WAITING;
+                })
+                .catch(function(error) {
+                    console.error(error);
+                    // null out our values if we never started our session.
+                    if (!conf.app) {
+                        alert(translations.SESSION_LAUNCH_FAILED);
+                        conf.destruct(); // shut things down if we don't have a valid session.
+                    }
+                });
+        };
+
+        this.destruct = function()
+        {
+            conf.inSession = false;
+            conf.waitingRoomTemplate = null;
+            conf.conferenceRoomTemplate = null;
+            if (conf.videoBar) {
+                conf.videoBar.destruct();
+                conf.videoBar = null;
+            }
+            if (conf.room == conf.ROOM_TYPE_WAITING)
+            {
+                // TODO: do any cleanup needed here
+            }
+            else if (conf.room == conf.ROOM_TYPE_CONFERENCE)
+            {
+                // TODO: do any cleanup needed here.
+            }
+            if (conf.sessionUpdateInterval !== null)
+            {
+                clearInterval(conf.sessionUpdateInterval);
+                conf.sessionUpdateInterval = null;
+            }
+            let container = document.getElementById('telehealth-container');
+            if (conf.app && conf.app.shutdown)
+            {
+                // catch any problems from the library so we can still clean up.
+                try {
+                    conf.app.shutdown();
+                }
+                catch (error)
+                {
+                    console.error(error);
+                }
+            }
+            if (container && container.parentNode)
+            {
+                container.parentNode.removeChild(container);
+            }
+
+            if (conf.isMinimized)
+            {
+                // clean up minimized elements now too
+                let minimizedContainer = document.getElementById('minimized-telehealth-video');
+                if (minimizedContainer && minimizedContainer.parentNode)
+                {
+                    minimizedContainer.parentNode.removeChild(minimizedContainer);
+                }
+                conf.isMinimized = false;
+            }
+            conf.callerSettings = null;
+            conf.telehealthSessionData = null;
+        };
+
+        this.initModalEvents = function(container)
+        {
+            var elements = document.getElementsByClassName('btn-telehealth-provider-close');
+            for (var i = 0; i < elements.length; i++)
+            {
+                elements[i].addEventListener('click', conf.handleCallHangup);
+            }
+        };
+
+        this.initWaitingRoomEvents = function(container)
+        {
+            conf.videoBar = new VideoBar(container, conf.getWaitingRoomVideoBarSettings());
+            conf.toggleJoinButton(conf.shouldEnableJoinButton());
+        };
+
+        this.togglePermissionBox = function(enabled)
+        {
+            let box = document.querySelector('#telehealth-container .permissions-box');
+            let boxRestartBtn = document.querySelector('#telehealth-container .permissions-box .restart-media-btn');
+            if (box && boxRestartBtn)
+            {
+                if (enabled) {
+                    boxRestartBtn.addEventListener('click', conf.recaptureLocalMedia);
+                    box.classList.remove('d-none');
+                } else {
+                    box.classList.add('d-none');
+                    boxRestartBtn.removeEventListener('click', conf.recaptureLocalMedia);
+                }
+            } else {
+                console.error("Could not find permissions box dom nodes");
+            }
+        };
+
+        this.recaptureLocalMedia = function()
+        {
+            if (conf.app && conf.app.restartMediaStream) {
+                // destroy the app and restart
+                conf.app.restartMediaStream();
+            }
+        };
+
+        this.hasLocalPermissionsEnabled = function()
+        {
+            if (conf.app) // && conf.app.isActive())
+            {
+                return conf.app.hasLocalPermissionsEnabled();
+            }
+            return false;
+        };
+
+        this.shouldEnableJoinButton = function()
+        {
+            return this.hasLocalPermissionsEnabled();
+        };
+
+        this.toggleJoinButton = function(enabled)
+        {
+            let btnJoin = document.querySelectorAll('.btn-comlink-conference-join');
+            if (btnJoin && btnJoin.length) {
+                for (let i = 0; i < btnJoin.length; i++) {
+                    if (enabled) {
+                        btnJoin[i].addEventListener('click', conf.startConferenceRoom);
+                        btnJoin[i].classList.remove('disabled');
+                        btnJoin[i].disabled = false;
+                    } else {
+                        btnJoin[i].removeEventListener('click', conf.startConferenceRoom);
+                        btnJoin[i].classList.add('disabled');
+                        btnJoin[i].disabled = true;
+                    }
+                }
+            }
+        };
+
+        this.startVideoStreams = function()
+        {
+            conf.app = new ATApp(conf, {
+                userId: conf.callerSettings.callerUuid,
+                password: conf.callerSettings.apiKey,
+                serviceUrl: conf.callerSettings.serviceUrl
+            });
+            conf.app.start();
+        };
+
+        this.sessionClose = function()
+        {
+            let conf = this;
+            if (conf.isMinimized)
+            {
+                conf.destruct();
+            }
+            else {
+                // have to use jquery to grab the jquery event
+                jQuery("#telehealth-container").on("hidden.bs.modal", function () {
+                    jQuery("#telehealth-container").off("hidden.bs.modal");
+                    conf.destruct()
+                });
+                conf.waitingRoomModal.hide();
+            }
+        };
+
+        function ConfirmSessionCloseDialog(pc_eid, scriptLocation)
+        {
+            let dialog = this;
+            let modal = null;
+            let container = null;
+
+            this.cancelDialog = function()
+            {
+                // reset everything here.
+                let sections = container.querySelectorAll(".hangup-section");
+                let startSection = container.querySelector('.hangup-section.hangup-section-start');
+                if (sections && sections.length)
+                {
+                    for (let i =0; i < sections.length; i++)
+                    {
+                        sections[i].classList.add("d-none");
+                    }
+                }
+                if (startSection)
+                {
+                    startSection.classList.remove("d-none");
+                }
+
+                modal.hide();
+            };
+
+            this.processConfirmYesAction = function(evt) {
+                // conf.app.shutdown();
+                container.querySelector('.row-confirm').classList.add('d-none');
+                container.querySelector('.row-update-status').classList.remove('d-none');
+            };
+
+            this.sendAppointmentStatusUpdate = function(status)
+            {
+                console.log("Setting appointment to status ", status);
+                let postData = "action=set_appointment_status&pc_eid=" + encodeURIComponent(pc_eid) + "&status=" + encodeURIComponent(status);
+                window.top.restoreSession();
+                window.fetch(scriptLocation,
+                {
+                    method: 'POST'
+                    ,headers: {
+                        'Content-Type': 'application/x-www-form-urlencoded'
+                    }
+                    ,body: postData
+                    ,redirect: 'manual'
+                })
+                .then(result => {
+                    if (!(result.ok && result.status == 200))
+                    {
+                        alert(translations.APPOINTMENT_STATUS_UPDATE_FAILED);
+                        console.error("Failed to update appointment " + pc_eid + " to status " + status);
+                    }
+                });
+            };
+
+            this.updateAppointmentStatusAndClose = function(status)
+            {
+
+                jQuery(container).on("hidden.bs.modal", function () {
+                    try {
+                        jQuery(container).off("hidden.bs.modal");
+                        conf.sessionClose();
+                    }
+                    catch (error)
+                    {
+                        console.error(error);
+                    }
+                    try {
+                        if (status != 'CloseWithoutUpdating')
+                        {
+                            dialog.sendAppointmentStatusUpdate(status);
+                        }
+                    }
+                    catch (updateError)
+                    {
+                        console.error(updateError);
+                    }
+                });
+                modal.hide();
+            };
+
+            this.processHangupSetting = function(evt)
+            {
+                let target = evt.currentTarget;
+                let status = target.dataset['status'] || 'CloseWithoutUpdating'; // - means none
+                dialog.updateAppointmentStatusAndClose(status);
+            };
+
+            this.processSetStatusFromSelector = function(evt)
+            {
+                let selector = container.querySelector('.appointment-status-update');
+                if (selector && selector.value)
+                {
+                    dialog.updateAppointmentStatusAndClose(selector.value);
+                } else {
+                    console.error("Failed to find selector .appointment-status-update node or value is not defined for node");
+                }
+            };
+
+            this.show = function() {
+                let id = 'telehealth-container-hangup-confirm';
+                // let bootstrapModalTemplate = window.document.createElement('div');
+                // we use min-height 90vh until we get the bootstrap full screen modal in bootstrap 5
+                container = document.getElementById(id);
+                modal = new bootstrap.Modal(container, {keyboard: false, focus: true, backdrop: 'static'});
+
+                let btns = container.querySelectorAll('.btn-telehealth-confirm-cancel');
+                for (var i = 0; i < btns.length; i++)
+                {
+                    btns[i].addEventListener('click', dialog.cancelDialog);
+                }
+                let confirmYes = container.querySelector('.btn-telehealth-confirm-yes');
+                if (confirmYes)
+                {
+                    confirmYes.addEventListener('click', dialog.processConfirmYesAction);
+                } else {
+                    console.error("Could not find selector with .btn-telehealth-confirm-yes");
+                }
+
+                let statusOtherUpdateBtn = container.querySelector('.btn-telehealth-session-select-update');
+                if (statusOtherUpdateBtn)
+                {
+                    statusOtherUpdateBtn.addEventListener('click', dialog.processSetStatusFromSelector);
+                }
+
+                btns = container.querySelectorAll('.btn-telehealth-session-close');
+                for (var i = 0; i < btns.length; i++)
+                {
+                    btns[i].addEventListener('click', dialog.processHangupSetting);
+                }
+                modal.show();
+            }
+        }
+
+        this.confirmSessionClose = function()
+        {
+            if (conf.room == conf.ROOM_TYPE_WAITING)
+            {
+                conf.sessionClose();
+            }
+            else {
+                let dialog = new ConfirmSessionCloseDialog(conf.telehealthSessionData.pc_eid, getTeleHealthScriptLocation(false));
+                dialog.show();
+            }
+        };
+
+        this.shutdownProviderWaitingRoom =  function()
+        {
+            let container = document.getElementById('telehealth-container');
+            if (conf.app && conf.app.shutdown)
+            {
+                // catch any problems from the library so we can still clean up.
+                try {
+                    conf.app.shutdown();
+                }
+                catch (error)
+                {
+                    console.error(error);
+                }
+            }
+            if (container && container.parentNode)
+            {
+                container.parentNode.removeChild(container);
+            }
+            conf.callerSettings = null;
+            conf.telehealthSessionData = null;
+        };
+
+        this.createModalWithContent = function(content)
+        {
+            let bootstrapModalTemplate = window.document.createElement('div');
+            // we use min-height 90vh until we get the bootstrap full screen modal in bootstrap 5
+            // TODO: @adunsulag now that both patient & portal are using the same dialog we can probably move this server side
+            // into the waiting room template.
+            bootstrapModalTemplate.innerHTML = `<div class="modal fade" id="telehealth-container" tabindex="-1" aria-hidden="true">
+              <div class="modal-dialog mw-100 ml-2 mr-2">
+                <div class="modal-content">
+                  <div class="modal-header">
+                    <h5 class="modal-title">` + jsText(translations.TELEHEALTH_MODAL_TITLE) + `</h5>
+                    <button type="button" class="close btn-telehealth-provider-close" aria-label="Close">
+                      <span aria-hidden="true">&times;</span>
+                    </button>
+                  </div>
+                  <div class="modal-body d-flex">
+                  ${content}
+                  </div>
+                </div>
+              </div>
+            </div>`;
+            window.document.body.appendChild(bootstrapModalTemplate.firstElementChild);
+            var container = document.getElementById('telehealth-container');
+            conf.waitingRoomModal = new bootstrap.Modal(container, {keyboard: false, focus: true, backdrop: 'static'});
+            conf.initModalEvents(container);
+            return conf.waitingRoomModal;
+        };
+
+        this.startConferenceRoom = function()
+        {
+            conf.startProviderConferenceRoom();
+        };
+
+        this.startProviderConferenceRoom = function()
+        {
+            let container = document.getElementById('telehealth-container');
+            // now grab our video container in our modal
+            let video = document.getElementById("local-video");
+
+            conf.videoBar.destruct();
+
+            // now we are going to replace the modal content
+            let modalBody = container.querySelector('.modal-body');
+            // clear out the modal body
+            do {
+                modalBody.removeChild(modalBody.firstChild);
+            } while (modalBody.childNodes.length);
+            modalBody.innerHTML = conf.conferenceRoomTemplate;
+
+            // now let's replace our template video container with our original video container from the waiting room.
+            let conferenceVideo = document.getElementById('local-video');
+            if (conferenceVideo && conferenceVideo.parentNode) {
+                conferenceVideo.parentNode.replaceChild(video, conferenceVideo);
+            }
+            let conferenceVideoBar = modalBody.querySelector(".telehealth-button-bar");
+            conf.videoBar = new VideoBar(conferenceVideoBar, conf.getFullConferenceVideoBarSettings());
+            conf.inConferenceRoom = true;
+            conf.room = conf.ROOM_TYPE_CONFERENCE;
+
+            this.sessionUpdateInterval = setInterval(conf.updateConferenceRoomSession.bind(conf), conf.sessionUpdatePollingTime);
+            conf.updateConferenceRoomSession();
+        };
+
+        this.updateConferenceRoomSession = function() {
+            let appt = conf.callerSettings.appointment || {};
+            let eid = appt.eid || {};
+            // TODO: if we ever need to take action on the session update we would do that here.
+            // TODO: @adunsulag change eid here to be pc_eid
+            window.top.restoreSession();
+            window.fetch(conferenceRoom.getRemoteScriptLocation() + '?action=conference_session_update&eid=' + encodeURIComponent(eid), {redirect: "manual"})
+                .then((request) => {
+                    if (request.ok) {
+                        return request.json();
+                    } else {
+                        throw new Error("Failed to update session");
+                    }
+                })
+                .catch(error => console.error("Conference session update ", error));
+        };
+
+        this.cancelUpdateConferenceRoomSession = function()
+        {
+            if (conferenceRoom.sessionUpdateInterval)
+            {
+                window.clearInterval(conferenceRoom.sessionUpdateInterval);
+            }
+        };
+
+        this.getDefaultVideoBarSettings = function()
+        {
+            var noop = function() {};
+
+            return {
+                notes: false
+                ,notesCallback: noop
+                ,microphone: conf.buttonSettings.microphoneEnabled
+                ,microphoneCallback: conf.toggleMicrophone.bind(conf)
+                ,video: conf.buttonSettings.cameraEnabled
+                ,videoCallback: conf.toggleVideo.bind(conf)
+                ,expand: false
+                ,expandCallback: noop
+                ,hangup: false
+                ,hangupCallback: noop
+            };
+        };
+
+        this.getWaitingRoomVideoBarSettings = function()
+        {
+            return conf.getDefaultVideoBarSettings();
+        };
+
+        this.getMinimizedConferenceVideoBarSettings = function()
+        {
+            let settings = conf.getDefaultVideoBarSettings();
+            settings.expandCallback = conf.maximizeProviderConferenceCall.bind(conf);
+            settings.hangupCallback = conf.handleCallHangup.bind(conf);
+            settings.expand = true;
+            settings.notes = false;
+            settings.hangup = true;
+            return settings;
+        };
+
+        this.getFullConferenceVideoBarPatientSettings = function()
+        {
+            let settings = conf.getDefaultVideoBarSettings();
+            settings.hangupCallback = conf.handleCallHangup.bind(conf);
+            settings.expand = false;
+            settings.notes = false; // patient doesn't get notes.
+            settings.hangup = true;
+            return settings;
+        };
+
+        this.getFullConferenceVideoBarSettings = function()
+        {
+            let settings = conf.getDefaultVideoBarSettings();
+            settings.hangupCallback = conf.handleCallHangup.bind(conf);
+            settings.notesCallback = conf.minimizeProviderConferenceCall.bind(conf);
+            settings.expand = false;
+            settings.notes = true;
+            settings.hangup = true;
+            return settings;
+        };
+
+        this.handleCallStartedEvent = function(call)
+        {
+            conferenceRoom.toggleRemoteVideo(true);
+        };
+
+        this.handleCallEndedEvent = function(call)
+        {
+            conferenceRoom.toggleRemoteVideo(false);
+        };
+
+        this.handleCallHangup = function()
+        {
+            // if we hangup the call we maximize the window since the confirm dialog is embedded inside the
+            // main window.
+            if (this.isMinimized) {
+                conf.maximizeProviderConferenceCall({});
+            }
+            conf.confirmSessionClose();
+        };
+
+        this.minimizeProviderConferenceCall = function()
+        {
+            // grab every dom node in the waiting room that is not the patient video
+            // grab the video and shrink it to bottom left window
+            // shrink container to be the size of the video
+            var container = document.getElementById('telehealth-container');
+            var localVideo = document.getElementById('remote-video');
+
+            var template = document.createElement('div');
+            template.id = "minimized-telehealth-video";
+            template.className = "col-lg-2 col-md-3 col-sm-4 col-6 drag-action";
+
+            window.document.body.appendChild(template);
+            template.appendChild(localVideo);
+
+            var oldButtonBar = container.querySelector('.telehealth-button-bar');
+            var clonedButtonBar = oldButtonBar.cloneNode(true);
+
+            template.appendChild(clonedButtonBar);
+
+            // now destruct the old button
+            conf.videoBar.destruct();
+            conf.videoBar = new VideoBar(clonedButtonBar, conf.getMinimizedConferenceVideoBarSettings());
+
+            conf.waitingRoomModal.hide();
+
+            // now make the video container draggable
+            if (window.initDragResize)
+            {
+                // let's initialize our drag action here.
+                window.initDragResize();
+            }
+
+            this.isMinimized = true;
+        };
+
+        this.maximizeProviderConferenceCall = function(evt)
+        {
+            // remove the event listener
+            var remoteVideoContainer = document.querySelector('.remote-video-container');
+            var remoteVideo = document.getElementById('remote-video');
+
+            // now let's move the video and cleanup the old container here
+            if (remoteVideo && remoteVideoContainer) {
+
+                var oldContainer = remoteVideo.parentNode;
+                var oldButtonBar = oldContainer.querySelector('.telehealth-button-bar');
+                if (oldButtonBar) {
+                    conf.videoBar.destruct();
+                    oldButtonBar.parentNode.removeChild(oldButtonBar);
+                }
+
+
+                if (remoteVideoContainer) {
+                    var newButtonBar = remoteVideoContainer.querySelector('.telehealth-button-bar');
+                    if (newButtonBar) {
+                        conf.videoBar = new VideoBar(newButtonBar, conf.getFullConferenceVideoBarSettings());
+                    } else {
+                        console.error("Failed to find #remote-video-container .telehealth-button-bar");
+                    }
+                } else {
+                    console.error("Failed to find #remote-video-container");
+                }
+                remoteVideoContainer.prepend(remoteVideo);
+
+                // need to clean up the original minimize container we created here
+                if (oldContainer && oldContainer.parentNode)
+                {
+                    oldContainer.parentNode.removeChild(oldContainer);
+                }
+            } else {
+                console.error("Failed to find remote video or remote video container");
+            }
+
+            // everything's moved we can now display the larger video modal.
+            if (conf.waitingRoomModal) {
+                conf.waitingRoomModal.show();
+                this.isMinimized = false;
+            } else {
+                console.error("Failed to find waitingRoomModal");
+            }
+        };
+
+
+        this.toggleMicrophone = function(event)
+        {
+            let node = event.target;
+            if (!node.classList.contains('fa'))
+            {
+                node = node.querySelector('.fa');
+            }
+            let toggle = !conf.buttonSettings.microphoneEnabled;
+            conf.buttonSettings.microphoneEnabled = toggle;
+            node.dataset.enabled = toggle;
+            if (conf.app && conf.app.enableMicrophone) {
+                conf.app.enableMicrophone(toggle);
+            } else {
+                console.error("app is not initalized and cannot toggle microphone");
+            }
+            toggleClass(node, toggle, 'fa-microphone','fa-microphone-slash');
+        };
+
+        this.toggleVideo = function(event)
+        {
+            let node = event.target;
+            if (!node.classList.contains('fa'))
+            {
+                node = node.querySelector('.fa');
+            }
+            let toggle = !conf.buttonSettings.cameraEnabled;
+            conf.buttonSettings.cameraEnabled = toggle;
+            // TODO: @adunsulag remove this reliance on the node.dataset here.
+            node.dataset.enabled = toggle;
+            if (conf.app && conf.app.enableCamera) {
+                conf.app.enableCamera(toggle);
+            } else {
+                console.error("app is not initalized and cannot toggle microphone");
+            }
+            toggleClass(node, toggle, 'fa-video','fa-video-slash');
+        };
+
+        this.toggleRemoteVideo = function(display)
+        {
+            var container = document.getElementById('telehealth-container');
+            var waitingContainer = container.querySelector('.waiting-container');
+            var remoteVideo = container.querySelector('.remote-video');
+
+            if (display)
+            {
+                waitingContainer.classList.add('d-none');
+                remoteVideo.classList.remove('d-none');
+            } else {
+                waitingContainer.classList.remove('d-none');
+                remoteVideo.classList.add('d-none');
+            }
+        };
+
+        // don't really need any class member variables here so we will let JS hoist this up.
+        function toggleClass(node, toggle, onClass, offClass)
+        {
+            if (toggle) {
+                node.classList.add(onClass);
+                node.classList.remove(offClass);
+            } else {
+                node.classList.add(offClass);
+                node.classList.remove(onClass);
+            }
+        }
+
+    }
+
+    function VideoBarButton(node, defaultValue, callback)
+    {
+        let btn = this;
+        btn.node = node;
+        btn.value = defaultValue;
+        btn.callback = callback;
+        btn.enabled = defaultValue === true;
+
+        btn.init = function()
+        {
+            if (btn.enabled)
+            {
+                btn.attach();
+            }
+            else
+            {
+                btn.detatch();
+            }
+        };
+
+        btn.attach = function() {
+          if (this.node)
+          {
+              this.node.addEventListener('click', this.callback);
+              this.node.classList.remove('d-none');
+          }
+        };
+
+        btn.detatch = function()
+        {
+            if (this.node)
+            {
+                this.node.removeEventListener('click', this.callback);
+                this.node.classList.add('d-none');
+            }
+        };
+        btn.destruct = function()
+        {
+            // remove event handlers and cleanup memory.
+            btn.detatch();
+            btn.node = null;
+            btn.callback = null;
+        }
+        btn.toggle = function()
+        {
+            btn.enabled = !btn.enabled;
+            if (btn.enabled)
+            {
+                this.attach();
+            }
+            else
+            {
+                this.detatch();
+            }
+        };
+        btn.init();
+        return btn;
+    }
+
+    function VideoBar(container, options)
+    {
+        var bar = this;
+        /**
+         * @var VideoBarButton[]
+         */
+        bar.__buttons = {};
+
+        /**
+         * @var HTMLElement
+         */
+        bar.__container = container;
+
+        function noop() {}
+
+        function init() {
+            options = options || {};
+            setDefaultValue(options,'notes', false);
+            setDefaultValue(options,'notesCallback', noop);
+
+            setDefaultValue(options,'microphone', true);
+            setDefaultValue(options,'microphoneCallback', noop);
+            setDefaultValue(options,'video', true);
+            setDefaultValue(options,'videoCallback', noop);
+            setDefaultValue(options,'expand', false);
+            setDefaultValue(options,'expandCallback', noop);
+            setDefaultValue(options,'hangup', false);
+            setDefaultValue(options,'hangupCallback', noop);
+
+            let btns = ['notes', 'microphone', 'video', 'expand', 'hangup'];
+            btns.forEach(btn => {
+                let node = bar.__container.querySelector(".telehealth-btn-" + btn);
+                let callback = options[btn + 'Callback'] || noop;
+
+                if (!node)
+                {
+                    console.error("Failed to find node for telehealth-btn-" + btn);
+                    return;
+                }
+                bar.__buttons[btn] = new VideoBarButton(node, options[btn], callback);
+            });
+
+            // we always make sure our microphone and video is displayed, but we swap the icons if they are disabled.
+            if (!bar.__buttons['microphone'].enabled)
+            {
+                let btn = bar.__buttons['microphone'];
+                let node = btn.node.querySelector('.fa');
+                if (btn && node) {
+                    btn.toggle();
+                    node.classList.add('fa-microphone-slash');
+                    node.classList.remove('fa-microphone');
+                } else {
+                    console.error("Failed to find microphone node and fa icon");
+                }
+            }
+            if (!bar.__buttons['video'].enabled)
+            {
+                let btn = bar.__buttons['video'];
+                let node = btn.node.querySelector('.fa');
+                if (btn && node) {
+                    btn.toggle();
+                    node.classList.add('fa-video-slash');
+                    node.classList.remove('fa-video');
+                } else {
+                    console.error("Failed to find video node and fa icon");
+                }
+            }
+        }
+
+        function destruct()
+        {
+            Object.values(bar.__buttons).forEach(button => button.detatch());
+            bar.__container = null;
+        }
+
+        function setDefaultValue(obj, property, value)
+        {
+            if (!obj.hasOwnProperty(property))
+            {
+                obj[property] = value;
+            }
+        }
+
+        function toggleButtons(toggleBtns)
+        {
+            toggleBtns.forEach(btn => {
+                if (bar.__buttons[btn])
+                {
+                    bar.__buttons[btn].toggle();
+                }
+                else
+                {
+                    console.error('Failed to find button to toggle for button ' + btn);
+                }
+
+            });
+        }
+
+
+        bar.init = init;
+        bar.destruct = destruct;
+        bar.toggleButtons = toggleButtons;
+
+        bar.init();
+        return bar;
+    }
+
+    function launchProviderVideoMessage(data)
+    {
+        if (conferenceRoom)
+        {
+            if (conferenceRoom.inSession) {
+                alert(translations.DUPLICATE_SESSION);
+                return;
+            }
+            else
+            {
+                // destroy the session.
+                conferenceRoom.destruct();
+                conferenceRoom = null;
+            }
+        }
+        conferenceRoom = new ConferenceRoom();
+        conferenceRoom.init(data);
+    }
+
+    function PatientConferenceRoom() {
+        let patientConferenceRoom = new ConferenceRoom();
+        let parentDestruct = patientConferenceRoom.destruct;
+        let checkProviderReadyForPatientInterval = null;
+        let providerIsReady = false;
+
+        function checkProviderReadyForPatient()
+        {
+            let pc_eid = patientConferenceRoom.telehealthSessionData.pc_eid;
+            window.top.restoreSession();
+            window.fetch(moduleLocation + 'public/index-portal.php?action=patient_appointment_ready&eid=' + encodeURIComponent(pc_eid), {redirect: "manual"})
+            .then(result => {
+                if (result.ok) {
+                   return result.json();
+                } else {
+                    throw new Error("Failed to get response back from server")
+                }
+            })
+            .then(apptReadyData => {
+                if (apptReadyData.session)
+                {
+                    // provider being ready is just one test, local camera permissions also must be checked
+                    providerIsReady = apptReadyData.session.providerReady === true;
+
+                    // we update the calleeUuid here in case another provider takes over the appointment session of
+                    // the patient.  This occurs if a provider is out of town and the patient is currently waiting
+                    // for the session to start.
+                    if (apptReadyData.session.calleeUuid)
+                    {
+                        patientConferenceRoom.callerSettings.calleeUuid = apptReadyData.session.calleeUuid;
+                    }
+                    patientConferenceRoom.toggleJoinButton(patientConferenceRoom.shouldEnableJoinButton());
+                }
+            })
+            .catch(error => {
+                let errorMessage = document.querySelector('.waiting-room-server-communication');
+                if (errorMessage) {
+                    errorMessage.classList.remove(('d-none'));
+                }
+                console.error(error);
+            });
+        }
+
+        patientConferenceRoom.getRemoteScriptLocation = function() {
+            return getTeleHealthScriptLocation(true);
+        };
+
+        patientConferenceRoom.getFullConferenceVideoBarSettings = patientConferenceRoom.getFullConferenceVideoBarPatientSettings;
+
+        patientConferenceRoom.startConferenceRoom = function()
+        {
+            patientConferenceRoom.stopProviderReadyCheck();
+            patientConferenceRoom.startProviderConferenceRoom(); // not sure there is much difference here
+            patientConferenceRoom.app.makeCall(patientConferenceRoom.callerSettings.calleeUuid);
+        };
+
+        patientConferenceRoom.handleIncomingCall = function()
+        {
+            // patient shouldn't get provider initiated call... so we will skip this for now.
+        };
+
+        patientConferenceRoom.handleCallEndedEvent = function(call)
+        {
+            alert(translations.HOST_LEFT);
+            // for patient conference if the provider leaves the call we need to send them back to the waiting room
+            patientConferenceRoom.replaceConferenceRoomWithWaitingRoom();
+            // cancel our session update sequence that happens during the conference room.
+            patientConferenceRoom.cancelUpdateConferenceRoomSession();
+        };
+
+        patientConferenceRoom.replaceConferenceRoomWithWaitingRoom = function()
+        {
+            let telehealthSessionData = patientConferenceRoom.telehealthSessionData;
+            let modalDialog = patientConferenceRoom.waitingRoomModal;
+            var container = document.getElementById('telehealth-container');
+            var body = container.querySelector('.modal-body');
+            var video = document.getElementById('local-video');
+
+            patientConferenceRoom.videoBar.destruct();
+            body.innerHTML = patientConferenceRoom.waitingRoomTemplate;
+            var replaceVideo = document.getElementById('local-video');
+            if (replaceVideo) {
+                replaceVideo.parentNode.replaceChild(video, replaceVideo);
+            } else {
+                console.error("Failed to find child video to replace");
+                return;
+            }
+            providerIsReady = false;
+            patientConferenceRoom.initWaitingRoomEvents(container);
+            patientConferenceRoom.startProviderReadyCheck();
+        };
+
+        patientConferenceRoom.handleCallHangup = function()
+        {
+            if (patientConferenceRoom.room == patientConferenceRoom.ROOM_TYPE_WAITING)
+            {
+                patientConferenceRoom.sessionClose();
+            } else {
+                // since we are already tied to the hidden event we can just hide the modal and it will destroy everything
+                // for the patient side of things.
+                if (confirm(translations.CONFIRM_SESSION_CLOSE)) {
+                    patientConferenceRoom.sessionClose();
+                }
+            }
+        };
+
+        patientConferenceRoom.setWaitingRoomModal = function(waitingRoomModal)
+        {
+            patientConferenceRoom.waitingRoomModal = waitingRoomModal;
+        };
+
+        patientConferenceRoom.setupWaitingRoom = function()
+        {
+            // do the provider work and let's enable our join button only if the provider is ready
+            patientConferenceRoom.setupProviderWaitingRoom();
+            patientConferenceRoom.startProviderReadyCheck();
+        };
+        patientConferenceRoom.destruct = function()
+        {
+            patientConferenceRoom.stopProviderReadyCheck();
+            // TODO: look at merging the two dialogs from patient versus provider
+            if (window.dlgclose) {
+                window.dlgclose();
+            }
+            parentDestruct.bind(patientConferenceRoom)();
+        };
+        patientConferenceRoom.stopProviderReadyCheck = function()
+        {
+            if (checkProviderReadyForPatientInterval) {
+                clearInterval(checkProviderReadyForPatientInterval);
+                checkProviderReadyForPatientInterval = null;
+            }
+        };
+        patientConferenceRoom.startProviderReadyCheck = function()
+        {
+            checkProviderReadyForPatientInterval = setInterval(checkProviderReadyForPatient, 2000);
+        };
+        patientConferenceRoom.shouldEnableJoinButton = function()
+        {
+            return providerIsReady && patientConferenceRoom.hasLocalPermissionsEnabled();
+        };
+        return patientConferenceRoom;
+    }
+
+    function showPatientPortalDialog(appointmentEventId, translations) {
+            let telehealthSessionData = {
+                pc_eid: appointmentEventId
+            };
+        conferenceRoom = new PatientConferenceRoom();
+        conferenceRoom.init(telehealthSessionData);
+    }
+
+    function launchRegistrationChecker(isPatient)
+    {
+        checker = new RegistrationChecker(isPatient);
+        checker.checkRegistration();
+    }
+
+    // now to export our object here
+    comlink.telehealth = {
+        showPatientPortalDialog: showPatientPortalDialog,
+        launchProviderVideoMessage: launchProviderVideoMessage,
+        launchRegistrationChecker: launchRegistrationChecker
+    };
+    // now reassign our comlink object or create it new if there are no other comlink extensions.
+    window.comlink = comlink;
+})(window, window.comlink || {}, bootstrap, $, window.dlgopen || function() {});

--- a/interface/modules/custom_modules/oe-form-templates/public/index-portal.php
+++ b/interface/modules/custom_modules/oe-form-templates/public/index-portal.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Handles API requests for patient portal.
+ *
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2022 Comlink Inc <https://comlinkinc.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+// since we are working inside the portal we have to use the portal session verification logic here...
+require_once "../../../../../portal/verify_session.php";
+
+use Comlink\OpenEMR\Modules\TeleHealthModule\Bootstrap;
+
+
+
+$kernel = $GLOBALS['kernel'];
+$bootstrap = new Bootstrap($kernel->getEventDispatcher(), $kernel);
+$roomController = $bootstrap->getTeleconferenceRoomController(true);
+
+$action = $_GET['action'] ?? '';
+$queryVars = $_GET ?? [];
+$queryVars['pid'] = $_SESSION['pid']; // we overwrite any pid value to make sure we only grab this patient.
+$roomController->dispatch($action, $queryVars);
+exit;

--- a/interface/modules/custom_modules/oe-form-templates/public/index.php
+++ b/interface/modules/custom_modules/oe-form-templates/public/index.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * API index page for receiving requests from the OpenEMR clinician requests.
+ *
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2022 Comlink Inc <https://comlinkinc.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+// since we are working inside the portal we have to use the portal session verification logic here...
+require_once "../../../../globals.php";
+
+use Comlink\OpenEMR\Modules\TeleHealthModule\Bootstrap;
+
+$kernel = $GLOBALS['kernel'];
+$bootstrap = new Bootstrap($kernel->getEventDispatcher(), $kernel);
+$roomController = $bootstrap->getTeleconferenceRoomController(false);
+
+$action = $_REQUEST['action'] ?? '';
+$queryVars = $_REQUEST ?? [];
+$queryVars['pid'] = $_SESSION['pid'] ?? null;
+$queryVars['authUser'] = $_SESSION['authUser'] ?? null;
+$roomController->dispatch($action, $queryVars);
+exit;

--- a/interface/modules/custom_modules/oe-form-templates/sql/table.sql
+++ b/interface/modules/custom_modules/oe-form-templates/sql/table.sql
@@ -1,0 +1,24 @@
+#IfNotTable form_templates_template
+CREATE TABLE IF NOT EXISTS `form_templates_template` (
+    `template_id` bigint(21) UNSIGNED NOT NULL AUTO_INCREMENT,
+    `form_id` bigint(20) NOT NULL COMMENT 'Form ID FK',
+    `acl` varchar(255) NOT NULL COMMENT 'Which ACL can use this template',
+    `beg_effective_date` DATETIME COMMENT 'When is this template effective from, defaulting to now',
+    `end_effective_date` DATETIME COMMENT 'When this template is no longer effective, defaults to 100 years from now',
+    `active` tinyint(1) DEFAULT 1 COMMENT 'Is this template active',
+    `form_data` text NOT NULL COMMENT 'The serialized form data for every element and its values',
+    PRIMARY KEY (`template_id`)
+) ENGINE=InnoDB;
+#EndIf
+
+#IfNotTable form_templates_forms
+CREATE TABLE IF NOT EXISTS `form_templates_form` (
+    `form_id` bigint(20) NOT NULL AUTO_INCREMENT,
+    `display_name` varchar(255) NOT NULL COMMENT 'Display name of this form',
+    `machine_name` varchar(255) NOT NULL COMMENT 'Machine-readbale name of the form, usually the name attribute of the HTML Input Element',
+    `method` varchar(10) NOT NULL DEFAULT 'POST' COMMENT 'The method of submitting the form',
+    `action` varchar(255) NULL COMMENT 'The full path of the PHP file processing the request',
+    `active` tinyint(1) DEFAULT 1 COMMENT 'Is this form active',
+    PRIMARY KEY (`form_id`)
+) ENGINE=InnoDB;
+#EndIf

--- a/interface/modules/custom_modules/oe-form-templates/src/Bootstrap.php
+++ b/interface/modules/custom_modules/oe-form-templates/src/Bootstrap.php
@@ -1,0 +1,178 @@
+<?php
+
+/**
+ * Bootstrap Forms Template Engine.
+ *
+ * @author    Robert Down <robertdown@live.com>
+ * @copyright Copyright (c) 2022-2023 Providence Healthtech
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Modules\FormTemplates;
+
+/**
+ * Note the below use statements are importing classes from the OpenEMR core codebase
+ */
+use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\Core\Kernel;
+use OpenEMR\Events\Core\TwigEnvironmentEvent;
+use OpenEMR\Events\Globals\GlobalsInitializedEvent;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Twig\Error\LoaderError;
+use Twig\Loader\FilesystemLoader;
+use OpenEMR\Events\Main\Tabs\RenderEvent;
+use OpenEMR\Menu\MenuEvent;
+
+class Bootstrap
+{
+    const MODULE_INSTALLATION_PATH = "/interface/modules/custom_modules/";
+
+    const MODULE_DISPLAY_NAME = "Form Templates";
+
+    const MODULE_MACHINE_NAME = "oe-form-templates";
+
+    const TEMPLATES_TABLE = "form_templates_template";
+
+    const FORMS_TABLE = "form_templates_form";
+
+    /**
+     * @var EventDispatcherInterface The object responsible for sending and subscribing to events through the OpenEMR system
+     */
+    private $eventDispatcher;
+
+    /**
+     * @var GlobalConfig Holds our module global configuration values that can be used throughout the module.
+     */
+    private $globalsConfig;
+
+    /**
+     * @var string The folder name of the module.  Set dynamically from searching the filesystem.
+     */
+    private $moduleDirectoryName;
+
+    /**
+     * @var \Twig\Environment The twig rendering environment
+     */
+    private $twig;
+
+    /**
+     * @var SystemLogger
+     */
+    private $logger;
+
+    public function __construct(EventDispatcherInterface $eventDispatcher, ?Kernel $kernel = null)
+    {
+        global $GLOBALS;
+
+        if (empty($kernel)) {
+            $kernel = new Kernel();
+        }
+
+        // NOTE: eventually you will be able to pull the twig container directly from the kernel instead of instantiating
+        // it here.
+        $twig = new TwigContainer($this->getTemplatePath(), $kernel);
+        $twigEnv = $twig->getTwig();
+        $this->twig = $twigEnv;
+
+        $this->moduleDirectoryName = basename(__DIR__);
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    static public function moduleURL(string $controller, string $action): string
+    {
+        $url = "%DIR%%NAME%/index.php?controller=%C%&action=%A%";
+        $replacements = [
+            "%DIR%" => self::MODULE_INSTALLATION_PATH,
+            "%NAME%" => self::MODULE_MACHINE_NAME,
+            "%C%" => $controller,
+            "%A%" => $action
+        ];
+        return str_replace(array_keys($replacements), array_values($replacements), $url);
+    }
+
+    public function subscribeToEvents()
+    {
+        // $this->addGlobalSettings();
+        $this->registerTemplateEvents();
+        $this->registerMenuEvents();
+
+        // we only add the rest of our event listeners and configuration if we have been fully setup and configured
+        // if ($this->globalsConfig->isConfigured()) {
+        // }
+    }
+
+    public function registerMenuEvents()
+    {
+        $this->eventDispatcher->addListener(MenuEvent::MENU_UPDATE, [$this, 'addMenuItem']);
+    }
+
+    /**
+     * We tie into any events dealing with the templates / page rendering of the system here
+     */
+    public function registerTemplateEvents()
+    {
+        $this->eventDispatcher->addListener(TwigEnvironmentEvent::EVENT_CREATED, [$this, 'addTemplateOverrideLoader']);
+    }
+
+    public function addMenuItem(MenuEvent $event)
+    {
+        $menu = $event->getMenu();
+
+        $menuItem = new \stdClass();
+        $menuItem->requirement = 0;
+        $menuItem->target = 'mod';
+        $menuItem->menu_id = 'mod_form_template';
+        $menuItem->label = xlt(self::MODULE_DISPLAY_NAME);
+        $menuItem->url = self::MODULE_INSTALLATION_PATH . "oe-form-templates/index.php?controller=configuration";
+        $menuItem->children = [];
+        $menuItem->acl_req = ['admin', 'super'];
+        $menuItem->global_req = [];
+
+        foreach ($menu as $item) {
+            if ($item->menu_id == 'admimg') {
+                $item->children[] = $menuItem;
+                break;
+            }
+        }
+
+        $event->setMenu($menu);
+        return $event;
+    }
+
+    /**
+     * @param TwigEnvironmentEvent $event
+     */
+    public function addTemplateOverrideLoader(TwigEnvironmentEvent $event)
+    {
+        try {
+            $twig = $event->getTwigEnvironment();
+            if ($twig === $this->twig) {
+                // we do nothing if its our own twig environment instantiated that we already setup
+                return;
+            }
+            // we make sure we can override our file system directory here.
+            $loader = $twig->getLoader();
+            if ($loader instanceof FilesystemLoader) {
+                $loader->prependPath($this->getTemplatePath());
+            }
+        } catch (LoaderError $error) {
+            $this->logger->errorLogCaller("Failed to create template loader", ['innerMessage' => $error->getMessage(), 'trace' => $error->getTraceAsString()]);
+        }
+    }
+
+    private function getPublicPath()
+    {
+        return self::MODULE_INSTALLATION_PATH . ($this->moduleDirectoryName ?? '') . DIRECTORY_SEPARATOR . 'public' . DIRECTORY_SEPARATOR;
+    }
+
+    private function getAssetPath()
+    {
+        return $this->getPublicPath() . 'assets' . DIRECTORY_SEPARATOR;
+    }
+
+    static public function getTemplatePath()
+    {
+        return \dirname(__DIR__) . DIRECTORY_SEPARATOR . "templates" . DIRECTORY_SEPARATOR;
+    }
+}

--- a/interface/modules/custom_modules/oe-form-templates/src/Constants.php
+++ b/interface/modules/custom_modules/oe-form-templates/src/Constants.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ *
+ */
+
+namespace OpenEMR\Modules\FormTemplates;
+
+class Constants
+{
+
+    const TABLE_TEMPLATE        = "form_templates_template";
+
+    const TABLE_TEMPLATE_FIELD  = "form_templates_template_field";
+
+    const TABLE_FORM            = "form_templates_form";
+
+    const TABLE_FIELD           = "form_templates_field";
+}

--- a/interface/modules/custom_modules/oe-form-templates/src/Controller/ConfigurationController.php
+++ b/interface/modules/custom_modules/oe-form-templates/src/Controller/ConfigurationController.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ *
+ */
+
+namespace OpenEMR\Modules\FormTemplates\Controller;
+
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Modules\FormTemplates\Bootstrap;
+use OpenEMR\Modules\FormTemplates\Controller\Controller;
+use OpenEMR\Modules\FormTemplates\Controller\ControllerInterface;
+use OpenEMR\Modules\FormTemplates\Service\FormTemplatesService;
+use Symfony\Component\HttpFoundation\Request;
+
+class ConfigurationController extends Controller implements ControllerInterface
+{
+    private $service;
+
+    public $templateName;
+
+    public function __construct()
+    {
+        $this->templateName = "configuration/index.html.twig";
+        $this->service = new FormTemplatesService();
+    }
+
+    public function index()
+    {
+        $templates = $this->service->getAllTemplates();
+        $results['templates'] = $templates;
+        return $results;
+    }
+
+    public function new()
+    {
+        $this->templateName = "configuration/detail.html.twig";
+        $url = Bootstrap::moduleURL('configuration', 'saveTemplate');
+        $forms = $this->service->getRegisteredForms();
+        $layouts = $this->service->getLayoutForms();
+        return [
+            'save_template_url' => $url,
+            'registered_forms' => array_merge($forms, $layouts),
+        ];
+    }
+
+    public function saveTemplate()
+    {
+        /** @var Request */
+        $request = Request::createFromGlobals();
+
+        $fields = $request->request->all();
+        $form = [
+            'display_name' => $request->request->get('templateName', 'not null'),
+            'machine_name' => $request->request->get('templateMachineName', 'default'),
+            'method' => $request->request->get('templateMethod', 'POST'),
+            'action' => $request->request->get('templateAction', 'some/path/file.php'),
+            'active' => $request->request->get('templateActive', '1'),
+        ];
+
+        // foreach ($form as $k => $v) {
+        //     $request->request->remove($k);
+        // }
+
+        $newForm = $this->service->saveNewForm($form);
+
+        $form_data = serialize($fields);
+        $request->request->add(['form_data' => $form_data]);
+
+        $form_details = [
+            'display_name' => $request->request->get('display_name', ''),
+            'machine_name' => $request->request->get('machine_name', ''),
+            'form_id' => $newForm,
+            'acl' => $request->request->get('acl', ''),
+            'beg_effective_date' => $request->request->get('beg_effective_date', ''),
+            'end_effective_date' => $request->request->get('end_effective_date', ''),
+            'active' => $request->request->get('active', ''),
+            'form_data' => $form_data,
+        ];
+
+        $this->service->saveNewTemplate($form_details);
+
+    }
+}

--- a/interface/modules/custom_modules/oe-form-templates/src/Controller/Controller.php
+++ b/interface/modules/custom_modules/oe-form-templates/src/Controller/Controller.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ *
+ */
+
+namespace OpenEMR\Modules\FormTemplates\Controller;
+
+class Controller
+{
+
+    /**
+     * The template name to render
+     */
+    public $templateName;
+
+    /**
+     * The $GLOBALS supervar, encapsulated in the class
+     */
+    public $globals;
+
+    public function __construct()
+    {
+        $this->globals = $GLOBALS;
+    }
+
+    public function getTemplateName()
+    {
+        return $this->templateName;
+    }
+}

--- a/interface/modules/custom_modules/oe-form-templates/src/Controller/ControllerInterface.php
+++ b/interface/modules/custom_modules/oe-form-templates/src/Controller/ControllerInterface.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ *
+ */
+
+namespace OpenEMR\Modules\FormTemplates\Controller;
+
+interface ControllerInterface
+{
+    public function getTemplateName();
+
+    public function index();
+}

--- a/interface/modules/custom_modules/oe-form-templates/src/Controller/DefaultController.php
+++ b/interface/modules/custom_modules/oe-form-templates/src/Controller/DefaultController.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ *
+ */
+
+namespace OpenEMR\Modules\FormTemplates\Controller;
+
+use OpenEMR\Modules\FormTemplates\Bootstrap;
+use OpenEMR\Modules\FormTemplates\Controller\Controller;
+use OpenEMR\Modules\FormTemplates\Controller\ControllerInterface;
+use stdClass;
+
+class DefaultController extends Controller implements ControllerInterface
+{
+    private $service;
+
+    public function __construct()
+    {
+        $this->templateName = "admin/index.html.twig";
+    }
+
+    public function index()
+    {
+        return [];
+    }
+}

--- a/interface/modules/custom_modules/oe-form-templates/src/Repository/TeleHealthUserRepository.php
+++ b/interface/modules/custom_modules/oe-form-templates/src/Repository/TeleHealthUserRepository.php
@@ -1,0 +1,153 @@
+<?php
+
+/**
+ * Saves and retrieves from the database TeleHealth user objects.
+ *
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2022 Comlink Inc <https://comlinkinc.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace Comlink\OpenEMR\Modules\TeleHealthModule\Repository;
+
+use Comlink\OpenEMR\Modules\TeleHealthModule\Models\TeleHealthUser;
+use OpenEMR\Common\Crypto\CryptoGen;
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Services\BaseService;
+use Ramsey\Uuid\UuidFactory;
+
+class TeleHealthUserRepository extends BaseService
+{
+    const TABLE_NAME = "comlink_telehealth_auth";
+
+    /**
+     * @var SystemLogger
+     */
+    private $logger;
+
+    public function __construct()
+    {
+        parent::__construct(self::TABLE_NAME);
+        $this->logger = new SystemLogger();
+    }
+
+    public function saveUser(TeleHealthUser $user)
+    {
+        $active = $user->getIsActive() ? 1 : 0;
+        $binds = [$user->getUsername(), $user->getAuthToken(), $active, $user->getRegistrationCode()];
+
+        if (empty($user->getId())) {
+            $sql = "INSERT INTO " . self::TABLE_NAME . "(`date_updated`, `username`,`auth_token`"
+                . ",`active`, `app_registration_code`, `user_id`,`patient_id`, `date_registered`) VALUES (NOW(),?,?,?,?,?,?,?)";
+        } else {
+            $sql = "UPDATE " . self::TABLE_NAME . " SET `date_updated`=NOW(),`username`=?,`auth_token`=?,`active`=?"
+            . ",`app_registration_code`=?,`user_id`=?,`patient_id`=?"
+            . " WHERE `id`=?";
+        }
+
+        // grab the user first
+        if (empty($user->getUsername())) {
+            throw new \InvalidArgumentException("username cannot be empty");
+        }
+        if (empty($user->getAuthToken())) {
+            throw new \InvalidArgumentException("authToken cannot be empty");
+        }
+
+        if ($user->getIsPatient()) {
+            $binds[] = null; // no user id
+            $binds[] = $user->getDbRecordId(); // set patient id
+        } else {
+            $binds[] = $user->getDbRecordId();
+            $binds[] = null;
+        }
+
+        if (!empty($user->getId())) {
+            $binds[] = $user->getId();
+        } else {
+            if (!empty($user->getDateRegistered())) {
+                $binds[] = $user->getDateRegistered()->format(DATE_ISO8601);
+            } else {
+                $binds[] = (new \DateTime())->format(DATE_ISO8601);
+            }
+        }
+
+        return QueryUtils::sqlInsert($sql, $binds);
+    }
+
+    public function getUser($username): ?TeleHealthUser
+    {
+        $result = $this->search(['username' => $username]);
+        if ($result->hasData()) {
+            return $result->getData()[0];
+        }
+        return null;
+    }
+
+    protected function createResultRecordFromDatabaseResult($row)
+    {
+        $dateFormat = "Y-m-d H:i:s";
+        $user = new TeleHealthUser();
+        $user->setId($row['id'])
+            ->setUsername($row['username'])
+            ->setAuthToken($row['auth_token'])
+            ->setDbRecordId($row['patient_id'] ?? $row['user_id'])
+            ->setIsPatient(isset($row['patient_id']))
+            ->setIsActive($row['active'] == 1)
+            ->setRegistrationCode($row['app_registration_code']);
+
+        if (isset($row['date_registered'])) {
+            $date = \DateTime::createFromFormat($dateFormat, $row['date_registered']);
+            if ($date !== false) {
+                $user->setDateRegistered($date);
+            } else {
+                $this->logger->errorLogCaller('failed to create date_registered', ['value' => $row['date_registered']]);
+            }
+        }
+        if (isset($row['date_created'])) {
+            $date = \DateTime::createFromFormat($dateFormat, $row['date_created']);
+            if ($date !== false) {
+                $user->setDateCreated($date);
+            } else {
+                $this->logger->errorLogCaller('failed to create date_created', ['value' => $row['date_created']]);
+            }
+        }
+        if (isset($row['date_updated'])) {
+            $date = \DateTime::createFromFormat($dateFormat, $row['date_updated']);
+            if ($date !== false) {
+                $user->setDateUpdated($date);
+            } else {
+                $this->logger->errorLogCaller('failed to create date_updated', ['value' => $row['date_updated']]);
+            }
+        }
+        return $user;
+    }
+
+
+    /**
+     * Since users can't see this password and they can't change this password w/o system user intervention we are just
+     * going to generate a random uuid for the password for the user.  The algorithm can be changed in the future in
+     * the event there is a compromise and we can use the registration API to change it.  Originally we wanted to use
+     * the user's password, however, we have no easy way that OpenEMR gives us access to the password and talking with
+     * the OpenEMR Administrators the hashing algorithm can be changed on the fly w/ OpenEMR so using the hash is not a
+     * good idea either.  Since the business requirement is that users can't see their password we will generate the
+     * password and use our standard encrypt method just in case the DB is taken.
+     */
+    public function createUniquePassword()
+    {
+        $factory = new UuidFactory();
+        $uuidString = $factory->uuid4()->toString();
+        $cryptoGen = new CryptoGen();
+        // we could make this even stronger by using the API password for the encryption password...
+        // but this is probably good enough
+        return $cryptoGen->encryptStandard($uuidString);
+    }
+
+    public function decryptPassword($password)
+    {
+        $cryptoGen = new CryptoGen();
+        return $cryptoGen->decryptStandard($password);
+    }
+}

--- a/interface/modules/custom_modules/oe-form-templates/src/Service/FormTemplatesService.php
+++ b/interface/modules/custom_modules/oe-form-templates/src/Service/FormTemplatesService.php
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ *
+ */
+
+namespace OpenEMR\Modules\FormTemplates\Service;
+
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Modules\FormTemplates\Constants;
+
+class FormTemplatesService
+{
+
+    const TEMPLATE_TBL = "form_templates_template";
+
+    const FORM_TBL = "form_templates_form";
+
+    public function getRegisteredForms()
+    {
+        $rs = getRegistered();
+        $return = [];
+        foreach ($rs as $row) {
+            $_tmp = [
+                'id' => $row['directory'],
+                'name' => $row['name'],
+                'type' => 'Registered',
+            ];
+            $return[] = $_tmp;
+        }
+        return $return;
+    }
+
+    public function getLayoutForms()
+    {
+        $sql = "SELECT grp_form_id, grp_title, grp_mapping
+            FROM layout_group_properties
+            WHERE grp_group_id = '' AND grp_activity = 1
+            ORDER BY grp_mapping, grp_seq, grp_title";
+
+        $rs = QueryUtils::fetchRecords($sql);
+        $return = [];
+        foreach ($rs as $row) {
+            $_tmp = [
+                'id' => $row['grp_form_id'],
+                'name' => $row['grp_title'],
+                'type' => 'LBF',
+            ];
+            $return[] = $_tmp;
+        }
+        return $return;
+    }
+
+    public function getAllTemplates()
+    {
+        $sql = "SELECT * FROM form_templates_template WHERE active = 1";
+
+        // $sql = str_replace(["%template_tbl%, %form_tbl%"], [self::TEMPLATE_TBL, self::FORM_TBL], $sql);
+        $query = QueryUtils::fetchRecords($sql);
+
+        $return = [];
+        while ($row = QueryUtils::fetchArrayFromResultSet($query)) {
+            $return[] = $row;
+        }
+        return $return;
+    }
+
+    public function getTemplateByName(string $templateName)
+    {
+        $sql = "SELECT * FROM ";
+    }
+
+    public function saveNewTemplate(array $template)
+    {
+        $sql = "SELECT template_id FROM %TEMPLATE_TBL% WHERE form_id = ? AND template_id = ?";
+        $sql = str_replace("%TEMPLATE_TBL%", self::TEMPLATE_TBL, $sql);
+        $binds = [
+            'form_id' => $template['form_id'] ?? '2',
+            'template_id' => $template['template_id'] ?? '',
+        ];
+        $res = QueryUtils::fetchRecordsNoLog($sql, $binds);
+
+        if (count($res) > 1) {
+            throw new \Exception("More than 1 template found");
+        }
+
+        if (count($res) == 1) {
+            // @todo We have a tmeplate, update it!
+        }
+
+        $sql = "INSERT INTO %TEMPLATE_TBL% (display_name, machine_name, form_id, acl, beg_effective_date, end_effective_date, active, field_data) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
+        $sql = str_replace("%TEMPLATE_TBL%", self::TEMPLATE_TBL, $sql);
+        $res = QueryUtils::sqlInsert($sql, $template);
+
+        if (!$res) {
+            throw new \Exception("Could not save data");
+        }
+
+        return $res;
+    }
+
+    /**
+     * Save a new form
+     *
+     * @param array $form
+     * @return void
+     */
+    public function saveNewForm(array $form)
+    {
+        $sql = "SELECT form_id FROM %FORM_TBL% WHERE machine_name = ? AND method = ?";
+        $sql = str_replace("%FORM_TBL%", self::FORM_TBL, $sql);
+
+        $res = QueryUtils::fetchRecordsNoLog($sql, [$form['machine_name'], $form['method']]);
+
+        if (count($res) > 1) {
+            throw new \Exception('More than 1 form identified');
+        }
+
+        if (count($res) == 1) {
+            // @todo This is an edit
+            return $res[0]['form_id'];
+        }
+
+        $sql = "INSERT INTO %FORM_TBL% (display_name, machine_name, method, action, active) VALUES (?, ?, ?, ?, ?)";
+        $sql = $sql = str_replace("%FORM_TBL%", self::FORM_TBL, $sql);
+        $res = QueryUtils::sqlInsert($sql, $form);
+
+        return $res;
+
+    }
+}

--- a/interface/modules/custom_modules/oe-form-templates/src/TelehealthGlobalConfig.php
+++ b/interface/modules/custom_modules/oe-form-templates/src/TelehealthGlobalConfig.php
@@ -1,0 +1,176 @@
+<?php
+
+/**
+ * Contains all of the TeleHealth global settings and configuration
+ *
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2022 Comlink Inc <https://comlinkinc.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace Comlink\OpenEMR\Modules\TeleHealthModule;
+
+use OpenEMR\Common\Crypto\CryptoGen;
+use OpenEMR\Services\Globals\GlobalSetting;
+
+class TelehealthGlobalConfig
+{
+    const COMLINK_VIDEO_TELEHEALTH_API = 'comlink_telehealth_video_uri';
+    const COMLINK_VIDEO_REGISTRATION_API = 'comlink_telehealth_registration_uri';
+    const COMLINK_VIDEO_API_USER_ID = 'comlink_telehealth_user_id';
+    const COMLINK_VIDEO_API_USER_PASSWORD = 'comlink_telehealth_user_password';
+    const COMLINK_VIDEO_TELEHEALTH_CMS_ID = 'comlink_telehealth_cms_id';
+    // note patients always auto provision
+    const COMLINK_AUTO_PROVISION_PROVIDER = 'comlink_autoprovision_provider';
+    const UNIQUE_INSTALLATION_ID = "unique_installation_id";
+    const INSTALLATION_NAME  = "openemr_name";
+
+    // character length to generate for the unique registration code for the user
+    const APP_REGISTRATION_CODE_LENGTH = 12;
+
+    // TODO: @adunsulag replace this with the name of the app that comlink is using.
+    const COMLINK_MOBILE_APP_TITLE = "Comlink App";
+
+    /**
+     * @var CryptoGen
+     */
+    private $cryptoGen;
+
+    public function __construct()
+    {
+        $this->cryptoGen = new CryptoGen();
+    }
+
+    /**
+     * @return string
+     */
+    public function getAppTitle()
+    {
+        return self::COMLINK_MOBILE_APP_TITLE;
+    }
+
+    /**
+     * Returns true if all of the telehealth settings have been configured.  Otherwise it returns false.
+     * @return bool
+     */
+    public function isTelehealthConfigured()
+    {
+        $config = $this->getGlobalSettingSectionConfiguration();
+        $keys = array_keys($config);
+        foreach ($keys as $key) {
+            if ($key == $this->isOptionalSetting($key)) {
+                continue;
+            }
+            $value = $this->getGlobalSetting($key);
+
+            if (empty($value)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public function getInstitutionId()
+    {
+        return $this->getGlobalSetting(self::UNIQUE_INSTALLATION_ID);
+    }
+
+    public function getInstitutionName()
+    {
+        return $this->getGlobalSetting(self::INSTALLATION_NAME);
+    }
+
+    public function getRegistrationAPIURI()
+    {
+        return $this->getGlobalSetting(self::COMLINK_VIDEO_REGISTRATION_API);
+    }
+
+    public function getTelehealthAPIURI()
+    {
+        return $this->getGlobalSetting(self::COMLINK_VIDEO_TELEHEALTH_API);
+    }
+
+    public function getRegistrationAPIUserId()
+    {
+        return $this->getGlobalSetting(self::COMLINK_VIDEO_API_USER_ID);
+    }
+
+    public function getRegistrationAPIPassword()
+    {
+        $encryptedValue = $this->getGlobalSetting(self::COMLINK_VIDEO_API_USER_PASSWORD);
+        return $this->cryptoGen->decryptStandard($encryptedValue);
+    }
+
+    public function getRegistrationAPICmsId()
+    {
+        return $this->getGlobalSetting(self::COMLINK_VIDEO_TELEHEALTH_CMS_ID);
+    }
+
+    public function shouldAutoProvisionProviders(): bool
+    {
+        $setting = $this->getGlobalSetting(self::COMLINK_AUTO_PROVISION_PROVIDER);
+        return $setting !== "";
+    }
+
+    public function getGlobalSetting($settingKey)
+    {
+        global $GLOBALS;
+        // don't like this as php 8.1 requires this but OpenEMR works with globals and this is annoying.
+        return $GLOBALS[$settingKey] ?? null;
+    }
+
+    public function getAppRegistrationCodeLength()
+    {
+        return self::APP_REGISTRATION_CODE_LENGTH;
+    }
+
+    public function getGlobalSettingSectionConfiguration()
+    {
+        $settings = [
+            self::COMLINK_VIDEO_REGISTRATION_API => [
+                'title' => 'Telehealth Registration URI'
+                ,'description' => 'Registration endpoint URI'
+                ,'type' => GlobalSetting::DATA_TYPE_TEXT
+                ,'default' => ''
+            ]
+            ,self::COMLINK_VIDEO_TELEHEALTH_API => [
+                'title' => 'Telehealth Video API URI'
+                ,'description' => 'The URI for the video bridge api'
+                ,'type' => GlobalSetting::DATA_TYPE_TEXT
+                ,'default' => ''
+            ]
+            ,self::COMLINK_VIDEO_API_USER_ID => [
+                'title' => 'Telehealth Installation User ID'
+                ,'description' => 'This is your unique video application api user id. Contact ComLink if you have not received it'
+                ,'type' => GlobalSetting::DATA_TYPE_TEXT
+                ,'default' => ''
+            ]
+            ,self::COMLINK_VIDEO_API_USER_PASSWORD => [
+                'title' => 'Telehealth Installation User Password (Encrypted)'
+                ,'description' => 'This is your unique video application api password. Contact ComLink if you have not received it'
+                ,'type' => GlobalSetting::DATA_TYPE_ENCRYPTED
+                ,'default' => ''
+            ]
+            ,self::COMLINK_VIDEO_TELEHEALTH_CMS_ID => [
+                'title' => 'Telehealth Installation CMSID'
+                ,'description' => 'This is your unique video application CMSID. Contact ComLink if you have not received it'
+                ,'type' => GlobalSetting::DATA_TYPE_TEXT
+                ,'default' => ''
+            ]
+            ,self::COMLINK_AUTO_PROVISION_PROVIDER => [
+                'title' => 'Auto Register Providers For Telehealth'
+                ,'description' => 'Disable this setting if you will manually enable the providers you wish to be registered for Telehealth'
+                ,'type' => GlobalSetting::DATA_TYPE_BOOL
+                ,'default' => '1'
+            ]
+        ];
+        return $settings;
+    }
+
+    private function isOptionalSetting($key)
+    {
+        return $key == self::COMLINK_AUTO_PROVISION_PROVIDER;
+    }
+}

--- a/interface/modules/custom_modules/oe-form-templates/templates/configuration/base.html
+++ b/interface/modules/custom_modules/oe-form-templates/templates/configuration/base.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}{% endblock %}</title>
+    {{ setupHeader('select2') }}
+    {% block header %}{% endblock %}
+</head>
+<body>
+    {% block pre_content %}{% endblock %}
+    {% block content %}{% endblock %}
+    {% block post_content %}{% endblock %}
+</body>
+{% block post_body %}{% endblock %}
+</html>

--- a/interface/modules/custom_modules/oe-form-templates/templates/configuration/detail.html.twig
+++ b/interface/modules/custom_modules/oe-form-templates/templates/configuration/detail.html.twig
@@ -1,0 +1,202 @@
+{% extends "configuration/base.html" %}
+
+{% block title %}{{ "New Form Template"|xlt }}{% endblock %}
+
+{% block content %}
+<div class="container bg-light mt-3 py-4">
+    <div class="row">
+        <div class="col-12">
+            <form action="{{ mod_index }}?controller=configuration&action=fetchForm" id="formFetchPath">
+
+            </form>
+        </div>
+    </div>
+    <div class="mt-3" id="templateDetails">
+        <div class="form-group row">
+            <label for="templateName" class="col-sm-2 col-form-label sr-only">{{ "Template Name"|xlt }}</label>
+            <div class="col">
+                <input type="text" class="form-control" name="templateName" id="templateName" placeholder="{{ 'Template Name'|xlt }}">
+            </div>
+            <div class="col">
+                <select name="target_form" id="target_form" class="select2 form-control">
+                    <option value=""></option>
+                    {% set _prevType = "" %}
+                    {% for f in registered_forms %}
+                        {% if f.type != _prevType %}
+                            {% if f.index > 0 %}
+                                </optgroup>
+                            {% endif %}
+                            <optgroup label="{{ f.type|xlt }}">
+                        {% endif %}
+
+                        <option value="{{ f.id|attr }}" data-type="{{ f.type|attr }}">{{ f.name|xlt }}</option>
+                        {% set _prevType = f.type %}
+                    {% endfor %}
+                </select>
+            </div>
+        </div>
+        <div class="form-group row">
+            <div class="col-sm-12">
+                <textarea name="templateDescription" id="templateDescription" class="form-control" rows="3" placeholder="{{ 'Template description'|xlt }}"></textarea>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-12 mt-2">
+                <button class="btn btn-primary btn-save btn-block" type="submit" form="formTemplate" id="saveTemplateData">{{ "Save Template"|xlt }}</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="container bg-light d-none" id="loading">
+    <div class="row">
+        <div class="col-12 text-center">
+            <h2 class="display-4 m-3"><i class="fa fa-circle-notch fa-spin"></i>&nbsp;{{ "Loading Form"|xlt }}</h2>
+        </div>
+    </div>
+</div>
+
+<div class="container bg-light d-none" id="hiddenFieldsContainer">
+    <div class="row">
+        <legend class="col-12">
+            {{ "Hidden Elements"|xlt }}
+        </legend>
+    </div>
+    <div id="hiddenFieldsList"></div>
+</div>
+
+<div class="invisible" id="formTemplateContainer"></div>
+
+<template id="hiddenFieldRendererTemplate">
+    <div class="form-group row">
+        <label for="" class="col-sm-2 col-form-label"></label>
+        <div class="col-4 mt-2">
+            <input type="text" class="form-control">
+        </div>
+    </div>
+</template>
+{% endblock %}
+
+{% block post_body %}
+<script>
+window.addEventListener('DOMContentLoaded', (e) => {
+    $(".select2").select2({
+        placeholder: "{{ "Select a Template Form"|xl }}",
+        theme: "bootstrap4",
+    });
+    $("#target_form").on("change", (e) => {getBaseForm();});
+});
+
+function injectFormFrame(src)
+{
+    let url = "/interface/patient_file/encounter/load_form.php?formname=" + src;
+
+    if (document.getElementById('formFrame'))
+        document.getElementById('formFrame').remove();
+
+    let f = document.createElement('iframe');
+    document.getElementById('formTemplateContainer').append(f);
+    f.id = "formFrame";
+    f.classList.add('w-100', 'border-0');
+    f.onload = function() {
+        formFrameLoaded();
+        formSubmissionListener();
+    }
+    f.src = url;
+}
+
+function formSubmissionListener()
+{
+    let elm = document.getElementById('formFrame').contentDocument.documentElement;
+    let form = elm.querySelector('form');
+
+    if (!form)
+        return;
+
+    form.addEventListener('submit', e => {
+        e.preventDefault();
+        processTemplate();
+    });
+}
+
+function formFrameLoaded() {
+    f = document.getElementById('formFrame');
+    f.style.height = f.contentDocument.documentElement.scrollHeight + "px";
+    parseHiddenFields();
+    document.getElementById('loading').classList.add('d-none');
+    document.getElementById('hiddenFieldsContainer').classList.remove('d-none');
+    document.getElementById('formTemplateContainer').classList.remove('invisible');
+}
+
+function parseHiddenFields()
+{
+    let fields = document.getElementById('formFrame').contentDocument.querySelectorAll('input[type="hidden"]');
+    let fieldsList = document.getElementById('hiddenFieldsList');
+    let container = document.getElementById('hiddenFieldsContainer');
+
+    if (!fields) {
+        if (!container.classList.contains('d-none'))
+            container.classList.add('d-none');
+    }
+
+    fieldsList.replaceChildren();
+    let template = document.getElementById('hiddenFieldRendererTemplate');
+    fields.forEach(field => {
+        let clone = template.content.cloneNode(true);
+        let i = clone.querySelector("input");
+        let l = clone.querySelector("label");
+        field.value = (field.name == "csrf_token_form") ? "___CSRF_TOKEN___" : field.value;
+        i.name = field.name;
+        i.value = field.value;
+        l.for = field.name;
+        l.innerHTML = field.name
+        hiddenFieldsList.append(clone);
+    });
+    container.classList.remove('d-none');
+}
+
+function getBaseForm()
+{
+    document.getElementById('loading').classList.remove('d-none');
+    document.getElementById('hiddenFieldsContainer').classList.add('d-none');
+    document.getElementById('formTemplateContainer').classList.add('invisible');
+    let _select = document.getElementById('target_form');
+    let selectedForm = _select.options[_select.selectedIndex];
+    injectFormFrame(selectedForm.value);
+}
+
+function processTemplate()
+{
+    let ft = document.getElementById('formFrame').contentDocument.documentElement.querySelector('form');
+    let elms = ft.elements;
+    let templateData = new FormData(ft);
+    let _select = document.getElementById('target_form');
+    let formAction = _select.options[_select.selectedIndex].value;
+    let templateName = document.getElementById('templateName').value;
+    templateData.append('templateAction', formAction);
+    templateData.append('templateName', templateName);
+    submitTemplateData(templateData);
+}
+
+function submitTemplateData(ft)
+{
+    let url = "{{ save_template_url }}";
+    let options = {
+        method: 'POST',
+        body: ft
+    };
+
+    fetch(url, options)
+        .then((response) => {
+            if (!response.ok) {
+                throw new Error(`HTTP error! Status: ${response.status}`);
+            }
+
+            return response.body;
+        })
+        .then((response) => {
+            console.log(response);
+        });
+}
+</script>
+{% endblock %}

--- a/interface/modules/custom_modules/oe-form-templates/templates/configuration/index.html.twig
+++ b/interface/modules/custom_modules/oe-form-templates/templates/configuration/index.html.twig
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ "Form Templates"|xlt }}</title>
+    {{ setupHeader() }}
+</head>
+<body>
+    <div class="container mt-2 mb-5">
+        <div class="row">
+            <div class="col-12">
+                <h1>Form Template Engine</h1>
+            </div>
+        </div>
+        <nav class="navbar navbar-expand-lg bg-light mt-2 mb-3">
+            <div class="collapse navbar-collapse ml-auto">
+                <ul class="navbar-nav ml-0">
+                    <li class="nav-item">
+                        <a href="{{ mod_index }}?controller=configuration&action=new" class="btn btn-add btn-primary active">{{ "New Template"|xlt }}</a>
+                    </li>
+                </ul>
+            </div>
+        </nav>
+        <div class="row">
+            <div class="col-12">
+                <table class="table table-responsive table-hover">
+                    <thead>
+                        <tr>
+                            <th>Template Name</th>
+                            <th>Target Form</th>
+                            <th>&nbsp;</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for t in templates %}
+                            <tr>
+                                <td>{{ t.display_name }}</td>
+                                <td>{{ t.form_display_name }}</td>
+                                <td>Action Buttons</td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</body>
+<script>
+</script>
+</html>


### PR DESCRIPTION
Starting the PR for the form templates feature.

My approach? While creating the new form, select the form from a list, load the form like it was being loaded in an encounter into an iframe, add a listener to ensure we don't actually submit the form, instead we push it into the templates table.

- [ ] Fix the insert query to capture the template name in the correct place
- [ ] Render active templates
- [ ] Develop the process for actually injecting the template-based data into a new form entry

Plan on supporting some constant replacement expressions for things like dates, times, user, and CSFR tokens. 

Note: Still a draft, wanted to get it pushed up to GH so the community can start to take a look at the process