### PR TITLE
fix: Return only active clinical note types and categories by default

### DIFF
--- a/src/Services/ClinicalNotesService.php
+++ b/src/Services/ClinicalNotesService.php
@@ -344,17 +344,19 @@ class ClinicalNotesService extends BaseService
         return !empty($options);
     }
 
-    public function getClinicalNoteTypes()
+    public function getClinicalNoteTypes($includeInactive = false)
     {
         $listService = new ListService();
-        $options = $listService->getOptionsByListName('Clinical_Note_Type');
+        $search = ($includeInactive) ? [] :  ['activity' => '1'];
+        $options = $listService->getOptionsByListName('Clinical_Note_Type', $search);
         return $this->getListAsSelectList($options);
     }
 
-    public function getClinicalNoteCategories()
+    public function getClinicalNoteCategories($includeInactive = false)
     {
         $listService = new ListService();
-        $options = $listService->getOptionsByListName('Clinical_Note_Category');
+        $search = ($includeInactive) ? [] :  ['activity' => '1'];
+        $options = $listService->getOptionsByListName('Clinical_Note_Category', $search);
         return $this->getListAsSelectList($options);
     }
 


### PR DESCRIPTION
Resolves both #6907 and #6908 

This changes the default behavior of the two relevant functions in the ClinicalNotesService by assuming the request is for active list options only. Can pass `true` to the function (Setting `$includeInactive`) which will return all options