### PR TITLE
fix: Ensure proper rendering of top cards

### DIFF
--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -1025,33 +1025,19 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
         ?>
         <div class="main mb-1">
             <!-- start main content div -->
-            <div class="row">
+            <div class="form-row">
                     <?php
                     $t = $twig->getTwig();
 
                     $allergy = (AclMain::aclCheckIssue('allergy')) ? 1 : 0;
                     $pl = (AclMain::aclCheckIssue('medical_problem')) ? 1 : 0;
                     $meds = (AclMain::aclCheckIssue('medication')) ? 1 : 0;
-                    $cards = $allergy + $pl + $meds;
+                    $rx = (!$GLOBALS['disable_prescriptions'] && AclMain::aclCheckCore('patients', 'rx')) ? 1 : 0;
+                    $cards = $allergy + $pl + $meds + $rx;
                     $col = "p-1 ";
 
-                    switch ($cards) {
-                        case '1':
-                            $col .= "col-12";
-                            break;
-
-                        case '2':
-                            $col .= "col-6";
-                            break;
-
-                        case '3':
-                            $col .= "col-4";
-                            break;
-
-                        default:
-                            $col .= "col";
-                            break;
-                    }
+                    $colInt = 12 / $cards;
+                    $col = "col-" . $colInt;
 
                     /**
                      * Helper function to return only issues with an outcome not equal to resolved
@@ -1202,7 +1188,9 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                         $viewArgs['content'] = ob_get_contents();
                         ob_end_clean();
 
+                        echo "<div class=\"$col\">";
                         echo $t->render('patient/card/rx.html.twig', $viewArgs);
+                        echo "</div>";
                     endif;
                     ?>
                 </div>


### PR DESCRIPTION
Resolves #6760 by accounting to the prescription card. Also swaps `.row` for `.form-row` for small gutters on that row. Not a great fix, we could probably add a utility class for smaller gutters but that is outside the scope of this fix