### PR TITLE
Questionnaire - configure where LOINC notice should go

### DIFF
--- a/interface/forms/questionnaire_assessments/questionnaire_assessments.php
+++ b/interface/forms/questionnaire_assessments/questionnaire_assessments.php
@@ -114,13 +114,13 @@ $top_note = $bottom_note = false; // value of '3' says don't display
 
 switch ($GLOBALS['questionnaire_display_LOINCnote']) {
     case '0':
-            $top_note = true;
-            break;
+        $top_note = true;
+        break;
     case '1':
-            $bottom_note = true;
-            break;
+        $bottom_note = true;
+        break;
     case '2':
-            $top_note = $bottom_note = true;
+        $top_note = $bottom_note = true;
 }
 
 ?>

--- a/interface/forms/questionnaire_assessments/questionnaire_assessments.php
+++ b/interface/forms/questionnaire_assessments/questionnaire_assessments.php
@@ -109,8 +109,10 @@ try {
 } catch (Exception $e) {
     die(xlt("Can not continue with reason.") . '<br />' . text($e->getMessage()));
 }
-/* where to put the LOINC statement */
+/* where to put the LOINC statement , and the statement itself */
 $top_note = $bottom_note = false; // value of '3' says don't display
+
+$loinc_text =  "<span class='font-weight-bold'>" .  xlt("Important to Note") . ": </span><i>" . xlt("LOINC form definitions are subject to the LOINC") . " <a href='http://loinc.org/terms-of-use' target='_blank'> " .  xlt("terms of use.") . "</i>" . "</a>";
 
 switch ($GLOBALS['questionnaire_display_LOINCnote']) {
     case '0':
@@ -396,9 +398,7 @@ switch ($GLOBALS['questionnaire_display_LOINCnote']) {
                <div>
 
                 <?php if ($top_note) : ?>
-                 <p class="text-center"><?php echo "<span class='font-weight-bold'>" .  xlt("Important to Note") . ": </span><i>" . xlt("LOINC form definitions are subject to the LOINC");  ?>
-                    <a href="http://loinc.org/terms-of-use" target="_blank">
-                        <?php echo xlt("terms of use.") . "</i>";  ?></a></p>
+                 <p class="text-center"><?php echo $loinc_text ?></p>
                 <?php endif; ?>
 
                 <p id="copyrightNotice">
@@ -441,9 +441,7 @@ switch ($GLOBALS['questionnaire_display_LOINCnote']) {
             <!-- RM check if LOINC terms configured to display notice at bottom of window -->
            <?php if ($bottom_note) : ?>
                <div>
-                 <p class="text-center"><?php echo "<span class='font-weight-bold'>" .  xlt("Important to Note") . ": </span><i>" . xlt("LOINC form definitions are subject to the LOINC");  ?>
-                    <a href="http://loinc.org/terms-of-use" target="_blank">
-                        <?php echo xlt("terms of use.") . "</i>";  ?></a></p>
+                 <p class="text-center"><?php echo $loinc_text ?></p>
               </div>
            <?php endif; ?>
 

--- a/interface/forms/questionnaire_assessments/questionnaire_assessments.php
+++ b/interface/forms/questionnaire_assessments/questionnaire_assessments.php
@@ -124,6 +124,7 @@ switch ($GLOBALS['questionnaire_display_LOINCnote']) {
 }
 
 ?>
+
 <!DOCTYPE html>
 <html>
 <head>
@@ -360,6 +361,7 @@ switch ($GLOBALS['questionnaire_display_LOINCnote']) {
             saveButton.classList.remove("d-none");
             registryButton.classList.remove("d-none");
         }
+
     </script>
 </head>
 <body class="bg-light text-dark">
@@ -390,18 +392,20 @@ switch ($GLOBALS['questionnaire_display_LOINCnote']) {
             <input type="hidden" id="questionnaire" name="questionnaire" value="<?php echo attr($form['questionnaire'] ?? ''); ?>" />
             <input type="hidden" id="questionnaire_response" name="questionnaire_response" value="<?php echo attr($form['questionnaire_response'] ?? ''); ?>" />
             <!--    RM check where configured to display LOINC copyright notice -->
-            <div>
-            <?php if ($top_note) : ?>
-               <p class="text-center">
-                    <span class='font-weight-bold'>" . xlt("Important to Note") . ": </span><i>" . xlt("LOINC form definitions are subject to the LOINC"); } ?>
+
+               <div>
+
+                <?php if ($top_note) : ?>
+                 <p class="text-center"><?php echo "<span class='font-weight-bold'>" .  xlt("Important to Note") . ": </span><i>" . xlt("LOINC form definitions are subject to the LOINC");  ?>
                     <a href="http://loinc.org/terms-of-use" target="_blank">
-                        echo xlt("terms of use.") . "</i>"; } ?></a></p>
+                        <?php echo xlt("terms of use.") . "</i>";  ?></a></p>
+                <?php endif; ?>
+
                 <p id="copyrightNotice">
                     <?php echo text($form['copyright'] ?? ''); ?>
                 </p>
-                <?php endif; ?>
+              </div>
 
-            </div>
 
             <div class="mb-3">
                 <div class="input-group isNew d-none">
@@ -434,18 +438,16 @@ switch ($GLOBALS['questionnaire_display_LOINCnote']) {
             </div>
             <hr />
             <div id="formContainer"></div>
-            <!-- RM check if configured to print notice at bottom of window -->
-              <div>
-                <p class="text-center"><?php if ($bottom_note) {
-                    echo "<span class='font-weight-bold'>" . xlt("Important to Note") . ": </span><i>" . xlt("LOINC form definitions are subject to the LOINC"); } ?>
-                    <a href="http://loinc.org/terms-of-use" target="_blank"><?php if ($bottom_note) {
-                        echo xlt("terms of use.") . "</i>"; } ?> </a></p>
-                <p id="copyrightNotice">
-                    <?php echo text($form['copyright'] ?? ''); ?>
-                </p>
-            </div>
+            <!-- RM check if LOINC terms configured to display notice at bottom of window -->
+           <?php if ($bottom_note) : ?>
+               <div>
+                 <p class="text-center"><?php echo "<span class='font-weight-bold'>" .  xlt("Important to Note") . ": </span><i>" . xlt("LOINC form definitions are subject to the LOINC");  ?>
+                    <a href="http://loinc.org/terms-of-use" target="_blank">
+                        <?php echo xlt("terms of use.") . "</i>";  ?></a></p>
+              </div>
+           <?php endif; ?>
 
-            <?php if (!$isPortal && !$patientPortalOther) { ?>
+           <?php if (!$isPortal && !$patientPortalOther) { ?>
                 <div class="btn-group my-2">
                     <button type="submit" class="btn btn-primary btn-save isNew" id="save_response" title="<?php echo xla('Save current form or create a new one time questionnaire for this encounter if this is a New Questionnaire form.'); ?>"><?php echo xlt("Save Current"); ?></button>
                     <button type="submit" class="btn btn-primary d-none" id="save_registry" name="save_registry" title="<?php echo xla('Register as a new encounter form for reuse in any encounter.'); ?>" onclick="formMode = 'register'"><?php echo xlt("or Register New"); ?></button>

--- a/interface/forms/questionnaire_assessments/questionnaire_assessments.php
+++ b/interface/forms/questionnaire_assessments/questionnaire_assessments.php
@@ -3,6 +3,9 @@
 /**
  * Questionnaire Assessment Encounters Template
  *
+ * version 1.0.0 ruth moulton
+ *  move LOINC temrs of use  notice to the end of the form
+ *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @author    Jerry Padgett <sjpadgett@gmail.com>
@@ -371,13 +374,8 @@ try {
             <input type="hidden" id="copyright" name="copyright" value="<?php echo attr($form['copyright'] ?? ''); ?>" />
             <input type="hidden" id="questionnaire" name="questionnaire" value="<?php echo attr($form['questionnaire'] ?? ''); ?>" />
             <input type="hidden" id="questionnaire_response" name="questionnaire_response" value="<?php echo attr($form['questionnaire_response'] ?? ''); ?>" />
-            <div>
-                <p class="text-center"><?php echo "<span class='font-weight-bold'>" . xlt("Important to Note") . ": </span><i>" . xlt("LOINC form definitions are subject to the LOINC"); ?>
-                    <a href="http://loinc.org/terms-of-use" target="_blank"><?php echo xlt("terms of use.") . "</i>"; ?></php></a></p>
-                <p id="copyrightNotice">
-                    <?php echo text($form['copyright'] ?? ''); ?>
-                </p>
-            </div>
+            <!--    move copyright notice from here to the foot of the form -->
+
             <div class="mb-3">
                 <div class="input-group isNew d-none">
                     <label for="loinc_item" class="font-weight-bold mt-2 mr-1"><?php echo xlt("Search and Select a LOINC form") . ': '; ?></label>
@@ -409,6 +407,15 @@ try {
             </div>
             <hr />
             <div id="formContainer"></div>
+
+              <div>
+                <p class="text-center"><?php echo "<span class='font-weight-bold'>" . xlt("Important to Note") . ": </span><i>" . xlt("LOINC form definitions are subject to the LOINC"); ?>
+                    <a href="http://loinc.org/terms-of-use" target="_blank"><?php echo xlt("terms of use.") . "</i>"; ?></php></a></p>
+                <p id="copyrightNotice">
+                    <?php echo text($form['copyright'] ?? ''); ?>
+                </p>
+            </div>
+
             <?php if (!$isPortal && !$patientPortalOther) { ?>
                 <div class="btn-group my-2">
                     <button type="submit" class="btn btn-primary btn-save isNew" id="save_response" title="<?php echo xla('Save current form or create a new one time questionnaire for this encounter if this is a New Questionnaire form.'); ?>"><?php echo xlt("Save Current"); ?></button>

--- a/interface/forms/questionnaire_assessments/questionnaire_assessments.php
+++ b/interface/forms/questionnaire_assessments/questionnaire_assessments.php
@@ -110,19 +110,27 @@ try {
     die(xlt("Can not continue with reason.") . '<br />' . text($e->getMessage()));
 }
 /* where to put the LOINC statement , and the statement itself */
-$top_note = $bottom_note = false; // value of '3' says don't display
+$top_note = true; // default to top if not set in configuration
+$bottom_note = false;
 
 $loinc_text =  "<span class='font-weight-bold'>" .  xlt("Important to Note") . ": </span><i>" . xlt("LOINC form definitions are subject to the LOINC") . " <a href='http://loinc.org/terms-of-use' target='_blank'> " .  xlt("terms of use.") . "</i>" . "</a>";
 
-switch ($GLOBALS['questionnaire_display_LOINCnote']) {
-    case '0':
-        $top_note = true;
-        break;
-    case '1':
-        $bottom_note = true;
-        break;
-    case '2':
-        $top_note = $bottom_note = true;
+if ( $GLOBALS['questionnaire_display_LOINCnote'] ){
+    switch ($GLOBALS['questionnaire_display_LOINCnote']) {
+        case '0':
+            $top_note = true;
+            $bottom_note = false; // not really neede as this is the default!!
+            break;
+        case '1':
+            $bottom_note = true;
+            $top_note = false;
+            break;
+        case '2':
+            $top_note = $bottom_note = true;
+            break;
+        case '3':
+            $top_note = $bottom_note = false;
+    }
 }
 
 ?>

--- a/interface/forms/questionnaire_assessments/questionnaire_assessments.php
+++ b/interface/forms/questionnaire_assessments/questionnaire_assessments.php
@@ -5,7 +5,7 @@
  *
  *  ruth moulton
  *  configurable where to display the LOINC notice  - at the top, at the bottom, both or don't display
- *  set in configuration/appearance
+ *  qset in configuration/appearance
  *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
@@ -112,11 +112,16 @@ try {
 /* where to put the LOINC statement */
 $top_note = $bottom_note = false; // value of '3' says don't display
 
-    switch ($GLOBALS['questionnaire_display_LOINCnote']){
-       case '0': $top_note = true; break;
-       case '1': $bottom_note = true; break;
-       case '2': $top_note = $bottom_note = true;
-    }
+switch ($GLOBALS['questionnaire_display_LOINCnote']) {
+    case '0':
+            $top_note = true;
+             break;
+    case '1':
+            $bottom_note = true;
+             break;
+    case '2':
+            $top_note = $bottom_note = true;
+}
 
 ?>
 <!DOCTYPE html>
@@ -386,8 +391,10 @@ $top_note = $bottom_note = false; // value of '3' says don't display
             <input type="hidden" id="questionnaire_response" name="questionnaire_response" value="<?php echo attr($form['questionnaire_response'] ?? ''); ?>" />
             <!--    RM check where configured to display LOINC copyright notice -->
             <div>
-               <p class="text-center"><?php if($top_note){ echo "<span class='font-weight-bold'>" . xlt("Important to Note") . ": </span><i>" . xlt("LOINC form definitions are subject to the LOINC"); } ?>
-                    <a href="http://loinc.org/terms-of-use" target="_blank"><?php if($top_note){echo xlt("terms of use.") . "</i>"; } ?></a></p>
+               <p class="text-center"><?php if ($top_note) {
+                   echo "<span class='font-weight-bold'>" . xlt("Important to Note") . ": </span><i>" . xlt("LOINC form definitions are subject to the LOINC"); } ?>
+                    <a href="http://loinc.org/terms-of-use" target="_blank"><?php if ($top_note) {
+                        echo xlt("terms of use.") . "</i>"; } ?></a></p>
                 <p id="copyrightNotice">
                     <?php echo text($form['copyright'] ?? ''); ?>
                 </p>
@@ -427,8 +434,10 @@ $top_note = $bottom_note = false; // value of '3' says don't display
             <div id="formContainer"></div>
             <!-- RM check if configured to print notice at bottom of window -->
               <div>
-                <p class="text-center"><?php if($bottom_note){echo "<span class='font-weight-bold'>" . xlt("Important to Note") . ": </span><i>" . xlt("LOINC form definitions are subject to the LOINC"); }?>
-                    <a href="http://loinc.org/terms-of-use" target="_blank"><?php if($bottom_note){echo xlt("terms of use.") . "</i>"; } ?> </a></p>
+                <p class="text-center"><?php if ($bottom_note) {
+                    echo "<span class='font-weight-bold'>" . xlt("Important to Note") . ": </span><i>" . xlt("LOINC form definitions are subject to the LOINC"); } ?>
+                    <a href="http://loinc.org/terms-of-use" target="_blank"><?php if ($bottom_note) {
+                        echo xlt("terms of use.") . "</i>"; } ?> </a></p>
                 <p id="copyrightNotice">
                     <?php echo text($form['copyright'] ?? ''); ?>
                 </p>

--- a/interface/forms/questionnaire_assessments/questionnaire_assessments.php
+++ b/interface/forms/questionnaire_assessments/questionnaire_assessments.php
@@ -115,10 +115,10 @@ $top_note = $bottom_note = false; // value of '3' says don't display
 switch ($GLOBALS['questionnaire_display_LOINCnote']) {
     case '0':
             $top_note = true;
-             break;
+            break;
     case '1':
             $bottom_note = true;
-             break;
+            break;
     case '2':
             $top_note = $bottom_note = true;
 }
@@ -392,7 +392,7 @@ switch ($GLOBALS['questionnaire_display_LOINCnote']) {
             <!--    RM check where configured to display LOINC copyright notice -->
             <div>
                <p class="text-center"><?php if ($top_note) {
-                   echo "<span class='font-weight-bold'>" . xlt("Important to Note") . ": </span><i>" . xlt("LOINC form definitions are subject to the LOINC"); } ?>
+                    echo "<span class='font-weight-bold'>" . xlt("Important to Note") . ": </span><i>" . xlt("LOINC form definitions are subject to the LOINC"); } ?>
                     <a href="http://loinc.org/terms-of-use" target="_blank"><?php if ($top_note) {
                         echo xlt("terms of use.") . "</i>"; } ?></a></p>
                 <p id="copyrightNotice">

--- a/interface/forms/questionnaire_assessments/questionnaire_assessments.php
+++ b/interface/forms/questionnaire_assessments/questionnaire_assessments.php
@@ -391,13 +391,15 @@ switch ($GLOBALS['questionnaire_display_LOINCnote']) {
             <input type="hidden" id="questionnaire_response" name="questionnaire_response" value="<?php echo attr($form['questionnaire_response'] ?? ''); ?>" />
             <!--    RM check where configured to display LOINC copyright notice -->
             <div>
-               <p class="text-center"><?php if ($top_note) {
-                    echo "<span class='font-weight-bold'>" . xlt("Important to Note") . ": </span><i>" . xlt("LOINC form definitions are subject to the LOINC"); } ?>
-                    <a href="http://loinc.org/terms-of-use" target="_blank"><?php if ($top_note) {
+            <?php if ($top_note) : ?>
+               <p class="text-center">
+                    <span class='font-weight-bold'>" . xlt("Important to Note") . ": </span><i>" . xlt("LOINC form definitions are subject to the LOINC"); } ?>
+                    <a href="http://loinc.org/terms-of-use" target="_blank">
                         echo xlt("terms of use.") . "</i>"; } ?></a></p>
                 <p id="copyrightNotice">
                     <?php echo text($form['copyright'] ?? ''); ?>
                 </p>
+                <?php endif; ?>
 
             </div>
 

--- a/interface/forms/questionnaire_assessments/questionnaire_assessments.php
+++ b/interface/forms/questionnaire_assessments/questionnaire_assessments.php
@@ -4,7 +4,8 @@
  * Questionnaire Assessment Encounters Template
  *
  *  ruth moulton
- *  configurable where to display the LOINC notice  - or don't display
+ *  configurable where to display the LOINC notice  - at the top, at the bottom, both or don't display
+ *  set in configuration/appearance
  *
  * @package   OpenEMR
  * @link      https://www.open-emr.org

--- a/interface/forms/questionnaire_assessments/questionnaire_assessments.php
+++ b/interface/forms/questionnaire_assessments/questionnaire_assessments.php
@@ -115,7 +115,7 @@ $bottom_note = false;
 
 $loinc_text =  "<span class='font-weight-bold'>" .  xlt("Important to Note") . ": </span><i>" . xlt("LOINC form definitions are subject to the LOINC") . " <a href='http://loinc.org/terms-of-use' target='_blank'> " .  xlt("terms of use.") . "</i>" . "</a>";
 
-if ( $GLOBALS['questionnaire_display_LOINCnote'] ){
+if ($GLOBALS['questionnaire_display_LOINCnote']) {
     switch ($GLOBALS['questionnaire_display_LOINCnote']) {
         case '0':
             $top_note = true;

--- a/interface/forms/questionnaire_assessments/questionnaire_assessments.php
+++ b/interface/forms/questionnaire_assessments/questionnaire_assessments.php
@@ -3,8 +3,8 @@
 /**
  * Questionnaire Assessment Encounters Template
  *
- * version 1.0.0 ruth moulton
- *  move LOINC temrs of use  notice to the end of the form
+ *  ruth moulton
+ *  configurable where to display the LOINC notice  - or don't display
  *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
@@ -108,6 +108,15 @@ try {
 } catch (Exception $e) {
     die(xlt("Can not continue with reason.") . '<br />' . text($e->getMessage()));
 }
+/* where to put the LOINC statement */
+$top_note = $bottom_note = false; // value of '3' says don't display
+
+    switch ($GLOBALS['questionnaire_display_LOINCnote']){
+       case '0': $top_note = true; break;
+       case '1': $bottom_note = true; break;
+       case '2': $top_note = $bottom_note = true;
+    }
+
 ?>
 <!DOCTYPE html>
 <html>
@@ -374,7 +383,15 @@ try {
             <input type="hidden" id="copyright" name="copyright" value="<?php echo attr($form['copyright'] ?? ''); ?>" />
             <input type="hidden" id="questionnaire" name="questionnaire" value="<?php echo attr($form['questionnaire'] ?? ''); ?>" />
             <input type="hidden" id="questionnaire_response" name="questionnaire_response" value="<?php echo attr($form['questionnaire_response'] ?? ''); ?>" />
-            <!--    move copyright notice from here to the foot of the form -->
+            <!--    RM check where configured to display LOINC copyright notice -->
+            <div>
+               <p class="text-center"><?php if($top_note){ echo "<span class='font-weight-bold'>" . xlt("Important to Note") . ": </span><i>" . xlt("LOINC form definitions are subject to the LOINC"); } ?>
+                    <a href="http://loinc.org/terms-of-use" target="_blank"><?php if($top_note){echo xlt("terms of use.") . "</i>"; } ?></a></p>
+                <p id="copyrightNotice">
+                    <?php echo text($form['copyright'] ?? ''); ?>
+                </p>
+
+            </div>
 
             <div class="mb-3">
                 <div class="input-group isNew d-none">
@@ -407,10 +424,10 @@ try {
             </div>
             <hr />
             <div id="formContainer"></div>
-
+            <!-- RM check if configured to print notice at bottom of window -->
               <div>
-                <p class="text-center"><?php echo "<span class='font-weight-bold'>" . xlt("Important to Note") . ": </span><i>" . xlt("LOINC form definitions are subject to the LOINC"); ?>
-                    <a href="http://loinc.org/terms-of-use" target="_blank"><?php echo xlt("terms of use.") . "</i>"; ?></php></a></p>
+                <p class="text-center"><?php if($bottom_note){echo "<span class='font-weight-bold'>" . xlt("Important to Note") . ": </span><i>" . xlt("LOINC form definitions are subject to the LOINC"); }?>
+                    <a href="http://loinc.org/terms-of-use" target="_blank"><?php if($bottom_note){echo xlt("terms of use.") . "</i>"; } ?> </a></p>
                 <p id="copyrightNotice">
                     <?php echo text($form['copyright'] ?? ''); ?>
                 </p>

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -441,6 +441,17 @@ $GLOBALS_METADATA = array(
             ,xl('Placement of the save/cancel, and other bottons where supported (Demographics, Encounter Forms, etc).')
         ),
 
+        'questionnaire_display_LOINCnote' => array(
+            xl('Display LOINC note on questionnaires'),
+            array(
+                '0' => xl('At the top of the page only'),
+                '1' => xl('At the foot of the page only'),
+                '2' => xl('At the top of the page and at the foot of the page'),
+                '3' => xl('Do not display the note')
+            ),
+            '0' ,                          // default = display at top of form
+            xl('Configure where LOINC statement should be displayed')
+        ),
     ),
 
     'Branding' => [


### PR DESCRIPTION
 
Fixes #7550

#### Short description of what this resolves:
adds a configuration/appearance item to specify where the LOINC copywrite statement should be displayed when editing a questionnaire - at the top, at the bottom, neither, both 

#### Changes proposed in this pull request:
option 'Display LOINC note on questionnaires' - in configuration/appearance. Possible values top, bottom, both, don't display - added to globals.inc.php
Modify questionnaire_assessments.php to take account of the configured option when displaying the note