### PR TITLE
username may be null for providers for Rel 701

### DIFF
--- a/interface/usergroup/addrbook_list.php
+++ b/interface/usergroup/addrbook_list.php
@@ -52,7 +52,7 @@ $sqlBindArray = array();
 $query = "SELECT u.*, lo.option_id AS ab_name, lo.option_value as ab_option FROM users AS u " .
   "LEFT JOIN list_options AS lo ON " .
   "list_id = 'abook_type' AND option_id = u.abook_type AND activity = 1 " .
-  "WHERE u.active = 1 AND ( u.authorized = 1 OR u.username = '' ) ";
+  "WHERE u.active = 1 AND ( u.authorized = 1 OR ( u.username = '' OR u.username IS NULL )) ";
 if ($form_organization) {
     $query .= "AND u.organization LIKE ? ";
     array_push($sqlBindArray, $form_organization . "%");
@@ -84,7 +84,7 @@ if ($form_abook_type) {
 }
 
 if ($form_external) {
-    $query .= "AND u.username = '' ";
+    $query .= "AND u.abook_type = 'external_provider' ";
 }
 
 if ($form_lname) {

--- a/library/options.inc.php
+++ b/library/options.inc.php
@@ -753,7 +753,7 @@ function generate_form_field($frow, $currvalue)
     } elseif ($data_type == 11) { // provider list, including address book entries with an NPI number
         $ures = sqlStatement("SELECT id, fname, lname, specialty FROM users " .
         "WHERE active = 1 AND ( info IS NULL OR info NOT LIKE '%Inactive%' ) " .
-        "AND ( authorized = 1 OR ( username = '' AND npi != '' ) ) " .
+        "AND ( authorized = 1 OR ((username = '' OR username IS NULL) AND npi != '' )) " .
         "ORDER BY lname, fname");
         echo "<select name='form_$field_id_esc' id='form_$field_id_esc' title='$description' class='form-control$smallform'";
         echo " $lbfonchange $disabled>";

--- a/src/Billing/X125010837P.php
+++ b/src/Billing/X125010837P.php
@@ -555,13 +555,15 @@ class X125010837P
         }
         $out .= "*";
         if (
-            (strlen($claim->payerZip()) == 5)
-            || (strlen($claim->payerZip()) == 9)
+            !(
+                (strlen($claim->payerZip()) == 5)
+                || (strlen($claim->payerZip()) == 9)
+            )
         ) {
-            $out .= $claim->x12Zip($claim->payerZip());
-        } else {
             $log .= "*** Payer zip is not 5 or 9 digits.\n";
         }
+
+        $out .= $claim->x12Zip($claim->payerZip());
         $out .= "~\n";
 
         // Segment REF (Payer Secondary Identification) omitted.


### PR DESCRIPTION
* output payer zip even if not 5 or 9 digits

* fix: username may be null for providers

* look for abook_type external providers in addr book

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:


#### Changes proposed in this pull request:
