### PR TITLE
Fix visible non-breaking space in Rx report

### DIFF
--- a/interface/reports/prescriptions_report.php
+++ b/interface/reports/prescriptions_report.php
@@ -287,16 +287,9 @@ if (!empty($_POST['form_refresh'])) {
                        generate_display_field(array('data_type' => '1','list_id' => 'drug_interval'), $row['interval']);
             //if ($row['patient_id'] == $last_patient_id) {
             if (strcmp($row['pubpid'], $last_patient_id) == 0) {
-                $patient_name = '&nbsp;';
-                $patient_id   = '&nbsp;';
+                $patient_name = $patient_id  = '';
                 if ($row['id'] == $last_prescription_id) {
-                    $prescription_id = '&nbsp;';
-                    $drug_name       = '&nbsp;';
-                    $ndc_number      = '&nbsp;';
-                    $drug_units      = '&nbsp;';
-                    $refills         = '&nbsp;';
-                    $reactions       = '&nbsp;';
-                    $instructed      = '&nbsp;';
+                    $prescription_id = $drug_name = $ndc_number = $drug_units = $refills = $reactions = $instructed = '';
                 }
             }
             ?>


### PR DESCRIPTION
Fixes #7057

#### Short description of what this resolves:

Fixes `&nbsp;` being visible in rows following parent rows, particularly after a patient is first mentioned.

#### Changes proposed in this pull request:

- Fix visible non-breaking spaces in child rows