### PR TITLE
fix: missing print label file for the quest lab hub

### DIFF
--- a/src/Events/Encounter/EncounterButtonEvent.php
+++ b/src/Events/Encounter/EncounterButtonEvent.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * package   OpenEMR
+ * link      http://www.open-emr.org
+ * author    Sherwin Gaddis <sherwingaddis@gmail.com>
+ * @Copyright 2019 Sherwin Gaddis <sherwingaddis@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\Encounter;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+class EncounterButtonEvent extends Event
+{
+    /**
+     * This event is fired where a button it to be rendered in the encounter form.
+     */
+    const BUTTON_RENDER = 'button.render';
+
+    private $button;
+
+    public function setButton($button): void
+    {
+        $this->button = $button;
+    }
+
+    public function displayButton()
+    {
+        return $this->button;
+    }
+}


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #7084

#### Short description of what this resolves:
Missing print label button

#### Changes proposed in this pull request:
Add print label button