### PR TITLE
fix: inadequate date time format in log viewer

### DIFF
--- a/interface/logview/logview.php
+++ b/interface/logview/logview.php
@@ -380,7 +380,7 @@ if (!empty($_GET)) {
                                                 }
                                                 ?>
                                                 <tr>
-                                                    <td><?php echo text(oeFormatDateTime($iter["date"])); ?></td>
+                                                    <td><?php echo text(oeFormatDateTime($iter["date"], 0, true)); ?></td>
                                                     <td><?php echo text(preg_replace('/select$/', 'Query', $iter["event"])); //Convert select term to Query for MU2 requirements ?></td>
                                                     <td><?php echo text($iter["category"]); ?></td>
                                                     <td><?php echo text($iter["user"]); ?></td>
@@ -412,7 +412,7 @@ if (!empty($_GET)) {
                                                     $comments = xl('Recipient Name') . ":" . $iter["recipient"] . ";" . xl('Disclosure Info') . ":" . $iter["description"];
                                                     ?>
                                                     <tr>
-                                                        <td><?php echo text(oeFormatDateTime($iter["date"])); ?></td>
+                                                        <td><?php echo text(oeFormatDateTime($iter["date"], 0, true)); ?></td>
                                                         <td><?php echo xlt($iter["event"]); ?></td>
                                                         <td><?php echo xlt($iter["category"] ?? ''); ?></td>
                                                         <td><?php echo text($iter["user"]); ?></td>

--- a/interface/logview/logview.php
+++ b/interface/logview/logview.php
@@ -380,7 +380,7 @@ if (!empty($_GET)) {
                                                 }
                                                 ?>
                                                 <tr>
-                                                    <td><?php echo text(oeFormatDateTime($iter["date"], 0, true)); ?></td>
+                                                    <td><?php echo text(oeFormatDateTime($iter["date"], 'global', true)); ?></td>
                                                     <td><?php echo text(preg_replace('/select$/', 'Query', $iter["event"])); //Convert select term to Query for MU2 requirements ?></td>
                                                     <td><?php echo text($iter["category"]); ?></td>
                                                     <td><?php echo text($iter["user"]); ?></td>
@@ -412,7 +412,7 @@ if (!empty($_GET)) {
                                                     $comments = xl('Recipient Name') . ":" . $iter["recipient"] . ";" . xl('Disclosure Info') . ":" . $iter["description"];
                                                     ?>
                                                     <tr>
-                                                        <td><?php echo text(oeFormatDateTime($iter["date"], 0, true)); ?></td>
+                                                        <td><?php echo text(oeFormatDateTime($iter["date"], 'global', true)); ?></td>
                                                         <td><?php echo xlt($iter["event"]); ?></td>
                                                         <td><?php echo xlt($iter["category"] ?? ''); ?></td>
                                                         <td><?php echo text($iter["user"]); ?></td>


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #7335

#### Short description of what this resolves:
The OpenEMR logs uses the time format as Hours:Minutes which is inadequate to determine the timeline of events. This fix changes the time format to Hours:Minutes:Seconds

![image](https://github.com/openemr/openemr/assets/55644854/2d51d867-0832-4faf-a0ce-56613f41544a)

#### Changes proposed in this pull request:
Add the parameter for seconds as true in two echo statements
