### PR TITLE
Allow repeater services to be turned off

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 # Possible options are prod or dev. No spaces, no quotes.
 OPENEMR__ENVIRONMENT=
+# Possible options are true to prevent dated reminders and background apps.Else empty or false. No spaces, no quotes.
+OPENEMR__NO_BACKGROUND_TASKS=

--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -406,9 +406,11 @@ if (!empty($GLOBALS['kernel']->getEventDispatcher())) {
             }
         });
         document.addEventListener('touchstart', {}); //specifically added for iOS devices, especially in iframes
-        $(function() {
-            goRepeaterServices();
-        });
+        <?php if (($_ENV['OPENEMR__NO_BACKGROUND_TASKS'] ?? 'false') !== 'true') { ?>
+            $(function () {
+                goRepeaterServices();
+            });
+        <?php } ?>
     </script>
     <?php
     // fire off an event here


### PR DESCRIPTION
add new environment debug variable to turn off dated reminders and background  service from running.

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #6601 


#### Short description of what this resolves:
Decided to keep as separate PR

