### PR TITLE
Reduce `maxlength` of `per_refill` to `9`

### DIFF
--- a/templates/prescription/general_edit.html
+++ b/templates/prescription/general_edit.html
@@ -249,7 +249,7 @@
                     &nbsp; &nbsp; # {xlt t='of tablets'}:
                 </div>
                 <div class="col">
-                    <input class="input-sm form-control" type="text" id="per_refill" name="per_refill" size="2" maxlength="10" value="{$prescription->per_refill|attr}" />
+                    <input class="input-sm form-control" type="text" id="per_refill" name="per_refill" size="2" maxlength="9" value="{$prescription->per_refill|attr}" />
                 </div>
             {/if}
         </div>


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #7314

#### Short description of what this resolves:
The `per_refill` field is declared as an `INT` in `sql` (whose maximum possible value is `2147483647`), hence setting the `maxlength` of `per_refill` to `9`, so that the value gets saved correctly.

#### Changes proposed in this pull request:
Reduced `maxlength` of `per_refill` to `9`