### PR TITLE
Fix institution id to generate if empty

### DIFF
--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/src/TelehealthGlobalConfig.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/src/TelehealthGlobalConfig.php
@@ -16,6 +16,7 @@ use Comlink\OpenEMR\Module\GlobalConfig;
 use OpenEMR\Common\Crypto\CryptoGen;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Common\Uuid\UniqueInstallationUuid;
 use OpenEMR\Services\Globals\GlobalSetting;
 use OpenEMR\Services\Globals\GlobalsService;
 use MyMailer;
@@ -253,7 +254,7 @@ class TelehealthGlobalConfig
 
     public function getInstitutionId()
     {
-        return $this->getGlobalSetting(self::UNIQUE_INSTALLATION_ID);
+        return UniqueInstallationUuid::getUniqueInstallationUuid();
     }
 
     public function getInstitutionName()


### PR DESCRIPTION
Telehealth settings needs to use the UniqueInstallationUuid instead of using the globals.

Fixes #6415.  This should be pretty rare that someone hasn't configured anything in their OpenEMR installation before setting up the telehealth settings, but this fixes that bug.