### PR TITLE
fixed an issue described in #7199

### DIFF
--- a/src/Common/Database/QueryUtils.php
+++ b/src/Common/Database/QueryUtils.php
@@ -85,12 +85,8 @@ class QueryUtils
     public static function fetchSingleValue($sqlStatement, $column, $binds = array())
     {
         $records = self::fetchTableColumn($sqlStatement, $column, $binds);
-        // note if $records[0] is actually the value 0 then the value returned is null...
-        // do we want that behavior?
-        if (!empty($records[0])) {
-            return $records[0];
-        }
-        return null;
+
+        return $records[0] ?? null;
     }
 
     public static function fetchRecords($sqlStatement, $binds = array(), $noLog = false)


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #7199

#### Short description of what this resolves: resolves an issue with returning null value when $records[0] is actually a 0 value, which should be returned.


#### Changes proposed in this pull request: "if" statement replaced with null coalescing operator to ensure that if the value is set and not null it will be returned, which is true for integer 0 as well.
