### PR TITLE
Feat openemr thirdparty onetime invitations

### DIFF
--- a/interface/main/calendar/add_edit_event.php
+++ b/interface/main/calendar/add_edit_event.php
@@ -1084,6 +1084,11 @@ function setpatient(pid, lname, fname, dob) {
     f.form_pid.value = pid;
     dobstyle = (dob == '' || dob.substr(5, 10) == '00-00') ? '' : 'none';
     document.getElementById('dob_row').style.display = dobstyle;
+    let event = new CustomEvent('openemr:appointment:patient:set', {
+        bubbles: true
+        ,detail: {form: f, pid: pid, lname: lname, fname: fname, dob: dob}
+    });
+    f.dispatchEvent(event);
 }
 
 // This invokes the find-patient popup.

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/public/assets/js/telehealth-appointment.js
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/public/assets/js/telehealth-appointment.js
@@ -13,6 +13,7 @@
      * @type {string} The path of where the module is installed at.  In a multisite we pull this from the server configuration, otherwise we default here
      */
     let moduleLocation = comlink.settings.modulePath || '/interface/modules/custom_modules/oe-module-comlink-telehealth/';
+    let csrfToken = comlink.settings.apiCSRFToken || "";
 
     let defaultTranslations = {
     };
@@ -72,6 +73,21 @@
         }
     }
 
+    function isCategoryTelehealth(category, telehealthCategories) {
+        let value = +(category || 0);
+        if (value > 0 && telehealthCategories.indexOf(value) !== -1) {
+            return true;
+        }
+        else {
+            return false;
+        }
+    }
+
+    function getValidationDiv(form) {
+        let validationDiv = form.querySelector(".patient-validation-div");
+        return validationDiv;
+    }
+
     function updateAppointmentScreenForCategory(category, telehealthProviders, telehealthCategories) {
 
         let node = window.document.querySelector("#form_category");
@@ -79,6 +95,7 @@
             console.error("Failed to find node with selector #form_category");
             return;
         }
+        let form = window.document.querySelector("#theform");
 
         // setup the change order
         // if the current category has an id of one of the telehealth categories
@@ -86,16 +103,89 @@
         // telehealth provider lists
         // Note this will probably max out at a few thousand providers... so if an OpenEMR install is larger than that
         // this will need to be adjusted.
-        let value = +(node.value || 0);
-        if (value > 0 && telehealthCategories.indexOf(value) !== -1) {
+        if (isCategoryTelehealth(node.value, telehealthCategories)) {
             // now let's hide our providers
             hideInvalidTelehealthProviders(telehealthProviders);
+            // if we have a patient, let's go ahead and validate.
+            let formPid = form.form_pid.value || 0;
+            if (formPid) {
+                validatePatientForTelehealthForm(form, formPid, telehealthCategories);
+            }
         } else {
             displayAllProviders();
+            let validationDiv = getValidationDiv(form);
+            validationDiv.classList.add('d-none');
+
         }
     }
