### PR TITLE
fix: set default x12 partner if only 1 effective insurance

### DIFF
--- a/interface/billing/billing_report.php
+++ b/interface/billing/billing_report.php
@@ -1125,7 +1125,7 @@ $partners = $x->_utility_array($x->x12_partner_factory());
                                         $lhtml .= "<option value=\"" . attr(substr($row['type'], 0, 1) . $row['provider']) . "\"";
                                         if (
                                             $key == $last_level_closed
-                                            || $insuranceCount = 1
+                                            || $insuranceCount == 1
                                         ) {
                                             $lhtml .= " selected";
                                             $default_x12_partner = $x12Partner;


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #7501 

#### Short description of what this resolves:


#### Changes proposed in this pull request:
