### PR TITLE
feat: Fixes #6839 show mfa shared secret

### DIFF
--- a/interface/usergroup/mfa_totp.php
+++ b/interface/usergroup/mfa_totp.php
@@ -185,6 +185,8 @@ $user_full_name = $user_name['fname'] . " " . $user_name['lname'];
                                             <br />
                                             <img src="<?php echo attr($qr); ?>" class="img-responsive center-block" style="height:200px !Important"/>
                                             <br />
+                                            <p><?php echo xlt("Or paste in the following code into your authenticator app"); ?></p>
+                                            <p><?php echo $mfaAuth->getSecret(); ?></p>
                                             <p><?php echo xlt('Example authenticator apps include'); ?></p>:
                                             <div class="col-sm-4 offset-sm-4">
                                                 <ul>

--- a/library/classes/Installer.class.php
+++ b/library/classes/Installer.class.php
@@ -490,6 +490,7 @@ class Installer
 
     /**
      * Generates the initial user's 2FA QR Code
+     * @deprecated Recommended to use get_initial_user_mfa_totp() instead
      * @return bool|string|void
      */
     public function get_initial_user_2fa_qr()
@@ -498,6 +499,19 @@ class Installer
             $adminTotp = new Totp($this->i2faSecret, $this->iuser);
             $qr = $adminTotp->generateQrCode();
             return $qr;
+        }
+        return false;
+    }
+
+    /**
+     * Generates the initial user's 2FA QR Code
+     * @return bool|string|void
+     */
+    public function get_initial_user_mfa_totp()
+    {
+        if (($this->i2faEnable) && (!empty($this->i2faSecret)) && (class_exists('Totp'))) {
+            $adminTotp = new Totp($this->i2faSecret, $this->iuser);
+            return $adminTotp;
         }
         return false;
     }

--- a/setup.php
+++ b/setup.php
@@ -1375,9 +1375,11 @@ STP2TBLBOT;
                     }
 
                     // If user has selected to set MFA App Based 2FA, display QR code to scan
-                    $qr = $installer->get_initial_user_2fa_qr();
-                    $qr_esc = attr($qr);
-                    if ($qr) {
+                    $mfa = $installer->get_initial_user_mfa_totp();
+                    if ($mfa !== false) {
+                        $qr = $mfa->generateQrCode();
+                        $qr_esc = attr($qr);
+                        $sharedSecret = text($mfa->getSecret());
                         $qrDisplay = <<<TOTP
                                     <br />
                                     <table>
@@ -1386,6 +1388,8 @@ STP2TBLBOT;
                                                 <strong class='text-danger'>IMPORTANT!!</strong>
                                                 <p><strong>You must scan the following QR code with your preferred authenticator app.</strong></p>
                                                 <img src='$qr_esc' width="150" />
+                                                <p>Or paste in the following code into your authenticator app</p>
+                                                <p>$sharedSecret</p>
                                             </td>
                                         </tr>
                                         <tr>


### PR DESCRIPTION
In order to use a non-qr type TOTP code we need to show the shared secret when going to add the code.

Fixes #6839 