### PR TITLE
feat: Fixes #6629 Encounter forms list render event

### DIFF
--- a/interface/patient_file/encounter/forms.php
+++ b/interface/patient_file/encounter/forms.php
@@ -1018,7 +1018,7 @@ if ($dispatcher instanceof EventDispatcher) {
     $event = new EncounterFormsListRenderEvent($_SESSION['encounter'], $attendant_type);
     $event->setGroupId($groupId ?? null);
     $event->setPid($pid ?? null);
-    $dispatcher->dispatch($event, EncounterFormsListRenderEvent::EVENT_SECTION_RENDER_POST;
+    $dispatcher->dispatch($event, EncounterFormsListRenderEvent::EVENT_SECTION_RENDER_POST);
 }
 ?>
 

--- a/interface/patient_file/encounter/forms.php
+++ b/interface/patient_file/encounter/forms.php
@@ -29,6 +29,7 @@ use OpenEMR\Events\Encounter\EncounterMenuEvent;
 use OpenEMR\Services\EncounterService;
 use OpenEMR\Services\UserService;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use OpenEMR\Events\Encounter\EncounterFormsListRenderEvent;
 
 $expand_default = (int)$GLOBALS['expand_form'] ? 'show' : 'hide';
 $reviewMode = false;
@@ -64,7 +65,7 @@ if ($GLOBALS['kernel']->getEventDispatcher() instanceof EventDispatcher) {
 
 <?php require $GLOBALS['srcdir'] . '/js/xl/dygraphs.js.php'; ?>
 
-<?php Header::setupHeader(['common','esign','dygraphs']); ?>
+<?php Header::setupHeader(['common','esign','dygraphs', 'utility']); ?>
 
 <?php
 $esignApi = new Api();
@@ -790,6 +791,15 @@ if ($attendant_type == 'pid') {
 if (!empty($docs_list) && count($docs_list) > 0) {
     ?>
 <div class='enc_docs'>
+    <?php
+    $dispatcher = $GLOBALS['kernel']->getEventDispatcher();
+    if ($dispatcher instanceof EventDispatcher) {
+        $event = new EncounterFormsListRenderEvent($_SESSION['encounter'], $attendant_type);
+        $event->setGroupId($groupId ?? null);
+        $event->setPid($pid ?? null);
+        $dispatcher->dispatch($event, EncounterFormsListRenderEvent::EVENT_SECTION_RENDER_PRE);
+    }
+    ?>
 <span class="font-weight-bold"><?php echo xlt("Document(s)"); ?>:</span>
     <?php
     $doc = new C_Document();
@@ -1001,6 +1011,14 @@ if (
 }
 if (!$pass_sens_squad) {
     echo xlt("Not authorized to view this encounter");
+}
+
+$dispatcher = $GLOBALS['kernel']->getEventDispatcher();
+if ($dispatcher instanceof EventDispatcher) {
+    $event = new EncounterFormsListRenderEvent($_SESSION['encounter'], $attendant_type);
+    $event->setGroupId($groupId ?? null);
+    $event->setPid($pid ?? null);
+    $dispatcher->dispatch($event, EncounterFormsListRenderEvent::EVENT_SECTION_RENDER_POST;
 }
 ?>
 

--- a/interface/patient_file/encounter/forms.php
+++ b/interface/patient_file/encounter/forms.php
@@ -629,6 +629,15 @@ echo $t->render('encounter/forms/navbar.html.twig', [
 
 <div id="encounter_forms" class="mx-1">
 <div class='encounter-summary-container'>
+    <?php
+    $dispatcher = $GLOBALS['kernel']->getEventDispatcher();
+    if ($dispatcher instanceof EventDispatcher) {
+        $event = new EncounterFormsListRenderEvent($_SESSION['encounter'], $attendant_type);
+        $event->setGroupId($groupId ?? null);
+        $event->setPid($pid ?? null);
+        $dispatcher->dispatch($event, EncounterFormsListRenderEvent::EVENT_SECTION_RENDER_PRE);
+    }
+    ?>
     <div class='encounter-summary-column'>
         <div>
             <?php
@@ -663,12 +672,12 @@ echo $t->render('encounter/forms/navbar.html.twig', [
 
         </div>
     </div>
+
 <div class='encounter-summary-column'>
 <?php if ($esign->isLogViewable()) {
     $esign->renderLog();
 } ?>
 </div>
-
 <div class='encounter-summary-column'>
 <?php if ($GLOBALS['enable_amc_prompting']) { ?>
     <div class="float-right border border-dark mr-2">
@@ -791,15 +800,6 @@ if ($attendant_type == 'pid') {
 if (!empty($docs_list) && count($docs_list) > 0) {
     ?>
 <div class='enc_docs'>
-    <?php
-    $dispatcher = $GLOBALS['kernel']->getEventDispatcher();
-    if ($dispatcher instanceof EventDispatcher) {
-        $event = new EncounterFormsListRenderEvent($_SESSION['encounter'], $attendant_type);
-        $event->setGroupId($groupId ?? null);
-        $event->setPid($pid ?? null);
-        $dispatcher->dispatch($event, EncounterFormsListRenderEvent::EVENT_SECTION_RENDER_PRE);
-    }
-    ?>
 <span class="font-weight-bold"><?php echo xlt("Document(s)"); ?>:</span>
     <?php
     $doc = new C_Document();

--- a/src/Events/Encounter/EncounterFormsListRenderEvent.php
+++ b/src/Events/Encounter/EncounterFormsListRenderEvent.php
@@ -43,7 +43,8 @@ class EncounterFormsListRenderEvent
         $this->setAttendantType($attendantType);
     }
 
-    public function getAttendantType() : string {
+    public function getAttendantType(): string
+    {
         return $this->attendantType;
     }
 

--- a/src/Events/Encounter/EncounterFormsListRenderEvent.php
+++ b/src/Events/Encounter/EncounterFormsListRenderEvent.php
@@ -28,7 +28,7 @@ class EncounterFormsListRenderEvent
     /**
      * Allows screen output after all of the encounter forms have been rendered for the encounter/forms.php screen
      */
-    const EVENT_SECTION_RENDER_PRE = 'forms.encounter.list.render.post';
+    const EVENT_SECTION_RENDER_PRE = 'forms.encounter.list.render.pre';
 
     /**
      * Allows screen output after all of the encounter forms have been rendered for the encounter/forms.php screen
@@ -38,13 +38,17 @@ class EncounterFormsListRenderEvent
     public function __construct(?int $encounter = null, $attendantType = 'pid')
     {
         $this->encounter = $encounter;
-        $this->pid = null;
-        $this->groupId = null;
-        $this->attendantType = $attendantType == 'gid' ? 'gid' : 'pid';
+        $this->setPid(null);
+        $this->setGroupId(null);
+        $this->setAttendantType($attendantType);
+    }
+
+    public function getAttendantType() : string {
+        return $this->attendantType;
     }
 
     /**
-     * @param string $attendantType
+     * @param string $attendantType 'gid' or 'pid' The type of encounter that is being rendered, a group encounter (gid), or an individual patient encounter (pid)
      */
     public function setAttendantType(string $attendantType): void
     {
@@ -57,6 +61,14 @@ class EncounterFormsListRenderEvent
     public function setGroupId(?int $groupId): void
     {
         $this->groupId = $groupId;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getGroupId()
+    {
+        return $this->groupId;
     }
 
     /**

--- a/src/Events/Encounter/EncounterFormsListRenderEvent.php
+++ b/src/Events/Encounter/EncounterFormsListRenderEvent.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * EncounterFormsListRenderEvent is used to launch different rendering action points that developers can output their
+ * own HTML content during the forms.php encounter list sequence.
+ *
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Discover and Change, Inc. <snielson@dicsoverandchange.com>
+ * @copyright Copyright (c) 2023 Discover and Change, Inc. <snielson@discoverandchange.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\Encounter;
+
+class EncounterFormsListRenderEvent
+{
+    /**
+     * @var int|null The patient pid that the encounter is for (matches the patient_data.pid column)
+     */
+    private ?int $pid;
+
+    /**
+     * @var int|null The encounter id that the encounter is for (matches the forms.encounter db id)
+     */
+    private ?int $encounter;
+
+    /**
+     * Allows screen output after all of the encounter forms have been rendered for the encounter/forms.php screen
+     */
+    const EVENT_SECTION_RENDER_PRE = 'forms.encounter.list.render.post';
+
+    /**
+     * Allows screen output after all of the encounter forms have been rendered for the encounter/forms.php screen
+     */
+    const EVENT_SECTION_RENDER_POST = "forms.encounter.list.render.post";
+
+    public function __construct(?int $encounter = null, $attendantType = 'pid')
+    {
+        $this->encounter = $encounter;
+        $this->pid = null;
+        $this->groupId = null;
+        $this->attendantType = $attendantType == 'gid' ? 'gid' : 'pid';
+    }
+
+    /**
+     * @param string $attendantType
+     */
+    public function setAttendantType(string $attendantType): void
+    {
+        $this->attendantType = $attendantType == 'gid' ? 'gid' : 'pid';
+    }
+
+    /**
+     * @param int|null $groupId The group id that the encounter is for
+     */
+    public function setGroupId(?int $groupId): void
+    {
+        $this->groupId = $groupId;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getPid(): ?int
+    {
+        return $this->pid;
+    }
+
+    /**
+     * @param int|null $pid
+     * @return EncounterFormsListRenderEvent
+     */
+    public function setPid(?int $pid): EncounterFormsListRenderEvent
+    {
+        $this->pid = $pid;
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getEncounter(): ?int
+    {
+        return $this->encounter;
+    }
+
+    /**
+     * @param int|null $encounter
+     * @return EncounterFormsListRenderEvent
+     */
+    public function setEncounter(?int $encounter): EncounterFormsListRenderEvent
+    {
+        $this->encounter = $encounter;
+        return $this;
+    }
+}

--- a/src/Services/EncounterService.php
+++ b/src/Services/EncounterService.php
@@ -42,7 +42,7 @@ class EncounterService extends BaseService
      */
     private $encounterValidator;
 
-    private const ENCOUNTER_TABLE = "form_encounter";
+    public const ENCOUNTER_TABLE = "form_encounter";
     private const PATIENT_TABLE = "patient_data";
     private const PROVIDER_TABLE = "users";
     private const FACILITY_TABLE = "facility";

--- a/src/Services/FormService.php
+++ b/src/Services/FormService.php
@@ -52,6 +52,7 @@ class FormService
             $all[$iter] = $row;
         }
 
+        // TODO: @adunsulag fire off a module filter event here letting us modify / restrict / add data to the form list.
         return $all;
     }
 


### PR DESCRIPTION
Fixes #6629 add render events to top and bottom of encounter form.

Exposed the table name in the encounters service as well so we can actually use it instead of copying the name elsewhere.