+    function validatePatientForTelehealthForm(form, patientId, telehealthCategories) {
 
-    function initAppointmentWithTelehealth(telehealthProviders, telehealthCategories) {
+        // now we need to check if the patient is setup for telehealth
+        let url = moduleLocation + 'public/index.php?action=patient_validate_telehealth_ready&validatePid=' + patientId;
+        // first show a message saying validating patient for telehealth appointment
+        let validationDiv = form.querySelector(".patient-validation-div");
+        validationDiv.innerText = translations.PATIENT_SETUP_FOR_TELEHEALTH_VALIDATING || "Checking if patient is setup for telehealth appointment...";
+        validationDiv.classList.remove('d-none');
+        validationDiv.classList.remove("alert-info");
+        validationDiv.classList.remove("alert-success");
+        validationDiv.classList.remove("alert-danger");
+        validationDiv.classList.add("alert-info");
+        let headers = {
+            'apicsrftoken': csrfToken
+        };
+        window.fetch(url, {
+            method: 'GET'
+            ,redirect: 'manual'
+            ,headers: headers
+        }).then(result => {
+            if (result.status == 400 || result.status == 401 || (result.ok && result.status == 200)) {
+                return result.json();
+            } else {
+                throw new Error("Failed to validate patient " + this.pid
+                    + " for telehealth data");
+            }
+        })
+            .then(data => {
+                validationDiv.classList.remove("alert-info");
+                if (data && data.success === true) {
+                    validationDiv.classList.add("alert-success");
+                    validationDiv.innerText = translations.PATIENT_SETUP_FOR_TELEHEALTH_SUCCESS || "Patient has portal credentials and is setup for telehealth sessions";
+                } else {
+                    validationDiv.classList.add("alert-danger");
+                    // we need to display an error message to the user
+                    validationDiv.innerText = translations.PATIENT_SETUP_FOR_TELEHEALTH_FAILED || "Failed to validate patient for telehealth appointment";
+                }
+            })
+            .catch(error => {
+                console.error(error);
+                validationDiv.classList.remove("alert-info");
+                validationDiv.classList.add("alert-danger");
+                // we need to display an error message to the user
+                validationDiv.innerText = translations.PATIENT_SETUP_FOR_TELEHEALTH_FAILED || "Failed to validate patient for telehealth appointment";
+            });
+    }
+    function validatePatientForTelehealth(evt, telehealthCategories) {
+        if (!evt.detail)
+        {
+            console.error("validatePatientForTelehealth() - Failed to find detail object on event");
+            return;
+        }
+        let node = window.document.querySelector("#form_category");
+        if (!node) {
+            console.error("Failed to find node with selector #form_category");
+            return;
+        }
+        if (!isCategoryTelehealth(node.value, telehealthCategories)) {
+            console.log("validatePatientForTelehealth() - category is not a telehealth category, skipping validation");
+            return;
+        }
+
+        let patientId = evt.detail.pid;
+        let form = evt.detail.form;
+        validatePatientForTelehealthForm(form, patientId, telehealthCategories);
+    }
+
+    function initAppointmentWithTelehealth(telehealthProviders, telehealthCategories, jsEventNames) {
         let node = window.document.querySelector("#form_category");
         if (!node) {
             console.error("Failed to find node with selector #form_category");
@@ -109,6 +199,15 @@
 
         // go with the initial value
         updateAppointmentScreenForCategory(node.value, telehealthProviders, telehealthCategories);
+
+        // now we need to handle when the patient is selected to do some backend validation and display messages
+        // if the patient is not setup properly for a telehealth session
+        let appointmentForm = document.getElementById('theform');
+        if (appointmentForm) {
+            appointmentForm.addEventListener(jsEventNames.appointmentSetEvent, function(evt) {
+                validatePatientForTelehealth(evt, telehealthCategories);
+            });
+        }
     }
 
     comlink.initAppointmentWithTelehealth = initAppointmentWithTelehealth;

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/public/assets/js/telehealth-appointment.js
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/public/assets/js/telehealth-appointment.js
@@ -121,7 +121,7 @@
     function validatePatientForTelehealthForm(form, patientId, telehealthCategories) {
 
         // now we need to check if the patient is setup for telehealth
-        let url = moduleLocation + 'public/index.php?action=patient_validate_telehealth_ready&validatePid=' + patientId;
+        let url = moduleLocation + 'public/index.php?action=patient_validate_telehealth_ready&validatePid=' + encodeURIComponent(patientId);
         // first show a message saying validating patient for telehealth appointment
         let validationDiv = form.querySelector(".patient-validation-div");
         validationDiv.innerText = translations.PATIENT_SETUP_FOR_TELEHEALTH_VALIDATING || "Checking if patient is setup for telehealth appointment...";

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/public/index-portal.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/public/index-portal.php
@@ -39,7 +39,9 @@ use Comlink\OpenEMR\Modules\TeleHealthModule\Bootstrap;
 $kernel = $GLOBALS['kernel'];
 $bootstrap = new Bootstrap($kernel->getEventDispatcher(), $kernel);
 $roomController = $bootstrap->getTeleconferenceRoomController(true);
-
+if (!empty($_SERVER['HTTP_APICSRFTOKEN'])) {
+    $queryVars['csrf_token'] = $_SERVER['HTTP_APICSRFTOKEN'];
+}
 $action = $_GET['action'] ?? '';
 $queryVars = $_GET ?? [];
 $queryVars['pid'] = $_SESSION['pid']; // we overwrite any pid value to make sure we only grab this patient.

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/public/index.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/public/index.php
@@ -23,5 +23,8 @@ $action = $_REQUEST['action'] ?? '';
 $queryVars = $_REQUEST ?? [];
 $queryVars['pid'] = $_SESSION['pid'] ?? null;
 $queryVars['authUser'] = $_SESSION['authUser'] ?? null;
+if (!empty($_SERVER['HTTP_APICSRFTOKEN'])) {
+    $queryVars['csrf_token'] = $_SERVER['HTTP_APICSRFTOKEN'];
+}
 $roomController->dispatch($action, $queryVars);
 exit;

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Controller/TeleHealthCalendarController.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Controller/TeleHealthCalendarController.php
@@ -153,12 +153,14 @@ class TeleHealthCalendarController
             'appointmentSetEvent' => AppointmentJavascriptEventNames::APPOINTMENT_PATIENT_SET_EVENT
         ];
         //
-        echo $this->twig->render("comlink/appointment/add_edit_event.js.twig",
+        echo $this->twig->render(
+            "comlink/appointment/add_edit_event.js.twig",
             [
                 'appt' => $appt
                 , 'providers' => $providerIds, 'categories' => $categoryIds
                 , 'jsAppointmentEventNames' => $jsAppointmentEventNames
-            ]);
+            ]
+        );
     }
 
     public function addCalendarJavascript(ScriptFilterEvent $event)
@@ -190,7 +192,8 @@ class TeleHealthCalendarController
         }
     }
 
-    public function renderPatientValidationDiv(AppointmentRenderEvent $event) {
+    public function renderPatientValidationDiv(AppointmentRenderEvent $event)
+    {
         echo "<div class='patient-validation-div d-none alert mt-1 mb-1'></div>";
     }
     public function renderAppointmentsLaunchSessionButton(AppointmentRenderEvent $event)

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Controller/TeleHealthFrontendSettingsController.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Controller/TeleHealthFrontendSettingsController.php
@@ -104,7 +104,7 @@ class TeleHealthFrontendSettingsController
                 'PATIENT_INVITATION_FAILURE' => xl("There was an error in generating the session link, try again or contact support"),
                 'PATIENT_SETUP_FOR_TELEHEALTH_SUCCESS' => xl("Patient has portal credentials and is setup for telehealth sessions"),
                 'PATIENT_SETUP_FOR_TELEHEALTH_FAILED' => xl("Patient is missing portal credentials, has not authorized the portal, or has not verified their email address."),
-                'PATIENT_SETUP_FOR_TELEHEALTH_VALIDATING' => xl( "Checking if patient is setup for telehealth appointment...")
+                'PATIENT_SETUP_FOR_TELEHEALTH_VALIDATING' => xl("Checking if patient is setup for telehealth appointment...")
         ];
         return $translations;
     }

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Controller/TeleHealthFrontendSettingsController.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Controller/TeleHealthFrontendSettingsController.php
@@ -102,6 +102,9 @@ class TeleHealthFrontendSettingsController
                 'PATIENT_CREATE_INVALID_NAME' => xl("Patient name is missing, or invalid"),
                 'PATIENT_INVITATION_GENERATED' => xl("Session Link Generated"),
                 'PATIENT_INVITATION_FAILURE' => xl("There was an error in generating the session link, try again or contact support"),
+                'PATIENT_SETUP_FOR_TELEHEALTH_SUCCESS' => xl("Patient has portal credentials and is setup for telehealth sessions"),
+                'PATIENT_SETUP_FOR_TELEHEALTH_FAILED' => xl("Patient is missing portal credentials, has not authorized the portal, or has not verified their email address."),
+                'PATIENT_SETUP_FOR_TELEHEALTH_VALIDATING' => xl( "Checking if patient is setup for telehealth appointment...")
         ];
         return $translations;
     }

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Controller/TeleconferenceRoomController.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Controller/TeleconferenceRoomController.php
@@ -348,7 +348,7 @@ class TeleconferenceRoomController
             // note we are NOT intentionally using $queryVars['pid'] here as we want to validate the pid that is being passed in
             // the appointment creator can choose a different patient than the one that is currently selected in the pid
             // we still need to make sure they have an ACL check.
-
+            // note this will stop portal access for patients as we don't want them to have access to this api.
             if (!AclMain::aclCheckCore('patients', 'appt')) {
                 throw new AccessDeniedException("patients", "appt", "Does not have ACL permission to patient appointments");
             }

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Controller/TeleconferenceRoomController.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Controller/TeleconferenceRoomController.php
@@ -328,7 +328,8 @@ class TeleconferenceRoomController
         }
     }
 
-    public function validatePatientIsTelehealthReadyAction($queryVars) {
+    public function validatePatientIsTelehealthReadyAction($queryVars)
+    {
 
         // grab the patient pid from the query vars
         // verify the current user can access patient demographics via the acl

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/templates/comlink/appointment/add_edit_event.js.twig
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/templates/comlink/appointment/add_edit_event.js.twig
@@ -3,9 +3,10 @@
     // call our init function with our variables
     let teleHealthProviders = {{ providers|json_encode }};
     let telehealthCategories = {{ categories|json_encode }};
+    let jsAppointmentEventNames = {{ jsAppointmentEventNames|json_encode }};
     if (comlink.initAppointmentWithTelehealth) {
         window.document.addEventListener("DOMContentLoaded", function() {
-            comlink.initAppointmentWithTelehealth(teleHealthProviders, telehealthCategories);
+            comlink.initAppointmentWithTelehealth(teleHealthProviders, telehealthCategories, jsAppointmentEventNames);
         });
     }
 })(window, window.comlink || {});

--- a/src/Events/Appointments/AppointmentJavascriptEventNames.php
+++ b/src/Events/Appointments/AppointmentJavascriptEventNames.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * AppointmentJavascriptEventNames class holds an array of javascript event names
  *

--- a/src/Events/Appointments/AppointmentJavascriptEventNames.php
+++ b/src/Events/Appointments/AppointmentJavascriptEventNames.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * AppointmentJavascriptEventNames class holds an array of javascript event names
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ *
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\Appointments;
+
+class AppointmentJavascriptEventNames
+{
+    /**
+     * This event is triggered in javascript when a patient is selected for an appointment in the add_edit_event.php class
+     * It fires on the form element that contains the appointment data and bubbles up.
+     * <example>
+     * const form = document.querySelector("form"); // could also use body since this bubbles up
+     * form.addEventListener("openemr:appointment:patient:set", (event) => {
+     *  console.log(event.detail.form); // the form that the patient was set in
+     *  console.log(event.detail.pid); // the pid of the patient that was set
+     *  console.log(event.detail); // for the remainder of the data passed in the event
+     * });
+     * </example>
+     * @see add_edit_event.php
+     */
+    const APPOINTMENT_PATIENT_SET_EVENT = 'openemr:appointment:patient:set';
+}


### PR DESCRIPTION
Fixes #6371 

Implemented a generate invite link feature since we have to dynamically
generate an invite link now for the one time login links.  Since the
links are generated on the backend server we have to have a two step
process for grabbing the session link.  First the link is generated and
inserted into the DOM and then the browser can copy the link and the
invitation.  Firefox and safari block the copy feature when the copied
content is generated asynchronously.

Fixed the settings stuff that got lost during the merge conflict.

Added a setting option to configure the expiration time on the the one
time links.  Has a minimum of 1 minute and a maximum of 30 minutes.  If
the setting is missing or invalid it defaults to 15 minutes.

Fixed the display of the request media permissions prompt.

Fixed some javascript errors when the conference room shuts down.

Fixed bug with the plain text email invitations missing the join link.

Implemented the ability to validate a patient is setup properly for
telehealth (with a valid email, portal turned on, etc) and able to
receive a one time login link as needed.

Added a feature to the add_edit_event in the calendar to fire off a
javascript custom event when the patient is selected.  Module writers
can tie into this event to do custom logic when the patient changes.
I use this to verify that the patient is setup properly for telehealth.
The messages are hidden and displayed based on the telehealth
category chosen.