### PR TITLE
search on demographics configured to 'fixed' uses finder if search box is empty

### DIFF
--- a/interface/main/tabs/js/user_data_view_model.js
+++ b/interface/main/tabs/js/user_data_view_model.js
@@ -55,13 +55,14 @@ function viewPtFinder(myMessage, searchAnyType, data, event)
         });
         srchBox.blur();
     } else if (srchBoxLength == 0 && srchBoxWidth > 50) {
-        if (searchAnyType == 'dual') {
+        // 'fixed is similar to dual'
+        if (searchAnyType == 'dual' || searchAnyType == 'fixed' ) {
             srchBox.blur();
             navigateTab(finderUrl,"fin", function () {
                 activateTabByName("fin",true);
             });
         } else if (searchAnyType == 'comprehensive') {
-            alert(arguments[0]);
+            alert(arguments[0] );
             srchBox.focus();
         }
     }


### PR DESCRIPTION
<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #7596

#### Short description of what this resolves:
if 'search on any demographics' is configured as 'fixed' nothing happens if the search box is empty, 

#### Changes proposed in this pull request:
in this PR if configured as fixed, and search box is empty, it behaves like 'dual' and goes to the patient finder, listing all the patients