### PR TITLE
Fix first party cookie redirect with post submit

### DIFF
--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/public/index-portal.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/public/index-portal.php
@@ -25,12 +25,6 @@ if (!empty($query)) {
 $landingpage = $basePath . "portal/index.php?site=" . urlencode($_GET['site_id'] ?? '') . "&redirect=" . urlencode($redirect);
 $skipLandingPageError = true;
 
-// TODO include after we securely pass session id.
-/*if (!empty($_REQUEST['me'] ?? null) && empty($_SESSION ?? null)) {
-    session_id($_REQUEST['me']);
-    session_start();
-}*/
-
 // since we are working inside the portal we have to use the portal session verification logic here...
 require_once "../../../../../portal/verify_session.php";
 

--- a/portal/index.php
+++ b/portal/index.php
@@ -75,7 +75,6 @@ if (isset($_GET['woops'])) {
  * and compared to portal credential account id lookup.
  * */
 if (!empty($_REQUEST['service_auth'] ?? null)) {
-
     if (!empty($_GET['service_auth'] ?? null)) {
         // we have to setup the csrf key to preven CSRF Login attacks
         // we also implement this mechanism in order to handle Same-Site cookie blocking when being referred by
@@ -92,8 +91,7 @@ if (!empty($_REQUEST['service_auth'] ?? null)) {
             'images_static_relative' => $GLOBALS['images_static_relative'] ?? ''
         ]);
         exit;
-    }
-    else if (!empty($_POST['service_auth'] ?? null)) {
+    } else if (!empty($_POST['service_auth'] ?? null)) {
         $token = $_POST['service_auth'];
         $redirect_token = $_POST['target'] ?? null;
         $csrfToken = $_POST['csrf_token'] ?? null;

--- a/templates/portal/login/autologin.html.twig
+++ b/templates/portal/login/autologin.html.twig
@@ -1,0 +1,54 @@
+{#
+# Patient telehealth auto login
+#
+# @package openemr
+# @link      http://www.open-emr.org
+# @author    Stephen Nielson <snielson@discoverandchange.com>
+# @copyright Copyright (c) 2023 Comlink Inc <https://comlinkinc.com/>
+# @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+#}
+
+{# Note that this is the global core portal template we are extending #}
+{% extends "portal/base.html.twig" %}
+{% block head %}
+    {{ parent() }}
+
+{% endblock %}
+{% block pagetitle %}
+    {{ pagetitle | text }}
+{% endblock %}
+{% block header %}
+    <nav id="topNav" class="navbar navbar-expand-lg navbar-light bg-light sticky-top">
+        <div class="navbar-brand">
+            <img class="img-fluid" width="140" src="{{ images_static_relative | attr }}/logo-full-con.png"/>
+        </div>
+    </nav>
+{% endblock %}
+{% block content %}
+    <div class="card overflow-auto text-center">
+        <header class="card-header bg-primary text-light">
+            <h1>{{ 'Authenticating Login Session' | xlt }}</h1>
+        </header>
+        <h5 class="m-5">{{ "Please wait while we authenticate your session"|xlt }}</h5>
+        <form method="POST" id="autologinform" action="{{ action }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token|attr }}" />
+            <input type="hidden" name="service_auth" value="{{ service_auth|attr }}" />
+            <input type="hidden" name="target" value="{{ target|attr_url }}" />
+            <input class="btn btn-lg btn-primary" type="submit" name="autoLoginSubmit" value="{{ "Go To Destination"|attr }}" />
+        </form>
+        <p>{{ "If you have not been redirected in a few seconds click the button above" }}</p>
+        <p>{{ "You will be sent to the following web page"|xlt }} {{ target|text }}</p>
+    </div>
+    <script>
+        (function() {
+            window.addEventListener("DOMContentLoaded", function() {
+                let form = window.document.getElementById("autologinform");
+                if (!form) {
+                    console.error("Failed to find autologinform");
+                    return;
+                }
+                form.submit(); // submit the form as soon as we load to start the session
+            });
+        })(window);
+    </script>
+{% endblock %}


### PR DESCRIPTION
We had a bug in gmail and other browser based email programs trying to use the one time login which would have their cookies blocked and the sessions would be lost.

Changed up the process so it takes the sso request and then submits it as a post request automatically via javascript.  User has a button to do the submission as well manually if anything goes wrong.

Also added CSRF protection to this.