### PR TITLE
fix parsing of response from NewCrop

### DIFF
--- a/interface/eRxSOAP.php
+++ b/interface/eRxSOAP.php
@@ -31,8 +31,11 @@ class eRxSOAP
     private $soapSettings = array();
     private $siteId;
 
-    protected static function fixHtmlEntities($array, $xmltoarray) {
-        if (!is_array($array)) return;
+    protected static function fixHtmlEntities($array, $xmltoarray)
+    {
+        if (!is_array($array)) {
+            return;
+        }
 
         foreach ($array as $key => $value) {
             if (is_array($value)) {

--- a/interface/eRxSOAP.php
+++ b/interface/eRxSOAP.php
@@ -31,19 +31,11 @@ class eRxSOAP
     private $soapSettings = array();
     private $siteId;
 
-    protected static function fixHtmlEntities(&$array, $xmltoarray)
+    protected static function fixHtmlEntities($array, $xmltoarray)
     {
-        if (!is_array($array)) {
-            return;
-        }
-
-        foreach ($array as $key => $value) {
-            if (is_array($value)) {
-                self::fixHtmlEntities($value, $xmltoarray);
-            } else {
-                $array[$key] = $xmltoarray->fix_html_entities($value);      //returns proper html values
-            }
-        }
+        $encoded = json_encode($array);
+        $fixed = $xmltoarray->fix_html_entities($encoded);
+        return json_decode($fixed, true);
     }
 
     /**
@@ -62,7 +54,7 @@ class eRxSOAP
 
         $array = $xmltoarray->createArray();                            //creates an array with fixed html values
 
-        self::fixHtmlEntities($array, $xmltoarray);
+        $array = self::fixHtmlEntities($array, $xmltoarray);
 
         if (array_key_exists('NewDataSet', $array) && array_key_exists('Table', $array['NewDataSet'])) {
             $array = $array['NewDataSet']['Table'];

--- a/interface/eRxSOAP.php
+++ b/interface/eRxSOAP.php
@@ -31,7 +31,7 @@ class eRxSOAP
     private $soapSettings = array();
     private $siteId;
 
-    protected static function fixHtmlEntities($array, $xmltoarray)
+    protected static function fixHtmlEntities(&$array, $xmltoarray)
     {
         if (!is_array($array)) {
             return;

--- a/interface/eRxSOAP.php
+++ b/interface/eRxSOAP.php
@@ -31,6 +31,18 @@ class eRxSOAP
     private $soapSettings = array();
     private $siteId;
 
+    protected static function fixHtmlEntities($array, $xmltoarray) {
+        if (!is_array($array)) return;
+
+        foreach ($array as $key => $value) {
+            if (is_array($value)) {
+                self::fixHtmlEntities($value, $xmltoarray);
+            } else {
+                $array[$key] = $xmltoarray->fix_html_entities($value);      //returns proper html values
+            }
+        }
+    }
+
     /**
      * Repair HTML/XML and return array
      * @param  string        $xml XML for processing
@@ -47,9 +59,7 @@ class eRxSOAP
 
         $array = $xmltoarray->createArray();                            //creates an array with fixed html values
 
-        foreach ($array as $key => $value) {
-            $array[$key] = $xmltoarray->fix_html_entities($value);      //returns proper html values
-        }
+        self::fixHtmlEntities($array, $xmltoarray);
 
         if (array_key_exists('NewDataSet', $array) && array_key_exists('Table', $array['NewDataSet'])) {
             $array = $array['NewDataSet']['Table'];

--- a/interface/eRxXMLBuilder.php
+++ b/interface/eRxXMLBuilder.php
@@ -735,7 +735,8 @@ class eRxXMLBuilder
                         $element->appendChild($this->createElementText('diagnosisType', $codeType));
 
                         if ($diagnosis['begdate']) {
-                            $element->appendChild($this->createElementText('onsetDate', str_replace("-", "", $diagnosis['begdate'])));
+                            $onsetDate = new DateTime($diagnosis['begdate']);
+                            $element->appendChild($this->createElementText('onsetDate', date_format($onsetDate, 'Ymd')));
                         }
 
                         if ($diagnosis['title']) {

--- a/interface/eRxXMLBuilder.php
+++ b/interface/eRxXMLBuilder.php
@@ -722,26 +722,33 @@ class eRxXMLBuilder
                 // explode() will return an array containing the individual diagnosis if there is no semicolon
                 $multiple = explode(";", $diagnosis['diagnosis']);
                 foreach ($multiple as $individual) {
-                    $element = $this->getDocument()->createElement('PatientDiagnosis');
                     $res = explode(":", $individual); //split diagnosis type and code
+                    $codeType = $res[0];
+                    $diagnosisId = $res[1];
+                    // NewCrop only accepts ICD10 codes, so only add XML elements for diagnosis with ICD10 code types
+                    if (
+                        $codeType == 'ICD10' &&
+                        !empty($diagnosisId)
+                    ) {
+                        $element = $this->getDocument()->createElement('PatientDiagnosis');
+                        $element->appendChild($this->createElementText('diagnosisID', $diagnosisId));
+                        $element->appendChild($this->createElementText('diagnosisType',$codeType));
 
-                    $element->appendChild($this->createElementText('diagnosisID', $res[1]));
-                    $element->appendChild($this->createElementText('diagnosisType', $res[0]));
+                        if ($diagnosis['begdate']) {
+                            $element->appendChild($this->createElementText('onsetDate', str_replace("-", "", $diagnosis['begdate'])));
+                        }
 
-                    if ($diagnosis['begdate']) {
-                        $element->appendChild($this->createElementText('onsetDate', str_replace("-", "", $diagnosis['begdate'])));
+                        if ($diagnosis['title']) {
+                            $element->appendChild($this->createElementText('diagnosisName', $diagnosis['title']));
+                        }
+
+                        if ($diagnosis['date']) {
+                            $date = new DateTime($diagnosis['date']);
+                            $element->appendChild($this->createElementText('recordedDate', date_format($date, 'Ymd')));
+                        }
+
+                        $elements[] = $element;
                     }
-
-                    if ($diagnosis['title']) {
-                        $element->appendChild($this->createElementText('diagnosisName', $diagnosis['title']));
-                    }
-
-                    if ($diagnosis['date']) {
-                        $date = new DateTime($diagnosis['date']);
-                        $element->appendChild($this->createElementText('recordedDate', date_format($date, 'Ymd')));
-                    }
-
-                    $elements[] = $element;
                 }
             }
         }

--- a/interface/eRxXMLBuilder.php
+++ b/interface/eRxXMLBuilder.php
@@ -732,7 +732,7 @@ class eRxXMLBuilder
                     ) {
                         $element = $this->getDocument()->createElement('PatientDiagnosis');
                         $element->appendChild($this->createElementText('diagnosisID', $diagnosisId));
-                        $element->appendChild($this->createElementText('diagnosisType',$codeType));
+                        $element->appendChild($this->createElementText('diagnosisType', $codeType));
 
                         if ($diagnosis['begdate']) {
                             $element->appendChild($this->createElementText('onsetDate', str_replace("-", "", $diagnosis['begdate'])));

--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -554,6 +554,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                 $soap_status = sqlStatement("select soap_import_status,pid from patient_data where pid=? and soap_import_status in ('1','3')", array($pid));
                 while ($row_soapstatus = sqlFetchArray($soap_status)) { ?>
                     top.restoreSession();
+                    let reloadRequired = false;
                     $.ajax({
                         type: "POST",
                         url: "../../soap_functions/soap_patientfullmedication.php",
@@ -563,7 +564,9 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                         },
                         async: false,
                         success: function(thedata) {
-                            //alert(thedata);
+                            if (!thedata.includes("Nothing")) {
+                                reloadRequired = true;
+                            }
                             msg_updation += thedata;
                         },
                         error: function() {
@@ -581,13 +584,20 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                         },
                         async: false,
                         success: function(thedata) {
-                            //alert(thedata);
+                            if (!thedata.includes("Nothing")) {
+                                reloadRequired = true;
+                            }
                             msg_updation += thedata;
                         },
                         error: function() {
                             alert('ajax error');
                         }
                     });
+
+                    if (reloadRequired) {
+                        document.location.reload();
+                    }
+
                     <?php
                     if ($GLOBALS['erx_import_status_message']) { ?>
                         if (msg_updation)

--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -587,7 +587,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
                             if (!thedata.includes("Nothing")) {
                                 reloadRequired = true;
                             }
-                            msg_updation += thedata;
+                            msg_updation += "\n" + thedata;
                         },
                         error: function() {
                             alert('ajax error');


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:
Something changed in PHP, or a package dependency that broke the parsing of allergy and medication responses from NewCrop.

This fixes that, and also prevents sending diags other than ICD10 to NewCrop because NewCrop only supports ICD10.

#### Changes proposed in this pull request:

@bradymiller If possible, this should also be merged into rel-701 and added to next patch.
