### PR TITLE
fix: use empty array if no cpts when posting era

### DIFF
--- a/interface/billing/sl_eob_process.php
+++ b/interface/billing/sl_eob_process.php
@@ -386,7 +386,7 @@ function era_callback(&$out)
             // processed by the primary payer so try to deal with that
             if (!$prev) {
                 if (!$svc['mod']) {
-                    if (in_array($svc['code'], $cpts)) {
+                    if (in_array($svc['code'], $cpts ?? [])) {
                         foreach ($cpts as $k => $v) {
                             if ($v == $codekey) {
                                 $codekey = $cpt . ':' . implode(':', $mods[$v]);


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #7387 

#### Short description of what this resolves:


#### Changes proposed in this pull request:
