### PR TITLE
fix: output other insco zip if not 5 or 9 digits and log if isn't for rel-701

### DIFF
--- a/src/Billing/X125010837P.php
+++ b/src/Billing/X125010837P.php
@@ -1200,13 +1200,15 @@ class X125010837P
             }
             $out .= "*";
             if (
-                strlen($claim->insuredZip($ins)) == 5
-                || strlen($claim->insuredZip($ins)) == 9
+                !(
+                    (strlen($claim->insuredZip($ins)) == 5)
+                    || (strlen($claim->insuredZip($ins) == 9))
+                )
             ) {
-                $out .= $claim->insuredZip($ins);
-            } else {
                 $log .= "*** Other insco insured zip is not 5 or 9 digits.\n";
             }
+
+            $out .= $claim->x12Zip($claim->insuredZip($ins));
             $out .= "~\n";
 
             // Segment REF (Other Subscriber Secondary Identification) omitted.
@@ -1260,13 +1262,15 @@ class X125010837P
             }
             $out .= "*";
             if (
-                (strlen($claim->payerZip($ins)) == 5)
-                || (strlen($claim->payerZip() == 9))
+                !(
+                    (strlen($claim->payerZip($ins)) == 5)
+                    || (strlen($claim->payerZip() == 9))
+                )
             ) {
-                $out .= $claim->x12Zip($claim->payerZip($ins));
-            } else {
                 $log .= "*** Other payer zip is not 5 or 9 digits.\n";
             }
+
+            $out .= $claim->x12Zip($claim->payerZip($ins));
             $out .= "~\n";
 
             // Segment DTP*573 (Claim Check or Remittance Date) omitted.


### PR DESCRIPTION
…600)

* fix: output other insco zip if not 5 or 9 digits and log if isn't

* fix: output other insco payer zip if not 5 or 9 digits and log if isn't

* fix first commit with insuredZip

* fix logic payerZip

* surround conditions

* formatting

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:


#### Changes proposed in this pull request:
