### PR TITLE
Prevent previous name fetch on pid = 0

### DIFF
--- a/library/options.inc.php
+++ b/library/options.inc.php
@@ -1704,7 +1704,7 @@ function generate_form_field($frow, $currvalue)
     // Previous Patient Names with add. Somewhat mirrors data types 44,45.
     } elseif ($data_type == 52) {
         global $pid;
-        $pid = ($frow['blank_form'] ?? null) ? 0 : $pid;
+        $pid = ($frow['blank_form'] ?? null) ? null : $pid;
         $patientService = new PatientService();
         $res = $patientService->getPatientNameHistory($pid);
         echo "<div class='input-group w-75'>";

--- a/src/Services/PatientService.php
+++ b/src/Services/PatientService.php
@@ -685,7 +685,9 @@ class PatientService extends BaseService
     {
         // we should never be null here but for legacy reasons we are going to default to this
         $createdBy = $_SESSION['authUserID'] ?? null; // we don't let anyone else but the current user be the createdBy
-
+        if ($pid <= 0) {
+            return false;
+        }
         $insertData = [
             'pid' => $pid,
             'history_type_key' => 'name_history',


### PR DESCRIPTION
- default pid to null if new patient
Needs to go back in patch. May not be able to cherry pick.
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #6769

#### Short description of what this resolves:
see issue

#### Changes proposed in this pull request:
null pid if 0