### PR TITLE
fix: output service facility zip if not 9 digits (#6489) for rel-701

### DIFF
--- a/src/Billing/X125010837P.php
+++ b/src/Billing/X125010837P.php
@@ -1024,11 +1024,10 @@ class X125010837P
                 $log .= "*** Missing service facility state.\n";
             }
             $out .= "*";
-            if (strlen($claim->facilityZip()) == 9) {
-                $out .= $claim->facilityZip();
-            } else {
+            if (strlen($claim->facilityZip()) != 9) {
                 $log .= "*** Service facility zip is not 9 digits.\n";
             }
+            $out .= $claim->facilityZip();
             $out .= "~\n";
         }
         // Segment REF (Service Facility Location Secondary Identification) omitted.


### PR DESCRIPTION
* fix: output service facility zip if not 9 digits

* fix log msg

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:


#### Changes proposed in this pull request:
