### PR TITLE
Feat openemr fix #6669 date partial seconds

### DIFF
--- a/src/Services/Search/DateSearchField.php
+++ b/src/Services/Search/DateSearchField.php
@@ -229,7 +229,7 @@ class DateSearchField extends BasicSearchField
         // Not sure how we want to handle timezone
         // we create a DateTime object as not all search fields are a DateTime so we go as precise as we can
         // and let the services go more imprecise if needed.
-        $stringDate = sprintf("%d-%02d-%02dT%02d:%02d:%02d.%04d%s", $datetime['y'], $datetime['m'], $datetime['d'], $datetime['H'], $datetime['i'], $datetime['s'], $datetime['ms'],$datetime['tz']);
+        $stringDate = sprintf("%d-%02d-%02dT%02d:%02d:%02d.%04d%s", $datetime['y'], $datetime['m'], $datetime['d'], $datetime['H'], $datetime['i'], $datetime['s'], $datetime['ms'], $datetime['tz']);
         // 'n' & 'j' don't have leading zeros
         $dateValue = \DateTime::createFromFormat(self::DATE_ATOM_MILLISECONDS, $stringDate);
         return $dateValue;

--- a/src/Services/Search/SearchFieldStatementResolver.php
+++ b/src/Services/Search/SearchFieldStatementResolver.php
@@ -295,7 +295,7 @@ class SearchFieldStatementResolver
      */
     public static function getDateFieldFormatForDateType($dateType)
     {
-        $format = "Y-m-d H:i:s"; // default format is datetime
+        $format = "Y-m-d H:i:s.u"; // default format is datetime
         if ($dateType == DateSearchField::DATE_TYPE_DATE) {
             $format = "Y-m-d";
         }


### PR DESCRIPTION
Fixes #6669 changed out the regex for the date parsing to handle partial seconds up to milliseconds. Also documented the code a little bit better for the regex.