### PR TITLE
refactor(ccdaservice): test and refactor populateProvider function

### DIFF
--- a/ccdaservice/utils/providers/providers.js
+++ b/ccdaservice/utils/providers/providers.js
@@ -1,0 +1,59 @@
+const { fDate } = require('../date/date');
+const { cleanCode } = require('../clean-code/clean-code');
+const { NOT_INFORMED } = require('../constants');
+
+function populateProvider(provider, documentData) {
+    const oidFacility =
+        documentData?.encounter_provider?.facility_oid ||
+        '2.16.840.1.113883.19.5.99999.1';
+    // The provider role is a maybe and will only be provided for physicians as a
+    // primary care role. All other team members will id via taxonomy only and if not physicians.
+    return {
+        function_code: provider.physician_type ? 'PP' : '',
+        date_time: {
+            low: {
+                date: fDate(provider.provider_since || ''),
+                precision: 'tz',
+            },
+        },
+        identity: [
+            {
+                root: provider.npi ? '2.16.840.1.113883.4.6' : oidFacility,
+                extension: provider.npi || provider.table_id || NOT_INFORMED,
+            },
+        ],
+        type: [
+            {
+                name: provider.taxonomy_description || '',
+                code: cleanCode(provider.taxonomy) || '',
+                code_system: '2.16.840.1.113883.6.101',
+                code_system_name: 'NUCC Health Care Provider Taxonomy',
+            },
+        ],
+        name: [
+            {
+                last: provider.lname || '',
+                first: provider.fname || '',
+            },
+        ],
+        address: [
+            {
+                street_lines: [documentData.encounter_provider.facility_street],
+                city: documentData.encounter_provider.facility_city,
+                state: documentData.encounter_provider.facility_state,
+                zip: documentData.encounter_provider.facility_postal_code,
+                country:
+                    documentData.encounter_provider.facility_country_code ||
+                    'US',
+            },
+        ],
+
+        phone: [
+            {
+                number: documentData.encounter_provider.facility_phone || '',
+            },
+        ],
+    };
+}
+
+exports.populateProvider = populateProvider;

