### PR TITLE
fix: set deleted flag for forms when delete person

### DIFF
--- a/interface/patient_file/deleter.php
+++ b/interface/patient_file/deleter.php
@@ -240,7 +240,8 @@ function popup_close() {
                     row_modify(
                         "forms",
                         "deleted = 1",
-                        "pid = '" . $row['pid'] . "' AND form_id = '" . $row['form_id'] . "'"
+                        "pid = '" . add_escape_custom($row['pid']) .
+                            "' AND form_id = '" . add_escape_custom($row['form_id']) . "'"
                     );
                 }
 

--- a/interface/patient_file/deleter.php
+++ b/interface/patient_file/deleter.php
@@ -169,8 +169,6 @@ function form_delete($formdir, $formid, $patient_id, $encounter_id)
         }
         row_delete("form_eye_mag_impplan", "form_id = '" . add_escape_custom($formid) . "'");
         row_delete("form_eye_mag_wearing", "FORM_ID = '" . add_escape_custom($formid) . "'");
-    } elseif ($formdir == 'HIS') {
-        // when history form is entered in portal, just ignore...
     } else {
         row_delete("form_$formdir", "id = '" . add_escape_custom($formid) . "'");
     }
@@ -239,10 +237,12 @@ function popup_close() {
 
                 $res = sqlStatement("SELECT * FROM forms WHERE pid = ?", array($patient));
                 while ($row = sqlFetchArray($res)) {
-                    form_delete($row['formdir'], $row['form_id'], $row['pid'], $row['encounter']);
+                    row_modify(
+                        "forms",
+                        "deleted = 1",
+                        "pid = '" . $row['pid'] . "' AND form_id = '" . $row['form_id'] . "'"
+                    );
                 }
-
-                row_delete("forms", "pid = '" . add_escape_custom($patient) . "'");
 
                 // Delete all documents for the patient.
                 $res = sqlStatement("SELECT id FROM documents WHERE foreign_id = ? AND deleted = 0", array($patient));


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #6319 

#### Short description of what this resolves:
instead of deleting forms we can set the deleted flag to 1 and this also avoids having to manage the different names of the `form_dir` created via the portal

#### Changes proposed in this pull request:
