### PR TITLE
chore: add php 8.4-dev syntax check to ci

### DIFF
--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.1', '8.2', '8.3']
+        php: ['8.1', '8.2', '8.3', '8.4']
     name: PHP ${{ matrix.php }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
chore: add php 8.4-dev syntax check to ci