### PR TITLE
refactor(registration-modal): improve button colors

### DIFF
--- a/templates/core/about.html.twig
+++ b/templates/core/about.html.twig
@@ -109,8 +109,8 @@
                     <p class="message font-italic"></p>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary submit">{{ "Submit"|xlt }}</button>
-                    <button type="button" class="btn btn-secondary nothanks">{{ "No Thanks"|xlt }}</button>
+                    <button type="button" class="btn btn-primary submit">{{ "Submit"|xlt }}</button>
+                    <button type="button" class="btn btn-light nothanks">{{ "No Thanks"|xlt }}</button>
                 </div>
             </div>
         </div>

--- a/templates/core/about.html.twig
+++ b/templates/core/about.html.twig
@@ -110,7 +110,7 @@
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-primary submit">{{ "Submit"|xlt }}</button>
-                    <button type="button" class="btn btn-light nothanks">{{ "No Thanks"|xlt }}</button>
+                    <button type="button" class="btn btn-secondary nothanks">{{ "No Thanks"|xlt }}</button>
                 </div>
             </div>
         </div>

--- a/templates/login/login_core.html.twig
+++ b/templates/login/login_core.html.twig
@@ -188,8 +188,8 @@
                         <p class="message font-italic"></p>
                     </div>
                     <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary submit">{{ "Submit"|xlt }}</button>
-                        <button type="button" class="btn btn-secondary nothanks">{{ "No Thanks"|xlt }}</button>
+                        <button type="button" class="btn btn-primary submit">{{ "Submit"|xlt }}</button>
+                        <button type="button" class="btn btn-light nothanks">{{ "No Thanks"|xlt }}</button>
                     </div>
                 </div>
             </div>

--- a/templates/login/login_core.html.twig
+++ b/templates/login/login_core.html.twig
@@ -189,7 +189,7 @@
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-primary submit">{{ "Submit"|xlt }}</button>
-                        <button type="button" class="btn btn-light nothanks">{{ "No Thanks"|xlt }}</button>
+                        <button type="button" class="btn btn-secondary nothanks">{{ "No Thanks"|xlt }}</button>
                     </div>
                 </div>
             </div>

--- a/templates/login/partials/html/product_registration_modal.html.twig
+++ b/templates/login/partials/html/product_registration_modal.html.twig
@@ -20,8 +20,8 @@ Product Registration modal
                 <p class="message font-italic"></p>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-secondary submit">{{ "Submit"|xlt }}</button>
-                <button type="button" class="btn btn-secondary nothanks">{{ "No Thanks"|xlt }}</button>
+                <button type="button" class="btn btn-primary submit">{{ "Submit"|xlt }}</button>
+                <button type="button" class="btn btn-light nothanks">{{ "No Thanks"|xlt }}</button>
             </div>
         </div>
     </div>

--- a/templates/login/partials/html/product_registration_modal.html.twig
+++ b/templates/login/partials/html/product_registration_modal.html.twig
@@ -21,7 +21,7 @@ Product Registration modal
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-primary submit">{{ "Submit"|xlt }}</button>
-                <button type="button" class="btn btn-light nothanks">{{ "No Thanks"|xlt }}</button>
+                <button type="button" class="btn btn-secondary nothanks">{{ "No Thanks"|xlt }}</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This is a proposal to change the colors of the buttons inside the registration modal:

![image](https://github.com/openemr/openemr/assets/22417165/3bb1c024-1f46-49e3-b1a9-7dbe5d351a1a)

This change has two purposes:
- provide better differentiation between the buttons
- grab the user's attention and highlight the action we want to encourage

This is a common UI pattern for CTAs

[Update]: following feedback by @robertdown, the "No Thanks" button will keep the `btn-secondary` class.