### PR TITLE
Fixes #6396 webroot path for safe filter

### DIFF
--- a/src/Core/ModulesApplication.php
+++ b/src/Core/ModulesApplication.php
@@ -189,7 +189,14 @@ class ModulesApplication
                 // scripts that have any kind of parameters in them such as a cache buster mess up finding the real path
                 // we need to strip that out and then check against the real path
                 $scriptSrcPath = parse_url($scriptSrc, PHP_URL_PATH);
-                $realPath = realpath($GLOBALS['fileroot'] . $scriptSrcPath);
+                // need to remove the web root as that is included in the $scriptSrc and also in the fileroot
+                $pos = strpos($scriptSrcPath, $GLOBALS['web_root']);
+                if ($pos !== false) {
+                    $scriptSrcPathWithoutWebroot = substr_replace($scriptSrcPath, '', $pos, strlen($GLOBALS['web_root']));
+                } else {
+                    $scriptSrcPathWithoutWebroot = $scriptSrcPath;
+                }
+                $realPath = realpath($GLOBALS['fileroot'] . $scriptSrcPathWithoutWebroot);
                 $moduleRootLocation = realpath($GLOBALS['fileroot'] . DIRECTORY_SEPARATOR . 'interface' . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR);
 
                 // make sure we haven't left our root path ie interface folder

--- a/src/Core/ModulesApplication.php
+++ b/src/Core/ModulesApplication.php
@@ -190,7 +190,7 @@ class ModulesApplication
                 // we need to strip that out and then check against the real path
                 $scriptSrcPath = parse_url($scriptSrc, PHP_URL_PATH);
                 // need to remove the web root as that is included in the $scriptSrc and also in the fileroot
-                $pos = strpos($scriptSrcPath, $GLOBALS['web_root']);
+                $pos = stripos($scriptSrcPath, $GLOBALS['web_root']);
                 if ($pos !== false) {
                     $scriptSrcPathWithoutWebroot = substr_replace($scriptSrcPath, '', $pos, strlen($GLOBALS['web_root']));
                 } else {


### PR DESCRIPTION
Fixes #6396

Makes it so the webroot path still functions in the safe filter. Prevents injection of scripts in the header unless the file actually exists in OpenEMR and that its locked down to the module directory.