### PR TITLE
feat: improve max failed login mechanism

### DIFF
--- a/interface/globals.php
+++ b/interface/globals.php
@@ -582,6 +582,9 @@ $GLOBALS['include_de_identification'] = 0;
 // don't include the authentication module - we do this to avoid
 // include loops.
 
+// EMAIL SETTINGS
+$SMTP_Auth = !empty($GLOBALS['SMTP_USER']);
+
 if (($ignoreAuth_onsite_portal === true) && ($GLOBALS['portal_onsite_two_enable'] == 1)) {
     $ignoreAuth = true;
 }
@@ -593,9 +596,6 @@ if (!$ignoreAuth) {
 // This is the background color to apply to form fields that are searchable.
 // Currently it is applicable only to the "Search or Add Patient" form.
 $GLOBALS['layout_search_color'] = '#ff9919';
-
-// EMAIL SETTINGS
-$SMTP_Auth = !empty($GLOBALS['SMTP_USER']);
 
 // module configurations
 // upgrade fails for versions prior to 4.2.0 since no modules table

--- a/interface/main/tabs/menu/menus/standard.json
+++ b/interface/main/tabs/menu/menus/standard.json
@@ -1982,6 +1982,18 @@
               "admin",
               "super"
             ]
+          },
+          {
+            "label": "IP Tracker",
+            "menu_id": "rep0",
+            "target": "rep",
+            "url": "/interface/reports/ip_tracker.php",
+            "children": [],
+            "requirement": 0,
+            "acl_req": [
+              "admin",
+              "super"
+            ]
           }
         ],
         "requirement": 0,

--- a/interface/reports/ip_tracker.php
+++ b/interface/reports/ip_tracker.php
@@ -1,0 +1,295 @@
+<?php
+
+/**
+ * IP tracker user interface.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2023 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+require_once("../globals.php");
+
+use OpenEMR\Common\Acl\AclMain;
+use OpenEMR\Common\Auth\AuthUtils;
+use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\Core\Header;
+
+
+if (!empty($_POST)) {
+    if (!CsrfUtils::verifyCsrfToken($_POST["csrf_token_form"], 'ip_tracker')) {
+        CsrfUtils::csrfNotVerified();
+    }
+}
+
+if (!AclMain::aclCheckCore('admin', 'super')) {
+    echo (new TwigContainer(null, $GLOBALS['kernel']))->getTwig()->render('core/unauthorized.html.twig', ['pageTitle' => xl("IP Tracker")]);
+    exit;
+}
+
+if (!empty($_POST['showOnlyWithCount'])) {
+    $showOnlyWithCount = true;
+} else {
+    $showOnlyWithCount = false;
+}
+
+if (!empty($_POST['showOnlyManuallyBlocked'])) {
+    $showOnlyManuallyBlocked = true;
+} else {
+    $showOnlyManuallyBlocked = false;
+}
+
+if (!empty($_POST['showOnlyAutoBlocked'])) {
+    $showOnlyAutoBlocked = true;
+} else {
+    $showOnlyAutoBlocked = false;
+}
+
+?>
+<html>
+
+<head>
+    <title><?php echo xlt('IP Tracker'); ?></title>
+
+    <?php Header::setupHeader(["report-helper"]); ?>
+
+    <script>
+        $(function () {
+            var win = top.printLogSetup ? top : opener.top;
+            win.printLogSetup(document.getElementById('printbutton'));
+        });
+
+        function refreshme() {
+            document.forms[0].submit();
+        }
+
+        function manualBlock(ipId) {
+            let func = "";
+            if (document.getElementById("manual-block-" + ipId).checked) {
+                func = "disableIp"
+            } else {
+                func = "enableIp"
+            }
+            top.restoreSession();
+            request = new FormData;
+            request.append("function", func);
+            request.append("ipId", ipId);
+            request.append("csrf_token_form", <?php echo js_escape(CsrfUtils::collectCsrfToken('counter')); ?>);
+            fetch("<?php echo $GLOBALS["webroot"]; ?>/library/ajax/login_counter_ip_tracker.php", {
+                method: 'POST',
+                credentials: 'same-origin',
+                body: request
+            });
+        }
+
+        function skipTiming(ipId) {
+            let func = "";
+            if (document.getElementById("timing-skip-" + ipId).checked) {
+                func = "skipTiming"
+            } else {
+                func = "noSkipTiming"
+            }
+            top.restoreSession();
+            request = new FormData;
+            request.append("function", func);
+            request.append("ipId", ipId);
+            request.append("csrf_token_form", <?php echo js_escape(CsrfUtils::collectCsrfToken('counter')); ?>);
+            fetch("<?php echo $GLOBALS["webroot"]; ?>/library/ajax/login_counter_ip_tracker.php", {
+                method: 'POST',
+                credentials: 'same-origin',
+                body: request
+            });
+        }
+
+        function resetCounterIp(ipId) {
+            top.restoreSession();
+            request = new FormData;
+            request.append("function", "resetIpCounter");
+            request.append("ipId", ipId);
+            request.append("csrf_token_form", <?php echo js_escape(CsrfUtils::collectCsrfToken('counter')); ?>);
+            fetch("<?php echo $GLOBALS["webroot"]; ?>/library/ajax/login_counter_ip_tracker.php", {
+                method: 'POST',
+                credentials: 'same-origin',
+                body: request
+            });
+            let failCounterElement = document.getElementById('fail-counter-' + ipId);
+            failCounterElement.innerHTML = "0";
+            let lastFailElement = document.getElementById('last-fail-' + ipId);
+            lastFailElement.innerHTML = jsText(xl("Not Applicable"));
+            let autoblockElement = document.getElementById('autoblock-' + ipId);
+            autoblockElement.innerHTML = jsText(xl("No"));
+        }
+
+    </script>
+
+    <style>
+        /* specifically include & exclude from printing */
+        @media print {
+            #report_parameters {
+                visibility: hidden;
+                display: none;
+            }
+            #report_results table {
+                margin-top: 0px;
+            }
+        }
+    </style>
+</head>
+
+<body class="body_top">
+
+<span class='title'><?php echo xlt('IP Tracker'); ?></span>
+
+<form method='post' name='theform' id='theform' action='ip_tracker.php' onsubmit='return top.restoreSession()'>
+    <input type="hidden" name="csrf_token_form" value="<?php echo attr(CsrfUtils::collectCsrfToken('ip_tracker')); ?>" />
+
+    <div id="report_parameters">
+
+        <table>
+            <tr>
+                <td width='650px'>
+                    <div style='float: left'>
+
+                        <table class='text'>
+                            <tr>
+                                <td>
+                                    <div class="checkbox">
+                                        <label>
+                                            <input type='checkbox' id='showOnlyWithCount' name='showOnlyWithCount' <?php echo ($showOnlyWithCount) ? ' checked' : ''; ?>> <?php echo xlt('Show Only With Applicable Failed Logins'); ?>
+                                        </label>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <div class="checkbox">
+                                        <label>
+                                            <input type='checkbox' id='showManuallyBlocked' name='showOnlyManuallyBlocked' <?php echo ($showOnlyManuallyBlocked) ? ' checked' : ''; ?>> <?php echo xlt('Show Only Manually Blocked'); ?>
+                                        </label>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <div class="checkbox">
+                                        <label>
+                                            <input type='checkbox' id='showAutoBlocked' name='showOnlyAutoBlocked' <?php echo ($showOnlyAutoBlocked) ? ' checked' : ''; ?>> <?php echo xlt('Show Only Auto Blocked'); ?>
+                                        </label>
+                                    </div>
+                                </td>
+                            </tr>
+                        </table>
+                    </div>
+                </td>
+                <td class='h-100' align='left' valign='middle'>
+                    <table class='w-100 h-100' style='border-left: 1px solid;'>
+                        <tr>
+                            <td>
+                                <div class="text-center">
+                                    <div class="btn-group" role="group">
+                                        <a href='#' class='btn btn-secondary btn-save' onclick='$("#form_refresh").attr("value","true"); $("#theform").submit();'>
+                                            <?php echo xlt('Submit'); ?>
+                                        </a>
+                                        <?php if (!empty($_POST['form_refresh'])) { ?>
+                                            <a href='#' class='btn btn-secondary btn-print' id='printbutton'>
+                                                <?php echo xlt('Print'); ?>
+                                            </a>
+                                        <?php } ?>
+                                    </div>
+                                </div>
+                            </td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+        </table>
+
+    </div>
+    <!-- end of search parameters --> <?php
+    if (!empty($_POST['form_refresh'])) {
+        ?>
+        <div id="report_results">
+            <table class='table'>
+
+                <thead class='thead-light'>
+                <th><?php echo xlt('IP String'); ?></th>
+                <th><?php echo xlt('Total Failed Logins'); ?></th>
+                <th><?php echo xlt('Applicable Failed Logins'); ?></th>
+                <th><?php echo xlt('Last Failed Login'); ?></th>
+                <th><?php echo xlt('Auto Blocked'); ?></th>
+                <th><?php echo xlt('Manual Settings'); ?></th>
+                </thead>
+                <tbody>
+                <!-- added for better print-ability -->
+                <?php
+                $ipLoginFailsSql = AuthUtils::collectIpLoginFailsSql($showOnlyWithCount, $showOnlyManuallyBlocked, $showOnlyAutoBlocked);
+
+                while ($row = SqlFetchArray($ipLoginFailsSql)) {
+                    ?>
+
+                    <tr valign='top' bgcolor='<?php echo attr($bgcolor ?? ''); ?>'>
+                        <td class="detail"><?php echo text($row['ip_string']); ?></td>
+                        <td class="detail"><?php echo text($row['total_ip_login_fail_counter']); ?></td>
+                        <td class="detail" id="fail-counter-<?php echo attr($row['id']) ?>">
+                            <?php
+                            echo text($row['ip_login_fail_counter']);
+                            if ($row['ip_login_fail_counter'] > 0) {
+                                echo '<button type="button" class="btn btn-sm btn-danger ml-2" onclick="resetCounterIp(' . attr_js($row["id"]) . ')">' . xlt("Reset Counter") . '</button>';
+                            }
+                            ?>
+                        </td>
+                        <td class="detail" id="last-fail-<?php echo attr($row['id']) ?>"><?php echo (!empty($row['ip_last_login_fail'])) ? text(oeFormatDateTime($row['ip_last_login_fail'])) : xlt("Not Applicable"); ?></td>
+                        <td class="detail" id="autoblock-<?php echo attr($row['id']) ?>">
+                            <?php
+                            $autoBlocked = false;
+                            $autoBlockEnd = null;
+                            if ((int)$GLOBALS['ip_max_failed_logins'] != 0 && ($row['ip_login_fail_counter'] > (int)$GLOBALS['ip_max_failed_logins'])) {
+                                if ((int)$GLOBALS['ip_time_reset_password_max_failed_logins'] != 0) {
+                                    if ($row['seconds_last_ip_login_fail'] < (int)$GLOBALS['ip_time_reset_password_max_failed_logins']) {
+                                        $autoBlocked = true;
+                                        $autoBlockEnd = date('Y-m-d H:i:s', (time() + ((int)$GLOBALS['ip_time_reset_password_max_failed_logins'] - $row['seconds_last_ip_login_fail'])));
+                                    }
+                                } else {
+                                    $autoBlocked = true;
+                                }
+                            }
+                            if ($autoBlocked) {
+                                echo xlt("Yes");
+                                if (!empty($autoBlockEnd)) {
+                                    echo ' (' . xlt("Autoblock ends on") . ' ' . text(oeFormatDateTime($autoBlockEnd)) . ')';
+                                }
+                            } else {
+                                echo xlt("No");
+                            }
+                            ?>
+                        </td>
+                        <td class="detail">
+                            <div class="form-check">
+                                <label class="form-check-label">
+                                    <input type="checkbox" class="form-check-input" id="manual-block-<?php echo attr($row['id']) ?>" title="<?php echo xla('Manually block this IP address'); ?>" onclick="manualBlock(<?php echo attr_js($row['id']) ?>)" <?php echo ($row['ip_force_block']) ? "checked" : ""; ?>><?php echo xlt('Manual Block'); ?>
+                                </label>
+                            </div>
+                            <div class="form-check">
+                                <label class="form-check-label">
+                                    <input type="checkbox" class="form-check-input" id="timing-skip-<?php echo attr($row['id']) ?>" title="<?php echo xla('Skip the Timing Attack Prevention'); ?>" onclick="skipTiming(<?php echo attr_js($row['id']) ?>)" <?php echo ($row['ip_no_prevent_timing_attack']) ? "checked" : ""; ?>><?php echo xlt('Skip Timing'); ?>
+                                </label>
+                            </div>
+                        </td>
+                    </tr>
+                <?php } ?>
+                </tbody>
+            </table>
+        </div>
+        <!-- end of search results -->
+    <?php } else { ?>
+        <div class='text'><?php echo xlt('Please select search criteria above, and click Submit to view results. If criteria(s) are not selected, then will show all.'); ?>
+        </div>
+    <?php } ?>
+    <input type='hidden' name='form_refresh' id='form_refresh' value='' /></form>
+
+</body>
+
+</html>

