### PR TITLE
Improve look and feel for highlighting items for custom color themes

### DIFF
--- a/interface/patient_file/download_template.php
+++ b/interface/patient_file/download_template.php
@@ -65,6 +65,7 @@ function dataFixup($data, $title = '')
         $data = str_replace('&', '[and]', $data);
         $data = str_replace('<', '[less]', $data);
         $data = str_replace('>', '[greater]', $data);
+        $data = str_replace("\r\n", '<text:line-break />', $data);
         // If in a group, include labels and separators.
         if ($groupLevel) {
             if ($title !== '') {

--- a/interface/themes/color_base.scss
+++ b/interface/themes/color_base.scss
@@ -161,11 +161,13 @@ $fa-font-path: "../assets/@fortawesome/fontawesome-free/webfonts";
 }
 
 .address_names:hover {
-  color: #f0f !important;
+  background: $darker !important;
+  color: $paler !important;
 }
 
 .highlight {
-  color: #f0f !important;
+  background: $darkest !important;
+  color: $paler !important;
 }
 
 #reports_list td,


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #6865 and #6868

#### Short description of what this resolves:
Actually, when you hover over an item, it will highlight it, by changing text color to #F0F (pink), I am proposing to set background to $darker color set in custom theme and set color (text) to $paler. This will contrast enough and will improve look and feel.

Also when we use a textarea field on any form and we save some line breaks, like if we create a numbered list, and we generate a patient document template forms the line breaks will switch to a single line.00

#### Changes proposed in this pull request:
Set background to address_names hover and highlight.
Add a dataFixup to convert \r\n to an instruction that openwriter will interpret as a line break.
