### PR TITLE
fix: use temp files dir for htmlpurify serializer path

### DIFF
--- a/src/Services/DocumentTemplates/DocumentTemplateRender.php
+++ b/src/Services/DocumentTemplates/DocumentTemplateRender.php
@@ -109,6 +109,7 @@ class DocumentTemplateRender
         // purify html (and remove js)
         $isLegacy = stripos($template, 'portal_version') === false;
         $config = HTMLPurifier_Config::createDefault();
+        $config->set('Cache.SerializerPath', $GLOBALS['temporary_files_dir']);
         $config->set('Core.Encoding', 'UTF-8');
         $config->set('CSS.AllowedProperties', '*');
         $purify = new HTMLPurifier($config);


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #7475

#### Short description of what this resolves:


#### Changes proposed in this pull request:
