### PR TITLE
Backport rel-702 Fixes #7133, #7134 SMART on FHIR style fixes (#7135)

### DIFF
--- a/src/RestControllers/SMART/SMARTAuthorizationController.php
+++ b/src/RestControllers/SMART/SMARTAuthorizationController.php
@@ -402,7 +402,8 @@ class SMARTAuthorizationController
     private function smartAppStyles()
     {
         $cssTheme = $GLOBALS['css_header'];
-        $parts = explode(".", $cssTheme);
+        $baseCssTheme = basename($cssTheme);
+        $parts = explode(".", $baseCssTheme);
         $coreTheme = $parts[0] ?? "style_light";
         $logoService = new LogoService();
         // do we want to expose each of the logos?  These really need to be cached instead of hitting FS each time...
@@ -412,7 +413,7 @@ class SMARTAuthorizationController
                 'primary' => $primaryLogo
             ]
         ];
-        $defaultFile = "/api/smart/smart-style_light.json";
-        $this->renderTwigJson('oauth2/authorize/smart-style', "/api/smart/smart-" . $coreTheme . ".json", $context, $defaultFile);
+        $defaultFile = "/api/smart/smart-style_light.json.twig";
+        $this->renderTwigJson('oauth2/authorize/smart-style', "/api/smart/smart-" . $coreTheme . ".json.twig", $context, $defaultFile);
     }
 }

--- a/templates/api/smart/smart-style_light.json.twig
+++ b/templates/api/smart/smart-style_light.json.twig
@@ -2,12 +2,13 @@
     "color_background": "#f8f9fa",
     "color_error": "#9e2d2d",
     "color_highlight": "#69b5ce",
-    "color_modal_backdrop": "",
+    "color_modal_backdrop": "#343a40",
     "color_success": "#498e49",
     "color_text": "#000",
     "dim_border_radius": "6px",
     "dim_font_size": "13px",
     "dim_spacing_size": "20px",
     "font_family_body": "'Lato','Helvetica',sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol','Noto Color Emoji'",
-    "font_family_heading": "'Lato','Helvetica',sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol','Noto Color Emoji'"
+    "font_family_heading": "'Lato','Helvetica',sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol','Noto Color Emoji'",
+    "logo_primary": "{{ logo.primary }}"
 }


### PR DESCRIPTION
Fix the 500 url loading error in issue #7133.

Add the logo and modal backdrop color to the twig files in #7134