### PR TITLE
Fixes #6503 httprequest PSR7

### DIFF
--- a/_rest_routes.inc.php
+++ b/_rest_routes.inc.php
@@ -9323,8 +9323,8 @@ RestConfig::$FHIR_ROUTE_MAP = array(
         $return = $fhirExportService->processExport(
             $exportParams,
             'Group',
-            $request->getHeader('Accept'),
-            $request->getHeader('Prefer')
+            $request->getHeader('Accept')[0] ?? '',
+            $request->getHeader('Prefer')[0] ?? ''
         );
         RestConfig::apiLog($return);
         return $return;
@@ -11173,8 +11173,8 @@ RestConfig::$FHIR_ROUTE_MAP = array(
         $return = $fhirExportService->processExport(
             $request->getQueryParams(),
             'Patient',
-            $request->getHeader('Accept'),
-            $request->getHeader('Prefer')
+            $request->getHeader('Accept')[0] ?? '',
+            $request->getHeader('Prefer')[0] ?? ''
         );
         RestConfig::apiLog($return);
         return $return;
@@ -12664,8 +12664,8 @@ RestConfig::$FHIR_ROUTE_MAP = array(
         $return = $fhirExportService->processExport(
             $request->getQueryParams(),
             'System',
-            $request->getHeader('Accept'),
-            $request->getHeader('Prefer')
+            $request->getHeader('Accept')[0] ?? '',
+            $request->getHeader('Prefer')[0] ?? ''
         );
         RestConfig::apiLog($return);
         return $return;

--- a/src/Common/Http/HttpRestRequest.php
+++ b/src/Common/Http/HttpRestRequest.php
@@ -11,12 +11,24 @@
 
 namespace OpenEMR\Common\Http;
 
+use Http\Message\Encoding\GzipDecodeStream;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7\ServerRequest;
+use Nyholm\Psr7\Uri;
 use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Common\System\System;
 use OpenEMR\Common\Uuid\UuidRegistry;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
 
-class HttpRestRequest
+class HttpRestRequest implements ServerRequestInterface
 {
+    /**
+     * @var ServerRequestInterface
+     */
+    private $innerServerRequest;
+
     /**
      * @var \RestConfig
      */
@@ -97,11 +109,6 @@ class HttpRestRequest
     private $isLocalApi;
 
     /**
-     * @var string
-     */
-    private $requestMethod;
-
-    /**
      * The kind of REST api request this object represents
      * @var string
      */
@@ -117,41 +124,43 @@ class HttpRestRequest
      */
     private $apiBaseFullUrl;
 
-    /**
-     * @var string[] The request headers
-     */
-    private $headers;
-
-    /**
-     * @var mixed[]
-     */
-    private $queryParams;
-
-    /**
-     * The raw POST or PUT body contents
-     * @var null|string
-     */
-    private $requestBody;
-
     public function __construct($restConfig, $server)
     {
         $this->restConfig = $restConfig;
         $this->requestSite = $restConfig::$SITE;
 
-        $this->setRequestMethod($server["REQUEST_METHOD"]);
-        $this->setRequestURI($server['REQUEST_URI'] ?? "");
-        $this->headers = $this->parseHeadersFromServer($server);
+
+        $headers = $this->parseHeadersFromServer($server);
+        $body = null;
+        $method = strtoupper($_SERVER['REQUEST_METHOD'] ?? '');
+        if ($method == "POST" || $method == "PUT") {
+            $body = file_get_contents("php://input") ?? null;
+        }
+        // we use the URI from the restConfig to handle our ServerRequestInterface
+        $requestUri = $this->restConfig::getRequestEndPoint();
+        $this->requestSite = $this->restConfig::$SITE;
+        $requestUri = str_replace('/' . $this->requestSite, '', $requestUri);
+        // we use this to handle our ServerRequestInterface
+        $this->innerServerRequest =  new ServerRequest(
+            $method,
+            $requestUri ?? "",
+            $headers,
+            $body,
+            '1.1',
+            $server
+        );
+
         $queryParams = $_GET ?? [];
         // remove the OpenEMR queryParams that our rewrite command injected so we don't mess stuff up.
         if (isset($queryParams['_REWRITE_COMMAND'])) {
             unset($queryParams['_REWRITE_COMMAND']);
         }
-        $this->setQueryParams($queryParams);
-
-        if ($this->getRequestMethod() == "POST" || $this->getRequestMethod() == "PUT") {
-            $this->requestBody = file_get_contents("php://input") ?? null;
-        }
+        $this->innerServerRequest = $this->innerServerRequest->withQueryParams($queryParams);
         $this->setPatientRequest(false); // default to false
+
+        if (!empty($headers['APICSRFTOKEN'])) {
+            $this->setIsLocalApi(true);
+        }
     }
 
     /**
@@ -159,54 +168,61 @@ class HttpRestRequest
      */
     public function getRequestBody()
     {
-        return $this->requestBody;
+        $stream = $this->innerServerRequest->getBody(); // Nyholm points things at the end of the stream, so we need to rewind it.
+        $stream->rewind();
+        return $stream->getContents();
     }
 
     public function getRequestBodyJSON()
     {
-        if (!empty($this->requestBody)) {
-            return (array) (json_decode($this->requestBody));
+        $stream = $this->innerServerRequest->getBody(); // Nyholm points things at the end of the stream, so we need to rewind it.
+        $stream->rewind();
+        $contentEncoding = $this->getHeader("Content-Encoding");
+        // let's decode the gzip content if we can
+        if (!empty($contentEncoding) && $contentEncoding[0] === "gzip") {
+            $stream = new GzipDecodeStream($stream);
         }
-        return null;
+        return json_decode($stream->getContents(), true);
     }
 
     public function setRequestMethod($requestMethod)
     {
-        $this->requestMethod = $requestMethod;
+        $this->innerServerRequest = $this->innerServerRequest->withMethod($requestMethod);
     }
 
     public function setQueryParams($queryParams)
     {
-        $this->queryParams = $queryParams;
+        return $this->innerServerRequest->withQueryParams($queryParams);
     }
 
     public function getQueryParams()
     {
-        return $this->queryParams;
+        return $this->innerServerRequest->getQueryParams();
     }
 
     public function getQueryParam($key)
     {
-        return $this->queryParams[$key] ?? null;
+        $params = $this->getQueryParams();
+        return $params[$key] ?? null;
     }
 
     /**
      * Return an array of HTTP request headers
-     * @return array|string[]
+     * @return array|string[][]
      */
     public function getHeaders()
     {
-        return array_values($this->headers);
+        return $this->innerServerRequest->getHeaders();
     }
 
     /**
-     * Retrieve the value of the passed in request's HTTP header.  Return's null if the value does not exist
+     * Retrieve the value of the passed in request's HTTP header.  Returns an empty array if the header is not found
      * @param $headerName string the name of the header value to retrieve.
-     * @return mixed|string|null
+     * @return string[]
      */
     public function getHeader($headerName)
     {
-        return $this->headers[$headerName] ?? null;
+        return $this->innerServerRequest->getHeader($headerName);
     }
 
     /**
@@ -216,6 +232,7 @@ class HttpRestRequest
      */
     public function hasHeader($headerName)
     {
+        return $this->innerServerRequest->hasHeader($headerName);
         return !empty($this->headers[$headerName]);
     }
 
@@ -233,16 +250,20 @@ class HttpRestRequest
      */
     public function getRequestURI()
     {
-        return $this->requestURI;
+        return $this->innerServerRequest->getUri();
     }
 
     /**
      * Return the Request URI (matches the $_SERVER['REQUEST_URI'])
+     * changing the request uri, resets all of the populated methods that derive from the URI as we can't determine
+     * what they are, these have to be manually reset
      * @param mixed|string $requestURI
      */
     public function setRequestURI($requestURI): void
     {
-        $this->requestURI = $requestURI;
+        $this->resource = null;
+        $this->requestPath = null;
+        $this->innerServerRequest = $this->innerServerRequest->withUri(new Uri($requestURI));
     }
 
     /**
@@ -381,6 +402,9 @@ class HttpRestRequest
      */
     public function setRequestSite(string $requestSite): void
     {
+        // while here parse site from endpoint
+        $resource = str_replace('/' . $requestSite, '', $this->innerServerRequest->getUri()->getPath());
+        $this->innerServerRequest->withUri(new Uri($resource));
         $this->requestSite = $requestSite;
     }
 
@@ -483,7 +507,7 @@ class HttpRestRequest
 
     /**
      * Returns the scope context (patient,user,system) that is used for the given resource as parsed from the request scopes
-     * @param $resource The resource to check (IE Patient, AllergyIntolerance, etc).
+     * @param $resource string The resource to check (IE Patient, AllergyIntolerance, etc).
      * @return string|null The context or null if the resource does not exist in the scopes.
      */
     public function getScopeContextForResource($resource)
@@ -515,7 +539,7 @@ class HttpRestRequest
      */
     public function getRequestMethod(): ?string
     {
-        return $this->requestMethod;
+        return $this->innerServerRequest->getMethod();
     }
 
 
@@ -548,12 +572,12 @@ class HttpRestRequest
 
     public function setRequestPath(string $requestPath)
     {
-        $this->requestPath = $requestPath;
+        $this->innerServerRequest = $this->innerServerRequest->withUri($this->innerServerRequest->getUri()->withPath($requestPath));
     }
 
     public function getRequestPath(): ?string
     {
-        return $this->requestPath;
+        return $this->innerServerRequest->getUri()->getPath();
     }
 
     /**
@@ -574,12 +598,165 @@ class HttpRestRequest
         $this->apiBaseFullUrl = $apiBaseFullUrl;
     }
 
-    /**
-     * Given an array of server variables (typically the $_SERVER superglobal) parse out all of the HTTP_X headers
-     * and convert them into a hashmap of header -> header
-     * @param $server array of server variables typically the $_SERVER superglobal
-     * @return array hashmap of header -> header
-     */
+    public function getProtocolVersion()
+    {
+        return $this->innerServerRequest->getProtocolVersion();
+    }
+
+    public function withProtocolVersion($version)
+    {
+        $clonedRequest = clone $this;
+        $clonedRequest->innerServerRequest = $clonedRequest->innerServerRequest->withProtocolVersion($version);
+        return $clonedRequest;
+    }
+
+    public function getHeaderLine($name)
+    {
+        return $this->innerServerRequest->getHeaderLine($name);
+    }
+
+    public function withHeader($name, $value)
+    {
+        $clonedRequest = clone $this;
+        $clonedRequest->innerServerRequest = $clonedRequest->innerServerRequest->withHeader($name, $value);
+        return $clonedRequest;
+    }
+
+    public function withAddedHeader($name, $value)
+    {
+        $clonedRequest = clone $this;
+        $clonedRequest->innerServerRequest = $clonedRequest->innerServerRequest->withAddedHeader($name, $value);
+        return $clonedRequest;
+    }
+
+    public function withoutHeader($name)
+    {
+        $clonedRequest = clone $this;
+        $clonedRequest->innerServerRequest = $clonedRequest->innerServerRequest->withoutHeader($name);
+        return $clonedRequest;
+    }
+
+    public function getBody()
+    {
+        return $this->innerServerRequest->getBody();
+    }
+
+    public function withBody(StreamInterface $body)
+    {
+        $clonedRequest = clone $this;
+        $clonedRequest->innerServerRequest = $clonedRequest->innerServerRequest->withBody($body);
+        return $clonedRequest;
+    }
+
+    public function getRequestTarget()
+    {
+        $this->innerServerRequest->getRequestTarget();
+    }
+
+    public function withRequestTarget($requestTarget)
+    {
+        $clonedRequest = clone $this;
+        $clonedRequest->innerServerRequest = $clonedRequest->innerServerRequest->withRequestTarget($requestTarget);
+        return $clonedRequest;
+    }
+
+    public function getMethod()
+    {
+        return $this->innerServerRequest->getMethod();
+    }
+
+    public function withMethod($method)
+    {
+        $clonedRequest = clone $this;
+        $clonedRequest->innerServerRequest = $clonedRequest->innerServerRequest->withRequestTarget($method);
+        return $clonedRequest;
+    }
+
+    public function getUri()
+    {
+        return $this->innerServerRequest->getUri();
+    }
+
+    public function withUri(UriInterface $uri, $preserveHost = false)
+    {
+        $clonedRequest = clone $this;
+        $clonedRequest->innerServerRequest = $clonedRequest->innerServerRequest->withUri($uri, $preserveHost);
+        $clonedRequest->resource = null;
+        $clonedRequest->requestPath = null;
+        return $clonedRequest;
+    }
+
+    public function getServerParams()
+    {
+        return $this->innerServerRequest->getServerParams();
+    }
+
+    public function getCookieParams()
+    {
+        return $this->innerServerRequest->getCookieParams();
+    }
+
+    public function withCookieParams(array $cookies)
+    {
+        $clonedRequest = clone $this;
+        $clonedRequest->innerServerRequest = $clonedRequest->innerServerRequest->withCookieParams($cookies);
+        return $clonedRequest;
+    }
+
+    public function withQueryParams(array $query)
+    {
+        $clonedRequest = clone $this;
+        $clonedRequest->innerServerRequest = $clonedRequest->innerServerRequest->withQueryParams($query);
+        return $clonedRequest;
+    }
+
+    public function getUploadedFiles()
+    {
+        return $this->innerServerRequest->getUploadedFiles();
+    }
+
+    public function withUploadedFiles(array $uploadedFiles)
+    {
+        $clonedRequest = clone $this;
+        $clonedRequest->innerServerRequest = $clonedRequest->innerServerRequest->withUploadedFiles($uploadedFiles);
+        return $clonedRequest;
+    }
+
+    public function getParsedBody()
+    {
+        return $this->innerServerRequest->getParsedBody();
+    }
+
+    public function withParsedBody($data)
+    {
+        $clonedRequest = clone $this;
+        $clonedRequest->innerServerRequest = $clonedRequest->innerServerRequest->withParsedBody($data);
+        return $clonedRequest;
+    }
+
+    public function getAttributes()
+    {
+        return $this->innerServerRequest->getAttributes();
+    }
+
+    public function getAttribute($name, $default = null)
+    {
+        return $this->innerServerRequest->getAttribute($name, $default);
+    }
+
+    public function withAttribute($name, $value)
+    {
+        $clonedRequest = clone $this;
+        $clonedRequest->innerServerRequest = $clonedRequest->innerServerRequest->withAttribute($name, $value);
+        return $clonedRequest;
+    }
+
+    public function withoutAttribute($name)
+    {
+        $clonedRequest = clone $this;
+        $clonedRequest->innerServerRequest = $clonedRequest->innerServerRequest->withoutAttribute($name);
+        return $clonedRequest;
+    }
     private function parseHeadersFromServer($server)
     {
         $headers = array();
@@ -594,7 +771,10 @@ class HttpRestRequest
             $uppercasedServerHeader = ucwords(str_replace('_', ' ', $serverHeader));
 
             $header = str_replace(' ', '-', $uppercasedServerHeader);
-            $headers[$header] = $value;
+            if (empty($headers[$header])) {
+                $headers[$header] = [];
+            }
+            $headers[$header][] = $value;
         }
         return $headers;
     }

--- a/src/Common/Http/HttpRestRouteHandler.php
+++ b/src/Common/Http/HttpRestRouteHandler.php
@@ -59,7 +59,11 @@ class HttpRestRouteHandler
 //        header("Access-Control-Allow-Origin: *");
         // we have already validated the token which authenticates our client_id
         // we will go ahead and allow the origin
-        header("Access-Control-Allow-Origin: " . $dispatchRestRequest->getHeader('Origin'));
+        $origins = $dispatchRestRequest->getHeader('Origin');
+        if (!empty($origins)) {
+            header("Access-Control-Allow-Origin: " . $origins[0]);
+        }
+
         if ($request_method === 'OPTIONS') {
             return true; // for now we just return true if we have the route.
         }


### PR DESCRIPTION
Makes the http request object PSR7 compliant so we can use it in other libraries that consume PSR7 requestinterface objects.

Fixes #6503.  By being interoperable with PSR7, module writers can leverage other libraries and pass the request into things such as Guzzle, Symfony, and other components that leverage an interoperable request object. 