### PR TITLE
feat: Improve the add/edit Issue UI

### DIFF
--- a/interface/patient_file/summary/add_edit_issue.php
+++ b/interface/patient_file/summary/add_edit_issue.php
@@ -933,7 +933,7 @@ function getCodeText($code)
                                     generate_form_field(array('data_type' => 1, 'field_id' => 'occur', 'list_id' => 'occurrence', 'empty_title' => 'SKIP'), ($irow['occurrence'] ?? null));
                                     ?>
                                 </div>
-                                <div class="form-group col-sm-12 col-md-4 <?php echo ($GLOBALS['ippf_specific']) ? 'd-none': '';?>">
+                                <div class="form-group col-sm-12 col-md-4 <?php echo ($GLOBALS['ippf_specific']) ? 'd-none' : '';?>">
                                     <label for="form_outcome"><?php echo xlt('Outcome'); ?>:</label>
                                     <?php
                                     echo generate_select_list('form_outcome', 'outcome', ($irow['outcome'] ?? null), '', '', '', 'outcomeClicked(this);');
@@ -974,7 +974,7 @@ function getCodeText($code)
                                     <label class="col-form-label" for="form_referredby"><?php echo xlt('Referred by'); ?>:</label>
                                     <input type='text' name='form_referredby' id='form_referredby' class='form-control' value='<?php echo attr($irow['referredby'] ?? '') ?>' title='<?php echo xla('Referring physician and practice'); ?>' />
                                 </div>
-                                <div class="form-group col-sm-12 col-md-4 <?php echo ($GLOBALS['ippf_specific']) ? 'd-none': ''; ?>">
+                                <div class="form-group col-sm-12 col-md-4 <?php echo ($GLOBALS['ippf_specific']) ? 'd-none' : ''; ?>">
                                     <label class="col-form-label" for="form_destination"><?php echo xlt('Destination'); ?>:</label>
                                     <?php if (true) { ?>
                                         <input type='text' class='form-control' name='form_destination' id='form_destination' value='<?php echo attr($irow['destination'] ?? '') ?>' style='width:100%' title='GP, Secondary care specialist, etc.' />

--- a/interface/patient_file/summary/add_edit_issue.php
+++ b/interface/patient_file/summary/add_edit_issue.php
@@ -75,23 +75,20 @@ if ($tmp['squad'] && !AclMain::aclCheckCore('squads', $tmp['squad'])) {
 
 function QuotedOrNull($fld)
 {
-    if ($fld) {
-        return "'" . add_escape_custom($fld) . "'";
-    }
-
-    return "NULL";
+    return ($fld) ? "'" . add_escape_custom($fld) . "'" : "NULL";
 }
 
 function rbinput($name, $value, $desc, $colname)
 {
     global $irow;
-    $ret  = "<input type='radio' name='" . attr($name) . "' value='" . attr($value) . "'";
-    if ($irow[$colname] == $value) {
-        $ret .= " checked";
-    }
-
-    $ret .= " />" . text($desc);
-    return $ret;
+    $_p = [
+        attr($name),
+        attr($value),
+        ($irow[$colname] == $value) ? " checked" : "",
+        text($desc)
+    ];
+    $str = '<input type="radio" name="%s" value="%s" %s>%s';
+    return vsprintf($str, $_p);
 }
 
 // Given an issue type as a string, compute its index.
@@ -103,10 +100,8 @@ function issueTypeIndex($tstr)
         if ($key == $tstr) {
             break;
         }
-
         ++$i;
     }
-
     return $i;
 }
 