--- a/interface/usergroup/usergroup_admin.php
+++ b/interface/usergroup/usergroup_admin.php
@@ -559,6 +559,21 @@ function authorized_clicked() {
  f.calendar.checked  =  f.authorized.checked;
 }
 
+function resetCounter(username) {
+    top.restoreSession();
+    request = new FormData;
+    request.append("function", "resetUsernameCounter");
+    request.append("username", username);
+    request.append("csrf_token_form", <?php echo js_escape(CsrfUtils::collectCsrfToken('counter')); ?>);
+    fetch("<?php echo $GLOBALS["webroot"]; ?>/library/ajax/login_counter_ip_tracker.php", {
+        method: 'POST',
+        credentials: 'same-origin',
+        body: request
+    });
+    let loginCounterElement = document.getElementById('login-counter-' + username);
+    loginCounterElement.innerHTML = "0";
+}
+
 </script>
 
 </head>
@@ -618,6 +633,7 @@ function authorized_clicked() {
                                 echo '<th>' . xlt('Password Expiration') . '</th>';
                             }
                             ?>
+                            <th><?php echo xlt('Failed Login Counter'); ?></th>
                         </tr>
                     <tbody>
                         <?php
@@ -687,6 +703,41 @@ function authorized_clicked() {
                                 }
                                 echo '</td>';
                             }
+                            if (empty($iter["active"])) {
+                                echo '<td>';
+                                echo xlt('Not Applicable');
+                            } else {
+                                echo '<td id="login-counter-' . attr($iter["username"]) .  '">';
+                                $queryCounter = privQuery("SELECT `login_fail_counter`, `last_login_fail`, TIMESTAMPDIFF(SECOND, `last_login_fail`, NOW()) as `seconds_last_login_fail` FROM `users_secure` WHERE BINARY `username` = ?", [$iter["username"]]);
+                                if (!empty($queryCounter['login_fail_counter'])) {
+                                    echo text($queryCounter['login_fail_counter']);
+                                    if (!empty($queryCounter['last_login_fail'])) {
+                                        echo ' (' . xlt('last on') . ' ' . text(oeFormatDateTime($queryCounter['last_login_fail'])) . ')';
+                                    }
+                                    echo ' ' . '<button type="button" class="btn btn-sm btn-danger ml-1" onclick="resetCounter(' . attr_js($iter["username"]) . ')">' . xlt("Reset Counter") . '</button>';
+                                    $autoBlocked = false;
+                                    $autoBlockEnd = null;
+                                    if ((int)$GLOBALS['password_max_failed_logins'] != 0 && ($queryCounter['login_fail_counter'] > (int)$GLOBALS['password_max_failed_logins'])) {
+                                        if ((int)$GLOBALS['time_reset_password_max_failed_logins'] != 0) {
+                                            if ($queryCounter['seconds_last_login_fail'] < (int)$GLOBALS['time_reset_password_max_failed_logins']) {
+                                                $autoBlocked = true;
+                                                $autoBlockEnd = date('Y-m-d H:i:s', (time() + ((int)$GLOBALS['time_reset_password_max_failed_logins'] - $queryCounter['seconds_last_login_fail'])));
+                                            }
+                                        } else {
+                                            $autoBlocked = true;
+                                        }
+                                    }
+                                    if ($autoBlocked) {
+                                        echo '<br>' . xlt("Currently Autoblocked");
+                                        if (!empty($autoBlockEnd)) {
+                                            echo ' (' . xlt("Autoblock ends on") . ' ' . text(oeFormatDateTime($autoBlockEnd)) . ')';
+                                        }
+                                    }
+                                } else {
+                                    echo '0';
+                                }
+                            }
+                            echo '</td>';
                             print "</tr>\n";
                         }
                         ?>

--- a/library/ajax/login_counter_ip_tracker.php
+++ b/library/ajax/login_counter_ip_tracker.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * login_counter_ip_tracker.php
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2023 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+use OpenEMR\Common\Acl\AclMain;
+use OpenEMR\Common\Auth\AuthUtils;
+use OpenEMR\Common\Csrf\CsrfUtils;
+
+require_once(__DIR__ . "/../../interface/globals.php");
+
+if (!CsrfUtils::verifyCsrfToken($_POST["csrf_token_form"], 'counter')) {
+    CsrfUtils::csrfNotVerified(false);
+}
+
+if (empty($_POST['function'])) {
+    exit;
+}
+
+if ($_POST['function'] == 'resetUsernameCounter') {
+    if (!AclMain::aclCheckCore('admin', 'users')) {
+        error_log("Failed ACL access to login_counter_ip_tracker.php script for resetUsernameCounter function");
+        exit;
+    }
+
+    if (empty($_POST['username'])) {
+        exit;
+    }
+    AuthUtils::resetLoginFailedCounter($_POST['username']);
+    exit;
+}
+
+
+// all function below require admin super access
+if (!AclMain::aclCheckCore('admin', 'super')) {
+    error_log("Failed ACL access to login_counter_ip_tracker.php script for " . errorLogEscape($_POST['function']) . " function");
+    exit;
+}
+
+if ($_POST['function'] == 'disableIp') {
+    if (empty((int)$_POST['ipId'])) {
+        exit;
+    }
+    AuthUtils::disableIp((int)$_POST['ipId']);
+    exit;
+}
+
+if ($_POST['function'] == 'enableIp') {
+    if (empty((int)$_POST['ipId'])) {
+        exit;
+    }
+    AuthUtils::enableIp((int)$_POST['ipId']);
+    exit;
+}
+
+if ($_POST['function'] == 'skipTiming') {
+    if (empty((int)$_POST['ipId'])) {
+        exit;
+    }
+    AuthUtils::skipTimingIp((int)$_POST['ipId']);
+    exit;
+}
+
+if ($_POST['function'] == 'noSkipTiming') {
+    if (empty((int)$_POST['ipId'])) {
+        exit;
+    }
+    AuthUtils::noSkipTimingIp((int)$_POST['ipId']);
+    exit;
+}
+
+if ($_POST['function'] == 'resetIpCounter') {
+    if (empty((int)$_POST['ipId'])) {
+        exit;
+    }
+    AuthUtils::resetIpCounter((int)$_POST['ipId']);
+    exit;
+}

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -2148,10 +2148,31 @@ $GLOBALS_METADATA = array(
         ),
 
         'password_max_failed_logins' => array(
-            xl('Maximum Failed Login Attempts'),
+            xl('Maximum Failed Login Attempts For User'),
             'num',                            // data type
-            '0',                              // default
-            xl('Maximum Failed Login Attempts (0 for no maximum).')
+            '20',                             // default
+            xl('Maximum Failed Login Attempts For User (0 for no maximum).')
+        ),
+
+        'time_reset_password_max_failed_logins' => array(
+            xl('Time (seconds) to Reset Maximum Failed Login Attempts For User'),
+            'num',                            // data type
+            '3600',                           // default to 1 hour
+            xl('Time (seconds) to Reset Maximum Failed Login Attempts Counter For User (0 for no reset).')
+        ),
+
+        'ip_max_failed_logins' => array(
+            xl('Maximum Failed Login Attempts From IP Address'),
+            'num',                            // data type
+            '100',                            // default
+            xl('Maximum Failed Login Attempts From IP Address (0 for no maximum).')
+        ),
+
+        'ip_time_reset_password_max_failed_logins' => array(
+            xl('Time (seconds) to Reset Maximum Failed Login Attempts From IP Address'),
+            'num',                            // data type
+            '3600',                           // default to 1 hour
+            xl('Time (seconds) to Reset Maximum Failed Login Attempts Counter From IP Address (0 for no reset).')
         ),
 
         'gbl_fac_warehouse_restrictions' => array(

--- a/sites/default/documents/custom_menus/Custom.json
+++ b/sites/default/documents/custom_menus/Custom.json
@@ -1982,6 +1982,18 @@
               "admin",
               "super"
             ]
+          },
+          {
+            "label": "IP Tracker",
+            "menu_id": "rep0",
+            "target": "rep",
+            "url": "/interface/reports/ip_tracker.php",
+            "children": [],
+            "requirement": 0,
+            "acl_req": [
+              "admin",
+              "super"
+            ]
           }
         ],
         "requirement": 0,

--- a/sql/7_0_1-to-7_0_2_upgrade.sql
+++ b/sql/7_0_1-to-7_0_2_upgrade.sql
@@ -144,3 +144,35 @@ ALTER TABLE `x12_partners` ADD COLUMN `x12_submitter_id` tinyint(1) DEFAULT NULL
 #IfNotRow2D list_options list_id abook_type option_id bill_svc
 INSERT INTO list_options (list_id, option_id, title, seq, option_value) VALUES ('abook_type', 'bill_svc', 'Billing Service', 125, 3);
 #EndIf
+
+#IfMissingColumn users_secure last_login_fail
+ALTER TABLE `users_secure` ADD `last_login_fail` datetime DEFAULT NULL;
+#EndIf
+
+#IfMissingColumn users_secure total_login_fail_counter
+ALTER TABLE `users_secure` ADD `total_login_fail_counter` bigint DEFAULT 0;
+#EndIf
+
+#IfMissingColumn users_secure auto_block_emailed
+ALTER TABLE `users_secure` ADD `auto_block_emailed` tinyint DEFAULT 0;
+#EndIf
+
+#IfNotRow globals gl_name time_reset_password_max_failed_logins
+UPDATE `globals` SET `gl_value` = 20 WHERE `gl_name` = 'password_max_failed_logins' AND `gl_value` = 0;
+#EndIf
+
+#IfNotTable ip_tracking
+CREATE TABLE `ip_tracking` (
+`id` bigint NOT NULL auto_increment,
+`ip_string` varchar(255) DEFAULT '',
+`total_ip_login_fail_counter` bigint DEFAULT 0,
+`ip_login_fail_counter` bigint DEFAULT 0,
+`ip_last_login_fail` datetime DEFAULT NULL,
+`ip_auto_block_emailed` tinyint DEFAULT 0,
+`ip_force_block` tinyint DEFAULT 0,
+`ip_no_prevent_timing_attack` tinyint DEFAULT 0,
+PRIMARY KEY (`id`),
+UNIQUE KEY `ip_string` (`ip_string`)
+) ENGINE=InnoDb AUTO_INCREMENT=1;
+#EndIf
+

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -3234,6 +3234,26 @@ INSERT INTO insurance_type_codes(`id`,`type`,`claim_type`) VALUES ('26','Mutuall
 -- --------------------------------------------------------
 
 --
+-- Table structure for table `ip_tracking`
+--
+DROP TABLE IF EXISTS `ip_tracking`;
+CREATE TABLE `ip_tracking` (
+    `id` bigint NOT NULL auto_increment,
+    `ip_string` varchar(255) DEFAULT '',
+    `total_ip_login_fail_counter` bigint DEFAULT 0,
+    `ip_login_fail_counter` bigint DEFAULT 0,
+    `ip_last_login_fail` datetime DEFAULT NULL,
+    `ip_auto_block_emailed` tinyint DEFAULT 0,
+    `ip_force_block` tinyint DEFAULT 0,
+    `ip_no_prevent_timing_attack` tinyint DEFAULT 0,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `ip_string` (`ip_string`)
+) ENGINE=InnoDb AUTO_INCREMENT=1;
+
+
+-- --------------------------------------------------------
+
+--
 -- Table structure for table `issue_encounter`
 --
 
@@ -8868,7 +8888,10 @@ CREATE TABLE `users_secure` (
   `password_history4` varchar(255),
   `last_challenge_response` datetime DEFAULT NULL,
   `login_work_area` text,
+  `total_login_fail_counter` bigint DEFAULT 0,
   `login_fail_counter` INT(11) DEFAULT '0',
+  `last_login_fail` datetime DEFAULT NULL,
+  `auto_block_emailed` tinyint DEFAULT 0,
   PRIMARY KEY (`id`),
   UNIQUE KEY `USERNAME_ID` (`id`,`username`)
 ) ENGINE=InnoDb;

--- a/src/Common/Auth/AuthUtils.php
+++ b/src/Common/Auth/AuthUtils.php
@@ -40,6 +40,7 @@
 namespace OpenEMR\Common\Auth;
 
 use Google_Client;
+use MyMailer;
 use OpenEMR\Common\Acl\AclExtended;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Auth\AuthHash;
@@ -275,8 +276,36 @@ class AuthUtils
         // Collect ip address for log
         $ip = collectIpAddresses();
 
+        // Check to ensure ip address has not been blocked
+        // check IP login counter if this option is set
+        if ($this->loginAuth || $this->apiAuth) {
+            $this->setupIpLoginFailedCounter($ip['ip_string']);
+            // Utilize this during logins (and not during standard password checks within openemr such as esign)
+            $returnArray = $this->checkIpLoginFailedCounter($ip['ip_string']);
+            if (!$returnArray['pass']) {
+                $this->incrementIpLoginFailedCounter($ip['ip_string']);
+                if ($returnArray['force_block']) {
+                    EventAuditLogger::instance()->newEvent($event, $username, '', 0, $beginLog . ": " . $ip['ip_string'] . ". IP address has been manually blocked");
+                } else {
+                    EventAuditLogger::instance()->newEvent($event, $username, '', 0, $beginLog . ": " . $ip['ip_string'] . ". IP address exceeded maximum number of failed logins");
+                }
+                $this->clearFromMemory($password);
+                if ($returnArray['email_notification']) {
+                    $this->notifyIpBlock($ip['ip_string']);
+                }
+                if (!$returnArray['skip_timing_attack']) {
+                    $this->preventTimingAttack();
+                }
+                return false;
+            }
+        }
+
         // Check to ensure username and password are not empty
         if (empty($username) || empty($password)) {
+            if ($this->loginAuth || $this->apiAuth) {
+                // Utilize this during logins (and not during standard password checks within openemr such as esign)
+                $this->incrementIpLoginFailedCounter($ip['ip_string']);
+            }
             EventAuditLogger::instance()->newEvent($event, $username, '', 0, $beginLog . ": " . $ip['ip_string'] . ". empty username or password");
             $this->clearFromMemory($password);
             $this->preventTimingAttack();
@@ -287,11 +316,19 @@ class AuthUtils
         $getUserSQL = "select `id`, `authorized`, `see_auth`, `active` from `users` where BINARY `username` = ?";
         $userInfo = privQuery($getUserSQL, [$username]);
         if (empty($userInfo) || empty($userInfo['id'])) {
+            if ($this->loginAuth || $this->apiAuth) {
+                // Utilize this during logins (and not during standard password checks within openemr such as esign)
+                $this->incrementIpLoginFailedCounter($ip['ip_string']);
+            }
             EventAuditLogger::instance()->newEvent($event, $username, '', 0, $beginLog . ": " . $ip['ip_string'] . ". user not found");
             $this->clearFromMemory($password);
             $this->preventTimingAttack();
             return false;
         } elseif ($userInfo['active'] != 1) {
+            if ($this->loginAuth || $this->apiAuth) {
+                // Utilize this during logins (and not during standard password checks within openemr such as esign)
+                $this->incrementIpLoginFailedCounter($ip['ip_string']);
+            }
             EventAuditLogger::instance()->newEvent($event, $username, '', 0, $beginLog . ": " . $ip['ip_string'] . ". user not active");
             $this->clearFromMemory($password);
             $this->preventTimingAttack();
@@ -301,6 +338,10 @@ class AuthUtils
         // Check to ensure user is in a group (and collect the group name)
         $authGroup = UserService::getAuthGroupForUser($username);
         if (empty($authGroup)) {
+            if ($this->loginAuth || $this->apiAuth) {
+                // Utilize this during logins (and not during standard password checks within openemr such as esign)
+                $this->incrementIpLoginFailedCounter($ip['ip_string']);
+            }
             EventAuditLogger::instance()->newEvent($event, $username, '', 0, $beginLog . ": " . $ip['ip_string'] . ". user not found in a group");
             $this->clearFromMemory($password);
             $this->preventTimingAttack();
@@ -309,6 +350,10 @@ class AuthUtils
 
         // Check to ensure user is in a acl group
         if (AclExtended::aclGetGroupTitles($username) == 0) {
+            if ($this->loginAuth || $this->apiAuth) {
+                // Utilize this during logins (and not during standard password checks within openemr such as esign)
+                $this->incrementIpLoginFailedCounter($ip['ip_string']);
+            }
             EventAuditLogger::instance()->newEvent($event, $username, $authGroup, 0, $beginLog . ": " . $ip['ip_string'] . ". user not in any phpGACL groups");
             $this->clearFromMemory($password);
             $this->preventTimingAttack();
@@ -321,6 +366,10 @@ class AuthUtils
             " WHERE BINARY `username` = ?";
         $userSecure = privQuery($getUserSecureSQL, [$username]);
         if (empty($userSecure) || empty($userSecure['id']) || empty($userSecure['password'])) {
+            if ($this->loginAuth || $this->apiAuth) {
+                // Utilize this during logins (and not during standard password checks within openemr such as esign)
+                $this->incrementIpLoginFailedCounter($ip['ip_string']);
+            }
             EventAuditLogger::instance()->newEvent($event, $username, $authGroup, 0, $beginLog . ": " . $ip['ip_string'] . ". user credentials not found");
             $this->clearFromMemory($password);
             $this->preventTimingAttack();
@@ -331,6 +380,11 @@ class AuthUtils
         if (self::useActiveDirectory($username)) {
             // ldap authentication
             if (!$this->activeDirectoryValidation($username, $password)) {
+                if ($this->loginAuth || $this->apiAuth) {
+                    // Utilize this during logins (and not during standard password checks within openemr such as esign)
+                    $this->incrementLoginFailedCounter($username);
+                    $this->incrementIpLoginFailedCounter($ip['ip_string']);
+                }
                 EventAuditLogger::instance()->newEvent($event, $username, $authGroup, 0, $beginLog . ": " . $ip['ip_string'] . ". user failed ldap authentication");
                 $this->clearFromMemory($password);
                 return false;
@@ -339,6 +393,10 @@ class AuthUtils
             // standard authentication
             // First, ensure the user hash is a valid hash
             if (!AuthHash::hashValid($userSecure['password'])) {
+                if ($this->loginAuth || $this->apiAuth) {
+                    // Utilize this during logins (and not during standard password checks within openemr such as esign)
+                    $this->incrementIpLoginFailedCounter($ip['ip_string']);
+                }
                 EventAuditLogger::instance()->newEvent($event, $username, $authGroup, 0, $beginLog . ": " . $ip['ip_string'] . ". user stored password hash is invalid");
                 $this->clearFromMemory($password);
                 $this->preventTimingAttack();
@@ -349,6 +407,7 @@ class AuthUtils
                 if ($this->loginAuth || $this->apiAuth) {
                     // Utilize this during logins (and not during standard password checks within openemr such as esign)
                     $this->incrementLoginFailedCounter($username);
+                    $this->incrementIpLoginFailedCounter($ip['ip_string']);
                 }
                 EventAuditLogger::instance()->newEvent($event, $username, $authGroup, 0, $beginLog . ": " . $ip['ip_string'] . ". user password incorrect");
                 $this->clearFromMemory($password);
@@ -367,19 +426,28 @@ class AuthUtils
             }
         }
 
-        // check login counter if this option is set (note ldap skips this)
+        // check login counter if this option is set
         if ($this->loginAuth || $this->apiAuth) {
             // Utilize this during logins (and not during standard password checks within openemr such as esign)
-            if (!$this->checkLoginFailedCounter($username)) {
+            $checkArray = $this->checkLoginFailedCounter($username);
+            if (!$checkArray['pass']) {
                 $this->incrementLoginFailedCounter($username);
+                $this->incrementIpLoginFailedCounter($ip['ip_string']);
                 EventAuditLogger::instance()->newEvent($event, $username, $authGroup, 0, $beginLog . ": " . $ip['ip_string'] . ". user exceeded maximum number of failed logins");
                 $this->clearFromMemory($password);
+                if ($checkArray['email_notification']) {
+                    $this->notifyUserBlock($username);
+                }
                 return false;
             }
         }
 
         // Check to ensure password not expired if this option is set (note ldap skips this)
         if (!$this->checkPasswordNotExpired($username)) {
+            if ($this->loginAuth || $this->apiAuth) {
+                // Utilize this during logins (and not during standard password checks within openemr such as esign)
+                $this->incrementIpLoginFailedCounter($ip['ip_string']);
+            }
             EventAuditLogger::instance()->newEvent($event, $username, $authGroup, 0, $beginLog . ": " . $ip['ip_string'] . ". user password is expired");
             $this->clearFromMemory($password);
             return false;
@@ -389,7 +457,8 @@ class AuthUtils
         $this->clearFromMemory($password);
         if ($this->loginAuth || $this->apiAuth) {
             // Utilize this during logins (and not during standard password checks within openemr such as esign)
-            $this->resetLoginFailedCounter($username);
+            self::resetLoginFailedCounter($username);
+            $this->resetIpLoginFailedCounter($ip['ip_string']);
         }
         if ($this->loginAuth) {
             // Specialized code for login auth (not api auth)
@@ -643,6 +712,8 @@ class AuthUtils
             $updateSQL = "UPDATE `users_secure`";
             $updateSQL .= " SET `last_update_password` = NOW()";
             $updateSQL .= ", `login_fail_counter` = 0";
+            $updateSQL .= ", `last_login_fail` = null";
+            $updateSQL .= ", `auto_block_emailed` = 0";
             $updateSQL .= ", `password` = ?";
             array_push($updateParams, $newHash);
             if ($GLOBALS['password_history'] != 0) {
@@ -943,34 +1014,273 @@ class AuthUtils
         return true;
     }
 
-    private function checkLoginFailedCounter($user)
+    public static function collectIpLoginFailsSql(bool $showOnlyWithCount, bool $showOnlyManuallyBlocked, bool $showOnlyAutoBlocked)
     {
-        if ($GLOBALS['password_max_failed_logins'] == 0 || self::useActiveDirectory($user)) {
-            // skip the check if turned off or using active directory for login
-            return true;
+        $sqlBind = [];
+        $where = [];
+        if ($showOnlyWithCount) {
+            $where[] = ' (`ip_login_fail_counter` > 0) ';
         }
-
-        $query = privQuery("SELECT `login_fail_counter` FROM `users_secure` WHERE BINARY `username` = ?", [$user]);
-        if ($query['login_fail_counter'] >= $GLOBALS['password_max_failed_logins']) {
-            return false;
+        if ($showOnlyManuallyBlocked) {
+            $where[] = ' (`ip_force_block` = 1) ';
+        }
+        if ($showOnlyAutoBlocked) {
+            if ((int)$GLOBALS['ip_max_failed_logins'] != 0) {
+                if (!empty((int)$GLOBALS['ip_time_reset_password_max_failed_logins']) && (int)$GLOBALS['ip_time_reset_password_max_failed_logins'] > 0) {
+                    $where[] = ' (ip_login_fail_counter > ? AND TIMESTAMPDIFF(SECOND, `ip_last_login_fail`, NOW()) < ?) ';
+                    array_push($sqlBind, (int)$GLOBALS['ip_max_failed_logins'], (int)$GLOBALS['ip_time_reset_password_max_failed_logins']);
+                } else {
+                    $where[] = ' (ip_login_fail_counter > ?) ';
+                    array_push($sqlBind, (int)$GLOBALS['ip_max_failed_logins']);
+                }
+            }
+        }
+        if (!empty($where)) {
+            $where = implode('AND', $where);
+            $where = 'WHERE ' . $where;
         } else {
-            return true;
+            $where = '';
+        }
+
+        return sqlStatement("SELECT `id`, `ip_string`, `ip_force_block`, `ip_no_prevent_timing_attack`, `total_ip_login_fail_counter`, `ip_login_fail_counter`, `ip_last_login_fail`, TIMESTAMPDIFF(SECOND, `ip_last_login_fail`, NOW()) as `seconds_last_ip_login_fail` FROM `ip_tracking` $where ORDER BY `ip_last_login_fail` DESC, `total_ip_login_fail_counter` DESC", $sqlBind);
+    }
+
+    private function setupIpLoginFailedCounter(string $ipString): void
+    {
+        if (empty($ipString)) {
+            // this should not happen, but will do this to ensure things do not break if it does happen
+            $ipString = 'blank';
+        }
+        $sql = sqlQuery("SELECT `ip_string` FROM `ip_tracking` WHERE `ip_string` = ?", [$ipString]);
+        if (empty($sql['ip_string'])) {
+            sqlStatement("INSERT INTO `ip_tracking` (`ip_string`) VALUES (?)", [$ipString]);
         }
     }
 
-    private function resetLoginFailedCounter($user)
+    private function checkLoginFailedCounter(string $user): array
     {
-        if (!self::useActiveDirectory($user)) {
-            // skip if using active directory for login
-            privStatement("UPDATE `users_secure` SET `login_fail_counter` = 0 WHERE BINARY `username` = ?", [$user]);
+        if ((int)$GLOBALS['password_max_failed_logins'] == 0) {
+            // skip the check if turned off
+            return ['pass' => true, 'email_notification' => null];
+        }
+
+        $query = privQuery("SELECT `auto_block_emailed`, `login_fail_counter`, TIMESTAMPDIFF(SECOND, `last_login_fail`, NOW()) as `seconds_last_login_fail` FROM `users_secure` WHERE BINARY `username` = ?", [$user]);
+        if ($query['login_fail_counter'] >= (int)$GLOBALS['password_max_failed_logins']) {
+            if (
+                !empty((int)$GLOBALS['time_reset_password_max_failed_logins']) &&
+                (int)$GLOBALS['time_reset_password_max_failed_logins'] > 0 &&
+                !empty($query['seconds_last_login_fail']) &&
+                $query['seconds_last_login_fail'] > (int)$GLOBALS['time_reset_password_max_failed_logins']
+            ) {
+                // the last login fail was longer than the timeout required to reset the failed logins, so will pass
+                //  (also need to reset the counter)
+                self::resetLoginFailedCounter($user);
+                return ['pass' => true, 'email_notification' => null];
+            }
+            if (empty($query['auto_block_emailed'])) {
+                $emailNotification = true;
+            } else {
+                $emailNotification = false;
+            }
+            return ['pass' => false, 'email_notification' => $emailNotification];
+        } else {
+            return ['pass' => true, 'email_notification' => null];
         }
     }
 
-    private function incrementLoginFailedCounter($user)
+    private function checkIpLoginFailedCounter(string $ipString): array
     {
-        if (!self::useActiveDirectory($user)) {
-            // skip if using active directory for login
-            privStatement("UPDATE `users_secure` SET `login_fail_counter` = login_fail_counter+1 WHERE BINARY `username` = ?", [$user]);
+        if (empty($ipString)) {
+            // this should not happen, but will do this to ensure things do not break if it does happen
+            $ipString = 'blank';
+        }
+
+        if ((int)$GLOBALS['ip_max_failed_logins'] == 0) {
+            // skip the check if turned off
+            return ['pass' => true, 'force_block' => null, 'skip_timing_attack' => null, 'email_notification' => null];
+        }
+
+        $query = sqlQuery("SELECT `ip_auto_block_emailed`, `ip_force_block`, `ip_no_prevent_timing_attack`, `ip_login_fail_counter`, TIMESTAMPDIFF(SECOND, `ip_last_login_fail`, NOW()) as `seconds_last_ip_login_fail` FROM `ip_tracking` WHERE `ip_string` = ?", [$ipString]);
+        if ($query['ip_force_block'] == 1) {
+            if ($query['ip_no_prevent_timing_attack'] == 1) {
+                return ['pass' => false, 'force_block' => true, 'skip_timing_attack' => true, 'email_notification' => false];
+            } else {
+                return ['pass' => false, 'force_block' => true, 'skip_timing_attack' => false, 'email_notification' => false];
+            }
+        }
+        if ($query['ip_login_fail_counter'] >= (int)$GLOBALS['ip_max_failed_logins']) {
+            if (
+                !empty((int)$GLOBALS['ip_time_reset_password_max_failed_logins']) &&
+                (int)$GLOBALS['ip_time_reset_password_max_failed_logins'] > 0 &&
+                !empty($query['seconds_last_ip_login_fail']) &&
+                $query['seconds_last_ip_login_fail'] > (int)$GLOBALS['ip_time_reset_password_max_failed_logins']
+            ) {
+                // the last ip login fail was longer than the timeout required to reset the failed logins, so will pass
+                //  (also need to reset the counter)
+                $this->resetIpLoginFailedCounter($ipString);
+                return ['pass' => true, 'force_block' => null, 'skip_timing_attack' => null, 'email_notification' => null];
+            }
+            if (empty($query['ip_auto_block_emailed'])) {
+                $emailNotification = true;
+            } else {
+                $emailNotification = false;
+            }
+            return ['pass' => false, 'force_block' => false, 'skip_timing_attack' => false, 'email_notification' => $emailNotification];
+        } else {
+            return ['pass' => true, 'force_block' => null, 'skip_timing_attack' => null, 'email_notification' => null];
+        }
+    }
+
+    public static function resetLoginFailedCounter($user)
+    {
+        privStatement("UPDATE `users_secure` SET `login_fail_counter` = 0, `last_login_fail` = null, `auto_block_emailed` = 0 WHERE BINARY `username` = ?", [$user]);
+    }
+
+    private function resetIpLoginFailedCounter(string $ipString): void
+    {
+        if (empty($ipString)) {
+            // this should not happen, but will do this to ensure things do not break if it does happen
+            $ipString = 'blank';
+        }
+
+        sqlStatement("UPDATE `ip_tracking` SET `ip_login_fail_counter` = 0, `ip_last_login_fail` = null, `ip_auto_block_emailed` = 0 WHERE `ip_string` = ?", [$ipString]);
+    }
+
+    private function incrementLoginFailedCounter($user): void
+    {
+        // If there is a timeout set for the autoblock, then need to check it when incrementing the counter
+        if (
+            !empty((int)$GLOBALS['time_reset_password_max_failed_logins']) &&
+            (int)$GLOBALS['time_reset_password_max_failed_logins'] > 0
+        ) {
+            $query = privQuery("SELECT TIMESTAMPDIFF(SECOND, `last_login_fail`, NOW()) as `seconds_last_login_fail` FROM `users_secure` WHERE BINARY `username` = ?", [$user]);
+            if (
+                !empty($query['seconds_last_login_fail']) &&
+                $query['seconds_last_login_fail'] > (int)$GLOBALS['time_reset_password_max_failed_logins']
+            ) {
+                // the last login fail was longer than the timeout required to reset the failed logins, so will set the login_fail_counter to 1 (ie. reset the counter to 0 and add the 1 for the most recent fail)
+                privStatement("UPDATE `users_secure` SET `total_login_fail_counter` = total_login_fail_counter+1, `login_fail_counter` = 1, `last_login_fail` = NOW(), `auto_block_emailed` = 0 WHERE BINARY `username` = ?", [$user]);
+                return;
+            }
+        }
+
+        privStatement("UPDATE `users_secure` SET `total_login_fail_counter` = total_login_fail_counter+1, `login_fail_counter` = login_fail_counter+1, `last_login_fail` = NOW() WHERE BINARY `username` = ?", [$user]);
+    }
+
+    private function incrementIpLoginFailedCounter(string $ipString): void
+    {
+        if (empty($ipString)) {
+            // this should not happen, but will do this to ensure things do not break if it does happen
+            $ipString = 'blank';
+        }
+
+        // If there is a timeout set for the autoblock, then need to check it when incrementing the counter
+        if (
+            !empty((int)$GLOBALS['ip_time_reset_password_max_failed_logins']) &&
+            (int)$GLOBALS['ip_time_reset_password_max_failed_logins'] > 0
+        ) {
+            $query = sqlQuery("SELECT TIMESTAMPDIFF(SECOND, `ip_last_login_fail`, NOW()) as `seconds_last_ip_login_fail` FROM `ip_tracking` WHERE `ip_string` = ?", [$ipString]);
+            if (
+                !empty($query['seconds_last_ip_login_fail']) &&
+                $query['seconds_last_ip_login_fail'] > (int)$GLOBALS['ip_time_reset_password_max_failed_logins']
+            ) {
+                // the last login fail was longer than the timeout required to reset the failed logins, so will set the login_fail_counter to 1 (ie. reset the counter to 0 and add the 1 for the most recent fail)
+                sqlStatement("UPDATE `ip_tracking` SET `total_ip_login_fail_counter` = total_ip_login_fail_counter+1, `ip_login_fail_counter` = 1, `ip_last_login_fail` = NOW(), `ip_auto_block_emailed` = 0 WHERE `ip_string` = ?", [$ipString]);
+                return;
+            }
+        }
+
+        sqlStatement("UPDATE `ip_tracking` SET `total_ip_login_fail_counter` = total_ip_login_fail_counter+1, `ip_login_fail_counter` = ip_login_fail_counter+1, `ip_last_login_fail` = NOW() WHERE `ip_string` = ?", [$ipString]);
+    }
+
+    public static function resetIpCounter(int $ipId): void
+    {
+        sqlStatement("UPDATE `ip_tracking` SET `ip_login_fail_counter` = 0, `ip_last_login_fail` = null, `ip_auto_block_emailed` = 0 WHERE `id` = ?", [$ipId]);
+    }
+
+    public static function disableIp(int $ipId): void
+    {
+        sqlStatement("UPDATE `ip_tracking` SET `ip_force_block` = 1 WHERE `id` = ?", [$ipId]);
+    }
+
+    public static function enableIp(int $ipId): void
+    {
+        sqlStatement("UPDATE `ip_tracking` SET `ip_force_block` = 0 WHERE `id` = ?", [$ipId]);
+    }
+
+    public static function skipTimingIp(int $ipId): void
+    {
+        sqlStatement("UPDATE `ip_tracking` SET `ip_no_prevent_timing_attack` = 1 WHERE `id` = ?", [$ipId]);
+    }
+
+    public static function noSkipTimingIp(int $ipId): void
+    {
+        sqlStatement("UPDATE `ip_tracking` SET `ip_no_prevent_timing_attack` = 0 WHERE `id` = ?", [$ipId]);
+    }
+
+    private function notifyIpBlock(string $ip_string): bool
+    {
+        sqlStatement("UPDATE `ip_tracking` SET `ip_auto_block_emailed` = 1 WHERE `ip_string` = ?", [$ip_string]);
+
+        if (!empty($GLOBALS['patient_reminder_sender_email']) && !empty($GLOBALS['practice_return_email_path'])) {
+            $mail = new MyMailer();
+            $email_subject = xl('IP Address Block Notification For OpenEMR Admin');
+            $email_sender = $GLOBALS['patient_reminder_sender_email'];
+            $email_address = $GLOBALS['practice_return_email_path'];
+            if (empty((int)$GLOBALS['ip_time_reset_password_max_failed_logins'])) {
+                $message = "IP address '" . text($ip_string) . "' has been blocked.";
+            } else {
+                $message = "IP address '" . text($ip_string) . "' has been temporarily blocked.";
+            }
+            $mail->AddReplyTo($email_sender, $email_sender);
+            $mail->SetFrom($email_sender, $email_sender);
+            $mail->AddAddress($email_address, "OpenEMR Admin");
+            $mail->Subject = $email_subject;
+            $mail->MsgHTML("<html><body><div class='wrapper'>" . $message . "</div></body></html>");
+            $mail->AltBody = $message;
+            $mail->IsHTML(true);
+            if ($mail->Send()) {
+                return true;
+            } else {
+                error_log("Failed to send OpenEMR admin email notification through Mymailer with error " . errorLogEscape($mail->ErrorInfo));
+                return false;
+            }
+        } else {
+            error_log("Unable to send OpenEMR admin email notification since either patient_reminder_sender_email or practice_return_email_path global was not set");
+            return false;
+        }
+    }
+
+    private function notifyUserBlock(string $username): bool
+    {
+        privStatement("UPDATE `users_secure` SET `auto_block_emailed` = 1 WHERE BINARY `username` = ?", [$username]);
+
+        if (!empty($GLOBALS['patient_reminder_sender_email']) && !empty($GLOBALS['practice_return_email_path'])) {
+            $mail = new MyMailer();
+            $email_subject = xl('Username Block Notification For OpenEMR Admin');
+            $email_sender = $GLOBALS['patient_reminder_sender_email'];
+            $email_address = $GLOBALS['practice_return_email_path'];
+            if (empty((int)$GLOBALS['time_reset_password_max_failed_logins'])) {
+                $message = "Username '" . text($username) . "' has been blocked.";
+            } else {
+                $message = "Username '" . text($username) . "' has been temporarily blocked.";
+            }
+            $mail->AddReplyTo($email_sender, $email_sender);
+            $mail->SetFrom($email_sender, $email_sender);
+            $mail->AddAddress($email_address, "OpenEMR Admin");
+            $mail->Subject = $email_subject;
+            $mail->MsgHTML("<html><body><div class='wrapper'>" . $message . "</div></body></html>");
+            $mail->AltBody = $message;
+            $mail->IsHTML(true);
+            if ($mail->Send()) {
+                return true;
+            } else {
+                error_log("Failed to send OpenEMR admin email notification through Mymailer with error " . errorLogEscape($mail->ErrorInfo));
+                return false;
+            }
+        } else {
+            error_log("Unable to send OpenEMR admin email notification since either patient_reminder_sender_email or practice_return_email_path global was not set");
+            return false;
         }
     }
 

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@ $v_realpatch = '0';
 // is a database change in the course of development.  It is used
 // internally to determine when a database upgrade is needed.
 //
-$v_database = 487;
+$v_database = 488;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
fixes #5627 

Basically provides ability to set a timeout (from last failed login) where then ok to login.
Also sets default setting of 20 for failed logins (and 1 hour for the timeout above)
Displayed the failed user login counter and last failed date in the Users display.

Would it also be helpful to have ability to reset the failed login counter in the Users display?
