### PR TITLE
Fixes #6500 Telehealth Transfer appointment

### DIFF
--- a/src/Services/AppointmentService.php
+++ b/src/Services/AppointmentService.php
@@ -135,6 +135,7 @@ class AppointmentService extends BaseService
                        pce.pc_billing_location,
                        pce.pc_catid,
                        pce.pc_pid,
+                       pce.pc_duration,
                        f1.name as facility_name,
                        f2.name as billing_location_name
                        FROM (
@@ -145,6 +146,7 @@ class AppointmentService extends BaseService
                                pc_apptstatus,
                                pc_eventDate,
                                pc_startTime,
+                               pc_duration,
                                pc_endTime,
                                pc_facility,
                                pc_billing_location,


### PR DESCRIPTION
the pc_duration field was missing from the appointment search which breaks the insert event piece for the transfer appointment in telehealth.  Exposing the property ensures its not null.

Fixes #6500 