### PR TITLE
Fix: OpenEMR logs sensitive information such as payment details

### DIFF
--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -645,8 +645,8 @@ MSG;
          * For any insert operation, if the current table contains any field containing sensitive information,
          * the value for that field is masked to match its length.
          */
-        foreach (self::SENSITIVE_RECORDS as $table => $fields) {
-            if ($querytype == "insert") {
+        if ($querytype == "insert") {
+            foreach (self::SENSITIVE_RECORDS as $table => $fields) {
                 if (strpos($comments, $table) !== false) {
                     foreach ($fields as $field) {
                         $pattern = "/($field)\s*=\s*'([^']+)'/";

--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -650,7 +650,7 @@ MSG;
                 if (strpos($comments, $table) !== false) {
                     foreach ($fields as $field) {
                         $pattern = "/($field)\s*=\s*'([^']+)'/";
-                        $comments = preg_replace_callback($pattern, function($matches) {
+                        $comments = preg_replace_callback($pattern, function ($matches) {
                             $field_name = $matches[1];
                             $field_value = $matches[2];
                             $masked_value = str_repeat('X', strlen($field_value));

--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -144,6 +144,14 @@ MSG;
 </ParticipantObjectIdentification>
 MSG;
 
+
+    /**
+     * Keep track of the tables and the fields in each table that contains sensitive information
+     */
+    private const SENSITIVE_RECORDS = [
+        "ar_session" => array("reference")
+    ];
+
     /**
      * @param $event
      * @param $user
@@ -629,6 +637,27 @@ MSG;
                 $event = "patient-record";
                 $category = $this->eventCategoryFinder($comments, $event, $table);
                 break;
+            }
+        }
+
+        /**
+         * Avoid logging sensitive information in logs.
+         * For any insert operation, if the current table contains any field containing sensitive information,
+         * the value for that field is masked to match its length.
+         */
+        foreach (self::SENSITIVE_RECORDS as $table => $fields) {
+            if ($querytype == "insert") {
+                if (strpos($comments, $table) !== false) {
+                    foreach ($fields as $field) {
+                        $pattern = "/($field)\s*=\s*'([^']+)'/";
+                        $comments = preg_replace_callback($pattern, function($matches) {
+                            $field_name = $matches[1];
+                            $field_value = $matches[2];
+                            $masked_value = str_repeat('X', strlen($field_value));
+                            return "$field_name = '$masked_value'";
+                        }, $comments);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #7340 

#### Short description of what this resolves:
This PR adds a log scrubbing template to mask sensitive details in the log(which is currently exposed in logs). Currently, this template only masks the field "reference" in the table "ar_session" to conceal sensitive payment details in the log. However, if approved, this template can be used to extend the masking of other sensitive details to other tables and fields too. Masking of sensitive information in logs is essential to prevent the stealing of information. (ASVS 7.1.1).

After update: 
<img width="1461" alt="log-sensitive-payment-detail-after-fix" src="https://github.com/openemr/openemr/assets/26566698/a746d3ef-de1f-40b6-806c-b30586450c94">

#### Changes proposed in this pull request:
1. In "EventAuditLogger.php", add a class constant to keep track of the tables and the fields in each table that contains sensitive information.
2. In "EventAuditLogger.php", for any insert operation, if the current table contains any field containing sensitive information, the value for that field is masked to match its length.