### PR TITLE
Fix: Update minimum password requirement to at least 12 characters

### DIFF
--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -2117,7 +2117,7 @@ $GLOBALS_METADATA = array(
                 '19' => '19',
                 '20' => '20',
             ),
-            '9',                              // default
+            '12',                              // default
             xl('Minimum length of password.')
         ),
 

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -8925,7 +8925,8 @@ CREATE TABLE `users_secure` (
   `last_login_fail` datetime DEFAULT NULL,
   `auto_block_emailed` tinyint DEFAULT 0,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `USERNAME_ID` (`id`,`username`)
+  UNIQUE KEY `USERNAME_ID` (`id`,`username`),
+  CONSTRAINT `min_password_length` CHECK ((LENGTH(`password`) >= 12))
 ) ENGINE=InnoDb;
 
 -- --------------------------------------------------------


### PR DESCRIPTION
Fixes #7357

#### Short description of what this resolves:
OpenEMR allows passwords at least 9 characters in length. To meet the ASVS 2.1.1 requirement, passwords under 12 characters should not be allowed. Additionally, OpenEMR does not have any constraints for the ‘password’ attribute of the ‘users_secure’ table to prevent bypassing the front-end validation and storing a password that does not meet minimum character requirements.

**After update:**
Screenshot of creating a new user with an 11-character password with a 12-character minimum password requirement enforced:
<img width="461" alt="image" src="https://github.com/openemr/openemr/assets/122830791/95617cb8-3691-443b-84db-c003155dc0fc">

Screenshot of changing a password to a 11-character password with a 12-character minimum password requirement enforced:
<img width="461" alt="image" src="https://github.com/openemr/openemr/assets/122830791/4d343696-31da-4bc3-a1d0-72a14a0f08a8">

Screenshot of adding a new row to the users_secure table with an 11-character password to the running database with a constraint enforcing a 12-character minimum length for the password attribute:
<img width="454" alt="image" src="https://github.com/openemr/openemr/assets/122830791/ab749cd0-584a-4e8a-b106-663a6e6469ac">



#### Changes proposed in this pull request:
1. In globals.inc.php, update the default value for the global variable ‘gbl_minimum_password_length’ from ‘9’ to ‘12’. This variable is used in ‘AuthUtils.php’ to enforce a minimum password length requirement on the front-end.
2. In database.sql, add a constraint to the ‘password’ attribute of the ‘users_secure’ table to complete a check of the length of the password entered and confirm it is greater than or equal to 12. OpenEMR hashes the password entered in the application before storing the value in the database, so passwords should be much greater than 12 characters when saved from the front-end; however, if a user identifies a way to bypass the front-end validation to create/update a user (such as using a REST API endpoint), then the constraint on the attribute within MySQL will still preserve the minimum password requirement. This ensures OpenEMR does not solely rely on the front-end validation to protect the minimum password length requirement.