### PR TITLE
Fixes #6190 Portal Login Redirect

### DIFF
--- a/portal/get_patient_info.php
+++ b/portal/get_patient_info.php
@@ -27,7 +27,7 @@ session_regenerate_id(true);
 $landingpage = "index.php?site=" . urlencode($_SESSION['site_id'] ?? ($_GET['site'] ?? 'default'));
 //
 
-if (isset($_REQUEST['redirect'])) {
+if (!empty($_REQUEST['redirect'])) {
     // let's add the redirect back in case there are any errors or other problems.
     $landingpage .= "&redirect=" . urlencode($_REQUEST['redirect']);
 }
@@ -287,7 +287,7 @@ if ($userData = sqlQuery($sql, array($auth['pid']))) { // if query gets executed
 
 // now that we are authorized, we need to check for the redirect, sanitize it (or eliminate it if we can't), and then redirect
 
-if (isset($_REQUEST['redirect'])) {
+if (!empty($_REQUEST['redirect'])) {
     // for now we are only going to allow redirects to locations in the module directories, we can open this up more
     // in future requests once we consider the threat vectors
     $safeRedirect = \OpenEMR\Core\ModulesApplication::filterSafeLocalModuleFiles([$_REQUEST['redirect']]);

--- a/portal/get_patient_info.php
+++ b/portal/get_patient_info.php
@@ -27,6 +27,11 @@ session_regenerate_id(true);
 $landingpage = "index.php?site=" . urlencode($_SESSION['site_id'] ?? ($_GET['site'] ?? 'default'));
 //
 
+if (isset($_REQUEST['redirect'])) {
+    // let's add the redirect back in case there are any errors or other problems.
+    $landingpage .= "&redirect=" . urlencode($_REQUEST['redirect']);
+}
+
 // checking whether the request comes from index.php
 if (!isset($_SESSION['itsme'])) {
     OpenEMR\Common\Session\SessionUtil::portalSessionCookieDestroy();
@@ -278,6 +283,18 @@ if ($userData = sqlQuery($sql, array($auth['pid']))) { // if query gets executed
     OpenEMR\Common\Session\SessionUtil::portalSessionCookieDestroy();
     header('Location: ' . $landingpage . '&w');
     exit();
+}
+
+// now that we are authorized, we need to check for the redirect, sanitize it (or eliminate it if we can't), and then redirect
+
+if (isset($_REQUEST['redirect'])) {
+    // for now we are only going to allow redirects to locations in the module directories, we can open this up more
+    // in future requests once we consider the threat vectors
+    $safeRedirect = \OpenEMR\Core\ModulesApplication::filterSafeLocalModuleFiles([$_REQUEST['redirect']]);
+    if (!empty($safeRedirect)) {
+        header('Location: ' . $safeRedirect[0]);
+        exit();
+    }
 }
 header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
 header("Cache-Control: no-cache");

--- a/portal/index.php
+++ b/portal/index.php
@@ -403,7 +403,8 @@ if (!(isset($_SESSION['password_update']) || (!empty($GLOBALS['portal_two_pass_r
                         </div>
                     </div>
                 <?php } ?>
-                <input class="btn btn-secondary float-left" type="button" onclick="document.location.replace('./index.php?woops=1&site=<?php echo attr_url($_SESSION['site_id']); ?><?php if (!empty($redirectUrl)) { echo "&redirect=" . attr_url($redirectUrl); } ?>');" value="<?php echo xla('Cancel'); ?>" />
+                <input class="btn btn-secondary float-left" type="button" onclick="document.location.replace('./index.php?woops=1&site=<?php echo attr_url($_SESSION['site_id']); ?><?php if (!empty($redirectUrl)) {
+                    echo "&redirect=" . attr_url($redirectUrl); } ?>');" value="<?php echo xla('Cancel'); ?>" />
                 <input class="btn btn-primary float-right" type="submit" value="<?php echo xla('Log In'); ?>" />
             </form>
         <?php } elseif (!empty($GLOBALS['portal_two_pass_reset']) && !empty($GLOBALS['google_recaptcha_site_key']) && !empty($GLOBALS['google_recaptcha_secret_key']) && isset($_GET['requestNew'])) { ?>
@@ -446,7 +447,8 @@ if (!(isset($_SESSION['password_update']) || (!empty($GLOBALS['portal_two_pass_r
                                 <div class="g-recaptcha" data-sitekey="<?php echo attr($GLOBALS['google_recaptcha_site_key']); ?>" data-callback="enableVerifyBtn"></div>
                             </div>
                         </div>
-                        <input class="btn btn-secondary float-left" type="button" onclick="document.location.replace('./index.php?woops=1&site=<?php echo attr_url($_SESSION['site_id']); ?><?php if (!empty($redirectUrl)) { echo "&redirect=" . attr_url($redirectUrl); } ?>');" value="<?php echo xla('Cancel'); ?>" />
+                        <input class="btn btn-secondary float-left" type="button" onclick="document.location.replace('./index.php?woops=1&site=<?php echo attr_url($_SESSION['site_id']); ?><?php if (!empty($redirectUrl)) {
+                            echo "&redirect=" . attr_url($redirectUrl); } ?>');" value="<?php echo xla('Cancel'); ?>" />
                         <button id="submitRequest" class="btn btn-primary nextBtn float-right" type="submit" disabled="disabled"><?php echo xlt('Verify') ?></button>
                     </fieldset>
                 </div>
@@ -518,7 +520,8 @@ if (!(isset($_SESSION['password_update']) || (!empty($GLOBALS['portal_two_pass_r
                             <button class="btn btn-secondary float-left" onclick="location.replace('./account/verify.php?site=<?php echo attr_url($_SESSION['site_id']); ?>')"><?php echo xlt('Register'); ?></button>
                         <?php } ?>
                         <?php if (!empty($GLOBALS['portal_two_pass_reset']) && !empty($GLOBALS['google_recaptcha_site_key']) && !empty($GLOBALS['google_recaptcha_secret_key']) && isset($_GET['w']) && (isset($_GET['u']) || isset($_GET['p']))) { ?>
-                            <button class="btn btn-danger ml-2" onclick="location.replace('./index.php?requestNew=1&site=<?php echo attr_url($_SESSION['site_id']); ?><?php if (!empty($redirectUrl)) { echo "&redirect=" . attr_url($redirectUrl); } ?>')"><?php echo xlt('Reset Credentials'); ?></button>
+                            <button class="btn btn-danger ml-2" onclick="location.replace('./index.php?requestNew=1&site=<?php echo attr_url($_SESSION['site_id']); ?><?php if (!empty($redirectUrl)) {
+                                echo "&redirect=" . attr_url($redirectUrl); } ?>')"><?php echo xlt('Reset Credentials'); ?></button>
                         <?php } ?>
                         <button class="btn btn-success float-right" type="submit"><?php echo xlt('Log In'); ?></button>
                     </div>

--- a/portal/index.php
+++ b/portal/index.php
@@ -403,7 +403,7 @@ if (!(isset($_SESSION['password_update']) || (!empty($GLOBALS['portal_two_pass_r
                         </div>
                     </div>
                 <?php } ?>
-                <input class="btn btn-secondary float-left" type="button" onclick="document.location.replace('./index.php?woops=1&site=<?php echo attr_url($_SESSION['site_id']); ?>');" value="<?php echo xla('Cancel'); ?>" />
+                <input class="btn btn-secondary float-left" type="button" onclick="document.location.replace('./index.php?woops=1&site=<?php echo attr_url($_SESSION['site_id']); ?><?php if (!empty($redirectUrl)) { echo "&redirect=" . attr_url($redirectUrl); } ?>');" value="<?php echo xla('Cancel'); ?>" />
                 <input class="btn btn-primary float-right" type="submit" value="<?php echo xla('Log In'); ?>" />
             </form>
         <?php } elseif (!empty($GLOBALS['portal_two_pass_reset']) && !empty($GLOBALS['google_recaptcha_site_key']) && !empty($GLOBALS['google_recaptcha_secret_key']) && isset($_GET['requestNew'])) { ?>
@@ -446,7 +446,7 @@ if (!(isset($_SESSION['password_update']) || (!empty($GLOBALS['portal_two_pass_r
                                 <div class="g-recaptcha" data-sitekey="<?php echo attr($GLOBALS['google_recaptcha_site_key']); ?>" data-callback="enableVerifyBtn"></div>
                             </div>
                         </div>
-                        <input class="btn btn-secondary float-left" type="button" onclick="document.location.replace('./index.php?woops=1&site=<?php echo attr_url($_SESSION['site_id']); ?>');" value="<?php echo xla('Cancel'); ?>" />
+                        <input class="btn btn-secondary float-left" type="button" onclick="document.location.replace('./index.php?woops=1&site=<?php echo attr_url($_SESSION['site_id']); ?><?php if (!empty($redirectUrl)) { echo "&redirect=" . attr_url($redirectUrl); } ?>');" value="<?php echo xla('Cancel'); ?>" />
                         <button id="submitRequest" class="btn btn-primary nextBtn float-right" type="submit" disabled="disabled"><?php echo xlt('Verify') ?></button>
                     </fieldset>
                 </div>
@@ -518,7 +518,7 @@ if (!(isset($_SESSION['password_update']) || (!empty($GLOBALS['portal_two_pass_r
                             <button class="btn btn-secondary float-left" onclick="location.replace('./account/verify.php?site=<?php echo attr_url($_SESSION['site_id']); ?>')"><?php echo xlt('Register'); ?></button>
                         <?php } ?>
                         <?php if (!empty($GLOBALS['portal_two_pass_reset']) && !empty($GLOBALS['google_recaptcha_site_key']) && !empty($GLOBALS['google_recaptcha_secret_key']) && isset($_GET['w']) && (isset($_GET['u']) || isset($_GET['p']))) { ?>
-                            <button class="btn btn-danger ml-2" onclick="location.replace('./index.php?requestNew=1&site=<?php echo attr_url($_SESSION['site_id']); ?>')"><?php echo xlt('Reset Credentials'); ?></button>
+                            <button class="btn btn-danger ml-2" onclick="location.replace('./index.php?requestNew=1&site=<?php echo attr_url($_SESSION['site_id']); ?><?php if (!empty($redirectUrl)) { echo "&redirect=" . attr_url($redirectUrl); } ?>')"><?php echo xlt('Reset Credentials'); ?></button>
                         <?php } ?>
                         <button class="btn btn-success float-right" type="submit"><?php echo xlt('Log In'); ?></button>
                     </div>
@@ -611,7 +611,7 @@ if (!(isset($_SESSION['password_update']) || (!empty($GLOBALS['portal_two_pass_r
                     let url = "./index.php?site=" + <?php echo js_url($_SESSION['site_id']); ?>; // Goto landing page.
                     let redirectUrl = $("#redirect").val();
                     if (redirectUrl) {
-                        url += "&redirect=" + redirectUrl;
+                        url += "&redirect=" + encodeURIComponent(redirectUrl);
                     }
                     window.location.href = url;
                 } else if (action === "reset_password") {

--- a/portal/index.php
+++ b/portal/index.php
@@ -353,7 +353,7 @@ if (!(isset($_SESSION['password_update']) || (!empty($GLOBALS['portal_two_pass_r
                 <input style="display: none" type="text" name="dummyuname" />
                 <input style="display: none" type="password" name="dummypass" />
                 <?php if (isset($redirectUrl)) { ?>
-                    <input id="redirect" class="d-none" type="text" name="redirect" value="<?php echo attr($redirectUrl); ?>" />
+                    <input id="redirect" type="hidden" name="redirect" value="<?php echo attr($redirectUrl); ?>" />
                 <?php } ?>
                 <div class="form-row my-3">
                     <label class="col-md-2 col-form-label" for="uname"><?php echo xlt('Account Name'); ?></label>
@@ -410,7 +410,7 @@ if (!(isset($_SESSION['password_update']) || (!empty($GLOBALS['portal_two_pass_r
             <form id="resetPass" action="#" method="post">
                 <input type='hidden' id='csrf_token_form' name='csrf_token_form' value='<?php echo attr(CsrfUtils::collectCsrfToken('passwordResetCsrf')); ?>' />
                 <?php if (isset($redirectUrl)) { ?>
-                    <input id="redirect" class="d-none" type="text" name="redirect" value="<?php echo attr($redirectUrl); ?>" />
+                    <input id="redirect" type="hidden" name="redirect" value="<?php echo attr($redirectUrl); ?>" />
                 <?php } ?>
                 <div class="text-center">
                     <fieldset>
@@ -456,7 +456,7 @@ if (!(isset($_SESSION['password_update']) || (!empty($GLOBALS['portal_two_pass_r
         <img class="img-fluid login-logo" src='<?php echo $logoSrc; ?>'>
         <form class="text-center" action="get_patient_info.php" method="POST" onsubmit="return process()">
             <?php if (isset($redirectUrl)) { ?>
-                <input id="redirect" class="d-none" type="text" name="redirect" value="<?php echo attr($redirectUrl); ?>" />
+                <input id="redirect" type="hidden" name="redirect" value="<?php echo attr($redirectUrl); ?>" />
             <?php } ?>
             <fieldset>
                 <legend class="bg-primary text-white pt-2 py-1"><h3><?php echo xlt('Patient Portal Login'); ?></h3></legend>

--- a/portal/verify_session.php
+++ b/portal/verify_session.php
@@ -26,7 +26,11 @@ require_once(__DIR__ . "/../src/Common/Session/SessionUtil.php");
 OpenEMR\Common\Session\SessionUtil::portalSessionStart();
 
 //landing page definition -- where to go if something goes wrong
-$landingpage = "index.php?site=" . urlencode($_SESSION['site_id'] ?? null);
+// if this script is included somewhere else we want to support them changing up the landingpage url such as adding
+// parameters, or even setting what the landing page should be for the portal verify session.
+if (!isset($landingpage)) {
+    $landingpage = "index.php?site=" . urlencode($_SESSION['site_id'] ?? null);
+}
 //
 
 // kick out if patient not authenticated


### PR DESCRIPTION
Fixes #6190 

This change allows the portal page to redirect to another page other than the SPA home.php file once a user has authenticated.  In this initial release we only allow this to go to a module page that exists in the OpenEMR directory.  As needed we can open this up to other areas of the application.

The redirect param is retained across password changes and the mfa auth that is handled in the portal/index.php.

I modified the verify_sessions so that the landingpage param can be updated so the script can be used inside of other pages we want to be protected by the portal session (such as inside a module).