### PR TITLE
Added scss-migrator

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "moment": "2.29.4",
     "numeral": "2.0.6",
     "purecss": "3.0.0",
+    "sass-migrator": "1.7.3",
     "select2": "4.0.13",
     "sortablejs": "1.15.0",
     "underscore": "1.13.6",


### PR DESCRIPTION
#### Short description of what this resolves:
This hopefully resolves the scss depreciation warning messages. In my testing, instead of many warning messages, `docker-compose up` now ends at couchdb cluster stable. 

#### Changes proposed in this pull request:
Add scss-migrator to package.json.