### PR TITLE
Issue #7363: Fix for negative payment record addition

### DIFF
--- a/ThreatDragonModels/New Threat Model/New Threat Model.json
+++ b/ThreatDragonModels/New Threat Model/New Threat Model.json
@@ -1,0 +1,16 @@
+{
+  "version": "2.2.0",
+  "summary": {
+    "title": "New Threat Model",
+    "owner": "",
+    "description": "",
+    "id": 0
+  },
+  "detail": {
+    "contributors": [],
+    "diagrams": [],
+    "diagramTop": 0,
+    "reviewer": "",
+    "threatTop": 0
+  }
+}

--- a/interface/billing/edit_payment.php
+++ b/interface/billing/edit_payment.php
@@ -103,6 +103,10 @@ if (isset($_POST["mode"])) {
             $global_account = "', global_amount = '" . trim(formData('global_reset'));
         }
 
+        if(((float)trim(formData('payment_amount')))<0){
+            die("Payment amount cannot be less than 0");
+        }
+
         sqlStatement("update ar_session set " .
             $QueryPart .
             "', user_id = '" . trim(add_escape_custom($user_id)) .

--- a/interface/billing/new_payment.php
+++ b/interface/billing/new_payment.php
@@ -63,6 +63,11 @@ if ($mode == "new_payment" || $mode == "distribute") {
     if ($post_to_date == '') {
         $post_to_date = date('Y-m-d');
     }
+
+    if(((float)trim(formData('payment_amount')))<0){
+        die("Payment amount cannot be less than 0");
+    }
+    
     if ($_POST['deposit_date'] == '') {
         $deposit_date = $post_to_date;
     }

--- a/library/payment_jav.inc.php
+++ b/library/payment_jav.inc.php
@@ -419,6 +419,16 @@
             document.getElementById('payment_amount').focus();
             return false;
         }
+        if (parseFloat(document.getElementById('payment_amount').value) < 0) {
+            let message = <?php echo xlj('Payment Amount must be Greater than 0') ?>;
+            (async (message, time) => {
+                await asyncAlertMsg(message, time, 'warning', 'lg');
+            })(message, 1500).then(res => {
+            });
+            document.getElementById('payment_amount').focus();
+            return false;
+        }
+        
         <?php
         if (!empty($screen) && ($screen == 'edit_payment')) {
             ?>


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #7363

#### Short description of what this resolves:
As admin was able to add a batch payment record with negative amount
Checks added on UI and Backend to validate if payment amount is negative and greater than 0
#### Changes proposed in this pull request:

UI side check added along with checks on backend in new_payment.php and edit_payment.php files
