### PR TITLE
fix: line breaks in textarea fields - when fetching data to a patient document template

### DIFF
--- a/interface/patient_file/download_template.php
+++ b/interface/patient_file/download_template.php
@@ -59,13 +59,15 @@ function keyReplace(&$s, $data)
 // Do some final processing of field data before it's put into the document.
 function dataFixup($data, $title = '')
 {
-    global $groupLevel, $groupCount, $itemSeparator;
+    global $groupLevel, $groupCount, $itemSeparator, $ext;
     if ($data !== '') {
         // Replace some characters that can mess up XML without assuming XML content type.
         $data = str_replace('&', '[and]', $data);
         $data = str_replace('<', '[less]', $data);
         $data = str_replace('>', '[greater]', $data);
-        $data = str_replace('\r\n', '<text:line-break />', $data);
+        if ($ext == 'odt') {
+            $data = str_replace("\r\n", "<text:line-break />", $data);
+        }
         // If in a group, include labels and separators.
         if ($groupLevel) {
             if ($title !== '') {
@@ -108,7 +110,7 @@ function getIssues($type)
 function doSubs($s)
 {
     global $ptrow, $hisrow, $enrow, $nextLocation, $keyLocation, $keyLength;
-    global $groupLevel, $groupCount, $itemSeparator, $pid, $encounter;
+    global $groupLevel, $groupCount, $itemSeparator, $pid, $encounter, $ext;
 
     $nextLocation = 0;
     $groupLevel   = 0;

--- a/interface/patient_file/download_template.php
+++ b/interface/patient_file/download_template.php
@@ -65,7 +65,7 @@ function dataFixup($data, $title = '')
         $data = str_replace('&', '[and]', $data);
         $data = str_replace('<', '[less]', $data);
         $data = str_replace('>', '[greater]', $data);
-        $data = str_replace('\r\n','<text:line-break />', $data);
+        $data = str_replace('\r\n', '<text:line-break />', $data);
         // If in a group, include labels and separators.
         if ($groupLevel) {
             if ($title !== '') {

--- a/interface/patient_file/download_template.php
+++ b/interface/patient_file/download_template.php
@@ -65,6 +65,7 @@ function dataFixup($data, $title = '')
         $data = str_replace('&', '[and]', $data);
         $data = str_replace('<', '[less]', $data);
         $data = str_replace('>', '[greater]', $data);
+        $data = str_replace('\r\n','<text:line-break />', $data);
         // If in a group, include labels and separators.
         if ($groupLevel) {
             if ($title !== '') {


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #6868

#### Short description of what this resolves:
Textarea fields of forms containing line breaks will shown as they are saved when generating a patient document template.

#### Changes proposed in this pull request:
add a dataFixup that sends text:line-break as required by OpenDocument writer.