### PR TITLE
Fit to window patch

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -38,6 +38,7 @@ function sqlQuery($statement, $link)
 <html>
 <head>
     <title>OpenEMR Site Administration</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="public/assets/bootstrap/dist/css/bootstrap.min.css">
     <script src="public/assets/jquery/dist/jquery.min.js"></script>
     <script src="public/assets/bootstrap/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #6460 

#### Short description of what this resolves:
I added this line of code to admin.php.
`<meta name="viewport" content="width=device-width, initial-scale=1.0">`

#### Changes proposed in this pull request:
The admin page should fit within the display.
