### PR TITLE
Mangled path fax send

### DIFF
--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php
@@ -180,7 +180,7 @@ class EtherFaxActions extends AppDispatch
         // needed args
         $isContent = $this->getRequest('isContent');
         $file = $this->getRequest('file');
-        $docId = $this->getRequest('docId');
+        $docId = $this->getRequest('docid');
         $phone = $this->formatPhone($this->getRequest('phone'));
         $isDocuments = (int)$this->getRequest('isDocuments');
         $email = $this->getRequest('email');
@@ -192,8 +192,14 @@ class EtherFaxActions extends AppDispatch
         $tag = $user['username'];
 
         if (empty($isContent)) {
-            $file = str_replace(["file://", "\\"], ['', "/"], realpath($file));
-            if (!$file) {
+            if (str_starts_with($file, 'file://')) {
+                // Remove the "file://" prefix
+                $file = substr($file, 7);
+            }
+            $realPath = realpath($file);
+            if ($realPath !== false) {
+                $file = str_replace("\\", "/", $realPath);
+            } else {
                 return xlt('Error: No content');
             }
         }
@@ -658,7 +664,7 @@ class EtherFaxActions extends AppDispatch
     public function chartDocument(): string
     {
         $pid = $this->getRequest('pid');
-        $docId = $this->getRequest('docId');
+        $docId = $this->getRequest('docid') ?? $this->getRequest('docId');
         $fileName = $this->getRequest('file_name');
         $result = $this->chartFaxDocument($pid, $docId, $fileName);
 


### PR DESCRIPTION


<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #7505


#### Short description of what this resolves:
normalize file path from document controller for fax send


#### Changes proposed in this pull request:
