### PR TITLE
Added a button to show/hide password on the login page

### DIFF
--- a/templates/login/partials/input/password.html.twig
+++ b/templates/login/partials/input/password.html.twig
@@ -16,7 +16,31 @@ Render the password row
 <div id="standard-auth-password" class="{{ password_container_class_list|default(['form-group', 'row'])|join(' ') }}">
     <label for="clearPass" class="{{ srOnly }} {{ password_label_class_list|default(['col-form-label', 'col-sm-4'])|join(' ') }}">{{ "Password"|xlt }}</label>
     <div class="{{ password_input_container_class_list|default(['col'])|join(' ') }}">
-        <input type="password" class="form-control" id="clearPass" name="clearPass" placeholder="{{ "Password"|xla }}">
+        <div class="input-group">
+            <input type="password" class="form-control" id="clearPass" name="clearPass" placeholder="{{ "Password"|xla }}">
+            <div class="input-group-append">
+                <span class="input-group-text" id="showPasswordBtn">
+                    <i class="fa fa-eye" aria-hidden="true"></i>
+                </span>
+            </div>
+        </div>
     </div>
 </div>
+
+<script>
+    $(document).ready(function() {
+        $('#showPasswordBtn').on('click', function() {
+            var passwordInput = $('#clearPass');
+            var passwordFieldType = passwordInput.attr('type');
+            
+            if (passwordFieldType === 'password') {
+                passwordInput.attr('type', 'text');
+                $(this).find('i').removeClass('fa-eye').addClass('fa-eye-slash');
+            } else {
+                passwordInput.attr('type', 'password');
+                $(this).find('i').removeClass('fa-eye-slash').addClass('fa-eye');
+            }
+        });
+    });
+</script>
 {% endblock %}


### PR DESCRIPTION
Fixes #7361 

#### Short description of what this resolves:
The fix adds a button with the eye icon to toggle the visibility of the password from masked to plain-text and vice-versa.

#### Changes proposed in this pull request:
- Add a button with the eye icon
- Add script to select the button and toggle the password state from masked to plain-text as well as toggle the icon between eye and slash-eye states.

![Show](https://github.com/openemr/openemr/assets/46598699/425306cb-434e-4d2b-a8f7-2f63ed360740)
![Hide](https://github.com/openemr/openemr/assets/46598699/51916bd4-9088-4767-9634-76487ad8c389)

