### PR TITLE
feat: Improve clinical note report UI

### DIFF
--- a/interface/forms/clinical_notes/report.php
+++ b/interface/forms/clinical_notes/report.php
@@ -17,6 +17,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Services\ClinicalNotesService;
 
 require_once(__DIR__ . "/../../globals.php");
@@ -31,38 +32,13 @@ function clinical_notes_report($pid, $encounter, $cols, $id)
         return $val['activity'] == ClinicalNotesService::ACTIVITY_ACTIVE;
     });
 
-    if ($data) {
-        ?>
-        <table class="table w-100">
-            <thead>
-            <tr>
-                <th class="border p-1"><?php echo xlt('Date'); ?></th>
-                <th class="border p-1"><?php echo xlt('Note Type'); ?></th>
-                <th class="border p-1"><?php echo xlt('Narrative'); ?></th>
-                <th class="border p-1"><?php echo xlt('Author'); ?></th>
-                <th class="border p-1"><?php echo xlt('Note Category'); ?></th>
-                <th class="border p-1"><?php echo xlt('Code'); ?></th>
-            </tr>
-            </thead>
-            <tbody>
-            <?php
-            foreach ($data as $key => $value) {
-                ?>
-                <tr>
-                    <td class="border p-1"><span class='text'><?php echo text($value['date']); ?></span></td>
-                    <td class="border p-1"><span class='text text-wrap'><?php echo text($value['codetext']); ?></span></td>
-                    <td class="border p-1"><span class='text'><?php echo text($value['description']); ?></span></td>
-                    <td class="border p-1"><span class='text'><?php echo text($value['user']); ?></span></td>
-                    <td class="border p-1"><span class='text text-wrap'><?php echo text($value['category_title']); ?></span></td>
-                    <td class="border p-1"><span class='text'><?php echo text($value['code']); ?></span></td>
-                </tr>
-                <?php
-            }
-            ?>
-            </tbody>
-        </table>
-        <?php
-    }
+    $viewArgs = [
+        'notes' => $data
+    ];
+
+    $twig = new TwigContainer(__DIR__, $GLOBALS['kernel']);
+    $t = $twig->getTwig();
+    echo $t->render('templates/report.html.twig', $viewArgs);
 }
 
 ?>

--- a/interface/forms/clinical_notes/templates/report.html.twig
+++ b/interface/forms/clinical_notes/templates/report.html.twig
@@ -1,0 +1,31 @@
+<div class="w-100">
+    {% for n in notes %}
+        <div class="d-flex justify-content-between bg-light border border-dark p-1">
+            <div class="form-group mb-0">
+                <div class="font-weight-bold">{{ "Date"|xlt }}</div>
+                <div>{{ n.date|date() }}</div>
+            </div>
+            <div class="form-group mb-0">
+                <div class="font-weight-bold">{{ "Type"|xlt }}</div>
+                <div>{{ n.codetext|default("Unspecified"|xl)|text }}</div>
+            </div>
+            <div class="form-group mb-0">
+                <div class="font-weight-bold">{{ "Category"|text }}</div>
+                <div>{{ n.clinical_notes_category|default("Unspecified"|xl)|text }}</div>
+            </div>
+            <div class="form-group mb-0">
+                <div class="font-weight-bold">{{ "Author"|xlt }}</div>
+                <div>{{ n.user|text }}</div>
+            </div>
+            {% if n.code %}
+            <div class="form-group mb-0">
+                <div class="font-weight-bold">{{ "Code"|xlt }}</div>
+                <div>{{ n.code|text }}</div>
+            </div>
+            {% endif %}
+        </div>
+        <div>
+            {{ n.description|text|nl2br }}
+        </div>
+    {% endfor %}
+</div>


### PR DESCRIPTION
Move clinical note report view to Twig. Improve the UI by dropping tables in favor of a more content-focused layout. Also introduce `nl2br` to the note content as status quo did not respect line breaks.

# Before
![image](https://github.com/openemr/openemr/assets/1381170/2d88a4aa-897a-4352-bbe8-73b20f1d4065)

# After
![image](https://github.com/openemr/openemr/assets/1381170/536e9752-29e9-41ef-b146-ead99e218021)
