### PR TITLE
Fixes #6499 telehealth patient api update

### DIFF
--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Controller/TeleHealthVideoRegistrationController.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Controller/TeleHealthVideoRegistrationController.php
@@ -107,7 +107,6 @@ class TeleHealthVideoRegistrationController
             $oldPatient = $event->getDataBeforeUpdate();
             // we need the patient uuid so we are going to grab it from the pid
             $patientService = new PatientService();
-
             $patient['uuid'] = UuidRegistry::uuidToString($oldPatient['uuid']); // convert uuid to a string value
             $this->logger->debug(
                 self::class . "->onPatientUpdatedEvent received for patient ",
@@ -120,7 +119,7 @@ class TeleHealthVideoRegistrationController
             }
         } catch (Exception $exception) {
             $this->logger->errorLogCaller("Failed to create patient registration. Error: "
-                . $exception->getMessage(), ['trace' => $exception->getTraceAsString(), 'patient' => $patient['uuid']]);
+                . $exception->getMessage(), ['trace' => $exception->getTraceAsString(), 'patient' => $patient['uuid'] ?? '']);
         }
     }
 

--- a/src/Services/PatientService.php
+++ b/src/Services/PatientService.php
@@ -296,7 +296,18 @@ class PatientService extends BaseService
             // Tell subscribers that a new patient has been updated
             // We have to do this here and in the databaseUpdate() because this lookup is
             // by uuid where the databseUpdate updates by pid.
-            $patientUpdatedEvent = new PatientUpdatedEvent($dataBeforeUpdate, $processingResult->getData());
+
+
+            $originalData = [];
+            if ($dataBeforeUpdate->hasData()) {
+                $originalData = $dataBeforeUpdate->getData()[0]; // so wierd the findOne returns an array
+            }
+            // in order to be consistent and backwards compatible with the other PatientUpdatedEvent event
+            // we need the uuid to be the same binary fomrat as the other event firing.
+            if (!empty($originalData['uuid'])) {
+                $originalData['uuid'] = UuidRegistry::uuidToBytes($originalData['uuid']);
+            }
+            $patientUpdatedEvent = new PatientUpdatedEvent($originalData, $processingResult->getData());
             $GLOBALS["kernel"]->getEventDispatcher()->dispatch($patientUpdatedEvent, PatientUpdatedEvent::EVENT_HANDLE, 10);
         }
         return $processingResult;
@@ -391,7 +402,7 @@ class PatientService extends BaseService
                     FROM patient_history
                 ) patient_history ON patient_data.pid = patient_history.patient_history_pid
                 LEFT JOIN (
-                    SELECT  
+                    SELECT
                         contact.id AS contact_address_contact_id
                         ,contact.foreign_id AS contact_address_patient_id
                         ,contact_address.`id` AS contact_address_id


### PR DESCRIPTION
Patient api updates were breaking the telehealth remote registration api.  This is due to the signature differences in the event firing which was inconsistent.  One sent a raw data array and the other a ProcessingResult.  I made the method signatures identical.

Fixes #6499 