### PR TITLE
Allow any flagged portal user to view portal pnotes

### DIFF
--- a/interface/main/messages/messages.php
+++ b/interface/main/messages/messages.php
@@ -343,7 +343,6 @@ if (!empty($_REQUEST['go'])) { ?>
                             $task = "edit";
                             $note = $_POST['note'];
                             $title = $_POST['form_note_type'];
-                            $reply_to = $_POST['reply_to'];
                             break;
                         case "edit":
                             $noteid = (int) $_GET['noteid'];
@@ -352,18 +351,18 @@ if (!empty($_REQUEST['go'])) { ?>
                             }
                             // Check to make sure the noteid is assigned to the user
                             if (!checkPnotesNoteId($noteid, $_SESSION['authUser'])) {
-                                die("There was an error processing your request.");
+                                die("Message is not assigned to you. Viewing is disallowed.");
                             }
                             // Update the message if it already exists; it's appended to an existing note in Patient Notes.
                             $result = getPnoteById($noteid);
                             if ($result) {
-                                if ($title == "") {
+                                if (empty($title)) {
                                     $title = $result['title'];
                                 }
                                 $body = $result['body'];
                                 // if our reply-to is 0 it breaks multi patient select and other functionality
                                 // this most likely didn't break before due to php implicit type conversion of 0 to ""
-                                if ($reply_to == "" && $result['pid'] != 0) {
+                                if (empty($reply_to) && $result['pid'] != 0) {
                                     $reply_to = $result['pid'];
                                 }
                                 $form_message_status = $result['message_status'];

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php
@@ -272,6 +272,10 @@ class CarecoordinationTable extends AbstractTableGateway
         }
         $this->documentData['field_name_value_array']['patient_data'][1]['referrerID'] = $xml['recordTarget']['patientRole']['id']['extension'] ?? '';
         //$this->documentData['field_name_value_array']['patient_data'][1]['ss'] = $xml['recordTarget']['patientRole']['id'][1]['extension'] ?? null;
+        if (is_array($xml['recordTarget']['patientRole']['addr'] ?? null) && !empty($xml['recordTarget']['patientRole']['addr'][0]['streetAddressLine'][0] ?? null)) {
+            // Since we don't have easy way to do additional addresses we'll grab the first.
+            $xml['recordTarget']['patientRole']['addr'] = $xml['recordTarget']['patientRole']['addr'][0];
+        }
         if (is_array($xml['recordTarget']['patientRole']['addr']['streetAddressLine'] ?? null)) {
             $this->documentData['field_name_value_array']['patient_data'][1]['street'] = $xml['recordTarget']['patientRole']['addr']['streetAddressLine'][0] ?? null;
             $this->documentData['field_name_value_array']['patient_data'][1]['street_line_2'] = $xml['recordTarget']['patientRole']['addr']['streetAddressLine'][1] ?? null;

--- a/library/pnotes.inc.php
+++ b/library/pnotes.inc.php
@@ -574,8 +574,13 @@ function reappearPnote($id)
 
 function deletePnote($id)
 {
+    $assigned = getAssignedToById($id);
+    if (!checkPortalAuthUser($_SESSION['authUser']) && $assigned == 'portal-user') {
+        return false;
+    }
     if (
-        getAssignedToById($id) == $_SESSION['authUser']
+        $assigned == $_SESSION['authUser']
+        || $assigned == 'portal-user'
         || getMessageStatusById($id) == 'Done'
     ) {
         sqlStatement("UPDATE pnotes SET deleted = '1', update_by = ?, update_date = NOW() WHERE id=?", array($_SESSION['authUserID'], $id));


### PR DESCRIPTION
New portal auth check function
modify get query to include portal users

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #6695 

#### Short description of what this resolves:
Allows portal messages to be view by users that are assigned to the portal.

#### Changes proposed in this pull request:
New portal auth check function
modify get query to include portal users