### PR TITLE
Fixes #6497 options check on /token endpoint

### DIFF
--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -1044,6 +1044,12 @@ class AuthorizationController
         $response = $this->createServerResponse();
         $request = $this->createServerRequest();
 
+        if ($request->getMethod() == 'OPTIONS') {
+            // nothing to do here, just return
+            $this->emitResponse($response->withStatus(200));
+            return;
+        }
+
         // authorization code which is normally only sent for new tokens
         // by the authorization grant flow.
         $code = $request->getParsedBody()['code'] ?? null;


### PR DESCRIPTION
Fixes the CORS bug on the options check by just skipping the rest of the request logic once we've handled our CORS logic if we are an OPTIONS request.

Fixes #6497 