### PR TITLE
Bug openemr fix #6820 fax api call

### DIFF
--- a/interface/modules/custom_modules/oe-module-faxsms/openemr.bootstrap.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/openemr.bootstrap.php
@@ -238,7 +238,7 @@ if ($allowSMSButtons) {
     $eventDispatcher->addListener(SendSmsEvent::JAVASCRIPT_READY_SMS_POST, 'oe_module_faxsms_sms_render_javascript_post_load');
 }
 
-if (!empty($_SESSION['session_database_uuid'] ?? null) && $allowSMS) {
+if (!(empty($_SESSION['authUserID'] ?? null) && ($_SESSION['pid'] ?? null)) && $allowSMS) {
     $eventDispatcher->addListener(SendNotificationEvent::SEND_NOTIFICATION_BY_SERVICE, [new NotificationEventListener(), 'onNotifyEvent']);
 }
 $eventDispatcher->addListener(SendNotificationEvent::ACTIONS_RENDER_NOTIFICATION_POST, 'notificationButton');

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php
@@ -83,7 +83,7 @@ class NotificationEventListener implements EventSubscriberInterface
         $to = $email;
         $to_name = $email;
         $mail->AddAddress($to, $to_name);
-        $subject = xlt("Your clinic ask for your attention.");
+        $subject = xlt("Your clinic asks for your attention.");
         $mail->Subject = $subject;
         $mail->Body = $body;
         if (!empty($file)) {


### PR DESCRIPTION
Fixes #6820 

Fixed it so that if you fire the SendNotificationEvent event inside an API
call it will no longer be silently ignored in the fax/sms module.

Changed the module to use the user_id or pid in the session as a
determinant of the session being populated instead of the
session_database_uuid.

Fixed spelling error in the email subject being sent.