### PR TITLE
Fixes #7497 datetimepicker invalid date format

### DIFF
--- a/library/js/xl/jquery-datetimepicker-2-5-4-translated.js
+++ b/library/js/xl/jquery-datetimepicker-2-5-4-translated.js
@@ -47,7 +47,7 @@ function datetimepickerTranslated(selector, params) {
     let jsGlobals = window.top.jsGlobals || {};
     let languageDirection = jsGlobals.languageDirection || 'ltr';
     let formatters = window.top.oeFormatters || {};
-    let DateFormatRead = formatters.DateFormatRead || function (mode = 'legacy') { return "%Y-%m-%d"; };
+    let DateFormatRead = formatters.DateFormatRead || function (mode = 'legacy') { return "Y-m-d"; };
     if (typeof params === 'undefined') {
         params = {
             timepicker: false


### PR DESCRIPTION
This fixes #7497 when the DateFormatRead is not defined and the date time picker uses its own internal function the format fails when using the % to do date formatting.