@@ -313,14 +308,11 @@ if (!empty($_POST['form_save'])) {
 
     // If requested, link the issue to a specified encounter.
     if ($thisenc) {
-        $query = "INSERT INTO issue_encounter ( " .
-            "pid, list_id, encounter " .
-            ") VALUES ( ?,?,? )";
-        sqlStatement($query, array($thispid, $issue, $thisenc));
+        $sql = "INSERT INTO issue_encounter(pid, list_id, encounter) VALUES (?, ?, ?)";
+        sqlStatement($sql, [$thispid, $issue, $thisenc]);
     }
 
-    $tmp_title = $ISSUE_TYPES[$text_type][2] . ": $form_begin " .
-        substr($_POST['form_title'], 0, 40);
+    $tmp_title = $ISSUE_TYPES[$text_type][2] . ": $form_begin " . substr($_POST['form_title'], 0, 40);
 
     // Close this window and redisplay the updated list of issues.
     //
@@ -383,390 +375,387 @@ function getCodeText($code)
 
 ?>
 <html>
-
 <head>
-    <?php Header::setupHeader(['common', 'datetime-picker', 'select2']); ?>
-    <title><?php echo ($issue) ? xlt('Edit Issue') : xlt('Add New Issue'); ?></title>
+<?php Header::setupHeader(['common', 'datetime-picker', 'select2']); ?>
+<title><?php echo ($issue) ? xlt('Edit Issue') : xlt('Add New Issue'); ?></title>
 
-    <style>
-        div.section {
-            border: 1px solid var(--primary) !important;
-            margin: 0 0 0 13px;
-            padding: 7px;
-        }
+<style>
+    div.section {
+        border: 1px solid var(--primary) !important;
+        margin: 0 0 0 13px;
+        padding: 7px;
+    }
 
-        /* Override theme's selected tab top color so it matches tab contents. */
-        ul.tabNav li.current a {
-            background: var(--white);
-        }
-    </style>
+    /* Override theme's selected tab top color so it matches tab contents. */
+    ul.tabNav li.current a {
+        background: var(--white);
+    }
+</style>
 
-    <script>
-        var aitypes = new Array(); // issue type attributes
-        var aopts = new Array(); // Option objects
-        var codeTexts = new Map()
-        <?php
-        $i = 0;
-        foreach ($ISSUE_TYPES as $key => $value) {
-            echo " aitypes[" . attr($i) . "] = " . js_escape($value[3]) . ";\n";
-            echo " aopts[" . attr($i) . "] = new Array();\n";
-            $qry = sqlStatement(
-                "SELECT * FROM list_options WHERE list_id = ? AND activity = 1",
-                array($key . "_issue_list")
-            );
-            while ($res = sqlFetchArray($qry)) {
-                echo " opt = new Option(" .
-                    js_escape(xl_list_label(trim($res['title']))) .
-                    ", " .
-                    js_escape(trim($res['option_id'])) .
-                    ", false, false);\n";
-                echo " aopts[" . attr($i) . "][aopts[" . attr($i) . "].length] = opt\n";
-                if ($res['codes']) {
-                    $codes = explode(";", $res['codes']);
-                    foreach ($codes as $code) {
-                        $text = getCodeText($code);
-                        echo " codeTexts.set(" . js_escape($code) . ", " . js_escape($text) . ");\n";
-                    }
-                    echo " opt.setAttribute('codes'," . js_escape(trim($res['codes'])) . ");\n";
+<script>
+    var aitypes = new Array(); // issue type attributes
+    var aopts = new Array(); // Option objects
+    var codeTexts = new Map()
+    <?php
+    $i = 0;
+    foreach ($ISSUE_TYPES as $key => $value) {
+        echo " aitypes[" . attr($i) . "] = " . js_escape($value[3]) . ";\n";
+        echo " aopts[" . attr($i) . "] = new Array();\n";
+        $qry = sqlStatement(
+            "SELECT * FROM list_options WHERE list_id = ? AND activity = 1",
+            array($key . "_issue_list")
+        );
+        while ($res = sqlFetchArray($qry)) {
+            echo " opt = new Option(" .
+                js_escape(xl_list_label(trim($res['title']))) .
+                ", " .
+                js_escape(trim($res['option_id'])) .
+                ", false, false);\n";
+            echo " aopts[" . attr($i) . "][aopts[" . attr($i) . "].length] = opt\n";
+            if ($res['codes']) {
+                $codes = explode(";", $res['codes']);
+                foreach ($codes as $code) {
+                    $text = getCodeText($code);
+                    echo " codeTexts.set(" . js_escape($code) . ", " . js_escape($text) . ");\n";
                 }
+                echo " opt.setAttribute('codes'," . js_escape(trim($res['codes'])) . ");\n";
             }
-
-            ++$i;
         }
 
-        ///////////
-        ActiveIssueCodeRecycleFn($thispid, $ISSUE_TYPES);
-        ///////////
-        ?>
+        ++$i;
+    }
 
-        <?php require $GLOBALS['srcdir'] . "/restoreSession.php"; ?>
+    ///////////
+    ActiveIssueCodeRecycleFn($thispid, $ISSUE_TYPES);
+    ///////////
+    ?>
 
-        ///////////////////////////
-        function onActiveCodeSelected() {
-            var f = document.forms[0];
-            var sel = f.form_active_codes.options[f.form_active_codes.selectedIndex];
-            addSelectedCode(sel.value, sel.text)
-            f.form_active_codes.selectedIndex = -1;
+    <?php require $GLOBALS['srcdir'] . "/restoreSession.php"; ?>
+
+    ///////////////////////////
+    function onActiveCodeSelected() {
+        var f = document.forms[0];
+        var sel = f.form_active_codes.options[f.form_active_codes.selectedIndex];
+        addSelectedCode(sel.value, sel.text)
+        f.form_active_codes.selectedIndex = -1;
+    }
+    ///////////////////////////
+    //
+    // React to selection of an issue type.  This loads the associated
+    // shortcuts into the selection list of titles, and determines which
+    // rows are displayed or hidden.
+    function newtype(index) {
+        var f = document.forms[0];
+        var theopts = f.form_titles.options;
+        theopts.length = 0;
+        var i = 0;
+        for (i = 0; i < aopts[index].length; ++i) {
+            theopts[i] = aopts[index][i];
         }
-        ///////////////////////////
+        document.getElementById('row_titles').style.display = i ? '' : 'none';
         //
-        // React to selection of an issue type.  This loads the associated
-        // shortcuts into the selection list of titles, and determines which
-        // rows are displayed or hidden.
-        function newtype(index) {
-            var f = document.forms[0];
-            var theopts = f.form_titles.options;
-            theopts.length = 0;
-            var i = 0;
-            for (i = 0; i < aopts[index].length; ++i) {
-                theopts[i] = aopts[index][i];
-            }
-            document.getElementById('row_titles').style.display = i ? '' : 'none';
-            //
-            ///////////////////////
-            var listBoxOpts2 = f.form_active_codes.options;
-            listBoxOpts2.length = 0;
-            var ix = 0;
-            for (ix = 0; ix < listBoxOptions2[index].length; ++ix) {
-                listBoxOpts2[ix] = listBoxOptions2[index][ix];
-                listBoxOpts2[ix].title = listBoxOptions2[index][ix].text;
-            }
-            document.getElementById('row_active_codes').style.display = ix ? '' : 'none';
-
-            //////////////////////
-            //
-            // Show or hide various rows depending on issue type, except do not
-            // hide the comments or referred-by fields if they have data.
-
-            $(function() {
-                var comdisp = (aitypes[index] == 1) ? 'none' : '';
-                var revdisp = (aitypes[index] == 1) ? '' : 'none';
-                var injdisp = (aitypes[index] == 2) ? '' : 'none';
-                var nordisp = (aitypes[index] == 0) ? '' : 'none';
-                // reaction row should be displayed only for medication allergy.
-                var alldisp = (index == <?php echo issueTypeIndex('allergy'); ?>) ? '' : 'none';
-                var verificationdisp = (index == <?php echo issueTypeIndex('medical_problem'); ?>) ||
-                    (index == <?php echo issueTypeIndex('allergy'); ?>) ? '' : 'none';
-                document.getElementById('row_enddate').style.display = comdisp;
-                // Note that by default all the issues will not show the active row
-                //  (which is desired functionality, since then use the end date
-                //   to inactivate the item.)
-                document.getElementById('row_active').style.display = revdisp;
-                document.getElementById('row_selected_codes').style.display = comdisp;
-                document.getElementById('row_occurrence').style.display = comdisp;
-                document.getElementById('row_classification').style.display = injdisp;
-                document.getElementById('row_reinjury_id').style.display = injdisp;
-                document.getElementById('row_severity').style.display = alldisp;
-                document.getElementById('row_reaction').style.display = alldisp;
-                document.getElementById('row_verification').style.display = verificationdisp;
-                document.getElementById('row_referredby').style.display = (f.form_referredby.value) ? '' : comdisp;
-                //document.getElementById('row_comments'      ).style.display = (f.form_comments.value) ? '' : revdisp;
-                document.getElementById('row_referredby').style.display = (f.form_referredby.value) ? '' : comdisp;
-            });
-            <?php
-            if (!empty($ISSUE_TYPES['ippf_gcac']) && empty($_POST['form_save'])) {
-                // Generate more of these for gcac and contraceptive fields.
-                if (empty($issue) || $irow['type'] == 'ippf_gcac') {
-                    issue_ippf_gcac_newtype();
-                }
-
-                if (empty($issue) || $irow['type'] == 'contraceptive') {
-                    issue_ippf_con_newtype();
-                }
-            }
-            ?>
+        ///////////////////////
+        var listBoxOpts2 = f.form_active_codes.options;
+        listBoxOpts2.length = 0;
+        var ix = 0;
+        for (ix = 0; ix < listBoxOptions2[index].length; ++ix) {
+            listBoxOpts2[ix] = listBoxOptions2[index][ix];
+            listBoxOpts2[ix].title = listBoxOptions2[index][ix].text;
         }
+        document.getElementById('row_active_codes').style.display = ix ? '' : 'none';
 
-        // If a clickoption title is selected, copy it to the title field.
-        // If it has a code, add that too.
-        function set_text() {
-            var f = document.forms[0];
-            var sel = f.form_titles.options[f.form_titles.selectedIndex];
-            f.form_title.value = sel.text;
-            f.form_title_id.value = sel.value;
-
-            f.form_selected_codes.options.length = 0
-
-            var str = sel.getAttribute('codes')
-            if (str) {
-                var codes = str.split(";")
-                for (i = 0; i < codes.length; i++) {
-                    addSelectedCode(codes[i], codeTexts.has(codes[i]) ? codeTexts.get(codes[i]) : codes[i])
-                }
-            }
-        }
-
-        function closeme() {
-            dlgclose();
-        }
-
-        // Called when the Active checkbox is clicked.  For consistency we
-        // use the existence of an end date to indicate inactivity, even
-        // though the simple verion of the form does not show an end date.
-        function activeClicked(cb) {
-            var f = document.forms[0];
-            if (cb.checked) {
-                f.form_end.value = '';
-            } else {
-                var today = new Date();
-                f.form_end.value = '' + (today.getYear() + 1900) + '-' +
-                    (today.getMonth() + 1) + '-' + today.getDate();
-            }
-        }
-
-        // Called when resolved outcome is chosen and the end date is entered.
-        function outcomeClicked(cb) {
-            var f = document.forms[0];
-            if (cb.value == '1') {
-                var today = new Date();
-                f.form_end.value = '' + (today.getYear() + 1900) + '-' +
-                    ("0" + (today.getMonth() + 1)).slice(-2) + '-' + ("0" + today.getDate()).slice(-2);
-                f.form_end.focus();
-            }
-        }
-
-        // This is for callback by the select codes popup.
-        // Appends to or erases the current list of diagnoses.
-        function OnCodeSelected(codetype, code, selector, codedesc) {
-            var codeKey = codetype + ':' + code
-            addSelectedCode(codeKey, codeKey + ' (' + codedesc + ')')
-
-            var f = document.forms[0]
-            if (f.form_title.value == '') {
-                f.form_title.value = codedesc;
-            }
-        }
-
-        function addSelectedCode(codeKey, codeText) {
-            var f = document.forms[0]
-            var sel = f.form_selected_codes
-            for (i = 0; i < sel.options.length; i++) {
-                if (sel.options[i].value == codeKey) {
-                    return
-                }
-            }
-
-            var option = document.createElement("option");
-            option.value = codeKey
-            option.text = codeText
-            sel.add(option);
-
-            updateDiagnosisFromSelectedCodes()
-        }
-
-        function updateDiagnosisFromSelectedCodes() {
-            var f = document.forms[0]
-            var diag = ''
-            options = f.form_selected_codes.options
-            if (options.length > 0) {
-                diag = options[0].value
-                for (i = 1; i < options.length; i++) {
-                    diag += ';' + options[i].value;
-                }
-            }
-
-            f.form_diagnosis.value = diag;
-        }
-
-        // This invokes the find-code popup.
-        function onAddCode() {
-            <?php
-            $url = '../encounter/select_codes.php?codetype=';
-            if (!empty($irow['type']) && ($irow['type'] == 'medical_problem')) {
-                $url .= urlencode(collect_codetypes("medical_problem", "csv"));
-            } else {
-                $url .= urlencode(collect_codetypes("diagnosis", "csv"));
-                $tmp_csv = collect_codetypes("drug", "csv");
-                $tmp_csv .= "," . collect_codetypes("clinical_term", "csv");
-                $tmp = explode(",", $tmp_csv);
-                if (!empty($irow['type']) && ($irow['type'] == 'allergy')) {
-                    if ($tmp) {
-                        foreach ($tmp as $item) {
-                            $pos = strpos($url, $item);
-                            if ($pos === false) {
-                                $item = urlencode($item);
-                                $url .= ",$item";
-                            }
-                        }
-                    }
-                } elseif (!empty($irow['type']) && ($irow['type'] == 'medication')) {
-                    if ($tmp) {
-                        foreach ($tmp as $item) {
-                            $pos = strpos($url, $item);
-                            if ($pos === false) {
-                                $item = urlencode($item);
-                                $url .= ",$item&default=$item";
-                            }
-                        }
-                    }
-                }
-            }
-            ?>
-            dlgopen(<?php echo js_escape($url); ?>, '_blank', 985, 800, '', <?php echo xlj("Select Codes"); ?>);
-        }
-
-        function onRemoveCode() {
-            var sel = document.forms[0].form_selected_codes
-            for (i = 0; i < sel.options.length; i++) {
-                if (sel.options[i].selected) {
-                    sel.remove(i)
-                    i--
-                }
-            }
-
-            onCodeSelectionChange()
-            updateDiagnosisFromSelectedCodes()
-        }
-
-        function onCodeSelectionChange() {
-            document.forms[0].rem_selected_code.disabled = document.forms[0].form_selected_codes.selectedIndex == -1
-        }
-
-        function processUdiEnter(event) {
-            if (event.key == 'Enter') {
-                event.preventDefault();
-                processUdi(document.getElementById('udi_process_button'));
-                return false;
-            } {
-                return true;
-            }
-        }
-
-        function processUdi(param) {
-            let udi = document.getElementById("form_udi").value;
-            if (!udi) {
-                alert(<?php echo xlj('UDI field is missing'); ?>);
-                document.getElementById('udi_display').innerHTML = <?php echo xlj('A valid UDI has not been processed yet.'); ?>;
-                document.getElementById('udi_data').value = '';
-                return false;
-            }
-
-            originalLabel = param.innerHTML;
-            param.innerHTML = "<i class='fa fa-circle-notch fa-spin'></i> " + jsText(<?php echo xlj('Processing'); ?>);
-
-            top.restoreSession();
-            let url = '../../../library/ajax/udi.php?udi=' + encodeURIComponent(udi) + '&csrf_token_form=' + <?php echo js_url(CsrfUtils::collectCsrfToken('udi')); ?>;
-            fetch(url, {
-                credentials: 'same-origin',
-                method: 'GET',
-            })
-            .then(response => response.json())
-            .then(data => {
-                if (data.raw_search == null || data.raw_search.udi == null || data.raw_search.udi.udi == null) {
-                    errorMessage = <?php echo xlj('UDI search failed'); ?>;
-                    if (data.raw_search != null && data.raw_search.error != null) {
-                        errorMessage += ': ' + data.raw_search.error;
-                    }
-                    document.getElementById('udi_display').innerHTML = jsText(errorMessage);
-                    document.getElementById('udi_data').value = '';
-                } else {
-                    let dataJSON = JSON.stringify(data);
-                    document.getElementById('udi_data').value = dataJSON;
-                    displayUdi(data);
-                }
-            })
-            .catch(error => console.error(error))
-
-            param.innerHTML = jsText(originalLabel);
-        }
-
-        function displayUdi(data) {
-            let display = '';
-            <?php echo MedicalDevice::fullOutputJavascript('display', 'data', false); ?>
-            document.getElementById('udi_display').innerHTML = display;
-            document.getElementById('form_title').value = data.standard_elements.deviceName;
-        }
-
-        // Check for errors when the form is submitted.
-        function validate() {
-            var f = document.forms[0];
-            var begin_date_val = f.form_begin.value;
-            begin_date_val = begin_date_val ? DateToYYYYMMDD_js(begin_date_val) : begin_date_val;
-            var end_date_val = f.form_end.value;
-            end_date_val = end_date_val ? DateToYYYYMMDD_js(end_date_val) : end_date_val;
-            var begin_date = new Date(begin_date_val);
-            var end_date = new Date(end_date_val);
-
-            if ((end_date_val) && (begin_date > end_date)) {
-                alert(<?php echo xlj('Please Enter End Date greater than Begin Date!'); ?>);
-                return false;
-            }
-            if (!f.form_title.value) {
-                alert(<?php echo xlj('Please enter a title!'); ?>);
-                return false;
-            }
-            top.restoreSession();
-            return true;
-        }
-
-        // Supports customizable forms (currently just for IPPF).
-        function divclick(cb, divid) {
-            var divstyle = document.getElementById(divid).style;
-            if (cb.checked) {
-                divstyle.display = 'block';
-            } else {
-                divstyle.display = 'none';
-            }
-            return true;
-        }
+        //////////////////////
+        //
+        // Show or hide various rows depending on issue type, except do not
+        // hide the comments or referred-by fields if they have data.
 
         $(function() {
-            $('.datepicker').datetimepicker({
-                <?php $datetimepicker_timepicker = true; ?>
-                <?php $datetimepicker_showseconds = false; ?>
-                <?php $datetimepicker_formatInput = true; ?>
-                <?php require $GLOBALS['srcdir'] . '/js/xl/jquery-datetimepicker-2-5-4.js.php'; ?>
-                <?php // can add any additional javascript settings to datetimepicker here; need to prepend first setting with a comma
-                ?>
-            });
+            var comdisp = (aitypes[index] == 1) ? 'none' : '';
+            var revdisp = (aitypes[index] == 1) ? '' : 'none';
+            var injdisp = (aitypes[index] == 2) ? '' : 'none';
+            var nordisp = (aitypes[index] == 0) ? '' : 'none';
+            // reaction row should be displayed only for medication allergy.
+            var alldisp = (index == <?php echo issueTypeIndex('allergy'); ?>) ? '' : 'none';
+            var verificationdisp = (index == <?php echo issueTypeIndex('medical_problem'); ?>) ||
+                (index == <?php echo issueTypeIndex('allergy'); ?>) ? '' : 'none';
+            document.getElementById('row_enddate').style.display = comdisp;
+            // Note that by default all the issues will not show the active row
+            //  (which is desired functionality, since then use the end date
+            //   to inactivate the item.)
+            document.getElementById('row_active').style.display = revdisp;
+            document.getElementById('row_selected_codes').style.display = comdisp;
+            document.getElementById('row_occurrence').style.display = comdisp;
+            document.getElementById('row_classification').style.display = injdisp;
+            document.getElementById('row_reinjury_id').style.display = injdisp;
+            document.getElementById('row_severity').style.display = alldisp;
+            document.getElementById('row_reaction').style.display = alldisp;
+            document.getElementById('row_verification').style.display = verificationdisp;
+            document.getElementById('row_referredby').style.display = (f.form_referredby.value) ? '' : comdisp;
+            //document.getElementById('row_comments'      ).style.display = (f.form_comments.value) ? '' : revdisp;
+            document.getElementById('row_referredby').style.display = (f.form_referredby.value) ? '' : comdisp;
         });
-        $('div').hide();
-    </script>
+        <?php
+        if (!empty($ISSUE_TYPES['ippf_gcac']) && empty($_POST['form_save'])) {
+            // Generate more of these for gcac and contraceptive fields.
+            if (empty($issue) || $irow['type'] == 'ippf_gcac') {
+                issue_ippf_gcac_newtype();
+            }
 
+            if (empty($issue) || $irow['type'] == 'contraceptive') {
+                issue_ippf_con_newtype();
+            }
+        }
+        ?>
+    }
+
+    // If a clickoption title is selected, copy it to the title field.
+    // If it has a code, add that too.
+    function set_text() {
+        var f = document.forms[0];
+        var sel = f.form_titles.options[f.form_titles.selectedIndex];
+        f.form_title.value = sel.text;
+        f.form_title_id.value = sel.value;
+
+        f.form_selected_codes.options.length = 0
+
+        var str = sel.getAttribute('codes')
+        if (str) {
+            var codes = str.split(";")
+            for (i = 0; i < codes.length; i++) {
+                addSelectedCode(codes[i], codeTexts.has(codes[i]) ? codeTexts.get(codes[i]) : codes[i])
+            }
+        }
+    }
+
+    function closeme() {
+        dlgclose();
+    }
+
+    // Called when the Active checkbox is clicked.  For consistency we
+    // use the existence of an end date to indicate inactivity, even
+    // though the simple verion of the form does not show an end date.
+    function activeClicked(cb) {
+        var f = document.forms[0];
+        if (cb.checked) {
+            f.form_end.value = '';
+        } else {
+            var today = new Date();
+            f.form_end.value = '' + (today.getYear() + 1900) + '-' +
+                (today.getMonth() + 1) + '-' + today.getDate();
+        }
+    }
+
+    // Called when resolved outcome is chosen and the end date is entered.
+    function outcomeClicked(cb) {
+        var f = document.forms[0];
+        if (cb.value == '1') {
+            var today = new Date();
+            f.form_end.value = '' + (today.getYear() + 1900) + '-' +
+                ("0" + (today.getMonth() + 1)).slice(-2) + '-' + ("0" + today.getDate()).slice(-2);
+            f.form_end.focus();
+        }
+    }
+
+    // This is for callback by the select codes popup.
+    // Appends to or erases the current list of diagnoses.
+    function OnCodeSelected(codetype, code, selector, codedesc) {
+        var codeKey = codetype + ':' + code
+        addSelectedCode(codeKey, codeKey + ' (' + codedesc + ')')
+
+        var f = document.forms[0]
+        if (f.form_title.value == '') {
+            f.form_title.value = codedesc;
+        }
+    }
+
+    function addSelectedCode(codeKey, codeText) {
+        var f = document.forms[0]
+        var sel = f.form_selected_codes
+        for (i = 0; i < sel.options.length; i++) {
+            if (sel.options[i].value == codeKey) {
+                return
+            }
+        }
+
+        var option = document.createElement("option");
+        option.value = codeKey
+        option.text = codeText
+        sel.add(option);
+
+        updateDiagnosisFromSelectedCodes()
+    }
+
+    function updateDiagnosisFromSelectedCodes() {
+        var f = document.forms[0]
+        var diag = ''
+        options = f.form_selected_codes.options
+        if (options.length > 0) {
+            diag = options[0].value
+            for (i = 1; i < options.length; i++) {
+                diag += ';' + options[i].value;
+            }
+        }
+
+        f.form_diagnosis.value = diag;
+    }
+
+    // This invokes the find-code popup.
+    function onAddCode() {
+        <?php
+        $url = '../encounter/select_codes.php?codetype=';
+        if (!empty($irow['type']) && ($irow['type'] == 'medical_problem')) {
+            $url .= urlencode(collect_codetypes("medical_problem", "csv"));
+        } else {
+            $url .= urlencode(collect_codetypes("diagnosis", "csv"));
+            $tmp_csv = collect_codetypes("drug", "csv");
+            $tmp_csv .= "," . collect_codetypes("clinical_term", "csv");
+            $tmp = explode(",", $tmp_csv);
+            if (!empty($irow['type']) && ($irow['type'] == 'allergy')) {
+                if ($tmp) {
+                    foreach ($tmp as $item) {
+                        $pos = strpos($url, $item);
+                        if ($pos === false) {
+                            $item = urlencode($item);
+                            $url .= ",$item";
+                        }
+                    }
+                }
+            } elseif (!empty($irow['type']) && ($irow['type'] == 'medication')) {
+                if ($tmp) {
+                    foreach ($tmp as $item) {
+                        $pos = strpos($url, $item);
+                        if ($pos === false) {
+                            $item = urlencode($item);
+                            $url .= ",$item&default=$item";
+                        }
+                    }
+                }
+            }
+        }
+        ?>
+        dlgopen(<?php echo js_escape($url); ?>, '_blank', 985, 800, '', <?php echo xlj("Select Codes"); ?>);
+    }
+
+    function onRemoveCode() {
+        var sel = document.forms[0].form_selected_codes
+        for (i = 0; i < sel.options.length; i++) {
+            if (sel.options[i].selected) {
+                sel.remove(i)
+                i--
+            }
+        }
+
+        onCodeSelectionChange()
+        updateDiagnosisFromSelectedCodes()
+    }
+
+    function onCodeSelectionChange() {
+        document.forms[0].rem_selected_code.disabled = document.forms[0].form_selected_codes.selectedIndex == -1
+    }
+
+    function processUdiEnter(event) {
+        if (event.key == 'Enter') {
+            event.preventDefault();
+            processUdi(document.getElementById('udi_process_button'));
+            return false;
+        } {
+            return true;
+        }
+    }
+
+    function processUdi(param) {
+        let udi = document.getElementById("form_udi").value;
+        if (!udi) {
+            alert(<?php echo xlj('UDI field is missing'); ?>);
+            document.getElementById('udi_display').innerHTML = <?php echo xlj('A valid UDI has not been processed yet.'); ?>;
+            document.getElementById('udi_data').value = '';
+            return false;
+        }
+
+        originalLabel = param.innerHTML;
+        param.innerHTML = "<i class='fa fa-circle-notch fa-spin'></i> " + jsText(<?php echo xlj('Processing'); ?>);
+
+        top.restoreSession();
+        let url = '../../../library/ajax/udi.php?udi=' + encodeURIComponent(udi) + '&csrf_token_form=' + <?php echo js_url(CsrfUtils::collectCsrfToken('udi')); ?>;
+        fetch(url, {
+            credentials: 'same-origin',
+            method: 'GET',
+        })
+        .then(response => response.json())
+        .then(data => {
+            if (data.raw_search == null || data.raw_search.udi == null || data.raw_search.udi.udi == null) {
+                errorMessage = <?php echo xlj('UDI search failed'); ?>;
+                if (data.raw_search != null && data.raw_search.error != null) {
+                    errorMessage += ': ' + data.raw_search.error;
+                }
+                document.getElementById('udi_display').innerHTML = jsText(errorMessage);
+                document.getElementById('udi_data').value = '';
+            } else {
+                let dataJSON = JSON.stringify(data);
+                document.getElementById('udi_data').value = dataJSON;
+                displayUdi(data);
+            }
+        })
+        .catch(error => console.error(error))
+
+        param.innerHTML = jsText(originalLabel);
+    }
+
+    function displayUdi(data) {
+        let display = '';
+        <?php echo MedicalDevice::fullOutputJavascript('display', 'data', false); ?>
+        document.getElementById('udi_display').innerHTML = display;
+        document.getElementById('form_title').value = data.standard_elements.deviceName;
+    }
+
+    // Check for errors when the form is submitted.
+    function validate() {
+        var f = document.forms[0];
+        var begin_date_val = f.form_begin.value;
+        begin_date_val = begin_date_val ? DateToYYYYMMDD_js(begin_date_val) : begin_date_val;
+        var end_date_val = f.form_end.value;
+        end_date_val = end_date_val ? DateToYYYYMMDD_js(end_date_val) : end_date_val;
+        var begin_date = new Date(begin_date_val);
+        var end_date = new Date(end_date_val);
+
+        if ((end_date_val) && (begin_date > end_date)) {
+            alert(<?php echo xlj('Please Enter End Date greater than Begin Date!'); ?>);
+            return false;
+        }
+        if (!f.form_title.value) {
+            alert(<?php echo xlj('Please enter a title!'); ?>);
+            return false;
+        }
+        top.restoreSession();
+        return true;
+    }
+
+    // Supports customizable forms (currently just for IPPF).
+    function divclick(cb, divid) {
+        var divstyle = document.getElementById(divid).style;
+        if (cb.checked) {
+            divstyle.display = 'block';
+        } else {
+            divstyle.display = 'none';
+        }
+        return true;
+    }
+
+    $(function() {
+        $('.datepicker').datetimepicker({
+            <?php $datetimepicker_timepicker = true; ?>
+            <?php $datetimepicker_showseconds = false; ?>
+            <?php $datetimepicker_formatInput = true; ?>
+            <?php require $GLOBALS['srcdir'] . '/js/xl/jquery-datetimepicker-2-5-4.js.php'; ?>
+            <?php // can add any additional javascript settings to datetimepicker here; need to prepend first setting with a comma
+            ?>
+        });
+    });
+    $('div').hide();
+</script>
 </head>
-
 <body>
-    <div class="container mt-3">
+    <div class="container-fluid mt-3">
         <ul class="tabNav">
             <li class='current'><a href='#'><?php echo xlt('Issue'); ?></a></li>
             <?php
@@ -796,252 +785,268 @@ function getCodeText($code)
             }
             ?>
         </ul>
-
-
         <div class="tabContainer">
-            <div class='tab current h-auto' style='width:97%;'>
-                <div class='col-sm-12'>
-                    <form class="form-horizontal" name='theform' method="post" onsubmit='return validate()'>
-                        <input type="hidden" name="csrf_token_form" value="<?php echo attr(CsrfUtils::collectCsrfToken()); ?>" />
-                        <?php
-                        // action setting not required in html5.  By default form will submit to itself.
-                        // Provide key values previously passed as part of action string.
-                        foreach (array('issue' => $issue, 'thispid' => $thispid, 'thisenc' => $thisenc) as $fldName => $fldVal) {
-                            printf('<input name="%s" type="hidden" value="%s"/>%s', attr($fldName), attr($fldVal), PHP_EOL);
-                        }
-                        ?>
-                        <div class="form-group col-12">
-                            <label class="col-form-label"><?php echo xlt('Type'); ?>:</label>
-                            <?php
-                            $index = 0;
-                            foreach ($ISSUE_TYPES as $key => $value) {
-                                if ($issue || $thistype) {
-                                    if ($index == $type_index) {
-                                        echo text($value[1]);
-                                        echo "<input type='hidden' name='form_type' value='" . attr($index) . "' />\n";
-                                    }
-                                } else {
-                                    echo "   <input type='radio' name='form_type' value='" . attr($index) . "' onclick='newtype(" . attr_js($index) . ")'";
-                                    if ($index == $type_index) {
-                                        echo " checked";
-                                    }
-
-                                    if (!AclMain::aclCheckIssue($key, '', array('write', 'addonly'))) {
-                                        echo " disabled";
-                                    }
-
-                                    echo " />" . text($value[1]) . "&nbsp;\n";
+            <div class='tab current h-auto'>
+                <form name='theform' method="post" onsubmit='return validate()'>
+                    <div class="container-fluid">
+                        <div class="row">
+                            <div class='col-sm-6'>
+                                <input type="hidden" name="csrf_token_form" value="<?php echo attr(CsrfUtils::collectCsrfToken()); ?>" />
+                                <?php
+                                // action setting not required in html5.  By default form will submit to itself.
+                                // Provide key values previously passed as part of action string.
+                                foreach (array('issue' => $issue, 'thispid' => $thispid, 'thisenc' => $thisenc) as $fldName => $fldVal) {
+                                    printf('<input name="%s" type="hidden" value="%s"/>%s', attr($fldName), attr($fldVal), PHP_EOL);
                                 }
+                                ?>
+                                    <label><?php echo xlt('Type'); ?>:</label>
+                                    <?php
+                                    $index = 0;
+                                    foreach ($ISSUE_TYPES as $key => $value) {
+                                        if ($issue || $thistype) {
+                                            if ($index == $type_index) {
+                                                echo text($value[1]);
+                                                echo "<input type='hidden' name='form_type' value='" . attr($index) . "' />\n";
+                                            }
+                                        } else {
+                                            $checked = ($index == $type_index) ? " checked" : '';
+                                            $disabled = (!AclMain::aclCheckIssue($key, '', ['write', 'addonly'])) ? " disabled" : '';
+                                            $str = '<input type="radio" name="form_type" value="%s" onclick="newtype(%s)" %s %s>';
+                                            echo vsprintf($str, [attr($index), attr_js($index), $checked, $disabled]);
+                                        }
 
-                                ++$index;
-                            }
-                            ?>
+                                        ++$index;
+                                    }
+                                    ?>
+                            </div>
+                            <div class="col-md-6 d-flex justify-content-end">
+                                <div class="form-check" id='row_active'>
+                                    <input type="checkbox" class="form-check-input" name="form_active" id="form_active" value='1' <?php echo (!empty($irow['enddate'])) ? "" : "checked"; ?> onclick='activeClicked(this);' title='<?php echo xla('Indicates if this issue is currently active'); ?>'>
+                                    <label class="form-check-label" for="form_active"><?php echo xlt('Active{{Issue}}'); ?></label>
+                                </div>
+                            </div>
                         </div>
-                        <div class="form-group col-12" id='row_titles'>
-                            <label for="form_titles" class="col-form-label"> </label>
-                            <select name='form_titles' id='form_titles' class="form-control" multiple size='4' onchange='set_text()'></select>
-                            <p><?php echo xlt('(Select one of these, or type your own title)'); ?></p>
+                        <div class="row">
+                            <div class="form-group col" id='row_titles'>
+                                <label for="form_titles" class=""><?php echo xlt('Select from list or type your own in Title'); ?></label>
+                                <select name='form_titles' id='form_titles' class="form-control select2" multiple onchange='set_text()'><option></option></select>
+                            </div>
+                            <div class="form-group col">
+                                <label for="title_diagnosis"><?php echo xlt('Title'); ?>:</label>
+                                <div class="input-group">
+                                    <input type='text' class="form-control" name='form_title' id='form_title' value='<?php echo attr($irow['title'] ?? '') ?>' />
+                                    <div class="input-group-append">
+                                        <button type="button" id="btnCodeSearch" class="btn btn-outline-secondary" onclick="onAddCode()" title="<?php echo xla("Select a Code"); ?>"><i class="fa fa-sm fa-magnifying-glass"></i></button>
+                                    </div>
+                                </div>
+                                <input type='hidden' name='form_title_id' value='<?php echo attr($irow['list_option_id'] ?? '') ?>'>
+                            </div>
+                            <div class="form-group col-sm-12 col-md-3">
+                                <label for="form_begin"><?php echo xlt('Begin Date and Time'); ?>:</label>
+                                <input type='text' class='datepicker form-control' name='form_begin' id='form_begin' value='<?php echo attr(trim(oeFormatDateTime($irow['begdate'] ?? ''))) ?>' title='<?php echo xla('yyyy-mm-dd HH:MM date of onset, surgery or start of medication'); ?>' />
+                            </div>
+                            <div class="form-group col-sm-12 col-md-3" id='row_enddate'>
+                                <label for="form_begin"><?php echo xlt('End Date and Time'); ?>:</label>
+                                <input type='text' class='datepicker form-control' placeholder="<?php echo xlt('leave blank if still active'); ?>" name='form_end' id='form_end' value='<?php echo attr(trim(oeFormatDateTime($irow['enddate'] ?? ''))) ?>' title='<?php echo xla('yyyy-mm-dd HH:MM date of recovery or end of medication'); ?>' />
+                            </div>
                         </div>
-                        <?php if ($thistype == 'medical_device' || (!empty($irow['type']) && $irow['type'] == 'medical_device')) { ?>
+                        <div class="row">
+                            <!-- Reaction For Medication Allergy -->
+                            <div class="form-group col" id='row_reaction'>
+                                <label for="form_reaction"><?php echo xlt('Reaction'); ?>:</label>
+                                <?php
+                                echo generate_select_list('form_reaction', 'reaction', ($irow['reaction'] ?? null), '', '', '', '');
+                                ?>
+                            </div>
+                            <div class="form-group col" id='row_severity'>
+                                <label for="form_severity_id"><?php echo xlt('Severity'); ?>:</label>
+                                <?php
+                                $severity = $irow['severity_al'] ?? null;
+                                generate_form_field(array('data_type' => 1, 'field_id' => 'severity_id', 'list_id' => 'severity_ccda', 'empty_title' => 'SKIP'), $severity);
+                                ?>
+                            </div>
+                            <!-- End of reaction -->
+                        </div>
+                        <?php if ($thistype == 'medical_device' || (!empty($irow['type']) && $irow['type'] == 'medical_device')) : ?>
+                        <div class="row">
                             <div class="form-group col-12">
                                 <label class="col-form-label" for="form_udi"><?php echo xlt('UDI{{Unique Device Identifier}}'); ?>:</label>
-                                <input type='text' class="form-control" name='form_udi' id='form_udi' onkeydown="processUdiEnter(event)" value='<?php echo attr($irow['udi'] ?? '') ?>' />
-                                <button type="button" class="btn btn-primary btn-sm" id='udi_process_button' style="margin-right:5px;" onclick='processUdi(this)'><?php echo (!empty($irow['udi_data'])) ? xlt('Re-Process UDI') : xlt('Process UDI'); ?></button>
-                                <div id="udi_display" class="shadow p-3 mb-5 rounded">
-                                    <?php if (!empty($irow['udi_data'])) { ?>
-                                        <?php echo (new MedicalDevice($irow['udi_data']))->fullOutputHtml(false); ?>
-                                    <?php } else { ?>
-                                        <?php echo xlt('A valid UDI has not been processed yet.'); ?>
-                                    <?php } ?>
+                                <div class="input-group">
+                                    <input type='text' class="form-control" name='form_udi' id='form_udi' onkeydown="processUdiEnter(event)" value='<?php echo attr($irow['udi'] ?? '') ?>' />
+                                    <div class="input-group-append">
+                                        <button type="button" class="btn btn-secondary btn-sm" id='udi_process_button' style="margin-right:5px;" onclick='processUdi(this)'><?php echo (!empty($irow['udi_data'])) ? xlt('Re-Process UDI') : xlt('Process UDI'); ?></button>
+                                    </div>
+                                </div>
+                                <div id="udi_display" class="alert alert-info m-2" role="alert">
+                                    <?php echo (!empty($irow['udi_data'])) ? (new MedicalDevice($irow['udi_idata']))->fullOutputHtml(false) : xlt('A valid UDI has not been processed yet'); ?>
                                 </div>
                                 <input type='hidden' name='udi_data' id='udi_data' value='<?php echo attr($irow['udi_data'] ?? '') ?>' />
                             </div>
-                        <?php } ?>
-                        <div class="form-group col-12">
-                            <label class="col-form-label" for="title_diagnosis"><?php echo xlt('Title'); ?>:</label>
-                            <input type='text' class="form-control" name='form_title' id='form_title' value='<?php echo attr($irow['title'] ?? '') ?>' />
-                            <input type='hidden' name='form_title_id' value='<?php echo attr($irow['list_option_id'] ?? '') ?>'>
                         </div>
-                        <div class="form-group col-12" id='row_active_codes'>
-                            <label for="form_active_codes" class="col-form-label"><?php echo xlt('Active Issue Codes'); ?>:</label>
-                            <select name='form_active_codes' id='form_active_codes' class= "form-control" size='4'
-                                onchange="onActiveCodeSelected()"></select>
-                        </div>
-                        <div class="form-group col-12" id='row_selected_codes'>
-                            <label for="form_selected_codes" class="col-form-label"><?php echo xlt('Coding'); ?>:</label>
-                            <select name='form_selected_codes' id='form_selected_codes' class= "form-control" multiple size='4'
-                                onchange="onCodeSelectionChange()">
-                            <?php
-                            if (!empty($irow['diagnosis'])) {
-                                $codes = explode(";", $irow['diagnosis']);
-                                foreach ($codes as $code) {
-                                    echo "   <option value='" . attr($code) . "'>" . text(getCodeText($code)) . "</option>\n";
-                                }
-                            }
-                            ?>
-                            </select>
-                            <div class="btn-group" style="margin-top:3px;">
-                                <button type="button" class="btn btn-primary btn-sm" style="margin-right:5px;" onclick='onAddCode()'><?php echo xlt('Add');?></button>
-                                <button type="button" id="rem_selected_code" class="btn btn-secondary btn-sm" onclick='onRemoveCode()'><?php echo xlt('Remove');?></button>
-                            </div>
-                            <input type='hidden' class="form-control" name='form_diagnosis' id='form_diagnosis'
-                                   value='<?php echo attr($irow['diagnosis'] ?? '') ?>' onclick='onAddCode()'
-                                   title='<?php echo xla('Click to select or change coding'); ?>' readonly />
-                        </div>
-                        <div class="form-group col-12">
-                            <label class="col-form-label" for="form_begin"><?php echo xlt('Begin Date and Time'); ?>:</label>
-                            <input type='text' class='datepicker form-control' name='form_begin' id='form_begin' value='<?php echo attr(trim(oeFormatDateTime($irow['begdate'] ?? ''))) ?>' title='<?php echo xla('yyyy-mm-dd HH:MM date of onset, surgery or start of medication'); ?>' />
-                        </div>
-                        <div class="form-group col-12" id='row_enddate'>
-                            <label class="col-form-label" for="form_begin"><?php echo xlt('End Date and Time'); ?>:</label>
-                            <input type='text' class='datepicker form-control' name='form_end' id='form_end' value='<?php echo attr(trim(oeFormatDateTime($irow['enddate'] ?? ''))) ?>' title='<?php echo xla('yyyy-mm-dd HH:MM date of recovery or end of medication'); ?>' />
-                            &nbsp;(<?php echo xlt('leave blank if still active'); ?>)
-                        </div>
-                        <div class="form-group col-12" id='row_active'>
-                            <label class="col-form-label" for="form_active"><?php echo xlt('Active{{Issue}}'); ?>: </label>
-                            <div class="checkbox">
-                                <label><input type='checkbox' name='form_active' id=='form_active' value='1' <?php echo (!empty($irow['enddate'])) ? "" : "checked"; ?> onclick='activeClicked(this);' title='<?php echo xla('Indicates if this issue is currently active'); ?>'></label>
-                            </div>
-                        </div>
-                        <div class="form-group" id='row_returndate'>
-                            <input type='hidden' name='form_return' id='form_return' />
-                            <input type='hidden' name='row_reinjury_id' id='row_reinjury_id' />
-                            <img id='img_return' />
-                        </div>
-                        <div class="form-group col-12" id='row_subtype'>
-                            <label class="col-form-label" for="form_subtype"><?php echo xlt('Classification Type'); ?>:</label>
-                            <?php
-                            echo generate_select_list('form_subtype', 'issue_subtypes', ($irow['subtype'] ?? null), '', 'NA', '', '');
-                            ?>
-                        </div>
-                        <div class="form-group col-12" id='row_occurrence'>
-                            <label class="col-form-label" for="form_occur"><?php echo xlt('Occurrence'); ?>:</label>
-                            <?php
-                            // Modified 6/2009 by BM to incorporate the occurrence items into the list_options listings
-                            generate_form_field(array('data_type' => 1, 'field_id' => 'occur', 'list_id' => 'occurrence', 'empty_title' => 'SKIP'), ($irow['occurrence'] ?? null));
-                            ?>
-                        </div>
-                        <div class="form-group col-12" id='row_classification'>
-                            <label class="col-form-label" for="form_classification"><?php echo xlt('Classification'); ?>:</label>
-                            <select name='form_classification' id='form_classification' class='form-control'>
-                                <?php
-                                foreach ($ISSUE_CLASSIFICATIONS as $key => $value) {
-                                    echo "   <option value='" . attr($key) . "'";
-                                    if (!empty($irow['classification']) && ($key == $irow['classification'])) {
-                                        echo " selected";
-                                    }
-                                    echo ">" . text($value) . "\n";
-                                }
-                                ?>
-                            </select>
-                        </div>
-                        <!-- Reaction For Medication Allergy -->
-                        <div class="form-group col-12" id='row_severity'>
-                            <label class="col-form-label" for="form_severity_id"><?php echo xlt('Severity'); ?>:</label>
-                            <?php
-                            $severity = $irow['severity_al'] ?? null;
-                            generate_form_field(array('data_type' => 1, 'field_id' => 'severity_id', 'list_id' => 'severity_ccda', 'empty_title' => 'SKIP'), $severity);
-                            ?>
-                        </div>
-                        <div class="form-group col-12" id='row_reaction'>
-                            <label class="col-form-label" for="form_reaction"><?php echo xlt('Reaction'); ?>:</label>
-                            <?php
-                            echo generate_select_list('form_reaction', 'reaction', ($irow['reaction'] ?? null), '', '', '', '');
-                            ?>
-                        </div>
-                        <!-- End of reaction -->
-                        <!-- Verification Status for Medication Allergy -->
-                        <div class="form-group col-12" id='row_verification'>
-                            <label class="col-form-label" for="form_verification"><?php echo xlt('Verification Status'); ?>:</label>
-                            <?php
-                            $codeListName = ($thistype == 'medical_problem') ? 'condition-verification' : 'allergyintolerance-verification';
-                            echo generate_select_list('form_verification', $codeListName, ($irow['verification'] ?? null), '', '', '', '');
-                            ?>
-                        </div>
-                        <!-- End of Verification Status -->
-                        <div class="form-group col-12" id='row_referredby'>
-                            <label class="col-form-label" for="form_referredby"><?php echo xlt('Referred by'); ?>:</label>
-                            <input type='text' name='form_referredby' id='form_referredby' class='form-control' value='<?php echo attr($irow['referredby'] ?? '') ?>' title='<?php echo xla('Referring physician and practice'); ?>' />
-                        </div>
-                        <div class="form-group col-12" id='row_comments'>
-                            <label class="col-form-label" for="form_comments"><?php echo xlt('Comments'); ?>:</label>
-                            <textarea class="form-control" name='form_comments' id='form_comments' rows="4" id='form_comments'><?php echo text($irow['comments'] ?? '') ?></textarea>
-                        </div>
-                        <div class="form-group col-12" <?php
-                        if ($GLOBALS['ippf_specific']) {
-                            echo " style='display:none;'";
-                        } ?>>
-                            <label class="col-form-label" for="form_outcome"><?php echo xlt('Outcome'); ?>:</label>
-                            <?php
-                            echo generate_select_list('form_outcome', 'outcome', ($irow['outcome'] ?? null), '', '', '', 'outcomeClicked(this);');
-                            ?>
-                        </div>
-                        <div class="form-group col-12" <?php
-                        if ($GLOBALS['ippf_specific']) {
-                            echo " style='display:none;'";
-                        } ?>>
-                            <label class="col-form-label" for="form_destination"><?php echo xlt('Destination'); ?>:</label>
-                            <?php if (true) { ?>
-                                <input type='text' class='form-control' name='form_destination' id='form_destination' value='<?php echo attr($irow['destination'] ?? '') ?>' style='width:100%' title='GP, Secondary care specialist, etc.' />
-                            <?php } else { // leave this here for now, please -- Rod
-                                ?>
-                                <?php echo rbinput('form_destination', '1', 'GP', 'destination') ?>&nbsp;
-                                <?php echo rbinput('form_destination', '2', 'Secondary care spec', 'destination') ?>&nbsp;
-                                <?php echo rbinput('form_destination', '3', 'GP via physio', 'destination') ?>&nbsp;
-                                <?php echo rbinput('form_destination', '4', 'GP via podiatry', 'destination') ?>
-                            <?php } ?>
-                        </div>
-
-                        <?php if (($irow['type'] ?? '') == 'medication') : ?>
-                            <!-- any medication specific issue information goes here -->
-                            <?php include "add_edit_issue_medication_fragment.php"; ?>
                         <?php endif; ?>
-
-                        <br />
-                        <?php //can change position of buttons by creating a class 'position-override' and adding rule text-alig:center or right as the case may be in individual stylesheets
-                        ?>
-                        <div class="form-group clearfix" id="button-container">
-                            <div class="col-sm-12 text-left position-override">
+                        <div class="row">
+                            <?php if (($irow['type'] ?? '') == 'medication') : ?>
+                                <!-- any medication specific issue information goes here -->
+                                <?php include "add_edit_issue_medication_fragment.php"; ?>
+                            <?php endif; ?>
+                        </div>
+                        <div class="row">
+                            <div class="form-group col-12" id='row_comments'>
+                                <label class="col-form-label" for="form_comments"><?php echo xlt('Comments'); ?>:</label>
+                                <textarea class="form-control" name='form_comments' id='form_comments' rows="2" id='form_comments'><?php echo text($irow['comments'] ?? '') ?></textarea>
+                            </div>
+                        </div>
+                        <div id="expanded_options" class="collapse">
+                            <div class="row">
+                                <div class="form-group col-sm-12 col-md-6" id='row_active_codes'>
+                                    <label for="form_active_codes" class="col-form-label"><?php echo xlt('Active Issue Codes'); ?>:</label>
+                                    <select name='form_active_codes' id='form_active_codes' class= "form-control" size='4'
+                                        onchange="onActiveCodeSelected()"></select>
+                                </div>
+                                <div class="form-group col-sm-12 col-md-6" id='row_selected_codes'>
+                                    <label for="form_selected_codes" class="col-form-label"><?php echo xlt('Coding'); ?>:</label>
+                                    <select name='form_selected_codes' id='form_selected_codes' class= "form-control" multiple size='4'
+                                        onchange="onCodeSelectionChange()">
+                                    <?php
+                                    if (!empty($irow['diagnosis'])) {
+                                        $codes = explode(";", $irow['diagnosis']);
+                                        foreach ($codes as $code) {
+                                            echo "<option value='" . attr($code) . "'>" . text(getCodeText($code)) . "</option>\n";
+                                        }
+                                    }
+                                    ?>
+                                    </select>
+                                    <div class="btn-group mt-1">
+                                        <button type="button" class="btn btn-secondary btn-sm" onclick='onAddCode()'><?php echo xlt('Add');?></button>
+                                        <button type="button" id="rem_selected_code" class="btn btn-secondary btn-sm" onclick='onRemoveCode()'><?php echo xlt('Remove');?></button>
+                                    </div>
+                                    <input type='hidden' class="form-control" name='form_diagnosis' id='form_diagnosis'
+                                        value='<?php echo attr($irow['diagnosis'] ?? '') ?>' onclick='onAddCode()'
+                                        title='<?php echo xla('Click to select or change coding'); ?>' readonly />
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="form-group col-sm-12 col-md-4" id='row_occurrence'>
+                                    <label for="form_occur"><?php echo xlt('Occurrence'); ?>:</label>
+                                    <?php
+                                    // Modified 6/2009 by BM to incorporate the occurrence items into the list_options listings
+                                    generate_form_field(array('data_type' => 1, 'field_id' => 'occur', 'list_id' => 'occurrence', 'empty_title' => 'SKIP'), ($irow['occurrence'] ?? null));
+                                    ?>
+                                </div>
+                                <div class="form-group col-sm-12 col-md-4 <?php echo ($GLOBALS['ippf_specific']) ? 'd-none': '';?>">
+                                    <label for="form_outcome"><?php echo xlt('Outcome'); ?>:</label>
+                                    <?php
+                                    echo generate_select_list('form_outcome', 'outcome', ($irow['outcome'] ?? null), '', '', '', 'outcomeClicked(this);');
+                                    ?>
+                                </div>
+                                <div class="form-group col-sm-12 col-md-4" id='row_subtype'>
+                                    <label for="form_subtype"><?php echo xlt('Classification Type'); ?>:</label>
+                                    <?php
+                                    echo generate_select_list('form_subtype', 'issue_subtypes', ($irow['subtype'] ?? null), '', 'NA', '', '');
+                                    ?>
+                                    <div class="form-group" id='row_classification'>
+                                        <label for="form_classification"><?php echo xlt('Classification'); ?>:</label>
+                                        <select name='form_classification' id='form_classification' class='form-control'>
+                                            <?php
+                                            foreach ($ISSUE_CLASSIFICATIONS as $key => $value) {
+                                                echo "   <option value='" . attr($key) . "'";
+                                                if (!empty($irow['classification']) && ($key == $irow['classification'])) {
+                                                    echo " selected";
+                                                }
+                                                echo ">" . text($value) . "\n";
+                                            }
+                                            ?>
+                                        </select>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <!-- Verification Status for Medication Allergy -->
+                                <div class="form-group col-sm-12 col-md-4" id='row_verification'>
+                                    <label class="col-form-label" for="form_verification"><?php echo xlt('Verification Status'); ?>:</label>
+                                    <?php
+                                    $codeListName = ($thistype == 'medical_problem') ? 'condition-verification' : 'allergyintolerance-verification';
+                                    echo generate_select_list('form_verification', $codeListName, ($irow['verification'] ?? null), '', '', '', '');
+                                    ?>
+                                </div>
+                                <!-- End of Verification Status -->
+                                <div class="form-group col-sm-12 col-md-4" id='row_referredby'>
+                                    <label class="col-form-label" for="form_referredby"><?php echo xlt('Referred by'); ?>:</label>
+                                    <input type='text' name='form_referredby' id='form_referredby' class='form-control' value='<?php echo attr($irow['referredby'] ?? '') ?>' title='<?php echo xla('Referring physician and practice'); ?>' />
+                                </div>
+                                <div class="form-group col-sm-12 col-md-4 <?php echo ($GLOBALS['ippf_specific']) ? 'd-none': ''; ?>">
+                                    <label class="col-form-label" for="form_destination"><?php echo xlt('Destination'); ?>:</label>
+                                    <?php if (true) { ?>
+                                        <input type='text' class='form-control' name='form_destination' id='form_destination' value='<?php echo attr($irow['destination'] ?? '') ?>' style='width:100%' title='GP, Secondary care specialist, etc.' />
+                                    <?php } else { // leave this here for now, please -- Rod
+                                        ?>
+                                        <?php echo rbinput('form_destination', '1', 'GP', 'destination') ?>&nbsp;
+                                        <?php echo rbinput('form_destination', '2', 'Secondary care spec', 'destination') ?>&nbsp;
+                                        <?php echo rbinput('form_destination', '3', 'GP via physio', 'destination') ?>&nbsp;
+                                        <?php echo rbinput('form_destination', '4', 'GP via podiatry', 'destination') ?>
+                                    <?php } ?>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="form-group col" id='row_returndate'>
+                                    <input type='hidden' name='form_return' id='form_return' />
+                                    <input type='hidden' name='row_reinjury_id' id='row_reinjury_id' />
+                                    <img id='img_return' />
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col d-flex justify-content-end">
+                                <button type="button" class="btn btn-text mr-3" data-toggle="collapse" data-target="#expanded_options" aria-expanded="false" aria-controls="expanded_options"><?php echo xlt("Show More Fields"); ?>&nbsp;<i class="fa fa-angles-down"></i></button>
                                 <div class="btn-group" role="group">
-                                    <button type='submit' name='form_save' class="btn btn-primary btn-save" value='<?php echo xla('Save'); ?>'><?php echo xlt('Save'); ?></button>
+                                    <button type='submit' name='form_save' value="<?php echo xla('Save'); ?>" class="btn btn-primary btn-save"><?php echo xlt('Save'); ?></button>
                                     <button type="button" class="btn btn-secondary btn-cancel" onclick='closeme();'><?php echo xlt('Cancel'); ?></button>
                                 </div>
                             </div>
                         </div>
-                        <?php
-                        if (!empty($ISSUE_TYPES['ippf_gcac'])) {
-                            if (empty($issue) || $irow['type'] == 'ippf_gcac') {
-                                issue_ippf_gcac_form($issue, $thispid);
-                            }
+                        <div class="row">
+                            <?php
+                            if (!empty($ISSUE_TYPES['ippf_gcac'])) {
+                                if (empty($issue) || $irow['type'] == 'ippf_gcac') {
+                                    issue_ippf_gcac_form($issue, $thispid);
+                                }
 
-                            if (empty($issue) || $irow['type'] == 'contraceptive') {
-                                issue_ippf_con_form($issue, $thispid);
+                                if (empty($issue) || $irow['type'] == 'contraceptive') {
+                                    issue_ippf_con_form($issue, $thispid);
+                                }
                             }
-                        }
-                        ?>
-                    </form>
-                </div>
+                            ?>
+                        </div>
+                    </div>
+                </form>
             </div>
             <?php echo $tabcontents; ?>
         </div>
     </div>
+</div>
 
-    <script>
-        newtype(<?php echo js_escape($type_index); ?>);
-        // Set up the tabbed UI.
-        tabbify();
+<script>
+    newtype(<?php echo js_escape($type_index); ?>);
+    // Set up the tabbed UI.
+    tabbify();
 
-        $(function() {
-            // Include bs3 / bs4 classes here.  Keep html tags functional.
-            $('table').addClass('table table-sm');
+    function toggleBtnExpOpts() {
+        let btnExpOpts = document.querySelector('button[data-target="#expanded_options"]');
+        let isOpen = btnExpOpts.toggleAttribute('data-open');
+        let txtShowHide = isOpen ? <?php echo xlj("Hide More Fields"); ?> : <?php echo xlj("Show More Fields"); ?>;
+        let iconShowHide = isOpen ? "fa-angles-up" : "fa-angles-down";
+        btnExpOpts.innerHTML = `${txtShowHide}&nbsp;<i class='fa ${iconShowHide}'></i>`;
+    }
 
-            onCodeSelectionChange()
-        });
-    </script>
+    $(function() {
+        // Include bs3 / bs4 classes here.  Keep html tags functional.
+        $('table').addClass('table table-sm');
+        $('.select2').select2({theme: 'bootstrap4'});
+        $('button[data-target="#expanded_options"]').on('click', () => {toggleBtnExpOpts()});
 
-    <?php validateUsingPageRules($_SERVER['PHP_SELF']); ?>
-
-
+        onCodeSelectionChange()
+    });
+</script>
+<?php validateUsingPageRules($_SERVER['PHP_SELF']); ?>
 </body>
-
 </html>

--- a/interface/patient_file/summary/add_edit_issue_medication_fragment.php
+++ b/interface/patient_file/summary/add_edit_issue_medication_fragment.php
@@ -19,19 +19,16 @@ $medication = $irow['medication'] ?? [];
 $usage_category = $medication['usage_category'] ?? null;
 $request_intent = $medication['request_intent'] ?? null;
 ?>
-<div class="form-group col-12">
+<div class="form-group col-sm-12 col-md-6">
     <label class="col-form-label" for="medication[usage_category]"><?php echo xlt('Medication Usage'); ?>:</label>
     <?php
-    generate_form_field(array('data_type' => 1, 'field_id' => 'medication[usage_category]', 'list_id' => 'medication-usage-category', 'empty_title' => 'SKIP'), $usage_category);
-    ?>
-</div>
-<div class="form-group col-12">
+    generate_form_field(['data_type' => 1, 'field_id' => 'medication[usage_category]', 'list_id' => 'medication-usage-category', 'empty_title' => 'SKIP'], $usage_category); ?>
     <label class="col-form-label" for="medication[request_intent]"><?php echo xlt('Medication Request Intent'); ?>:</label>
     <?php
-    generate_form_field(array('data_type' => 1, 'field_id' => 'medication[request_intent]', 'list_id' => 'medication-request-intent'), $request_intent);
+    generate_form_field(['data_type' => 1, 'field_id' => 'medication[request_intent]', 'list_id' => 'medication-request-intent'], $request_intent);
     ?>
 </div>
-<div class="form-group col-12">
+<div class="form-group col-sm-12 col-md-6">
     <label class="col-form-label" for="form_medication[drug_dosage_instructions]"><?php echo xlt('Medication Dosage Instructions'); ?>:</label>
     <textarea class="form-control" name='form_medication[drug_dosage_instructions]' id='form_medication[drug_dosage_instructions]'
               rows="4"><?php echo text($medication['drug_dosage_instructions'] ?? '') ?></textarea>

--- a/interface/patient_file/summary/stats_full.php
+++ b/interface/patient_file/summary/stats_full.php
@@ -69,7 +69,8 @@ function refreshIssue(issue, title) {
 function dopclick(id, category) {
     top.restoreSession();
     if (category == 0) category = '';
-    dlgopen('add_edit_issue.php?issue=' + encodeURIComponent(id) + '&thistype=' + encodeURIComponent(category), '_blank', 650, 500, '', <?php echo xlj("Add/Edit Issue"); ?>);
+    let dlg_url = 'add_edit_issue.php?issue=' + encodeURIComponent(id) + '&thistype=' + encodeURIComponent(category);
+    dlgopen(dlg_url, '_blank', 1280, 900, '', <?php echo xlj("Add/Edit Issue"); ?>);
 }
 
 // Process click on number of encounters.


### PR DESCRIPTION
Resolves #6664 

I still think there's improvements that can be made to the quick-pick list versus title versus code but this is still much improved. By default, only the clinically critical fields are displayed, with a collapsing div to hold everything else. The title field now has a helper button to open the code window. The dialog box opens wide and taller now. Something I couldn't figure out is why we hide the Active checkbox, which seems like it would be a nice little feature. However, since I couldn't determine why it's not shown when it is, I chose not to change the logic.

<details><summary>Before / After</summary>

# Before
![image](https://github.com/openemr/openemr/assets/1381170/5b3cb166-7b39-484a-94dc-2b79aff1b0ff)

# After
![2023-07-16_13-59-29](https://github.com/openemr/openemr/assets/1381170/362f1632-9f61-4c2a-a913-000d04462fcb)
</details> 
