### PR TITLE
fix: use datetime of procedure result to match existing encounter

### DIFF
--- a/interface/orders/receive_hl7_results.inc.php
+++ b/interface/orders/receive_hl7_results.inc.php
@@ -1089,7 +1089,6 @@ function receive_hl7_results(&$hl7, &$matchreq, $lab_id = 0, $direction = 'B', $
                     // Create order.
                     // Need to identify the ordering provider and, if possible, a recent encounter.
                     $datetime_report = rhl7DateTime($a[22]);
-                    $date_report = substr($datetime_report, 0, 10) . ' 00:00:00';
                     $encounter_id = 0;
                     $provider_id = 0;
                     $external_id = rhl7Text($a[3]) ?? null;
@@ -1098,7 +1097,7 @@ function receive_hl7_results(&$hl7, &$matchreq, $lab_id = 0, $direction = 'B', $
                         "SELECT encounter FROM form_encounter WHERE " .
                         "pid = ? AND date <= ? AND DATE_ADD(date, INTERVAL 30 DAY) > ? " .
                         "ORDER BY date DESC, encounter DESC LIMIT 1",
-                        array($patient_id, $date_report, $date_report)
+                        array($patient_id, $datetime_report, $datetime_report)
                     );
                     if (!empty($encrow)) {
                         $encounter_id = intval($encrow['encounter']);


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:


#### Changes proposed in this pull request:
