### PR TITLE
fix: encounter pos_code to null to honor config

### DIFF
--- a/interface/forms/newpatient/common.php
+++ b/interface/forms/newpatient/common.php
@@ -368,10 +368,7 @@ $ires = sqlStatement("SELECT id, type, title, begdate FROM lists WHERE " .
                 <input type='hidden' name='id' value='<?php echo (isset($_GET["id"])) ? attr($_GET["id"]) : '' ?>' />
             <?php } else { ?>
                 <input type='hidden' name='mode' value='new' />
-                <?php if (empty($GLOBALS['set_pos_code_encounter'])) : ?>
-                    <input type='hidden' name='pos_code' value='<?php echo attr($posCode); ?>' />
-                <?php endif;
-            } ?>
+            <?php } ?>
             <input type="hidden" name="csrf_token_form" value="<?php echo attr(CsrfUtils::collectCsrfToken()); ?>" />
 
             <?php if ($mode === "followup") { ?>


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #6928 

#### Short description of what this resolves:
it's okay for `pos_code` to be `null` since billing will check for that and grab the proper code for the service facility

#### Changes proposed in this pull request:
