### PR TITLE
feat: Hook into the CDA Parsing functions

### DIFF
--- a/src/Events/CDA/CDAParseEvent.php
+++ b/src/Events/CDA/CDAParseEvent.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ *
+ */
+
+namespace OpenEMR\Events\CDA;
+
+use Carecoordination\Model\CcdaDocumentTemplateOids;
+use OpenEMR\Services\Cda\CdaTemplateParse;
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class CDAParseEvent extends Event
+{
+    public const EVENT_HANDLE = 'cda.component.parse';
+
+    /**
+     * @var array The component of the CDA document, see parseCDAEntryComponents() in CdaTemplateParse
+     */
+    private $templateData;
+
+    /**
+     * @var array Should equal the $templateData property in CdaTemplateParse
+     */
+    private $component;
+
+    /**
+     * @var string The name of the component. allergies, encounters, etc.
+     */
+    private $componentName;
+
+    /**
+     * @var string The OID of the template
+     */
+    private $oid;
+
+    /**
+     *
+     * @param string $componentName
+     * @param array $component
+     * @param array $templateData
+     */
+    public function __construct(string $componentName, string $oid, array $component, array $templateData)
+    {
+        $this->componentName = $componentName;
+        $this->component = $component;
+        $this->templateData = $templateData;
+        $this->oid = $oid;
+    }
+
+    public function getComponentName() : string {
+        return $this->componentName;
+    }
+
+    /**
+     * @return array The component of the CDA document, see parseCDAEntryComponents() in CdaTemplateParse
+     */
+    public function getComponent() : array
+    {
+        return $this->component;
+    }
+
+    /**
+     * @return array Should equal the $templateData property in CdaTemplateParse
+     */
+    public function getTemplateData() : array
+    {
+        return $this->templateData;
+    }
+
+    public function getOid() : string
+    {
+        return $this->oid;
+    }
+
+    /**
+     * @param string $componentName The name of the component. allergies, encounters, etc.
+     */
+    public function setcomponentName(string $componentName) : void {
+        $this->componentName = $componentName;
+    }
+
+    /**
+     * @param string $component
+     */
+    public function setComponent(array $component) : void
+    {
+        $this->component = $component;
+    }
+
+    /**
+     * @param array $templateData
+     */
+    public function setTemplateData($templateData) : void
+    {
+        $this->templateData = $templateData;
+    }
+
+    /**
+     * Set the OID
+     */
+    public function setOid(string $oid) : void
+    {
+        $this->oid = $oid;
+    }
+
+}

--- a/src/Events/CDA/CDAParseEvent.php
+++ b/src/Events/CDA/CDAParseEvent.php
@@ -75,7 +75,7 @@ final class CDAParseEvent extends Event
     /**
      * @param string $componentName The name of the component. allergies, encounters, etc.
      */
-    public function setcomponentName(string $componentName) : void {
+    public function setComponentName(string $componentName) : void {
         $this->componentName = $componentName;
     }
 

--- a/src/Events/CDA/CDAParseEvent.php
+++ b/src/Events/CDA/CDAParseEvent.php
@@ -1,12 +1,18 @@
 <?php
 /**
+ * CDA Parse Event
  *
+ * This event is dispatched when the CDA document is parsed.  It is dispatched for each component
+ *
+ * @package OpenEMR
+ * @subpackage CareCoordination
+ * @author Robert Down <robertdown@live.com>
+ * @copyright 2023 Robert Down <robertdown@live.com>
+ * @copyright 2023 Providence Healthtech
  */
 
 namespace OpenEMR\Events\CDA;
 
-use Carecoordination\Model\CcdaDocumentTemplateOids;
-use OpenEMR\Services\Cda\CdaTemplateParse;
 use Symfony\Contracts\EventDispatcher\Event;
 
 final class CDAParseEvent extends Event

--- a/src/Events/CDA/CDAPostParseEvent.php
+++ b/src/Events/CDA/CDAPostParseEvent.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * CDAPreParseEvent.php
  *
@@ -61,14 +62,15 @@ final class CDAPostParseEvent extends Event
     /**
      * @return string The name of the component. allergies, encounters, etc.
      */
-    public function getComponentName() : string {
+    public function getComponentName(): string
+    {
         return $this->componentName;
     }
 
     /**
      * @return array The component of the CDA document, see parseCDAEntryComponents() in CdaTemplateParse
      */
-    public function getComponent() : array
+    public function getComponent(): array
     {
         return $this->component;
     }
@@ -76,7 +78,7 @@ final class CDAPostParseEvent extends Event
     /**
      * @return array Should equal the $templateData property in CdaTemplateParse
      */
-    public function getTemplateData() : array
+    public function getTemplateData(): array
     {
         return $this->templateData;
     }
@@ -84,7 +86,7 @@ final class CDAPostParseEvent extends Event
     /**
      * @return string The OID of the template
      */
-    public function getOid() : string
+    public function getOid(): string
     {
         return $this->oid;
     }
@@ -92,14 +94,15 @@ final class CDAPostParseEvent extends Event
     /**
      * @param string $componentName The name of the component. allergies, encounters, etc.
      */
-    public function setComponentName(string $componentName) : void {
+    public function setComponentName(string $componentName): void
+    {
         $this->componentName = $componentName;
     }
 
     /**
      * @param string $component
      */
-    public function setComponent(array $component) : void
+    public function setComponent(array $component): void
     {
         $this->component = $component;
     }
@@ -107,7 +110,7 @@ final class CDAPostParseEvent extends Event
     /**
      * @param array $templateData
      */
-    public function setTemplateData($templateData) : void
+    public function setTemplateData($templateData): void
     {
         $this->templateData = $templateData;
     }
@@ -115,9 +118,8 @@ final class CDAPostParseEvent extends Event
     /**
      * Set the OID
      */
-    public function setOid(string $oid) : void
+    public function setOid(string $oid): void
     {
         $this->oid = $oid;
     }
-
 }

--- a/src/Events/CDA/CDAPostParseEvent.php
+++ b/src/Events/CDA/CDAPostParseEvent.php
@@ -1,23 +1,28 @@
 <?php
 /**
- * CDA Parse Event
+ * CDAPreParseEvent.php
  *
- * This event is dispatched when the CDA document is parsed.  It is dispatched for each component
- *
- * @package OpenEMR
- * @subpackage CareCoordination
- * @author Robert Down <robertdown@live.com>
- * @copyright 2023 Robert Down <robertdown@live.com>
- * @copyright 2023 Providence Healthtech
+ * @package     OpenEMR
+ * @subpackage  CareCoordination
+ * @author      Robert Down <robertdown@live.com>
+ * @copyright   2023 Robert Down <robertdown@live.com>
+ * @copyright   2023 Providence Healthtech
+ * @license     https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
 namespace OpenEMR\Events\CDA;
 
 use Symfony\Contracts\EventDispatcher\Event;
 
-final class CDAParseEvent extends Event
+/**
+ *
+ * This event is dispatched when the CDA document is parsed. It is dispatched
+ * once for each component in the list of components and occurs after the core
+ * processing has occurred. It can return the manipulated templateData.
+ */
+final class CDAPostParseEvent extends Event
 {
-    public const EVENT_HANDLE = 'cda.component.parse';
+    public const EVENT_HANDLE = 'cda.component.post.parse';
 
     /**
      * @var array The component of the CDA document, see parseCDAEntryComponents() in CdaTemplateParse
@@ -53,6 +58,9 @@ final class CDAParseEvent extends Event
         $this->oid = $oid;
     }
 
+    /**
+     * @return string The name of the component. allergies, encounters, etc.
+     */
     public function getComponentName() : string {
         return $this->componentName;
     }
@@ -73,6 +81,9 @@ final class CDAParseEvent extends Event
         return $this->templateData;
     }
 
+    /**
+     * @return string The OID of the template
+     */
     public function getOid() : string
     {
         return $this->oid;

--- a/src/Events/CDA/CDAPostParseEvent.php
+++ b/src/Events/CDA/CDAPostParseEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * CDAPreParseEvent.php
+ * CDAPostParseEvent.php
  *
  * @package     OpenEMR
  * @subpackage  CareCoordination

--- a/src/Events/CDA/CDAPreParseEvent.php
+++ b/src/Events/CDA/CDAPreParseEvent.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * CDAPreParseEvent.php
  *
@@ -41,7 +42,7 @@ final class CDAPreParseEvent extends Event
     /**
      * @return array The components of the CDA document, see parseCDAEntryComponentss() in CdaTemplateParse
      */
-    public function getComponents() : array
+    public function getComponents(): array
     {
         return $this->components;
     }
@@ -49,7 +50,7 @@ final class CDAPreParseEvent extends Event
     /**
      * @param string $components
      */
-    public function setComponents(array $components) : void
+    public function setComponents(array $components): void
     {
         $this->components = $components;
     }

--- a/src/Events/CDA/CDAPreParseEvent.php
+++ b/src/Events/CDA/CDAPreParseEvent.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * CDAPreParseEvent.php
+ *
+ * @package     OpenEMR
+ * @subpackage  CareCoordination
+ * @author      Robert Down <robertdown@live.com>
+ * @copyright   2023 Robert Down <robertdown@live.com>
+ * @copyright   2023 Providence Healthtech
+ * @license     https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\CDA;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ *
+ * This event is dispatched when the CDA document is parsed. It is dispatched
+ * prior to any processing of the data. It accepts the component data and returns
+ * data in the same shape as the component data
+ */
+final class CDAPreParseEvent extends Event
+{
+    public const EVENT_HANDLE = 'cda.component.pre.parse';
+
+    /**
+     * @var array Should equal the $templateData property in CdaTemplateParse
+     */
+    private $components;
+
+    /**
+     *
+     * @param array $components
+     */
+    public function __construct(array $components = [])
+    {
+        $this->components = $components;
+    }
+
+    /**
+     * @return array The components of the CDA document, see parseCDAEntryComponentss() in CdaTemplateParse
+     */
+    public function getComponents() : array
+    {
+        return $this->components;
+    }
+
+    /**
+     * @param string $components
+     */
+    public function setComponents(array $components) : void
+    {
+        $this->components = $components;
+    }
+}

--- a/src/Services/Cda/CdaTemplateParse.php
+++ b/src/Services/Cda/CdaTemplateParse.php
@@ -13,7 +13,6 @@
 namespace OpenEMR\Services\Cda;
 
 use DOMDocument;
-use Laminas\I18n\View\Helper\DateFormat;
 use OpenEMR\Events\CDA\CDAParseEvent;
 use OpenEMR\Services\CodeTypesService;
 

--- a/src/Services/Cda/CdaTemplateParse.php
+++ b/src/Services/Cda/CdaTemplateParse.php
@@ -31,7 +31,6 @@ class CdaTemplateParse
 
     public function __construct()
     {
-        global $GLOBALS;
         $this->templateData = [];
         $this->is_qrda_import = false;
         $this->codeService = new CodeTypesService();
@@ -71,16 +70,16 @@ class CdaTemplateParse
         );
 
         $preParseEvent = new CDAPreParseEvent($components);
-        $preParseEventDispatch = $this->ed->dispatch($preParseEvent, CDAPreParseEvent::EVENT_HANDLE);
+        $this->ed->dispatch($preParseEvent, CDAPreParseEvent::EVENT_HANDLE);
 
-        foreach ($preParseEventDispatch->getCompnents() as $component) {
+        foreach ($preParseEvent->getComponents() as $component) {
             if (!empty($component['section']['templateId']['root'])) {
                 if (!empty($components_oids[$component['section']['templateId']['root']])) {
                     $this->currentOid = $component['section']['templateId']['root'];
                     $func_name = $components_oids[$component['section']['templateId']['root']];
                     $this->$func_name($component);
                     $postParseEvent = new CDAPostParseEvent($func_name, $this->currentOid, $component, $this->templateData);
-                    $postParseEventDispatch = $this->ed->dispatch($postParseEvent, CDAPostParseEvent::EVENT_HANDLE);
+                    $this->ed->dispatch($postParseEvent, CDAPostParseEvent::EVENT_HANDLE);
                 }
             } elseif (empty($component['section']['templateId'])) {
                 // uncomment for debugging information.
@@ -93,12 +92,12 @@ class CdaTemplateParse
                         $func_name = $components_oids[$component['section']['templateId'][$key_1]['root']];
                         $this->$func_name($component);
                         $postParseEvent = new CDAPostParseEvent($func_name, $this->currentOid, $component, $this->templateData);
-                        $postParseEventDispatch = $this->ed->dispatch($postParseEvent, CDAPostParseEvent::EVENT_HANDLE);
+                        $this->ed->dispatch($postParseEvent, CDAPostParseEvent::EVENT_HANDLE);
                         break;
                     }
                 }
             }
-            $this->templateData = $postParseEventDispatch->getTemplateData();
+            $this->templateData = $postParseEvent->getTemplateData();
         }
         return $this->templateData;
     }


### PR DESCRIPTION
Will resolve #6715. Add a new Event allowing hooks into `parseCDAEntryComponents()` for every component that gets parsed. The event dispatches the string of the component (encounter, allergy, medication, problems, etc), the OID, the component array, and the current state of `$templateData`.

`CdaTemplateParse->templateData` is always updated with the results of `$event->getTemplateData()` The event runs __after__ the core parsing function runs