### PR TITLE
Fix errors and warnings in various reports

### DIFF
--- a/interface/billing/sl_receipts_report.php
+++ b/interface/billing/sl_receipts_report.php
@@ -22,17 +22,17 @@
 // TODO: Replace tables with BS4 grid classes for GSoC
 
 
-require_once('../globals.php');
-require_once($GLOBALS['srcdir'] . '/patient.inc.php');
-require_once($GLOBALS['srcdir'] . '/options.inc.php');
-require_once($GLOBALS['fileroot'] . '/custom/code_types.inc.php');
+require_once '../globals.php';
+require_once $GLOBALS['srcdir'] . '/patient.inc.php';
+require_once $GLOBALS['srcdir'] . '/options.inc.php';
+require_once $GLOBALS['fileroot'] . '/custom/code_types.inc.php';
 // This determines if a particular procedure code corresponds to receipts
 // for the "Clinic" column as opposed to receipts for the practitioner.  Each
 // practice will have its own policies in this regard, so you'll probably
 // have to customize this function.  If you use the "fee sheet" encounter
 // form then the code below may work for you.
 //
-require_once('../forms/fee_sheet/codes.php');
+require_once '../forms/fee_sheet/codes.php';
 
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
@@ -122,7 +122,7 @@ $form_facility   = $_POST['form_facility'] ?? null;
                 <?php $datetimepicker_timepicker = false; ?>
                 <?php $datetimepicker_showseconds = false; ?>
                 <?php $datetimepicker_formatInput = true; ?>
-                <?php require($GLOBALS['srcdir'] . '/js/xl/jquery-datetimepicker-2-5-4.js.php'); ?>
+                <?php require $GLOBALS['srcdir'] . '/js/xl/jquery-datetimepicker-2-5-4.js.php'; ?>
                 <?php // can add any additional javascript settings to datetimepicker here; need to prepend first setting with a comma ?>
             });
         });
@@ -420,33 +420,31 @@ $form_facility   = $_POST['form_facility'] ?? null;
                             }
 
                             /************************************************************/
-                            //
+
                             $res = sqlStatement($query, $sqlBindArray);
                             while ($row = sqlFetchArray($res)) {
                                 $trans_id = $row['trans_id'];
                                 $thedate = substr($row['date'], 0, 10);
                                 $patient_id = $row['pid'];
                                 $encounter_id = $row['encounter'];
-                            //
+
                                 if (!empty($ids_to_skip[$trans_id])) {
                                     continue;
                                 }
 
-                            //
-                            // If a diagnosis code was given then skip any invoices without
-                            // that diagnosis.
+                                // If a diagnosis code was given then skip any invoices without that diagnosis.
                                 if ($form_dx_code && $form_dx_codetype) {
-                                    $tmp = sqlQuery("SELECT count(*) AS count FROM billing WHERE " .
-                                    "pid = ? AND encounter = ? AND " .
-                                    "code_type = ? AND code LIKE ? AND " .
-                                    "activity = 1", array($patient_id,$encounter_id,$form_dx_codetype,$form_dx_code));
+                                    $tmp = sqlQuery(
+                                        "SELECT count(*) AS count FROM billing " .
+                                        "WHERE pid = ? AND encounter = ? AND code_type = ? AND code LIKE ? AND activity = 1",
+                                        array($patient_id, $encounter_id, $form_dx_codetype, $form_dx_code)
+                                    );
                                     if (empty($tmp['count'])) {
                                         $ids_to_skip[$trans_id] = 1;
                                         continue;
                                     }
                                 }
 
-                            //
                                 $key = sprintf(
                                     "%08u%s%08u%08u%06u",
                                     $row['docid'],
@@ -561,10 +559,11 @@ $form_facility   = $_POST['form_facility'] ?? null;
                             // If a diagnosis code was given then skip any invoices without
                             // that diagnosis.
                             if ($form_dx_code && $form_dx_codetype) {
-                                $tmp = sqlQuery("SELECT count(*) AS count FROM billing WHERE " .
-                                "pid = ? AND encounter = ? AND " .
-                                "code_type = ? AND code LIKE ? AND " .
-                                "activity = 1", array($patient_id,$encounter_id,$form_dx_codetype,$form_dx_code));
+                                $tmp = sqlQuery(
+                                    "SELECT count(*) AS count FROM billing " .
+                                    "WHERE pid = ? AND encounter = ? AND code_type = ? AND code LIKE ? AND activity = 1",
+                                    array($patient_id, $encounter_id, $form_dx_codetype, $form_dx_code)
+                                );
                                 if (empty($tmp['count'])) {
                                     $ids_to_skip[$trans_id] = 1;
                                     continue;
@@ -600,11 +599,10 @@ $form_facility   = $_POST['form_facility'] ?? null;
                         $docid = 0;
 
                         foreach ($arows as $row) {
-                        // Get insurance company name
+                            // Get insurance company name
                             $insconame = '';
                             if ($form_proc_codefull  && $row['project_id']) {
-                                $tmp = sqlQuery("SELECT name FROM insurance_companies WHERE " .
-                                "id = ?", array($row['project_id']));
+                                $tmp = sqlQuery("SELECT name FROM insurance_companies WHERE id = ?", array($row['project_id']));
                                 $insconame = $tmp['name'];
                             }
 
@@ -616,7 +614,7 @@ $form_facility   = $_POST['form_facility'] ?? null;
                                 $amount1 -= $row['amount'];
                             }
 
-                        // if ($docid != $row['employee_id']) {
+                            // if ($docid != $row['employee_id']) {
                             if ($docid != $row['docid']) {
                                 if ($docid) {
                                     // Print doc totals.
@@ -633,7 +631,7 @@ $form_facility   = $_POST['form_facility'] ?? null;
                 <td align="right">
                                         <?php echo text(FormatMoney::getBucks($doctotal2)) ?>
                 </td>
-                    <?php } ?>
+                                    <?php } ?>
                 </tr>
                                     <?php
                                 }
@@ -662,14 +660,16 @@ $form_facility   = $_POST['form_facility'] ?? null;
                 <td class="detail">
                                     <?php echo empty($row['irnumber']) ? text($row['invnumber']) : text($row['irnumber']); ?>
                 </td>
-                    <?php } ?>
+                                <?php } ?>
                                 <?php
                                 if ($form_proc_code && $form_proc_codetype) {
                                         echo "  <td class='detail' align='right'>";
                                         list($patient_id, $encounter_id) = explode(".", $row['invnumber']);
-                                        $tmp = sqlQuery("SELECT SUM(fee) AS sum FROM billing WHERE " .
-                                            "pid = ? AND encounter = ? AND " .
-                                            "code_type = ? AND code = ? AND activity = 1", array($patient_id,$encounter_id,$form_proc_codetype,$form_proc_code));
+                                        $tmp = sqlQuery(
+                                            "SELECT SUM(fee) AS sum FROM billing " .
+                                            "WHERE pid = ? AND encounter = ? AND code_type = ? AND code = ? AND activity = 1",
+                                            array($patient_id, $encounter_id, $form_proc_codetype, $form_proc_code)
+                                        );
                                         echo text(FormatMoney::getBucks($tmp['sum']));
                                         echo "  </td>\n";
                                 }
@@ -679,12 +679,12 @@ $form_facility   = $_POST['form_facility'] ?? null;
                     <td class="detail">
                                         <?php echo text($insconame) ?>
                     </td>
-                                    <?php } ?>
+                                <?php } ?>
                                 <?php if ($form_procedures) { ?>
                 <td class="detail">
                                     <?php echo text($row['memo']) ?>
                 </td>
-                            <?php } ?>
+                                <?php } ?>
                 <td class="detail" align="right">
                                 <?php echo text(FormatMoney::getBucks($amount1)) ?>
                 </td>
@@ -692,7 +692,7 @@ $form_facility   = $_POST['form_facility'] ?? null;
                 <td class="detail" align="right">
                                     <?php echo text(FormatMoney::getBucks($amount2)) ?>
                 </td>
-                            <?php } ?>
+                                <?php } ?>
                 </tr>
                                 <?php
                             } // end details
@@ -716,9 +716,11 @@ $form_facility   = $_POST['form_facility'] ?? null;
                 </td>
                         <?php if ($form_procedures) { ?>
                 <td align="right">
-                            <?php echo text(FormatMoney::getBucks($doctotal2)) ?>
+                            <?php if (isset($doctotal2)) {
+                                echo text(FormatMoney::getBucks($doctotal2));
+                            } ?>
                 </td>
-                <?php } ?>
+                        <?php } ?>
                 </tr>
 
                 <!-- TODO: Replace bgcolor with BS4 !-->
@@ -731,12 +733,14 @@ $form_facility   = $_POST['form_facility'] ?? null;
                 </td>
                         <?php if ($form_procedures) { ?>
                 <td align="right">
-                            <?php echo text(FormatMoney::getBucks($grandtotal2)) ?>
+                            <?php if (isset($grandtotal2)) {
+                                echo text(FormatMoney::getBucks($grandtotal2));
+                            } ?>
                 </td>
-                <?php } ?>
+                        <?php } ?>
                 </tr>
