### PR TITLE
 add print button and put patient's details at top of visit history page #7270

### DIFF
--- a/interface/patient_file/history/encounters.php
+++ b/interface/patient_file/history/encounters.php
@@ -310,12 +310,13 @@ window.onload = function() {
     <br />
     <span class="heading" >
     <?php
+    if ($attendant_type == 'pid') {
   // RM put patienes name, id and dob at top of the history -->
         $name =  getPatientNameFirstLast($pid);
         $dob =  text(oeFormatShortDate(getPatientData($pid, "DOB")['DOB']));
          $external_id = getPatientData($pid, "pubpid")['pubpid'];
         echo $name . " (" . $external_id . ")" .  "&nbsp;  &nbsp; DOB: " . $dob ;
-
+    }
     ?>
     </span>
 

--- a/interface/patient_file/history/encounters.php
+++ b/interface/patient_file/history/encounters.php
@@ -316,7 +316,7 @@ window.onload = function() {
          $external_id = getPatientData($pid, "pubpid")['pubpid'];
         echo $name . " (" . $external_id . ")" .  "&nbsp;  &nbsp; DOB: " . $dob ;
 
-        ?>
+    ?>
     </span>
 
     <div class="table-responsive">
@@ -390,7 +390,6 @@ window.onload = function() {
             }
 
             $numRes = 0;
-(new SystemLogger())->debug("size, start, numRes", array( $pagesize, $pagestart, $numRes));
 
             $sqlBindArray = array();
             if ($attendant_type == 'pid') {
@@ -482,11 +481,7 @@ window.onload = function() {
 
                     // This generates document lines as appropriate for the date order.
                 while ($drow && $raw_encounter_date && $drow['docdate'] > $raw_encounter_date) {
-
-                    (new SystemLogger())->debug(" generate: size, start, numRes", array( $pagesize, $pagestart, $numRes));
-
-                        showDocument($drow);
-
+                         showDocument($drow);
                     $drow = sqlFetchArray($dres);
                 }
 
@@ -840,7 +835,6 @@ window.onload = function() {
 
             // Dump remaining document lines if count not exceeded.
             while ($drow  ) {
-
                 showDocument($drow);
                 $drow = sqlFetchArray($dres);
             }

--- a/interface/patient_file/history/encounters.php
+++ b/interface/patient_file/history/encounters.php
@@ -30,7 +30,6 @@ use OpenEMR\Billing\BillingUtilities;
 use OpenEMR\Billing\InvoiceSummary;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
-use OpenEMR\Common\Logging\SystemLogger;
 
 $is_group = ($attendant_type == 'gid') ? true : false;
 

--- a/interface/patient_file/history/encounters.php
+++ b/interface/patient_file/history/encounters.php
@@ -834,7 +834,7 @@ window.onload = function() {
             } // end while
 
             // Dump remaining document lines if count not exceeded.
-            while ($drow  ) {
+            while ($drow){
                 showDocument($drow);
                 $drow = sqlFetchArray($dres);
             }

--- a/interface/patient_file/history/encounters.php
+++ b/interface/patient_file/history/encounters.php
@@ -2,6 +2,8 @@
 
 /**
  * Encounter list.
+ *  rm: print button to print page; include patients name, id and dob on the page
+ * version 1.0.0
  *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
@@ -28,6 +30,7 @@ use OpenEMR\Billing\BillingUtilities;
 use OpenEMR\Billing\InvoiceSummary;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Core\Header;
+use OpenEMR\Common\Logging\SystemLogger;
 
 $is_group = ($attendant_type == 'gid') ? true : false;
 
@@ -180,6 +183,12 @@ function generatePageElement($start, $pagesize, $billing, $issue, $text)
 <script src="<?php echo $GLOBALS['webroot'] ?>/library/js/ajtooltip.js"></script>
 
 <script>
+
+$(function () {
+   // print the history - as displayed
+    top.printLogSetup(document.getElementById('printbutton'));
+});
+
 // open dialog to edit an invoice w/o opening encounter.
 function editInvoice(e, id) {
     e.stopPropagation();
@@ -272,6 +281,8 @@ window.onload = function() {
     <?php } else { ?>
         <a href='encounters.php?billing=1&issue=<?php echo $issue . $getStringForPage; ?>' class="btn btn-small btn-info" onclick='top.restoreSession()' style='font-size: 11px'><?php echo xlt('To Billing View'); ?></a>
     <?php } ?>
+    &nbsp; &nbsp;
+     <a  href='#' id='printbutton' class='btn btn-secondary btn-print'>  <?php echo xlt('Print page'); ?>   </a>
 
     <span class="float-right">
         <?php echo xlt('Results per page'); ?>:
@@ -297,6 +308,16 @@ window.onload = function() {
     </span>
 
     <br />
+    <span class="heading" >
+    <?php
+  // RM put patienes name, id and dob at top of the history -->
+        $name =  getPatientNameFirstLast($pid);
+        $dob =  text(oeFormatShortDate(getPatientData($pid, "DOB")['DOB']));
+         $external_id = getPatientData($pid, "pubpid")['pubpid'];
+        echo $name . " (" . $external_id . ")" .  "&nbsp;  &nbsp; DOB: " . $dob ;
+
+        ?>
+    </span>
 
     <div class="table-responsive">
         <table class="table table-hover jumbotron py-4 mt-3">
@@ -368,7 +389,8 @@ window.onload = function() {
                 $drow = sqlFetchArray($dres);
             }
 
-            // $count = 0;
+            $numRes = 0;
+(new SystemLogger())->debug("size, start, numRes", array( $pagesize, $pagestart, $numRes));
 
             $sqlBindArray = array();
             if ($attendant_type == 'pid') {
@@ -401,7 +423,7 @@ window.onload = function() {
 
             $countRes = sqlStatement($countQuery, $sqlBindArray);
             $count = sqlFetchArray($countRes);
-            $numRes = $count['c'];
+            $numRes += $count['c'];
 
 
             if ($pagesize > 0) {
@@ -460,7 +482,11 @@ window.onload = function() {
 
                     // This generates document lines as appropriate for the date order.
                 while ($drow && $raw_encounter_date && $drow['docdate'] > $raw_encounter_date) {
-                    showDocument($drow);
+
+                    (new SystemLogger())->debug(" generate: size, start, numRes", array( $pagesize, $pagestart, $numRes));
+
+                        showDocument($drow);
+
                     $drow = sqlFetchArray($dres);
                 }
 
@@ -813,7 +839,8 @@ window.onload = function() {
             } // end while
 
             // Dump remaining document lines if count not exceeded.
-            while ($drow /* && $count <= $N */) {
+            while ($drow  ) {
+
                 showDocument($drow);
                 $drow = sqlFetchArray($dres);
             }

--- a/interface/patient_file/history/encounters.php
+++ b/interface/patient_file/history/encounters.php
@@ -2,8 +2,8 @@
 
 /**
  * Encounter list.
- *  rm: print button to print page; include patients name, id and dob on the page
- * version 1.0.0
+ *  rm: print button to print page & generate pdf; include patients name, id and dob on the page. issue #7270
+ *
  *
  * @package   OpenEMR
  * @link      http://www.open-emr.org

--- a/interface/patient_file/history/encounters.php
+++ b/interface/patient_file/history/encounters.php
@@ -834,7 +834,7 @@ window.onload = function() {
             } // end while
 
             // Dump remaining document lines if count not exceeded.
-            while ($drow){
+            while ($drow) {
                 showDocument($drow);
                 $drow = sqlFetchArray($dres);
             }


### PR DESCRIPTION
 
Fixes #7270

#### Short description of what this resolves:
to print or make a pdf of a visit history report one had to use the browsers print function, with ctrl+p or file/print etc. This only prints what had been displayed on the screen, so for a long history that takes several screens only the first would be printed.

#### Changes proposed in this pull request:
add a 'print' button that prints the complete page of the history being displayed. for page length 'ALL' this is the complete history which will produce a multi page document where necessary
display the patient's details at the top of the history window and on the first page of the print or pdf document. 
