### PR TITLE
Fixes #6363 verify telehealth settings button

### DIFF
--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Bootstrap.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Bootstrap.php
@@ -130,7 +130,7 @@ class Bootstrap
 
         $this->moduleDirectoryName = basename(dirname(__DIR__));
         $this->logger = new SystemLogger();
-        $this->globalsConfig = new TelehealthGlobalConfig($this->getURLPath(), $this->moduleDirectoryName);
+        $this->globalsConfig = new TelehealthGlobalConfig($this->getURLPath(), $this->moduleDirectoryName, $this->twig);
     }
 
     public function getTemplatePath()

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Controller/TeleconferenceRoomController.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Controller/TeleconferenceRoomController.php
@@ -23,10 +23,12 @@ use Comlink\OpenEMR\Modules\TeleHealthModule\Repository\TeleHealthUserRepository
 use Comlink\OpenEMR\Modules\TeleHealthModule\Controller\TeleHealthVideoRegistrationController;
 use Comlink\OpenEMR\Modules\TeleHealthModule\Services\FormattedPatientService;
 use Comlink\OpenEMR\Modules\TeleHealthModule\Services\ParticipantListService;
+use Comlink\OpenEMR\Modules\TeleHealthModule\Services\TelehealthConfigurationVerifier;
 use Comlink\OpenEMR\Modules\TeleHealthModule\Services\TeleHealthParticipantInvitationMailerService;
 use Comlink\OpenEMR\Modules\TeleHealthModule\Services\TeleHealthProvisioningService;
 use Comlink\OpenEMR\Modules\TeleHealthModule\TelehealthGlobalConfig;
 use Comlink\OpenEMR\Modules\TeleHealthModule\The;
+use Comlink\OpenEMR\Modules\TeleHealthModule\Util\AuthUtils;
 use Comlink\OpenEMR\Modules\TeleHealthModule\Util\CalendarUtils;
 use Comlink\OpenEMR\Modules\TeleHealthModule\Validators\TelehealthPatientValidator;
 use OpenEMR\Common\Acl\AccessDeniedException;
@@ -453,24 +455,20 @@ class TeleconferenceRoomController
 
     public function verifyInstallationSettings($queryVars)
     {
-        $config = $this->config;
-        if (!$config->isTelehealthConfigured()) {
-            echo xlt("Telehealth settings must be saved to verify configuration");
-        } else {
-//             settings have been saved... now we need to hit the remote server and verify we can talk to them
-//             TODO: we need a mechanism to verify the video bridge is working
-            $verificationResult = $this->telehealthRegistrationController->verifyProvisioningServiceIsValid();
-            if ($verificationResult['status'] == 200) {
-                echo xlt("Settings verified");
-            } else {
-                http_response_code($verificationResult['status']);
-                if ($verificationResult['status'] == 401) {
-                    echo xlt("Could not successfully communicate with provisioning server.  Check that your Telehealth registration settings are valid.");
-                } else {
-                    echo text($verificationResult['message']);
-                }
-            }
+        $configVerifier = new TelehealthConfigurationVerifier(
+            $this->logger,
+            $this->provisioningService,
+            $this->telehealthUserRepo,
+            $this->config
+        );
+        $userService = new UserService();
+        $user = $userService->getUserByUsername($queryVars['authUser']);
+        if (empty($user)) {
+            echo json_encode(['status' => 'error', 'message' => xlt("Could not find authenticated user")]);
+            return;
         }
+
+        $configVerifier->verifyInstallationSettings($user);
     }
 
     public function setAppointmentStatusAction($queryVars)
@@ -1234,7 +1232,6 @@ class TeleconferenceRoomController
     private function getApiKeyForPassword($password)
     {
         $decrypted = $this->telehealthUserRepo->decryptPassword($password);
-        $hash = hash('sha256', $decrypted);
-        return $hash;
+        return AuthUtils::getFormattedPassword($decrypted);
     }
 }

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Controller/TeleconferenceRoomController.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Controller/TeleconferenceRoomController.php
@@ -28,7 +28,7 @@ use Comlink\OpenEMR\Modules\TeleHealthModule\Services\TeleHealthParticipantInvit
 use Comlink\OpenEMR\Modules\TeleHealthModule\Services\TeleHealthProvisioningService;
 use Comlink\OpenEMR\Modules\TeleHealthModule\TelehealthGlobalConfig;
 use Comlink\OpenEMR\Modules\TeleHealthModule\The;
-use Comlink\OpenEMR\Modules\TeleHealthModule\Util\AuthUtils;
+use Comlink\OpenEMR\Modules\TeleHealthModule\Util\TelehealthAuthUtils;
 use Comlink\OpenEMR\Modules\TeleHealthModule\Util\CalendarUtils;
 use Comlink\OpenEMR\Modules\TeleHealthModule\Validators\TelehealthPatientValidator;
 use OpenEMR\Common\Acl\AccessDeniedException;
@@ -1232,6 +1232,6 @@ class TeleconferenceRoomController
     private function getApiKeyForPassword($password)
     {
         $decrypted = $this->telehealthUserRepo->decryptPassword($password);
-        return AuthUtils::getFormattedPassword($decrypted);
+        return TelehealthAuthUtils::getFormattedPassword($decrypted);
     }
 }

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Services/TelehealthConfigurationVerifier.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Services/TelehealthConfigurationVerifier.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Comlink\OpenEMR\Modules\TeleHealthModule\Services;
+
+use Comlink\OpenEMR\Modules\TeleHealthModule\Models\TeleHealthUser;
+use Comlink\OpenEMR\Modules\TeleHealthModule\Repository\TeleHealthUserRepository;
+use Comlink\OpenEMR\Modules\TeleHealthModule\TelehealthGlobalConfig;
+use Comlink\OpenEMR\Modules\TeleHealthModule\Util\AuthUtils;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use OpenEMR\Common\Http\Psr17Factory;
+use OpenEMR\Common\Logging\SystemLogger;
+
+class TelehealthConfigurationVerifier
+{
+    private Client $httpClient;
+
+    public function __construct(private SystemLogger $logger, private TeleHealthProvisioningService $provisioningService, private TeleHealthUserRepository $userRepository, private TelehealthGlobalConfig $config)
+    {
+        $this->httpClient = new Client();
+    }
+
+    public function verifyInstallationSettings($user)
+    {
+        // using a json object so we can add additional checks / messages later
+        $resultObject = [
+            'status' => 'error'
+            ,'message' => xlt('Could not verify settings')
+        ];
+
+        $config = $this->config;
+        if (!$config->isTelehealthConfigured()) {
+            $resultObject['message'] = xlt('Telehealth settings must be saved to verify configuration');
+        } else {
+            try {
+                $provider = $this->provisioningService->getOrCreateTelehealthProvider($user);
+                $bridgeSettings = $this->getVerifyBridgeSettings($provider);
+                http_response_code(200);
+                $resultObject['message'] = xlt('Settings verified');
+                $resultObject['status'] = 'success';
+                $resultObject['bridgeSettings'] = $bridgeSettings;
+            } catch (\Exception $exception) {
+                $this->logger->errorLogCaller(
+                    "Failed to verify telehealth connection settings" . $exception->getMessage(),
+                    ['trace' => $exception->getTraceAsString()]
+                );
+                $resultObject["message"] = xlt("Could not successfully communicate with telehealth servers.  Check that your Telehealth configuration settings are valid.");
+            }
+        }
+        echo json_encode($resultObject);
+    }
+
+    private function getVerifyBridgeSettings(TeleHealthUser $user)
+    {
+        $password = $this->userRepository->decryptPassword($user->getAuthToken());
+        $hashedPassword = AuthUtils::getFormattedPassword($password);
+        $data = ["userId" => $user->getUsername(), "passwordHash" => $hashedPassword
+            , "type" => "normal"
+            , 'telehealthApiUrl' => $this->config->getTelehealthAPIURI()
+            , 'successMessage' => xlj("Successfully verified settings")
+            , 'errorMessage' => xlj("Telehealth Video API URI is invalid")
+        ];
+        return $data;
+    }
+}

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Services/TelehealthConfigurationVerifier.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Services/TelehealthConfigurationVerifier.php
@@ -5,7 +5,7 @@ namespace Comlink\OpenEMR\Modules\TeleHealthModule\Services;
 use Comlink\OpenEMR\Modules\TeleHealthModule\Models\TeleHealthUser;
 use Comlink\OpenEMR\Modules\TeleHealthModule\Repository\TeleHealthUserRepository;
 use Comlink\OpenEMR\Modules\TeleHealthModule\TelehealthGlobalConfig;
