### PR TITLE
Module Manager Refactor

### DIFF
--- a/interface/modules/custom_modules/oe-module-weno/ModuleManagerListener.php
+++ b/interface/modules/custom_modules/oe-module-weno/ModuleManagerListener.php
@@ -88,6 +88,13 @@ class ModuleManagerListener extends AbstractModuleActionListener
      */
     private function install($modId, $currentActionStatus): mixed
     {
+        $modService = new ModuleService();
+        /* setting the active ui flag here will allow the config button to show
+         * before enable. This is a good thing because it allows the user to
+         * configure the module before enabling it. However, if the module is disabled
+         * this flag is reset by MM.
+        */
+        $modService::setModuleState($modId, '0', '1');
         return $currentActionStatus;
     }
 
@@ -98,12 +105,6 @@ class ModuleManagerListener extends AbstractModuleActionListener
      */
     private function preenable($modId, $currentActionStatus): mixed
     {
-        $modService = new ModuleService();
-        if ($modService->isWenoConfigured()) {
-            $modService::setModuleState($modId, '0', '0');
-            return $currentActionStatus;
-        }
-        $modService::setModuleState($modId, '0', '1');
         return $currentActionStatus;
     }
 
@@ -130,7 +131,8 @@ class ModuleManagerListener extends AbstractModuleActionListener
      */
     private function disable($modId, $currentActionStatus): mixed
     {
-        ModuleService::setModuleState($modId, '0', '0');
+        // allow config button to show before enable.
+        ModuleService::setModuleState($modId, '0', '1');
         return $currentActionStatus;
     }
 

--- a/interface/modules/custom_modules/oe-module-weno/moduleConfig.php
+++ b/interface/modules/custom_modules/oe-module-weno/moduleConfig.php
@@ -12,9 +12,15 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+use OpenEMR\Core\ModulesClassLoader;
+
 require_once dirname(__FILE__, 4) . '/globals.php';
 
-$module_config = 1;
-?>
+/* required for config before install */
+$classLoader = new ModulesClassLoader($GLOBALS['fileroot']);
+$classLoader->registerNamespaceIfNotExists("OpenEMR\\Modules\\WenoModule\\", __DIR__ . DIRECTORY_SEPARATOR . 'src');
 
-<iframe src="templates/weno_setup.php?module_config=1" style="border:none;height:100vh;width:100%;"></iframe>
+$module_config = 1;
+/* renders in a Laminas created iframe */
+require_once dirname(__FILE__) . '/templates/weno_setup.php';
+exit;

--- a/interface/modules/custom_modules/oe-module-weno/src/Services/ModuleService.php
+++ b/interface/modules/custom_modules/oe-module-weno/src/Services/ModuleService.php
@@ -129,7 +129,12 @@ class ModuleService
         $config = $this->getVendorGlobals();
         $keys = array_keys($config);
         foreach ($keys as $key) {
-            if ($key === 'weno_rx_enable_test') {
+            if (
+                $key === 'weno_rx_enable_test'
+                || $key === 'weno_secondary_admin_username'
+                || $key === 'weno_secondary_admin_password'
+                || $key === 'weno_secondary_encryption_key'
+            ) {
                 continue;
             }
             $value = $GLOBALS[$key] ?? null;
@@ -161,7 +166,7 @@ class ModuleService
     /**
      * @param $modId   string|int module id or directory name
      * @param $flag    string|int 1 or 0 to activate or deactivate module.
-     * @param $flag_ui string|int custom module ui flag to activate or deactivate Manager UI states.
+     * @param $flag_ui string|int custom flag to activate or deactivate Manager UI button states.
      * @return array|bool|null
      */
     public static function setModuleState($modId, $flag, $flag_ui): array|bool|null

--- a/interface/modules/custom_modules/oe-module-weno/src/Services/TransmitProperties.php
+++ b/interface/modules/custom_modules/oe-module-weno/src/Services/TransmitProperties.php
@@ -512,7 +512,7 @@ insurance;
         // get the weno provider id from the user table (weno_prov_id
         $provider = sqlQuery("SELECT weno_prov_id FROM users WHERE id = ?", [$id]);
         if (!empty(trim($provider['weno_prov_id'] ?? ''))) {
-            $doIt = $GLOBALS['weno_provider_uid'] != trim($provider['weno_prov_id']);
+            $doIt = ($GLOBALS['weno_provider_uid'] ?? '') != trim($provider['weno_prov_id']);
             if ($doIt) {
                 $GLOBALS['weno_provider_uid'] = trim($provider['weno_prov_id']);
                 $sql = "UPDATE `user_settings` SET `setting_value` = ? WHERE `setting_user` = ? AND `setting_label` = 'global:weno_provider_uid'";

--- a/interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php
+++ b/interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php
@@ -9,7 +9,7 @@
  * @author    Vipin Kumar <vipink@zhservices.com>
  * @author    Remesh Babu S <remesh@zhservices.com>
  * @author    Jerry Padgett <sjpadgett@gmail.com>
- * @copyright Copyright (c) 2020 Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright Copyright (c) 2020-2024 Jerry Padgett <sjpadgett@gmail.com>
  * @copyright Copyright (c) 2013 Z&H Consultancy Services Private Limited <sam@zhservices.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
@@ -50,6 +50,9 @@ class InstallerController extends AbstractActionController
         $this->dbAdapter = $adapter ?? null;
     }
 
+    /**
+     * @return ViewModel
+     */
     public function nolayout()
     {
         // Turn off the layout, i.e. only render the view script.
@@ -58,18 +61,21 @@ class InstallerController extends AbstractActionController
         return $viewModel;
     }
 
+    /**
+     * @return ViewModel
+     */
     public function indexAction()
     {
+        $this->scanAndRegisterCustomModules();
         //get the list of installed and new modules
         $result = $this->getInstallerTable()->allModules();
-
         $allModules = array();
         foreach ($result as $dataArray) {
             $mod = new InstModule();
             $mod->exchangeArray($dataArray);
             $mod = $this->makeButtonForSqlAction($mod);
             $mod = $this->makeButtonForAClAction($mod);
-            array_push($allModules, $mod);
+            $allModules[] = $mod;
         }
 
         return new ViewModel(array(
@@ -83,6 +89,56 @@ class InstallerController extends AbstractActionController
     }
 
     /**
+     * @return void
+     */
+    private function scanAndRegisterCustomModules(): void
+    {
+        $baseModuleDir = $GLOBALS['baseModDir'];
+        $customDir = $GLOBALS['customModDir'];
+        $zendModDir = $GLOBALS['zendModDir'];
+
+        $result = $this->getInstallerTable()->allModules();
+        $allModules = array();
+        foreach ($result as $dataArray) {
+            $mod = new InstModule();
+            $mod->exchangeArray($dataArray);
+            $mod = $this->makeButtonForSqlAction($mod);
+            $mod = $this->makeButtonForAClAction($mod);
+            $allModules[] = $mod;
+        }
+
+        $dpath = $GLOBALS['srcdir'] . "/../$baseModuleDir$customDir/";
+        $dp = opendir($dpath);
+        $inDir = array();
+        for ($i = 0; false != ($fname = readdir($dp)); $i++) {
+            if ($fname != "." && $fname != ".." && $fname != "Application" && is_dir($dpath . $fname)) {
+                $inDir[$i] = $fname;
+            }
+        }
+        // do not show registered modules in the unregistered list
+        if (sizeof($allModules) > 0) {
+            foreach ($allModules as $modules) {
+                $key = array_search($modules->modDirectory, $inDir);
+                if ($key !== false) {
+                    unset($inDir[$key]);
+                }
+            }
+        }
+        foreach ($inDir as $fname) {
+            $form_title_file = @file($GLOBALS['srcdir'] . "/../$baseModuleDir$customDir/$fname/info.txt");
+            if ($form_title_file) {
+                $form_title = trim($form_title_file[0]);
+            } else {
+                $form_title = $fname;
+            }
+            $rel_path = $fname . "/index.php";
+            if ($this->getInstallerTable()->register($fname, $rel_path)) {
+                $status = true;
+            }
+        }
+    }
+
+    /**
      * @return Installer\Model\InstModuleTable
      */
     public function getInstallerTable(): InstModuleTable
@@ -90,6 +146,9 @@ class InstallerController extends AbstractActionController
         return $this->InstallerTable;
     }
 
+    /**
+     * @return void
+     */
     public function registerAction()
     {
         if (!AclMain::aclCheckCore('admin', 'manage_modules')) {
@@ -126,6 +185,9 @@ class InstallerController extends AbstractActionController
         }
     }
 
+    /**
+     * @return void
+     */
     public function manageAction()
     {
         if (!AclMain::aclCheckCore('admin', 'manage_modules')) {
@@ -143,8 +205,13 @@ class InstallerController extends AbstractActionController
             // cleanup action.
             if ($modType == InstModuleTable::MODULE_TYPE_CUSTOM) {
                 $status = $this->callModuleAfterAction("pre" . $request->getPost('modAction'), $modId, $dirModule, $status);
-                if ($status == 'bypass') {
-                    // future use
+                if ($status == 'bypass_event') {
+                    $output = "";
+                    if (!empty($div) && is_array($div)) {
+                        $output = implode("<br />\n", $div);
+                    }
+                    echo json_encode(["status" => 'Success', "output" => $output]);
+                    exit(0);
                 }
             }
             if ($request->getPost('modAction') == "enable") {
@@ -283,6 +350,9 @@ class InstallerController extends AbstractActionController
         return $string;
     }
 
+    /**
+     * @return JsonModel
+     */
     public function SaveHooksAction()
     {
         $request = $this->getRequest();
@@ -305,6 +375,9 @@ class InstallerController extends AbstractActionController
         return $arr;
     }
 
+    /**
+     * @return ViewModel
+     */
     public function configureAction()
     {
         $request = $this->getRequest();
@@ -377,6 +450,9 @@ class InstallerController extends AbstractActionController
         ));
     }
 
+    /**
+     * @return JsonModel
+     */
     public function saveConfigAction()
     {
         $request = $this->getRequest();
@@ -396,6 +472,9 @@ class InstallerController extends AbstractActionController
         return $return;
     }
 
+    /**
+     * @return JsonModel
+     */
     public function DeleteAclAction()
     {
         $request = $this->getRequest();
@@ -405,6 +484,9 @@ class InstallerController extends AbstractActionController
         return $arr;
     }
 
+    /**
+     * @return JsonModel
+     */
     public function DeleteHooksAction()
     {
         $request = $this->getRequest();
@@ -414,6 +496,9 @@ class InstallerController extends AbstractActionController
         return $arr;
     }
 
+    /**
+     * @return void
+     */
     public function nickNameAction()
     {
         $request = $this->getRequest();
@@ -422,6 +507,10 @@ class InstallerController extends AbstractActionController
         exit(0);
     }
 
+    /**
+     * @param $modId
+     * @return false|string
+     */
     function getModuleVersionFromFile($modId)
     {
         //SQL version of Module
@@ -442,6 +531,11 @@ class InstallerController extends AbstractActionController
         return false;
     }
 
+    /**
+     * @param $modDirectory
+     * @param $sqldir
+     * @return array|false
+     */
     public function getFilesForUpgrade($modDirectory, $sqldir)
     {
         $ModulePath = $GLOBALS['srcdir'] . "/../" . $GLOBALS['baseModDir'] . "zend_modules/module/" . $modDirectory;
@@ -470,6 +564,10 @@ class InstallerController extends AbstractActionController
         return $sortVersions;
     }
 
+    /**
+     * @param InstModule $mod
+     * @return InstModule
+     */
     public function makeButtonForSqlAction(InstModule $mod)
     {
         $dirModule = $this->getInstallerTable()->getRegistryEntry($mod->modId, "mod_directory");
@@ -506,6 +604,10 @@ class InstallerController extends AbstractActionController
         return $mod;
     }
 
+    /**
+     * @param InstModule $mod
+     * @return InstModule
+     */
     public function makeButtonForACLAction(InstModule $mod)
     {
         $dirModule = $this->getInstallerTable()->getRegistryEntry($mod->modId, "mod_directory");

--- a/interface/modules/zend_modules/module/Installer/src/Installer/Model/InstModuleTable.php
+++ b/interface/modules/zend_modules/module/Installer/src/Installer/Model/InstModuleTable.php
@@ -9,7 +9,7 @@
  * @author    Vipin Kumar <vipink@zhservices.com>
  * @author    Remesh Babu S <remesh@zhservices.com>
  * @author    Jerry Padgett <sjpadgett@gmail.com>
- * @copyright Copyright (c) 2020 Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright Copyright (c) 2020-2024 Jerry Padgett <sjpadgett@gmail.com>
  * @copyright Copyright (c) 2013 Z&H Consultancy Services Private Limited <sam@zhservices.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
@@ -246,10 +246,6 @@ class InstModuleTable
     /**
      * this will be used to register a module
      *
-     * @param unknown_type $directory
-     * @param unknown_type $rel_path
-     * @param unknown_type $state
-     * @param unknown_type $base
      * @return boolean
      */
     public function register($directory, $rel_path, $state = 0, $base = "custom_modules")

--- a/interface/modules/zend_modules/module/Installer/view/installer/installer/configure.phtml
+++ b/interface/modules/zend_modules/module/Installer/view/installer/installer/configure.phtml
@@ -7,6 +7,8 @@
  * @author    Jacob T.Paul <jacob@zhservices.com>
  * @author    Vipin Kumar <vipink@zhservices.com>
  * @author    Remesh Babu S <remesh@zhservices.com>
+ * @author    Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright Copyright (c) 2020-2024 Jerry Padgett <sjpadgett@gmail.com>
  * @copyright Copyright (c) 2013 Z&H Consultancy Services Private Limited <sam@zhservices.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
@@ -27,7 +29,7 @@ $customDir = $GLOBALS['customModDir'];
 $zendModDir = $GLOBALS['zendModDir'];
 $confirmationMSG = $listener->z_xlt("Do you really want to delete?");
 // TODO: Change all of these magic numbers into constants, set them in the view and use them here so we can know what this all means.
-if (count($TabSettings) > 0) { ?>
+if (count($TabSettings ?? []) > 0) { ?>
     <div class="easyui-tabs container" id="tab<?php echo $this->escapeHtml($mod_id); ?>" style="width:950px;height:auto;">
         <?php
         if (isset($TabSettings[1]) && $TabSettings[1] > 0) {
@@ -77,7 +79,7 @@ if (count($TabSettings) > 0) { ?>
                                         ?>
                                     </tr>
                                     <?php
-                                    if (count($Hooks) > 0) {
+                                    if (count($Hooks ?? []) > 0) {
                                         foreach ($Hooks as $obj_hooks) {
                                             ?>
                                             <tr>
@@ -168,7 +170,7 @@ if (count($TabSettings) > 0) { ?>
             <?php
         }
         ?>
-        <?php if (count($setup) > 0) { ?>
+        <?php if (count($setup ?? []) > 0) { ?>
             <div title="<?php echo $listener->z_xla($setup['title']); ?>" style="height:auto;"
                 id="tab_config<?php echo $this->escapeHtml($mod_id); ?>"
                 iconCls="icon-setup">
@@ -180,7 +182,7 @@ if (count($TabSettings) > 0) { ?>
         <?php } ?>
     </div>
     <?php
-} elseif (count($setup) > 0) { ?>
+} elseif (count($setup ?? []) > 0) { ?>
     <div class="easyui-tabs container" id="tab<?php echo $this->escapeHtml($mod_id); ?>" style="height:auto;">
         <div title="<?php echo $listener->z_xla($setup['title']); ?>"
             id="tab_config<?php echo $this->escapeHtml($mod_id); ?>"
@@ -195,7 +197,7 @@ if (count($TabSettings) > 0) { ?>
 } else {
     // Final check for config
     // TBD : clsOeModule
-    $rs_mod = sqlQuery('select * from modules where mod_id=? and (mod_active=1 or mod_ui_active=1)', [$mod_id]);
+    $rs_mod = sqlQuery('select * from modules where `mod_id` = ?', [$mod_id]);
     $fConfig = dirname(realpath('.')) . '/custom_modules/' . $rs_mod['mod_directory'] . '/moduleConfig.php';
     if (($rs_mod['type'] == 0) && file_exists($fConfig)) {
         ?>
@@ -205,12 +207,10 @@ if (count($TabSettings) > 0) { ?>
             </iframe>
         </div>
         <?php
-    } else {
-        ?>
+    } else { ?>
         <div class="easyui-tabs container" id="tab<?php echo $this->escapeHtml($mod_id); ?>" style="height:auto;">
             <?php echo $listener->z_xlt('No Configuration Defined for this Module'); ?>
         </div>
         <?php
     }
 }
-?>

--- a/interface/modules/zend_modules/module/Installer/view/installer/installer/configure.phtml
+++ b/interface/modules/zend_modules/module/Installer/view/installer/installer/configure.phtml
@@ -15,7 +15,7 @@
 
 // Warning : PoC code
 // TBD - Must handle modules in external namespaces
-Use OpenEMR\Modules;
+use OpenEMR\Modules;
 
 $listener = $this->listenerObject;
 $hangers = $this->hangers;
@@ -199,11 +199,9 @@ if (count($TabSettings ?? []) > 0) { ?>
     // TBD : clsOeModule
     $rs_mod = sqlQuery('select * from modules where `mod_id` = ?', [$mod_id]);
     $fConfig = dirname(realpath('.')) . '/custom_modules/' . $rs_mod['mod_directory'] . '/moduleConfig.php';
-    if (($rs_mod['type'] == 0) && file_exists($fConfig)) {
-        ?>
+    if (($rs_mod['type'] == 0) && file_exists($fConfig)) { ?>
         <div class="container-xl" id="tab<?php echo $this->escapeHtml($mod_id); ?>" style="height:100vh;">
-            <iframe src="<?php echo dirname($this->basePath(), 2) . '/custom_modules/' . $rs_mod['mod_directory'] . '/moduleConfig.php'; ?>"
-                style="width:100%;height:100%;border:0">
+            <iframe src="<?php echo dirname($this->basePath(), 2) . '/custom_modules/' . $rs_mod['mod_directory'] . '/moduleConfig.php'; ?>" style="width:100%;height:100%;border:0">
             </iframe>
         </div>
         <?php
@@ -211,6 +209,5 @@ if (count($TabSettings ?? []) > 0) { ?>
         <div class="easyui-tabs container" id="tab<?php echo $this->escapeHtml($mod_id); ?>" style="height:auto;">
             <?php echo $listener->z_xlt('No Configuration Defined for this Module'); ?>
         </div>
-        <?php
-    }
+    <?php }
 }

--- a/interface/modules/zend_modules/module/Installer/view/installer/installer/index.phtml
+++ b/interface/modules/zend_modules/module/Installer/view/installer/installer/index.phtml
@@ -51,7 +51,6 @@ $coreModules = $this->coreModules ?? [];
 
   table {
     font-family: Arial, Helvetica, sans-serif;
-    font-size: 1rem;
   }
 
   .fa-2x {
@@ -65,7 +64,7 @@ $coreModules = $this->coreModules ?? [];
     padding: 5px;
     text-align: center;
     cursor: pointer;
-    margin: 5px 5px 0px 0px;
+    margin: 5px 5px 0 0;
     color: gray;
     width: 97%;
   }
@@ -76,7 +75,7 @@ $coreModules = $this->coreModules ?? [];
     border: 1px solid #c9c6c6;
     padding: 5px;
     width: 95%;
-    border-top: 0px;
+    border-top: 0;
   }
 
   .modal {
@@ -112,58 +111,7 @@ $coreModules = $this->coreModules ?? [];
                 </thead>
                 <tbody>
                 <?php
-                /* Laminas directory Unregistered scan */
-                $slno = 0;
-                $dpath = $GLOBALS['srcdir'] . "/../{$baseModuleDir}{$zendModDir}/module";
-                $dp = opendir($dpath);
-                $inDir = array();
-                for ($i = 0; false != ($fname = readdir($dp)); $i++) {
-                    if ($fname != "." && $fname != ".." && (!in_array($fname, $coreModules)) && is_dir($dpath . "/" . $fname))
-                        $inDir[$i] = $fname;
-                }
-                if (sizeof($InstallersExisting) > 0) {
-                    foreach ($InstallersExisting as $modules) {
-                        $key = "";
-                        $key = array_search($modules->modDirectory, $inDir);  /* returns integer or FALSE */
-                        if ($key !== false)
-                            unset($inDir[$key]);
-                    }
-                }
-                foreach ($inDir as $fname) {
-                    $slno++; ?>
-                    <tr>
-                        <td><?php echo $this->escapeHtml($slno); ?></td>
-                        <td>
-                            <?php
-                            $form_title_file = null;
-                            if (is_file($GLOBALS['srcdir'] . "/../{$baseModuleDir}{$zendModDir}/$fname/info.txt")) {
-                                $form_title_file = file($GLOBALS['srcdir'] . "/../{$baseModuleDir}{$zendModDir}/module/$fname/info.txt");
-                            }
-                            if (!empty($form_title_file)) {
-                                $form_title = $form_title_file[0];
-                            } else {
-                                $form_title = $fname;
-                            }
-                            echo $this->escapeHtml($listener->z_xlt($form_title));
-                            ?>
-                        </td>
-                        <td>--</td>
-                        <td>--</td>
-                        <td>--</td>
-                        <td>
-                            <?php echo $listener->z_xlt('Laminas'); ?>
-                        </td>
-                        <td>--</td>
-                        <td>
-                            <a href="javascript:void(0)" onclick="register(1,'<?php echo $this->escapeHtml($form_title); ?>','<?php echo $this->escapeHtml($fname) ?>','register','zend');"><input type='button' class='activate' value="<?php echo $listener->z_xla('Register'); ?>" /></a>
-                        </td>
-                        <td>--</td>
-                    </tr>
-                <?php }
-
-                flush();
-                /*
-                 * Custorm modules directory Unregistered scan
+                /* Laminas and Custom modules directory Unregistered scan
                  * moved to InstallerController auto register.
                  * */
                 /******** Laminas Module List Creation ********/
@@ -185,7 +133,7 @@ $coreModules = $this->coreModules ?? [];
                                 <?php
                                 if ($moduleResult->sqlRun == 0) {
                                     ?>
-                                    <?php echo $listener->z_xlt('Not Installed'); ?>
+                                    <?php echo $listener->z_xlt('Registered'); ?>
                                     <?php
                                 } elseif ($moduleResult->modActive == 1) { ?>
                                     <?php echo $listener->z_xlt('Active'); ?>
@@ -296,8 +244,7 @@ $coreModules = $this->coreModules ?? [];
                             </td>
                             <td>
                                 <?php
-                                if ($moduleResult->sqlRun == 0) {
-                                    ?>
+                                if ($moduleResult->sqlRun == 0) { ?>
                                     <input type="text" onchange="validateNickName('<?php echo $this->escapeHtml($moduleResult->modId); ?>');" name="mod_nick_name_<?php echo $this->escapeHtml($moduleResult->modId); ?>" id="mod_nick_name_<?php echo $this->escapeHtml($moduleResult->modId); ?>" value="">
                                     <div class="mod_nick_name_message" id="mod_nick_name_message_<?php echo $this->escapeHtml($moduleResult->modId); ?>"></div>
                                     <?php

--- a/interface/modules/zend_modules/module/Installer/view/installer/installer/index.phtml
+++ b/interface/modules/zend_modules/module/Installer/view/installer/installer/index.phtml
@@ -7,7 +7,7 @@
  * @author    Jacob T.Paul <jacob@zhservices.com>
  * @author    Vipin Kumar <vipink@zhservices.com>
  * @author    Jerry Padgett <sjpadgett@gmail.com>
- * @copyright Copyright (c) 2020 Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright Copyright (c) 2020-2024 Jerry Padgett <sjpadgett@gmail.com>
  * @copyright Copyright (c) 2013 Z&H Consultancy Services Private Limited <sam@zhservices.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
@@ -31,301 +31,374 @@ $depObj = $this->dependencyObject;
 $coreModules = $this->coreModules ?? [];
 
 ?>
-<ul class="tabNav bg-light text-dark">
+<!-- Retain for future use. Config and enable new page buttons here. -->
+<!--<ul class="tabNav bg-light text-dark">
     <li class="current divMenu" onclick="$('.registered').show();$('.unregistered').hide();$('.divMenu').removeClass('current');$(this).addClass('current');">
-        <a class="btn btn-lg btn-primary" href="javascript:void(0)" id="header_tab_Registered">
-            <?php echo $listener->z_xlt('Registered'); ?>
-        </a>
+        <button type="button" class="btn btn-primary" id="header_tab_Registered">
+            <?php /*echo $listener->z_xlt('Custom Modules'); */ ?>
+        </button>
     </li>
     <li class="divMenu" onclick="$('.registered').hide();$('.unregistered').show();$('.divMenu').removeClass('current');$(this).addClass('current');">
-        <a class="btn btn-lg btn-light" href="javascript:void(0)" id="header_tab_UnReg">
-            <?php echo $listener->z_xlt('Unregistered'); ?> <span id='ct'></span>
-        </a>
+        <button type="button" class="btn btn-primary" href="javascript:void(0)" id="header_tab_UnReg">
+            <?php /*echo $listener->z_xlt('Laminas Modules'); */ ?> <span id='ct'></span>
+        </button>
     </li>
-</ul>
+</ul>-->
+<style>
+  body {
+    font-family: Arial, Helvetica, sans-serif !important;
+  }
+
+  table {
+    font-family: Arial, Helvetica, sans-serif;
+    font-size: 1rem;
+  }
+
+  .fa-2x {
+    font-size: 1.5rem;
+  }
+
+  /* installer log for upgrades maybe? */
+  .show_hide_log {
+    border-radius: 5px;
+    border: 1px solid #c9c6c6;
+    padding: 5px;
+    text-align: center;
+    cursor: pointer;
+    margin: 5px 5px 0px 0px;
+    color: gray;
+    width: 97%;
+  }
+
+  .spoiler {
+    display: none;
+    margin-left: 10px;
+    border: 1px solid #c9c6c6;
+    padding: 5px;
+    width: 95%;
+    border-top: 0px;
+  }
+
+  .modal {
+    display: none;
+    position: fixed;
+    z-index: 1000;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+    background: rgba(255, 255, 255, .8) url('/interface/modules/zend_modules/public/images/ajax-loader.gif') 50% 50% no-repeat;
+  }
+</style>
 <div class="installer bg-light text-dark">
     <div id='err' class='bold '></div>
-    <div class="installer_code notranslate registered bg-light">
-        <?php //REGISTERED SECTION ?>
-        <div class="imagetable">
-            <div class="imagetable_code notranslate table-resposive">
-                <table id="table-6" class="table table-light table-hover table-condensed" align="center">
-                    <thead>
-                        <tr>
-                            <th class="bg-light text-dark">
-                                <span style="font-size: 1.25rem"><?php echo $listener->z_xlt('Registered Modules'); ?></span>
-                            </th>
-                        <tr>
-                        <tr style="font-size: 16px;">
-                            <th scope="col"><?php echo $listener->z_xlt('ID'); ?></th>
-                            <th scope="col"><?php echo $listener->z_xlt('Module'); ?> </th>
-                            <th scope="col"><?php echo $listener->z_xlt('Status'); ?> </th>
-                            <th scope="col"><?php echo $listener->z_xlt('Menu Text'); ?> </th>
-                            <th scope="col"><?php echo $listener->z_xlt('Nick Name'); ?> </th>
-                            <th scope="col"><?php echo $listener->z_xlt('Type'); ?> </th>
-                            <th scope="col"><?php echo $listener->z_xlt('Dependency Modules'); ?> </th>
-                            <th scope="col"><?php echo $listener->z_xlt('Action'); ?> </th>
-                            <th scope="col"><?php echo $listener->z_xlt('Config'); ?> </th>
-                        </tr>
-                    </thead>
-                    <?php
-                    /******** Module Creation ********/
-                    $count = 0;
-                    if (sizeof($InstallersAll) > 0)
-                        foreach ($InstallersAll as $moduleResult) {
-                            if ($moduleResult->modName == 'Acl') continue;
-                            $count++;
-                            ?>
-                            <tr id="<?php echo $this->escapeHtml($moduleResult->modId); ?>">
-                                <td><?php echo $this->escapeHtml($count); ?>    </td>
-                                <td><?php echo $this->escapeHtml($moduleResult->modName); ?></td>
-                                <td>
-                                    <?php
-
-                                    if ($moduleResult->sqlRun == 0) {
-                                        ?>
-                                        <?php echo $listener->z_xlt('Not Installed'); ?>
-                                        <?php
-                                    } elseif ($moduleResult->modActive == 1) { ?>
-                                        <?php echo $listener->z_xlt('Active'); ?>
-                                    <?php } else {
-                                        ?>
-                                        <?php echo $listener->z_xlt('Inactive'); ?>
-                                        <?php
-                                    }
-                                    ?>
-                                </td>
-                                <td>
-                                    <?php echo $this->escapeHtml($moduleResult->modUiName); ?>
-                                </td>
-                                <td>
-                                    <?php
-                                    if ($moduleResult->sqlRun == 0) {
-                                        ?>
-                                        <input type="text" onchange="validateNickName('<?php echo $this->escapeHtml($moduleResult->modId); ?>');" name="mod_nick_name_<?php echo $this->escapeHtml($moduleResult->modId); ?>" id="mod_nick_name_<?php echo $this->escapeHtml($moduleResult->modId); ?>" value="">
-                                        <div class="mod_nick_name_message" id="mod_nick_name_message_<?php echo $this->escapeHtml($moduleResult->modId); ?>"></div>
-                                        <?php
-                                    } else {
-                                        echo $this->escapeHtml($moduleResult->modnickname);
-                                    }
-                                    ?>
-                                </td>
-                                <td>
-                                    <?php echo $this->escapeHtml(($moduleResult->type == 1) ? "Laminas" : "Custom"); ?>
-                                </td>
-                                <td>
-                                    <?php
-                                    $depStr = $depObj->getDependencyModules($moduleResult->modId);
-                                    echo ($depStr <> "") ? $listener->z_xlt($depStr) : "--";
-                                    ?>
-                                </td>
-                                <td>
-                                    <?php if ($moduleResult->sqlRun == 0) { ?>
-                                        <a href="javascript:void(0)" class="link_submit install" onclick="manage('<?php echo $this->escapeHtml($moduleResult->modId) ?>','install');" title="<?php echo $listener->z_xla('Click Here to Install This module'); ?>"><input type='button' class='activate' value="<?php echo $listener->z_xla('Install'); ?>" /></a>
-                                    <?php } elseif ($moduleResult->modActive == 1 && $moduleResult->modUiActive == 0) { ?>
-                                        <a href="javascript:void(0)" class="link_submit active" onclick="manage('<?php echo $this->escapeHtml($moduleResult->modId) ?>','disable');" title="<?php echo $listener->z_xla('Click Here to Disable This module'); ?>"><input type='button' class='deactivate' value="<?php echo $listener->z_xla('Disable'); ?>" /></a>
-                                    <?php } elseif ($moduleResult->modName != 'Acl') { ?>
-                                        <a href="javascript:void(0)" class="link_submit inactive" onclick="manage('<?php echo $this->escapeHtml($moduleResult->modId) ?>','enable');" title="<?php echo $listener->z_xla('Click Here to Enable This module'); ?>"><input type='button' class='activate' value="<?php echo $listener->z_xla('Enable'); ?>" /></a>
-                                    <?php } ?>
-                                    <?php if ($moduleResult->sql_action == "install") { ?>
-                                        <a href="javascript:void(0)" class="link_submit install_sql" onclick="manage('<?php echo $this->escapeHtml($moduleResult->modId) ?>','install_sql');" title="<?php echo $listener->z_xla('Click Here to Install SQL for module'); ?>"><input type='button' value="<?php echo $listener->z_xla('Install SQL'); ?>" /></a>
-                                    <?php } elseif ($moduleResult->sql_action == "upgrade") { ?>
-                                        <a href="javascript:void(0)" class="link_submit upgrade_sql" onclick="manage('<?php echo $this->escapeHtml($moduleResult->modId) ?>','upgrade_sql');" title="<?php echo $listener->z_xla('Click Here to Upgrade SQL for module'); ?>"><input type='button' onclick="blockInput(this);" value="<?php echo $listener->z_xla('Upgrade SQL'); ?>" /></a>
-                                        <?php } ?>
-                                    <?php if ($moduleResult->acl_action == "install") { ?>
-                                        <a href="javascript:void(0)" class="link_submit install_acl" onclick="manage('<?php echo $this->escapeHtml($moduleResult->modId) ?>','install_acl');" title="<?php echo $listener->z_xla('Click Here to Install ACL for module'); ?>"><input type='button' onclick="blockInput(this);" value="<?php echo $listener->z_xla('Install ACL'); ?>" /></a>
-                                    <?php } elseif ($moduleResult->acl_action == "upgrade") { ?>
-                                        <a href="javascript:void(0)" class="link_submit upgrade_acl" onclick="manage('<?php echo $this->escapeHtml($moduleResult->modId) ?>','upgrade_acl');" title="<?php echo $listener->z_xla('Click Here to Upgrade ACL for module'); ?>"><input type='button' onclick="blockInput(this);" value="<?php echo $listener->z_xla('Upgrade ACL'); ?>" /></a>
-                                    <?php } ?>
-                                </td>
-                                <td>
-                                    <?php if ($moduleResult->sqlRun == 0) { ?>
-                                        --
-                                    <?php } elseif ($moduleResult->modActive == 1) { ?>
-                                        <a href="javascript:void(0)" class="link_submit active" onclick="configure('<?php echo $this->escapeHtml($moduleResult->modId) ?>','<?php echo $this->basePath() ?>');" title="<?php echo $listener->z_xla('Click Here to Configure This module'); ?>"><i class="fa fa-cog fa-2x <?php echo $moduleResult->modUiActive == 1 ? ' fa-spin text-danger' : 'text-dark'; ?>"></i></a>
-                                        <?php if ($moduleResult->modUiActive == 1 && $moduleResult->type == 0) { ?>
-                                            <a href="javascript:void(0)" class="link_submit active" onclick="manage('<?php echo $this->escapeHtml($moduleResult->modId) ?>','unregister');" title="<?php echo $listener->z_xla('Click Here to UnRegister this Module'); ?>"><i class="fa fa-trash text-warning fa-2x" aria-hidden="true"></i></a>
-                                        <?php } ?>
-                                    <?php } elseif ($moduleResult->modActive == 0 && $moduleResult->type == 0) { ?>
-                                        <a href="javascript:void(0)" class="link_submit active" onclick="manage('<?php echo $this->escapeHtml($moduleResult->modId) ?>','unregister');" title="<?php echo $listener->z_xla('Click Here to UnRegister this Module'); ?>"><i class="fa fa-trash text-warning fa-2x" aria-hidden="true"></i></a>
-                                    <?php } else { ?>
-                                        --
-                                    <?php } ?>
-                                </td>
-                            </tr>
-                            <tr style="display:none" class="config" id="ConfigRow_<?php echo $this->escapeHtml($moduleResult->modId); ?>">
-                                <td colspan="10" align="center">
-                                </td>
-                            </tr>
+    <div class="imagetable">
+        <div class="modal"></div>
+        <div id="install_upgrade_log" style="overflow-y: auto; height: 500px; display: none;"></div>
+        <div class="imagetable_code notranslate table-responsive">
+            <table id="table-6" class="table table-light table-hover table-condensed" align="center">
+                <thead>
+                <tr style="font-size: 16px;">
+                    <th scope="col"><?php echo $listener->z_xlt('ID'); ?></th>
+                    <th scope="col"><?php echo $listener->z_xlt('Module'); ?> </th>
+                    <th scope="col"><?php echo $listener->z_xlt('Status'); ?> </th>
+                    <th scope="col"><?php echo $listener->z_xlt('Menu Text'); ?> </th>
+                    <th scope="col"><?php echo $listener->z_xlt('Nick Name'); ?> </th>
+                    <th scope="col"><?php echo $listener->z_xlt('Type'); ?> </th>
+                    <th scope="col"><?php echo $listener->z_xlt('Dependency Modules'); ?> </th>
+                    <th scope="col"><?php echo $listener->z_xlt('Action'); ?> </th>
+                    <th scope="col"><?php echo $listener->z_xlt('Settings'); ?> </th>
+                </tr>
+                </thead>
+                <tbody>
+                <?php
+                /* Laminas directory Unregistered scan */
+                $slno = 0;
+                $dpath = $GLOBALS['srcdir'] . "/../{$baseModuleDir}{$zendModDir}/module";
+                $dp = opendir($dpath);
+                $inDir = array();
+                for ($i = 0; false != ($fname = readdir($dp)); $i++) {
+                    if ($fname != "." && $fname != ".." && (!in_array($fname, $coreModules)) && is_dir($dpath . "/" . $fname))
+                        $inDir[$i] = $fname;
+                }
+                if (sizeof($InstallersExisting) > 0) {
+                    foreach ($InstallersExisting as $modules) {
+                        $key = "";
+                        $key = array_search($modules->modDirectory, $inDir);  /* returns integer or FALSE */
+                        if ($key !== false)
+                            unset($inDir[$key]);
+                    }
+                }
+                foreach ($inDir as $fname) {
+                    $slno++; ?>
+                    <tr>
+                        <td><?php echo $this->escapeHtml($slno); ?></td>
+                        <td>
                             <?php
+                            $form_title_file = null;
+                            if (is_file($GLOBALS['srcdir'] . "/../{$baseModuleDir}{$zendModDir}/$fname/info.txt")) {
+                                $form_title_file = file($GLOBALS['srcdir'] . "/../{$baseModuleDir}{$zendModDir}/module/$fname/info.txt");
+                            }
+                            if (!empty($form_title_file)) {
+                                $form_title = $form_title_file[0];
+                            } else {
+                                $form_title = $fname;
+                            }
+                            echo $this->escapeHtml($listener->z_xlt($form_title));
+                            ?>
+                        </td>
+                        <td>--</td>
+                        <td>--</td>
+                        <td>--</td>
+                        <td>
+                            <?php echo $listener->z_xlt('Laminas'); ?>
+                        </td>
+                        <td>--</td>
+                        <td>
+                            <a href="javascript:void(0)" onclick="register(1,'<?php echo $this->escapeHtml($form_title); ?>','<?php echo $this->escapeHtml($fname) ?>','register','zend');"><input type='button' class='activate' value="<?php echo $listener->z_xla('Register'); ?>" /></a>
+                        </td>
+                        <td>--</td>
+                    </tr>
+                <?php }
+
+                flush();
+                /*
+                 * Custorm modules directory Unregistered scan
+                 * moved to InstallerController auto register.
+                 * */
+                /******** Laminas Module List Creation ********/
+                $count = 0;
+                if (sizeof($InstallersAll) > 0) {
+                    foreach ($InstallersAll as $moduleResult) {
+                        if ($moduleResult->modName == 'Acl') {
+                            continue;
                         }
-                    //end of if & while
-                    ?>
-                </table>
-            </div>
+                        if ($moduleResult->type == 0) {
+                            continue;
+                        }
+                        $count++;
+                        ?>
+                        <tr id="<?php echo $this->escapeHtml($moduleResult->modId); ?>">
+                            <td><?php echo $this->escapeHtml($count); ?>    </td>
+                            <td><?php echo $this->escapeHtml($moduleResult->modName); ?></td>
+                            <td>
+                                <?php
+                                if ($moduleResult->sqlRun == 0) {
+                                    ?>
+                                    <?php echo $listener->z_xlt('Not Installed'); ?>
+                                    <?php
+                                } elseif ($moduleResult->modActive == 1) { ?>
+                                    <?php echo $listener->z_xlt('Active'); ?>
+                                <?php } else {
+                                    ?>
+                                    <?php echo $listener->z_xlt('Inactive'); ?>
+                                    <?php
+                                }
+                                ?>
+                            </td>
+                            <td>
+                                <?php echo $this->escapeHtml($moduleResult->modUiName); ?>
+                            </td>
+                            <td>
+                                <?php
+                                if ($moduleResult->sqlRun == 0) { ?>
+                                    <input type="text" onchange="validateNickName('<?php echo $this->escapeHtml($moduleResult->modId); ?>');" name="mod_nick_name_<?php echo $this->escapeHtml($moduleResult->modId); ?>" id="mod_nick_name_<?php echo $this->escapeHtml($moduleResult->modId); ?>" value="">
+                                    <div class="mod_nick_name_message" id="mod_nick_name_message_<?php echo $this->escapeHtml($moduleResult->modId); ?>"></div>
+                                    <?php
+                                } else {
+                                    echo $this->escapeHtml($moduleResult->modnickname);
+                                }
+                                ?>
+                            </td>
+                            <td>
+                                <?php echo $this->escapeHtml(($moduleResult->type == 1) ? "Laminas" : "Custom"); ?>
+                            </td>
+                            <td>
+                                <?php
+                                $depStr = $depObj->getDependencyModules($moduleResult->modId);
+                                echo ($depStr <> "") ? $listener->z_xlt($depStr) : "--";
+                                ?>
+                            </td>
+                            <td>
+                                <?php if ($moduleResult->sqlRun == 0) { ?>
+                                    <a href="javascript:void(0)" class="link_submit install" onclick="manage('<?php echo $this->escapeHtml($moduleResult->modId) ?>','install');" title="<?php echo $listener->z_xla('Click Here to Install This module'); ?>"><input type='button' class='activate' value="<?php echo $listener->z_xla('Install'); ?>" /></a>
+                                <?php } elseif ($moduleResult->modActive == 1 && $moduleResult->modUiActive == 0) { ?>
+                                    <a href="javascript:void(0)" class="link_submit active" onclick="manage('<?php echo $this->escapeHtml($moduleResult->modId) ?>','disable');" title="<?php echo $listener->z_xla('Click Here to Disable This module'); ?>"><input type='button' class='deactivate' value="<?php echo $listener->z_xla('Disable'); ?>" /></a>
+                                <?php } elseif ($moduleResult->modName != 'Acl') { ?>
+                                    <a href="javascript:void(0)" class="link_submit inactive" onclick="manage('<?php echo $this->escapeHtml($moduleResult->modId) ?>','enable');" title="<?php echo $listener->z_xla('Click Here to Enable This module'); ?>"><input type='button' class='activate' value="<?php echo $listener->z_xla('Enable'); ?>" /></a>
+                                <?php } ?>
+                                <?php if ($moduleResult->sql_action == "install") { ?>
+                                    <a href="javascript:void(0)" class="link_submit install_sql" onclick="manage('<?php echo $this->escapeHtml($moduleResult->modId) ?>','install_sql');" title="<?php echo $listener->z_xla('Click Here to Install SQL for module'); ?>"><input type='button' value="<?php echo $listener->z_xla('Install SQL'); ?>" /></a>
+                                <?php } elseif ($moduleResult->sql_action == "upgrade") { ?>
+                                    <a href="javascript:void(0)" class="link_submit upgrade_sql" onclick="manage('<?php echo $this->escapeHtml($moduleResult->modId) ?>','upgrade_sql');" title="<?php echo $listener->z_xla('Click Here to Upgrade SQL for module'); ?>"><input type='button' onclick="blockInput(this);" value="<?php echo $listener->z_xla('Upgrade SQL'); ?>" /></a>
+                                <?php } ?>
+                                <?php if ($moduleResult->acl_action == "install") { ?>
+                                    <a href="javascript:void(0)" class="link_submit install_acl" onclick="manage('<?php echo $this->escapeHtml($moduleResult->modId) ?>','install_acl');" title="<?php echo $listener->z_xla('Click Here to Install ACL for module'); ?>"><input type='button' onclick="blockInput(this);" value="<?php echo $listener->z_xla('Install ACL'); ?>" /></a>
+                                <?php } elseif ($moduleResult->acl_action == "upgrade") { ?>
+                                    <a href="javascript:void(0)" class="link_submit upgrade_acl" onclick="manage('<?php echo $this->escapeHtml($moduleResult->modId) ?>','upgrade_acl');" title="<?php echo $listener->z_xla('Click Here to Upgrade ACL for module'); ?>"><input type='button' onclick="blockInput(this);" value="<?php echo $listener->z_xla('Upgrade ACL'); ?>" /></a>
+                                <?php } ?>
+                            </td>
+                            <td>
+                                <?php if ($moduleResult->sqlRun == 0) { ?>
+                                    <a href="javascript:void(0)" class="link_submit active" onclick="manage('<?php echo $this->escapeHtml($moduleResult->modId) ?>','unregister');" title="<?php echo $listener->z_xla('Click Here to UnRegister this Module'); ?>"><i class="fa fa-registered text-warning fa-2x" aria-hidden="true"></i></a>
+                                <?php } elseif ($moduleResult->modActive == 1) { ?>
+                                    <a href="javascript:void(0)" class="link_submit active" onclick="configure('<?php echo $this->escapeHtml($moduleResult->modId) ?>','<?php echo $this->basePath() ?>');" title="<?php echo $listener->z_xla('Click Here to Configure This module'); ?>"><i class="fa fa-cog fa-2x <?php echo $moduleResult->modUiActive == 1 ? ' fa-spin text-danger' : 'text-dark'; ?>"></i></a>
+                                    <?php if ($moduleResult->modUiActive == 1) { ?>
+                                        <a href="javascript:void(0)" class="link_submit active" onclick="manage('<?php echo $this->escapeHtml($moduleResult->modId) ?>','unregister');" title="<?php echo $listener->z_xla('Click Here to UnRegister this Module'); ?>"><i class="fa fa-trash text-warning fa-2x" aria-hidden="true"></i></a>
+                                    <?php } ?>
+                                <?php } elseif ($moduleResult->modActive == 0) { ?>
+                                    <a href="javascript:void(0)" class="link_submit active" onclick="manage('<?php echo $this->escapeHtml($moduleResult->modId) ?>','unregister');" title="<?php echo $listener->z_xla('Click Here to UnRegister this Module'); ?>"><i class="fa fa-trash text-warning fa-2x" aria-hidden="true"></i></a>
+                                <?php } else { ?>
+                                    --
+                                <?php } ?>
+                            </td>
+                        </tr>
+                        <tr style="display:none" class="config" id="ConfigRow_<?php echo $this->escapeHtml($moduleResult->modId); ?>">
+                            <td colspan="10" align="center">
+                            </td>
+                        </tr>
+                        <?php
+                    }
+                }
+                //end of laminas if
+                /******** Custom Module Creation ********/
+                $count = 0;
+                if (sizeof($InstallersAll) > 0) {
+                    foreach ($InstallersAll as $moduleResult) {
+                        if ($moduleResult->modName == 'Acl') {
+                            continue;
+                        }
+                        if ($moduleResult->type == 1) {
+                            continue;
+                        }
+                        $count++;
+                        ?>
+                        <tr id="<?php echo $this->escapeHtml($moduleResult->modId); ?>">
+                            <td><?php echo $this->escapeHtml($count); ?>    </td>
+                            <td><?php echo $this->escapeHtml($moduleResult->modName); ?></td>
+                            <td>
+                                <?php
+                                if ($moduleResult->sqlRun == 0) {
+                                    ?>
+                                    <?php echo $listener->z_xlt('Registered'); ?>
+                                    <?php
+                                } elseif ($moduleResult->modActive == 1) { ?>
+                                    <?php echo $listener->z_xlt('Active'); ?>
+                                <?php } else {
+                                    ?>
+                                    <?php echo $listener->z_xlt('Inactive'); ?>
+                                    <?php
+                                }
+                                ?>
+                            </td>
+                            <td>
+                                <?php echo $this->escapeHtml($moduleResult->modUiName); ?>
+                            </td>
+                            <td>
+                                <?php
+                                if ($moduleResult->sqlRun == 0) {
+                                    ?>
+                                    <input type="text" onchange="validateNickName('<?php echo $this->escapeHtml($moduleResult->modId); ?>');" name="mod_nick_name_<?php echo $this->escapeHtml($moduleResult->modId); ?>" id="mod_nick_name_<?php echo $this->escapeHtml($moduleResult->modId); ?>" value="">
+                                    <div class="mod_nick_name_message" id="mod_nick_name_message_<?php echo $this->escapeHtml($moduleResult->modId); ?>"></div>
+                                    <?php
+                                } else {
+                                    echo $this->escapeHtml($moduleResult->modnickname);
+                                }
+                                ?>
+                            </td>
+                            <td>
+                                <?php echo $this->escapeHtml(($moduleResult->type == 1) ? "Laminas" : "Custom"); ?>
+                            </td>
+                            <td>
+                                <?php
+                                $depStr = $depObj->getDependencyModules($moduleResult->modId);
+                                echo ($depStr <> "") ? $listener->z_xlt($depStr) : "--";
+                                ?>
+                            </td>
+                            <td>
+                                <?php if ($moduleResult->sqlRun == 0) { ?>
+                                    <a href="javascript:void(0)" class="link_submit install" onclick="manage('<?php echo $this->escapeHtml($moduleResult->modId) ?>','install');" title="<?php echo $listener->z_xla('Click Here to Install This module'); ?>"><input type='button' class='activate' value="<?php echo $listener->z_xla('Install'); ?>" /></a>
+                                <?php } elseif ($moduleResult->modActive == 1 && $moduleResult->modUiActive == 0) { ?>
+                                    <a href="javascript:void(0)" class="link_submit active" onclick="manage('<?php echo $this->escapeHtml($moduleResult->modId) ?>','disable');" title="<?php echo $listener->z_xla('Click Here to Disable This module'); ?>"><input type='button' class='deactivate' value="<?php echo $listener->z_xla('Disable'); ?>" /></a>
+                                <?php } elseif ($moduleResult->modName != 'Acl') { ?>
+                                    <a href="javascript:void(0)" class="link_submit inactive" onclick="manage('<?php echo $this->escapeHtml($moduleResult->modId) ?>','enable');" title="<?php echo $listener->z_xla('Click Here to Enable This module'); ?>"><input type='button' class='activate' value="<?php echo $listener->z_xla('Enable'); ?>" /></a>
+                                <?php } ?>
+                                <?php if ($moduleResult->sql_action == "install") { ?>
+                                    <a href="javascript:void(0)" class="link_submit install_sql" onclick="manage('<?php echo $this->escapeHtml($moduleResult->modId) ?>','install_sql');" title="<?php echo $listener->z_xla('Click Here to Install SQL for module'); ?>"><input type='button' value="<?php echo $listener->z_xla('Install SQL'); ?>" /></a>
+                                <?php } elseif ($moduleResult->sql_action == "upgrade") { ?>
+                                    <a href="javascript:void(0)" class="link_submit upgrade_sql" onclick="manage('<?php echo $this->escapeHtml($moduleResult->modId) ?>','upgrade_sql');" title="<?php echo $listener->z_xla('Click Here to Upgrade SQL for module'); ?>"><input type='button' onclick="blockInput(this);" value="<?php echo $listener->z_xla('Upgrade SQL'); ?>" /></a>
+                                <?php } ?>
+                                <?php if ($moduleResult->acl_action == "install") { ?>
+                                    <a href="javascript:void(0)" class="link_submit install_acl" onclick="manage('<?php echo $this->escapeHtml($moduleResult->modId) ?>','install_acl');" title="<?php echo $listener->z_xla('Click Here to Install ACL for module'); ?>"><input type='button' onclick="blockInput(this);" value="<?php echo $listener->z_xla('Install ACL'); ?>" /></a>
+                                <?php } elseif ($moduleResult->acl_action == "upgrade") { ?>
+                                    <a href="javascript:void(0)" class="link_submit upgrade_acl" onclick="manage('<?php echo $this->escapeHtml($moduleResult->modId) ?>','upgrade_acl');" title="<?php echo $listener->z_xla('Click Here to Upgrade ACL for module'); ?>"><input type='button' onclick="blockInput(this);" value="<?php echo $listener->z_xla('Upgrade ACL'); ?>" /></a>
+                                <?php } ?>
+                            </td>
+                            <td><!-- We should be able to unregister even if not installed i.e sql_run = 0 -->
+                                <?php if ($moduleResult->sqlRun == 0 && $moduleResult->modActive == 0) { ?>
+                                    <a href="javascript:void(0)" class="link_submit active" onclick="manage('<?php echo $this->escapeHtml($moduleResult->modId) ?>','unregister');" title="<?php echo $listener->z_xla('Click Here to UnRegister this Module'); ?>"><i class="fa fa-registered text-warning fa-2x" aria-hidden="true"></i></a>
+                                <?php } elseif ($moduleResult->modActive == 1) { ?>
+                                    <a href="javascript:void(0)" class="link_submit active" onclick="configure('<?php echo $this->escapeHtml($moduleResult->modId) ?>','<?php echo $this->basePath() ?>');" title="<?php echo $listener->z_xla('Click Here to Configure This module'); ?>"><i class="fa fa-cog fa-2x <?php echo $moduleResult->modUiActive == 1 ? ' fa-spin text-danger' : 'text-dark'; ?>"></i></a>
+                                    <?php if ($moduleResult->modUiActive == 1 && $moduleResult->type == 0) { ?>
+                                        <a href="javascript:void(0)" class="link_submit active" onclick="manage('<?php echo $this->escapeHtml($moduleResult->modId) ?>','unregister');" title="<?php echo $listener->z_xla('Click Here to UnRegister this Module'); ?>"><i class="fa fa-trash text-warning fa-2x" aria-hidden="true"></i></a>
+                                    <?php } ?>
+                                <?php } elseif ($moduleResult->modActive == 0 && $moduleResult->type == 0) { ?>
+                                    <?php if ($moduleResult->modUiActive == 1) {
+                                        // only allow if module requests by setting the mod_ui_active column
+                                        // because module will have to deal with namespace setting for called config script.
+                                        ?>
+                                        <a href="javascript:void(0)" class="link_submit active" onclick="configure('<?php echo $this->escapeHtml($moduleResult->modId) ?>','<?php echo $this->basePath() ?>');" title="<?php echo $listener->z_xla('Click Here to Configure This module'); ?>"><i class="fa fa-cog fa-2x text-dark"></i>
+                                        </a>
+                                    <?php } ?>
+                                    <a href="javascript:void(0)" class="link_submit active" onclick="manage('<?php echo $this->escapeHtml($moduleResult->modId) ?>','unregister');" title="<?php echo $listener->z_xla('Click Here to UnRegister this Module'); ?>"><i class="fa fa-trash text-warning fa-2x" aria-hidden="true"></i></a>
+                                <?php } else { ?>
+                                    --
+                                <?php } ?>
+                            </td>
+                        </tr>
+                        <tr style="display:none" class="config" id="ConfigRow_<?php echo $this->escapeHtml($moduleResult->modId); ?>">
+                            <td colspan="10" align="center">
+                            </td>
+                        </tr>
+                        <?php
+                    }
+                }
+                //end of custom if
+                ?>
+                </tbody>
+            </table>
         </div>
     </div>
-
-    <style>
-      table {
-        font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-      }
-
-      .table td {
-        padding: .50rem;
-      }
-
-      .table th {
-        background-color: var(--dark);
-        color: var(--light);
-        padding: .50rem;
-      }
-
-      .show_hide_log {
-        border-radius: 5px;
-        border: 1px solid #c9c6c6;
-        padding: 5px;
-        text-align: center;
-        cursor: pointer;
-        margin: 5px 5px 0px 0px;
-        color: gray;
-        width: 97%;
-      }
-
-      .spoiler {
-        display: none;
-        margin-left: 10px;
-        border: 1px solid #c9c6c6;
-        padding: 5px;
-        width: 95%;
-        border-top: 0px;
-      }
-
-      .modal {
-        display: none;
-        position: fixed;
-        z-index: 1000;
-        top: 0;
-        left: 0;
-        height: 100%;
-        width: 100%;
-        background: rgba(255, 255, 255, .8) url('/interface/modules/zend_modules/public/images/ajax-loader.gif') 50% 50% no-repeat;
-      }
-    </style>
-    <div class="modal"></div>
-    <div id="install_upgrade_log" style="overflow-y: auto; height: 500px; display: none;"></div>
-
-    <div class="installer_code notranslate unregistered bg-light" style="display:none">
-        <table class="table table-light table-hover table-condensed" id="unregistered">
-            <thead>
-                <tr>
-                    <th class="bg-light text-dark">
-                        <span style="font-size: 1.25rem"><?php echo $listener->z_xlt('Unregistered Modules'); ?></span>
-                    </th>
-                <tr>
-                <tr style="font-size: 1.00rem">
-                    <th scope="col"><?php echo $listener->z_xlt('ID'); ?></th>
-                    <th scope="col"><?php echo $listener->z_xlt('Module Name'); ?></th>
-                    <th scope="col"><?php echo $listener->z_xlt('Type'); ?></th>
-                    <th scope="col"><?php echo $listener->z_xlt('Action'); ?></th>
-                </tr>
-            </thead>
-            <?php
-            $dpath = $GLOBALS['srcdir'] . "/../{$baseModuleDir}{$customDir}/";
-            $dp = opendir($dpath);
-            $inDir = array();
-            for ($i = 0; false != ($fname = readdir($dp)); $i++) {
-                if ($fname != "." && $fname != ".." && $fname != "Application" && is_dir($dpath . $fname))
-                    $inDir[$i] = $fname;
-            }
-            if (sizeof($InstallersExisting) > 0) {
-                foreach ($InstallersExisting as $modules) {
-                    $key = "";
-                    $key = array_search($modules->modDirectory, $inDir);  /* returns integer or FALSE */
-                    if ($key !== false)
-                        unset($inDir[$key]);
-                }
-            }
-            $slno = 0;
-            foreach ($inDir as $fname) {
-                $slno++;
-                ?>
-                <tr>
-                    <td><?php echo $this->escapeHtml($slno); ?> </td>
-                    <td>
-                        <?php
-                        $form_title_file = @file($GLOBALS['srcdir'] . "/../{$baseModuleDir}{$customDir}/$fname/info.txt");
-                        if ($form_title_file)
-                            $form_title = trim($form_title_file[0]);
-                        else
-                            $form_title = $fname;
-                        echo $listener->z_xlt($form_title);
-                        ?>
-                    </td>
-                    <td>
-                        <?php echo $listener->z_xlt('Normal'); ?>
-                    </td>
-                    <td>
-                        <a href="javascript:void(0)" onclick="register(1,'<?php echo $this->escapeHtml($form_title); ?>','<?php echo $this->escapeHtml($fname) ?>','register','');"><input type='button' class='activate' value="<?php echo $listener->z_xla('Register'); ?>" /></a>
-                    </td>
-                </tr>
-                <?php
-                flush();
-            }//end of foreach
-            $dpath = $GLOBALS['srcdir'] . "/../{$baseModuleDir}{$zendModDir}/module";
-            $dp = opendir($dpath);
-            $inDir = array();
-            for ($i = 0; false != ($fname = readdir($dp)); $i++) {
-                if ($fname != "." && $fname != ".." && (array_search($fname, $coreModules) === false) && is_dir($dpath . "/" . $fname))
-                    $inDir[$i] = $fname;
-            }
-            if (sizeof($InstallersExisting) > 0) {
-                foreach ($InstallersExisting as $modules) {
-                    $key = "";
-                    $key = array_search($modules->modDirectory, $inDir);  /* returns integer or FALSE */
-                    if ($key !== false)
-                        unset($inDir[$key]);
-                }
-            }
-            foreach ($inDir as $fname) {
-                $slno++;
-                ?>
-                <tr>
-                    <td><?php echo $this->escapeHtml($slno); ?> </td>
-                    <td>
-                        <?php
-                        $form_title_file = null;
-                        if (is_file($GLOBALS['srcdir'] . "/../{$baseModuleDir}{$zendModDir}/$fname/info.txt")) {
-                          $form_title_file = file($GLOBALS['srcdir'] . "/../{$baseModuleDir}{$zendModDir}/module/$fname/info.txt");
-                        }
-                        if (!empty($form_title_file)) {
-                            $form_title = $form_title_file[0];
-                        } else {
-                            $form_title = $fname;
-                        }
-                        echo $this->escapeHtml($listener->z_xlt($form_title));
-                        ?>
-                    </td>
-                    <td>
-                        <?php echo $listener->z_xlt('Laminas Module'); ?>
-                    </td>
-                    <td>
-                        <a href="javascript:void(0)" onclick="register(1,'<?php echo $this->escapeHtml($form_title); ?>','<?php echo $this->escapeHtml($fname) ?>','register','zend');"><input type='button' class='activate' value="<?php echo $listener->z_xla('Register'); ?>" /></a>
-                    </td>
-                </tr>
-                <?php
-                flush();
-            }//end of foreach
-            ?>
-
-        </table>
-    </div>
+</div>
+<!-- Future use for new tab. Enable buttons at top. -->
+<div class="installer_code notranslate unregistered bg-light" style="display:none">
+    <table id="table-6" class="table table-light table-hover table-condensed" align="center">
+        <thead>
+        <tr>
+            <th class="bg-light text-dark">
+                <span style="font-size: 1.25rem"><?php echo $listener->z_xlt('Manage Laminas Modules'); ?></span>
+            </th>
+        <tr>
+        <tr style="font-size: 16px;">
+            <th scope="col"><?php echo $listener->z_xlt('ID'); ?></th>
+            <th scope="col"><?php echo $listener->z_xlt('Module'); ?> </th>
+            <th scope="col"><?php echo $listener->z_xlt('Status'); ?> </th>
+            <th scope="col"><?php echo $listener->z_xlt('Menu Text'); ?> </th>
+            <th scope="col"><?php echo $listener->z_xlt('Nick Name'); ?> </th>
+            <th scope="col"><?php echo $listener->z_xlt('Type'); ?> </th>
+            <th scope="col"><?php echo $listener->z_xlt('Dependency Modules'); ?> </th>
+            <th scope="col"><?php echo $listener->z_xlt('Action'); ?> </th>
+            <th scope="col"><?php echo $listener->z_xlt('Config'); ?> </th>
+        </tr>
+        </thead>
+        <?php ?>
+    </table>
 </div>
 <?php
-if ($slno > 0) {
-    ?>
+/*if ($slno > 0) {
+    */ ?><!--
     <script>
-        $('#ct').html('(<?php echo $this->escapeHtml($slno) ?>)');
+        $('#ct').html('(<?php /*echo $this->escapeHtml($slno) */ ?>)');
     </script>
-    <?php
-} ?>
+    --><?php
+/*}*/ ?>

--- a/interface/modules/zend_modules/public/js/installer/action.js
+++ b/interface/modules/zend_modules/public/js/installer/action.js
@@ -19,7 +19,7 @@ function register(status, title, name, method, type) {
             if (data == "Success") {
                 window.location.reload();
             } else {
-                var resultTranslated = js_xl(data);
+                const resultTranslated = js_xl(data);
                 $('#err').html(resultTranslated.msg).fadeIn().delay(2000).fadeOut();
             }
         }

--- a/src/Core/AbstractModuleActionListener.php
+++ b/src/Core/AbstractModuleActionListener.php
@@ -155,4 +155,23 @@ abstract class AbstractModuleActionListener
 
         return $registry;
     }
+
+    /**
+     * Set enable/disable module state.
+     * If the mod_ui_active flag is set to 1, then the module config button
+     * is allowed in modules disabled state. In this state calling the config
+     * script will be in the Laminas namespace and not the module namespace.
+     * So remember to set namespace in the config script.
+     *
+     * @param $modId   string|int module id or directory name
+     * @param $flag    string|int 1 or 0 to activate or deactivate module.
+     * @param $flag_ui string|int custom flag to activate or deactivate Manager UI button states.
+     * @return array|bool|null
+     */
+    public static function setModuleActiveState($modId, $flag, $flag_ui): array|bool|null
+    {
+        // set module state.
+        $sql = "UPDATE `modules` SET `mod_active` = ?, `mod_ui_active` = ? WHERE `mod_id` = ? OR `mod_directory` = ?";
+        return sqlQuery($sql, array($flag, $flag_ui, $modId, $modId));
+    }
 }

--- a/src/Core/ModulesApplication.php
+++ b/src/Core/ModulesApplication.php
@@ -92,7 +92,7 @@ class ModulesApplication
             $folderName = strtok($truncatedPath, '/');
             if ($folderName !== false) {
                 $resultSet = sqlStatementNoLog($statement = "SELECT mod_name, mod_directory FROM modules "
-                . " WHERE mod_active = 1 AND type = ? AND mod_directory = ? ", [$type, $folderName]);
+                . " WHERE (mod_active = 1 OR mod_ui_active = 1) AND type = ? AND mod_directory = ? ", [$type, $folderName]);
                 $row = sqlFetchArray($resultSet);
                 if (empty($row)) {
                     throw new AccessDeniedException("admin", "super", "Access to module path for disabled module is denied");


### PR DESCRIPTION


<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #7247 

#### Short description of what this resolves:
Complete refactor of Module Manager to a one page table of all module types.

We now auto register modules to install ready state. You will still get an unregister button that will remove module database entry then will auto reregister to a new registered state. Biggest reason to allow this is so that if the modules action event listener needs to reinstall or other cleanup activities, it can.

If you want or need to use the modules config/settings(for David!:)) script before the module is enabled, you'll need to set the modules table mod_ui_active flag. I added a convenience function to abstract base class to example or use.

- See Wenos or FaxSMS ModuleManagerListener class for examples of  using the new mod_ui_active flag and trapping events.
- To be safe and ensure classes inclusion for module config app, register your modules namespace. The registerNamespaceIfNotExists() method by Stephen Nielson is perfect for this use case.

#### Changes proposed in this pull request:
- add a convenience function to set module activity state to the abstract base class..
- consolidate all modules on one page in MM.
- Allow various MM enables and module running using the mod_ui_active flag in module table.
- considerable restyle refactor to a single page table