### PR TITLE
Increased contrast in navbar hover in dark theme

### DIFF
--- a/interface/themes/tabs_style_full.scss
+++ b/interface/themes/tabs_style_full.scss
@@ -344,9 +344,15 @@ body {
   width: 100%;
 }
 
+/**
+ * The colors of --light and --dark are flipped. 
+ * Instead of making changes to --dark and --light, which may have unintended consequences,
+ * this localized change was made to ensure the nav bar met contrast requirements when hovering.
+ */
+
 .menuLabel:hover {
-  background: #cce3f8;
-  color: var(--dark);
+  background-color: var(--dark);
+  color: var(--light);
 }
 
 /** Only apply if not an actual link **/
@@ -362,8 +368,8 @@ div.menuLabel:hover {
 }
 
 .menuEntries li .menuLabel:hover {
-  background-color: #cce3f8;
-  color: var(--dark);
+  background-color: var(--dark);
+  color: var(--light);
 }
 
 .logo {


### PR DESCRIPTION
<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #6746 

#### Short description of what this resolves:
The contrast of the navigation bar in dark theme when hovered over was not accessible. 

#### Changes proposed in this pull request:
This commit resolves this issue to match the background of the hovered submenu.
