### PR TITLE
Displaying date in specimen column of lab results.

### DIFF
--- a/interface/orders/single_order_results.inc.php
+++ b/interface/orders/single_order_results.inc.php
@@ -211,7 +211,7 @@ function generate_result_row(&$ctx, &$row, &$rrow, $priors_omitted = false)
         echo "</td>\n";
 
         echo "  <td>";
-        echo myCellText($specimen_num);
+        echo !empty($specimen_num) ? myCellText($specimen_num) : myCellText($date_collected); //quest wanted the specimen date to show here
         echo "</td>\n";
 
         echo "  <td title='" . xla('Check mark indicates reviewed') . "'>";


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #6917

#### Short description of what this resolves:
The lab results don't show a date in the specimen column. 
Quest would like a date to be shown there. The specimen column would show the specimen number if one were entered into the results page; however, if one is not entered. Then, the field is blank. Ron at Quest asked that the date be shown in the column under specimen.

#### Changes proposed in this pull request:
