### PR TITLE
addresses the date-picker bug that prevents end user from entering in…

### DIFF
--- a/library/formatting.inc.php
+++ b/library/formatting.inc.php
@@ -178,14 +178,16 @@ function DateToYYYYMMDD($DateValue)
 
 function TimeToHHMMSS($TimeValue)
 {
-    //For now, just return the $TimeValue, since input fields are not formatting time.
-    // This can be upgraded if decided to format input time fields.
-
     if (trim($TimeValue) == '') {
         return '';
     }
 
-    return $TimeValue;
+    $is_pm = (stripos($TimeValue, 'PM') !== false || stripos($TimeValue, 'pm') !== false);
+    $dt = new DateTime('1970-01-01' . $TimeValue);
+
+
+
+    return $dt->modify('+0 hours')->format('H:i:s');;
 }
 
 

--- a/library/formatting_DateToYYYYMMDD_js.js.php
+++ b/library/formatting_DateToYYYYMMDD_js.js.php
@@ -32,13 +32,20 @@ function DateToYYYYMMDD_js(value){
 }
 
 function TimeToHHMMSS_js(value){
-    //For now, just return the Value, since input fields are not formatting time.
-    // This can be upgraded if decided to format input time fields.
+    if (value.trim() == '') {
+        return '';
+    }
+
+    var is_pm = value.trim().toUpperCase().indexOf('PM');
+    if (is_pm > 0) {
+        let d = new Date("1970-01-01 " + value);
+        let value = d.setHours(d.getHours() + 12).toTimeString();
+    }
     return value.trim();
 }
 
 function DateToYYYYMMDDHHMMSS_js(value){
-    if (typeof value === 'undefined') {
+    if (typeof value === 'undefined' || value.trim() == '') {
         return undefined;
     }
     var parts = value.split(' ');

--- a/library/js/xl/jquery-datetimepicker-2-5-4.js.php
+++ b/library/js/xl/jquery-datetimepicker-2-5-4.js.php
@@ -92,7 +92,9 @@
             <?php } ?>
         <?php } else { ?>
             <?php if ($datetimepicker_formatInput) { ?>
-                format: '<?php echo DateFormatRead("jquery-datetimepicker"); ?> H:i',
+                format: '<?php echo DateFormatRead("jquery-datetimepicker"); ?> g:i a',
+                formatTime:'g:i a',
+                validateOnBlur: false,
             <?php } else { ?>
                 format: 'Y-m-d H:i',
             <?php } ?>


### PR DESCRIPTION
Addresses Issue #6306
Issue:  The date picker causes issues when we try to manually edit it. Although this works fine for 24 hour set-up, for the people who wish to use 12-hour format the am / pm string disappears when the Date of Service is edited. The user has the option to use the 24 hour date picker, but this defeats the purpose of having a 12 hour option.
