### PR TITLE
Fixes #6238

### DIFF
--- a/src/Services/AppointmentService.php
+++ b/src/Services/AppointmentService.php
@@ -138,7 +138,7 @@ class AppointmentService extends BaseService
                        f1.name as facility_name,
                        f2.name as billing_location_name
                        FROM (
-                             SELECT 
+                             SELECT
                                pc_eid,
                                uuid AS pc_uuid, -- we do this because our uuid registry requires the field to be named this way
                                pc_aid,
@@ -150,7 +150,7 @@ class AppointmentService extends BaseService
                                pc_billing_location,
                                pc_catid,
                                pc_pid
-                            FROM 
+                            FROM
                                  openemr_postcalendar_events
                        ) pce
                        LEFT JOIN facility as f1 ON pce.pc_facility = f1.id
@@ -161,7 +161,7 @@ class AppointmentService extends BaseService
                            ,lname
                            ,DOB
                            ,pid
-                           FROM 
+                           FROM
                                 patient_data
                       ) pd ON pd.pid = pce.pc_pid
                        LEFT JOIN users as providers ON pce.pc_aid = providers.id";
@@ -274,7 +274,7 @@ class AppointmentService extends BaseService
         $uuid = (new UuidRegistry())->createUuid();
 
         $sql  = " INSERT INTO openemr_postcalendar_events SET";
-        $sql .= "     uuid=?";
+        $sql .= "     uuid=?,";
         $sql .= "     pc_pid=?,";
         $sql .= "     pc_catid=?,";
         $sql .= "     pc_title=?,";


### PR DESCRIPTION
#### Short description of what this resolves:
When the POST /api/patient/{pid}/appointment standard api endpoint is called it returns the following error:

ERROR: insert failed: INSERT INTO openemr_postcalendar_events SET uuid=? pc_pid=?, pc_catid=?, pc_title=?, pc_duration=?, pc_hometext=?, pc_eventDate=?, pc_apptstatus=?, pc_startTime=?, pc_endTime=?, pc_facility=?, pc_billing_location=?, pc_informant=1, pc_eventstatus=1, pc_sharing=1, pc_aid=?

Error: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'pc_pid='1', pc_catid='5', pc_title='Office Visit', pc_duration='9...' at line 1

/var/www/localhost/htdocs/openemr/src/Services/AppointmentService.php at 297:sqlInsert
/var/www/localhost/htdocs/openemr/src/RestControllers/AppointmentRestController.php at 78:insert(1,Array)
/var/www/localhost/htdocs/openemr/_rest_routes.inc.php at 5161:post(1,Array)
/var/www/localhost/htdocs/openemr/src/Common/Http/HttpRestRouteHandler.php at 91:{closure}

#### Changes proposed in this pull request:
Added a comma after the question mark on the uuid param in the insert function on line 277 of AppointmentService.php.
