### PR TITLE
fix: In Collection option in Encounter Form configurable

### DIFF
--- a/interface/forms/newpatient/common.php
+++ b/interface/forms/newpatient/common.php
@@ -632,7 +632,8 @@ $ires = sqlStatement("SELECT id, type, title, begdate FROM lists WHERE " .
                                 </select>
                             </div>
                         </div>
-                        <div class="col-sm <?php echo ($GLOBALS['hide_billing_widget'] != 1) ?: 'd-none';?>">
+                        <?php $collectionDisplay = ($GLOBALS['hide_billing_widget'] == 1) ? 'd-none' : displayOption('enc_in_collection'); ?>
+                        <div class="col-sm <?php echo $collectionDisplay; ?>">
                             <div class="form-group">
                                 <label for='in_collection' class="text-right"><?php echo xlt('In Collection'); ?>:</label>
                                 <select class='form-control' name='in_collection' id='in_collection'>

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -4265,6 +4265,13 @@ $GLOBALS_METADATA = array(
             xl('How to display the sensitivity option'),
         ],
 
+        'enc_in_collection' => [
+            xl('Show In Collection on Encounter Form'),
+            getDefaultRenderListOptions(),
+            RenderFormFieldHelper::SHOW_ALL,
+            xl("How to display the 'In Collection' option. May be overriden by Hide Billing Widget setting"),
+        ],
+
         'enc_enable_issues' => [
             xl('Allow Linking/Adding Issues on Encounter'),
             getDefaultRenderListOptions(),


### PR DESCRIPTION
Resolves #6909 by creating a new global similar to other options on the Encounter form. The only difference is rendering also accounts for the Hide Billing Widget global.