### PR TITLE
ccdaservice/package-lock.json has been updated by the openemr-cmd up …

### DIFF
--- a/ccdaservice/package-lock.json
+++ b/ccdaservice/package-lock.json
@@ -2484,7 +2484,6 @@
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "oe-blue-button-generate": {
-            "name": "oe-blue-button-generate",
             "version": "1.5.10",
             "license": "Apache-2.0",
             "devDependencies": {},


### PR DESCRIPTION

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #6979

#### Short description of what this resolves:
Running openemr-cmd up results in an updated version of the ccdaservice/package-lock.json file.  Update master with current version of that file.

#### Changes proposed in this pull request:
