### PR TITLE
fix: output other insco zip if not 5 or 9 digits and log if isn't

### DIFF
--- a/src/Billing/X125010837P.php
+++ b/src/Billing/X125010837P.php
@@ -1200,13 +1200,13 @@ class X125010837P
             }
             $out .= "*";
             if (
-                strlen($claim->insuredZip($ins)) == 5
-                || strlen($claim->insuredZip($ins)) == 9
+                !(strlen($claim->payerZip($ins)) == 5)
+                || (strlen($claim->payerZip($ins) == 9))
             ) {
-                $out .= $claim->insuredZip($ins);
-            } else {
-                $log .= "*** Other insco insured zip is not 5 or 9 digits.\n";
+                $log .= "*** Other payer zip is not 5 or 9 digits.\n";
             }
+
+            $out .= $claim->x12Zip($claim->payerZip($ins));
             $out .= "~\n";
 
             // Segment REF (Other Subscriber Secondary Identification) omitted.

--- a/src/Billing/X125010837P.php
+++ b/src/Billing/X125010837P.php
@@ -1200,8 +1200,10 @@ class X125010837P
             }
             $out .= "*";
             if (
-                !((strlen($claim->insuredZip($ins)) == 5)
-                || (strlen($claim->insuredZip($ins) == 9)))
+                !(
+                    (strlen($claim->insuredZip($ins)) == 5)
+                    || (strlen($claim->insuredZip($ins) == 9))
+                )
             ) {
                 $log .= "*** Other insco insured zip is not 5 or 9 digits.\n";
             }
@@ -1260,8 +1262,10 @@ class X125010837P
             }
             $out .= "*";
             if (
-                !((strlen($claim->payerZip($ins)) == 5)
-                || (strlen($claim->payerZip() == 9)))
+                !(
+                    (strlen($claim->payerZip($ins)) == 5)
+                    || (strlen($claim->payerZip() == 9))
+                )
             ) {
                 $log .= "*** Other payer zip is not 5 or 9 digits.\n";
             }

--- a/src/Billing/X125010837P.php
+++ b/src/Billing/X125010837P.php
@@ -1200,8 +1200,8 @@ class X125010837P
             }
             $out .= "*";
             if (
-                !(strlen($claim->insuredZip($ins)) == 5)
-                || (strlen($claim->insuredZip($ins) == 9))
+                !((strlen($claim->insuredZip($ins)) == 5)
+                || (strlen($claim->insuredZip($ins) == 9)))
             ) {
                 $log .= "*** Other insco insured zip is not 5 or 9 digits.\n";
             }
@@ -1260,8 +1260,8 @@ class X125010837P
             }
             $out .= "*";
             if (
-                !(strlen($claim->payerZip($ins)) == 5)
-                || (strlen($claim->payerZip() == 9))
+                !((strlen($claim->payerZip($ins)) == 5)
+                || (strlen($claim->payerZip() == 9)))
             ) {
                 $log .= "*** Other payer zip is not 5 or 9 digits.\n";
             }

--- a/src/Billing/X125010837P.php
+++ b/src/Billing/X125010837P.php
@@ -1200,13 +1200,13 @@ class X125010837P
             }
             $out .= "*";
             if (
-                !(strlen($claim->payerZip($ins)) == 5)
-                || (strlen($claim->payerZip($ins) == 9))
+                !(strlen($claim->insuredZip($ins)) == 5)
+                || (strlen($claim->insuredZip($ins) == 9))
             ) {
-                $log .= "*** Other payer zip is not 5 or 9 digits.\n";
+                $log .= "*** Other insco insured zip is not 5 or 9 digits.\n";
             }
 
-            $out .= $claim->x12Zip($claim->payerZip($ins));
+            $out .= $claim->x12Zip($claim->insuredZip($ins));
             $out .= "~\n";
 
             // Segment REF (Other Subscriber Secondary Identification) omitted.

--- a/src/Billing/X125010837P.php
+++ b/src/Billing/X125010837P.php
@@ -1263,10 +1263,10 @@ class X125010837P
                 (strlen($claim->payerZip($ins)) == 5)
                 || (strlen($claim->payerZip() == 9))
             ) {
-                $out .= $claim->x12Zip($claim->payerZip($ins));
-            } else {
                 $log .= "*** Other payer zip is not 5 or 9 digits.\n";
             }
+
+            $out .= $claim->x12Zip($claim->payerZip($ins));
             $out .= "~\n";
 
             // Segment DTP*573 (Claim Check or Remittance Date) omitted.

--- a/src/Billing/X125010837P.php
+++ b/src/Billing/X125010837P.php
@@ -1260,7 +1260,7 @@ class X125010837P
             }
             $out .= "*";
             if (
-                (strlen($claim->payerZip($ins)) == 5)
+                !(strlen($claim->payerZip($ins)) == 5)
                 || (strlen($claim->payerZip() == 9))
             ) {
                 $log .= "*** Other payer zip is not 5 or 9 digits.\n";


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #6599 

#### Short description of what this resolves:


#### Changes proposed in this pull request:
