### PR TITLE
fix: promote $groupId in EncounterFormsListRenderEvent.php constructor

### DIFF
--- a/src/Events/Encounter/EncounterFormsListRenderEvent.php
+++ b/src/Events/Encounter/EncounterFormsListRenderEvent.php
@@ -26,11 +26,13 @@ class EncounterFormsListRenderEvent
     const EVENT_SECTION_RENDER_POST = "forms.encounter.list.render.post";
 
     public function __construct(
-        /** @var int|null The encounter id that the encounter is for (matches the forms.encounter db id)  */
+        /** @var int|null The encounter id that the encounter is for (matches the forms.encounter db id) */
         private ?int $encounter = null,
+        /** @var string $attendantType 'gid' or 'pid' The type of encounter that is being rendered, a group encounter (gid), or an individual patient encounter (pid) */
         private string $attendantType = 'pid',
         /** @var int|null The patient pid that the encounter is for (matches the patient_data.pid column) */
         private ?int $pid = null,
+        /** @var int|null $groupId The group id that the encounter is for */
         private ?int $groupId = null
     ) {
     }


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #6815 

#### Short description of what this resolves:
fix deprecation php

#### Changes proposed in this pull request:
if [this guide](https://stitcher.io/blog/constructor-promotion-in-php-8) is correct, can use property promotion in the constructor to fix this and other going forward