### PR TITLE
feat: new Twig function for getting logo url

### DIFF
--- a/src/Common/Twig/TwigExtension.php
+++ b/src/Common/Twig/TwigExtension.php
@@ -22,6 +22,7 @@ use OpenEMR\Core\Header;
 use OpenEMR\Core\Kernel;
 use OpenEMR\OeUI\OemrUI;
 use OpenEMR\Services\Globals\GlobalsService;
+use OpenEMR\Services\LogoService;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\GlobalsInterface;
@@ -181,6 +182,13 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
                 'aclCore',
                 function ($section, $value, $user = '', $return_value = '') {
                     return AclMain::aclCheckCore($section, $value, $user, $return_value);
+                }
+            ),
+            new TwigFunction(
+                'getLogo',
+                function (string $type, string $filename = "logo.*") {
+                    $ls = new LogoService();
+                    return $ls->getLogo($type, $filename);
                 }
             )
         ];


### PR DESCRIPTION
Resolves #6247 

New wrapper for the `getLogo()` function from `LogoService` available in twig.