### PR TITLE
bug fixes password expired global

### DIFF
--- a/interface/login/login.php
+++ b/interface/login/login.php
@@ -267,6 +267,6 @@ $event = $ed->dispatch($templatePageEvent, TemplatePageEvent::RENDER_EVENT);
 
 try {
     echo $t->render($event->getTwigTemplate(), $event->getTwigVariables());
-} catch (LoaderError|RuntimeError|SyntaxError $e) {
+} catch (LoaderError | RuntimeError | SyntaxError $e) {
     echo "<p style='font-size:24px; color: red;'>" . text($e->getMessage()) . '</p>';
 }

--- a/interface/login/login.php
+++ b/interface/login/login.php
@@ -34,6 +34,9 @@ use OpenEMR\Events\Core\TemplatePageEvent;
 use OpenEMR\Services\FacilityService;
 use OpenEMR\Services\LogoService;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Twig\Error\LoaderError;
+use Twig\Error\RuntimeError;
+use Twig\Error\SyntaxError;
 
 $ignoreAuth = true;
 // Set $sessionAllowWrite to true to prevent session concurrency issues during authorization related code
@@ -262,4 +265,8 @@ $ed = $GLOBALS['kernel']->getEventDispatcher();
 $templatePageEvent = new TemplatePageEvent('login/login.php', [], $layout, $viewArgs);
 $event = $ed->dispatch($templatePageEvent, TemplatePageEvent::RENDER_EVENT);
 
-echo $t->render($event->getTwigTemplate(), $event->getTwigVariables());
+try {
+    echo $t->render($event->getTwigTemplate(), $event->getTwigVariables());
+} catch (LoaderError|RuntimeError|SyntaxError $e) {
+    echo "<p style='font-size:24px; color: red;'>" . text($e->getMessage()) . '</p>';
+}

--- a/src/Common/Auth/AuthUtils.php
+++ b/src/Common/Auth/AuthUtils.php
@@ -106,6 +106,11 @@ class AuthUtils
                 privStatement("UPDATE `globals` SET `gl_value` = ? WHERE `gl_name` = 'hidden_auth_dummy_hash'", [$this->dummyHash]);
             }
         }
+        if ($GLOBALS['password_expiration_days'] === '') {
+            $GLOBALS['password_expiration_days'] = 0;
+            sqlQuery("UPDATE `globals` SET `gl_value` = ? WHERE `globals`.`gl_name` = 'password_expiration_days' AND `globals`.`gl_index` = '0' ", ['0']);
+            error_log("Blank global password_expiration_days updated to 0");
+        }
     }
 
     /**
@@ -1008,7 +1013,7 @@ class AuthUtils
             $current_date = date("Y-m-d");
             $expiredPlusGraceTime = date("Y-m-d", strtotime($query['last_update_password'] . "+" . ((int)$GLOBALS['password_expiration_days'] + (int)$GLOBALS['password_grace_time']) . " days"));
             if (strtotime($current_date) > strtotime($expiredPlusGraceTime)) {
-                error_log("OpenEMR Notice: Password is expired. User: " . $user);
+                error_log("OpenEMR Notice: Password is expired and outside of grace period. User: " . $user);
                 return false;
             }
         } else {

--- a/src/Common/Auth/AuthUtils.php
+++ b/src/Common/Auth/AuthUtils.php
@@ -450,6 +450,7 @@ class AuthUtils
                 $this->incrementIpLoginFailedCounter($ip['ip_string']);
             }
             EventAuditLogger::instance()->newEvent($event, $username, $authGroup, 0, $beginLog . ": " . $ip['ip_string'] . ". user password is expired");
+            error_log($username . ": " . $ip['ip_string'] . ". user password is expired");
             $this->clearFromMemory($password);
             return false;
         }
@@ -998,7 +999,7 @@ class AuthUtils
 
     private function checkPasswordNotExpired($user)
     {
-        if (($GLOBALS['password_expiration_days'] == 0) || self::useActiveDirectory($user)) {
+        if ((empty($GLOBALS['password_expiration_days'] ?? 0)) || self::useActiveDirectory($user)) {
             // skip the check if turned off or using active directory for login
             return true;
         }
@@ -1007,6 +1008,7 @@ class AuthUtils
             $current_date = date("Y-m-d");
             $expiredPlusGraceTime = date("Y-m-d", strtotime($query['last_update_password'] . "+" . ((int)$GLOBALS['password_expiration_days'] + (int)$GLOBALS['password_grace_time']) . " days"));
             if (strtotime($current_date) > strtotime($expiredPlusGraceTime)) {
+                error_log("OpenEMR Notice: Password is expired. User: " . $user);
                 return false;
             }
         } else {


### PR DESCRIPTION

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #7067 

#### Short description of what this resolves:
 include in 7.0.2 patch 1
- wrap login twig loader in try/catch so user is notified
- ignore ($GLOBALS['password_expiration_days'] if is set to blank/empty string in password auth validation.
- report password expired to error log as a notice.

#### Changes proposed in this pull request:
