### PR TITLE
Patient Portal address link Fixes #6227

### DIFF
--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -3072,7 +3072,7 @@ $GLOBALS_METADATA = array(
         ),
 
         'portal_onsite_two_register' => array(
-            xl('Allow New Patient Registration Widget'),
+            xl('Allow New Patient Registration Widget') . ' ' . xl('This requires reCAPTCHA to be setup'),
             'bool',                           // data type
             '0',
             xl('Enable Patient Portal new patient to self register.')
@@ -3107,7 +3107,7 @@ $GLOBALS_METADATA = array(
         ),
 
         'portal_two_pass_reset' => array(
-            xl('Allow Patients to Reset Credentials'),
+            xl('Allow Patients to Reset Credentials') . ' ' . xl('This requires reCAPTCHA to be setup'),
             'bool',                           // data type
             '0',
             xl('Patient may change their logon from portal login dialog.')

--- a/src/Services/PatientAccessOnsiteService.php
+++ b/src/Services/PatientAccessOnsiteService.php
@@ -121,7 +121,8 @@ class PatientAccessOnsiteService
         // Create the message
         $fhirServerConfig = new ServerConfig();
         $data = [
-            'portal_onsite_two_address' => $GLOBALS['portal_onsite_two_address']
+            'portal_onsite_two_enable' => $GLOBALS['portal_onsite_two_enable']
+            ,'portal_onsite_two_address' => $GLOBALS['portal_onsite_two_address']
             ,'enforce_signin_email' => $GLOBALS['enforce_signin_email']
             ,'uname' => $username
             ,'login_uname' => $loginUsername

--- a/templates/emails/patient/portal_login/message.html.twig
+++ b/templates/emails/patient/portal_login/message.html.twig
@@ -3,8 +3,7 @@
         <div class='wrapper'>
             {% if portal_onsite_two_enable is not empty %}
                 {{ "Patient Portal Web Address"|xlt }}:<br />
-                <a href='{{ portal_onsite_two_address|attr }}' target='_blank'>{{ portal_onsite_two_address|text }}</a>
-                <br /><br />
+                <a href='{{ portal_onsite_two_address|attr }}' target='_blank'>{{ portal_onsite_two_address|text }}</a><br /><br />
             {% endif %}
             <strong>{{ "Portal Account Name"|xlt }}</strong>: {{ uname }}<br /><br />
             <strong>{{ "Login User Name"|xlt }}:</strong> {{ login_uname|text }}

--- a/templates/emails/patient/portal_login/message.text.twig
+++ b/templates/emails/patient/portal_login/message.text.twig
@@ -1,4 +1,6 @@
-{% if portal_onsite_two_enable is not empty %}{{ "Patient Portal Web Address"|xlt }}: {{ portal_onsite_two_address|text }}{% endif %}
+{% if portal_onsite_two_enable is not empty %}
+{{ "Patient Portal Web Address"|xlt }}: {{ portal_onsite_two_address|text }}
+{% endif %}
 {{ "Portal Account Name"|xlt }}: {{ uname }}
 {{ "Login User Name"|xlt }}: {{ login_uname|text }}
 {{ "Password"|xlt }}: {{ pwd|text }}


### PR DESCRIPTION
Fixes #6227 patient portal address link not showing.

Also adds more explanation details to the globals config about patient portal configuration.

This does not address the duplicate portal email address issue yet until I get more clarification on the security fix @bradymiller was addressing in his earlier commits.