-use Comlink\OpenEMR\Modules\TeleHealthModule\Util\AuthUtils;
+use Comlink\OpenEMR\Modules\TeleHealthModule\Util\TelehealthAuthUtils;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use OpenEMR\Common\Http\Psr17Factory;
@@ -53,7 +53,7 @@ class TelehealthConfigurationVerifier
     private function getVerifyBridgeSettings(TeleHealthUser $user)
     {
         $password = $this->userRepository->decryptPassword($user->getAuthToken());
-        $hashedPassword = AuthUtils::getFormattedPassword($password);
+        $hashedPassword = TelehealthAuthUtils::getFormattedPassword($password);
         $data = ["userId" => $user->getUsername(), "passwordHash" => $hashedPassword
             , "type" => "normal"
             , 'telehealthApiUrl' => $this->config->getTelehealthAPIURI()

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Util/AuthUtils.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Util/AuthUtils.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Comlink\OpenEMR\Modules\TeleHealthModule\Util;
+
+class AuthUtils
+{
+    public static function getFormattedPassword($password)
+    {
+        $hash = hash('sha256', $password);
+        return $hash;
+    }
+}

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Util/TelehealthAuthUtils.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Util/TelehealthAuthUtils.php
@@ -2,7 +2,7 @@
 
 namespace Comlink\OpenEMR\Modules\TeleHealthModule\Util;
 
-class AuthUtils
+class TelehealthAuthUtils
 {
     public static function getFormattedPassword($password)
     {

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/templates/comlink/admin/telehealth_footer_box.html.twig
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/templates/comlink/admin/telehealth_footer_box.html.twig
@@ -1,0 +1,150 @@
+<!-- bootstrap alert box for telehealth information -->
+<script>
+    (function(window) {
+
+        function verifyBridgeSettings(bridgeSettings) {
+            // first need to import the
+            let url = {{ telehealthCvbUrl|json_encode }};
+            let responseReceived = false; // used for timeout if we don't get a response from the bridge.
+            function displayResponse(type, message) {
+                let settingsContainer = document.querySelector('.section-verify-configuration-settings');
+                settingsContainer.classList.remove('d-none');
+                settingsContainer.classList.add('text-' + type);
+                // removes any html so safe to inject message
+                settingsContainer.textContent = message;
+            }
+            import(url).then((cvb) => {
+                let settings = {
+                    userId: bridgeSettings.userId
+                    ,passwordHash: bridgeSettings.passwordHash
+                    ,serviceUrl: bridgeSettings.telehealthApiUrl
+                    ,type: 'normal'
+                };
+               let videoBridge = new cvb.VideoBridge(settings);
+               videoBridge.onbridgeactive = function() {
+                   displayResponse('success', bridgeSettings.successMessage);
+                   responseReceived = true;
+                   videoBridge.shutdown();
+               };
+               videoBridge.onbridgefailure = function() {
+                   responseReceived = true;
+                   displayResponse('danger', bridgeSettings.errorMessage);
+               };
+               videoBridge.start();
+               setTimeout(function() {
+                   if (!responseReceived) {
+                       displayResponse('danger', bridgeSettings.errorMessage);
+                   }
+               }, 5000);
+            });
+        }
+
+        function verifySettings() {
+            let url = {{ verifyInstallationPathUrl|json_encode }};
+            let confirmMessage ={{ "Verifying your installation settings will provision the currently logged in user with the Telehealth service if the user is not already provisioned."|xlj }}
+            + {{ "Do you wish to proceed?"|xlj }}
+            if (confirm(confirmMessage)) {
+                let settings = document.querySelector('.section-verify-configuration-settings');
+                settings.classList.add("d-none");
+                window.fetch(url)
+                    .then(function (response) {
+                        return response.json();
+                    })
+                    .then(json => {
+                        if (json.status == 'success') {
+                            verifyBridgeSettings(json.bridgeSettings);
+                        } else {
+                            settings.classList.remove('d-none');
+                            settings.classList.add('text-danger');
+                            // removes any html so safe to inject message
+                            settings.textContent = json.message;
+                        }
+                    })
+                    .catch((error) => {
+                        console.log(error);
+                        settings.classList.remove('d-none');
+                        settings.classList.add('text-danger');
+                        settings.textContent = {{ "An error occurred while verifying your installation settings."|xlj }}
+                        + " " + {{ "Check your internet connection,try again, or contact a System Administrator"|xlj }};
+                    });
+            }
+        }
+
+        window.document.addEventListener("DOMContentLoaded", function() {
+            let comlinkBtn = document.querySelector('.btn-verify-comlink-configuration');
+            comlinkBtn.addEventListener('click', verifySettings);
+        });
+    })(window);
+</script>
+<div class="alert alert-info">
+    <details>
+        <summary class="h4">
+            {{ "Telehealth Configuration Settings Check"|xlt }}
+        </summary>
+        <ul>
+            <li class="h5">
+                {{ "Config"|xlt }} -> {{ "Telehealth"|xlt }}
+                <input type="button" class="btn btn-primary btn-verify-comlink-configuration" value="{{ "Check Telehealth Configuration" }}" />
+                <p class="d-none section-verify-configuration-settings"></p>
+                <p>
+                    {{ "The following setting must be configured in the Config Globals section for Telehealth to be enabled" }}
+                </p>
+                <ul class="h6">
+                    <li>{{ "Telehealth Registration URI"|xlt }}
+                        {% if isValidRegistrationUri %}
+{#                            <span class="text-success">{{ "Valid URL"|xlt }}</span>#}
+                        {% else %}
+                            - <span class="text-danger">{{ "Missing"|xlt }}</span>
+                        {% endif %}
+                    </li>
+                    <li>{{ "Telehealth Video API URI"|xlt }}
+                        {% if isValidTelehealthApi %}
+                            {#                            <span class="text-success">{{ "Valid URL"|xlt }}</span>#}
+                        {% else %}
+                            - <span class="text-danger">{{ "Missing"|xlt }}</span>
+                        {% endif %}
+                    </li>
+                    <li>{{ "Telehealth Installation User ID"|xlt }}</li>
+                    <li>{{ "Telehealth Installation User Password (Encrypted)"|xlt }}</li>
+                    <li>{{ "Telehealth Installation CMSID"|xlt }}</li>
+                </ul>
+            </li>
+            <li class="h5">
+                {{ "Config"|xlt }} -> {{ "Portal"|xlt }} -
+                {% if isThirdPartyConfigurationSetup %}
+                    <span class="text-success">{{ "Configured"|xlt }}</span>
+                {% else %}
+                    <span class="text-danger">{{ "Incorrect"|xlt }}</span>
+                {% endif %}
+                <p>
+                    {{ "The following settings must be configured in the Config Portal section for patients to join the telehealth session" }}
+                </p>
+                <ul class="h6">
+                    <li>{{ "Enable Patient Portal"|xlt }}</li>
+                    <li>{{ "Patient Portal Site Address"|xlt }}</li>
+                </ul>
+            </li>
+            <li class="h5">
+                {{ "Config"|xlt }} -> {{ "Notifications"|xlt }} -
+                {% if emailNotificationsConfigured %}
+                    <span class="text-success">{{ "Configured"|xlt }}</span>
+                {% else %}
+                    <span class="text-danger">{{ "Incorrect"|xlt }}</span>
+                {% endif %}
+                <p>
+                    {{ "The following settings must be configured in the Config Notifications section for Telehealth invitations to go out" }}
+                </p>
+                <ul class="h6">
+                    <li>{{ "Patient Reminder Sender Email"|xlt }}</li>
+                    <li>{{ "Email Transport Method"|xlt }}</li>
+                    <li>{{ "SMTP Server Hostname"|xlt }} - {{ "When using SMTP transport method"|xlt }}</li>
+                    <li>{{ "SMTP Server Port Number"|xlt }} - {{ "When using SMTP transport method"|xlt }}</li>
+                    <li>{{ "SMTP Security Protocol"|xlt }} - {{ "Recommended to use TLS when using SMTP transport method"|xlt }}</li>
+                    <li>{{ "SMTP User for Authentication"|xlt }} - {{ "When using SMTP transport method and SMTP Security Protocol"|xlt }}</li>
+                    <li>{{ "SMTP Password for Authentication"|xlt }} - {{ "When using SMTP transport method and SMTP Security Protocol"|xlt }}</li>
+                </ul>
+            </li>
+        </ul>
+    </details>
+
+</div>

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/templates/comlink/admin/telehealth_footer_box.html.twig
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/templates/comlink/admin/telehealth_footer_box.html.twig
@@ -84,10 +84,10 @@
         <ul>
             <li class="h5">
                 {{ "Config"|xlt }} -> {{ "Telehealth"|xlt }}
-                <input type="button" class="btn btn-primary btn-verify-comlink-configuration" value="{{ "Check Telehealth Configuration" }}" />
+                <input type="button" class="btn btn-primary btn-verify-comlink-configuration" value="{{ "Check Telehealth Configuration"|xla }}" />
                 <p class="d-none section-verify-configuration-settings"></p>
                 <p>
-                    {{ "The following setting must be configured in the Config Globals section for Telehealth to be enabled" }}
+                    {{ "The following setting must be configured in the Config Globals section for Telehealth to be enabled"|xlt }}
                 </p>
                 <ul class="h6">
                     <li>{{ "Telehealth Registration URI"|xlt }}
@@ -132,7 +132,7 @@
                     <span class="text-danger">{{ "Incorrect"|xlt }}</span>
                 {% endif %}
                 <p>
-                    {{ "The following settings must be configured in the Config Notifications section for Telehealth invitations to go out" }}
+                    {{ "The following settings must be configured in the Config Notifications section for Telehealth invitations to go out"|xlt }}
                 </p>
                 <ul class="h6">
                     <li>{{ "Patient Reminder Sender Email"|xlt }}</li>

--- a/interface/super/edit_globals.php
+++ b/interface/super/edit_globals.php
@@ -29,6 +29,7 @@ use OpenEMR\Common\Crypto\CryptoGen;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Logging\EventAuditLogger;
 use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Core\Header;
 use OpenEMR\OeUI\OemrUI;
 use OpenEMR\Services\Globals\GlobalSetting;
@@ -111,7 +112,7 @@ function checkBackgroundServices()
 {
   //load up any necessary globals
     $bgservices = sqlStatement(
-        "SELECT gl_name, gl_index, gl_value FROM globals WHERE gl_name IN 
+        "SELECT gl_name, gl_index, gl_value FROM globals WHERE gl_name IN
         (
             'phimail_enable',
             'phimail_interval',
@@ -488,6 +489,12 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                                                     $fldvalue = $userSetting;
                                                     $settingDefault = "";
                                                 }
+                                            }
+                                            if ($fldtype == GlobalSetting::DATA_TYPE_HTML_DISPLAY_SECTION) {
+                                                // if the field is an html display box we want to take over the entire real estate so we will continue from here.
+                                                include_once 'templates/field_html_display_section.php';
+                                                ++$i; // make sure we advance the iterator here...
+                                                continue;
                                             }
 
                                             if ($userMode) {

--- a/interface/super/templates/field_html_display_section.php
+++ b/interface/super/templates/field_html_display_section.php
@@ -1,0 +1,29 @@
+<?php
+
+use OpenEMR\Services\Globals\GlobalSetting;
+use OpenEMR\Common\Logging\SystemLogger;
+
+$fldid = $fldid ?? '';
+$fldarr = $fldarr ?? [];
+echo "<div class='row form-group'><div class='col-12'>";
+if (
+    isset($fldoptions[GlobalSetting::DATA_TYPE_OPTION_RENDER_CALLBACK])
+    && is_callable($fldoptions[GlobalSetting::DATA_TYPE_OPTION_RENDER_CALLBACK])
+) {
+    try {
+        $displaySection = call_user_func(
+            $fldoptions[GlobalSetting::DATA_TYPE_OPTION_RENDER_CALLBACK],
+            $fldid,
+            $fldarr
+        );
+        if (!empty($displaySection)) {
+            echo $displaySection;
+        }
+    } catch (\Exception $e) {
+        ob_end_clean();
+        (new SystemLogger())->errorLogCaller($e->getMessage(), ['trace' => $e->getMessage()]);
+        echo xlt("Error in rendering html display section.")
+            . xlt("Field name") . " '" . $fldname . "'";
+    }
+}
+echo "</div></div>";

--- a/interface/super/templates/field_html_display_section.php
+++ b/interface/super/templates/field_html_display_section.php
@@ -23,7 +23,7 @@ if (
         ob_end_clean();
         (new SystemLogger())->errorLogCaller($e->getMessage(), ['trace' => $e->getMessage()]);
         echo xlt("Error in rendering html display section.")
-            . xlt("Field name") . " '" . $fldname . "'";
+            . xlt("Field name") . " '" . text($fldname) . "'";
     }
 }
 echo "</div></div>";

--- a/src/Services/Globals/GlobalSetting.php
+++ b/src/Services/Globals/GlobalSetting.php
@@ -53,6 +53,9 @@ class GlobalSetting
     // textbox
     const DATA_TYPE_TEXT = "text";
 
+    // html display section
+    const DATA_TYPE_HTML_DISPLAY_SECTION = "html_display_section";
+
     /**
      * Multiple list box with a dropdown selector to add list items.  Items can be re-arranged in order.  Selected
      * list items save the options property of the list into the globals setting.  Multiple values are separated by a
@@ -63,7 +66,7 @@ class GlobalSetting
     /**
      * Add to this list if the field supports options
      */
-    const DATA_TYPES_WITH_OPTIONS = [self::DATA_TYPE_MULTI_SORTED_LIST_SELECTOR];
+    const DATA_TYPES_WITH_OPTIONS = [self::DATA_TYPE_MULTI_SORTED_LIST_SELECTOR, self::DATA_TYPE_HTML_DISPLAY_SECTION];
 
     /**
      * Mappings of the data types and the options they support
@@ -72,9 +75,14 @@ class GlobalSetting
         self::DATA_TYPE_MULTI_SORTED_LIST_SELECTOR => [
             self::DATA_TYPE_OPTION_LIST_ID
         ]
+        ,self::DATA_TYPE_HTML_DISPLAY_SECTION => [
+            self::DATA_TYPE_OPTION_RENDER_CALLBACK
+        ]
     ];
 
     const DATA_TYPE_OPTION_LIST_ID = 'list_id';
+
+    const DATA_TYPE_OPTION_RENDER_CALLBACK = 'render_callback';
 
     protected $label = null;
     /**


### PR DESCRIPTION
Added the ability to verify the telehealth configuration settings to the Telehealth settings.

Also added a new GlobalSetting option to provide html sections to the global settings.  That way information boxes and any other custom large display of code for the settings can be displayed in the GlobalsConfiguration area.

