### PR TITLE
chore(stylelint): specify interface folders with errors

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -13,8 +13,17 @@ public/themes/**/*.scss
 swagger/**/*.css
 swagger/**/*.scss
 coverage/**/*.css
+coverage/**/*.scss
 
 # To be fixed and removed from this list
 gacl/**/*.css
-interface/**/*.css
-interface/**/*.scss
+interface/forms/**/*.css
+interface/forms/**/*.scss
+interface/main/**/*.css
+interface/main/**/*.scss
+interface/modules/**/*.css
+interface/modules/**/*.scss
+interface/super/**/*.css
+interface/super/**/*.scss
+interface/themes/**/*.css
+interface/themes/**/*.scss


### PR DESCRIPTION
Specifying interface folders with errors, so they can be separately fixed in future changes. This also reincorporates folders without errors in the stylelint analysis, so they can be monitored for errors from now on.