### PR TITLE
Global user settings not set

### DIFF
--- a/interface/globals.php
+++ b/interface/globals.php
@@ -434,6 +434,13 @@ if (!empty($glrow)) {
             $GLOBALS[$gl_name] = $gl_value;
         }
     }
+    // Set any user settings that are not also in GLOBALS.
+    // This is for modules support.
+    foreach ($gl_user as $setting) {
+        if (!array_key_exists($setting['setting_label'], $GLOBALS)) {
+            $GLOBALS[$setting['setting_label']] = $setting['setting_value'];
+        }
+    }
 
   // Language cleanup stuff.
     $GLOBALS['language_menu_login'] = false;


### PR DESCRIPTION
add routine to set uninitialized user settings not in globals.

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #7194 
