### PR TITLE
fix: Only render Portal Card on MRD if Portal is enabled globally

### DIFF
--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -1550,8 +1550,9 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                 <div class="col-md-4">
                     <!-- start right column div -->
                     <?php
-                    // it's important enough to always show it
-                    $portalCard = new PortalCard($GLOBALS);
+                    if ($GLOBALS['portal_onsite_two_enable']) {
+                        $portalCard = new PortalCard($GLOBALS);
+                    }
 
                     $sectionRenderEvents = $ed->dispatch(new SectionEvent('secondary'), SectionEvent::EVENT_HANDLE);
                     $sectionCards = $sectionRenderEvents->getCards();


### PR DESCRIPTION
Only render card if enabled in $GLOBALS

fixes #6653 