### PR TITLE
fix: Better UI of PAM UI

### DIFF
--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -1016,12 +1016,35 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
             $idcard_doc_id = get_document_by_catg($pid, $GLOBALS['patient_id_category_name'], 3);
         }
         ?>
-        <div class="main mb-5">
+        <div class="main mb-1">
             <!-- start main content div -->
             <div class="row">
-                <div class="col-12 d-flex flex-row">
                     <?php
                     $t = $twig->getTwig();
+
+                    $allergy = (AclMain::aclCheckIssue('allergy')) ? 1 : 0;
+                    $pl = (AclMain::aclCheckIssue('medical_problem')) ? 1 : 0;
+                    $meds = (AclMain::aclCheckIssue('medication')) ? 1 : 0;
+                    $cards = $allergy + $pl + $meds;
+                    $col = "p-1 ";
+
+                    switch ($cards) {
+                        case '1':
+                            $col .= "col-12";
+                            break;
+
+                        case '2':
+                            $col .= "col-6";
+                            break;
+
+                        case '3':
+                            $col .= "col-4";
+                            break;
+
+                        default:
+                            $col .= "col";
+                            break;
+                    }
 
                     // ALLERGY CARD
                     if (AclMain::aclCheckIssue('allergy')) {
@@ -1038,7 +1061,9 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                             'btnLabel' => 'Edit',
                             'btnLink' => "return load_location('{$GLOBALS['webroot']}/interface/patient_file/summary/stats_full.php?active=all&category=allergy')"
                         ];
+                        echo "<div class=\"$col\">";
                         echo $t->render('patient/card/allergies.html.twig', $viewArgs);
+                        echo "</div>";
                     }
 
                     $patIssueService = new PatientIssuesService();
@@ -1057,7 +1082,9 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                             'btnLabel' => 'Edit',
                             'btnLink' => "return load_location('{$GLOBALS['webroot']}/interface/patient_file/summary/stats_full.php?active=all&category=medical_problem')"
                         ];
+                        echo "<div class=\"$col\">";
                         echo $t->render('patient/card/medical_problems.html.twig', $viewArgs);
+                        echo "</div>";
                     }
 
                     // MEDICATION CARD
@@ -1074,7 +1101,9 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                             'btnLabel' => 'Edit',
                             'btnLink' => "return load_location('{$GLOBALS['webroot']}/interface/patient_file/summary/stats_full.php?active=all&category=medication')"
                         ];
-                        echo $t->render('patient/card/medical_problems.html.twig', $viewArgs);
+                        echo "<div class=\"$col\">";
+                        echo $t->render('patient/card/medication.html.twig', $viewArgs);
+                        echo "</div>";
                     }
 
                     // Render the Prescriptions card if turned on


### PR DESCRIPTION
Move from a flawed flex-based layout to a column based layout to ensure the UI remains usable. Also update the medication card to render the dosage instructions.

Fixes #6651 

Note I copied and pasted a few problem list many times to render a mock PL that is incredibly long as a test that this looks better.

# Before
![image](https://github.com/openemr/openemr/assets/1381170/b9b92f87-bca9-4581-8605-3a82784911c6)

# After
![image](https://github.com/openemr/openemr/assets/1381170/10bd6163-7df8-4e47-9372-16dba4d083ac)
