### PR TITLE
Fix #7579: Disappearing services in LBF

### DIFF
--- a/interface/forms/LBF/new.php
+++ b/interface/forms/LBF/new.php
@@ -1643,7 +1643,10 @@ if (
                     echo "  <td class='border-top-0 font-weight-bold' colspan='2'>" . xlt('Diagnosis') . "&nbsp;</td>\n";
                     echo "  <td class='border-top-0 font-weight-bold text-right'>" . xlt('Delete') . "</td>\n";
                     echo " </tr>\n";
-                    foreach ($fs->serviceitems as $lino => $li) {
+                    // Start from 1000 to avoid collisions caused by sharing form_fs_bill[]  with services.
+                    // Keep track of only diagnoses to avoid gaps and thus potential collisions with newly added diagnoses.
+                    $lino = 1000;
+                    foreach ($fs->serviceitems as $li) {
                         // Skip anything that is not a diagnosis; those are in the Services section above.
                         if (!$code_types[$li['codetype']]['diag']) {
                             continue;
@@ -1660,6 +1663,7 @@ if (
                         }
                         echo "  </td>\n";
                         echo " </tr>\n";
+                        $lino += 1;
                     }
                     echo "</table>\n";
                     echo "</center>\n";


### PR DESCRIPTION
Fixes #7579

#### Short description of what this resolves:

Prevent collisions for newly added services and existing diagnoses, which caused the newly added services to disappear when saving.

#### Changes proposed in this pull request:

Start the line number of existing diagnoses at 1,000, bringing them in line with the code for new diagnoses.
Also separate the line counter from the loop, so that existing services don't increment it and cause gaps in the numbering of existing diagnoses, which could potentially cause collisions with newly added diagnoses.