### PR TITLE
Add SHA-512 hashing to session token in URL

### DIFF
--- a/interface/main/main_screen.php
+++ b/interface/main/main_screen.php
@@ -470,6 +470,6 @@ if ((isset($_POST['appChoice'])) && ($_POST['appChoice'] !== '*OpenEMR')) {
 
 // Pass a unique token, so main.php script can not be run on its own
 $_SESSION['token_main_php'] = RandomGenUtils::createUniqueToken();
-header('Location: ' . $web_root . "/interface/main/tabs/main.php?token_main=" . urlencode($_SESSION['token_main_php']));
+header('Location: ' . $web_root . "/interface/main/tabs/main.php?token_main=" . urlencode(hash('sha512',$_SESSION['token_main_php'])));
 exit();
 ?>

--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -37,7 +37,7 @@ $menuLogo = $logoService->getLogo('core/menu/primary/');
 if (
     (empty($_SESSION['token_main_php'])) ||
     (empty($_GET['token_main'])) ||
-    ($_GET['token_main'] != $_SESSION['token_main_php'])
+    ($_GET['token_main'] != hash('sha512',$_SESSION['token_main_php']))
 ) {
     // Below functions are from auth.inc, which is included in globals.php
     authCloseSession();


### PR DESCRIPTION
This change adds SHA-512 hashing to the session token in the URL parameter to thwart visibility of session token which is currently being exposed through plain-text URL encoding.
