### PR TITLE
Syntax error Dated Reminders

### DIFF
--- a/interface/main/dated_reminders/dated_reminders.php
+++ b/interface/main/dated_reminders/dated_reminders.php
@@ -163,7 +163,7 @@ function goPid(pid) {
 <?php
     // initialize html string
     $pdHTML = '<div class="">
-                      <div class="drHide>' .
+                      <div class="drHide">' .
                           '<a title="' . xla('View Past and Future Reminders') . '" onclick="openLogScreen()" class="btn btn-secondary  btn-sm btn-show" href="#">' . xlt('View Log') . '</a>&nbsp;' . '<a onclick="openAddScreen(0)" class="btn btn-primary btn-sm btn-add" href="#">' . xlt('Create A Dated Reminder') . '</a>
                       </div>
                       <div class="pre-scrollable mt-3">


### PR DESCRIPTION
- missing quote causes log and add dialogs to both popup

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #6440 

#### Short description of what this resolves:
Dated reminder popups misbehaving.

For patch 1