### PR TITLE
Fixes #6677 Questionnaire die fix

### DIFF
--- a/interface/forms/questionnaire_assessments/report.php
+++ b/interface/forms/questionnaire_assessments/report.php
@@ -21,7 +21,8 @@ function questionnaire_assessments_report($pid, $encounter, $cols, $id)
 {
     $form = formFetch("form_questionnaire_assessments", $id);
     if (!$form) {
-        die(xlt('Nothing to report.'));
+        echo xlt('Nothing to report.');
+        return;
     }
     $responseService = new QuestionnaireResponseService();
     try {

--- a/interface/patient_file/encounter/forms.php
+++ b/interface/patient_file/encounter/forms.php
@@ -996,8 +996,16 @@ if (
             include_once($GLOBALS['incdir'] . "/forms/LBF/report.php");
             lbf_report($attendant_id, $encounter, 2, $iter['form_id'], $formdir, true);
         } else {
-            include_once($GLOBALS['incdir'] . "/forms/$formdir/report.php");
-            call_user_func($formdir . "_report", $attendant_id, $encounter, 2, $iter['form_id']);
+            if (file_exists($GLOBALS['incdir'] . "/forms/$formdir/report.php")) {
+                include_once($GLOBALS['incdir'] . "/forms/$formdir/report.php");
+                if (function_exists($formdir . "_report")) {
+                    call_user_func($formdir . "_report", $attendant_id, $encounter, 2, $iter['form_id']);
+                } else {
+                    (new \OpenEMR\Common\Logging\SystemLogger())->errorLogCaller("form is missing report function", ['formdir' => $formdir]);
+                }
+            } else {
+                (new \OpenEMR\Common\Logging\SystemLogger())->errorLogCaller("form is missing report.php file", ['formdir' => $formdir]);
+            }
         }
 
         if ($esign->isLogViewable()) {


### PR DESCRIPTION
Fixes #6677.  Dieing in the questionnaire report kills other forms that want to render.  We shouldn't allow that to happen.  We catch exceptions in the forms and log them so that other forms can continue to render.