### PR TITLE
fix: set default x12 partner for item in billing manager

### DIFF
--- a/interface/billing/billing_report.php
+++ b/interface/billing/billing_report.php
@@ -1133,7 +1133,7 @@ $partners = $x->_utility_array($x->x12_partner_factory());
                                         )
                                     );
                                     $count = 0;
-                                    $default_x12_partner = $iter['ic_x12id'] ?? null;
+                                    $default_x12_partner = $iter['x12_partner_id'] ?? null;
                                     $prevtype = '';
 
                                     while ($row = sqlFetchArray($result)) {


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #7501 

#### Short description of what this resolves:


#### Changes proposed in this pull request:
