### PR TITLE
Fix User Admin screen Google Email for Login does not save when creating new user

### DIFF
--- a/interface/usergroup/usergroup_admin.php
+++ b/interface/usergroup/usergroup_admin.php
@@ -351,6 +351,7 @@ if (isset($_POST["mode"])) {
             "', mname = '"         . add_escape_custom(trim((isset($_POST['mname']) ? $_POST['mname'] : ''))) .
             "', lname = '"         . add_escape_custom(trim((isset($_POST['lname']) ? $_POST['lname'] : ''))) .
             "', suffix = '"         . add_escape_custom(trim((isset($_POST['suffix']) ? $_POST['suffix'] : ''))) .
+            "', google_signin_email = '" . add_escape_custom(trim((isset($_POST['google_signin_email']) ? $_POST['google_signin_email'] : ''))) .
             "', valedictory = '"         . add_escape_custom(trim((isset($_POST['valedictory']) ? $_POST['valedictory'] : ''))) .
             "', federaltaxid = '"  . add_escape_custom(trim((isset($_POST['federaltaxid']) ? $_POST['federaltaxid'] : ''))) .
             "', state_license_number = '"  . add_escape_custom(trim((isset($_POST['state_license_number']) ? $_POST['state_license_number'] : ''))) .


### PR DESCRIPTION
Fixes #7393

#### Short description of what this resolves:
Not exist insert statement for google_signin_email column in users table.
So add insert statement value to column in interface/usergroup/usergroup_admin.php.
