### PR TITLE
Snomed-CT for Spanish speaking countries

### DIFF
--- a/custom/code_types.inc.php
+++ b/custom/code_types.inc.php
@@ -155,7 +155,7 @@ array_push($code_external_tables[9][EXT_JOINS][0][JOIN_FIELDS], "FullySpecifiedN
 
 // SNOMED RF2 definitions
 define_external_table($code_external_tables, 11, 'sct2_description', 'conceptId', 'term', 'term', array("active=1"), "");
-if (isSnomedSpanish()) {
+if (isSnomedSpanishLang()) {
     define_external_table($code_external_tables, 10, 'sct2_description', 'conceptId', 'term', 'term', array("active=1", "term LIKE '%(trastorno)'"), "");
     define_external_table($code_external_tables, 12, 'sct2_description', 'conceptId', 'term', 'term', array("active=1", "term LIKE '%(procedimiento)'"), "");
 } else {
@@ -204,13 +204,13 @@ $eventDispatcher->dispatch($externalCodesEvent, ExternalCodesCreatedEvent::EVENT
 $ct_external_options = $externalCodesEvent->getExternalCodeData();
 
 /**
- *  Checks to see if using spanish snomed
+ *  Checks to see if using spanish language snomed
  */
-function isSnomedSpanish()
+function isSnomedSpanishLang()
 {
-    // See if most recent SNOMED entry is International:Spanish
+    // See if most recent SNOMED entry is International:SpanishLang
     $sql = sqlQuery("SELECT `revision_version` FROM `standardized_tables_track` WHERE `name` = 'SNOMED' ORDER BY `id` DESC");
-    if ((!empty($sql)) && ($sql['revision_version'] == "International:Spanish")) {
+    if ((!empty($sql)) && ($sql['revision_version'] == "International:SpanishLang")) {
         return true;
     }
     return false;

--- a/interface/code_systems/list_staged.php
+++ b/interface/code_systems/list_staged.php
@@ -213,6 +213,17 @@ if (is_dir($mainPATH)) {
                     $temp_date = array('date' => $date_release, 'version' => $version, 'path' => $mainPATH . "/" . $matches[0]);
                     array_push($revisions, $temp_date);
                     $supported_file = 1;
+                } elseif (preg_match("/SnomedCT_Argentina-EditionRelease_PRODUCTION_([0-9]{8})[0-9a-zA-Z]{8}.zip/", $file, $matches)) {
+                    // Hard code the version SNOMED feed to be International:SpanishLang. Argentinian format.
+                    // Contains the Snapshot, Delta and Full folders with the Argentina extension files already unified
+                    // with the Spanish and International files
+                    //
+                    $version = "International:SpanishLang";
+                    $rf2 = true;
+                    $date_release = substr($matches[1], 0, 4) . "-" . substr($matches[1], 4, -2) . "-" . substr($matches[1], 6);
+                    $temp_date = array('date' => $date_release, 'version' => $version, 'path' => $mainPATH . "/" . $matches[0]);
+                    array_push($revisions, $temp_date);
+                    $supported_file = 1;
                 } else {
                     // nothing
                 }


### PR DESCRIPTION
<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:
Muchos paises latinoamericanos de habla hispana estan usando SNOMED CT, desde hace timpo. 
https://www.snomed.org/news/snomed-ct-implementation-experiences%3A--a-spanish-language-feature-on-argentina%2C-chile%2C-spain-and-uruguay?lang=es

#### Changes proposed in this pull request: It is changed in the table standardized_tables_track International;Spanish by International:SpanishLang.
We modify the script ../interfase/code_system/list_staged.php, in this we add Snomed CT with Argentina variant and ../custom/code_type
we replace International:Spanish with International:SpanisLang