### PR TITLE
fix: fix the generic_sql_affected_rows function

### DIFF
--- a/library/sql.inc.php
+++ b/library/sql.inc.php
@@ -677,7 +677,7 @@ function generic_sql_select_db($database, $link = null)
  */
 function generic_sql_affected_rows()
 {
-    return mysqli_affected_rows($GLOBALS['dbh']);
+    return $GLOBALS['adodb']['db']->affected_rows();
 }
 
 /**


### PR DESCRIPTION
fixes #6212

fix the generic_sql_affected_rows function

Guessing this is secondary to adodb libary since broken in master but not in prior 7.0.0 release. Changed the function to use a adodb function rather than a native mysqli function and appears to be working.
