### PR TITLE
Auth security fix previous PR#7068

### DIFF
--- a/library/forms.inc.php
+++ b/library/forms.inc.php
@@ -160,5 +160,5 @@ function hasFormPermission($formDir)
     // get the aco spec from registry table
     $formRow = sqlQuery("SELECT aco_spec FROM registry WHERE directory = ?", array($formDir));
     $permission = explode('|', ($formRow['aco_spec'] ?? ''));
-    return AclMain::aclCheckCore($permission[0], $permission[1]);
+    return AclMain::aclCheckCore($permission[0], $permission[1] ?? null);
 }

--- a/src/Common/Auth/AuthUtils.php
+++ b/src/Common/Auth/AuthUtils.php
@@ -106,9 +106,11 @@ class AuthUtils
                 privStatement("UPDATE `globals` SET `gl_value` = ? WHERE `gl_name` = 'hidden_auth_dummy_hash'", [$this->dummyHash]);
             }
         }
-        if ($GLOBALS['password_expiration_days'] === '') {
+
+        $password_expiration_days = (privQuery("SELECT * FROM `globals` WHERE `gl_name` = 'password_expiration_days' AND `gl_index` = 0")['gl_value'] ?? null);
+        if ($password_expiration_days === '') {
             $GLOBALS['password_expiration_days'] = 0;
-            sqlQuery("UPDATE `globals` SET `gl_value` = ? WHERE `globals`.`gl_name` = 'password_expiration_days' AND `globals`.`gl_index` = '0' ", ['0']);
+            privStatement("UPDATE `globals` SET `gl_value` = ? WHERE `globals`.`gl_name` = 'password_expiration_days' AND `globals`.`gl_index` = '0'", ['0']);
             error_log("Blank global password_expiration_days updated to 0");
         }
     }
@@ -1004,7 +1006,7 @@ class AuthUtils
 
     private function checkPasswordNotExpired($user)
     {
-        if ((empty($GLOBALS['password_expiration_days'] ?? 0)) || self::useActiveDirectory($user)) {
+        if (($GLOBALS['password_expiration_days'] == 0) || self::useActiveDirectory($user)) {
             // skip the check if turned off or using active directory for login
             return true;
         }


### PR DESCRIPTION
- query and set global value for test in constructor

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:
Security concerns previous password_expiration_days is blank fix.
