### PR TITLE
Bug openemr fix 6389 telehealth bugs

### DIFF
--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Controller/TeleHealthVideoRegistrationController.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Controller/TeleHealthVideoRegistrationController.php
@@ -281,7 +281,7 @@ class TeleHealthVideoRegistrationController
 
     public function resumeUser(string $username, string $password): bool
     {
-        return $this->remoteService->suspendUser($username, $password);
+        return $this->remoteService->resumeUser($username, $password);
     }
 
     public function deactivateUser(string $username, string $password)

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Services/TeleHealthRemoteRegistrationService.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Services/TeleHealthRemoteRegistrationService.php
@@ -285,6 +285,8 @@ class TeleHealthRemoteRegistrationService
         if ($response['status'] != 200) {
             $this->logger->errorLogCaller("Failed to suspend user", ['username' => $username, 'response' => $response]);
             return false;
+        } else {
+            $this->logger->debug("Suspended user on comlink api ", ['username' => $username]);
         }
         $dbUserRecord->setIsActive(false);
         $this->userRepository->saveUser($dbUserRecord);
@@ -308,6 +310,8 @@ class TeleHealthRemoteRegistrationService
         if ($response['status'] != 200) {
             $this->logger->errorLogCaller("Failed to resume user", ['username' => $username, 'response' => $response]);
             return false;
+        } else {
+            $this->logger->debug("Resumed user on comlink api ", ['username' => $username]);
         }
         $dbUserRecord->setIsActive(true);
         $this->userRepository->saveUser($dbUserRecord);
@@ -329,6 +333,8 @@ class TeleHealthRemoteRegistrationService
         if ($response['status'] != 200) {
             $this->logger->errorLogCaller("Failed to deactivate user", ['username' => $username, 'response' => $response]);
             return false;
+        } else {
+            $this->logger->debug("Deactivated user on comlink api ", ['username' => $username]);
         }
         $dbUserRecord->setIsActive(false);
         $this->userRepository->saveUser($dbUserRecord);

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Services/TelehealthConfigurationVerifier.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Services/TelehealthConfigurationVerifier.php
@@ -37,8 +37,10 @@ class TelehealthConfigurationVerifier
         ];
 
         $config = $this->config;
-        if (!$config->isTelehealthConfigured()) {
+        if (!$config->isTelehealthCoreSettingsConfigured()) { // no settings saved, means we can't continue.
             $resultObject['message'] = xlt('Telehealth settings must be saved to verify configuration');
+        } elseif (!$config->isTelehealthConfigured()) {
+            $resultObject['message'] = xlt('Telehealth settings portal is not setup for patient session invitations');
         } else {
             try {
                 // for existing users we need to make sure we can issue operations on the user so we are going to

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/templates/comlink/admin/telehealth_footer_box.html.twig
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/templates/comlink/admin/telehealth_footer_box.html.twig
@@ -9,6 +9,9 @@
             function displayResponse(type, message) {
                 let settingsContainer = document.querySelector('.section-verify-configuration-settings');
                 settingsContainer.classList.remove('d-none');
+                settingsContainer.classList.remove('text-success');
+                settingsContainer.classList.remove('text-danger');
+                settingsContainer.classList.remove('text-info');
                 settingsContainer.classList.add('text-' + type);
                 // removes any html so safe to inject message
                 settingsContainer.textContent = message;
@@ -46,6 +49,9 @@
             if (confirm(confirmMessage)) {
                 let settings = document.querySelector('.section-verify-configuration-settings');
                 settings.classList.add("d-none");
+                settings.classList.remove('text-success');
+                settings.classList.remove('text-danger');
+                settings.classList.remove('text-info');
                 window.fetch(url)
                     .then(function (response) {
                         return response.json();

--- a/src/Common/Auth/OneTimeAuth.php
+++ b/src/Common/Auth/OneTimeAuth.php
@@ -287,15 +287,15 @@ class OneTimeAuth
     {
         // ensure both portal and patient data match using portal account id.
         $patient = sqlQuery(
-            "Select CONCAT(`fname`, `id`) As account, `pid`, `email`, `email_direct` From `patient_data` Where `pid` = ?",
+            "Select `pid`, `email`, `email_direct` From `patient_data` Where `pid` = ?",
             array($pid)
         );
         $portal = sqlQuery(
-            "Select `pid`, `portal_username` From `patient_access_onsite` Where `portal_username` = ? And `pid` = ?",
-            array($patient['account'], $patient['pid'])
+            "Select `pid`, `portal_username` From `patient_access_onsite` Where `pid` = ?",
+            array($patient['pid'])
         );
 
-        $patient['valid'] = !empty($portal) && ((int)$pid === (int)$portal['pid']);
+        $patient['valid'] = !empty($portal['portal_username']) && ((int)$pid === (int)$portal['pid']);
 
         return $patient;
     }


### PR DESCRIPTION
Fixes #6389 

Fix telehealth provisioning resume to resume the user not suspend it.

Add debug logging for telehealth resume, suspend, and deactivate actions
in provisioning service.

Add more detailed messages on the verifier to detail whether the config
is not saved vs the portal is not setup.

Made the login time limit setting an optional setting so it doesn't
break the configuration setting.

Fixed a minor issue where if the settings fail validation and then
succeed afterwards, the text color is set to be a success message
instead of a failure.

If the patient's first name changed, isValidPatient would fail.  Fixed
the check so we just verify that there is a valid username and don't try
to match the patient first name with the portal username.