### PR TITLE
Fixes #7503 user admin create empty google sign in

### DIFF
--- a/interface/usergroup/usergroup_admin.php
+++ b/interface/usergroup/usergroup_admin.php
@@ -344,9 +344,10 @@ if (isset($_POST["mode"])) {
 
         if ($doit == true) {
             // google_signin_email has unique key constraint, needs to be handled differently
+            $googleSigninEmail = "NULL";
             if (isset($_POST["google_signin_email"])) {
                 if (empty($_POST["google_signin_email"])) {
-                    $googleSigninEmail = null;
+                    $googleSigninEmail = "NULL";
                 } else {
                     $googleSigninEmail = "'" . add_escape_custom(trim($_POST["google_signin_email"])) . "'";
                 }
@@ -359,7 +360,7 @@ if (isset($_POST["mode"])) {
             "', mname = '"         . add_escape_custom(trim((isset($_POST['mname']) ? $_POST['mname'] : ''))) .
             "', lname = '"         . add_escape_custom(trim((isset($_POST['lname']) ? $_POST['lname'] : ''))) .
             "', suffix = '"         . add_escape_custom(trim((isset($_POST['suffix']) ? $_POST['suffix'] : ''))) .
-            "', google_signin_email = " . add_escape_custom($googleSigninEmail) .
+            "', google_signin_email = " . $googleSigninEmail .
             ", valedictory = '"         . add_escape_custom(trim((isset($_POST['valedictory']) ? $_POST['valedictory'] : ''))) .
             "', federaltaxid = '"  . add_escape_custom(trim((isset($_POST['federaltaxid']) ? $_POST['federaltaxid'] : ''))) .
             "', state_license_number = '"  . add_escape_custom(trim((isset($_POST['state_license_number']) ? $_POST['state_license_number'] : ''))) .

--- a/interface/usergroup/usergroup_admin.php
+++ b/interface/usergroup/usergroup_admin.php
@@ -343,6 +343,14 @@ if (isset($_POST["mode"])) {
         }
 
         if ($doit == true) {
+            // google_signin_email has unique key constraint, needs to be handled differently
+            if (isset($_POST["google_signin_email"])) {
+                if (empty($_POST["google_signin_email"])) {
+                    $googleSigninEmail = null;
+                } else {
+                    $googleSigninEmail = "'" . add_escape_custom(trim($_POST["google_signin_email"])) . "'";
+                }
+            }
             $insertUserSQL =
             "insert into users set " .
             "username = '"         . add_escape_custom(trim((isset($_POST['rumple']) ? $_POST['rumple'] : ''))) .
@@ -351,8 +359,8 @@ if (isset($_POST["mode"])) {
             "', mname = '"         . add_escape_custom(trim((isset($_POST['mname']) ? $_POST['mname'] : ''))) .
             "', lname = '"         . add_escape_custom(trim((isset($_POST['lname']) ? $_POST['lname'] : ''))) .
             "', suffix = '"         . add_escape_custom(trim((isset($_POST['suffix']) ? $_POST['suffix'] : ''))) .
-            "', google_signin_email = '" . add_escape_custom(trim((isset($_POST['google_signin_email']) ? $_POST['google_signin_email'] : ''))) .
-            "', valedictory = '"         . add_escape_custom(trim((isset($_POST['valedictory']) ? $_POST['valedictory'] : ''))) .
+            "', google_signin_email = " . add_escape_custom($googleSigninEmail) .
+            ", valedictory = '"         . add_escape_custom(trim((isset($_POST['valedictory']) ? $_POST['valedictory'] : ''))) .
             "', federaltaxid = '"  . add_escape_custom(trim((isset($_POST['federaltaxid']) ? $_POST['federaltaxid'] : ''))) .
             "', state_license_number = '"  . add_escape_custom(trim((isset($_POST['state_license_number']) ? $_POST['state_license_number'] : ''))) .
             "', newcrop_user_role = '"  . add_escape_custom(trim((isset($_POST['erxrole']) ? $_POST['erxrole'] : ''))) .


### PR DESCRIPTION
Fixes #7503 by allowing the multiple users to have an empty google sign in email address. If the address is empty it sets the value to null which doesn't trigger the unique constraint.