### PR TITLE
Fix: Input sanitation on google signin email

### DIFF
--- a/interface/usergroup/user_admin.php
+++ b/interface/usergroup/user_admin.php
@@ -129,6 +129,18 @@ function submitform() {
         }
 
     }//If pwd null ends here
+
+    // Valiate Google email (if provided)
+    if(document.forms[0].google_signin_email.value != ""){
+        // https://owasp.org/www-community/OWASP_Validation_Regex_Repository
+        var mailformat = /^[a-zA-Z0-9_+&*-]+(?:\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/;
+        if(!document.forms[0].google_signin_email.value.match(mailformat)) {
+            flag=1;
+            alert(<?php echo xlj('Google email provided is invalid/not properly formatted (e.g. first.last@gmail.com)') ?>);
+            return false;
+        }
+    }
+
 <?php } ?>
   if (document.forms[0].access_group_id) {
     var sel = getSelected(document.forms[0].access_group_id.options);

--- a/interface/usergroup/user_admin.php
+++ b/interface/usergroup/user_admin.php
@@ -131,7 +131,7 @@ function submitform() {
     }//If pwd null ends here
 
     // Valiate Google email address (if provided)
-    if(document.forms[0].google_signin_email.value != "" && !isValidEmail(document.forms[0].google_signin_email.value)){
+    if(document.forms[0].google_signin_email.value != "" && !isValidEmail(document.forms[0].google_signin_email.value)) {
         flag=1;
         alert(<?php echo xlj('Google email provided is invalid/not properly formatted (e.g. first.last@gmail.com)') ?>);
         return false;

--- a/interface/usergroup/user_admin.php
+++ b/interface/usergroup/user_admin.php
@@ -130,15 +130,11 @@ function submitform() {
 
     }//If pwd null ends here
 
-    // Valiate Google email (if provided)
-    if(document.forms[0].google_signin_email.value != ""){
-        // https://owasp.org/www-community/OWASP_Validation_Regex_Repository
-        var mailformat = /^[a-zA-Z0-9_+&*-]+(?:\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/;
-        if(!document.forms[0].google_signin_email.value.match(mailformat)) {
-            flag=1;
-            alert(<?php echo xlj('Google email provided is invalid/not properly formatted (e.g. first.last@gmail.com)') ?>);
-            return false;
-        }
+    // Valiate Google email address (if provided)
+    if(document.forms[0].google_signin_email.value != "" && !isValidEmail(document.forms[0].google_signin_email.value)){
+        flag=1;
+        alert(<?php echo xlj('Google email provided is invalid/not properly formatted (e.g. first.last@gmail.com)') ?>);
+        return false;
     }
 
 <?php } ?>

--- a/interface/usergroup/usergroup_admin.php
+++ b/interface/usergroup/usergroup_admin.php
@@ -303,7 +303,7 @@ if (isset($_POST["privatemode"]) && $_POST["privatemode"] == "user_admin") {
         }
         if (isset($_POST["google_signin_email"])) {
             // Save email as null if input was empty or invalid email address format (prevent attacks such as stored xss)
-            if (empty($_POST["google_signin_email"]) || !ValidationUtils::isValidEmail($_POST["google_signin_email"]))  {
+            if (empty($_POST["google_signin_email"]) || !ValidationUtils::isValidEmail($_POST["google_signin_email"])) {
                 $googleSigninEmail = null;
             } else {
                 $googleSigninEmail = $_POST["google_signin_email"];

--- a/interface/usergroup/usergroup_admin.php
+++ b/interface/usergroup/usergroup_admin.php
@@ -301,7 +301,9 @@ if (isset($_POST["privatemode"]) && $_POST["privatemode"] == "user_admin") {
             sqlStatement("update users set supervisor_id = ? where id = ? ", array((int)$_POST["supervisor_id"], $_POST["id"]));
         }
         if (isset($_POST["google_signin_email"])) {
-            if (empty($_POST["google_signin_email"])) {
+            // Save email as null if input was empty or invalid email address format (prevent attacks such as stored xss)
+            // https://www.php.net/manual/en/filter.filters.validate.php
+            if (empty($_POST["google_signin_email"]) || !filter_var($_POST["google_signin_email"], FILTER_VALIDATE_EMAIL))  {
                 $googleSigninEmail = null;
             } else {
                 $googleSigninEmail = $_POST["google_signin_email"];

--- a/interface/usergroup/usergroup_admin.php
+++ b/interface/usergroup/usergroup_admin.php
@@ -27,7 +27,6 @@ use OpenEMR\Common\Acl\AclExtended;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Auth\AuthUtils;
 use OpenEMR\Common\Csrf\CsrfUtils;
-use OpenEMR\Common\Utils\ValidationUtils;
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Core\Header;
@@ -302,8 +301,7 @@ if (isset($_POST["privatemode"]) && $_POST["privatemode"] == "user_admin") {
             sqlStatement("update users set supervisor_id = ? where id = ? ", array((int)$_POST["supervisor_id"], $_POST["id"]));
         }
         if (isset($_POST["google_signin_email"])) {
-            // Save email as null if input was empty or invalid email address format (prevent attacks such as stored xss)
-            if (empty($_POST["google_signin_email"]) || !ValidationUtils::isValidEmail($_POST["google_signin_email"])) {
+            if (empty($_POST["google_signin_email"])) {
                 $googleSigninEmail = null;
             } else {
                 $googleSigninEmail = $_POST["google_signin_email"];

--- a/interface/usergroup/usergroup_admin.php
+++ b/interface/usergroup/usergroup_admin.php
@@ -27,6 +27,7 @@ use OpenEMR\Common\Acl\AclExtended;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Auth\AuthUtils;
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Utils\ValidationUtils;
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Core\Header;
@@ -302,8 +303,7 @@ if (isset($_POST["privatemode"]) && $_POST["privatemode"] == "user_admin") {
         }
         if (isset($_POST["google_signin_email"])) {
             // Save email as null if input was empty or invalid email address format (prevent attacks such as stored xss)
-            // https://www.php.net/manual/en/filter.filters.validate.php
-            if (empty($_POST["google_signin_email"]) || !filter_var($_POST["google_signin_email"], FILTER_VALIDATE_EMAIL))  {
+            if (empty($_POST["google_signin_email"]) || !ValidationUtils::isValidEmail($_POST["google_signin_email"]))  {
                 $googleSigninEmail = null;
             } else {
                 $googleSigninEmail = $_POST["google_signin_email"];

--- a/interface/usergroup/usergroup_admin_add.php
+++ b/interface/usergroup/usergroup_admin_add.php
@@ -118,13 +118,9 @@ function submitform() {
     } //secure_pwd if ends here
 
     // Valiate Google email (if provided)
-    if(document.new_user.google_signin_email.value != ""){
-        // https://owasp.org/www-community/OWASP_Validation_Regex_Repository
-        var mailformat = /^[a-zA-Z0-9_+&*-]+(?:\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/;
-        if(!document.new_user.google_signin_email.value.match(mailformat)) {
-            alert(<?php echo xlj('Google email provided is invalid/not properly formatted (e.g. first.last@gmail.com)') ?>);
-            return false;
-        }
+    if(document.new_user.google_signin_email.value != "" !isValidEmail(document.new_user.google_signin_email.value){
+        alert(<?php echo xlj('Google email provided is invalid/not properly formatted (e.g. first.last@gmail.com)') ?>);
+        return false;
     }
 
     <?php if ($GLOBALS['erx_enable']) { ?>

--- a/interface/usergroup/usergroup_admin_add.php
+++ b/interface/usergroup/usergroup_admin_add.php
@@ -118,7 +118,7 @@ function submitform() {
     } //secure_pwd if ends here
 
     // Valiate Google email (if provided)
-    if(document.new_user.google_signin_email.value != "" !isValidEmail(document.new_user.google_signin_email.value){
+    if(document.new_user.google_signin_email.value != "" && !isValidEmail(document.new_user.google_signin_email.value)) {
         alert(<?php echo xlj('Google email provided is invalid/not properly formatted (e.g. first.last@gmail.com)') ?>);
         return false;
     }

--- a/interface/usergroup/usergroup_admin_add.php
+++ b/interface/usergroup/usergroup_admin_add.php
@@ -117,6 +117,16 @@ function submitform() {
         }
     } //secure_pwd if ends here
 
+    // Valiate Google email (if provided)
+    if(document.new_user.google_signin_email.value != ""){
+        // https://owasp.org/www-community/OWASP_Validation_Regex_Repository
+        var mailformat = /^[a-zA-Z0-9_+&*-]+(?:\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/;
+        if(!document.new_user.google_signin_email.value.match(mailformat)) {
+            alert(<?php echo xlj('Google email provided is invalid/not properly formatted (e.g. first.last@gmail.com)') ?>);
+            return false;
+        }
+    }
+
     <?php if ($GLOBALS['erx_enable']) { ?>
    alertMsg='';
    f=document.forms[0];

--- a/library/js/utility.js
+++ b/library/js/utility.js
@@ -503,3 +503,22 @@ if (typeof top.userDebug !== 'undefined' && (top.userDebug === '1' || top.userDe
     window.oeSMART = oeSMART;
 })(window, window.top.oeSMART || {});
 
+/*
+* @function isValidEmail(emailAddress)
+* @summary call this function where you need to validate an email address
+*  is formatted correctly, function will return bool true/false
+*
+* @param string An email address to validate, e.g. e.g. first.last@gmail.com
+*/
+function isValidEmail(emailAddress) {
+    // RegEx from https://owasp.org/www-community/OWASP_Validation_Regex_Repository
+    var mailformat = /^[a-zA-Z0-9_+&*-]+(?:\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/;
+    if(emailAddress.match(mailformat)) {
+        return true;
+    }
+    else {
+        return false;
+    }
+}
+
+

--- a/library/js/utility.js
+++ b/library/js/utility.js
@@ -513,12 +513,9 @@ if (typeof top.userDebug !== 'undefined' && (top.userDebug === '1' || top.userDe
 function isValidEmail(emailAddress) {
     // RegEx from https://owasp.org/www-community/OWASP_Validation_Regex_Repository
     var mailformat = /^[a-zA-Z0-9_+&*-]+(?:\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/;
-    if(emailAddress.match(mailformat)) {
+    if (emailAddress.match(mailformat)) {
         return true;
-    }
-    else {
+    } else {
         return false;
     }
 }
-
-


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes https://github.com/openemr/openemr/issues/7355

#### Short description of what this resolves:
This PR adds validation on the front-end UI and the backend to ensure that input is validated and sanitized for the google signin email input field. Without the PR, invalid or potentially malicious data can be saved in the field, such as JavaScript or scripts. (ASVS 5.1.3 and CWE-20)

After update:
![image](https://github.com/openemr/openemr/assets/38800918/5fb97644-b8a1-4875-9bf3-929f5fe9a5b6)


#### Changes proposed in this pull request:

1. Use an industry standard Regular Expression (RegEx) from the Open Worldwide Application Security Project (OWASP) on the front-end https://owasp.org/www-community/OWASP_Validation_Regex_Repository
2. Use the built in PHP function filter_var to validate the email on the backend https://www.php.net/manual/en/function.filter-var.php or https://www.w3schools.com/php/filter_validate_email.asp
