### PR TITLE
Fix lexical sorting of external ID in finder page, Fixes #6183

### DIFF
--- a/interface/main/finder/dynamic_finder_ajax.php
+++ b/interface/main/finder/dynamic_finder_ajax.php
@@ -76,6 +76,9 @@ if (isset($_GET['iSortCol_0'])) {
             //
             if ($aColumns[$iSortCol] == 'name') {
                 $orderby .= "lname $sSortDir, fname $sSortDir, mname $sSortDir";
+            } else if ($aColumns[$iSortCol] == 'pubpid') {
+                // If selected the external ID column for sorting, use the INT casted column to get them sorted numerically
+                $orderby .= "`pubpid_int` $sSortDir";
             } else {
                 $orderby .= "`" . escape_sql_column_name($aColumns[$iSortCol], array('patient_data')) . "` $sSortDir";
             }
@@ -258,7 +261,8 @@ while ($row = sqlFetchArray($res)) {
     $fieldsInfo[$row['field_id']] = $row;
 }
 
-$query = "SELECT $sellist FROM patient_data WHERE $where $orderby $limit";
+// Cast pubpid to INT to allow it to be sorted numerically
+$query = "SELECT $sellist, CAST(`pubpid` AS int) AS `pubpid_int` FROM patient_data WHERE $where $orderby $limit";
 $res = sqlStatement($query, $srch_bind);
 while ($row = sqlFetchArray($res)) {
     // Each <tr> will have an ID identifying the patient.


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #6183

#### Short description of what this resolves:
Fixes the lexical sorting of external ID in finder page

#### Changes proposed in this pull request:
Casting the `pubpid` to INT before ordering