### PR TITLE
Fixes #6505,#6509 fhir,patient helper methods

### DIFF
--- a/src/Services/FHIR/FhirValidationService.php
+++ b/src/Services/FHIR/FhirValidationService.php
@@ -15,7 +15,7 @@ class FhirValidationService
     public function validate($data)
     {
         if (!array_key_exists('resourceType', $data)) {
-            return $this->operationOutcomeResourceService('error', 'invalid', false, 'resourceType Not Found');
+            return $this->operationOutcomeResourceService('error', 'invalid', 'resourceType Not Found');
         }
         if ($data['resourceType']) {
             $class = 'OpenEMR\FHIR\R4\FHIRDomainResource\FHIR' . $data['resourceType'];
@@ -24,10 +24,10 @@ class FhirValidationService
                 $patientResource = new $class($data);
             } catch (\InvalidArgumentException $e) {
                 return $this->
-                operationOutcomeResourceService('fatal', 'invalid', false, $e->getMessage());
+                operationOutcomeResourceService('fatal', 'invalid', $e->getMessage());
             } catch (\Error $e) {
                 return $this->
-                operationOutcomeResourceService('fatal', 'invalid', false, 'resourceType Not Found');
+                operationOutcomeResourceService('fatal', 'invalid', 'resourceType Not Found');
             }
             $diff = array_diff_key($data, (array) $patientResource);
             if ($diff) {
@@ -35,7 +35,6 @@ class FhirValidationService
                     'error',
                     'invalid',
                     "Invalid content " . array_key_first($diff) . " Found",
-                    false
                 );
             }
         }
@@ -44,39 +43,8 @@ class FhirValidationService
     public function operationOutcomeResourceService(
         $severity_value,
         $code_value,
-        $encode = true,
-        $details_value = '',
-        $diagnostics_value = '',
-        $expression = ''
+        $details_value
     ) {
-        $resource = new FHIROperationOutcome();
-        $issue = new FHIROperationOutcomeIssue();
-        $severity = new FHIRIssueSeverity();
-        $severity->setValue($severity_value);
-        $issue->setSeverity($severity);
-        $code = new FHIRIssueType();
-        $code->setValue($code_value);
-        $issue->setCode($code);
-        if ($details_value) {
-            $details = new FHIRCodeableConcept();
-            $details->setText($details_value);
-            $issue->setDetails($details);
-        }
-        if ($diagnostics_value) {
-            $diagnostics = new FHIRString();
-            $diagnostics->setValue($diagnostics_value);
-            $issue->setDiagnostics($diagnostics);
-        }
-        if ($expression_value) {
-            $expression = new FHIRCodeableConcept();
-            $expression->setText($expression_value);
-            $issue->setExpression($expression);
-        }
-        $resource->addIssue($issue);
-        if ($encode) {
-            return json_encode($resource);
-        } else {
-            return $resource;
-        }
+        return UtilsService::createOperationOutcomeResource($severity_value, $code_value, $details_value);
     }
 }

--- a/src/Services/FHIR/UtilsService.php
+++ b/src/Services/FHIR/UtilsService.php
@@ -13,9 +13,12 @@ namespace OpenEMR\Services\FHIR;
 
 use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Common\ORDataObject\ContactAddress;
+use OpenEMR\FHIR\Config\ServerConfig;
+use OpenEMR\FHIR\R4\FHIRDomainResource\FHIROperationOutcome;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRAddress;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRAddressType;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRAddressUse;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRCanonical;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRCode;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRCoding;
@@ -23,11 +26,14 @@ use OpenEMR\FHIR\R4\FHIRElement\FHIRContactPoint;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRDateTime;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRExtension;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRHumanName;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRIssueSeverity;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRIssueType;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRMeta;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRNarrative;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRPeriod;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRQuantity;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRReference;
+use OpenEMR\FHIR\R4\FHIRResource\FHIROperationOutcome\FHIROperationOutcomeIssue;
 use OpenEMR\Services\Utils\DateFormatterUtils;
 
 class UtilsService
@@ -44,6 +50,51 @@ class UtilsService
             $reference->setDisplay($displayName);
         }
         return $reference;
+    }
+
+    public static function createCanonicalUrlForResource($resourceType, $uuid): FHIRCanonical
+    {
+
+        $siteConfig = new ServerConfig();
+        $url = $siteConfig->getFhirUrl() . $resourceType . '/' . $uuid;
+        $cannonical = new FHIRCanonical();
+        $cannonical->setValue($url);
+        return $cannonical;
+    }
+
+    public static function parseCanonicalUrl(?string $url)
+    {
+        $parsed_url = [
+            'localResource' => false
+            ,'validUrl' => false
+            ,'resource' => null
+            ,'uuid' => null
+        ];
+        if (empty($url)) {
+            return $parsed_url;
+        }
+
+        $parsed_url['validUrl'] = true;
+        $oauthAddress = (new ServerConfig())->getOauthAddress();
+        $oauthHost = parse_url($oauthAddress, PHP_URL_HOST);
+        $parts = parse_url($url);
+        $parsed_url['localResource'] = $parts['host'] == $oauthHost;
+        $splitParts = explode("/", $parts['path']);
+        if (count($splitParts) >= 2) {
+            $uuid = array_pop($splitParts);
+            $resource = array_pop($splitParts);
+            $resourceClassCheck = 'OpenEMR\\FHIR\\R4\\FHIRDomainResource\\FHIR' . $resource;
+            // we should always be getting canonical urls to a specific resource id, but just in case we are going
+            // to
+            $idClassCheck = 'OpenEMR\\FHIR\\R4\\FHIRElement\\' . $uuid;
+            if (class_exists($resourceClassCheck)) {
+                $parsed_url['resource'] = $resource;
+                $parsed_url['uuid'] = $uuid;
+            } else if (class_exists($idClassCheck)) {
+                $parsed_url['resource'] = $uuid; // root level resource at the end
+            }
+        }
+        return $parsed_url;
     }
 
     public static function getUuidFromReference(FHIRReference $reference)
@@ -307,5 +358,63 @@ class UtilsService
         $date = new \DateTime($date, new \DateTimeZone(date('P')));
         $utcDate = $date->format(DATE_ATOM);
         return $utcDate;
+    }
+
+    public static function createOperationOutcomeSuccess(string $resourceType, int|string $id)
+    {
+        $operation = self::createOperationOutcomeResource('success', 'success');
+        // TODO: if we wanted to put the resource path we would do that here
+        return $operation;
+    }
+
+    public static function createOperationOutcomeResource(
+        $severity_value,
+        $code_value,
+        $details_value = ''
+    ) {
+        $resource = new FHIROperationOutcome();
+        $issue = new FHIROperationOutcomeIssue();
+        $severity = new FHIRIssueSeverity();
+        $severity->setValue($severity_value);
+        $issue->setSeverity($severity);
+        $code = new FHIRIssueType();
+        $code->setValue($code_value);
+        $issue->setCode($code);
+        if ($details_value) {
+            $details = new FHIRCodeableConcept();
+            $details->setText($details_value);
+            $issue->setDetails($details);
+        }
+        $resource->addIssue($issue);
+        return $resource;
+    }
+
+    public static function parseReference(?FHIRReference $reference)
+    {
+        $parsed_reference = [
+            'localResource' => false
+            ,'uuid' => null
+            ,'type' => null
+        ];
+        if (empty($parsed_reference) || empty($reference->getReference())) {
+            return $parsed_reference;
+        }
+
+        $oauthAddress = (new ServerConfig())->getOauthAddress();
+        $oauthHost = parse_url($oauthAddress, PHP_URL_HOST);
+        $parts = parse_url($reference->getReference());
+
+        // if all we have is a path then we skip the host check
+        if (isset($parts['host'])) {
+            $parsed_reference['localResource'] = $parts['host'] == $oauthHost;
+        } else {
+            $parsed_reference['localResource'] = true;
+        }
+        $splitParts = explode("/", $parts['path']);
+        if (count($splitParts) >= 2) {
+            $parsed_reference['uuid'] = array_pop($splitParts);
+            $parsed_reference['type'] = array_pop($splitParts);
+        }
+        return $parsed_reference;
     }
 }

--- a/src/Services/PatientService.php
+++ b/src/Services/PatientService.php
@@ -391,7 +391,7 @@ class PatientService extends BaseService
                     FROM patient_history
                 ) patient_history ON patient_data.pid = patient_history.patient_history_pid
                 LEFT JOIN (
-                    SELECT  
+                    SELECT
                         contact.id AS contact_address_contact_id
                         ,contact.foreign_id AS contact_address_patient_id
                         ,contact_address.`id` AS contact_address_id
@@ -883,6 +883,47 @@ class PatientService extends BaseService
         // round the years to 2 floating points
         $ageinYMD = $age_year . "y " . $months_since_birthday . "m " . $days_since_dobday . "d";
         return compact('age', 'age_in_months', 'ageinYMD');
+    }
+
+    public function getProviderIDsForPatientPids(array $patientPids)
+    {
+        // get integer only filtered pids for sql safety
+        $pids = array_map('intval', $patientPids);
+        $pids = array_filter($pids, function ($pid) {
+            return $pid > 0;
+        });
+
+        $sql = "SELECT pid,providerID FROM patient_data WHERE pid IN (" . implode(",", $pids) . ") "
+        . " AND providerID IS NOT NULL AND providerID != 0 ORDER BY pid";
+        $providerIds = QueryUtils::fetchRecords($sql, []);
+        $mappedPids = [];
+        if (!empty($providerIds)) {
+            foreach ($providerIds as $record) {
+                $mappedPids[$record['pid']] = $record['providerID'];
+            }
+        }
+        return $mappedPids;
+    }
+
+    public function getProviderIDsForPatientUuids(array $patientUuids)
+    {
+        // get integer only filtered pids for sql safety
+        $bindString = rtrim(str_repeat("?,", count($patientUuids) - 1)) . "?";
+        $patientUuids = array_map(function ($uuid) {
+            return UuidRegistry::uuidToBytes($uuid);
+        }, $patientUuids);
+
+        $sql = "SELECT uuid,providerID FROM patient_data WHERE uuid IN (" . $bindString . ") "
+            . " AND providerID IS NOT NULL AND providerID != 0 ORDER BY uuid";
+        $providerIds = QueryUtils::fetchRecords($sql, $patientUuids);
+        $mappedUuids = [];
+        if (!empty($providerIds)) {
+            foreach ($providerIds as $record) {
+                $uuid = UuidRegistry::uuidToString($record['uuid']);
+                $mappedUuids[$uuid] = $record['providerID'];
+            }
+        }
+        return $mappedUuids;
     }
 
     private function parseSuffixForPatientRecord($patientRecord)


### PR DESCRIPTION
Add helper methods to the UtilsService for parsing and creating canonical urls, for parsing references, and creating operation outcome resources.

Also added two helper methods to retrieve the list of providerIDs for a given list of patients.
Fixes #6505 
Fixes #6509 