### PR TITLE
Fixes #6254 Lock down module script files to enabled modules

### DIFF
--- a/interface/globals.php
+++ b/interface/globals.php
@@ -619,6 +619,10 @@ if (!file_exists($webserver_root . "/interface/modules/")) {
             $GLOBALS['baseModDir'],
             $GLOBALS['zendModDir']
         );
+    } catch (\OpenEMR\Common\Acl\AccessDeniedException $accessDeniedException) {
+        // this occurs when the current SCRIPT_PATH is to a module that is not currently allowed to be accessed
+        http_response_code(401);
+        error_log(errorLogEscape($ex->getMessage() . $ex->getTraceAsString()));
     } catch (\Exception $ex) {
         error_log(errorLogEscape($ex->getMessage() . $ex->getTraceAsString()));
         die();

--- a/interface/modules/zend_modules/config/application.config.php
+++ b/interface/modules/zend_modules/config/application.config.php
@@ -21,23 +21,11 @@ $core_modules = [
     'PatientFlowBoard', // Handle any functionality needed for the patient flow board
 ];
 
-/**
- * Grabs the actively enabled modules from the database and injects them into the system.
- * For the list of active modules you can see them from the modules installer tab, or by querying the modules table
- * Otherwise the modules are found inside the modules/zend_modules folder.  The uninstalled script will dynamically find them
- * in the filesystem.
- */
-function oemr_zend_load_modules_from_db()
-{
-    // we skip the audit log as it has no bearing on user activity and is core system related...
-    $resultSet = sqlStatementNoLog($statement = "SELECT mod_name FROM modules WHERE mod_active = 1 AND type = 1 ORDER BY `mod_ui_order`, `date`");
-    $db_modules = [];
-    while ($row = sqlFetchArray($resultSet)) {
-        $db_modules[] = $row["mod_name"];
-    }
-    return $db_modules;
-}
-$plugin_modules = oemr_zend_load_modules_from_db();
+// $zendConfigurationPath is loaded using ModulesApplication.php from globals.php
+$plugin_modules = \OpenEMR\Core\ModulesApplication::oemr_zend_load_modules_from_db(
+    $webRootPath ?? '',
+    $zendConfigurationPath ?? ''
+);
 $vendor_path = !empty($GLOBALS['vendor_dir']) ? $GLOBALS['vendor_dir'] : (realpath(__DIR__) . '/../vendor');
 
 return [


### PR DESCRIPTION
Fixes #6254 
Adds a security check in the ModulesApplication system to check if the currently executed script is a module script file (IE its in the module directory or a sub directory).  If it does it grabs the module name and checks if the module is enabled.  If the module is not enabled it throws an AccessDenied exception.  This is caught in the globals.php file.  

So now any script that tries to use the system globals will have this security check.  I believe this is a nice clean way to make limit the attack surface of our core modules.  If they aren't enabled then there are fewer security risks for them to execute.  

I tried to make the code as efficient as possible as this essentially runs two string comparisons on every single request against the current path and the module directory.  It only incurs the db hit if it actually encounters a module file.