### PR TITLE
 fix: skip empty insurance for claim validation in billing manager 

### DIFF
--- a/src/Billing/Claim.php
+++ b/src/Billing/Claim.php
@@ -261,8 +261,8 @@ class Claim
             $this->payers[$ins]['object']  = $orow;
         }
 
-        // if the claim was previously billed to another primary insurance
-        // that has now been removed from the patient't insurance data
+        // if the claim was previously billed to another insurance
+        // that has now been removed from the patient's insurance data
         // then we need to skip this for validation of the claim in the
         // billing manager so that it grabs a valid insurance
         if (empty($this->payers[0]['data'] ?? '')) {

--- a/src/Billing/Claim.php
+++ b/src/Billing/Claim.php
@@ -261,6 +261,14 @@ class Claim
             $this->payers[$ins]['object']  = $orow;
         }
 
+        // if the claim was previously billed to another primary insurance
+        // that has now been removed from the patient't insurance data
+        // then we need to skip this for validation of the claim in the
+        // billing manager so that it grabs a valid insurance
+        if (empty($this->payers[0]['data'] ?? '')) {
+            array_shift($this->payers);
+        }
+
         // This kludge hands most cases of a rare ambiguous situation, where
         // the primary insurance company is the same as the secondary.  It seems
         // nobody planned for that!

--- a/src/Validators/CoverageValidator.php
+++ b/src/Validators/CoverageValidator.php
@@ -136,7 +136,6 @@ class CoverageValidator extends BaseValidator
                         }
                         return true;
                     });
-                $context->required('subscriber_ss')->lengthBetween(2, 255);
                 $context->required('subscriber_DOB')->datetime('Y-m-d');
                 $context->required('subscriber_street')->lengthBetween(2, 255);
                 $context->required('subscriber_postal_code')->lengthBetween(2, 255);


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #7263 

also removes required ss entry for insurance since is unnecessary

#### Short description of what this resolves:


#### Changes proposed in this pull request:
