### PR TITLE
chore: only stale-bot issues that lack info for reproduction or are unassigned

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -3,6 +3,11 @@
 daysUntilStale: 90
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 7
+# Only close triaged issues that lack reproduction / clear next steps
+onlyLabels:
+    - WaitingForInfo
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: true
 # Issues with these labels will never be considered stale
 exemptLabels:
   - pinned


### PR DESCRIPTION
Fixes #6201

Nota bene: this requires an additional label `WaitingForInfo` when maintainers decide something should be closed without further input. Feels like a fair tradeoff to me. 

... Hopefully this is the winner. Multi-user git is hard. 