### PR TITLE
Fixes #7001 Bulk FHIR 500 error patient ids

### DIFF
--- a/src/Services/FHIR/FhirProvenanceService.php
+++ b/src/Services/FHIR/FhirProvenanceService.php
@@ -473,7 +473,10 @@ class FhirProvenanceService extends FhirServiceBase implements IResourceUSCIGPro
 
         $servicesByResource = $this->serviceLocator->findServices(IResourceUSCIGProfileService::class);
 
-        $patientUuids = $job->getPatientUuidsToExport();
+        $patientUuids = [];
+        if ($type == ExportJob::EXPORT_OPERATION_GROUP) {
+            $patientUuids = $job->getPatientUuidsToExport();
+        }
 
         foreach ($job->getResources() as $resource) {
             $searchParams = [];


### PR DESCRIPTION
Provenance was relying on patient ids for patient/$export and system/$export operation.  This should resolve that issue.

Fixes #7001 