### PR TITLE
Update C_Prescription.class.php to display no of tablets left in stock, with expiry date, in the drop down menu when prescribing a drug to a patient.

### DIFF
--- a/controllers/C_Prescription.class.php
+++ b/controllers/C_Prescription.class.php
@@ -73,7 +73,6 @@ class C_Prescription extends Controller
                     $tmp_output .= ' [' . $row['ndc_number'] . ']';
                     $tmp_output .= ' - ' . xl('No left in stock:') . ' ' . $row['on_hand']; //xl function added for translation.
                     $tmp_output .= ' - ' . xl('Expiry Date:') . ' ' . $row['expiration']; //xl function added for translation.
-
                 }
                 $drug_array_values[] = $row['drug_id'];
                 $drug_array_output[] = $tmp_output;

--- a/controllers/C_Prescription.class.php
+++ b/controllers/C_Prescription.class.php
@@ -59,18 +59,22 @@ class C_Prescription extends Controller
 
             // $res = sqlStatement("SELECT * FROM drugs ORDER BY selector");
 
-            $res = sqlStatement("SELECT d.name, d.ndc_number, d.form, d.size, " .
-                "d.unit, d.route, d.substitute, t.drug_id, t.selector, t.dosage, " .
-                "t.period, t.quantity, t.refills, d.drug_code " .
-                "FROM drug_templates AS t, drugs AS d WHERE " .
-                "d.drug_id = t.drug_id ORDER BY t.selector");
+           $res = sqlStatement("SELECT d.name, d.ndc_number, d.form, d.size, " .
+            "d.unit, d.route, d.substitute, t.drug_id, t.selector, t.dosage, " .
+            "t.period, t.quantity, t.refills, d.drug_code, i.on_hand,i.expiration " .
+            "FROM drug_templates AS t " .
+            "JOIN drugs AS d ON d.drug_id = t.drug_id " .
+            "JOIN drug_inventory AS i ON d.drug_id = i.drug_id " .
+            "ORDER BY t.selector");
 
             while ($row = sqlFetchArray($res)) {
                 $tmp_output = $row['selector'];
                 if ($row['ndc_number']) {
-                    $tmp_output .= ' [' . $row['ndc_number'] . ']';
-                }
 
+                    $tmp_output .= ' - Price of One Tab: ' . $row['ndc_number'];
+                    $tmp_output .= ' - No left in stock: ' . $row['on_hand'];
+                    $tmp_output .= ' - Expiry Date: ' . $row['expiration'];
+                   }
                 $drug_array_values[] = $row['drug_id'];
                 $drug_array_output[] = $tmp_output;
                 if ($drug_attributes) {

--- a/controllers/C_Prescription.class.php
+++ b/controllers/C_Prescription.class.php
@@ -70,9 +70,10 @@ class C_Prescription extends Controller
             while ($row = sqlFetchArray($res)) {
                 $tmp_output = $row['selector'];
                 if ($row['ndc_number']) {
-                    $tmp_output .= ' - Price of One Tab: ' . $row['ndc_number'];
-                    $tmp_output .= ' - No left in stock: ' . $row['on_hand'];
-                    $tmp_output .= ' - Expiry Date: ' . $row['expiration'];
+                    $tmp_output .= ' - ' . xl('Price of One Tab:') . ' ' . $row['ndc_number']; //xl function added for translation.
+                    $tmp_output .= ' - ' . xl('No left in stock:') . ' ' . $row['on_hand']; //xl function added for translation.
+                    $tmp_output .= ' - ' . xl('Expiry Date:') . ' ' . $row['expiration']; //xl function added for translation.
+
                 }
                 $drug_array_values[] = $row['drug_id'];
                 $drug_array_output[] = $tmp_output;

--- a/controllers/C_Prescription.class.php
+++ b/controllers/C_Prescription.class.php
@@ -70,7 +70,7 @@ class C_Prescription extends Controller
             while ($row = sqlFetchArray($res)) {
                 $tmp_output = $row['selector'];
                 if ($row['ndc_number']) {
-                    $tmp_output .= ' - ' . xl('Price of One Tab:') . ' ' . $row['ndc_number']; //xl function added for translation.
+                    $tmp_output .= ' [' . $row['ndc_number'] . ']';
                     $tmp_output .= ' - ' . xl('No left in stock:') . ' ' . $row['on_hand']; //xl function added for translation.
                     $tmp_output .= ' - ' . xl('Expiry Date:') . ' ' . $row['expiration']; //xl function added for translation.
 

--- a/controllers/C_Prescription.class.php
+++ b/controllers/C_Prescription.class.php
@@ -59,7 +59,7 @@ class C_Prescription extends Controller
 
             // $res = sqlStatement("SELECT * FROM drugs ORDER BY selector");
 
-           $res = sqlStatement("SELECT d.name, d.ndc_number, d.form, d.size, " .
+            $res = sqlStatement("SELECT d.name, d.ndc_number, d.form, d.size, " .
             "d.unit, d.route, d.substitute, t.drug_id, t.selector, t.dosage, " .
             "t.period, t.quantity, t.refills, d.drug_code, i.on_hand,i.expiration " .
             "FROM drug_templates AS t " .
@@ -70,11 +70,10 @@ class C_Prescription extends Controller
             while ($row = sqlFetchArray($res)) {
                 $tmp_output = $row['selector'];
                 if ($row['ndc_number']) {
-
                     $tmp_output .= ' - Price of One Tab: ' . $row['ndc_number'];
                     $tmp_output .= ' - No left in stock: ' . $row['on_hand'];
                     $tmp_output .= ' - Expiry Date: ' . $row['expiration'];
-                   }
+                }
                 $drug_array_values[] = $row['drug_id'];
                 $drug_array_output[] = $tmp_output;
                 if ($drug_attributes) {


### PR DESCRIPTION
Added option to display no of tablets left in stock, with expiry date, in the drop down menu when prescribing a drug to a patient. This can be very helpful to the pharmacist /doctor to decide from which stock to give the drug.  In addition as suggested in the openemr documentation ndc_number field can be used to display the price of one tablet etc so  while adding a drug to the inventory, the price of one tablet can be calculated and added in ndc_number.  Regards
Dr Robert James

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #7486

#### Short description of what this resolves:
Added option to display no of tablets left in stock, with expiry date, in the drop down menu when prescribing a drug to a patient. This can be very helpful to the pharmacist /doctor to decide from which stock to give the drug.  In addition as suggested in the openemr documentation ndc_number field can be used to display the price of one tablet etc so  while adding a drug to the inventory, the price of one tablet can be calculated and added in ndc_number.

#### Changes proposed in this pull request:
Added option to display no of tablets left in stock, with expiry date, in the drop down menu when prescribing a drug to a patient. This can be very helpful to the pharmacist /doctor to decide from which stock to give the drug.  In addition as suggested in the openemr documentation ndc_number field can be used to display the price of one tablet etc so  while adding a drug to the inventory, the price of one tablet can be calculated and added in ndc_number.