### PR TITLE
fix: line breaks in textarea fields - when fetching data to a patient document template

### DIFF
--- a/interface/patient_file/download_template.php
+++ b/interface/patient_file/download_template.php
@@ -65,6 +65,7 @@ function dataFixup($data, $title = '')
         $data = str_replace('&', '[and]', $data);
         $data = str_replace('<', '[less]', $data);
         $data = str_replace('>', '[greater]', $data);
+        $data = str_replace('\r\n','<text:line-break />', $data);
         // If in a group, include labels and separators.
         if ($groupLevel) {
             if ($title !== '') {

--- a/interface/themes/color_base.scss
+++ b/interface/themes/color_base.scss
@@ -161,11 +161,13 @@ $fa-font-path: "../assets/@fortawesome/fontawesome-free/webfonts";
 }
 
 .address_names:hover {
-  color: #f0f !important;
+  background: $darker !important;
+  color: $paler !important;
 }
 
 .highlight {
-  color: #f0f !important;
+  background: $darkest !important;
+  color: $paler !important;
 }
 
 #reports_list td,


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #6868

#### Short description of what this resolves:
Line break fix for textarea field when creating a patient document template forms
#### Changes proposed in this pull request:
Add a fataFixup line to convert \r\n to linebreak that can interpret OpenDocument writer.