### PR TITLE
Fixes #6781 hide overlay on external domain

### DIFF
--- a/interface/main/tabs/js/custom_bindings.js
+++ b/interface/main/tabs/js/custom_bindings.js
@@ -78,6 +78,10 @@ ko.bindingHandlers.location={
                             tabData.title(titleText);
                         }
                     );
+                } else {
+                    // need to cancel the loading if we are on another domain
+                    // setting the title will hide the spinner and remove the Loading... text
+                    tabData.title(xl("Unknown"));
                 }
             } ,true
         );

--- a/oauth2/smart/ehr-launch-autosubmit.html.twig
+++ b/oauth2/smart/ehr-launch-autosubmit.html.twig
@@ -1,4 +1,7 @@
 <html>
+<head>
+    <title>{{ "Launching Application"|xlt }}</title>
+</head>
 <body>
 <form method="POST" action="{{ endpoint }}">
     {# Do we want to show any kind of message...? For satellite or slow latency connections... we'd want to show something here. #}


### PR DESCRIPTION
Fixed the menu item to hide the overlay on the external domain.

I still don't like that it sets the title to unknown but without some heavier refactoring to populate a default label as defined in the menu system there's not a lot that can be done here.

Fixes #6781