### PR TITLE
feat: Twigified SMART Style url for module writers - Fixes #6919

### DIFF
--- a/src/Common/Auth/OpenIDConnect/IdTokenSMARTResponse.php
+++ b/src/Common/Auth/OpenIDConnect/IdTokenSMARTResponse.php
@@ -30,6 +30,7 @@ use OpenIDConnectServer\IdTokenResponse;
 use OpenIDConnectServer\Repositories\IdentityProviderInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
+use Twig\Environment;
 
 class IdTokenSMARTResponse extends IdTokenResponse
 {
@@ -58,13 +59,20 @@ class IdTokenSMARTResponse extends IdTokenResponse
      */
     private $contextForNewTokens;
 
+    /**
+     * @var Environment The twig environment.
+     */
+    private $twig;
+
     public function __construct(
         IdentityProviderInterface $identityProvider,
-        ClaimExtractor $claimExtractor
+        ClaimExtractor $claimExtractor,
+        Environment $twig
     ) {
         $this->isAuthorizationGrant = false;
         $this->logger = new SystemLogger();
-        $this->contextBuilder = new SMARTSessionTokenContextBuilder($_SESSION);
+        $this->contextBuilder = new SMARTSessionTokenContextBuilder($_SESSION, $twig);
+        $this->twig = $twig;
         parent::__construct($identityProvider, $claimExtractor);
     }
 

--- a/src/Common/Auth/OpenIDConnect/SMARTSessionTokenContextBuilder.php
+++ b/src/Common/Auth/OpenIDConnect/SMARTSessionTokenContextBuilder.php
@@ -19,6 +19,8 @@ use League\OAuth2\Server\Exception\OAuthServerException;
 use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\FHIR\SMART\SmartLaunchController;
 use OpenEMR\FHIR\SMART\SMARTLaunchToken;
+use OpenEMR\RestControllers\AuthorizationController;
+use OpenEMR\RestControllers\SMART\SMARTAuthorizationController;
 use OpenEMR\Services\FHIR\UtilsService;
 
 class SMARTSessionTokenContextBuilder
@@ -132,7 +134,9 @@ class SMARTSessionTokenContextBuilder
      */
     private function getSmartStyleURL()
     {
-        return $GLOBALS['site_addr_oath'] . $GLOBALS['web_root'] . "/public/smart-styles/smart-light.json";
+        // "/public/smart-styles/smart-light.json";
+        // need to make sure we grab the site id for this.
+        return $GLOBALS['site_addr_oath'] . $GLOBALS['web_root'] . "/oauth2/" . $_SESSION['site_id'] . SMARTAuthorizationController::SMART_STYLE_URL;
     }
 
     /**

--- a/src/FHIR/SMART/Capability.php
+++ b/src/FHIR/SMART/Capability.php
@@ -18,7 +18,7 @@ class Capability
 {
     /**
      * The SMART extension capabilites that our system supports
-     * @see http://hl7.org/fhir/smart-app-launch/conformance/index.html
+     * @see https://hl7.org/fhir/smart-app-launch/conformance/index.html
      *
      * All of these capabilities for MU3 are required to be implemented before HIT certification
      * can be complete.
@@ -61,7 +61,7 @@ class Capability
     // NOTE: context-style is marked in HL7 SMART as EXPERIMENTAL, so expect this to change in time
     // HL7/SMART chat forum was a bit confused by ONC's decision to include this, so again expect
     // to see this change.
-    // @see SMARTConfigurationController->getStyles()
+    // @see SMARTSessionTokenContextBuilder->getSmartStyleURL()
     const CONTEXT_STYLE = "context-style";
 
     // FHIR capability statement for some reason requires this capability which is the same as context-style...

--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -165,7 +165,8 @@ class AuthorizationController
                 $this->authBaseFullUrl,
                 $this->authBaseFullUrl . self::ENDPOINT_SCOPE_AUTHORIZE_CONFIRM,
                 __DIR__ . "/../../oauth2/",
-                $this->getTwig()
+                $this->getTwig(),
+                $GLOBALS['kernel']->getEventDispatcher()
             );
         }
         return $this->smartAuthController;
@@ -568,7 +569,7 @@ class AuthorizationController
 
         // OpenID Connect Response Type
         $this->logger->debug("AuthorizationController->getAuthorizationServer() creating server");
-        $responseType = new IdTokenSMARTResponse(new IdentityRepository(), new ClaimExtractor($customClaim));
+        $responseType = new IdTokenSMARTResponse(new IdentityRepository(), new ClaimExtractor($customClaim), $this->getTwig());
 
         if (empty($this->grantType)) {
             $this->grantType = 'authorization_code';

--- a/src/RestControllers/SMART/SMARTConfigurationController.php
+++ b/src/RestControllers/SMART/SMARTConfigurationController.php
@@ -29,33 +29,6 @@ class SMARTConfigurationController
         $this->authServer = $authServer;
     }
 
-    /**
-     * Needed for OpenEMR\FHIR\SMART\Capability::CONTEXT_STYLE support
-     * TODO: adunsulag do we want to try and read from the scss files and generate some kind of styles...
-     * Reading the SMART FHIR spec author forums so few app writers are actually using this at all, it seems like we
-     * can just use defaults without getting into our skins... so that we can be spec compliant with ONC.
-     */
-    public function getStyles()
-    {
-        $styles = [
-            // copied from light theme background color
-            "color_background" => "#f8f9fa",
-            "color_error" => "#9e2d2d",
-            "color_highlight" => "#69b5ce",
-            "color_modal_backdrop" => "",
-            "color_success" => "#498e49",
-            // set text to black
-            "color_text" => "#000",
-            "dim_border_radius" => "6px",
-            "dim_font_size" => "13px",
-            "dim_spacing_size" => "20px",
-            // copied from our light theme font families
-            "font_family_body" => '"Lato","Helvetica",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji"',
-            "font_family_heading" => '"Lato","Helvetica",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji"'
-        ];
-        return $styles;
-    }
-
     public function getConfig(): array
     {
         $authServer = $this->authServer;

--- a/templates/api/smart/smart-style_light.json.twig
+++ b/templates/api/smart/smart-style_light.json.twig
@@ -1,0 +1,13 @@
+{
+    "color_background": "#f8f9fa",
+    "color_error": "#9e2d2d",
+    "color_highlight": "#69b5ce",
+    "color_modal_backdrop": "",
+    "color_success": "#498e49",
+    "color_text": "#000",
+    "dim_border_radius": "6px",
+    "dim_font_size": "13px",
+    "dim_spacing_size": "20px",
+    "font_family_body": "'Lato','Helvetica',sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol','Noto Color Emoji'",
+    "font_family_heading": "'Lato','Helvetica',sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol','Noto Color Emoji'"
+}


### PR DESCRIPTION
Fixes #6919
Moves location of the SMART URL to be part of the OAuth2 url scheme which lets us customize it and use it in twig.

Fires off a TemplateRender event now that allows module writers to override the template if they want to.

Changed up the php documentation in the Capability statement with some minor url fixes.

Removed unused code where we had leftover SMART style code.