### PR TITLE
Fixes #7002 FHIR api warnings missing keys

### DIFF
--- a/src/Services/FHIR/FhirAllergyIntoleranceService.php
+++ b/src/Services/FHIR/FhirAllergyIntoleranceService.php
@@ -171,7 +171,8 @@ class FhirAllergyIntoleranceService extends FhirServiceBase implements IResource
 
         // cardinality is 0..*
         // however in OpenEMR we currently only track a single reaction, we will populate it if we have it.
-        if (!empty($dataRecord['reaction'])) {
+        // if a reaction is unassigned, it has no codes and so we will skip over this as it has no meaning in FHIR.
+        if (!empty($dataRecord['reaction']) && $dataRecord['reaction'] !== 'unassigned') {
             $reaction = new FHIRAllergyIntoleranceReaction();
             $reactionConcept = new FHIRCodeableConcept();
             $conceptText = $dataRecord['reaction_title'] ?? "";

--- a/src/Services/FHIR/Observation/FhirObservationSocialHistoryService.php
+++ b/src/Services/FHIR/Observation/FhirObservationSocialHistoryService.php
@@ -212,8 +212,6 @@ class FhirObservationSocialHistoryService extends FhirServiceBase implements IPa
                 ,"description" => $this->getDescriptionForCode($code)
                 ,"category" => "social-history"
                 , "puuid" => $record['puuid']
-                , "euuid" => $record['euuid']
-                , "user_uuid" => $record['user_uuid']
                 ,"uuid" => UuidRegistry::uuidToString($uuidMappings[$code])
                 ,"date" => $record['date']
             ];

--- a/src/Services/FHIR/Observation/FhirObservationVitalsService.php
+++ b/src/Services/FHIR/Observation/FhirObservationVitalsService.php
@@ -105,7 +105,7 @@ class FhirObservationVitalsService extends FhirServiceBase implements IPatientCo
             'fullcode' => 'LOINC:8327-9',
             'code' => '8327-9',
             'description' => 'Temperature Location',
-            'column' => 'temp_method',
+            'column' => ['temp_method'],
             'in_vitals_panel' => true
         ]
         ,'8302-2' => [
@@ -696,8 +696,12 @@ class FhirObservationVitalsService extends FhirServiceBase implements IPatientCo
 
     private function populateBodyTemperatureLocation(FHIRObservation $observation, $record)
     {
-        // no guidance on how to pass this on, so we are using the value string to pass this on.
-        $observation->setValueString($record['temp_method']);
+        if (empty($record['temp_method'])) {
+            $observation->setDataAbsentReason(UtilsService::createDataAbsentUnknownCodeableConcept());
+        } else {
+            // no guidance on how to pass this on, so we are using the value string to pass this on.
+            $observation->setValueString($record['temp_method']);
+        }
     }
 
     /**

--- a/src/Services/ProcedureService.php
+++ b/src/Services/ProcedureService.php
@@ -62,14 +62,14 @@ class ProcedureService extends BaseService
                     ,porder.order_diagnosis
                     ,porder.order_encounter_id
                     ,porder.order_lab_id
-     
+
                     ,preport.report_date
                     ,preport.procedure_report_id
                     ,preport.report_uuid
                     ,preport.report_notes
-       
+
                     ,presult.procedure_result_id
-                    ,presult.result_uuid 
+                    ,presult.result_uuid
                     ,presult.result_code
                     ,presult.result_text
                     ,presult.result_units
@@ -78,18 +78,18 @@ class ProcedureService extends BaseService
                     ,presult.result_abnormal
                     ,presult.result_comments
                     ,presult.result_status
-     
+
                     ,order_codes.procedure_name
                     ,order_codes.procedure_code
                     ,order_codes.procedure_type
-     
+
                     ,pcode_types.standard_code
 
                     ,labs.lab_id
                     ,labs.lab_uuid
                     ,labs.lab_npi
                     ,labs.lab_name
-     
+
                     ,patients.puuid
                     ,patients.pid
 
@@ -99,7 +99,7 @@ class ProcedureService extends BaseService
 
                     ,docs.doc_id
                     ,docs.doc_uuid
-                    
+
                     ,provider.provider_uuid
                     ,provider.provider_id
                     ,provider.provider_fname
@@ -118,7 +118,7 @@ class ProcedureService extends BaseService
                     procedure_report
                 ) preport
                 LEFT JOIN (
-                    SELECT 
+                    SELECT
                         procedure_result_id
                          ,procedure_report_id
                          ,uuid AS result_uuid
@@ -137,10 +137,10 @@ class ProcedureService extends BaseService
                     FROM
                         `procedure_result`
                 ) presult
-                ON 
+                ON
                     preport.procedure_report_id = presult.procedure_report_id
                 LEFT JOIN (
-                    SELECT 
+                    SELECT
                         procedure_order_id
                         ,uuid AS order_uuid
                         ,provider_id AS order_provider_id
@@ -154,7 +154,7 @@ class ProcedureService extends BaseService
                     FROM
                         procedure_order
                 ) porder
-                ON 
+                ON
                     porder.procedure_order_id = preport.procedure_order_id
                 LEFT JOIN
                 (
@@ -173,12 +173,12 @@ class ProcedureService extends BaseService
                                ,npi AS lab_npi
                                ,`name` AS lab_name
                                ,`active` AS lab_active
-                        FROM 
+                        FROM
                              procedure_providers
                     ) labs
-                ON 
+                ON
                     labs.lab_id = porder.order_lab_id
-                LEFT JOIN 
+                LEFT JOIN
                     (
                         select
                             procedure_order_id
@@ -190,7 +190,7 @@ class ProcedureService extends BaseService
                         FROM procedure_order_code
                     )
                     order_codes
-                ON 
+                ON
                     order_codes.procedure_order_id = porder.procedure_order_id AND order_codes.procedure_order_seq = preport.procedure_order_seq
                 LEFT JOIN (
                     select
@@ -199,17 +199,17 @@ class ProcedureService extends BaseService
                     FROM procedure_type
                 ) pcode_types ON order_codes.procedure_code = pcode_types.proc_code
                 LEFT JOIN (
-                    select 
+                    select
                         pid
                         ,uuid AS puuid
                     FROM
                         patient_data
                 ) patients
-                ON 
-                    patients.pid = porder.order_patient_id 
-                
+                ON
+                    patients.pid = porder.order_patient_id
+
                 LEFT JOIN (
-                    select 
+                    select
                        id AS doc_id
                        ,uuid AS doc_uuid
                     FROM
@@ -298,10 +298,10 @@ class ProcedureService extends BaseService
                     $procedure['provider'] = [
                         'id' => $record['provider_id']
                         ,'uuid' => $record['provider_uuid']
-                        ,'fname' => $record['fname']
-                        ,'mname' => $record['mname']
-                        ,'lname' => $record['lname']
-                        ,'npi' => $record['npi']
+                        ,'fname' => $record['provider_fname']
+                        ,'mname' => $record['provider_mname']
+                        ,'lname' => $record['provider_lname']
+                        ,'npi' => $record['provider_npi']
                     ];
                 }
                 if (!empty($record['lab_id'])) {
@@ -366,7 +366,7 @@ class ProcedureService extends BaseService
                     , 'range' => $record['result_range']
                     , 'abnormal' => $record['result_abnormal']
                     , 'comments' => $record['result_comments']
-                    , 'document_id' => $record['result_document_id']
+                    , 'document_id' => $record['doc_id']
                     , 'status' => $record['result_status']
                 ];
                 $report['results'][] = $result;

--- a/src/Services/SocialHistoryService.php
+++ b/src/Services/SocialHistoryService.php
@@ -188,7 +188,7 @@ class SocialHistoryService extends BaseService
     {
         // note the uuid here is the uuid_mapping table's uuid since each column in the table has its own distinct uuid
         // in the system.
-        return ['puuid', 'euuid', 'uuid', 'user_uuid'];
+        return ['puuid', 'uuid'];
     }
 
 


### PR DESCRIPTION
Allergy intollerance was failing when the unassigned reaction was given since there are no codes and that threw a warning.

social history was relying on columns that didn't exist that also threw warnings.

Vitals services temp_method was not being set properly and threw a warning.

Procedure service had a number of columns it attempted to populate but the actual data values did not match with the array keys.

Fixes #7002.