### PR TITLE
fix: Hide the portal card if the portal is disabled and ALL APIs are disabled

### DIFF
--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -1579,8 +1579,17 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                 <div class="col-md-4">
                     <!-- start right column div -->
                     <?php
-                    if ($GLOBALS['portal_onsite_two_enable']) {
-                        $portalCard = new PortalCard($GLOBALS);
+                    $_extAccess = [
+                        $GLOBALS['portal_onsite_two_enable'],
+                        $GLOBALS['rest_fhir_api'],
+                        $GLOBALS['rest_api'],
+                        $GLOBALS['rest_portal_api'],
+                    ];
+                    foreach ($_extAccess as $_) {
+                        if ($_) {
+                            $portalCard = new PortalCard($GLOBALS);
+                            break;
+                        }
                     }
 
                     $sectionRenderEvents = $ed->dispatch(new SectionEvent('secondary'), SectionEvent::EVENT_HANDLE);


### PR DESCRIPTION
Ensure the portal card is rendered if any of the API options or the portal is enabled, otherwise hide the portal card.

See #6653 