### PR TITLE
Openemr fix 6574 6575 6576 fhir updates

### DIFF
--- a/src/Common/Auth/OpenIDConnect/Repositories/ClientRepository.php
+++ b/src/Common/Auth/OpenIDConnect/Repositories/ClientRepository.php
@@ -16,6 +16,8 @@ use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
 use OpenEMR\Common\Auth\OpenIDConnect\Entities\ClientEntity;
 use OpenEMR\Common\Crypto\CryptoGen;
 use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Common\Utils\HttpUtils;
+use OpenEMR\Common\Utils\RandomGenUtils;
 use Psr\Log\LoggerInterface;
 
 class ClientRepository implements ClientRepositoryInterface
@@ -25,9 +27,104 @@ class ClientRepository implements ClientRepositoryInterface
      */
     private $logger;
 
+    private $cryptoGen;
+
     public function __construct()
     {
         $this->logger = new SystemLogger();
+        $this->cryptoGen = new CryptoGen();
+    }
+
+    /**
+     * @return CryptoGen
+     */
+    public function getCryptoGen(): CryptoGen
+    {
+        return $this->cryptoGen;
+    }
+
+    /**
+     * @param CryptoGen $cryptoGen
+     * @return ClientRepository
+     */
+    public function setCryptoGen(CryptoGen $cryptoGen): ClientRepository
+    {
+        $this->cryptoGen = $cryptoGen;
+        return $this;
+    }
+
+    public function insertNewClient($clientId, $info, $site): bool
+    {
+        $user = $_SESSION['authUserID'] ?? null; // future use for provider client.
+        $is_confidential_client = empty($info['client_secret']) ? 0 : 1;
+
+        $contacts = $info['contacts'];
+        $redirects = $info['redirect_uris'];
+        if (is_array($redirects)) {
+            // need to combine our redirects if we are an array... this is due to the legacy implementation of this data
+            $redirects = implode("|", $redirects);
+        }
+        $logout_redirect_uris = $info['post_logout_redirect_uris'] ?? null;
+        $info['client_secret'] = $info['client_secret'] ?? null; // just to be sure empty is null;
+        // set our list of default scopes for the registration if our scope is empty
+        // This is how a client can set if they support SMART apps and other stuff by passing in the 'launch'
+        // scope to the dynamic client registration.
+        // per RFC 7591 @see https://tools.ietf.org/html/rfc7591#section-2
+        // TODO: adunsulag do we need to reject the registration if there are certain scopes here we do not support
+        // TODO: adunsulag should we check these scopes against our '$this->supportedScopes'?
+        $info['scope'] = $info['scope'] ?? 'openid email phone address api:oemr api:fhir api:port';
+
+        $scopes = explode(" ", $info['scope']);
+        $scopeRepo = new ScopeRepository();
+
+        if ($scopeRepo->hasScopesThatRequireManualApproval($is_confidential_client == 1, $scopes)) {
+            $is_client_enabled = 0; // disabled
+        } else {
+            $is_client_enabled = 1; // enabled
+        }
+
+        // encrypt the client secret
+        if (!empty($info['client_secret'])) {
+            $cryptoGen = $this->getCryptoGen();
+            $info['client_secret'] = $cryptoGen->encryptStandard($info['client_secret']);
+        }
+
+        // TODO: @adunsulag why do we skip over request_uris when we have it in the outer function?
+        $sql = "INSERT INTO `oauth_clients` (`client_id`, `client_role`, `client_name`, `client_secret`, `registration_token`, `registration_uri_path`, `register_date`, `revoke_date`, `contacts`, `redirect_uri`, `grant_types`, `scope`, `user_id`, `site_id`, `is_confidential`, `logout_redirect_uris`, `jwks_uri`, `jwks`, `initiate_login_uri`, `endorsements`, `policy_uri`, `tos_uri`, `is_enabled`) VALUES (?, ?, ?, ?, ?, ?, NOW(), NULL, ?, ?, 'authorization_code', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+        $i_vals = array(
+            $clientId,
+            $info['client_role'],
+            $info['client_name'],
+            $info['client_secret'],
+            $info['registration_access_token'],
+            $info['registration_client_uri_path'],
+            $contacts,
+            $redirects,
+            $info['scope'],
+            $user,
+            $site,
+            $is_confidential_client,
+            $logout_redirect_uris,
+            ($info['jwks_uri'] ?? null),
+            ($info['jwks'] ?? null),
+            ($info['initiate_login_uri'] ?? null),
+            ($info['endorsements'] ?? null),
+            ($info['policy_uri'] ?? null),
+            ($info['tos_uri'] ?? null),
+            $is_client_enabled
+        );
+
+        return sqlQueryNoLog($sql, $i_vals, true); // throw an exception if it fails
+    }
+
+    public function generateClientId()
+    {
+        return HttpUtils::base64url_encode(RandomGenUtils::produceRandomBytes(32));
+    }
+
+    public function generateClientSecret()
+    {
+        return HttpUtils::base64url_encode(RandomGenUtils::produceRandomBytes(64));
     }
 
     /**
@@ -164,5 +261,15 @@ class ClientRepository implements ClientRepositoryInterface
         $client->setContacts($client_record['contacts']);
         $client->setRegistrationDate($client_record['register_date']);
         return $client;
+    }
+
+    public function generateRegistrationAccessToken()
+    {
+        return HttpUtils::base64url_encode(RandomGenUtils::produceRandomBytes(32));
+    }
+
+    public function generateRegistrationClientUriPath()
+    {
+        return HttpUtils::base64url_encode(RandomGenUtils::produceRandomBytes(16));
     }
 }

--- a/src/Common/Utils/HttpUtils.php
+++ b/src/Common/Utils/HttpUtils.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * HttpUtils utility class for functions dealing with urls and http.
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Discover and Change, Inc. <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2023 Discover and Change, Inc. <snielson@discoverandchange.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Common\Utils;
+
+class HttpUtils
+{
+    public static function base64url_encode($data): string
+    {
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+    }
+}

--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -59,6 +59,7 @@ use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Http\Psr17Factory;
 use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Common\Session\SessionUtil;
+use OpenEMR\Common\Utils\HttpUtils;
 use OpenEMR\Common\Utils\RandomGenUtils;
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\FHIR\Config\ServerConfig;
@@ -214,9 +215,10 @@ class AuthorizationController
                 // @see https://tools.ietf.org/html/rfc7591#section-2
                 'scope' => null
             );
-            $client_id = $this->base64url_encode(RandomGenUtils::produceRandomBytes(32));
-            $reg_token = $this->base64url_encode(RandomGenUtils::produceRandomBytes(32));
-            $reg_client_uri_path = $this->base64url_encode(RandomGenUtils::produceRandomBytes(16));
+            $clientRepository = new ClientRepository();
+            $client_id = $clientRepository->generateClientId();
+            $reg_token = $clientRepository->generateRegistrationAccessToken();
+            $reg_client_uri_path = $clientRepository->generateRegistrationClientUriPath();
             $params = array(
                 'client_id' => $client_id,
                 'client_id_issued_at' => time(),
@@ -228,7 +230,7 @@ class AuthorizationController
             // only include secret if a confidential app else force PKCE for native and web apps.
             $client_secret = '';
             if ($data['application_type'] === 'private') {
-                $client_secret = $this->base64url_encode(RandomGenUtils::produceRandomBytes(64));
+                $client_secret = $clientRepository->generateClientSecret();
                 $params['client_secret'] = $client_secret;
                 $params['client_role'] = 'user';
 
@@ -271,9 +273,10 @@ class AuthorizationController
                 throw new OAuthServerException('post_logout_redirect_uris is invalid', 0, 'invalid_client_metadata');
             }
             // save to oauth client table
-            $badSave = $this->newClientSave($client_id, $params);
-            if (!empty($badSave)) {
-                throw OAuthServerException::serverError("Try again. Unable to create account");
+            try {
+                $clientRepository->insertNewClient($client_id, $params, $this->siteId);
+            } catch (\Exception $exception) {
+                throw OAuthServerException::serverError("Try again. Unable to create account", $exception);
             }
             $reg_uri = $this->authBaseFullUrl . '/client/' . $reg_client_uri_path;
             unset($params['registration_client_uri_path']);
@@ -352,78 +355,13 @@ class AuthorizationController
 
     public function base64url_encode($data): string
     {
-        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+        return HttpUtils::base64url_encode($data);
     }
 
     public function base64url_decode($token)
     {
         $b64 = strtr($token, '-_', '+/');
         return base64_decode($b64);
-    }
-
-    public function newClientSave($clientId, $info): bool
-    {
-        $user = $_SESSION['authUserID'] ?? null; // future use for provider client.
-        $site = $this->siteId;
-        $is_confidential_client = empty($info['client_secret']) ? 0 : 1;
-
-        $contacts = $info['contacts'];
-        $redirects = $info['redirect_uris'];
-        $logout_redirect_uris = $info['post_logout_redirect_uris'] ?? null;
-        $info['client_secret'] = $info['client_secret'] ?? null; // just to be sure empty is null;
-        // set our list of default scopes for the registration if our scope is empty
-        // This is how a client can set if they support SMART apps and other stuff by passing in the 'launch'
-        // scope to the dynamic client registration.
-        // per RFC 7591 @see https://tools.ietf.org/html/rfc7591#section-2
-        // TODO: adunsulag do we need to reject the registration if there are certain scopes here we do not support
-        // TODO: adunsulag should we check these scopes against our '$this->supportedScopes'?
-        $info['scope'] = $info['scope'] ?? 'openid email phone address api:oemr api:fhir api:port';
-
-        $scopes = explode(" ", $info['scope']);
-        $scopeRepo = new ScopeRepository();
-
-        if ($scopeRepo->hasScopesThatRequireManualApproval($is_confidential_client == 1, $scopes)) {
-            $is_client_enabled = 0; // disabled
-        } else {
-            $is_client_enabled = 1; // enabled
-        }
-
-        // encrypt the client secret
-        if (!empty($info['client_secret'])) {
-            $info['client_secret'] = $this->cryptoGen->encryptStandard($info['client_secret']);
-        }
-
-
-        try {
-            // TODO: @adunsulag why do we skip over request_uris when we have it in the outer function?
-            $sql = "INSERT INTO `oauth_clients` (`client_id`, `client_role`, `client_name`, `client_secret`, `registration_token`, `registration_uri_path`, `register_date`, `revoke_date`, `contacts`, `redirect_uri`, `grant_types`, `scope`, `user_id`, `site_id`, `is_confidential`, `logout_redirect_uris`, `jwks_uri`, `jwks`, `initiate_login_uri`, `endorsements`, `policy_uri`, `tos_uri`, `is_enabled`) VALUES (?, ?, ?, ?, ?, ?, NOW(), NULL, ?, ?, 'authorization_code', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
-            $i_vals = array(
-                $clientId,
-                $info['client_role'],
-                $info['client_name'],
-                $info['client_secret'],
-                $info['registration_access_token'],
-                $info['registration_client_uri_path'],
-                $contacts,
-                $redirects,
-                $info['scope'],
-                $user,
-                $site,
-                $is_confidential_client,
-                $logout_redirect_uris,
-                ($info['jwks_uri'] ?? null),
-                ($info['jwks'] ?? null),
-                ($info['initiate_login_uri'] ?? null),
-                ($info['endorsements'] ?? null),
-                ($info['policy_uri'] ?? null),
-                ($info['tos_uri'] ?? null),
-                $is_client_enabled
-            );
-
-            return sqlQueryNoLog($sql, $i_vals);
-        } catch (\RuntimeException $e) {
-            die($e);
-        }
     }
 
     public function emitResponse($response): void

--- a/src/RestControllers/RestControllerHelper.php
+++ b/src/RestControllers/RestControllerHelper.php
@@ -367,6 +367,9 @@ class RestControllerHelper
 
                 if (empty($capResource)) {
                     $capResource = new FHIRCapabilityStatementResource();
+                    // make it explicit that we do not let the user use their own resource ids to create a new resource
+                    // in the PUT/update operation.
+                    $capResource->setUpdateCreate(false);
                     $capResource->setType(new FHIRCode($type));
                     $capResource->setProfile(new FHIRCanonical($structureDefinition . $type));
 

--- a/src/Services/FHIR/FhirCodeSystemConstants.php
+++ b/src/Services/FHIR/FhirCodeSystemConstants.php
@@ -80,4 +80,12 @@ class FhirCodeSystemConstants
      * available here: https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.27/expansion/Latest
      */
     const CARE_TEAM_MEMBER_FUNCTION_SNOMEDCT = "2.16.840.1.113762.1.4.1099.27";
