### PR TITLE
fix: pass referenced variable instead of integer to genX12837P

### DIFF
--- a/src/Billing/BillingProcessor/Tasks/GeneratorX12.php
+++ b/src/Billing/BillingProcessor/Tasks/GeneratorX12.php
@@ -67,6 +67,7 @@ class GeneratorX12 extends AbstractGenerator implements GeneratorInterface, Gene
     {
         // Generate the file
         $log = '';
+        $hlCount = 1;
         $segs = explode(
             "~\n",
             X125010837P::genX12837P(
@@ -76,7 +77,7 @@ class GeneratorX12 extends AbstractGenerator implements GeneratorInterface, Gene
                 $log,
                 $this->encounter_claim,
                 false,
-                1 // HLCount
+                $hlCount
             )
         );
         $this->appendToLog($log);


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #6495 

#### Short description of what this resolves:


#### Changes proposed in this pull request:
