### PR TITLE
fix: add margin defaults to prevent mpdf php8 fatal math error LBF printing

### DIFF
--- a/interface/forms/LBF/printable.php
+++ b/interface/forms/LBF/printable.php
@@ -91,6 +91,10 @@ $PDF_OUTPUT = ($formid && $isblankform) ? false : true;
 
 if ($PDF_OUTPUT) {
     $config_mpdf = Config_Mpdf::getConfigMpdf();
+    $config_mpdf['margin_top'] = $config_mpdf['margin_top'] * 1.5;
+    $config_mpdf['margin_bottom'] = $config_mpdf['margin_bottom'] * 1.5;
+    $config_mpdf['margin_header'] = $GLOBALS['pdf_top_margin'];
+    $config_mpdf['margin_footer'] =  $GLOBALS['pdf_bottom_margin'];
     $pdf = new mPDF($config_mpdf);
     $pdf->SetDisplayMode('real');
     if ($_SESSION['language_direction'] == 'rtl') {


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #7148 

#### Short description of what this resolves:


#### Changes proposed in this pull request:
