### PR TITLE
fix: Claim.php, loadPayerInfo(), use empty instead of equals null for legacy

### DIFF
--- a/src/Billing/Claim.php
+++ b/src/Billing/Claim.php
@@ -241,7 +241,10 @@ class Claim
 
             $ins = count($this->payers);
             if (
-                ($drow['provider'] == $billrow['payer_id'] || $billrow['payer_id'] == null) &&
+                (
+                    $drow['provider'] == $billrow['payer_id']
+                    || empty($billrow['payer_id'])
+                ) &&
                 empty($this->payers[0]['data'])
             ) {
                 $ins = 0;

--- a/src/Billing/Claim.php
+++ b/src/Billing/Claim.php
@@ -244,8 +244,8 @@ class Claim
                 (
                     $drow['provider'] == $billrow['payer_id']
                     || empty($billrow['payer_id'])
-                ) &&
-                empty($this->payers[0]['data'])
+                )
+                && empty($this->payers[0]['data'])
             ) {
                 $ins = 0;
             }

--- a/src/Billing/X125010837P.php
+++ b/src/Billing/X125010837P.php
@@ -160,7 +160,6 @@ class X125010837P
                     "*" .
                     "*" .
                     "*" .
-                    "*" .
                     "*" . "46" .
                     "*" . $claim->x12_sender_id();
                 // else use provider's group name


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:


#### Changes proposed in this pull request:
