### PR TITLE
Openemr fix telehealth signup locale (#6413)

### DIFF
--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/moduleConfig.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/moduleConfig.php
@@ -16,6 +16,7 @@ require_once dirname(__FILE__, 4) . '/globals.php';
 
 use OpenEMR\Common\Crypto\CryptoGen;
 use OpenEMR\Common\Csrf\CsrfUtils;
+use Comlink\OpenEMR\Modules\TeleHealthModule\TelehealthGlobalConfig;
 
 $module_config = 1;
 
@@ -37,11 +38,12 @@ if (!empty($_GET['setup']) ?? null) {
     $content = trim(file_get_contents("php://input"));
     $credentials = json_decode($content, true);
     $cryptoGen = new CryptoGen();
-    $items['comlink_telehealth_registration_uri'] = $credentials['registrationUri'];
-    $items['comlink_telehealth_video_uri'] = $credentials['videoApiUri'];
-    $items['comlink_telehealth_user_id'] = $credentials['ctsiOrgUid'];
-    $items['comlink_telehealth_user_password'] = $cryptoGen->encryptStandard(trim($credentials['ctsiOrgPwd']));
-    $items['comlink_telehealth_cms_id'] = $credentials['ctsiOrgId'];
+    $items[TelehealthGlobalConfig::COMLINK_VIDEO_REGISTRATION_API] = $credentials['registrationUri'] ?? '';
+    $items[TelehealthGlobalConfig::COMLINK_VIDEO_TELEHEALTH_API] = $credentials['videoApiUri'] ?? '';
+    $items[TelehealthGlobalConfig::COMLINK_VIDEO_API_USER_ID] = $credentials['ctsiOrgUid'] ?? '';
+    $items[TelehealthGlobalConfig::COMLINK_VIDEO_API_USER_PASSWORD] = isset($credentials['ctsiOrgPwd']) ? $cryptoGen->encryptStandard(trim($credentials['ctsiOrgPwd'])) : '';
+    $items[TelehealthGlobalConfig::COMLINK_VIDEO_TELEHEALTH_CMS_ID] = $credentials['ctsiOrgId'] ?? '';
+    $items[TelehealthGlobalConfig::COMLINK_TELEHEALTH_PAYMENT_SUBSCRIPTION_ID] = $credentials['paypal_subscription_id'] ?? '';
     // Save to globals table.
     foreach ($items as $key => $credential) {
         sqlQuery(

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Bootstrap.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Bootstrap.php
@@ -133,6 +133,11 @@ class Bootstrap
         $this->globalsConfig = new TelehealthGlobalConfig($this->getURLPath(), $this->moduleDirectoryName, $this->twig);
     }
 
+    public function getGlobalConfig(): TelehealthGlobalConfig
+    {
+        return $this->globalsConfig;
+    }
+
     public function getTemplatePath()
     {
         return \dirname(__DIR__) . DIRECTORY_SEPARATOR . "templates" . DIRECTORY_SEPARATOR;

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/templates/comlink/admin/telehealth_footer_box.html.twig
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/templates/comlink/admin/telehealth_footer_box.html.twig
@@ -82,6 +82,10 @@
         });
     })(window);
 </script>
+<p>
+    {{ "The Telehealth module allows you to conduct video visits with your patients."|xlt }}
+    {{ "After saving these settings you must log out and log back in for the Telehealth Settings to be applied"|xlt }}
+</p>
 <div class="alert alert-info">
     <details>
         <summary class="h4">
@@ -148,6 +152,20 @@
                     <li>{{ "SMTP Security Protocol"|xlt }} - {{ "Recommended to use TLS when using SMTP transport method"|xlt }}</li>
                     <li>{{ "SMTP User for Authentication"|xlt }} - {{ "When using SMTP transport method and SMTP Security Protocol"|xlt }}</li>
                     <li>{{ "SMTP Password for Authentication"|xlt }} - {{ "When using SMTP transport method and SMTP Security Protocol"|xlt }}</li>
+                </ul>
+            </li>
+            <li class="h5">
+                {{ "Config"|xlt }} -> {{ "Locale"|xlt }} -
+                {% if isLocaleConfigured %}
+                    <span class="text-success">{{ "Configured"|xlt }}</span>
+                {% else %}
+                    <span class="text-danger">{{ "Incorrect"|xlt }}</span>
+                {% endif %}
+                <p>
+                    {{ "The following settings must be configured in the Config Locale section for Telehealth Calendar Sessions to work properly"|xlt }}
+                </p>
+                <ul class="h6">
+                    <li>{{ "Time Zone"|xlt }}</li>
                 </ul>
             </li>
         </ul>

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/welcome.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/welcome.php
@@ -13,6 +13,15 @@ use OpenEMR\Core\Header;
 
 require_once dirname(__FILE__, 4) . "/globals.php";
 
+use Comlink\OpenEMR\Modules\TeleHealthModule\Bootstrap;
+use Comlink\OpenEMR\Modules\TeleHealthModule\TelehealthGlobalConfig;
+
+$kernel = $GLOBALS['kernel'];
+$bootstrap = new Bootstrap($kernel->getEventDispatcher(), $kernel);
+$globalConfig = $bootstrap->getGlobalConfig();
+$subscriptionId = $globalConfig->getGlobalSetting(TelehealthGlobalConfig::COMLINK_TELEHEALTH_PAYMENT_SUBSCRIPTION_ID) ?? '';
+$isCoreConfigured = $globalConfig->isTelehealthCoreSettingsConfigured() === true;
+
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -71,14 +80,77 @@ require_once dirname(__FILE__, 4) . "/globals.php";
         </div>
         <div class="card-body">
 
-            <p><?php echo xlt("To get your telehealth configuration information"); ?>,
+            <p><?php echo xlt("To get your telehealth configuration information you must first signup for a subscription trial and then setup your telehealth credentials"); ?>,
                 <?php echo xlt("Please select the subscription button below."); ?></p>
-            <p>
-                <?php echo xlt("There is a 7 day trial period included with the subscription"); ?>
-            </p>
-            <div id="paypal-button-container-P-25N86285GY8825203MMWZEIY"></div>
-            <script src="https://www.paypal.com/sdk/js?client-id=AUQ1tRakVcTZ0wIOjQ0CicVxB8K47tXo4l8PucxwmmB1v_LIE4-_pJ-kEZf3fsk3uKZuhb_3WuDasVBC&vault=true&intent=subscription" data-sdk-integration-source="button-factory"></script>
+            <div id="step-1-subscription-signup" class="<?php if (!empty($subscriptionId)) {
+                echo 'd-none';} ?>">
+                <h2><?php echo xlt("Step 1 - Subscription Signup"); ?></h2>
+                <p>
+                    <?php echo xlt("There is a 14 day free trial period included with the subscription"); ?>
+                </p>
+                <div id="paypal-button-container-P-4FU17140CF274883DMREHHFA"></div>
+                <script src="https://www.paypal.com/sdk/js?client-id=AU0Ql21fQp5jd-Vn2jPU1dCdTse_DFpGiBjfBAsrBW9lEeNNBmEm7NpKim6W3vt3RxOVH-Wa_VFwz3mw&vault=true&intent=subscription" data-sdk-integration-source="button-factory"></script>
+            </div>
+            <div id="step-1-subscription-signup-complete" class="<?php if (empty($subscriptionId)) {
+                echo 'd-none';} ?>">
+                <h2><?php echo xlt("Step 1 - Subscription Signup"); ?> - <span class="text-success"><?php echo xlt("Complete"); ?></span></h2>
+                <div class="alert alert-success <?php if (empty($subscriptionId)) {
+                    echo 'd-none';} ?>">
+                    <h3><?php echo xlt("Your payment subscription has been created."); ?></h3>
+                    <p><?php echo xlt("Your Subscription ID / Profile ID is the following"); ?></p>
+                    <h3><input type="text" disabled="disabled" id="paypal-subscription-id" value="<?php echo attr($subscriptionId); ?>" /><i class="ml-2 fa fa-copy" id="btnCopy"></i></h3>
+                    <p><?php echo xlt("Copy your subscription ID / Profile ID for obtaining your telehealth credentials"); ?></p>
+                    <p><small><?php echo xlt("You have been sent an email from Paypal with your subscription information"); ?></small></p>
+                </div>
+            </div>
             <script>
+                // handles the copying of the subscription id for the client's reference.
+                function btnCopy() {
+                    try {
+                        let el = document.querySelector('#paypal-subscription-id');
+                        if (el) {
+                            el.select();
+                        }
+                        let text = el.value;
+                        if (navigator.clipboard && navigator.clipboard.writeText) {
+                            navigator.clipboard.writeText(text).then(() => {
+                                alert(<?php echo xlj("Copied to clipboard"); ?>);
+                            }, (error) => {
+                                console.error(error);
+                                alert(<?php echo xlj("Failed to copy to clipboard"); ?>);
+                            });
+                        } else {
+                            document.execCommand("copy");
+                            alert(<?php echo xlj("Copied to clipboard"); ?>);
+                        }
+                    } catch (error) {
+                        console.error(error);
+                        alert(<?php echo xlj("Failed to copy to clipboard"); ?>);
+                    }
+                }
+                function paypalOnApproveHandler(data, actions) {
+                    let el = document.querySelector('.alert-success');
+                    el.classList.remove("d-none");
+                    let el2 = document.querySelector('#paypal-subscription-id');
+                    el2.value = data.subscriptionID;
+
+                    let el3 = document.querySelector('#step-1-subscription-signup-complete');
+                    el3.classList.remove("d-none");
+
+                    let payPalSection = document.querySelector('#step-1-subscription-signup');
+                    payPalSection.classList.add('d-none');
+
+                    let sinupLink = document.querySelector('#signupLink');
+                    // if we want to pass along the subscription_id we can do that, right now that causes the signup page
+                    // to fail.
+                    // sinupLink.href = sinupLink.href + "?subscription_id=" + encodeURIComponent(data.subscriptionID);
+                }
+                window.addEventListener("DOMContentLoaded", function() {
+                    let btnCopyElement = document.querySelector('#btnCopy');
+                    btnCopyElement.addEventListener('click', btnCopy);
+                    // uncomment for testing
+                    // paypalOnApproveHandler({subscriptionID: 'testingId1'}, {});
+                });
                 paypal.Buttons({
                     style: {
                         shape: 'rect',
@@ -89,17 +161,25 @@ require_once dirname(__FILE__, 4) . "/globals.php";
                     createSubscription: function(data, actions) {
                         return actions.subscription.create({
                             /* Creates the subscription */
-                            plan_id: 'P-25N86285GY8825203MMWZEIY',
-                            quantity: 1 // The quantity of the product for a subscription
+                            plan_id: 'P-4FU17140CF274883DMREHHFA'
                         });
                     },
-                    onApprove: function(data, actions) {
-                        alert(data.subscriptionID); // You can add optional success message for the subscriber here
-                    }
-                }).render('#paypal-button-container-P-25N86285GY8825203MMWZEIY'); // Renders the PayPal button
+                    onApprove: paypalOnApproveHandler
+                }).render('#paypal-button-container-P-4FU17140CF274883DMREHHFA'); // Renders the PayPal button
             </script>
+            <div class="<?php if ($isCoreConfigured) {
+                echo 'd-none';} ?>">
+                <h2><?php echo xlt("Step 2 - Credentials Signup"); ?></h2>
+                <p><h3><a id='signupLink' href="https://credentials.affordablecustomehr.com/customer"><?php echo xlt("Click Here to get credentials after subscribing"); ?></a></h3></p>
+            </div>
+            <div class="<?php if (!$isCoreConfigured) {
+                echo 'd-none';} ?>">
+                <h2><?php echo xlt("Step 2 - Credentials Signup"); ?> - <span class="text-success"><?php echo xlt("Complete"); ?></span></h2>
+                <p><?php echo xlt("Your credentials have been setup and saved in the Telehealth configuration"); ?></p>
+            </div>
             <div>
-                <p><h3><a href="https://credentials.affordablecustomehr.com/customer"><?php echo xlt("Click Here to get credentials after subscribing"); ?></a></h3></p>
+                <h3><?php echo xlt("Step 3 - Complete Telehealth Configuration"); ?></h3>
+                <p><?php echo xlt("Finish the telehealth configuration and verify your setup is fully functionining in the Admin -> Config -> Telehealth settings section"); ?></p>
             </div>
         </div>
     </section>


### PR DESCRIPTION
* Add save and locale telehealth check instructions

Added a check for the locale settings which should be setup to avoid clinic problems.

Added instructions that the user needs to log out and log back in after saving the telehealth settings.

* Fix psr problems.

* Fix telehealth subscription signup.

Include instructions and the subscription id for the user to use when they signup for the credentials.

Add a copy button and switch the alert of the subscription id to actually show up in a success message info box.  Before the change the user had limited understanding on how to proceed to the next steps in the configuration system.

* Improve signup verbiage, add subscription id

To make the signup process easier for users, we break the signup into three steps with instructions.  We also add saving the paypal subscription id so we can check if the paypal process has already completed and been signed up.

We show progress to the user as they signup.

* Fix if conditions, paypal key

Fixed the paypal key coming back from Sherwin to be the right key value. Fixed the conditions on the subscription id.

* Include the free verbiage in the description.

* Updated telehealth plan for 14 day free trial.

* Defaulting values to avoid sql error.