-                        <?php $report_from_date = oeFormatShortDate($form_from_date)  ;
-                        $report_to_date = oeFormatShortDate($form_to_date)  ;
+                        <?php $report_from_date = oeFormatShortDate($form_from_date);
+                        $report_to_date = oeFormatShortDate($form_to_date);
                         ?>
                 <div align='right'><span class='title'><?php echo xlt('Report Date') . ' '; ?><?php echo text($report_from_date);?> - <?php echo text($report_to_date);?></span></div>
 

--- a/interface/reports/inventory_list.php
+++ b/interface/reports/inventory_list.php
@@ -12,9 +12,9 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once("../globals.php");
-require_once("$srcdir/options.inc.php");
-require_once("$include_root/drugs/drugs.inc.php");
+require_once "../globals.php";
+require_once "$srcdir/options.inc.php";
+require_once "$include_root/drugs/drugs.inc.php";
 
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
@@ -176,7 +176,7 @@ function zeroDays($product_id, $begdate, $extracond, $extrabind, $min_sale = 1)
         "lo.option_id = di.warehouse_id AND lo.activity = 1 " .
         "WHERE " .
         "di.destroy_date IS NOT NULL AND di.destroy_date >= ? " .
-        "$prodcond $extracond" .
+        "$prodcond $extracond " .
         "GROUP BY di.destroy_date ORDER BY di.destroy_date",
         array_merge(array($begdate), $prodbind, $extrabind)
     );
@@ -198,7 +198,7 @@ function zeroDays($product_id, $begdate, $extracond, $extrabind, $min_sale = 1)
         "WHERE " .
         "ds.sale_date >= ? AND " .
         "di.inventory_id = ds.inventory_id " .
-        "$prodcond $extracond" .
+        "$prodcond $extracond " .
         "GROUP BY ds.sale_date ORDER BY ds.sale_date",
         array_merge(array($begdate), $prodbind, $extrabind)
     );
@@ -220,7 +220,7 @@ function zeroDays($product_id, $begdate, $extracond, $extrabind, $min_sale = 1)
         "WHERE " .
         "ds.sale_date >= ? AND " .
         "di.inventory_id = ds.xfer_inventory_id " .
-        "$prodcond $extracond" .
+        "$prodcond $extracond " .
         "GROUP BY ds.sale_date ORDER BY ds.sale_date",
         array_merge(array($begdate), $prodbind, $extrabind)
     );
@@ -393,8 +393,7 @@ function write_report_line(&$row)
     // activity, then this message doesn't matter any more either.
     if ($form_details == 2) {
         if (checkReorder($drug_id, $row['pw_min_level'], $warehouse_id)) {
-            addWarning(xl("Reorder point has been reached for warehouse") .
-                " '" . $row['title'] . "'");
+            addWarning(xl("Reorder point has been reached for warehouse") . " '" . $row['title'] . "'");
         }
     }
 
@@ -845,9 +844,7 @@ table.mymaintable td, table.mymaintable th {
     }
     ?></select>&nbsp;
 
-   <input type='checkbox' name='form_inactive' value='1'<?php if ($form_inactive) {
-        echo " checked";} ?>
-   /><?php echo xlt('Include Inactive'); ?>&nbsp;
+   <input type='checkbox' name='form_inactive' value='1'<?php echo $form_inactive ? " checked" : ""; ?>/><?php echo xlt('Include Inactive'); ?>&nbsp;
 
     <?php
     echo "   <select name='form_details'>\n";
@@ -886,7 +883,8 @@ table.mymaintable td, table.mymaintable th {
    <th>
     <a href="#" onclick="return dosort('name')"
         <?php if ($form_orderby == "name") {
-            echo " style=\"color:#00cc00\"";} ?>>
+            echo " style=\"color:#00cc00\"";
+        } ?>>
         <?php echo xlt('Name'); ?> </a>
    </th>
    <th><?php echo xlt('Relates To'); ?></th>
@@ -906,8 +904,8 @@ table.mymaintable td, table.mymaintable th {
    <th><?php echo xlt('Facility'); ?></th>
             <?php if ($form_details == 2) { ?>
    <th><?php echo xlt('Warehouse'); ?></th>
-<?php } ?>
-<?php } ?>
+            <?php } ?>
+        <?php } ?>
    <th align='right'><?php echo text("$mmtype " . xl('Min')); ?></th>
    <th align='right'><?php echo text("$mmtype " . xl('Max')); ?></th>
    <th align='right'><?php echo xlt('QOH'); ?></th>

--- a/interface/reports/services_by_category.php
+++ b/interface/reports/services_by_category.php
@@ -12,8 +12,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once("../globals.php");
-require_once("../../custom/code_types.inc.php");
+require_once "../globals.php";
+require_once "../../custom/code_types.inc.php";
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Utils\FormatMoney;
@@ -163,12 +163,11 @@ if (!empty($_POST['form_refresh'])) {
 <th class='bold'><?php echo xlt('Description'); ?></th>
     <?php if (related_codes_are_used()) { ?>
    <th class='bold'><?php echo xlt('Related'); ?></th>
-<?php } ?>
-    <?php
-    $pres = sqlStatement("SELECT title FROM list_options " .
-     "WHERE list_id = 'pricelevel' AND activity = 1 ORDER BY seq");
+    <?php }
+
+    $pres = sqlStatement("SELECT title FROM list_options WHERE list_id = 'pricelevel' AND activity = 1 ORDER BY seq");
     while ($prow = sqlFetchArray($pres)) {
-    // Added 5-09 by BM - Translate label if applicable
+        // Added 5-09 by BM - Translate label if applicable
         echo "   <th class='bold' align='right' nowrap>" . text(xl_list_label($prow['title'])) . "</th>\n";
     }
     ?>
@@ -188,10 +187,12 @@ if (!empty($_POST['form_refresh'])) {
         $where .= " AND c.superbill != '' AND c.superbill != '0'";
     }
 
-    $res = sqlStatement("SELECT c.*, lo.title FROM codes AS c " .
-    "LEFT OUTER JOIN list_options AS lo ON lo.list_id = 'superbill' " .
-    "AND lo.option_id = c.superbill AND lo.activity = 1 " .
-    "WHERE $where ORDER BY lo.title, c.code_type, c.code, c.modifier", $sqlBindArray);
+    $res = sqlStatement(
+        "SELECT c.*, lo.title FROM codes AS c " .
+        "LEFT OUTER JOIN list_options AS lo ON lo.list_id = 'superbill' AND lo.option_id = c.superbill AND lo.activity = 1 " .
+        "WHERE $where ORDER BY lo.title, c.code_type, c.code, c.modifier",
+        $sqlBindArray
+    );
 
     $last_category = '';
     $irow = 0;
@@ -222,23 +223,28 @@ if (!empty($_POST['form_refresh'])) {
         if (related_codes_are_used()) {
             // Show related codes.
             echo "   <td class='text'>";
-            $arel = explode(';', $row['related_code']);
-            foreach ($arel as $tmp) {
-                list($reltype, $relcode) = explode(':', $tmp);
-                $reltype = $code_types[$reltype]['id'];
-                $relrow = sqlQuery("SELECT code_text FROM codes WHERE " .
-                "code_type = ? AND code = ? LIMIT 1", array($reltype, $relcode));
-                echo text($relcode) . ' ' . text(trim($relrow['code_text'])) . '<br />';
+            if ($row['related_code'] != "") {
+                $arel = explode(';', $row['related_code']);
+                foreach ($arel as $tmp) {
+                    list($reltype, $relcode) = explode(':', $tmp);
+                    $reltype = $code_types[$reltype]['id'];
+                    $relrow = sqlQuery(
+                        "SELECT code_text FROM codes WHERE code_type = ? AND code = ? LIMIT 1",
+                        array($reltype, $relcode)
+                    );
+                    echo text($relcode) . ' ' . text(trim($relrow['code_text'])) . '<br />';
+                }
             }
 
             echo "</td>\n";
         }
 
-        $pres = sqlStatement("SELECT p.pr_price " .
-        "FROM list_options AS lo LEFT OUTER JOIN prices AS p ON " .
-        "p.pr_id = ? AND p.pr_selector = '' " .
-        "AND p.pr_level = lo.option_id " .
-        "WHERE lo.list_id = 'pricelevel' AND lo.activity = 1 ORDER BY lo.seq", array($row['id']));
+        $pres = sqlStatement(
+            "SELECT p.pr_price FROM list_options AS lo " . 
+            "LEFT OUTER JOIN prices AS p ON p.pr_id = ? AND p.pr_selector = '' AND p.pr_level = lo.option_id " .
+            "WHERE lo.list_id = 'pricelevel' AND lo.activity = 1 ORDER BY lo.seq",
+            array($row['id'])
+        );
         while ($prow = sqlFetchArray($pres)) {
             echo "   <td class='text' align='right'>" . text(FormatMoney::getBucks($prow['pr_price'])) . "</td>\n";
         }


### PR DESCRIPTION
Fixes #7076

#### Short description of what this resolves:

Resolves errors and warnings that appear in the following Reports: **Visits > Services**, **Financial > Cash Rec**, and **Inventory > List** and **Activity**.

#### Changes proposed in this pull request:

- Do not display related codes in **Reports > Visits > Services** if there are none
- Do not display monetary totals for procedures in **Reports > Financial > Cash Rec** if there are none
- Fix SQL queries in **Reports > Inventory > List**
- Do not access POST variables in **Reports > Inventory > Activity** if they have not been set