### PR TITLE
Fix for opening new tab from picker

### DIFF
--- a/src/Common/Twig/TwigExtension.php
+++ b/src/Common/Twig/TwigExtension.php
@@ -160,6 +160,9 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
             new TwigFunction(
                 'csrfToken',
                 function ($subject = 'default', $fieldName = "_token") {
+                    if (empty($subject)) {
+                        $subject = 'default';
+                    }
                     return sprintf('<input type="hidden" name="%s" value="%s">', $fieldName, attr(CsrfUtils::collectCsrfToken($subject)));
                 }
             ),


### PR DESCRIPTION
The twig custom function csrfToken($subject = 'default', $fieldName = "_token") sig arg $subject will not default to arg value unless null is passed in. Quote counts as populated.

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #7167 

#### Short description of what this resolves:


#### Changes proposed in this pull request:
Modify twig function to ensure proper subject from csrf token creation is used in verification.