### PR TITLE
Openemr fix telehealth signup locale

### DIFF
--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/moduleConfig.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/moduleConfig.php
@@ -38,12 +38,12 @@ if (!empty($_GET['setup']) ?? null) {
     $content = trim(file_get_contents("php://input"));
     $credentials = json_decode($content, true);
     $cryptoGen = new CryptoGen();
-    $items[TelehealthGlobalConfig::COMLINK_VIDEO_REGISTRATION_API] = $credentials['registrationUri'];
-    $items[TelehealthGlobalConfig::COMLINK_VIDEO_TELEHEALTH_API] = $credentials['videoApiUri'];
-    $items[TelehealthGlobalConfig::COMLINK_VIDEO_API_USER_ID] = $credentials['ctsiOrgUid'];
-    $items[TelehealthGlobalConfig::COMLINK_VIDEO_API_USER_PASSWORD] = $cryptoGen->encryptStandard(trim($credentials['ctsiOrgPwd']));
-    $items[TelehealthGlobalConfig::COMLINK_VIDEO_TELEHEALTH_CMS_ID] = $credentials['ctsiOrgId'];
-    $items[TelehealthGlobalConfig::COMLINK_TELEHEALTH_PAYMENT_SUBSCRIPTION_ID] = $credentials['paypal_subscription_id'] ?? null;
+    $items[TelehealthGlobalConfig::COMLINK_VIDEO_REGISTRATION_API] = $credentials['registrationUri'] ?? '';
+    $items[TelehealthGlobalConfig::COMLINK_VIDEO_TELEHEALTH_API] = $credentials['videoApiUri'] ?? '';
+    $items[TelehealthGlobalConfig::COMLINK_VIDEO_API_USER_ID] = $credentials['ctsiOrgUid'] ?? '';
+    $items[TelehealthGlobalConfig::COMLINK_VIDEO_API_USER_PASSWORD] = isset($credentials['ctsiOrgPwd']) ? $cryptoGen->encryptStandard(trim($credentials['ctsiOrgPwd'])) : '';
+    $items[TelehealthGlobalConfig::COMLINK_VIDEO_TELEHEALTH_CMS_ID] = $credentials['ctsiOrgId'] ?? '';
+    $items[TelehealthGlobalConfig::COMLINK_TELEHEALTH_PAYMENT_SUBSCRIPTION_ID] = $credentials['paypal_subscription_id'] ?? '';
     // Save to globals table.
     foreach ($items as $key => $credential) {
         sqlQuery(

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/moduleConfig.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/moduleConfig.php
@@ -16,6 +16,7 @@ require_once dirname(__FILE__, 4) . '/globals.php';
 
 use OpenEMR\Common\Crypto\CryptoGen;
 use OpenEMR\Common\Csrf\CsrfUtils;
+use Comlink\OpenEMR\Modules\TeleHealthModule\TelehealthGlobalConfig;
 
 $module_config = 1;
 
@@ -37,11 +38,12 @@ if (!empty($_GET['setup']) ?? null) {
     $content = trim(file_get_contents("php://input"));
     $credentials = json_decode($content, true);
     $cryptoGen = new CryptoGen();
-    $items['comlink_telehealth_registration_uri'] = $credentials['registrationUri'];
-    $items['comlink_telehealth_video_uri'] = $credentials['videoApiUri'];
-    $items['comlink_telehealth_user_id'] = $credentials['ctsiOrgUid'];
-    $items['comlink_telehealth_user_password'] = $cryptoGen->encryptStandard(trim($credentials['ctsiOrgPwd']));
-    $items['comlink_telehealth_cms_id'] = $credentials['ctsiOrgId'];
+    $items[TelehealthGlobalConfig::COMLINK_VIDEO_REGISTRATION_API] = $credentials['registrationUri'];
+    $items[TelehealthGlobalConfig::COMLINK_VIDEO_TELEHEALTH_API] = $credentials['videoApiUri'];
+    $items[TelehealthGlobalConfig::COMLINK_VIDEO_API_USER_ID] = $credentials['ctsiOrgUid'];
+    $items[TelehealthGlobalConfig::COMLINK_VIDEO_API_USER_PASSWORD] = $cryptoGen->encryptStandard(trim($credentials['ctsiOrgPwd']));
+    $items[TelehealthGlobalConfig::COMLINK_VIDEO_TELEHEALTH_CMS_ID] = $credentials['ctsiOrgId'];
+    $items[TelehealthGlobalConfig::COMLINK_TELEHEALTH_PAYMENT_SUBSCRIPTION_ID] = $credentials['subscriptionID'] ?? null;
     // Save to globals table.
     foreach ($items as $key => $credential) {
         sqlQuery(

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/moduleConfig.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/moduleConfig.php
@@ -43,7 +43,7 @@ if (!empty($_GET['setup']) ?? null) {
     $items[TelehealthGlobalConfig::COMLINK_VIDEO_API_USER_ID] = $credentials['ctsiOrgUid'];
     $items[TelehealthGlobalConfig::COMLINK_VIDEO_API_USER_PASSWORD] = $cryptoGen->encryptStandard(trim($credentials['ctsiOrgPwd']));
     $items[TelehealthGlobalConfig::COMLINK_VIDEO_TELEHEALTH_CMS_ID] = $credentials['ctsiOrgId'];
-    $items[TelehealthGlobalConfig::COMLINK_TELEHEALTH_PAYMENT_SUBSCRIPTION_ID] = $credentials['subscriptionID'] ?? null;
+    $items[TelehealthGlobalConfig::COMLINK_TELEHEALTH_PAYMENT_SUBSCRIPTION_ID] = $credentials['paypal_subscription_id'] ?? null;
     // Save to globals table.
     foreach ($items as $key => $credential) {
         sqlQuery(

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Bootstrap.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Bootstrap.php
@@ -133,6 +133,11 @@ class Bootstrap
         $this->globalsConfig = new TelehealthGlobalConfig($this->getURLPath(), $this->moduleDirectoryName, $this->twig);
     }
 
+    public function getGlobalConfig(): TelehealthGlobalConfig
+    {
+        return $this->globalsConfig;
+    }
+
     public function getTemplatePath()
     {
         return \dirname(__DIR__) . DIRECTORY_SEPARATOR . "templates" . DIRECTORY_SEPARATOR;

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/src/TelehealthGlobalConfig.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/src/TelehealthGlobalConfig.php
@@ -58,6 +58,8 @@ class TelehealthGlobalConfig
 
     public const COMLINK_ONETIME_PASSWORD_LOGIN_TIME_LIMIT = "comlink_onetime_password_login_time_limit";
 
+    public const COMLINK_TELEHEALTH_PAYMENT_SUBSCRIPTION_ID = "comlink_telehealth_payment_subscription_id";
+
     public const MAX_LOGIN_LIMIT_TIME = 30;
     const LOCALE_TIMEZONE_DEFAULT = "Unassigned";
     const LOCALE_TIMEZONE = "gbl_time_zone";
@@ -345,6 +347,12 @@ class TelehealthGlobalConfig
                 ,'type' => GlobalSetting::DATA_TYPE_TEXT
                 ,'default' => ''
             ]
+            ,self::COMLINK_TELEHEALTH_PAYMENT_SUBSCRIPTION_ID => [
+                'title' => 'Telehealth Payment Subscription ID'
+                ,'description' => 'This is your unique video application payment subscription id. Signup via the Manage Modules configuration screen if you have not received it'
+                ,'type' => GlobalSetting::DATA_TYPE_TEXT
+                ,'default' => ''
+            ]
             ,self::COMLINK_AUTO_PROVISION_PROVIDER => [
                 'title' => 'Auto Register Providers For Telehealth'
                 ,'description' => 'Disable this setting if you will manually enable the providers you wish to be registered for Telehealth'
@@ -495,7 +503,8 @@ class TelehealthGlobalConfig
             || $key == self::DEBUG_MODE_FLAG
             || $key == self::COMLINK_SECTION_FOOTER_BOX
             || $key == self::COMLINK_ONETIME_PASSWORD_LOGIN
-            || $key == self::COMLINK_ONETIME_PASSWORD_LOGIN_TIME_LIMIT;
+            || $key == self::COMLINK_ONETIME_PASSWORD_LOGIN_TIME_LIMIT
+            || $key == self::COMLINK_TELEHEALTH_PAYMENT_SUBSCRIPTION_ID; // we don't require the payment subscription id
     }
 
     /**

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/src/TelehealthGlobalConfig.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/src/TelehealthGlobalConfig.php
@@ -441,7 +441,8 @@ class TelehealthGlobalConfig
         return $this->twig->render("comlink/admin/telehealth_footer_box.html.twig", $dataArray);
     }
 
-    private function isLocaleConfigured() {
+    private function isLocaleConfigured()
+    {
         // timezone is not set in the $GLOBALS array oddly, not sure why, check against the database
         $record = QueryUtils::fetchRecords("SELECT gl_name, gl_index, gl_value FROM globals WHERE gl_name=?", [self::LOCALE_TIMEZONE]);
         if (!empty($record)) {

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/templates/comlink/admin/telehealth_footer_box.html.twig
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/templates/comlink/admin/telehealth_footer_box.html.twig
@@ -82,6 +82,10 @@
         });
     })(window);
 </script>
+<p>
+    {{ "The Telehealth module allows you to conduct video visits with your patients."|xlt }}
+    {{ "After saving these settings you must log out and log back in for the Telehealth Settings to be applied"|xlt }}
+</p>
 <div class="alert alert-info">
     <details>
         <summary class="h4">
@@ -148,6 +152,20 @@
                     <li>{{ "SMTP Security Protocol"|xlt }} - {{ "Recommended to use TLS when using SMTP transport method"|xlt }}</li>
                     <li>{{ "SMTP User for Authentication"|xlt }} - {{ "When using SMTP transport method and SMTP Security Protocol"|xlt }}</li>
                     <li>{{ "SMTP Password for Authentication"|xlt }} - {{ "When using SMTP transport method and SMTP Security Protocol"|xlt }}</li>
+                </ul>
+            </li>
+            <li class="h5">
+                {{ "Config"|xlt }} -> {{ "Locale"|xlt }} -
+                {% if isLocaleConfigured %}
+                    <span class="text-success">{{ "Configured"|xlt }}</span>
+                {% else %}
+                    <span class="text-danger">{{ "Incorrect"|xlt }}</span>
+                {% endif %}
+                <p>
+                    {{ "The following settings must be configured in the Config Locale section for Telehealth Calendar Sessions to work properly"|xlt }}
+                </p>
+                <ul class="h6">
+                    <li>{{ "Time Zone"|xlt }}</li>
                 </ul>
             </li>
         </ul>

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/welcome.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/welcome.php
@@ -82,7 +82,7 @@ $isCoreConfigured = $globalConfig->isTelehealthCoreSettingsConfigured() === true
 
             <p><?php echo xlt("To get your telehealth configuration information you must first signup for a subscription trial and then setup your telehealth credentials"); ?>,
                 <?php echo xlt("Please select the subscription button below."); ?></p>
-            <div id="step-1-subscription-signup" class="<?php if ($isCoreConfigured) {
+            <div id="step-1-subscription-signup" class="<?php if (!empty($subscriptionId)) {
                 echo 'd-none';} ?>">
                 <h2><?php echo xlt("Step 1 - Subscription Signup"); ?></h2>
                 <p>
@@ -91,14 +91,14 @@ $isCoreConfigured = $globalConfig->isTelehealthCoreSettingsConfigured() === true
                 <div id="paypal-button-container-P-25N86285GY8825203MMWZEIY"></div>
                 <script src="https://www.paypal.com/sdk/js?client-id=AUQ1tRakVcTZ0wIOjQ0CicVxB8K47tXo4l8PucxwmmB1v_LIE4-_pJ-kEZf3fsk3uKZuhb_3WuDasVBC&vault=true&intent=subscription" data-sdk-integration-source="button-factory"></script>
             </div>
-            <div id="step-1-subscription-signup-complete" class="<?php if (!$isCoreConfigured) {
+            <div id="step-1-subscription-signup-complete" class="<?php if (empty($subscriptionId)) {
                 echo 'd-none';} ?>">
                 <h2><?php echo xlt("Step 1 - Subscription Signup"); ?> - <span class="text-success"><?php echo xlt("Complete"); ?></span></h2>
-                <div class="alert alert-success <?php if (!$isCoreConfigured) {
+                <div class="alert alert-success <?php if (empty($subscriptionId)) {
                     echo 'd-none';} ?>">
                     <h3><?php echo xlt("Your payment subscription has been created."); ?></h3>
                     <p><?php echo xlt("Your Subscription ID / Profile ID is the following"); ?></p>
-                    <h3><input type="text" disabled="disabled" id="paypal-subscription-id" value="<?php echo attr($subscriptionId); ?>" /><i class="fa fa-copy" id="btnCopy"></i></h3>
+                    <h3><input type="text" disabled="disabled" id="paypal-subscription-id" value="<?php echo attr($subscriptionId); ?>" /><i class="ml-2 fa fa-copy" id="btnCopy"></i></h3>
                     <p><?php echo xlt("Copy your subscription ID / Profile ID for obtaining your telehealth credentials"); ?></p>
                     <p><small><?php echo xlt("You have been sent an email from Paypal with your subscription information"); ?></small></p>
                 </div>

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/welcome.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/welcome.php
@@ -13,6 +13,15 @@ use OpenEMR\Core\Header;
 
 require_once dirname(__FILE__, 4) . "/globals.php";
 
+use Comlink\OpenEMR\Modules\TeleHealthModule\Bootstrap;
+use Comlink\OpenEMR\Modules\TeleHealthModule\TelehealthGlobalConfig;
+
+$kernel = $GLOBALS['kernel'];
+$bootstrap = new Bootstrap($kernel->getEventDispatcher(), $kernel);
+$globalConfig = $bootstrap->getGlobalConfig();
+$subscriptionId = $globalConfig->getGlobalSetting(TelehealthGlobalConfig::COMLINK_TELEHEALTH_PAYMENT_SUBSCRIPTION_ID) ?? '';
+$isCoreConfigured = $globalConfig->isTelehealthCoreSettingsConfigured() === true;
+
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -71,13 +80,29 @@ require_once dirname(__FILE__, 4) . "/globals.php";
         </div>
         <div class="card-body">
 
-            <p><?php echo xlt("To get your telehealth configuration information"); ?>,
+            <p><?php echo xlt("To get your telehealth configuration information you must first signup for a subscription trial and then setup your telehealth credentials"); ?>,
                 <?php echo xlt("Please select the subscription button below."); ?></p>
-            <p>
-                <?php echo xlt("There is a 7 day trial period included with the subscription"); ?>
-            </p>
-            <div id="paypal-button-container-P-25N86285GY8825203MMWZEIY"></div>
-            <script src="https://www.paypal.com/sdk/js?client-id=AUQ1tRakVcTZ0wIOjQ0CicVxB8K47tXo4l8PucxwmmB1v_LIE4-_pJ-kEZf3fsk3uKZuhb_3WuDasVBC&vault=true&intent=subscription" data-sdk-integration-source="button-factory"></script>
+            <div id="step-1-subscription-signup" class="<?php if ($isCoreConfigured) {
+                echo 'd-none';} ?>">
+                <h2><?php echo xlt("Step 1 - Subscription Signup"); ?></h2>
+                <p>
+                    <?php echo xlt("There is a 7 day trial period included with the subscription"); ?>
+                </p>
+                <div id="paypal-button-container-P-25N86285GY8825203MMWZEIY"></div>
+                <script src="https://www.paypal.com/sdk/js?client-id=AUQ1tRakVcTZ0wIOjQ0CicVxB8K47tXo4l8PucxwmmB1v_LIE4-_pJ-kEZf3fsk3uKZuhb_3WuDasVBC&vault=true&intent=subscription" data-sdk-integration-source="button-factory"></script>
+            </div>
+            <div id="step-1-subscription-signup-complete" class="<?php if (!$isCoreConfigured) {
+                echo 'd-none';} ?>">
+                <h2><?php echo xlt("Step 1 - Subscription Signup"); ?> - <span class="text-success"><?php echo xlt("Complete"); ?></span></h2>
+                <div class="alert alert-success <?php if (!$isCoreConfigured) {
+                    echo 'd-none';} ?>">
+                    <h3><?php echo xlt("Your payment subscription has been created."); ?></h3>
+                    <p><?php echo xlt("Your Subscription ID / Profile ID is the following"); ?></p>
+                    <h3><input type="text" disabled="disabled" id="paypal-subscription-id" value="<?php echo attr($subscriptionId); ?>" /><i class="fa fa-copy" id="btnCopy"></i></h3>
+                    <p><?php echo xlt("Copy your subscription ID / Profile ID for obtaining your telehealth credentials"); ?></p>
+                    <p><small><?php echo xlt("You have been sent an email from Paypal with your subscription information"); ?></small></p>
+                </div>
+            </div>
             <script>
                 // handles the copying of the subscription id for the client's reference.
                 function btnCopy() {
@@ -109,7 +134,10 @@ require_once dirname(__FILE__, 4) . "/globals.php";
                     let el2 = document.querySelector('#paypal-subscription-id');
                     el2.value = data.subscriptionID;
 
-                    let payPalSection = document.querySelector('#paypal-button-container-P-25N86285GY8825203MMWZEIY');
+                    let el3 = document.querySelector('#step-1-subscription-signup-complete');
+                    el3.classList.remove("d-none");
+
+                    let payPalSection = document.querySelector('#step-1-subscription-signup');
                     payPalSection.classList.add('d-none');
 
                     let sinupLink = document.querySelector('#signupLink');
@@ -140,15 +168,19 @@ require_once dirname(__FILE__, 4) . "/globals.php";
                     onApprove: paypalOnApproveHandler
                 }).render('#paypal-button-container-P-25N86285GY8825203MMWZEIY'); // Renders the PayPal button
             </script>
-            <div class="alert alert-success d-none">
-                <h1><?php echo xlt("Your subscription trial has been created."); ?></h1>
-                <p><?php echo xlt("Your Subscription ID / Profile ID is the following"); ?></p>
-                <h3><input type="text" disabled="disabled" id="paypal-subscription-id"></input> <i class="fa fa-copy" id="btnCopy"></i></h3>
-                <p><?php echo xlt("Copy your subscription ID / Profile ID for obtaining your telehealth credentials"); ?></p>
-                <p><small><?php echo xlt("You have been sent an email from Paypal with your subscription information"); ?></small></p>
+            <div class="<?php if ($isCoreConfigured) {
+                echo 'd-none';} ?>">
+                <h2><?php echo xlt("Step 2 - Credentials Signup"); ?></h2>
+                <p><h3><a id='signupLink' href="https://credentials.affordablecustomehr.com/customer"><?php echo xlt("Click Here to get credentials after subscribing"); ?></a></h3></p>
+            </div>
+            <div class="<?php if (!$isCoreConfigured) {
+                echo 'd-none';} ?>">
+                <h2><?php echo xlt("Step 2 - Credentials Signup"); ?> - <span class="text-success"><?php echo xlt("Complete"); ?></span></h2>
+                <p><?php echo xlt("Your credentials have been setup and saved in the Telehealth configuration"); ?></p>
             </div>
             <div>
-                <p><h3><a id='signupLink' href="https://credentials.affordablecustomehr.com/customer"><?php echo xlt("Click Here to get credentials after subscribing"); ?></a></h3></p>
+                <h3><?php echo xlt("Step 3 - Complete Telehealth Configuration"); ?></h3>
+                <p><?php echo xlt("Finish the telehealth configuration and verify your setup is fully functionining in the Admin -> Config -> Telehealth settings section"); ?></p>
             </div>
         </div>
     </section>

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/welcome.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/welcome.php
@@ -86,7 +86,7 @@ $isCoreConfigured = $globalConfig->isTelehealthCoreSettingsConfigured() === true
                 echo 'd-none';} ?>">
                 <h2><?php echo xlt("Step 1 - Subscription Signup"); ?></h2>
                 <p>
-                    <?php echo xlt("There is a 7 day trial period included with the subscription"); ?>
+                    <?php echo xlt("There is a 7 day free trial period included with the subscription"); ?>
                 </p>
                 <div id="paypal-button-container-P-25N86285GY8825203MMWZEIY"></div>
                 <script src="https://www.paypal.com/sdk/js?client-id=AUQ1tRakVcTZ0wIOjQ0CicVxB8K47tXo4l8PucxwmmB1v_LIE4-_pJ-kEZf3fsk3uKZuhb_3WuDasVBC&vault=true&intent=subscription" data-sdk-integration-source="button-factory"></script>

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/welcome.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/welcome.php
@@ -79,6 +79,50 @@ require_once dirname(__FILE__, 4) . "/globals.php";
             <div id="paypal-button-container-P-25N86285GY8825203MMWZEIY"></div>
             <script src="https://www.paypal.com/sdk/js?client-id=AUQ1tRakVcTZ0wIOjQ0CicVxB8K47tXo4l8PucxwmmB1v_LIE4-_pJ-kEZf3fsk3uKZuhb_3WuDasVBC&vault=true&intent=subscription" data-sdk-integration-source="button-factory"></script>
             <script>
+                // handles the copying of the subscription id for the client's reference.
+                function btnCopy() {
+                    try {
+                        let el = document.querySelector('#paypal-subscription-id');
+                        if (el) {
+                            el.select();
+                        }
+                        let text = el.value;
+                        if (navigator.clipboard && navigator.clipboard.writeText) {
+                            navigator.clipboard.writeText(text).then(() => {
+                                alert(<?php echo xlj("Copied to clipboard"); ?>);
+                            }, (error) => {
+                                console.error(error);
+                                alert(<?php echo xlj("Failed to copy to clipboard"); ?>);
+                            });
+                        } else {
+                            document.execCommand("copy");
+                            alert(<?php echo xlj("Copied to clipboard"); ?>);
+                        }
+                    } catch (error) {
+                        console.error(error);
+                        alert(<?php echo xlj("Failed to copy to clipboard"); ?>);
+                    }
+                }
+                function paypalOnApproveHandler(data, actions) {
+                    let el = document.querySelector('.alert-success');
+                    el.classList.remove("d-none");
+                    let el2 = document.querySelector('#paypal-subscription-id');
+                    el2.value = data.subscriptionID;
+
+                    let payPalSection = document.querySelector('#paypal-button-container-P-25N86285GY8825203MMWZEIY');
+                    payPalSection.classList.add('d-none');
+
+                    let sinupLink = document.querySelector('#signupLink');
+                    // if we want to pass along the subscription_id we can do that, right now that causes the signup page
+                    // to fail.
+                    // sinupLink.href = sinupLink.href + "?subscription_id=" + encodeURIComponent(data.subscriptionID);
+                }
+                window.addEventListener("DOMContentLoaded", function() {
+                    let btnCopyElement = document.querySelector('#btnCopy');
+                    btnCopyElement.addEventListener('click', btnCopy);
+                    // uncomment for testing
+                    // paypalOnApproveHandler({subscriptionID: 'testingId1'}, {});
+                });
                 paypal.Buttons({
                     style: {
                         shape: 'rect',
@@ -93,13 +137,18 @@ require_once dirname(__FILE__, 4) . "/globals.php";
                             quantity: 1 // The quantity of the product for a subscription
                         });
                     },
-                    onApprove: function(data, actions) {
-                        alert(data.subscriptionID); // You can add optional success message for the subscriber here
-                    }
+                    onApprove: paypalOnApproveHandler
                 }).render('#paypal-button-container-P-25N86285GY8825203MMWZEIY'); // Renders the PayPal button
             </script>
+            <div class="alert alert-success d-none">
+                <h1><?php echo xlt("Your subscription trial has been created."); ?></h1>
+                <p><?php echo xlt("Your Subscription ID / Profile ID is the following"); ?></p>
+                <h3><input type="text" disabled="disabled" id="paypal-subscription-id"></input> <i class="fa fa-copy" id="btnCopy"></i></h3>
+                <p><?php echo xlt("Copy your subscription ID / Profile ID for obtaining your telehealth credentials"); ?></p>
+                <p><small><?php echo xlt("You have been sent an email from Paypal with your subscription information"); ?></small></p>
+            </div>
             <div>
-                <p><h3><a href="https://credentials.affordablecustomehr.com/customer"><?php echo xlt("Click Here to get credentials after subscribing"); ?></a></h3></p>
+                <p><h3><a id='signupLink' href="https://credentials.affordablecustomehr.com/customer"><?php echo xlt("Click Here to get credentials after subscribing"); ?></a></h3></p>
             </div>
         </div>
     </section>

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/welcome.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/welcome.php
@@ -86,10 +86,10 @@ $isCoreConfigured = $globalConfig->isTelehealthCoreSettingsConfigured() === true
                 echo 'd-none';} ?>">
                 <h2><?php echo xlt("Step 1 - Subscription Signup"); ?></h2>
                 <p>
-                    <?php echo xlt("There is a 7 day free trial period included with the subscription"); ?>
+                    <?php echo xlt("There is a 14 day free trial period included with the subscription"); ?>
                 </p>
-                <div id="paypal-button-container-P-25N86285GY8825203MMWZEIY"></div>
-                <script src="https://www.paypal.com/sdk/js?client-id=AUQ1tRakVcTZ0wIOjQ0CicVxB8K47tXo4l8PucxwmmB1v_LIE4-_pJ-kEZf3fsk3uKZuhb_3WuDasVBC&vault=true&intent=subscription" data-sdk-integration-source="button-factory"></script>
+                <div id="paypal-button-container-P-4FU17140CF274883DMREHHFA"></div>
+                <script src="https://www.paypal.com/sdk/js?client-id=AU0Ql21fQp5jd-Vn2jPU1dCdTse_DFpGiBjfBAsrBW9lEeNNBmEm7NpKim6W3vt3RxOVH-Wa_VFwz3mw&vault=true&intent=subscription" data-sdk-integration-source="button-factory"></script>
             </div>
             <div id="step-1-subscription-signup-complete" class="<?php if (empty($subscriptionId)) {
                 echo 'd-none';} ?>">
@@ -161,12 +161,11 @@ $isCoreConfigured = $globalConfig->isTelehealthCoreSettingsConfigured() === true
                     createSubscription: function(data, actions) {
                         return actions.subscription.create({
                             /* Creates the subscription */
-                            plan_id: 'P-25N86285GY8825203MMWZEIY',
-                            quantity: 1 // The quantity of the product for a subscription
+                            plan_id: 'P-4FU17140CF274883DMREHHFA'
                         });
                     },
                     onApprove: paypalOnApproveHandler
-                }).render('#paypal-button-container-P-25N86285GY8825203MMWZEIY'); // Renders the PayPal button
+                }).render('#paypal-button-container-P-4FU17140CF274883DMREHHFA'); // Renders the PayPal button
             </script>
             <div class="<?php if ($isCoreConfigured) {
                 echo 'd-none';} ?>">


### PR DESCRIPTION
Fixed up the verbiage and some problems with the telehealth live payment signup process. It was popping up an alert box with the paypal subscriber id and expected the patient to copy and remember that value for signup.  This is most likely what was causing the multiple signup problems that users of the module were dealing with.

Broke the signup into three steps and provide progress status to the users as they signup.  Better instructions on how to move to the next step are included in each process.