+
+    /**
+     * Required for Structured Data Collection (SDC) Task implementations
+     * @see https://build.fhir.org/ig/HL7/sdc/ValueSet-task-code.html
+     */
+    const HL7_SDC_TASK_TEMP = "https://build.fhir.org/ig/HL7/sdc/CodeSystem-temp.html";
+
+    const HL7_SDC_TASK_SERVICE_REQUEST = "http://hl7.org/fhir/CodeSystem/task-code";
 }

--- a/src/Services/FHIR/Traits/MappedServiceTrait.php
+++ b/src/Services/FHIR/Traits/MappedServiceTrait.php
@@ -64,6 +64,21 @@ trait MappedServiceTrait
         return $processingResult;
     }
 
+    public function searchServices(array $services, $fhirSearchParams, $puuidBind)
+    {
+        $processingResult = new ProcessingResult();
+        foreach ($services as $service) {
+            $innerResult = $service->getAll($fhirSearchParams, $puuidBind);
+            $processingResult->addProcessingResult($innerResult);
+            if ($processingResult->hasErrors()) {
+                // clear our data out and just return the errors
+                $processingResult->clearData();
+                return $processingResult;
+            }
+        }
+        return $processingResult;
+    }
+
     public function searchAllServicesWithSupportedFields($fhirSearchParams, $puuidBind)
     {
         $processingResult = new ProcessingResult();

--- a/src/Services/FHIR/UtilsService.php
+++ b/src/Services/FHIR/UtilsService.php
@@ -56,7 +56,11 @@ class UtilsService
     {
 
         $siteConfig = new ServerConfig();
-        $url = $siteConfig->getFhirUrl() . $resourceType . '/' . $uuid;
+        $fhirUrl = $siteConfig->getFhirUrl() ?? "";
+        if (strrpos("/", $fhirUrl) != strlen($fhirUrl)) {
+            $fhirUrl .= "/";
+        }
+        $url = $fhirUrl . $resourceType . '/' . $uuid;
         $cannonical = new FHIRCanonical();
         $cannonical->setValue($url);
         return $cannonical;

--- a/src/Services/Search/TokenSearchField.php
+++ b/src/Services/Search/TokenSearchField.php
@@ -26,6 +26,11 @@ class TokenSearchField extends BasicSearchField
         parent::__construct($field, SearchFieldType::TOKEN, $field, $values);
     }
 
+    public function isUuid()
+    {
+        return $this->isUUID;
+    }
+
     public function addValue(TokenSearchValue $value)
     {
         $values = $this->getValues();


### PR DESCRIPTION
Fixes #6574 
The questionnaire response search would fail when searching on things
such as id due to duplicate column names.  In order to make this service
work in a FHIR context we need to fix up the search method and handle
the uuid translations.

Fixes #6575 
Made it possible to save an oauth2 client using the client repository.
This makes it so OpenEMR callers don't need to include the RestConfig
class or deal with the AuthorizationController to generate a smart app
client record if needed.  Module writers can register their own smart
app as needed using this functionality.

Fixes #6576 
made it so the create update flag is set to false so API consumers know
they can't provider their own logical ids when creating a resource.

Also had some minor utility methods added in preparation for future FHIR work with Task/Questionnaire endpoints.
