### PR TITLE
Recent patients fixes rel-702

### DIFF
--- a/interface/main/finder/dynamic_finder.php
+++ b/interface/main/finder/dynamic_finder.php
@@ -398,7 +398,62 @@ function rp()
     }
     $patientService = new PatientService();
     $rp = $patientService->getRecentPatientList();
-    return ['headers' => $headers, 'rp' => $rp];
+    // Get a list of the columns in patient_data that are either date or datetime:
+    $sql_dtCols = "SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = DATABASE() AND TABLE_NAME = 'patient_data' AND (data_type = 'datetime' OR data_type = 'date')";
+    $res_dtCols = sqlStatement($sql_dtCols);
+    $pd_dtCols = [];
+    while ($row = sqlFetchArray($res_dtCols)) {
+        $pd_dtCols[] = $row;
+    }
+    $date_cols = [];
+    $datetime_cols = [];
+    foreach ($pd_dtCols as $k => $v) {
+        if ($v['data_type'] == "datetime") {
+            $datetime_cols[] = $v['column_name'];
+        } else if ($v['data_type'] == "date") {
+            $date_cols[] = $v['column_name'];
+        }
+    }
+    // Build SQL statement to pull desired columns from patient_data table...
+    $pd_sql = "SELECT pid";
+    foreach ($headers as $k => $v) {
+        $pd_sql .= ', ';
+        $col_name = $v['option_id'];
+        $dt_format = '';
+        if (in_array($col_name, $date_cols) || in_array($col_name, $datetime_cols)) {
+            switch ($GLOBALS['date_display_format']) {
+                case 0: // mysql YYYY-MM-DD format
+                    $dt_format = "'%Y-%m-%d";
+                    break;
+                case 1: // MM/DD/YYYY format
+                    $dt_format = "'%m/%d/%Y";
+                    break;
+                case 2: // DD/MM/YYYY format
+                    $dt_format = "'%d/%m/%Y";
+                    break;
+            }
+            if (in_array($col_name, $datetime_cols)) {
+                switch ($GLOBALS['time_display_format']) {
+                    case 0: // 24 Hr fmt
+                        $dt_format .= " %T";
+                        break;
+                    case 1: // AM PM fmt
+                        $dt_format .= " %r";
+                        break;
+                }
+            }
+            $dt_format .= "'";  // Don't forget the closing '!
+            $pd_sql .= "DATE_FORMAT(" . $col_name . ", " . $dt_format . ") AS " . $col_name;
+        } else {
+            $pd_sql .= $col_name;
+        }
+    }
+    $pd_sql .= " FROM patient_data WHERE pid = ?";
+    $pd_data = [];
+    foreach ($rp as $k => $v) {
+        $pd_data[] = sqlQuery($pd_sql, $v['pid']);
+    }
+    return ['headers' => $headers, 'rp' => $pd_data];
 }
 
 $rp = rp();

--- a/src/Services/PatientService.php
+++ b/src/Services/PatientService.php
@@ -1031,9 +1031,6 @@ class PatientService extends BaseService
         $query = "SELECT option_id FROM list_options WHERE list_id = 'recent_patient_columns' and activity = '1'";
         $res = sqlStatement($query);
         $cols = ['pid'];
-        while ($row = sqlFetchArray($res)) {
-            $cols[] = $row['option_id'];
-        }
 
         // Trim down the incoming patient array to just the whitelisted columns
         foreach ($patient as $k => $v) {
@@ -1069,6 +1066,13 @@ class PatientService extends BaseService
         $currUser = ($user_id > 0) ? ['id' => $user_id] : $user->getCurrentlyLoggedInUser();
         $sql = "SELECT patients FROM recent_patients WHERE user_id = ?";
         $res = sqlQuery($sql, [$currUser['id']]);
-        return ($res) ? unserialize($res['patients']) : [];
+        // original code:  return ($res) ? unserialize($res['patients']) : [];
+        // We only want the pid value so we can fetch the data from patient_data...
+        //
+        $pids = [];
+        foreach (($res) ? unserialize($res['patients']) : [] as $k => $v) {
+            $pids[]['pid'] = $v['pid'];
+        }
+        return($pids);
     }
 }

--- a/templates/patient_finder/finder.html.twig
+++ b/templates/patient_finder/finder.html.twig
@@ -38,17 +38,21 @@
                                 <thead class="thead-light">
                                     <tr>
                                         {% for h in headers %}
-                                            <th scope="col">{{ h.title|text }}</th>
+                                            <th scope="col">{{ h.title|xlListLabel }}</th>
                                         {% endfor %}
                                     </tr>
                                 </thead>
                                 <tbody>
                                     {% for p in rp %}
-                                        <tr>
+                                        <tr class="clickable-row" style="cursor:pointer;" data-pid="{{ p.pid|attr }}">
                                             {% for h in headers %}
                                                 {% set value = p[h.option_id] %}
                                                 <td>
-                                                    <a href="#" data-pid="{{ p.pid|attr }}">{{ value|text }}</a>
+                                                    {% if loop.first %}
+                                                        <a href="#">{{ value|text }}</a>
+                                                    {% else %}
+                                                        {{ value|text }}
+                                                    {% endif %}
                                                 </td>
                                             {% endfor %}
                                         </tr>


### PR DESCRIPTION
* This version does not preserve the order of recent_patients data.

* This version preserves the order.

* This version is updated to ONLY store the pid values in the recent_patients table.

* Code style cleanup...

* Correctly format date and datetime columns from patient_data in the Recent Patients tab

* Correct PHP styling

* chore: bump db version for prior commit (#7044)

* Chore: change production docker to 7.0.2

* Update docker-compose.yml to 7.0.2

* Make Recent Patients Tab more similar to the Patient List tab -- i.e. clickable rows, etc.

* Use patient_data.pid to uniquely identify patients for Recent Patients list ;  Change twig to xlt the table headers.

* fix SQL statements so SQL commands are capitalized consistently.

* change from xlt to xlListLabel for column titles.

---------

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:


#### Changes proposed in this pull request:
