### PR TITLE
Change search behaviour of select codes

### DIFF
--- a/interface/patient_file/encounter/select_codes.php
+++ b/interface/patient_file/encounter/select_codes.php
@@ -20,7 +20,7 @@ use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
 
 $codetype = empty($_GET['codetype']) ? '' : $_GET['codetype'];
-if (! empty($codetype)) {
+if (!empty($codetype)) {
     $allowed_codes = split_csv_line($codetype);
 }
 
@@ -28,163 +28,176 @@ if (! empty($codetype)) {
 <!DOCTYPE html>
 <html>
 <head>
-<title><?php echo xlt('Select Codes'); ?></title>
+    <title><?php echo xlt('Select Codes'); ?></title>
 
-<?php Header::setupHeader(['opener', 'datatables', 'datatables-bs', 'datatables-colreorder']); ?>
+    <?php Header::setupHeader(['opener', 'datatables', 'datatables-bs', 'datatables-colreorder']); ?>
 
-<script>
+    <script>
 
-var oTable;
+        var oTable;
 
-// Keeps track of which items have been selected during this session.
-var oSelectedIDs = {};
+        // Keeps track of which items have been selected during this session.
+        var oSelectedIDs = {};
 
-$(function () {
-    // Initializing the DataTable.
-    oTable = $('#my_data_table').dataTable({
-        "bProcessing": true,
+        $(function () {
+            // Initializing the DataTable.
+            oTable = $('#my_data_table').dataTable({
+                "bProcessing": true,
 
-        // Next 2 lines invoke server side processing
-        "bServerSide": true,
-        "sAjaxSource": "find_code_dynamic_ajax.php?csrf_token_form=" + <?php echo js_url(CsrfUtils::collectCsrfToken()); ?>,
+                // Next 2 lines invoke server side processing
+                "bServerSide": true,
+                "sAjaxSource": "find_code_dynamic_ajax.php?csrf_token_form=" + <?php echo js_url(CsrfUtils::collectCsrfToken()); ?>,
 
-        // Vertical length options and their default
-        "aLengthMenu": [ 15, 25, 50, 100 ],
-        "iDisplayLength": 15,
+                // Vertical length options and their default
+                "aLengthMenu": [15, 25, 50, 100],
+                "iDisplayLength": 15,
 
-        // Specify a width for the first column.
-        "aoColumns": [{"sWidth":"10%"}, null],
+                // Specify a width for the first column.
+                "aoColumns": [{"sWidth": "10%"}, null],
 
-        // This callback function passes some form data on each call to the ajax handler.
-        "fnServerParams": function (aoData) {
-            aoData.push({"name": "what", "value": <?php echo js_escape('codes'); ?>});
-            aoData.push({"name": "codetype", "value": document.forms[0].form_code_type.value});
-            aoData.push({"name": "inactive", "value": (document.forms[0].form_include_inactive.checked ? 1 : 0)});
-        },
+                // This callback function passes some form data on each call to the ajax handler.
+                "fnServerParams": function (aoData) {
+                    aoData.push({"name": "what", "value": <?php echo js_escape('codes'); ?>});
+                    aoData.push({"name": "codetype", "value": document.forms[0].form_code_type.value});
+                    aoData.push({"name": "inactive", "value": (document.forms[0].form_include_inactive.checked ? 1 : 0)});
+                },
 
-        // Drawing a row, apply styling if it is previously selected.
-        "fnCreatedRow": function (nRow, aData, iDataIndex) {
-            showRowSelection(nRow)
-        },
+                // Drawing a row, apply styling if it is previously selected.
+                "fnCreatedRow": function (nRow, aData, iDataIndex) {
+                    showRowSelection(nRow)
+                },
 
-        // Language strings are included so we can translate them
-        "oLanguage": {
-            "sSearch"       : <?php echo xlj('Search for'); ?> + ":",
-            "sLengthMenu"   : <?php echo xlj('Show'); ?> + " _MENU_ " + <?php echo xlj('entries'); ?>,
-            "sZeroRecords"  : <?php echo xlj('No matching records found'); ?>,
-            "sInfo"         : <?php echo xlj('Showing'); ?> + " _START_ " + <?php echo xlj('to{{range}}'); ?> + " _END_ " + <?php echo xlj('of'); ?> + " _TOTAL_ " + <?php echo xlj('entries'); ?>,
-            "sInfoEmpty"    : <?php echo xlj('Nothing to show'); ?>,
-            "sInfoFiltered" : "(" + <?php echo xlj('filtered from'); ?> + " _MAX_ " + <?php echo xlj('total entries'); ?> + ")",
-            "oPaginate"     : {
-                "sFirst"        : <?php echo xlj('First'); ?>,
-                    "sPrevious" : <?php echo xlj('Previous'); ?>,
-                    "sNext"    : <?php echo xlj('Next'); ?>,
-                    "sLast"    : <?php echo xlj('Last'); ?>
-            }
-        }
-    });
+                // Language strings are included so we can translate them
+                "oLanguage": {
+                    "sSearch": <?php echo xlj('Search for'); ?> +":",
+                    "sLengthMenu": <?php echo xlj('Show'); ?> +" _MENU_ " + <?php echo xlj('entries'); ?>,
+                    "sZeroRecords": <?php echo xlj('No matching records found'); ?>,
+                    "sInfo": <?php echo xlj('Showing'); ?> +" _START_ " + <?php echo xlj('to{{range}}'); ?> +" _END_ " + <?php echo xlj('of'); ?> +" _TOTAL_ " + <?php echo xlj('entries'); ?>,
+                    "sInfoEmpty": <?php echo xlj('Nothing to show'); ?>,
+                    "sInfoFiltered": "(" + <?php echo xlj('filtered from'); ?> +" _MAX_ " + <?php echo xlj('total entries'); ?> +")",
+                    "oPaginate": {
+                        "sFirst": <?php echo xlj('First'); ?>,
+                        "sPrevious": <?php echo xlj('Previous'); ?>,
+                        "sNext": <?php echo xlj('Next'); ?>,
+                        "sLast": <?php echo xlj('Last'); ?>
+                    }
+                },
+                initComplete: function () {
+                    var input = $('.dataTables_filter input').unbind(),
+                        self = this.api(),
+                        $searchButton = $('<button class="btn btn-sm btn-outline-primary btn-search">').click(function () {
+                            event.preventDefault();
+                            event.stopPropagation();
+                            self.search(input.val()).draw();
+                        }),
+                        $clearButton = $('<button class="btn btn-sm btn-outline-warning btn-refresh">').click(function () {
+                            input.val('');
+                            $searchButton.click();
+                        })
+                    $('.dataTables_filter').append($searchButton, $clearButton);
+                }
+            });
 
-    // OnClick handler for the rows
-    oTable.on('click', 'tbody tr', function () {
-        oSelectedIDs[this.id] = oSelectedIDs[this.id] ? 0 : 1;
-        showRowSelection(this)
-     });
+            // OnClick handler for the rows
+            oTable.on('click', 'tbody tr', function () {
+                oSelectedIDs[this.id] = oSelectedIDs[this.id] ? 0 : 1;
+                showRowSelection(this)
+            });
 
-    // onmouseover handler for rows
-    oTable.on('mouseover', 'tr', function() {
-        showCursor(this);
-    });
-});
+            // onmouseover handler for rows
+            oTable.on('mouseover', 'tr', function () {
+                showCursor(this);
+            });
+        });
 
-function showRowSelection(row) {
-    row.style.fontWeight = oSelectedIDs[row.id] ? 'bold' : 'normal';
-}
-
-function showCursor(row) {
-    row.style.cursor = "pointer";
-}
-
-function onOK() {
-    if (opener.closed || ! opener.OnCodeSelected) {
-        alert(<?php echo xlj('The destination form was closed.'); ?>);
-    }
-    else {
-        var ids = Object.keys(oSelectedIDs)
-        for (i = 0; i < ids.length; i++) {
-            if (!oSelectedIDs[ids[i]]) {
-                continue
-            }
-
-            // Row ids are of the form "CID|jsonstring".
-            var jobj = JSON.parse(ids[i].substring(4));
-            var code = jobj['code'].toString().split('|');
-            var msg = opener.OnCodeSelected(jobj['codetype'], code[0], code[1], jobj['description']);
-            if (msg) {
-                alert(msg);
-            }
+        function showRowSelection(row) {
+            row.style.fontWeight = oSelectedIDs[row.id] ? 'bold' : 'normal';
         }
 
-        dlgclose()
-        return false;
-    }
-}
+        function showCursor(row) {
+            row.style.cursor = "pointer";
+        }
 
-</script>
+        function onOK() {
+            if (opener.closed || !opener.OnCodeSelected) {
+                alert(<?php echo xlj('The destination form was closed.'); ?>);
+            } else {
+                var ids = Object.keys(oSelectedIDs)
+                for (i = 0; i < ids.length; i++) {
+                    if (!oSelectedIDs[ids[i]]) {
+                        continue
+                    }
+
+                    // Row ids are of the form "CID|jsonstring".
+                    var jobj = JSON.parse(ids[i].substring(4));
+                    var code = jobj['code'].toString().split('|');
+                    var msg = opener.OnCodeSelected(jobj['codetype'], code[0], code[1], jobj['description']);
+                    if (msg) {
+                        alert(msg);
+                    }
+                }
+
+                dlgclose()
+                return false;
+            }
+        }
+
+    </script>
 
 </head>
 
 <body id="codes_search">
     <div class="container-fluid">
         <form method='post' name='theform'>
-        <?php
-        echo "<div class='form-group row mb-3'>\n";
-        if (isset($allowed_codes)) {
-            if (count($allowed_codes) == 1) {
-                echo "<div class='col'><input type='text' name='form_code_type' value='" . attr($codetype) . "' size='5' readonly /></div>\n";
-            } else {
-                echo "<div class='col'><select name='form_code_type' onchange='oTable.fnDraw()'>\n";
-                foreach ($allowed_codes as $code) {
-                    echo " <option value='" . attr($code) . "'>" . xlt($code_types[$code]['label']) . "</option>\n";
+            <?php
+            echo "<div class='form-group row mb-3'>\n";
+            if (isset($allowed_codes)) {
+                if (count($allowed_codes) == 1) {
+                    echo "<div class='col'><input type='text' name='form_code_type' value='" . attr($codetype) . "' size='5' readonly /></div>\n";
+                } else {
+                    echo "<div class='col'><select name='form_code_type' onchange='oTable.fnDraw()'>\n";
+                    foreach ($allowed_codes as $code) {
+                        echo " <option value='" . attr($code) . "'>" . xlt($code_types[$code]['label']) . "</option>\n";
+                    }
+                    echo "</select></div>\n";
                 }
-                echo "</select></div>\n";
+            } else {
+                echo "<div class='col'><select class='form-control' name='form_code_type' onchange='oTable.fnDraw()'>\n";
+                foreach ($code_types as $key => $value) {
+                    echo " <option value='" . attr($key) . "'";
+                    echo ">" . xlt($value['label']) . "</option>\n";
+                }
+                echo " <option value='PROD'";
+                echo ">" . xlt("Product") . "</option>\n";
+                echo "   </select></div>\n";
             }
-        } else {
-            echo "<div class='col'><select class='form-control' name='form_code_type' onchange='oTable.fnDraw()'>\n";
-            foreach ($code_types as $key => $value) {
-                echo " <option value='" . attr($key) . "'";
-                echo ">" . xlt($value['label']) . "</option>\n";
-            }
-            echo " <option value='PROD'";
-            echo ">" . xlt("Product") . "</option>\n";
-            echo "   </select></div>\n";
-        }
-        echo "\n";
-        echo "<div class='col'>";
-        echo "<input type='checkbox' name='form_include_inactive' value='1' onclick='oTable.fnDraw()' />" . xlt('Include Inactive') . "\n";
-        echo "\n";
-        echo "<button class='btn btn-secondary btn-sm btn-save' value='" . xla('OK') . "' onclick='onOK()'>" . xla('Ok') . "</button>\n";
-        echo "\n";
-        echo "<button class='btn btn-secondary btn-sm btn-cancel' value='" . xla('Cancel') . "' onclick='dlgclose()'>" . xla('Cancel') . "</button>\n";
-        echo "</div>";
+            echo "\n";
+            echo "<div class='col'>";
+            echo "<input type='checkbox' name='form_include_inactive' value='1' onclick='oTable.fnDraw()' />" . xlt('Include Inactive') . "\n";
+            echo "\n";
+            echo "<button class='btn btn-secondary btn-sm btn-save' value='" . xla('OK') . "' onclick='onOK()'>" . xla('Ok') . "</button>\n";
+            echo "\n";
+            echo "<button class='btn btn-secondary btn-sm btn-cancel' value='" . xla('Cancel') . "' onclick='dlgclose()'>" . xla('Cancel') . "</button>\n";
+            echo "</div>";
 
-        echo "</div>\n";
-        ?>
+            echo "</div>\n";
+            ?>
 
-          <!-- Exception here: Do not use table-responsive as it breaks datatables !-->
-          <table id="my_data_table" class="table table-sm">
-              <thead>
-                  <tr>
-                      <th><?php echo xlt('Code'); ?></th>
-                      <th><?php echo xlt('Description'); ?></th>
-                  </tr>
-              </thead>
-              <tbody>
-                  <tr>
-                      <!-- Class "dataTables_empty" is defined in jquery.dataTables.css -->
-                      <td colspan="2" class="dataTables_empty">...</td>
-                  </tr>
-              </tbody>
-          </table>
+            <!-- Exception here: Do not use table-responsive as it breaks datatables !-->
+            <table id="my_data_table" class="table table-sm">
+                <thead>
+                <tr>
+                    <th><?php echo xlt('Code'); ?></th>
+                    <th><?php echo xlt('Description'); ?></th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                    <!-- Class "dataTables_empty" is defined in jquery.dataTables.css -->
+                    <td colspan="2" class="dataTables_empty">...</td>
+                </tr>
+                </tbody>
+            </table>
         </form>
     </div>
 </body>

--- a/interface/patient_file/encounter/select_codes.php
+++ b/interface/patient_file/encounter/select_codes.php
@@ -83,17 +83,17 @@ if (!empty($codetype)) {
                     }
                 },
                 initComplete: function () {
-                    var input = $('.dataTables_filter input').unbind(),
+                    const input = $('.dataTables_filter input').unbind(),
                         self = this.api(),
-                        $searchButton = $('<button class="btn btn-sm btn-outline-primary btn-search">').click(function () {
+                        $searchButton = $('<button class="btn btn-sm btn-outline-primary fa fa-search p-2">').click(function () {
                             event.preventDefault();
                             event.stopPropagation();
                             self.search(input.val()).draw();
                         }),
-                        $clearButton = $('<button class="btn btn-sm btn-outline-warning btn-refresh">').click(function () {
+                        $clearButton = $('<button type="button" class="btn btn-sm btn-outline-warning fa-solid fa-eraser p-2">')
+                        .click(function () {
                             input.val('');
-                            $searchButton.click();
-                        })
+                        });
                     $('.dataTables_filter').append($searchButton, $clearButton);
                 }
             });


### PR DESCRIPTION
- change by adding a search and reset button implemented by datatables search function.

Removes the type ahead feature. Even on a very fast machine search is slow on the large code datasets. 
With type ahead an event fired a search request every character where events would stack in DOM. IMO a no no
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #7276 

![image](https://github.com/openemr/openemr/assets/1859985/14702e17-9bb7-4caa-8a8a-55017445629f)

