### PR TITLE
chore: documentation for flex docker now using alpine 3.18 with php 8.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,7 +169,7 @@ The OpenEMR development docker environment has a very rich advanced feature set.
           docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools register-oauth2-client-demo https://eleven.openemr.io/a/openemr'
           ```
 3. <a name="other_php_versions"></a>Testing other PHP versions.
-    - The standard `flex` docker used in the easy development environments is PHP 8.1. This can be modified by changing the image (`image: openemr/openemr:flex`) used in the docker-compose.yml script. To use PHP 8.0, then just need to change it to `image: openemr/openemr:flex-3.15-8`. To use PHP 8.2, then just need to change it to `image: openemr/openemr:flex-edge`.
+    - The standard `flex` docker used in the easy development environments is PHP 8.2. This can be modified by changing the image (`image: openemr/openemr:flex`) used in the docker-compose.yml script. To use PHP 8.1, then just need to change it to `image: openemr/openemr:flex-3.17`. To use PHP 8.0, then just need to change it to `image: openemr/openemr:flex-3.15-8`.
 4. <a name="dev_tools_tests"></a>Php syntax checking, psr12 checking, and automated testing.
     - To check PHP error logs:
       ```sh

--- a/ci/apache_82_1011/docker-compose.yml
+++ b/ci/apache_82_1011/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       MYSQL_ROOT_PASSWORD: root
   openemr:
     restart: always
-    image: openemr/openemr:flex-edge
+    image: openemr/openemr:flex-3.18
     ports:
     - 80:80
     - 443:443


### PR DESCRIPTION
chore: documentation for flex docker now using alpine 3.18 with php 8.2