### PR TITLE
Fix encounter location to provide facility data

### DIFF
--- a/src/Services/FHIR/FhirLocationService.php
+++ b/src/Services/FHIR/FhirLocationService.php
@@ -169,12 +169,33 @@ class FhirLocationService extends FhirServiceBase implements IFhirExportableReso
         // even though its not a patient compartment issue we still don't want certain location data such as clinician home addresses
         // being returned... or other patient locations...  Wierd that its not in the patient compartment
         if (!empty($this->patientUuid)) {
-            // when we are patient bound we only want facility data returned or return just that patient's information.
-            $patientType = new CompositeSearchField('patient-type', [], false);
+            // if there is no uuid search field this becomes
+            //      (table_uuid = ? and type = 'patient') OR (type = 'facility')
+            // if there is an uuid search field this becomes:
+            //      (table_uuid = ? and type = 'patient' and uuid = ?) OR (type = 'facility' AND uuid = ?)
+
+            $patientType = new CompositeSearchField('patient-type', [], true);
             // patient id is the target_uuid, the uuid column is the mapped 'Location' resource in FHIR
             $patientType->addChild(new TokenSearchField('table_uuid', [new TokenSearchValue($this->patientUuid, null, true)]));
-            $patientType->addChild(new TokenSearchField('type', [new TokenSearchValue(LocationService::TYPE_FACILITY)]));
-            $openEMRSearchParameters['patient-type'] = $patientType;
+            $patientType->addChild(new TokenSearchField('type', [new TokenSearchValue(LocationService::TYPE_PATIENT)]));
+
+            $facilityType = new CompositeSearchField('facility-type', [], true);
+            $facilityType->addChild(new TokenSearchField('type', [new TokenSearchValue(LocationService::TYPE_FACILITY)]));
+
+            if (!empty($openEMRSearchParameters['uuid'])) {
+                // id must match the patient type as well
+                $patientType->addChild($openEMRSearchParameters['uuid']);
+
+                // or id must match the facility location
+                $facilityType->addChild($openEMRSearchParameters['uuid']);
+                unset($openEMRSearchParameters['uuid']);
+            }
+
+            // if we are patient bound we want to make sure we grab only patient locations or facility locations
+            $patientFacilityType = new CompositeSearchField('patient-facility-type', [], false);
+            $patientFacilityType->addChild($facilityType);
+            $patientFacilityType->addChild($patientType);
+            $openEMRSearchParameters['patient-facility-type'] = $patientFacilityType;
         }
         return $this->locationService->getAll($openEMRSearchParameters, false);
     }


### PR DESCRIPTION
Fixes #6384 

The facility data was being excluded in a patient bound context.  If the access token is bound to a patient context it will return the patient location data when requesting a specific facility location id.  This was due to the OR clause in the patient bound search.

Fixed up the search query binding so patients get their own data or the facility data but it still prevents access to other patient data.
