### PR TITLE
Allergies entry causes sql error.

### DIFF
--- a/custom/code_types.inc.php
+++ b/custom/code_types.inc.php
@@ -154,14 +154,17 @@ define_external_table($code_external_tables, 9, 'sct_descriptions', 'ConceptId',
 array_push($code_external_tables[9][EXT_JOINS][0][JOIN_FIELDS], "FullySpecifiedName like '%(procedure)'");
 
 // SNOMED RF2 definitions
-define_external_table($code_external_tables, 11, 'sct2_description', 'conceptId', 'term', 'term', array("active=1"), "");
-if (isSnomedSpanish()) {
-    define_external_table($code_external_tables, 10, 'sct2_description', 'conceptId', 'term', 'term', array("active=1", "term LIKE '%(trastorno)'"), "");
-    define_external_table($code_external_tables, 12, 'sct2_description', 'conceptId', 'term', 'term', array("active=1", "term LIKE '%(procedimiento)'"), "");
-} else {
-    define_external_table($code_external_tables, 10, 'sct2_description', 'conceptId', 'term', 'term', array("active=1", "term LIKE '%(disorder)'"), "");
-    define_external_table($code_external_tables, 12, 'sct2_description', 'conceptId', 'term', 'term', array("active=1", "term LIKE '%(procedure)'"), "");
-}
+//When SNOMED is not installed, and allergies are added, mysql error shows after adding the allergy and that patients details cant be seen anymore, unless we hide the allergies from admin> config > appearence. commenting out lines 158-165 solves this issue.
+//this can be used as a temporary fix for users who dont have access to paid SNOMED but still want to use allergies feature.
+// Dr Robert James
+// define_external_table($code_external_tables, 11, 'sct2_description', 'conceptId', 'term', 'term', array("active=1"), "");
+// if (isSnomedSpanish()) {
+//     define_external_table($code_external_tables, 10, 'sct2_description', 'conceptId', 'term', 'term', array("active=1", "term LIKE '%(trastorno)'"), "");
+//     define_external_table($code_external_tables, 12, 'sct2_description', 'conceptId', 'term', 'term', array("active=1", "term LIKE '%(procedimiento)'"), "");
+// } else {
+//     define_external_table($code_external_tables, 10, 'sct2_description', 'conceptId', 'term', 'term', array("active=1", "term LIKE '%(disorder)'"), "");
+//     define_external_table($code_external_tables, 12, 'sct2_description', 'conceptId', 'term', 'term', array("active=1", "term LIKE '%(procedure)'"), "");
+// }
 
 //**** End SNOMED Definitions
 


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #7533

#### Short description of what this resolves:
Commented lines 177-167 in custom/code_types.inc.php

When SNOMED is not installed, and allergies are added, mysql error shows after adding the allergy and that patients details cant be seen anymore, unless we hide the allergies from admin> config > appearence. commenting out lines 158-165 solves this issue.
this can be used as a temporary fix for users who dont have access to paid SNOMED but still want to use allergies feature.

snapshot of error
![allergybug](https://github.com/openemr/openemr/assets/162261340/6857f218-fb1e-4ed5-a487-d65bad535a04)
![allergybug2](https://github.com/openemr/openemr/assets/162261340/be30efc7-7d6d-4ae9-afaf-e8bb78749d23)

Regards
Dr Robert James

#### Changes proposed in this pull request:
When SNOMED is not installed, and allergies are added, mysql error shows after adding the allergy and that patients details cant be seen anymore, unless we hide the allergies from admin> config > appearence. commenting out lines 158-165 solves this issue.
this can be used as a temporary fix for users who dont have access to paid SNOMED but still want to use allergies feature.
Dr Robert James
