### PR TITLE
fix: reduce 'maxlength' of 'per_refill' to '9' since it stored as 'INT' (max value is '2147483647') (#7315)

### DIFF
--- a/templates/prescription/general_edit.html
+++ b/templates/prescription/general_edit.html
@@ -249,7 +249,7 @@
                     &nbsp; &nbsp; # {xlt t='of tablets'}:
                 </div>
                 <div class="col">
-                    <input class="input-sm form-control" type="text" id="per_refill" name="per_refill" size="2" maxlength="10" value="{$prescription->per_refill|attr}" />
+                    <input class="input-sm form-control" type="text" id="per_refill" name="per_refill" size="2" maxlength="9" value="{$prescription->per_refill|attr}" />
                 </div>
             {/if}
         </div>


### PR DESCRIPTION
reduce 'maxlength' of 'per_refill' to '9' since it stored as 'INT' (max value is '2147483647') (#7315)

