### PR TITLE
fix: fix not_due label in the Clinical Reminders widget

### DIFF
--- a/library/clinical_rules.php
+++ b/library/clinical_rules.php
@@ -173,7 +173,7 @@ function clinical_summary_widget($patient_id, $mode, $dateTarget = '', $organize
             } elseif ($action['due_status'] == "due") {
                 echo "<span class='text-warning'>";
             } elseif ($action['due_status'] == "not_due") {
-                echo "<span class='text-success>";
+                echo "<span class='text-success'>";
             } else {
                 echo "<span>";
             }


### PR DESCRIPTION
fixes #7200 

fix not_due label in the Clinical Reminders widget