### PR TITLE
feat: Fixes #6772 adds twig email templates to emails

### DIFF
--- a/interface/usergroup/addrbook_list.php
+++ b/interface/usergroup/addrbook_list.php
@@ -242,12 +242,7 @@ function refreshme() {
 // Process click to pop up the add window.
 function doedclick_add(type) {
  top.restoreSession();
- let url = 'addrbook_edit.php?type=' + encodeURIComponent(type);
- const urlParams = new URLSearchParams(window.location.search);
- if (urlParams.has("popup")) {
-     url += "&popup=" + urlParams.get("popup");
- }
- dlgopen(url, '_blank', 650, (screen.availHeight * 75/100));
+ dlgopen('addrbook_edit.php?type=' + encodeURIComponent(type), '_blank', 650, (screen.availHeight * 75/100));
 }
 
 // Process click to pop up the edit window.

--- a/interface/usergroup/addrbook_list.php
+++ b/interface/usergroup/addrbook_list.php
@@ -242,7 +242,12 @@ function refreshme() {
 // Process click to pop up the add window.
 function doedclick_add(type) {
  top.restoreSession();
- dlgopen('addrbook_edit.php?type=' + encodeURIComponent(type), '_blank', 650, (screen.availHeight * 75/100));
+ let url = 'addrbook_edit.php?type=' + encodeURIComponent(type);
+ const urlParams = new URLSearchParams(window.location.search);
+ if (urlParams.has("popup")) {
+     url += "&popup=" + urlParams.get("popup");
+ }
+ dlgopen(url, '_blank', 650, (screen.availHeight * 75/100));
 }
 
 // Process click to pop up the edit window.

--- a/library/classes/postmaster.php
+++ b/library/classes/postmaster.php
@@ -79,8 +79,7 @@ class MyMailer extends PHPMailer
             $body = json_encode($templateData);
             QueryUtils::sqlInsert("INSERT into `email_queue` (`sender`, `recipient`, `subject`, `body`,  `template_name`, `datetime_queued`) VALUES (?, ?, ?, ?, ?, NOW())", [$sender, $recipient, $subject, $body, $template]);
             return true;
-        }
-        catch (\Exception $e) {
+        } catch (\Exception $e) {
             (new SystemLogger())->errorLogCaller("Failed to add email to queue notification error " . $e->getMessage(), ['trace' => $e->getTraceAsString()]);
         }
         return false;
@@ -143,12 +142,10 @@ class MyMailer extends PHPMailer
                             sqlStatement("UPDATE `email_queue` SET `error` = 1, `error_message`= ?, , `datetime_error` = NOW() WHERE `id` = ?", [$mail->ErrorInfo, $ret['id']]);
                             error_log("Failed to send email notification through Mymailer emailServiceRun with error " . errorLogEscape($mail->ErrorInfo));
                         }
-                    }
-                    catch (\Exception $e) {
+                    } catch (\Exception $e) {
                         (new SystemLogger())->errorLogCaller("Failed to generate email contents for queued email" . $e->getMessage(), ['trace' => $e->getTraceAsString(), 'id' => $ret['id']]);
                         sqlStatement("UPDATE `email_queue` SET `error` = 1, `error_message`= ?, `datetime_error` = NOW() WHERE `id` = ?", [$e->getMessage(), $ret['id']]);
                     }
-
                 } else {
                     sqlStatement("UPDATE `email_queue` SET `error` = 1, `error_message`= 'email method is not configured correctly', `datetime_error` = NOW() WHERE `id` = ?", [$ret['id']]);
                     error_log("Failed to send email notification through Mymailer since email method is not configured correctly");

--- a/library/classes/postmaster.php
+++ b/library/classes/postmaster.php
@@ -13,6 +13,9 @@
 
 use OpenEMR\Common\Crypto\CryptoGen;
 use PHPMailer\PHPMailer\PHPMailer;
+use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Common\Database\QueryUtils;
 
 class MyMailer extends PHPMailer
 {
@@ -59,6 +62,31 @@ class MyMailer extends PHPMailer
         return true;
     }
 
+    /**
+     * Adds an email to the email queue
+     * @param string $sender
+     * @param string $recipient
+     * @param string $template
+     * @param array $templateData
+     * @return bool
+     */
+    public static function emailServiceQueueTemplatedEmail(string $sender, string $recipient, string $subject, string $template, array $templateData)
+    {
+        if (empty($sender) || empty($recipient) || empty($subject) || empty($template) || empty($templateData)) {
+            return false;
+        }
+        try {
+            $body = json_encode($templateData);
+            QueryUtils::sqlInsert("INSERT into `email_queue` (`sender`, `recipient`, `subject`, `body`,  `template_name`, `datetime_queued`) VALUES (?, ?, ?, ?, ?, NOW())", [$sender, $recipient, $subject, $body, $template]);
+            return true;
+        }
+        catch (\Exception $e) {
+            (new SystemLogger())->errorLogCaller("Failed to add email to queue notification error " . $e->getMessage(), ['trace' => $e->getTraceAsString()]);
+        }
+        return false;
+    }
+
+
     public static function emailServiceQueue(string $sender, string $recipient, string $subject, string $body): bool
     {
         if (empty($sender) || empty($recipient) || empty($subject) || empty($body)) {
@@ -72,7 +100,8 @@ class MyMailer extends PHPMailer
     public static function emailServiceRun(): void
     {
         // collect the queue
-        $res = sqlStatement("SELECT `id`, `sender`, `recipient`, `subject`, `body` FROM `email_queue` WHERE `sent` = 0");
+        // TODO: @adunsulag is there a reason we don't use a transaction here to prevent race conditions?
+        $res = sqlStatement("SELECT `id`, `sender`, `recipient`, `subject`, `body`, `template_name` FROM `email_queue` WHERE `sent` = 0");
 
         // send emails in the queue (to avoid race conditions, sent flag is rechecked before sending the email and then quickly set before proceeding to send the email)
         //  (first ensure the email method is properly configured)
@@ -86,22 +115,40 @@ class MyMailer extends PHPMailer
                 sqlStatement("UPDATE `email_queue` SET `sent` = 1, `datetime_sent` = NOW() WHERE `id` = ?", [$ret['id']]);
 
                 if ($emailMethodConfigured) {
-                    $mail = new MyMailer();
-                    $email_subject = $ret['subject'];
-                    $email_sender = $ret['sender'];
-                    $email_address = $ret['recipient'];
-                    $message = $ret['body'];
-                    $mail->AddReplyTo($email_sender, $email_sender);
-                    $mail->SetFrom($email_sender, $email_sender);
-                    $mail->AddAddress($email_address);
-                    $mail->Subject = $email_subject;
-                    $mail->MsgHTML("<html><body><div class='wrapper'>" . text($message) . "</div></body></html>");
-                    $mail->AltBody = $message;
-                    $mail->IsHTML(true);
-                    if (!$mail->Send()) {
-                        sqlStatement("UPDATE `email_queue` SET `error` = 1, `error_message`= ?, , `datetime_error` = NOW() WHERE `id` = ?", [$mail->ErrorInfo, $ret['id']]);
-                        error_log("Failed to send email notification through Mymailer emailServiceRun with error " . errorLogEscape($mail->ErrorInfo));
+                    try {
+                        $twigContainer = new TwigContainer(null, $GLOBALS['kernel']);
+                        $twig = $twigContainer->getTwig();
+                        if (!empty($ret['template_name'])) {
+                            $templateData = json_decode($ret['body'], true);
+                            // we make sure to prefix this so that people have to work inside the openemr namespace for email templates
+                            $htmlBody = $twig->render($ret['template_name'] . ".html.twig", $templateData);
+                            $textBody = $twig->render($ret['template_name'] . ".text.twig", $templateData);
+                        } else {
+                            $htmlBody = $twig->render("emails/system/system-notification.html.twig", ['message' => $ret['body']]);
+                            $textBody = $twig->render("emails/system/system-notification.text.twig", ['message' => $ret['body']]);
+                        }
+
+                        $mail = new MyMailer();
+                        $email_subject = $ret['subject'];
+                        $email_sender = $ret['sender'];
+                        $email_address = $ret['recipient'];
+                        $mail->AddReplyTo($email_sender, $email_sender);
+                        $mail->SetFrom($email_sender, $email_sender);
+                        $mail->AddAddress($email_address);
+                        $mail->Subject = $email_subject;
+                        $mail->MsgHTML($htmlBody);
+                        $mail->AltBody = $textBody;
+                        $mail->IsHTML(true);
+                        if (!$mail->Send()) {
+                            sqlStatement("UPDATE `email_queue` SET `error` = 1, `error_message`= ?, , `datetime_error` = NOW() WHERE `id` = ?", [$mail->ErrorInfo, $ret['id']]);
+                            error_log("Failed to send email notification through Mymailer emailServiceRun with error " . errorLogEscape($mail->ErrorInfo));
+                        }
                     }
+                    catch (\Exception $e) {
+                        (new SystemLogger())->errorLogCaller("Failed to generate email contents for queued email" . $e->getMessage(), ['trace' => $e->getTraceAsString(), 'id' => $ret['id']]);
+                        sqlStatement("UPDATE `email_queue` SET `error` = 1, `error_message`= ?, `datetime_error` = NOW() WHERE `id` = ?", [$e->getMessage(), $ret['id']]);
+                    }
+
                 } else {
                     sqlStatement("UPDATE `email_queue` SET `error` = 1, `error_message`= 'email method is not configured correctly', `datetime_error` = NOW() WHERE `id` = ?", [$ret['id']]);
                     error_log("Failed to send email notification through Mymailer since email method is not configured correctly");

--- a/sql/7_0_1-to-7_0_2_upgrade.sql
+++ b/sql/7_0_1-to-7_0_2_upgrade.sql
@@ -245,6 +245,7 @@ CREATE TABLE recent_patients (
     patients TEXT,
     PRIMARY KEY (user_id)
 ) ENGINE=InnoDB;
+#EndIf
 
 #IfMissingColumn oauth_clients skip_ehr_launch_authorization_flow
 ALTER TABLE `oauth_clients` ADD COLUMN `skip_ehr_launch_authorization_flow` tinyint(1) NOT NULL DEFAULT '0';
@@ -262,4 +263,8 @@ UPDATE `layout_options` SET `seq` = (@seq_start := @seq_start+1)*10 WHERE group_
 SET @seq_add_to = (SELECT seq FROM layout_options WHERE group_id = @group_id AND field_id='suffix' AND form_id='DEM');
 INSERT INTO `layout_options` (`form_id`, `field_id`, `group_id`, `title`, `seq`, `data_type`, `uor`, `fld_length`, `max_length`, `list_id`, `titlecols`, `datacols`, `default_value`, `edit_options`, `description`, `fld_rows`) VALUES ('DEM','preferred_name',@group_id,'Preferred Name',@seq_add_to+5,2,1,32,64,'',1,3,'','[\"J\",\"DAP\"]','Patient preferred name or name patient is commonly known.',0);
 ALTER TABLE `patient_data` ADD `preferred_name` TINYTEXT;
-#Endif
+#EndIf
+
+#IfNotColumn email_queue template_name
+ALTER TABLE `email_queue` ADD `template_name` VARCHAR(255) DEFAULT NULL COMMENT 'The folder prefix and base filename (w/o extension) of the twig template file to use for this email';
+#EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -1529,6 +1529,7 @@ CREATE TABLE `email_queue` (
   `error` tinyint DEFAULT 0,
   `error_message` text,
   `datetime_error` datetime default NULL,
+  `template_name` VARCHAR(255) DEFAULT NULL COMMENT 'The folder prefix and base filename (w/o extension) of the twig template file to use for this email',
 PRIMARY KEY (`id`),
 KEY `sent` (`sent`)
 ) ENGINE=InnoDb AUTO_INCREMENT=1;

--- a/templates/emails/system/system-notification.html.twig
+++ b/templates/emails/system/system-notification.html.twig
@@ -1,0 +1,1 @@
+<html><body><div class='wrapper'>{{ message|text }}</div></body></html>

--- a/templates/emails/system/system-notification.text.twig
+++ b/templates/emails/system/system-notification.text.twig
@@ -1,0 +1,1 @@
+{{ message|text }}


### PR DESCRIPTION
Add a new column to the email queue to hold the template name, we use the email message body to store json details for the twig templates.

Add two vanilla system notification templates.
Fixes #6772 