### PR TITLE
fix: allow a field with date somewhere in it's name to be null in BaseService buildUpdateColumns()

### DIFF
--- a/src/Services/BaseService.php
+++ b/src/Services/BaseService.php
@@ -265,7 +265,13 @@ class BaseService
             if ($value == 'YYYY-MM-DD' || $value == 'MM/DD/YYYY') {
                 $value = "";
             }
-            if ($value === null || $value === false) {
+            if (
+                (
+                    $value === null
+                    || $value === false
+                )
+                && (strpos($key, 'date') === false)
+            ) {
                 // in case unwanted values passed in.
                 continue;
             }

--- a/src/Services/MedicationPatientIssueService.php
+++ b/src/Services/MedicationPatientIssueService.php
@@ -78,9 +78,9 @@ class MedicationPatientIssueService extends BaseService
 
     public function getRecordByIssueListId($list_id)
     {
-        $records = $this->search(['list_id' => new TokenSearchField('list_id', [$list_id])]);
-        if (!empty($records->getData())) {
-            return array_pop($records->getData());
+        $records = $this->search(['list_id' => new TokenSearchField('list_id', [$list_id])])->getData();
+        if (!empty($records)) {
+            return array_pop($records);
         }
         return null;
     }


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #6619

#### Short description of what this resolves:


#### Changes proposed in this pull request:
