### PR TITLE
Improve dup patients

### DIFF
--- a/interface/new/new.php
+++ b/interface/new/new.php
@@ -15,6 +15,8 @@ require_once("../globals.php");
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
 
+error_log (" *** in new.php *** ");
+
 if ($GLOBALS['full_new_patient_form']) {
     require("new_comprehensive.php");
     exit;
@@ -100,8 +102,7 @@ $(function () {
 
 <body class="body_top" onload="javascript:document.new_patient.fname.focus();">
 
-<form name='new_patient' method='post' action="new_patient_save.php"
- onsubmit='return validate()'>
+<form name='new_patient' method='post' action="new_patient_save.php" onsubmit='return validate()'>
 <input type="hidden" name="csrf_token_form" value="<?php echo attr(CsrfUtils::collectCsrfToken()); ?>" />
 
 <span class='title'><?php echo xlt('Add Patient Record'); ?></span>

--- a/interface/patient_file/manage_dup_patients.php
+++ b/interface/patient_file/manage_dup_patients.php
@@ -262,7 +262,7 @@ if ($form_action == 'U') {
         array($_POST['form_toppid'])
     );
 } else if ($form_action == 'R') {
-    updateDupScore($_POST['form_toppid']);
+    updateDupScore($_POST['form_toppid'], false); /* this is not a new patient so check against all other patients */
 }
 
 $query = "SELECT * FROM patient_data WHERE dupscore > 7 " .
@@ -272,7 +272,10 @@ while ($row1 = sqlFetchArray($res1)) {
     displayRow($row1);
     $query = "SELECT p2.*, ($scorecalc) AS myscore " .
     "FROM patient_data AS p1, patient_data AS p2 WHERE " .
-    "p1.pid = ? AND p2.pid < p1.pid AND ($scorecalc) > 7 " .
+ /*   "p1.pid = ? AND p2.pid < p1.pid AND ($scorecalc) > 7 " .  */
+ /* check against all other patients, to fix bug where a lone patient appears in the table */
+    "p1.pid = ? AND p2.pid != p1.pid AND ($scorecalc) > 7 " .
+
     "ORDER BY myscore DESC, p2.pid DESC";
     $res2 = sqlStatement($query, array($row1['pid']));
     while ($row2 = sqlFetchArray($res2)) {

--- a/interface/patient_file/manage_dup_patients.php
+++ b/interface/patient_file/manage_dup_patients.php
@@ -262,24 +262,39 @@ if ($form_action == 'U') {
         array($_POST['form_toppid'])
     );
 } else if ($form_action == 'R') {
-    updateDupScore($_POST['form_toppid'], false); /* this is not a new patient so check against all other patients */
+    updateDupScore($_POST['form_toppid']); /* this is not a new patient so check against all other patients */
 }
 
+/* generate a new table of possible duplicate patients */
 $query = "SELECT * FROM patient_data WHERE dupscore > 7 " .
     "ORDER BY dupscore DESC, pid DESC LIMIT 100";
 $res1 = sqlStatement($query);
+$used = array(); /* record which patients we display in the table, so as not to use them more than once */
 while ($row1 = sqlFetchArray($res1)) {
-    displayRow($row1);
-    $query = "SELECT p2.*, ($scorecalc) AS myscore " .
-    "FROM patient_data AS p1, patient_data AS p2 WHERE " .
- /*   "p1.pid = ? AND p2.pid < p1.pid AND ($scorecalc) > 7 " .  */
- /* check against all other patients, to fix bug where a lone patient appears in the table */
-    "p1.pid = ? AND p2.pid != p1.pid AND ($scorecalc) > 7 " .
-
-    "ORDER BY myscore DESC, p2.pid DESC";
-    $res2 = sqlStatement($query, array($row1['pid']));
-    while ($row2 = sqlFetchArray($res2)) {
-        displayRow($row2, $row1['pid']);
+    global $used;
+    error_log ("p1 & score ".$row1['pid']." , ". $row1['dupscore']);
+    if (array_search($row1['pid'],$used) === false){ //haven't used this one yet
+    // build the sql query to compare to all other patients
+        $query = "SELECT p2.*, ($scorecalc) AS myscore " .
+        "FROM patient_data AS p1, patient_data AS p2 WHERE " .
+  /* check against all other patients - e.g. when demogrphics changed */
+        "p1.pid = ? AND p2.pid != p1.pid AND ($scorecalc) > 7 " .
+        "ORDER BY myscore DESC, p2.pid DESC";
+        $res2 = sqlStatement($query, array($row1['pid']));
+    /*only if more patients are potential duplicates display the first one -correct bug where only 1 patient in agroup displayed*/
+        $displayFirst = true;
+        while ($row2 = sqlFetchArray($res2)) {
+            error_log ("p2 & score ".$row2['pid']." , ".$row2['dupscore']);
+            if ($row2['dupscore'] != -1) { // don't use if marked as unique
+                if ($displayFirst )
+                {
+                    displayRow($row1);
+                    $displayFirst = false;
+                }
+                displayRow($row2, $row1['pid']);
+                $used[] = $row2['pid'];
+            }
+        }
     }
 }
 ?>

--- a/interface/patient_file/merge_patients.php
+++ b/interface/patient_file/merge_patients.php
@@ -567,8 +567,8 @@ if (!AclMain::aclCheckCore('admin', 'super')) {
                 resolveDuplicateEncounters($targets);
             }
 
-            // Recompute dupscore for target patient.
-            updateDupScore($target_pid);
+            // Recompute dupscore for target patient. check against all patients
+            updateDupScore($target_pid, false);
 
             echo "<br />" . xlt('Merge complete.') . "</div>";
 

--- a/library/dupscore.inc.php
+++ b/library/dupscore.inc.php
@@ -15,7 +15,6 @@
 //
 function getDupScoreSQL()
 {
-    error_log ("***getDupScore called***");
     return
     //  5 First name
     "5 * (SOUNDEX(p1.fname) = SOUNDEX(p2.fname)) + " .

--- a/library/dupscore.inc.php
+++ b/library/dupscore.inc.php
@@ -15,6 +15,7 @@
 //
 function getDupScoreSQL()
 {
+    error_log ("***getDupScore called***");
     return
     //  5 First name
     "5 * (SOUNDEX(p1.fname) = SOUNDEX(p2.fname)) + " .

--- a/library/patient.inc.php
+++ b/library/patient.inc.php
@@ -1205,11 +1205,11 @@ function updatePatientData($pid, $new, $create = false)
         $pid === null
     ) {
         $result = $patientService->databaseInsert($new);
-        updateDupScore($result['pid'], true);
+        updateDupScore($result['pid']);
     } else {
         $new['pid'] = $pid;
         $result = $patientService->databaseUpdate($new);
-        updateDupScore($result['pid'], false);
+        updateDupScore($result['pid']);
     }
 
     // From the returned patient data array

--- a/library/patient.inc.php
+++ b/library/patient.inc.php
@@ -1825,28 +1825,18 @@ function is_patient_deceased($pid, $date = '')
 }
 
 // This computes, sets and returns the dup score for the given patient, compared to all patients earlier in the patient_data table
-// for updateing after patients demographics have been changed need to check against whole table
+// for updateing after patients demographics have been changed need to check against whole table, i.e. patients who come earlier and later in the table, i.e. where p2 != p1, this works for new patients as well
 //
-function updateDupScore($pid, $new=true)
+function updateDupScore($pid)
 {
-    if ($new)
-    {   // new patient
+        // new patient or patient with editted demographics
     $row = sqlQuery(
-        "SELECT MAX(" . getDupScoreSQL() . ") AS dupscore " .
-        "FROM patient_data AS p1, patient_data AS p2 WHERE " .
-        "p1.pid = ? AND p2.pid < p1.pid",
-        array($pid)
-    );
-    }
-    else   //updateing demographics
-    {
-         $row = sqlQuery(
         "SELECT MAX(" . getDupScoreSQL() . ") AS dupscore " .
         "FROM patient_data AS p1, patient_data AS p2 WHERE " .
         "p1.pid = ? AND p2.pid != p1.pid",
         array($pid)
-        );
-    }
+    );
+
     $dupscore = empty($row['dupscore']) ? 0 : $row['dupscore'];
     sqlStatement(
         "UPDATE patient_data SET dupscore = ? WHERE pid = ?",

--- a/src/Services/PatientService.php
+++ b/src/Services/PatientService.php
@@ -211,6 +211,7 @@ class PatientService extends BaseService
      */
     public function databaseUpdate($data)
     {
+        error_log("$$$ databaseupdate called $$$");
         // Get the data before update to send to the event listener
         $dataBeforeUpdate = $this->findByPid($data['pid']);
 
@@ -391,7 +392,7 @@ class PatientService extends BaseService
                     FROM patient_history
                 ) patient_history ON patient_data.pid = patient_history.patient_history_pid
                 LEFT JOIN (
-                    SELECT  
+                    SELECT
                         contact.id AS contact_address_contact_id
                         ,contact.foreign_id AS contact_address_patient_id
                         ,contact_address.`id` AS contact_address_id


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->
Fixes #6517

#### Short description of what this resolves:

resolves incorrect reporting of potentially duplicate patients in admin/patients/manage duplicates, particularly when a patients demographics are changed
#### Changes proposed in this pull request:
when a patient's demographics are changed generate it's dupscore by looking at all patients in the db, not just those with a smaller pid
when deciding which patients to display in the table do not display any who do not have a potential duplicate in the data base, i.e. would be in a group of 1, i.e. on their own