### PR TITLE
feat: #6525 Use EHR authorization for SMART Apps

### DIFF
--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -348,7 +348,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
 
 <head>
     <?php
-    Header::setupHeader(['common']);
+    Header::setupHeader(['common','utility']);
     require_once("$srcdir/options.js.php");
     ?>
     <script>

--- a/interface/smart/ehr-launch-client.php
+++ b/interface/smart/ehr-launch-client.php
@@ -20,8 +20,7 @@ try {
     $controller->redirectAndLaunchSmartApp(
         $_REQUEST['intent'] ?? null,
         $_REQUEST['client_id'] ?? null,
-        $_REQUEST['csrf_token'] ?? null,
-        $intentData
+        $_REQUEST['csrf_token'] ?? null
     );
 } catch (CsrfInvalidException $exception) {
     CsrfUtils::csrfNotVerified();

--- a/interface/smart/ehr-launch-client.php
+++ b/interface/smart/ehr-launch-client.php
@@ -12,7 +12,13 @@
 
 require_once("../globals.php");
 
-$controller = new \OpenEMR\FHIR\SMART\SmartLaunchController();
+use OpenEMR\Common\Acl\AccessDeniedException;
+use OpenEMR\Common\Csrf\CsrfInvalidException;
+use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\FHIR\SMART\SmartLaunchController;
+
+$controller = new SmartLaunchController();
 
 $intentData = [];
 try {
@@ -20,7 +26,8 @@ try {
     $controller->redirectAndLaunchSmartApp(
         $_REQUEST['intent'] ?? null,
         $_REQUEST['client_id'] ?? null,
-        $_REQUEST['csrf_token'] ?? null
+        $_REQUEST['csrf_token'] ?? null,
+        $intentData
     );
 } catch (CsrfInvalidException $exception) {
     CsrfUtils::csrfNotVerified();

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -3233,6 +3233,12 @@ $GLOBALS_METADATA = array(
             '0',
             xl('Approval settings for 3rd party app/api access')
         ),
+        'oauth_ehr_launch_authorization_flow_skip' => array(
+            xl('OAuth2 EHR-Launch Authorization Flow Skip Enable App Setting'),
+            'bool',
+            '0',
+            xl('Enable an OAuth2 Client application to be configured to skip the login screen and the scope authorization screen if the user is already logged into the EHR.')
+        ),
 
         'cc_front_payments' => array(
             xl('Accept Credit Card transactions from Front Payments'),

--- a/library/js/utility.js
+++ b/library/js/utility.js
@@ -475,3 +475,31 @@ if (typeof top.userDebug !== 'undefined' && (top.userDebug === '1' || top.userDe
     };
 }
 
+(function(window, oeSMART) {
+    oeSMART.initLaunch = function(webroot, csrfToken) {
+        // allows this to be lazy defined
+        let xl = window.top.xl || function(text) { return text; };
+        let smartLaunchers = document.querySelectorAll('.smart-launch-btn');
+        for (let launch of smartLaunchers) {
+                launch.addEventListener('click', function (evt) {
+                    let node = evt.target;
+                    let intent = node.dataset.intent;
+                    let clientId = node.dataset.clientId;
+                    if (!intent || !clientId) {
+                        console.error("mising intent parameter or client-id parameter");
+                        return;
+                    }
+
+                    let url = webroot + '/interface/smart/ehr-launch-client.php?intent='
+                        + encodeURIComponent(intent) + '&client_id=' + encodeURIComponent(clientId)
+                        + "&csrf_token=" + encodeURIComponent(csrfToken);
+                    let title = node.dataset.smartName || JSON.stringify(xl("Smart App"));
+                    // we allow external dialog's  here because that is what a SMART app is
+                    let height = window.top.innerHeight; // do our full height here
+                    dlgopen(url, '_blank', 'modal-full', height, '', title, {allowExternal: true});
+                });
+        }
+    };
+    window.oeSMART = oeSMART;
+})(window, window.top.oeSMART || {});
+

--- a/oauth2/smart/ehr-launch-autosubmit.html.twig
+++ b/oauth2/smart/ehr-launch-autosubmit.html.twig
@@ -1,0 +1,16 @@
+<html>
+<body>
+<form method="POST" action="{{ endpoint }}">
+    {# Do we want to show any kind of message...? For satellite or slow latency connections... we'd want to show something here. #}
+</form>
+<script>
+    // grab the launch token and autosubmit it to the launch endpoint
+    (function() {
+        document.addEventListener("DOMContentLoaded", function(event) {
+            var form = document.getElementsByTagName('form')[0];
+            form.submit();
+        });
+    })();
+</script>
+</body>
+</html>

--- a/sql/7_0_1-to-7_0_2_upgrade.sql
+++ b/sql/7_0_1-to-7_0_2_upgrade.sql
@@ -245,6 +245,9 @@ CREATE TABLE recent_patients (
     patients TEXT,
     PRIMARY KEY (user_id)
 ) ENGINE=InnoDB;
+
+#IfMissingColumn oauth_clients skip_ehr_launch_authorization_flow
+ALTER TABLE `oauth_clients` ADD COLUMN `skip_ehr_launch_authorization_flow` tinyint(1) NOT NULL DEFAULT '0';
 #EndIf
 
 #IfMissingColumn document_template_profiles notify_trigger

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -13075,6 +13075,7 @@ CREATE TABLE `oauth_clients` (
 `policy_uri` text,
 `tos_uri` text,
 `is_enabled` tinyint(1) NOT NULL DEFAULT '0',
+`skip_ehr_launch_authorization_flow` tinyint(1) NOT NULL DEFAULT '0',
 PRIMARY KEY (`client_id`)
 ) ENGINE=InnoDB;
 

--- a/src/Common/Auth/OpenIDConnect/Entities/ClientEntity.php
+++ b/src/Common/Auth/OpenIDConnect/Entities/ClientEntity.php
@@ -54,9 +54,15 @@ class ClientEntity implements ClientEntityInterface
 
     protected $registrationDate;
 
+    /**
+     * @var bool true if the authorization flow (authentication and scope authorization) should be skipped for logged in ehr users
+     */
+    private $skipEHRLaunchAuthorizationFlow;
+
     public function __construct()
     {
         $this->scopes = [];
+        $this->skipEHRLaunchAuthorizationFlow = false;
     }
 
     public function setName($name): void
@@ -241,5 +247,18 @@ class ClientEntity implements ClientEntityInterface
     public function setLogoutRedirectUris(?string $logoutRedirectUris): void
     {
         $this->logoutRedirectUris = $logoutRedirectUris;
+    }
+
+    /**
+     * Whether the ehr launch should skip the authorization flow for a logged in user.
+     * @return bool
+     */
+    public function shouldSkipEHRLaunchAuthorizationFlow() : bool
+    {
+        return $this->skipEHRLaunchAuthorizationFlow;
+    }
+
+    public function setSkipEHRLaunchAuthorizationFlow(bool $shouldSkip) {
+        $this->skipEHRLaunchAuthorizationFlow = $shouldSkip;
     }
 }

--- a/src/Common/Auth/OpenIDConnect/Entities/ClientEntity.php
+++ b/src/Common/Auth/OpenIDConnect/Entities/ClientEntity.php
@@ -253,12 +253,13 @@ class ClientEntity implements ClientEntityInterface
      * Whether the ehr launch should skip the authorization flow for a logged in user.
      * @return bool
      */
-    public function shouldSkipEHRLaunchAuthorizationFlow() : bool
+    public function shouldSkipEHRLaunchAuthorizationFlow(): bool
     {
         return $this->skipEHRLaunchAuthorizationFlow;
     }
 
-    public function setSkipEHRLaunchAuthorizationFlow(bool $shouldSkip) {
+    public function setSkipEHRLaunchAuthorizationFlow(bool $shouldSkip)
+    {
         $this->skipEHRLaunchAuthorizationFlow = $shouldSkip;
     }
 }

--- a/src/Common/Auth/OpenIDConnect/SMARTSessionTokenContextBuilder.php
+++ b/src/Common/Auth/OpenIDConnect/SMARTSessionTokenContextBuilder.php
@@ -33,6 +33,7 @@ class SMARTSessionTokenContextBuilder
     public function getEHRLaunchContext()
     {
         $launch = $this->sessionArray['launch'] ?? null;
+        $this->logger->debug("SMARTSessionTokenContextBuilder->getEHRLaunchContext() launch context is", ['launch' => $launch]);
         if (empty($launch)) {
             return [];
         }
@@ -101,6 +102,7 @@ class SMARTSessionTokenContextBuilder
     public function getContextForScopes($scopes): array
     {
         $context = [];
+        $this->logger->debug("SMARTSessionTokenContextBuilder->getContextForScopes()");
         if ($this->isStandaloneLaunchPatientRequest($scopes)) {
             $context = $this->getStandaloneLaunchContext();
         } else if ($this->isEHRLaunchRequest($scopes)) {

--- a/src/Common/Session/SessionUtil.php
+++ b/src/Common/Session/SessionUtil.php
@@ -61,6 +61,9 @@ namespace OpenEMR\Common\Session;
 
 class SessionUtil
 {
+    private const CORE_SESSION_ID = "OpenEMR";
+    private const OAUTH_SESSION_ID = 'authserverOpenEMR';
+
     private static $gc_maxlifetime = 14400;
     private static $sid_bits_per_character = 6;
     private static $sid_length = 48;
@@ -71,6 +74,13 @@ class SessionUtil
     private static $use_cookie_httponly = true;
     private static $use_cookie_secure = false;
 
+    public static function switchToCoreSession($web_root, $read_only = true): void
+    {
+        session_write_close();
+        session_id($_COOKIE[self::CORE_SESSION_ID] ?? '');
+        self::coreSessionStart($web_root, $read_only);
+    }
+
     public static function coreSessionStart($web_root, $read_only = true): void
     {
         // Note there is no system logger here since that class does not
@@ -79,7 +89,7 @@ class SessionUtil
             'read_and_close' => $read_only,
             'cookie_samesite' => self::$use_cookie_samesite,
             'cookie_secure' => self::$use_cookie_secure,
-            'name' => 'OpenEMR',
+            'name' => self::CORE_SESSION_ID,
             'cookie_httponly' => false,
             'cookie_path' => ((!empty($web_root)) ? $web_root . '/' : '/'),
             'gc_maxlifetime' => self::$gc_maxlifetime,
@@ -187,12 +197,19 @@ class SessionUtil
         self::standardSessionCookieDestroy();
     }
 
+    public static function switchToOAuthSession($web_root): void
+    {
+        session_write_close();
+        session_id($_COOKIE[self::OAUTH_SESSION_ID] ?? '');
+        self::oauthSessionStart($web_root);
+    }
+
     public static function oauthSessionStart($web_root): void
     {
         session_start([
             'cookie_samesite' => "None",
             'cookie_secure' => true,
-            'name' => 'authserverOpenEMR',
+            'name' => self::OAUTH_SESSION_ID,
             'cookie_httponly' => self::$use_cookie_httponly,
             'cookie_path' => ((!empty($web_root)) ? $web_root . '/oauth2/' : '/oauth2/'),
             'gc_maxlifetime' => self::$gc_maxlifetime,

--- a/src/FHIR/SMART/ClientAdminController.php
+++ b/src/FHIR/SMART/ClientAdminController.php
@@ -1138,7 +1138,8 @@ class ClientAdminController
         <?php
         $this->renderFooter();
     }
-    private function enableAuthorizationFlowSkipAction(string$clientId,array$request){
+    private function enableAuthorizationFlowSkipAction(string $clientId, array $request)
+    {
          $client = $this->clientRepo->getClientEntity($clientId);
         if ($client === false) {
             $this->notFoundAction($request);
@@ -1148,7 +1149,8 @@ class ClientAdminController
         $this->handleAuthorizationFlowSkipAction($client, true, $message);
         exit;
     }
-    private function disableAuthorizationFlowSkipAction(string $clientId ,array $request){
+    private function disableAuthorizationFlowSkipAction(string $clientId, array $request)
+    {
          $client = $this->clientRepo->getClientEntity($clientId);
         if ($client === false) {
             $this->notFoundAction($request);
@@ -1158,7 +1160,8 @@ class ClientAdminController
         $this->handleAuthorizationFlowSkipAction($client, false, $message);
         exit;
     }
-    private function handleAuthorizationFlowSkipAction(ClientEntity$client,bool $skipFlow,string $successMessage){
+    private function handleAuthorizationFlowSkipAction(ClientEntity $client, bool $skipFlow, string $successMessage)
+    {
         $client->setSkipEHRLaunchAuthorizationFlow($skipFlow);
         try {
             $this->clientRepo->saveSkipEHRLaunchFlow($client, $skipFlow);

--- a/src/FHIR/SMART/SMARTLaunchToken.php
+++ b/src/FHIR/SMART/SMARTLaunchToken.php
@@ -40,13 +40,6 @@ class SMARTLaunchToken
      */
     private ?string $appointmentUuid;
 
-    private ?string $userUuid;
-
-    /**
-     * @var string The user type, either 'user' or 'patient' referring to coming from users table or patient_data
-     */
-    private string $userType;
-
     public function __construct($patientUUID = null, $encounterUUID = null)
     {
         if (isset($patientUUID) && !is_string($patientUUID)) {
@@ -140,7 +133,7 @@ class SMARTLaunchToken
         return $launchParams;
     }
 
-    public static function deserializeToken($serialized) : self
+    public static function deserializeToken($serialized): self
     {
         $token = new self();
         $token->deserialize($serialized);

--- a/src/FHIR/SMART/SMARTLaunchToken.php
+++ b/src/FHIR/SMART/SMARTLaunchToken.php
@@ -20,7 +20,7 @@ class SMARTLaunchToken
 {
     public const INTENT_PATIENT_DEMOGRAPHICS_DIALOG = 'patient.demographics.dialog';
 
-    public const VALID_INTENTS = [self::INTENT_PATIENT_DEMOGRAPHICS_DIALOG, self::INTENT_APPOINTMENT_DIALOG, self::INTENT_ENCOUNTER_DIALOG];
+    public const VALID_INTENTS = [self::INTENT_PATIENT_DEMOGRAPHICS_DIALOG, self::INTENT_APPOINTMENT_DIALOG, self::INTENT_ENCOUNTER_DIALOG, self::INTENT_MAIN_TAB];
 
     // used on the appointment add/edit dialog, context will include the selected appointment
     // for now this intent is used by custom apps that consume the openemr.appointment.add_edit_event.close.before event
@@ -28,6 +28,11 @@ class SMARTLaunchToken
     public const INTENT_APPOINTMENT_DIALOG = 'appointment.edit.dialog';
 
     public const INTENT_ENCOUNTER_DIALOG = 'encounter.forms.dialog';
+
+    /*
+     * When a module is launched from a main menu item into a main tab, the intent is set to this value.
+     */
+    public const INTENT_MAIN_TAB = 'main.tab';
 
     /**
      * @var string|null The patient UUID If
@@ -51,8 +56,6 @@ class SMARTLaunchToken
         $this->patient = $patientUUID;
         $this->encounter = $encounterUUID;
         $this->appointmentUuid = null;
-        $this->userUuid = null;
-        $this->setUserType('user');
     }
 
     /**
@@ -121,7 +124,6 @@ class SMARTLaunchToken
         if (!empty($this->getAppointmentUuid())) {
             $context['apt'] = $this->getAppointmentUuid();
         }
-        $context['sub'] = $this->userType . '/' . $this->userUuid;
 
         // no security is really needed here... just need to be able to wrap
         // the current context into some kind of opaque id that the app will pass to the server and we can then
@@ -163,13 +165,6 @@ class SMARTLaunchToken
         if (!empty($context['apt'])) {
             $this->setAppointmentUuid($context['apt']);
         }
-        $sub = $context['sub'] ?? '';
-        $subParts = explode('/', $sub);
-        if (count($subParts) !== 2) {
-            throw new \InvalidArgumentException("sub field in token must be in the format of 'user/uuid' or 'patient/uuid'");
-        }
-        $this->setUserType($subParts[0]);
-        $this->setUserUuid($subParts[1]);
     }
 
     public function isValidIntent($intent)
@@ -184,28 +179,5 @@ class SMARTLaunchToken
     public function getAppointmentUuid(): ?string
     {
         return $this->appointmentUuid;
-    }
-
-    public function setUserUuid(?string $userUuid)
-    {
-        $this->userUuid = $userUuid;
-    }
-
-    public function getUserUuid(): ?string
-    {
-        return $this->userUuid;
-    }
-
-    public function getUserType(): string
-    {
-        return $this->userType;
-    }
-
-    public function setUserType(string $userType)
-    {
-        if ($userType !== 'patient') {
-            $userType = 'user';
-        }
-        $this->userType = $userType;
     }
 }

--- a/src/FHIR/SMART/SMARTLaunchToken.php
+++ b/src/FHIR/SMART/SMARTLaunchToken.php
@@ -20,7 +20,7 @@ class SMARTLaunchToken
 {
     public const INTENT_PATIENT_DEMOGRAPHICS_DIALOG = 'patient.demographics.dialog';
 
-    public const VALID_INTENTS = [self::INTENT_PATIENT_DEMOGRAPHICS_DIALOG, self::INTENT_APPOINTMENT_DIALOG];
+    public const VALID_INTENTS = [self::INTENT_PATIENT_DEMOGRAPHICS_DIALOG, self::INTENT_APPOINTMENT_DIALOG, self::INTENT_ENCOUNTER_DIALOG];
 
     // used on the appointment add/edit dialog, context will include the selected appointment
     // for now this intent is used by custom apps that consume the openemr.appointment.add_edit_event.close.before event
@@ -191,15 +191,18 @@ class SMARTLaunchToken
         $this->userUuid = $userUuid;
     }
 
-    public function getUserUuid() : ?string{
+    public function getUserUuid(): ?string
+    {
         return $this->userUuid;
     }
 
-    public function getUserType() : string {
+    public function getUserType(): string
+    {
         return $this->userType;
     }
 
-    public function setUserType(string $userType) {
+    public function setUserType(string $userType)
+    {
         if ($userType !== 'patient') {
             $userType = 'user';
         }

--- a/src/FHIR/SMART/SmartLaunchController.php
+++ b/src/FHIR/SMART/SmartLaunchController.php
@@ -142,7 +142,7 @@ class SmartLaunchController
         <?php
     }
 
-    public function redirectAndLaunchSmartApp($intent, $client_id, $csrf_token)
+    public function redirectAndLaunchSmartApp($intent, $client_id, $csrf_token, array $intentData)
     {
         $clientRepository = new ClientRepository();
         $client = $clientRepository->getClientEntity($client_id);
@@ -180,7 +180,7 @@ class SmartLaunchController
                 }
             }
         }
-        if (isset($_SESSION['encounter'])) {
+        if (!empty($_SESSION['encounter'])) {
             // grab the encounter euuid
             $euuid = UuidRegistry::uuidToString(EncounterService::getUuidById($_SESSION['encounter'], 'form_encounter', 'encounter'));
         }
@@ -190,16 +190,6 @@ class SmartLaunchController
 
         if (!empty($appointmentUuid)) {
             $launchCode->setAppointmentUuid($appointmentUuid);
-        }
-        if (isset($_SESSION['authUser'])) {
-            $userService = new UserService();
-            $user = $userService->getUserByUsername($_SESSION['authUser']);
-            $launchCode->setUserUuid($user['uuid']);
-            $launchCode->setUserType('provider');
-        } else {
-            // we don't have authUser and we are a patient at this point
-            $launchCode->setUserUuid($puuid);
-            $launchCode->setUserType('patient');
         }
         $serializedCode = $launchCode->serialize();
         $launchParams = "?launch=" . urlencode($serializedCode) . "&iss=" . urlencode($issuer) . "&aud=" . urlencode($issuer);

--- a/src/FHIR/SMART/SmartLaunchController.php
+++ b/src/FHIR/SMART/SmartLaunchController.php
@@ -22,6 +22,7 @@ use OpenEMR\Events\PatientDemographics\RenderEvent;
 use OpenEMR\Services\AppointmentService;
 use OpenEMR\Services\EncounterService;
 use OpenEMR\Services\PatientService;
+use OpenEMR\Services\UserService;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use OpenEMR\FHIR\Config\ServerConfig;
 
@@ -42,7 +43,7 @@ class SmartLaunchController
      */
     private $dispatcher;
 
-    public function __construct(EventDispatcher $dispatcher = null)
+    public function __construct(?EventDispatcher $dispatcher = null)
     {
         $this->dispatcher = $dispatcher;
     }
@@ -71,6 +72,7 @@ class SmartLaunchController
         UuidRegistry::createMissingUuidsForTables(['patient_data']);
         // going to work with string uuids
         $puuid = UuidRegistry::uuidToString($patientService->getUuid($pid));
+        // TODO: @adunsulag could this all be moved to twig?
         ?>
         <section>
             <?php
@@ -92,7 +94,7 @@ class SmartLaunchController
 
             $issuer = (new ServerConfig())->getFhirUrl();
             // issuer and audience are the same in a EHR SMART Launch
-            $launchParams = "?launch=" . urlencode($launchCode) . "&iss=" . urlencode($issuer) . "&aud=" . urlencode($issuer);
+
 
             expand_collapse_widget(
                 $widgetTitle,
@@ -114,10 +116,7 @@ class SmartLaunchController
                         <?php endif; ?>
                         <?php foreach ($smartClients as $client) : ?>
                             <li class="summary_item">
-                                <button class='btn btn-primary btn-sm smart-launch-btn' data-smart-name="<?php echo attr($client->getName()); ?>"
-                                        data-smart-redirect-url="<?php echo attr($client->getLaunchUri($launchParams)); ?>">
-                                    <?php echo xlt("Launch"); ?>
-                                </button>
+                                <?php $this->renderLaunchButton($client, $issuer, $launchCode); ?>
                                 <?php echo text($client->getName()); ?>
                             </li>
                         <?php endforeach; ?>
@@ -127,9 +126,23 @@ class SmartLaunchController
         <?php
         // it's too bad we don't have a centralized page renderer we could tie this into and render javascript at the
         // end of our footer pages on everything...
+        $this->renderLaunchScript();
     }
 
-    public function redirectAndLaunchSmartApp($intent, $client_id, $csrf_token, array $intentData)
+    public function renderLaunchButton(ClientEntity $client, string $issuer, SMARTLaunchToken $launchToken, $launchText = "Launch")
+    {
+        $launchCode = $launchToken->serialize();
+        $launchParams = "?launch=" . urlencode($launchCode) . "&iss=" . urlencode($issuer) . "&aud=" . urlencode($issuer);
+        ?>
+        <button class='btn btn-primary btn-sm smart-launch-btn' data-smart-name="<?php echo attr($client->getName()); ?>"
+                            data-intent="<?php echo attr(SMARTLaunchToken::INTENT_PATIENT_DEMOGRAPHICS_DIALOG); ?>"
+                            data-client-id="<?php echo attr($client->getIdentifier()); ?>">
+                                    <?php echo xlt($launchText); ?>
+        </button>
+        <?php
+    }
+
+    public function redirectAndLaunchSmartApp($intent, $client_id, $csrf_token)
     {
         $clientRepository = new ClientRepository();
         $client = $clientRepository->getClientEntity($client_id);
@@ -167,12 +180,26 @@ class SmartLaunchController
                 }
             }
         }
+        if (isset($_SESSION['encounter'])) {
+            // grab the encounter euuid
+            $euuid = UuidRegistry::uuidToString(EncounterService::getUuidById($_SESSION['encounter'], 'form_encounter', 'encounter'));
+        }
 
         $issuer = (new ServerConfig())->getFhirUrl();
         $launchCode = $this->getLaunchCodeContext($puuid, $euuid, $intent);
 
         if (!empty($appointmentUuid)) {
             $launchCode->setAppointmentUuid($appointmentUuid);
+        }
+        if (isset($_SESSION['authUser'])) {
+            $userService = new UserService();
+            $user = $userService->getUserByUsername($_SESSION['authUser']);
+            $launchCode->setUserUuid($user['uuid']);
+            $launchCode->setUserType('provider');
+        } else {
+            // we don't have authUser and we are a patient at this point
+            $launchCode->setUserUuid($puuid);
+            $launchCode->setUserType('patient');
         }
         $serializedCode = $launchCode->serialize();
         $launchParams = "?launch=" . urlencode($serializedCode) . "&iss=" . urlencode($issuer) . "&aud=" . urlencode($issuer);
@@ -185,22 +212,11 @@ class SmartLaunchController
     {
         ?>
         <script>
-            (function(window) {
-                let smartLaunchers = document.querySelectorAll('.smart-launch-btn');
-                for (let launch of smartLaunchers) {
-                    let url =
-                        launch.addEventListener('click', function(evt) {
-                            let node = evt.target;
-                            let url = node.dataset.smartRedirectUrl;
-                            if (!url) {
-                                return;
-                            }
-                            let title = node.dataset.smartName || "<?php echo xlt("Smart App"); ?>";
-                            // we allow external dialog's  here because that is what a SMART app is
-                            dlgopen(url, '_blank', 950, 650, '', title, {allowExternal: true});
-                        });
+            (function(oeSMART) {
+                if (oeSMART && oeSMART.initLaunch) {
+                    oeSMART.initLaunch(<?php echo js_escape($GLOBALS['webroot']); ?>, <?php echo js_escape(CsrfUtils::collectCsrfToken()); ?>);
                 }
-            })(window);
+            })(window.oeSMART || {});
 
         </script>
         <?php

--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -1379,10 +1379,12 @@ class AuthorizationController
         // if don't allow our globals settings to allow skipping the authorization flow when inside an ehr launch
         // we just return false
         if ($GLOBALS['oauth_ehr_launch_authorization_flow_skip'] !== '1') {
+            $this->logger->debug("AuthorizationController->shouldSkipAuthorizationFlow() - oauth_ehr_launch_authorization_flow_skip not set, not skipping even though launch is present.");
             return false;
         }
         if ($client instanceof ClientEntity) {
             if ($client->shouldSkipEHRLaunchAuthorizationFlow()) {
+                $this->logger->debug("AuthorizationController->shouldSkipAuthorizationFlow() - client is configured to skip authorization flow.");
                 return true;
             }
         }
@@ -1394,6 +1396,7 @@ class AuthorizationController
         $queryParams = $request->getQueryParams();
 
         if (empty($queryParams['autosubmit']) || $queryParams['autosubmit'] !== '1') {
+            $this->logger->debug("AuthorizationController->processAuthorizeFlowForLaunch() - autosubmit not set, redirecting to autosubmit page.");
             // we are going to display a form here with a javascript to autosubmit this page so we can make our session
             // cookies on a first party domain to verify the user is logged in.  It requires a whole page load and it's
             // a slower approach but we can then rely on the session cookie as a first party domain.
@@ -1403,6 +1406,7 @@ class AuthorizationController
             $this->getSmartAuthController()->dispatchRoute(SMARTAuthorizationController::EHR_SMART_LAUNCH_AUTOSUBMIT);
             exit;
         }
+        $this->logger->debug("AuthorizationController->processAuthorizeFlowForLaunch() - autosubmit set, processing authorization flow.");
         // if we have come back from an autosubmit we are going to check to see if we are logged in
 
         $launch = $request->getQueryParams()['launch'];

--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -153,7 +153,7 @@ class AuthorizationController
     private function getSmartAuthController(): SMARTAuthorizationController
     {
         if (!isset($this->smartAuthController)) {
-            $twigContainer = new TwigContainer(__DIR__ . "/../../oauth2/", $GLOBALS['kenerl']);
+            $twigContainer = new TwigContainer(__DIR__ . "/../../oauth2/", $GLOBALS['kernel']);
             $twig = $twigContainer->getTwig();
 
             $this->smartAuthController = new SMARTAuthorizationController(


### PR DESCRIPTION
First stab at #6525 by allowing the EHR to launch a smart app and reuse the authorization context that the currently logged in user has.  Keeping it as draft for now in order to discuss the security implications and for a followup commit to add the database tracking to prevent replay attacks.

I introduce a global that by default is off to allow OpenEMR administrators to enable smart apps to skip the authorization screen when the smart app is launched inside the EHR.

I refactored the launch sequence now to be an on-demand generation of the launch token using javascript instead of generating the token and stuffing it into the html.

I added a flag on the individual client app to turn on or off the authorization skip flag.  This gives admins control over allowing apps to launch immediately inside the EHR without requiring an authorization / authentication step.

I expanded the size of the SMART app window so that the app can take up more of the window and offer more functionality.  I'm wondering if we should offer different size options based upon the registered intent, or if there is some mechanism the app can communicate of how much real estate it wants to take up.

The app will receive any permissions it requests that was originally granted in its registration request.  The flow will continue to discard permissions that were not granted in the original registration request or were reduced in a subset of the refresh token.

Added to the launch token the currently authenticated user and the type of user.  Right now the ehr-launch is only inside the provider side of things, but I put in infrastructure so we can later extend it to launch inside the patient portal.

I originally relied on opening up the OpenEMR session cookie, but this doesn't work if the SMART app is hosted on a domain other than the domain OpenEMR is running under.  Browsers will drop the cookies on the browser redirect as its not considered a first-party origin so we have to rely on the launch token being the authority for the authentication / authorization.

I'm thinking that for more security in order to prevent replay attacks we need to store the generated launch token in the database, time expire it, and make it a one time use token.  If a repeat is detected we should invalidate all of the current user's access tokens and do some kind of notification to the administrator. I'm not sure yet if this is warranted, but it seems like we should treat this as serious as what we do with the refresh token.