### PR TITLE
Fixes #6504 Security Api Extension Event

### DIFF
--- a/interface/globals.php
+++ b/interface/globals.php
@@ -622,7 +622,7 @@ if (!file_exists($webserver_root . "/interface/modules/")) {
     } catch (\OpenEMR\Common\Acl\AccessDeniedException $accessDeniedException) {
         // this occurs when the current SCRIPT_PATH is to a module that is not currently allowed to be accessed
         http_response_code(401);
-        error_log(errorLogEscape($ex->getMessage() . $ex->getTraceAsString()));
+        error_log(errorLogEscape($accessDeniedException->getMessage() . $accessDeniedException->getTraceAsString()));
     } catch (\Exception $ex) {
         error_log(errorLogEscape($ex->getMessage() . $ex->getTraceAsString()));
         die();

--- a/src/Common/Http/HttpRestRouteHandler.php
+++ b/src/Common/Http/HttpRestRouteHandler.php
@@ -16,6 +16,7 @@ namespace OpenEMR\Common\Http;
 
 use OpenEMR\Common\Acl\AccessDeniedException;
 use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Events\RestApiExtend\RestApiSecurityCheckEvent;
 use Psr\Http\Message\ResponseInterface;
 
 class HttpRestRouteHandler
@@ -83,8 +84,12 @@ class HttpRestRouteHandler
                     }
 
                     // make sure our scopes pass the security checks
-                    self::checkSecurity($dispatchRestRequest);
-                    (new SystemLogger())->debug("HttpRestRouteHandler->dispatch() dispatching route", ["route" => $routePath,]);
+                    $securityCheck = self::checkSecurity($dispatchRestRequest);
+                    if ($securityCheck instanceof ResponseInterface) {
+                        (new SystemLogger())->debug("HttpRestRouteHandler->dispatch() security check failed", ["route" => $routePath]);
+                        return $securityCheck;
+                    }
+                    (new SystemLogger())->debug("HttpRestRouteHandler->dispatch() dispatching route", ["route" => $routePath]);
                     $hasRoute = true;
 
                     // now grab our url parameters and issue the controller callback for the route
@@ -217,6 +222,7 @@ class HttpRestRouteHandler
      * Security check on the request route against the Access Token scopes.
      * @param HttpRestRequest $restRequest
      * @throws AccessDeniedException If the security check fails
+     * @returns ResponseInterface|bool
      */
     private static function checkSecurity(HttpRestRequest $restRequest)
     {
@@ -245,33 +251,49 @@ class HttpRestRouteHandler
         }
 
         $config = $restRequest->getRestConfig();
-
         if ($restRequest->isPatientRequest()) {
             (new SystemLogger())->debug("checkSecurity() - patient specific request, so only allowing access to records to that one patient");
             if (empty($restRequest->getPatientUUIDString())) { // we MUST have a patient uuid string if its a patient request
                 // need to fail here since this means the downstream patient binding mechanism will be broken
                 (new SystemLogger())->error("checkSecurity() - exited since patient binding mechanism broken");
-                http_response_code(401);
+                $psrFactory = new Psr17Factory();
                 $config::destroySession();
-                exit;
+                return $psrFactory->createResponse(401);
             }
             // if we are a patient only request and we have a patient uuid populated (from session) then we set our scope type to be patient.
             $scopeType = 'patient';
+        }
+        // let module writers handle there own security checking or bypass the security as needed
+        // this allows experiments to be done on a module basis such as opening up patient write requests if a module
+        // allows that to occur, or more comprehensive in depth permission checks occurring.
+        $restApiSecurityCheckEvent = new RestApiSecurityCheckEvent($restRequest);
+        $restApiSecurityCheckEvent->setRestRequest($restRequest);
+        $restApiSecurityCheckEvent->setScopeType($scopeType);
+        $restApiSecurityCheckEvent->setResource($resource);
+        $restApiSecurityCheckEvent->setPermission($permission);
+        $checkedRestApiSecurityCheckEvent = $GLOBALS['kernel']->getEventDispatcher()->dispatch($restApiSecurityCheckEvent, RestApiSecurityCheckEvent::EVENT_HANDLE);
+        if (!$checkedRestApiSecurityCheckEvent instanceof RestApiSecurityCheckEvent) {
+            throw new \RuntimeException("Invalid event object returned as part of dispatch");
+        }
+        if ($checkedRestApiSecurityCheckEvent->hasSecurityCheckFailedResponse()) {
+            return $checkedRestApiSecurityCheckEvent->getSecurityCheckFailedResponse();
+        } else if ($checkedRestApiSecurityCheckEvent->shouldSkipSecurityCheck()) {
+            return true;
         }
 
         if ($restRequest->isFhir()) {
             // don't do any checks on our open fhir resources
             if (self::fhirRestRequestSkipSecurityCheck($restRequest)) {
-                return;
+                return true;
             }
             // we do NOT want logged in patients writing data at this point so we fail
             // TODO: when we have better auditing and provider merge/verification mechanisms look at opening up patient write access to data.
             if ($restRequest->isPatientWriteRequest() && $restRequest->getRequestUserRole() == 'patient') {
                 // not allowing patient userrole write for fhir
                 (new SystemLogger())->debug("checkSecurity() - not allowing patient role write for fhir");
-                http_response_code(401);
+                $psrFactory = new Psr17Factory();
                 $config::destroySession();
-                exit;
+                return $psrFactory->createResponse(401);
             }
         } elseif (($restRequest->getApiType() === 'oemr') || ($restRequest->getApiType() === 'port')) {
             // don't do any checks on our open non-fhir resources
@@ -280,27 +302,27 @@ class HttpRestRouteHandler
                 || $restRequest->getResource() == 'product'
                 || $restRequest->isLocalApi() // skip security check if its a local api
             ) {
-                return;
+                return true;
             }
             // ensure correct user role type for the non-fhir routes
             if (($restRequest->getApiType() === 'oemr') && (($restRequest->getRequestUserRole() !== 'users') || ($scopeType !== 'user'))) {
                 (new SystemLogger())->debug("checkSecurity() - not allowing patient role to access oemr api");
-                http_response_code(401);
+                $psrFactory = new Psr17Factory();
                 $config::destroySession();
-                exit;
+                return $psrFactory->createResponse(401);
             }
             if (($restRequest->getApiType() === 'port') && (($restRequest->getRequestUserRole() !== 'patient') || ($scopeType !== 'patient'))) {
                 (new SystemLogger())->debug("checkSecurity() - not allowing users role to access port api");
-                http_response_code(401);
+                $psrFactory = new Psr17Factory();
                 $config::destroySession();
-                exit;
+                return $psrFactory->createResponse(401);
             }
         } else {
             // should never be here
             (new SystemLogger())->error("checkSecurity() - illegal api type");
-            http_response_code(401);
+            $psrFactory = new Psr17Factory();
             $config::destroySession();
-            exit;
+            return $psrFactory->createResponse(401);
         }
 
         // handle our scope checks

--- a/src/Events/RestApiExtend/RestApiSecurityCheckEvent.php
+++ b/src/Events/RestApiExtend/RestApiSecurityCheckEvent.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * RestApiSecurityCheckEvent is fired when the HttpRestRouteHandler is going to check the security of the current api
+ * call. The consumer of the event can tell the core api to skip the security check and return a valid security check.
+ * This allows the consumer to implement their own security checks, either completely replacing the security system
+ * or enhancing it with additional checks.
+ *
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2023 Discover and Change <snielson@discoverandchange.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\RestApiExtend;
+
+use OpenEMR\Common\Http\HttpRestRequest;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class RestApiSecurityCheckEvent extends Event
+{
+    const EVENT_HANDLE = 'api.route.security.check';
+
+    /**
+     * @var HttpRestRequest
+     */
+    private $restRequest;
+
+    private $scopeType;
+
+    /**
+     * @var bool Whether to skip the OpenEMR core security checks and return a valid security check response
+     */
+    private bool $skipSecurityCheck;
+
+    /**
+     * @var ResponseInterface A http response to return to the api caller for security check failed response
+     */
+    private ?ResponseInterface $securityCheckFailedResponse;
+
+    /**
+     * @var string The resource / api endpoint we are working
+     */
+    private string $resource;
+
+    /**
+     * @var string The permission required for this api, such as read / write and eventually with SMART 2.0 create,update, etc.
+     */
+    private string $permission;
+
+    /**
+     * @param HttpRestRequest|null $request
+     */
+    public function __construct(HttpRestRequest $request = null)
+    {
+        $this->permission = "";
+        $this->scopeType = "";
+        $this->resource = "";
+        $this->restRequest = $request;
+        $this->securityCheckFailedResponse = null;
+        $this->skipSecurityCheck = false;
+    }
+
+    /**
+     * @param HttpRestRequest $restRequest
+     */
+    public function setRestRequest(HttpRestRequest $restRequest): void
+    {
+        $this->restRequest = $restRequest;
+    }
+
+    public function getRestRequest(): HttpRestRequest
+    {
+        return $this->restRequest;
+    }
+
+    public function setScopeType(string $scopeType)
+    {
+        $this->scopeType = $scopeType;
+    }
+
+    public function getScopeType(): string
+    {
+        return $this->scopeType;
+    }
+
+    public function setResource(string $resource)
+    {
+        $this->resource = $resource;
+    }
+
+    public function getResource()
+    {
+        return $this->resource;
+    }
+
+    public function setPermission(string $permission)
+    {
+        $this->permission = $permission;
+    }
+
+    public function getPermission(): string
+    {
+        return $this->permission;
+    }
+
+    public function hasSecurityCheckFailedResponse(): bool
+    {
+        return $this->getSecurityCheckFailedResponse() != null;
+    }
+
+    public function getSecurityCheckFailedResponse(): ?ResponseInterface
+    {
+        return $this->securityCheckFailedResponse;
+    }
+
+    public function setSecurityCheckFailedResponse(ResponseInterface $response)
+    {
+        $this->securityCheckFailedResponse = $response;
+    }
+
+    public function shouldSkipSecurityCheck()
+    {
+        return $this->skipSecurityCheck;
+    }
+
+    public function skipSecurityCheck(bool $shouldSecuritySkip)
+    {
+        $this->skipSecurityCheck = $shouldSecuritySkip;
+    }
+}

--- a/src/Services/BaseService.php
+++ b/src/Services/BaseService.php
@@ -21,7 +21,9 @@ use OpenEMR\Services\Search\SearchFieldException;
 use OpenEMR\Services\Search\SearchFieldStatementResolver;
 use OpenEMR\Validators\ProcessingResult;
 use Particle\Validator\Exception\InvalidValueException;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 require_once(__DIR__  . '/../../custom/code_types.inc.php');
 
@@ -53,6 +55,11 @@ class BaseService
     );
 
     /**
+     * @var EventDispatcher
+     */
+    private $eventDispatcher;
+
+    /**
      * Default constructor.
      */
     public function __construct($table)
@@ -61,6 +68,17 @@ class BaseService
         $this->fields = sqlListFields($table);
         $this->autoIncrements = self::getAutoIncrements($table);
         $this->setLogger(new SystemLogger());
+        $this->eventDispatcher = $GLOBALS['kernel']->getEventDispatcher();
+    }
+
+    public function getEventDispatcher(): EventDispatcher
+    {
+        return $this->eventDispatcher;
+    }
+
+    public function setEventDispatcher(EventDispatcher $dispatcher)
+    {
+        $this->eventDispatcher = $dispatcher;
     }
 
     /**


### PR DESCRIPTION
I add a new RestApiSecurityCheckEvent that allows module writers to initiate their own security checks or replace the current OpenEMR API security checks.

Fix a minor typo bug on the accessdenied exception in the globals.

I also add methods to the BaseService class to be able to get and set the event dispatcher.
Fixes #6504 