### PR TITLE
Add PATCH and PUT functions for Appointments

### DIFF
--- a/_rest_routes.inc.php
+++ b/_rest_routes.inc.php
@@ -5288,6 +5288,82 @@ RestConfig::$ROUTE_MAP = array(
     },
 
     /**
+     *  @OA\Patch(
+     *      path="/api/appointment/{eid}",
+     *      description="Edits an appointment",
+     *      tags={"standard"},
+     *      @OA\Parameter(
+     *          name="eid",
+     *          in="path",
+     *          description="The eid for the appointment.",
+     *          required=true,
+     *          @OA\Schema(
+     *              type="string"
+     *          )
+     *      ),
+     *      @OA\Response(
+     *          response="200",
+     *          ref="#/components/responses/standard"
+     *      ),
+     *      @OA\Response(
+     *          response="400",
+     *          ref="#/components/responses/badrequest"
+     *      ),
+     *      @OA\Response(
+     *          response="401",
+     *          ref="#/components/responses/unauthorized"
+     *      ),
+     *      security={{"openemr_auth":{}}}
+     *  )
+     */
+    "PATCH /api/appointment/:eid" => function ($eid) {
+        RestConfig::authorization_check("patients", "appt");
+        $data = (array) (json_decode(file_get_contents("php://input")));
+        $return = (new AppointmentRestController())->patch($eid, $data);
+
+        RestConfig::apiLog($return);
+        return $return;
+    },
+
+    /**
+     *  @OA\Put(
+     *      path="/api/appointment/{eid}",
+     *      description="Updates an appointment",
+     *      tags={"standard"},
+     *      @OA\Parameter(
+     *          name="eid",
+     *          in="path",
+     *          description="The eid for the appointment.",
+     *          required=true,
+     *          @OA\Schema(
+     *              type="string"
+     *          )
+     *      ),
+     *      @OA\Response(
+     *          response="200",
+     *          ref="#/components/responses/standard"
+     *      ),
+     *      @OA\Response(
+     *          response="400",
+     *          ref="#/components/responses/badrequest"
+     *      ),
+     *      @OA\Response(
+     *          response="401",
+     *          ref="#/components/responses/unauthorized"
+     *      ),
+     *      security={{"openemr_auth":{}}}
+     *  )
+     */
+    "PUT /api/appointment/:eid" => function ($eid) {
+        RestConfig::authorization_check("patients", "appt");
+        $data = (array) (json_decode(file_get_contents("php://input")));
+        $return = (new AppointmentRestController())->put($eid, $data);
+
+        RestConfig::apiLog($return);
+        return $return;
+    },
+
+    /**
      *  @OA\Delete(
      *      path="/api/patient/{pid}/appointment/{eid}",
      *      description="Delete a appointment",

--- a/src/RestControllers/AppointmentRestController.php
+++ b/src/RestControllers/AppointmentRestController.php
@@ -90,4 +90,48 @@ class AppointmentRestController
         }
         return RestControllerHelper::responseHandler($serviceResult, null, 200);
     }
+
+    /**
+     * Processes an HTTP PATCH request used to update an existing Appointment.
+     *
+     * @param string $uuid The identifier of the Appointment.
+     * @param array $data The new data for the Appointment.
+     *
+     * @return void
+     */
+    public function patch(string $uuid, array $data): void
+    {
+        try {
+            $result =  $this->appointmentService->edit($uuid, $data);
+        } catch (\Exception $exception) {
+            (new SystemLogger())->errorLogCaller($exception->getMessage(), ['trace' => $exception->getTraceAsString(), 'uuid' => $uuid, 'data' => $data]);
+            RestControllerHelper::responseHandler(['message' => 'Failed to update appointment'], null, 500);
+
+            return;
+        }
+
+        RestControllerHelper::responseHandler($result, null, 200);
+    }
+
+    /**
+     * Processes an HTTP PUT request used to update an existing Appointment.
+     *
+     * @param string $uuid The identifier of the Appointment.
+     * @param array $data The new data for the Appointment.
+     *
+     * @return void
+     */
+    public function put(string $uuid, array $data): void
+    {
+        try {
+            $result =  $this->appointmentService->update($uuid, $data);
+        } catch (\Exception $exception) {
+            (new SystemLogger())->errorLogCaller($exception->getMessage(), ['trace' => $exception->getTraceAsString(), 'uuid' => $uuid, 'data' => $data]);
+            RestControllerHelper::responseHandler(['message' => 'Failed to update appointment'], null, 500);
+
+            return;
+        }
+
+        RestControllerHelper::responseHandler($result, null, 200);
+    }
 }

--- a/src/Services/AppointmentService.php
+++ b/src/Services/AppointmentService.php
@@ -32,6 +32,7 @@ class AppointmentService extends BaseService
     const PATIENT_TABLE = "patient_data";
     const PRACTITIONER_TABLE = "users";
     const FACILITY_TABLE = "facility";
+    const APPOINTMENT_TABLE = self::TABLE_NAME;
 
     /**
      * @var EncounterService
@@ -94,7 +95,7 @@ class AppointmentService extends BaseService
         $validator->required('pc_hometext')->string();
         $validator->required('pc_apptstatus')->string();
         $validator->required('pc_eventDate')->datetime('Y-m-d');
-        $validator->required('pc_startTime')->length(5); // HH:MM is 5 chars
+        $validator->required('pc_startTime')->lengthBetween(5, 8); // HH:MM is 5 chars, HH:MM:SS is 8 as returned by OpenEMR.
         $validator->required('pc_facility')->numeric();
         $validator->required('pc_billing_location')->numeric();
         $validator->optional('pc_aid')->numeric()
@@ -189,7 +190,7 @@ class AppointmentService extends BaseService
         return $processingResult;
     }
 
-    public function getAppointmentsForPatient($pid)
+    public function getAppointmentsForPatient(?string $pid)
     {
         $sqlBindArray = array();
 
@@ -646,5 +647,97 @@ class AppointmentService extends BaseService
     {
         $sql = "SELECT * FROM openemr_postcalendar_categories WHERE pc_catid = ?";
         return QueryUtils::fetchRecords($sql, [$cat_id]);
+    }
+
+    public function edit(string $id, array $data): ProcessingResult
+    {
+        if (empty($data)) {
+            $result = new ProcessingResult();
+            $result->setValidationMessages('Invalid Data');
+
+            return $result;
+        }
+
+        $data['pc_eid'] = $id;
+        $appointment = $this->getAppointment($id)[0] ?? null; // We really need to fix the getAppointment function...
+
+        if ($appointment === null) {
+            $result = new ProcessingResult();
+            $result->setValidationMessages('Invalid Appointment');
+
+            return $result;
+        }
+
+        foreach ($appointment as $key => $value) {
+            if (!array_key_exists($key, $data)) {
+                $data[$key] = $value;
+            }
+        }
+
+        $validation = $this->validate($data);
+
+        if (!$validation->isValid()) {
+            $result = new ProcessingResult();
+            $result->setValidationMessages($validation->getMessages());
+
+            return $result;
+        }
+
+        $query = $this->buildUpdateColumns($data);
+        $sql = " UPDATE " . self::APPOINTMENT_TABLE . " SET ";
+        $sql .= $query['set'];
+        $sql .= " WHERE `pc_eid` = ?";
+
+        array_push($query['bind'], $id);
+        $sqlResult = sqlStatement($sql, $query['bind']);
+
+
+        if (!$sqlResult) {
+            $result = new ProcessingResult();
+            $result->addErrorMessage('error processing SQL Update');
+
+            return $result;
+        }
+
+        return $this->search(['pc_eid' => $id]);
+    }
+
+    public function update(string $id, array $data): ProcessingResult
+    {
+        if (empty($data)) {
+            $result = new ProcessingResult();
+            $result->setValidationMessages('Invalid Data');
+
+            return $result;
+        }
+
+        $data['pc_eid'] = $id;
+
+        $validation = $this->validate($data);
+
+        if (!$validation->isValid()) {
+            $result = new ProcessingResult();
+            $result->setValidationMessages($validation->getMessages());
+
+            return $result;
+        }
+
+        $query = $this->buildUpdateColumns($data);
+        $sql = " UPDATE " . self::APPOINTMENT_TABLE . " SET ";
+        $sql .= $query['set'];
+        $sql .= " WHERE `pc_eid` = ?";
+
+        array_push($query['bind'], $id);
+        $sqlResult = sqlStatement($sql, $query['bind']);
+
+
+        if (!$sqlResult) {
+            $result = new ProcessingResult();
+            $result->addErrorMessage('error processing SQL Update');
+
+            return $result;
+        }
+
+        return $this->search(['pc_eid' => $id]);
     }
 }

--- a/swagger/openemr-api.yaml
+++ b/swagger/openemr-api.yaml
@@ -2586,6 +2586,50 @@ paths:
       security:
         -
           openemr_auth: []
+    patch:
+        tags:
+            - standard
+        description: 'Edits an appointment'
+        parameters:
+            -
+                name: eid
+                in: path
+                description: 'The eid for the appointment.'
+                required: true
+                schema:
+                    type: string
+        responses:
+            '200':
+                $ref: '#/components/responses/standard'
+            '400':
+                $ref: '#/components/responses/badrequest'
+            '401':
+                $ref: '#/components/responses/unauthorized'
+        security:
+            -
+                openemr_auth: []
+    put:
+        tags:
+            - standard
+        description: 'Updates an appointment'
+        parameters:
+            -
+                name: eid
+                in: path
+                description: 'The eid for the appointment.'
+                required: true
+                schema:
+                    type: string
+        responses:
+            '200':
+                $ref: '#/components/responses/standard'
+            '400':
+                $ref: '#/components/responses/badrequest'
+            '401':
+                $ref: '#/components/responses/unauthorized'
+        security:
+            -
+                openemr_auth: []
   '/api/patient/{pid}/appointment/{eid}':
     get:
       tags:


### PR DESCRIPTION
This patch will add two new api end-points, PUT and PATCH /api/appointment/{eid} these can be used to update the entity or part of the entity.

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

#### Short description of what this resolves:
In order to make a more feature complete API, and to support the use case of wanting to e.g. edit the status of an appointment
the ability to update and alter the appointment has been made available.

#### Changes proposed in this pull request:
+ Add PUT request for Appointments
+ Add PATCH request for Appointments

I copy-pasted a lot of code or used it as an example but there are quite a few bits I am uncertain about if it is correct, please advise where necessary.