### PR TITLE
fix: puuid search param in AllergyIntoleranceService file

### DIFF
--- a/src/Services/AllergyIntoleranceService.php
+++ b/src/Services/AllergyIntoleranceService.php
@@ -199,6 +199,9 @@ class AllergyIntoleranceService extends BaseService
         if (isset($puuidBind)) {
             $search['puuid'] = new TokenSearchField('puuid', $puuidBind, true);
         }
+        if (!empty($search['puuid'])) {
+            $search['puuid'] = new TokenSearchField('puuid', $search['puuid'], true);
+        }
 
         return $this->search($search, $isAndCondition);
     }


### PR DESCRIPTION
Fixes #6242

#### Short description of what this resolves:
Modify the process so that the PUUID is properly tokenized
#### Changes proposed in this pull request:
I'm unsure if this is the correct approach. Can you please advise? Currently, the "api/patient/:puuid/allergy" API is using the PUUID in the search array without being tokenized.