### PR TITLE
Validate file size before upload

### DIFF
--- a/templates/documents/general_upload.html
+++ b/templates/documents/general_upload.html
@@ -10,8 +10,29 @@
 * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
 *}
 
+<script>
+    function checkFileSize() {
+        var fileInput = document.querySelector('input[type="file"]');
+        var totalSize = 0;
+
+        // Get the size of the selected file
+        for (var i = 0; i < fileInput.files.length; i++) {
+            totalSize += fileInput.files[i].size;
+        }
+
+        // Check if the file size exceeds the maximum allowed size.
+        if (totalSize > 64000000) {
+            alert('Total file size exceeds the maximum limit of 64MB.');
+            // Prevent form submission
+            return false;
+        }
+        // Allow form submission
+        return true;
+    }
+</script>
+
 <div class="col-sm-12">
-    <form class="form" method="post" enctype="multipart/form-data" action="{$FORM_ACTION}" onsubmit="return top.restoreSession()">
+    <form class="form" method="post" enctype="multipart/form-data" action="{$FORM_ACTION}" onsubmit="return checkFileSize()">
         <input type="hidden" name="MAX_FILE_SIZE" value="64000000" />
         <h3>{if !empty($error)}{$error|text|nl2br}{/if}</h3>
         {if (!($patient_id > 0))}


### PR DESCRIPTION

Fixes #7382 

#### Short description of what this resolves:
This pull request addresses the issue where OpenEMR fails to display an error message when attempting to upload large files, leaving users unaware of the upload failure.

#### Changes proposed in this pull request:
- Implemented client-side file size validation using JavaScript to prevent submission of files exceeding the maximum size limit.
- Modified the upload form in "./templates/documents/general_upload.html" to incorporate the checkFileSize() JavaScript function.
- Updated the "onsubmit" attribute of the form element to trigger the checkFileSize() function before form submission, ensuring validation occurs prior to data submission to the server.

![unnamed](https://github.com/openemr/openemr/assets/112002925/4142ef02-4d93-4282-91e1-472518fcb07f)
