### PR TITLE
show issue type in 'add issue' form from encounter form

### DIFF
--- a/interface/patient_file/summary/add_edit_issue.php
+++ b/interface/patient_file/summary/add_edit_issue.php
@@ -812,8 +812,10 @@ function getCodeText($code)
                                             $checked = ($index == $type_index) ? " checked" : '';
                                             $disabled = (!AclMain::aclCheckIssue($key, '', ['write', 'addonly'])) ? " disabled" : '';
                                             $str = '<input type="radio" name="form_type" value="%s" onclick="newtype(%s)" %s %s>';
-                                            echo vsprintf($str, [attr($index), attr_js($index), $checked, $disabled]);
-                                            echo text($value[1] . " "); /*rm - display issue type name */
+                                            if ($key != 'medical_device') { /* rm/brady millr - medical device does not work correctly */
+                                                echo vsprintf($str, [attr($index), attr_js($index), $checked, $disabled]);
+                                                echo text($value[1] . " "); /*rm - display issue type name */
+                                            }
                                         }
 
                                         ++$index;

--- a/interface/patient_file/summary/add_edit_issue.php
+++ b/interface/patient_file/summary/add_edit_issue.php
@@ -813,6 +813,7 @@ function getCodeText($code)
                                             $disabled = (!AclMain::aclCheckIssue($key, '', ['write', 'addonly'])) ? " disabled" : '';
                                             $str = '<input type="radio" name="form_type" value="%s" onclick="newtype(%s)" %s %s>';
                                             echo vsprintf($str, [attr($index), attr_js($index), $checked, $disabled]);
+                                            echo text($value[1]. " "); /*rm - display issue type name */
                                         }
 
                                         ++$index;

--- a/interface/patient_file/summary/add_edit_issue.php
+++ b/interface/patient_file/summary/add_edit_issue.php
@@ -813,7 +813,7 @@ function getCodeText($code)
                                             $disabled = (!AclMain::aclCheckIssue($key, '', ['write', 'addonly'])) ? " disabled" : '';
                                             $str = '<input type="radio" name="form_type" value="%s" onclick="newtype(%s)" %s %s>';
                                             echo vsprintf($str, [attr($index), attr_js($index), $checked, $disabled]);
-                                            echo text($value[1]. " "); /*rm - display issue type name */
+                                            echo text($value[1] . " "); /*rm - display issue type name */
                                         }
 
                                         ++$index;


### PR DESCRIPTION
 
Fixes #7563

#### Short description of what this resolves:
 Type name not displayed next to radio button when choosing which issue type to add from an encounter form

#### Changes proposed in this pull request:
adds Type name to radio button when choosing which issue type to add from an encounter form
