### PR TITLE
Fixes #7019 operation name export operation

### DIFF
--- a/src/Common/Auth/OpenIDConnect/JWT/JsonWebKeySet.php
+++ b/src/Common/Auth/OpenIDConnect/JWT/JsonWebKeySet.php
@@ -80,7 +80,7 @@ class JsonWebKeySet implements Key
      */
     public function getJSONWebKey($kid, $alg)
     {
-        $this->logger->debug("Attempting to find web key for kid & alg", ['kid' => $kid, 'alg' => $alg]);
+        $this->logger->debug("JsonWebKeySet::getJSONWebKey() Attempting to find web key for kid & alg", ['kid' => $kid, 'alg' => $alg]);
         foreach ($this->jwks as $key) {
             if ($key->kty === 'RSA') {
                 if (!isset($kid) || $key->kid === $kid) {

--- a/src/Common/Auth/OpenIDConnect/JWT/RsaSha384Signer.php
+++ b/src/Common/Auth/OpenIDConnect/JWT/RsaSha384Signer.php
@@ -103,7 +103,7 @@ class RsaSha384Signer implements Signer
 
         if ($key instanceof JsonWebKeySet) {
             $kid = $this->headers['kid'] ?? null;
-            $this->logger->debug("RsaSha384Signer->verify() attempting to retrieve jwk");
+            $this->logger->debug("RsaSha384Signer->verify() attempting to retrieve jwk", ['kid' => $kid]);
             $jwk = $key->getJSONWebKey($kid, $this->algorithmId());
         } else {
             $key = $key instanceof Key ? $key->contents() : $key;

--- a/src/RestControllers/RestControllerHelper.php
+++ b/src/RestControllers/RestControllerHelper.php
@@ -278,15 +278,17 @@ class RestControllerHelper
         }
 
         if ($operation == '$export') {
+            // operation definition must use the operation 'name'
+            // rest.resource.operation.name must come from the OperationDefinition's code attribute which in this case is 'export'
+            $definitionName = 'export';
+            $operationName = 'export';
             if ($resource != '$export') {
-                $operationName = strtolower($resource) . '-export';
-            } else {
-                $operationName = 'export';
+                $definitionName = strtolower($resource) . '-export';
             }
             // define export operation
             $fhirOperation = new FHIRCapabilityStatementOperation();
-            $fhirOperation->setName($operation);
-            $fhirOperation->setDefinition(new FHIRCanonical('http://hl7.org/fhir/uv/bulkdata/OperationDefinition/' . $operationName));
+            $fhirOperation->setName($operationName);
+            $fhirOperation->setDefinition(new FHIRCanonical('http://hl7.org/fhir/uv/bulkdata/OperationDefinition/' . $definitionName));
             $capResource->addOperation($fhirOperation);
         } else if ($operation === '$bulkdata-status') {
             $fhirOperation = new FHIRCapabilityStatementOperation();


### PR DESCRIPTION
Fixes the export operation name to be 'export' which is the expected name coming from the OperationDefinition.code property for the $export operation for Patient/Group/System export.

Also added a few more debug logs to the json key stuff to help with debugging.
Fixes #7019.