### PR TITLE
fix: highlight when using custom theme shows text colored pink  (https://github.com/openemr/openemr/issues/6865)

### DIFF
--- a/interface/themes/color_base.scss
+++ b/interface/themes/color_base.scss
@@ -161,11 +161,13 @@ $fa-font-path: "../assets/@fortawesome/fontawesome-free/webfonts";
 }
 
 .address_names:hover {
-  color: #f0f !important;
+  background: $darker !important;
+  color: $paler !important;
 }
 
 .highlight {
-  color: #f0f !important;
+  background: $darkest !important;
+  color: $paler !important;
 }
 
 #reports_list td,


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #6865

#### Short description of what this resolves:
Sets highlight according to custom color palette when using styles with customized colors.

#### Changes proposed in this pull request:
Add backgrpund based on color palette to make it contrast (darker background and pale text)