--- a/ccdaservice/utils/providers/providers.mock.js
+++ b/ccdaservice/utils/providers/providers.mock.js
@@ -1,0 +1,157 @@
+const { NOT_INFORMED, NULL_FLAVOR } = require("../constants");
+
+const TODAY = '2021-04-10T18:55:55.301Z';
+
+const documentData = {
+    encounter_provider: {
+        facility_oid: 'mock_facility_oid',
+        facility_street: 'mock_facility_street',
+        facility_city: 'mock_facility_city',
+        facility_state: 'mock_facility_state',
+        facility_postal_code: 'mock_facility_postal_code',
+        facility_country_code: 'mock_facility_country_code',
+        facility_phone: 'mock_facility_phone',
+    },
+};
+
+const provider = {
+    physician_type: 'mock_physician_type',
+    provider_since: '07/05/2010',
+    npi: 'mock_npi',
+    taxonomy: 'mock_taxonomy',
+    taxonomy_description: 'mock_taxonomy_description',
+    fname: 'mock_provider_fname',
+    lname: 'mock_provider_lname',
+};
+
+const providerResult = {
+    address: [
+        {
+            city: documentData.encounter_provider.facility_city,
+            country: documentData.encounter_provider.facility_country_code,
+            state: documentData.encounter_provider.facility_state,
+            street_lines: [documentData.encounter_provider.facility_street],
+            zip: documentData.encounter_provider.facility_postal_code,
+        },
+    ],
+    date_time: {
+        low: {
+            date: '2010-07-05',
+            precision: 'tz',
+        },
+    },
+    function_code: 'PP',
+    identity: [
+        {
+            extension: provider.npi,
+            root: '2.16.840.1.113883.4.6',
+        },
+    ],
+    name: [
+        {
+            first: provider.fname,
+            last: provider.lname,
+        },
+    ],
+    phone: [
+        {
+            number: documentData.encounter_provider.facility_phone,
+        },
+    ],
+    type: [
+        {
+            code: provider.taxonomy,
+            code_system: '2.16.840.1.113883.6.101',
+            code_system_name: 'NUCC Health Care Provider Taxonomy',
+            name: provider.taxonomy_description,
+        },
+    ],
+};
+
+const PROVIDER_TEST_DATA = [
+    [
+        // INPUT
+        provider,
+        documentData,
+        // RESULT
+        providerResult,
+    ],
+    [
+        // INPUT
+        {
+            ...provider,
+            npi: undefined,
+            table_id: undefined,
+        },
+        documentData,
+        // RESULT
+        {
+            ...providerResult,
+            identity: [
+                {
+                    extension: NOT_INFORMED,
+                    root: documentData.encounter_provider.facility_oid,
+                },
+            ],
+        },
+    ],
+    [
+        // INPUT
+        {
+            ...provider,
+            table_id: 'mock_table_id',
+            physician_type: undefined,
+            provider_since: undefined,
+            npi: undefined,
+            taxonomy: undefined,
+            taxonomy_description: undefined,
+            fname: undefined,
+            lname: undefined,
+        },
+        {
+            encounter_provider: {
+                ...documentData.encounter_provider,
+                facility_oid: undefined,
+                facility_country_code: undefined,
+                facility_phone: undefined,
+            },
+        },
+        // RESULT
+        {
+            address: [
+                {
+                    city: documentData.encounter_provider.facility_city,
+                    country: 'US',
+                    state: documentData.encounter_provider.facility_state,
+                    street_lines: [
+                        documentData.encounter_provider.facility_street,
+                    ],
+                    zip: documentData.encounter_provider.facility_postal_code,
+                },
+            ],
+            date_time: {
+                low: { date: TODAY, precision: 'tz' },
+            },
+            function_code: '',
+            identity: [
+                {
+                    extension: 'mock_table_id',
+                    root: '2.16.840.1.113883.19.5.99999.1',
+                },
+            ],
+            name: [{ first: '', last: '' }],
+            phone: [{ number: '' }],
+            type: [
+                {
+                    code: NULL_FLAVOR,
+                    code_system: '2.16.840.1.113883.6.101',
+                    code_system_name: 'NUCC Health Care Provider Taxonomy',
+                    name: '',
+                },
+            ],
+        },
+    ],
+];
+
+exports.TODAY = TODAY;
+exports.PROVIDER_TEST_DATA = PROVIDER_TEST_DATA;

--- a/ccdaservice/utils/providers/providers.spec.js
+++ b/ccdaservice/utils/providers/providers.spec.js
@@ -1,0 +1,19 @@
+const { populateProvider } = require('./providers');
+const { PROVIDER_TEST_DATA, TODAY } = require('./providers.mock');
+
+describe('populateProvider', () => {
+    beforeAll(() => {
+        jest.useFakeTimers().setSystemTime(new Date(TODAY));
+    });
+
+    test.each(PROVIDER_TEST_DATA)(
+        'should map the input data to a provider info',
+        (provider, documentData, result) => {
+            expect(populateProvider(provider, documentData)).toEqual(result);
+        }
+    );
+
+    afterAll(() => {
+        jest.useRealTimers();
+    });
+});

--- a/ccdaservice/utils/providers/providers.spec.js
+++ b/ccdaservice/utils/providers/providers.spec.js
@@ -7,7 +7,7 @@ describe('populateProvider', () => {
     });
 
     test.each(PROVIDER_TEST_DATA)(
-        'should map the input data to a provider info',
+        'should map the input data to provider data object',
         (provider, documentData, result) => {
             expect(populateProvider(provider, documentData)).toEqual(result);
         }


### PR DESCRIPTION
With this one, we finally reach 1% coverage :partying_face: 

![image](https://github.com/openemr/openemr/assets/22417165/248322f8-0c3a-4d01-bfb2-8bc489474c12)
