### PR TITLE
Layout editor list dialog error fix

### DIFF
--- a/interface/login/login.php
+++ b/interface/login/login.php
@@ -96,9 +96,9 @@ if (count($emr_app)) {
 
         $div_app = sprintf(
             '
-            <div id="divApp" class="form-group">
-                <label for="appChoice" class="text-right">%s:</label>
-                <div>
+            <div id="divApp" class="form-group row">
+                <label for="appChoice" class="col-form-label col-sm-4">%s:</label>
+                <div class="col">
                     <select class="form-control" id="selApp" name="appChoice" size="1">%s</select>
                 </div>
             </div>',

--- a/interface/login/login.php
+++ b/interface/login/login.php
@@ -83,11 +83,13 @@ if (count($emr_app)) {
     if (isset($_REQUEST['app']) && $emr_app[$_REQUEST['app']]) {
         $div_app = sprintf('<input type="hidden" name="appChoice" value="%s">', attr($_REQUEST['app']));
     } else {
+        $opt_htm = '';
+        // Is $opt_default suppose to be defined somewhere?
         foreach ($emr_app as $opt_disp => $opt_value) {
             $opt_htm .= sprintf(
                 '<option value="%s" %s>%s</option>\n',
                 attr($opt_disp),
-                ($opt_disp == $opt_default ? 'selected="selected"' : ''),
+                ($opt_disp == ($opt_default ?? '') ? 'selected="selected"' : ''),
                 text(xl_list_label($opt_disp))
             );
         }

--- a/interface/login/login.php
+++ b/interface/login/login.php
@@ -55,6 +55,7 @@ $layout = $GLOBALS['login_page_layout'];
 // If this script is called with app parameter, validate it without showing other apps.
 //
 // Build a list of valid entries
+// Original merge v5.0.1
 $emr_app = array();
 $sql = "SELECT option_id, title,is_default FROM list_options WHERE list_id=? and activity=1 ORDER BY seq, option_id";
 $rs = sqlStatement($sql, ['apps']);
@@ -84,12 +85,11 @@ if (count($emr_app)) {
         $div_app = sprintf('<input type="hidden" name="appChoice" value="%s">', attr($_REQUEST['app']));
     } else {
         $opt_htm = '';
-        // Is $opt_default suppose to be defined somewhere?
         foreach ($emr_app as $opt_disp => $opt_value) {
             $opt_htm .= sprintf(
                 '<option value="%s" %s>%s</option>\n',
                 attr($opt_disp),
-                ($opt_disp == ($opt_default ?? '') ? 'selected="selected"' : ''),
+                ($opt_disp == ($emr_app_def ?? '') ? 'selected="selected"' : ''),
                 text(xl_list_label($opt_disp))
             );
         }
@@ -210,16 +210,16 @@ if (session_name()) {
 
 $viewArgs = [
     'title' => $openemr_name,
-    'displayLanguage' => ($GLOBALS["language_menu_login"] && (count($languageList) != 1)) ? true : false,
+    'displayLanguage' => $GLOBALS["language_menu_login"] && (count($languageList) != 1),
     'defaultLangID' => $defaultLanguage['id'],
     'defaultLangName' => $defaultLanguage['language'],
     'languageList' => $languageList,
     'relogin' => $relogin,
-    'loginFail' => (isset($_SESSION["loginfailure"]) && $_SESSION["loginfailure"] == 1) ? true : false,
-    'displayFacilities' => ($GLOBALS["login_into_facility"]) ? true : false,
+    'loginFail' => isset($_SESSION["loginfailure"]) && $_SESSION["loginfailure"] == 1,
+    'displayFacilities' => (bool)$GLOBALS["login_into_facility"],
     'facilityList' => $facilities,
     'facilitySelected' => $facilitySelected,
-    'displayGoogleSignin' => (!empty($GLOBALS['google_signin_enabled']) && !empty($GLOBALS['google_signin_client_id'])) ? true : false,
+    'displayGoogleSignin' => !empty($GLOBALS['google_signin_enabled']) && !empty($GLOBALS['google_signin_client_id']),
     'googleSigninClientID' => $GLOBALS['google_signin_client_id'],
     'displaySmallLogo' => $displaySmallLogo,
     'smallLogoOne' => $smallLogoOne,
@@ -228,7 +228,7 @@ $viewArgs = [
     'displayTagline' => $GLOBALS['show_tagline_on_login'],
     'tagline' => $GLOBALS['login_tagline_text'],
     'displayAck' => $GLOBALS['display_acknowledgements_on_login'],
-    'hasSession' => (session_name()) ? true : false,
+    'hasSession' => (bool)session_name(),
     'cookieText' => $cookie,
     'regTranslations' => $regTranslations,
     'regConstants' => json_encode(['webroot' => $GLOBALS['webroot']]),

--- a/interface/patient_file/encounter/find_code_dynamic_ajax.php
+++ b/interface/patient_file/encounter/find_code_dynamic_ajax.php
@@ -339,7 +339,8 @@ if ($what == 'fields' && $source == 'V') {
             $arow[] = $row['title'];
         } else {
             $arow[] = str_replace('|', ':', rtrim($row['code'], '|'));
-            $arow[] = $row['description'];
+            $arow[] = $row['description'] ?? "";
+            $arow[] = $row['modifier'] ?? "";
         }
         $out['aaData'][] = $arow;
     }


### PR DESCRIPTION
- add modifier to lists search returned array

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #6984 

#### Short description of what this resolves:
- see issue
Apparently datatables project is now enforcing all columns from table build has a data object.
In the past we default to the code type header for lists (three columns) however failed to populate the modifier column on search return results.

