### PR TITLE
Fixes #7370 support select-fields alias

### DIFF
--- a/src/Services/BaseService.php
+++ b/src/Services/BaseService.php
@@ -105,17 +105,26 @@ class BaseService
 
     /**
      * Return the fields that should be used in a standard select clause.  Can be overwritten by inheriting classes
+     * @param string $alias if the field should be prefixed with a table alias
+     * @param string $columnPrefix prefix to add to each field, used if there is a possibility of column name conflicts in select statement, prefix's can only be ascii alphabetic and the underscore characters
      * @return array
      */
-    public function getSelectFields(): array
+    public function getSelectFields(string $tableAlias = '', string $columnPrefix = ""): array
     {
+        $tableAlias = trim($tableAlias);
+        if ($tableAlias == '') {
+            $tableAlias = '`' . $this->getTable() . '`';
+        }
+        // only allow ascii characters and underscore
+        $columnPrefix = preg_replace("/[^a-z_]+/i", "", $columnPrefix);
+        $tableAlias .= ".";
         // since we are often joining a bunch of fields we need to make sure we normalize our regular field array
         // by adding the table name for our own table values.
         $fields = $this->getFields();
         $normalizedFields = [];
         // processing is cheap
         foreach ($fields as $field) {
-            $normalizedFields[] = '`' . $this->getTable() . '`.`' . $field . '`';
+            $normalizedFields[] = $tableAlias . '`' . $columnPrefix . $field . '`';
         }
 
         return $normalizedFields;

--- a/src/Services/EmployerService.php
+++ b/src/Services/EmployerService.php
@@ -22,9 +22,9 @@ class EmployerService extends BaseService
     }
 
     // we want to grab the puuid from the patient table so people can search on it
-    public function getSelectFields(): array
+    public function getSelectFields(string $tableAlias = '', string $columnPrefix = ""): array
     {
-        $fields = parent::getSelectFields();
+        $fields = parent::getSelectFields($tableAlias, $columnPrefix);
         $fields[] = '`patient`.`puuid`';
         return $fields;
     }

--- a/src/Services/PractitionerService.php
+++ b/src/Services/PractitionerService.php
@@ -50,7 +50,7 @@ class PractitionerService extends BaseService
             ];
     }
 
-    public function getSelectFields(): array
+    public function getSelectFields(string $tableAlias = '', string $columnPrefix = ""): array
     {
         // since we are joining a bunch of fields we need to make sure we normalize our regular field array by adding
         // the table name for our own table values.


### PR DESCRIPTION
This changes the getSelectFields method signature to support column and table aliases.

Fixes #7370.

I do have concerns as this would be a breaking change if anyone private fork or custom module extends the BaseService method and override the getSelectFields method.  It doesn't break any logic in core but I wonder if this will have problems.  As this is likely to go into a minor patch I'm not sure if we bring it in or not.