### PR TITLE
fix: use btn-link instead of a link for dashboard cards (#6995)

### DIFF
--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -853,7 +853,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
 
         // Update the User's visibility setting when the card header is clicked
         function cardTitleButtonClickListener() {
-            const buttons = document.querySelectorAll(".card-title a[data-toggle='collapse']");
+            const buttons = document.querySelectorAll(".card-title button[data-toggle='collapse']");
             buttons.forEach((b) => {
                 b.addEventListener("click", (e) => {
                     updateUserVisibilitySetting(e);

--- a/templates/patient/card/card_base.html.twig
+++ b/templates/patient/card/card_base.html.twig
@@ -1,7 +1,7 @@
-<section class="{{ card_container_class_list|default(['card', 'mb-2'])|join(' ') }} card mb-2 {{ card_bg_color }} {{ card_text_color }}">
+<section class="{{ card_container_class_list|default(['card', 'mb-2'])|join(' ') }} {{ card_bg_color }} {{ card_text_color }}">
     <div class="card-body p-1">
         <h6 class="card-title mb-0 d-flex p-1 justify-content-between">
-            <a class="text-left font-weight-bolder" href="#" {% if forceAlwaysOpen != true %}data-toggle="collapse" data-target="#{{ id|attr }}"{% endif %} aria-expanded="true" aria-controls="{{ id|attr }}">{{ title|text }}<i class="ml-1 fa fa-fw fa-sm fa-expand">&nbsp;</i></a>
+            <button class="btn btn-sm btn-link" href="#" {% if forceAlwaysOpen != true %} data-toggle="collapse" data-target="#{{ id|attr }}" {% endif %} aria-expanded="true" aria-controls="{{ id|attr }}">{{ title|text }}</button>
             {% if auth %}
                 <span>
                 {% if card.canAdd() or btnLabel == "Add" %}


### PR DESCRIPTION
* fix: use btn-link instead of a tag for dashboard cards

* remove redundant section classes card mb-2

* change listening element to button

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:


#### Changes proposed in this pull request:
