### PR TITLE
refactor(ccdaservice): extract and test cleanCode function

### DIFF
--- a/ccdaservice/serveccda.js
+++ b/ccdaservice/serveccda.js
@@ -17,6 +17,7 @@ const to_json = require('xmljson').to_json;
 const bbg = require(__dirname + '/oe-blue-button-generate');
 const fs = require('fs');
 const DataStack = require('./data-stack/data-stack').DataStack;
+const cleanCode = require('./utils/clean-code/clean-code').cleanCode;
 
 var conn = ''; // make our connection scope global to script
 var oidFacility = "";
@@ -114,17 +115,6 @@ function getPrecision(str) {
 
 function templateDate(date, precision) {
     return {'date': fDate(date), 'precision': precision}
-}
-
-function cleanCode(code) {
-    if (typeof code === 'undefined') {
-        return "null_flavor";
-    }
-    if (code.length < 1) {
-        code = "null_flavor";
-        return code;
-    }
-    return code.replace(/[.#]/, "");
 }
 
 function isOne(who) {

--- a/ccdaservice/utils/clean-code/clean-code.js
+++ b/ccdaservice/utils/clean-code/clean-code.js
@@ -1,0 +1,9 @@
+const NULL_FLAVOR = require('../constants').NULL_FLAVOR;
+
+function cleanCode(code) {
+    return typeof code === 'undefined' || code.length < 1
+        ? NULL_FLAVOR
+        : code.replace(/[.#]/, '');
+}
+
+exports.cleanCode = cleanCode;

--- a/ccdaservice/utils/clean-code/clean-code.spec.js
+++ b/ccdaservice/utils/clean-code/clean-code.spec.js
@@ -1,0 +1,23 @@
+const cleanCode = require('./clean-code').cleanCode;
+const NULL_FLAVOR = require('../constants').NULL_FLAVOR;
+
+describe('cleanCode', () => {
+    it('should return NULL_FLAVOR for undefined input', () => {
+        expect(cleanCode()).toEqual(NULL_FLAVOR);
+    });
+
+    it('should return NULL_FLAVOR for input with length < 1', () => {
+        expect(cleanCode('')).toEqual(NULL_FLAVOR);
+    });
+
+    it('should remove . and # characters from input for input with length > 1',  () => {
+        expect(cleanCode('.A')).toEqual('A');
+        expect(cleanCode('A.')).toEqual('A');
+        expect(cleanCode('A.B')).toEqual('AB');
+        expect(cleanCode('A..B')).toEqual('A.B');
+        expect(cleanCode('#A')).toEqual('A');
+        expect(cleanCode('A#')).toEqual('A');
+        expect(cleanCode('A#B')).toEqual('AB');
+        expect(cleanCode('A##B')).toEqual('A#B');
+    });
+});

--- a/ccdaservice/utils/constants.js
+++ b/ccdaservice/utils/constants.js
@@ -1,0 +1,1 @@
+exports.NULL_FLAVOR = 'null_flavor';


### PR DESCRIPTION
- extract cleanCode function to a separate file
- add tests
- create constant NULL_FLAVOR

The constant allows us to reuse the value without having to type it repeatedly, which is error-prone. It also simplifies the process of updating the value, if needed in the future.