### PR TITLE
Fixes #6732 fhir _search query params

### DIFF
--- a/src/Common/Http/HttpRestRequest.php
+++ b/src/Common/Http/HttpRestRequest.php
@@ -192,7 +192,7 @@ class HttpRestRequest implements ServerRequestInterface
 
     public function setQueryParams($queryParams)
     {
-        return $this->innerServerRequest->withQueryParams($queryParams);
+        $this->innerServerRequest = $this->innerServerRequest->withQueryParams($queryParams);
     }
 
     public function getQueryParams()


### PR DESCRIPTION
Query params were not being set due to how the http rest request is not being populated.

Fixes #6732 