### PR TITLE
Modifications in InternalApiTest and InternalFhirTest files to make it work locally in a new module

### DIFF
--- a/tests/api/InternalApiTest.php
+++ b/tests/api/InternalApiTest.php
@@ -94,7 +94,9 @@ $gbl = RestConfig::GetInstance();
 $gbl::setNotRestCall();
 $restRequest = new HttpRestRequest($gbl, $_SERVER);
 $restRequest->setRequestMethod("GET");
-$restRequest->setRequestURI("/api/facility");
+$restRequest->setRequestPath("/api/facility");
+$restRequest->setIsLocalApi(true); 
+$restRequest->setApiType("oemr");
 // below will return as json
 echo "<b>api via route handler call returning json:</b><br />";
 echo HttpRestRouteHandler::dispatch($gbl::$ROUTE_MAP, $restRequest, 'direct-json');

--- a/tests/api/InternalApiTest.php
+++ b/tests/api/InternalApiTest.php
@@ -95,7 +95,7 @@ $gbl::setNotRestCall();
 $restRequest = new HttpRestRequest($gbl, $_SERVER);
 $restRequest->setRequestMethod("GET");
 $restRequest->setRequestPath("/api/facility");
-$restRequest->setIsLocalApi(true); 
+$restRequest->setIsLocalApi(true);
 $restRequest->setApiType("oemr");
 // below will return as json
 echo "<b>api via route handler call returning json:</b><br />";

--- a/tests/api/InternalFhirTest.php
+++ b/tests/api/InternalFhirTest.php
@@ -30,7 +30,7 @@ use OpenEMR\Core\Header;
         function testAjaxApi() {
             $.ajax({
                 type: 'GET',
-                url: '../../apis/api/facility',
+                url: '../../apis/fhir/Patient',
                 dataType: 'json',
                 headers: {
                     'apicsrftoken': <?php echo js_escape(CsrfUtils::collectCsrfToken('api')); ?>
@@ -45,7 +45,7 @@ use OpenEMR\Core\Header;
         }
 
         function testFetchApi() {
-            fetch('../../apis/api/facility', {
+            fetch('../../apis/fhir/Patient', {
                 credentials: 'same-origin',
                 method: 'GET',
                 headers: new Headers({
@@ -96,16 +96,19 @@ $gbl = RestConfig::GetInstance();
 $gbl::setNotRestCall();
 $restRequest = new HttpRestRequest($gbl, $_SERVER);
 $restRequest->setRequestMethod("GET");
-$restRequest->setRequestURI("/fhir/encounter");
+$restRequest->setApiType("fhir");
+$restRequest->setRequestPath("/fhir/Patient");
+$restRequest->setIsLocalApi(true);
 $getParams = $restRequest->getQueryParams();
+
 // below will return as json
 echo "<b>api via route handler call returning json:</b><br />";
-echo HttpRestRouteHandler::dispatch($gbl::$ROUTE_MAP, $restRequest, 'direct-json');
+echo HttpRestRouteHandler::dispatch($gbl::$FHIR_ROUTE_MAP, $restRequest, 'direct-json');
 echo "<br /><br />";
 
 // below will return as php array
 echo "<b>api via route handler call returning php array:</b><br />";
-echo print_r(HttpRestRouteHandler::dispatch($gbl::$ROUTE_MAP, $restRequest, 'direct'));
+echo print_r(HttpRestRouteHandler::dispatch($gbl::$FHIR_ROUTE_MAP, $restRequest, 'direct'));
 echo "<br /><br />";
 
 


### PR DESCRIPTION

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #6744

#### Short description of what this resolves:

Have made the changes for the internal and fhir apis to work as expected


#### Changes proposed in this pull request:

InternalApiTest.php -

Added setIsLocalApi and setApiType  for the $restRequest, Modified setRequestURI to setRequestPath for the $restRequest

InternalFhirTest.php -

Changed the URL endpoint from '/apis/api/facility' to '/apis/fhir/Patient' in the functions  testFetchApi and testAjaxApi, Added setIsLocalApi and setApiType  for the $restRequest, Modified setRequestURI to setRequestPath for the $restRequest, Changed $routes list from $ROUTE_MAP to $FHIR_ROUTE_MAP to fetch the Fhir endpoints
