### PR TITLE
feat(jest): coverage reports for js unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ ccdaservice/node_modules
 
 # testing
 .phpunit.result.cache
+coverage/js-unit

--- a/ccdaservice/data-stack/data-stack.spec.js
+++ b/ccdaservice/data-stack/data-stack.spec.js
@@ -13,6 +13,7 @@ describe('DataStack', () => {
     });
 
     it('should store and return data', () => {
+        expect(stack.returnData()).toEqual(null);
         const hello = 'Hello';
         const world = 'World!';
         stack.push(hello + delimiter);

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,28 @@ const config = {
     modulePathIgnorePatterns: [
         'public/assets',
         'vendor'
+    ],
+    coverageDirectory: 'coverage/js-unit',
+    collectCoverageFrom: ['**/*.js'],
+    coveragePathIgnorePatterns: [
+        'gulpfile.js',
+        'jest.config.js',
+        'node_modules',
+        'ccdaservice/node_modules',
+        'coverage',
+        'interface/forms/eye_mag/js/jquery-1-10-2',
+        'interface/forms/eye_mag/js/jquery-panelslider',
+        'interface/forms/eye_mag/js/jquery-ui-1-11-4',
+        'interface/forms/eye_mag/js/jquery-1-10-2',
+        'interface/forms/questionnaire_assessments/lforms/fhir',
+        'interface/forms/questionnaire_assessments/lforms/webcomponent',
+        'interface/modules/zend_modules/public/js/lib',
+        'interface/super/rules/www/js/cdr-multiselect',
+        'portal/patient/scripts/libs',
+        'public/assets',
+        'swagger',
+        'tests',
+        'vendor'
     ]
 };
   

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint:js": "eslint '**/*.js' --quiet",
     "lint:js-fix": "npm run lint:js -- --fix",
-    "test:js": "jest"
+    "test:js": "jest",
+    "test:js-coverage": "jest --coverage"
   },
   "keywords": [
     "openemr"


### PR DESCRIPTION
Create script to generate test coverage reports for JS files.

Running `test:js-coverage` will generate the report inside the folder `coverage/js-unit`.

By opening the `index.html` file inside the folder `coverage/js-unit/lcov-report`, you can easily navigate through the project and check statistics for each file:

![image](https://github.com/openemr/openemr/assets/22417165/574c58da-9ca8-4b60-818e-edbefdc77f3f)

![image](https://github.com/openemr/openemr/assets/22417165/0552e51c-8b54-43cc-af5a-d442b668cf83)

![image](https://github.com/openemr/openemr/assets/22417165/397ce931-7af6-4f8c-bfb0-810c76044b29)

If there's interest, we could also include the `coverageThreshold` option to discourage people from adding more JS without including tests. The initial value would allow the project to pass as is. As coverage increases over time, we would increase the value of the threshold to prevent coverage from falling. This is a decision to be made by the team, so it's not included in this initial proposal.