### PR TITLE
Feat openemr fix #7609 dashboard cards size consistency

### DIFF
--- a/templates/portal/header.html.twig
+++ b/templates/portal/header.html.twig
@@ -2,12 +2,15 @@
     <a class="navbar-brand" href="home.php">
         <img class="d-inline-block align-top" height="{{ primaryMenuLogoHeight|attr }}" src="{{ menuLogo | attr }}"/>
     </a>
+    {% if navMenu|length > 0 %}
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#nav" aria-controls="nav" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
     </button>
+    {% endif %}
     <a class="btn btn-outline-primary" id="quickstart_dashboard" href="#quickstart-card" data-toggle="collapse" data-parent="#cardgroup" aria-expanded="true">
         <i class="ml-1 fas fa-tasks mr-1"></i>{{ 'Dashboard' | xlt }}
     </a>
+    {% if navMenu|length > 0 %}
     <div class="collapse navbar-collapse justify-content-end" id="nav">
         <ul class="navbar-nav mt-2 mt-lg-0">
             {% for item in navMenu %}
@@ -45,4 +48,5 @@
             {% endfor %}
         </ul>
     </div>
+    {% endif %}
 </nav>

--- a/templates/portal/home.html.twig
+++ b/templates/portal/home.html.twig
@@ -563,7 +563,7 @@
                                 {% if portal_two_payments %}
                                     {% include "portal/partial/_nav_icon.html.twig"
                                         with {
-                                        url: "#paymentcard"|attr_url
+                                        url: "paymentcard"|attr_url
                                         , icon: "wallet"
                                         , navText: "Make Payment"|xl
                                         , id: "payments-go"
@@ -640,6 +640,14 @@
                                     , id: "help-go"
                                 } %}
                                 {{ fireEvent(eventNames.dashboardInjectCard) }}
+                                {% include "portal/partial/_nav_icon.html.twig"
+                                    with {
+                                    url:  webroot ~ "./logout.php"
+                                    ,localLink: false
+                                    , icon: "right-from-bracket"
+                                    , navText: "Logout"|xl
+                                    , id: "logout-go"
+                                } %}
                             </div>
                         </div>
                     </div>

--- a/templates/portal/home.html.twig
+++ b/templates/portal/home.html.twig
@@ -732,7 +732,7 @@
                 ,{
                     title: "Make Payment"|xl
                     ,icon: "wallet"
-                    ,description: ""|xl
+                    ,description: "Submit payments for amounts you owe for your medical care."|xl
                     ,enabled: portal_two_payments
                 }
                 ,{
@@ -744,13 +744,13 @@
                 ,{
                     title: "Health Snapshot"|xl
                     ,icon: "clipboard"
-                    ,description: "See your immunization, medications, active prescriptions, allergy list, current problems list, and lab results"|xl
+                    ,description: "See your immunization, medications, active prescriptions, allergy list, current problems list, and lab results."|xl
                     ,enabled: true
                 }
                 ,{
                     title: "Profile"|xl
                     ,icon: "user"
-                    ,description: "Review and edit your medical profile information.  This includes your basic demographics (name, address, emergency contact). You can also review your insurance information if you use a third party insurer to help pay for treatment of care."|xl
+                    ,description: "Review and edit your medical profile information. This includes your basic demographics (name, address, emergency contact). You can also review your insurance information if you use a third party insurer to help pay for treatment of care."|xl
                     ,enabled: true
                 }
                 ,{
@@ -791,13 +791,13 @@
                 {
                     title: "View Summary of Care"|xl
                     ,icon: "notes-medical"
-                    ,description: "View your Summary of Care document that includes a printable version of your healthcare information.  This document can be used to transfer your care to another healthcare facility. In technical terms it is called a C-CDA."|xl
+                    ,description: "View your Summary of Care document that includes a printable version of your healthcare information. This document can be used to transfer your care to another healthcare facility. In technical terms it is called a C-CDA."|xl
                     ,enabled: ccdaOk
                 }
                 ,{
                     title: "Download Summary of Care"|xl
                     ,icon: "notes-medical"
-                    ,description: "Download a copy of your Summary of Care document.  This document can be used to transfer your care to another healthcare facility. In technical terms it is called a C-CDA."|xl
+                    ,description: "Download a copy of your Summary of Care document. This document can be used to transfer your care to another healthcare facility. In technical terms it is called a C-CDA."|xl
                     ,enabled: ccdaOk
                 }
                 ,{

--- a/templates/portal/home.html.twig
+++ b/templates/portal/home.html.twig
@@ -864,7 +864,7 @@
                 <a href="#reports-list-card"
                      data-toggle="collapse" data-parent="#cardgroup" aria-expanded="false"
                      class="reports-list-back-btn btn btn-light text-dark d-none"><i class="fa fa-arrow-left"></i> {{ "Back"|xlt }}</a>
-                {{ 'Custom Itemised Report' | xlt }}</header>
+                {{ 'Customized Medical History Report' | xlt }}</header>
             <div id="reports" class="card-body">{% include "portal/partial/_alert_loading.html.twig" %}</div>
         </div>
 

--- a/templates/portal/home.html.twig
+++ b/templates/portal/home.html.twig
@@ -137,8 +137,13 @@
                 persist($(e.target).attr('href'), false);
             });
 
-            $('#quickstart-card [data-parent="#cardgroup"]').on('click', (e) => {
-                persist($(e.target).attr('href'), false);
+            $('#quickstart-card [data-parent="#cardgroup"]' +
+                ', #reports-list-card [data-parent="#cardgroup"]'
+                + ',.reports-list-back-btn').on('click', (e) => {
+                // we use currentTarget so we grab the event with the original data-parent, if there are buttons or
+                // other stuff inside we want to go to the href.
+                persist($(e.currentTarget).attr('href'), false);
+                return true;
             });
 
             $('#quickstart_dashboard').on('click', (e) => {
@@ -249,6 +254,8 @@
             // Persist last card used for returns for actions.
             let gowhere = {{ whereto | js_escape }};
             $(gowhere).collapse('show');
+            // update home button in case our last location is the quickstart
+            updateDashboardHomeButton();
 
             // TODO: prevent current card collapse. for top menu only remove later
             $('#cardgroup').on('hide.bs.collapse', '.show', function (e) {
@@ -257,6 +264,7 @@
                     whereto = '';
                     return false;
                 }
+                updateDashboardHomeButton();
             });
 
             $('#popwait').addClass('d-none');
@@ -268,6 +276,25 @@
             // start watch for inactivity
             activityMonitor();
         });
+
+        function updateDashboardHomeButton() {
+            // the navigation between places isn't very extensible / maintainable.
+            // for now we'll just go with it, but may need to refactor the entire routing system
+            // in order to make this all more extensible
+            let isDashboard = whereto == '#quickstart-card'; // $("#quickstart-card").hasClass('show');
+            let isReportsList = whereto == '#reportcard' || whereto == '#downloadcard' || whereto == '#help-card-reports-list';
+            // we only want to show dashboard home button when not on dashboard.
+            if (isDashboard) {
+                $("#quickstart_dashboard").addClass('active');
+            } else {
+                $("#quickstart_dashboard").removeClass('active');
+            }
+            if (isReportsList) {
+                $(".reports-list-back-btn").removeClass('d-none');
+            } else {
+                $(".reports-list-back-btn").addClass('d-none');
+            }
+        }
 
         function editAppointment(mode, deid) {
             let mdata = {};
@@ -437,7 +464,8 @@
 {% endblock %}
 
 {% block header %}
-    {% include "portal/header.html.twig" %}
+    {# We disable the header for now #}
+    {% include "portal/header.html.twig" with {navMenu: []} %}
 {% endblock %}
 
 {% block content %}
@@ -445,8 +473,9 @@
     <section class="flex-column accordion" id="cardgroup">
         <div id="popwait" class="alert alert-warning d-none"><strong>{{ 'Working!' | xlt }}</strong>{{ 'Please wait...' | xlt }}</div>
 
+        <!-- Dashboard Quickstart Card Main Screen originally shown -->
         <div class="card collapse overflow-auto" data-parent="#cardgroup" id="quickstart-card">
-            <div id="quickstart-div" class="card-body">
+            <div id="quickstart-div" class="card-body p-0 p-sm-2">
                 <script>
                     $(function () {
                         let ele = parent.document.getElementById('topNav');
@@ -502,135 +531,114 @@
                             </div>
                         </div>
                     </div>
-                    <div class="container-fluid p-3">
+                    <div class="container-fluid p-0 p-sm-3">
                         <div class="jumbotron jumbotron-fluid text-center mb-1 p-1">
-                            <h2>{{ 'Quick Start Dashboard' | xlt }}<i class="fa fa-user -danger ml-2" style="font-size: 3rem;"></i></h2>
+                            <h2>{{ 'Dashboard' | xlt }}</h2>
                             {# <p>
                                 <button class="btn btn-sm btn-secondary" data-toggle="modal" data-target="#formdialog">{{ 'Tell me more' | xlt }}</button>
                             </p> #}
                         </div>
                         <div class='jumbotron jumbotron-fluid p-4'>
+
                             <div class="row" id="inject_card">
-                                <!-- Signature -->
-                                <div class="card d-flex mr-1 mb-1">
-                                    <div class="card-body row">
-                                        <h4 class="card-title d-flex align-items-center btn-link"><a role="button" href="#openSignModal" data-toggle="modal" data-parent="#cardgroup"><i class="fas fa-file-signature mr-1"></i>{{ 'Default Signature' | xlt }}</a></h4>
-                                    </div>
-                                </div>
-                                <!-- Password -->
-                                <div class="card d-flex mr-1 mb-1">
-                                    <div class="card-body row">
-                                        <h4 class="card-title d-flex align-items-center btn-link" role="button" onclick="changeCredentials(event)"><i class="fa fa-cog fa-fw mr-1"></i>{{ 'Manage Login Credentials' | xlt }}</h4>
-                                    </div>
-                                </div>
-                                <!-- Theme -->
-                                <div class="card d-flex mr-1 mb-1">
-                                    <div class="card-body row">
-                                        <h4 class="card-title d-flex align-items-center btn-link" data-toggle="collapse" data-target="#settings-content" role="button">
-                                            <i class="fa fa-link mx-1"></i>{{ 'Select Theme' | xlt }}
-                                        </h4>
-                                        <div id="settings-content" class="collapse col-12">
-                                            <div class="form-group">
-                                                <div class="col">
-                                                    <label class="" for='my_theme'>{{ 'Current Theme' | xlt }}</label>
-                                                    <div class="input-group">
-                                                        <select class='form-control' id='my_theme'>
-                                                            {% for styleKey, styleValue in styleArray %}
-                                                                {{ "<option value='" ~ styleKey | attr ~ "'" }}
-                                                                {% if styleKey == current_theme %}
-                                                                    {{ " selected" }}
-                                                                {% endif %}
-                                                                {{ ">" }}{{ styleValue | text }}{{ "</option>\n" }}
-                                                            {% endfor %}
-                                                        </select>
-                                                        <div class="input-group-append">
-                                                            <a class="btn btn-primary" href="./home.php" target="_parent">{{ 'Apply' | xlt }}</a>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <!-- Document -->
-                                <div class="card d-flex mr-1 mb-1">
-                                    <div class="card-body">
-                                        <h4 class="card-title"><i class="fa fa-file mr-1"></i>{{ 'Clinical Forms or Documents' | xlt }}</h4>
-                                        <a id="documents-go" class="btn btn-success mb-1" href="{{ web_root }}/portal/patient/onsitedocuments?pid={{ pid | attr_url }} ">{{ 'Manage Forms and Documents' | xlt }}</a>
-                                    </div>
-                                </div>
-                                <!-- Messages -->
-                                <div class="card d-flex mr-1 mb-1">
-                                    <div class="card-body">
-                                        <h4 class="card-title"><i class="fa fa-envelope mr-1"></i>{{ 'Secure Messaging' | xlt }}
-                                            {% if newcnt > 0 %}<small><span class="badge-pill badge-danger ml-1">{{ newcnt ~ "(New)" | text }}</span></small>{% endif %}
-                                        </h4>
-                                        <a id="lists-go" class="btn btn-success mb-1" href="#secure-msgs-card" data-toggle="collapse" data-parent="#cardgroup" aria-expanded="false">{{ 'Securely Message with Providers' | xlt }}</a>
-                                    </div>
-                                </div>
-                                <!-- Demo -->
-                                <div class="card d-flex mr-1 mb-1">
-                                    <div class="card-body">
-                                        <h4 class="card-title"><i class="fas fa-user mr-1"></i>{{ 'Profile' | xlt }}</h4>
-                                        <a id="lists-go" class="btn btn-success mb-1" href="#profilecard" data-toggle="collapse" data-parent="#cardgroup" aria-expanded="false">{{ 'View or Edit Current.' | xlt }}</a>
-                                    </div>
-                                </div>
-                                <!-- Health -->
-                                <div class="card d-flex mr-1 mb-1">
-                                    <div class="card-body">
-                                        <h4 class="card-title"><i class="fa fa-list mr-1"></i>{{ 'Health Snapshot' | xlt }}</h4>
-                                        <a id="lists-go" class="btn btn-success mb-1" href="#lists" data-toggle="collapse" data-parent="#cardgroup" aria-expanded="false">{{ 'View Medical Lists' | xlt }}</a>
-                                    </div>
-                                </div>
-                                <!-- Report -->
-                                {% if portal_two_ledger or portal_two_payments %}
-                                    <div class="card d-flex mr-1 mb-1">
-                                        <div class="card-body">
-                                            <h4 class="card-title"><i class="fa fa-credit-card mr-1"></i>{{ 'Financial' | xlt }}</h4>
-                                            {% if portal_two_ledger %}
-                                                <a id="lists-go" class="btn btn-success mb-1" href="#ledgercard" data-toggle="collapse" data-parent="#cardgroup" aria-expanded="false">{{ 'Billing Summary' | xlt }}</a>
-                                            {% endif %}
-                                            {% if portal_two_payments %}
-                                                <a id="lists-go" class="btn btn-success mb-1" href="#paymentcard" data-toggle="collapse" data-parent="#cardgroup" aria-expanded="false">{{ 'Make Payment' | xlt }}</a>
-                                            {% endif %}
-                                        </div>
-                                    </div>
-                                {% endif %}
+                                <!-- Forms and Documents -->
+                                {% include "portal/partial/_nav_icon.html.twig"
+                                    with {
+                                    url: web_root~"/portal/patient/onsitedocuments?pid="~patientID|attr_url
+                                    , icon: "file"
+                                    , navText: "Clinical Documents"|xl
+                                    , localLink: false
+                                    , id: "documents-go"
+                                } %}
                                 <!-- Appointments -->
                                 {% if allow_portal_appointments %}
-                                    <div class="card d-flex mr-1 mb-1">
-                                        <div class="card-body">
-                                            <h4 class="card-title"><i class="fa fa-calendar-check mr-1"></i>{{ 'Appointments' | xlt }}</h4>
-                                            <a id="appointments-go" class="btn btn-success mb-1" href="#appointmentcard" data-toggle="collapse" data-parent="#cardgroup" aria-expanded="false">{{ 'View or Schedule Appointments' | xlt }}</a>
-                                        </div>
-                                    </div>
+                                    {% include "portal/partial/_nav_icon.html.twig"
+                                        with {
+                                        url: "appointmentcard"|attr_url
+                                        , icon: "calendar-check"
+                                        , navText: "Appointments"|xl
+                                        , id: "appointments-go"
+                                    } %}
+                                {% endif %}
+                                {% if portal_two_payments %}
+                                    {% include "portal/partial/_nav_icon.html.twig"
+                                        with {
+                                        url: "#paymentcard"|attr_url
+                                        , icon: "wallet"
+                                        , navText: "Make Payment"|xl
+                                        , id: "payments-go"
+                                    } %}
+                                {% endif %}
+                                <!-- Messages -->
+                                {% include "portal/partial/_nav_icon_secure_messaging.html.twig"
+                                    with {
+                                    url: "secure-msgs-card"|attr_url
+                                    , icon: "envelope"
+                                    , navText: "Secure Messaging"|xl
+                                    , newcnt: newcnt
+                                    , id: "messages-go"
+                                } %}
+                                <!-- Health -->
+                                {% include "portal/partial/_nav_icon.html.twig"
+                                    with {
+                                    url: "lists"|attr_url
+                                    , icon: "list"
+                                    , navText: "Health Snapshot"|xl
+                                    , id: "lists-go"
+                                } %}
+                                <!-- Demo -->
+                                {% include "portal/partial/_nav_icon.html.twig"
+                                    with {
+                                    url: "profilecard"|attr_url
+                                    , icon: "user"
+                                    , navText: "Profile"|xl
+                                    , id: "profile-go"
+                                } %}
+                                <!-- Ledger / Billing Summary -->
+                                {% if portal_two_ledger %}
+                                    {% include "portal/partial/_nav_icon.html.twig"
+                                        with {
+                                        url: "ledgercard"|attr_url
+                                        , icon: "credit-card"
+                                        , navText: "Billing Summary"|xl
+                                        , id: "ledger-go"
+                                    } %}
                                 {% endif %}
                                 <!-- Reports -->
-                                <div class="card d-flex mr-1 mb-1">
-                                    <div class="card-body">
-                                        <h4 class="card-title"><i class="fa fa-eye mr-1"></i>{{ 'Reports' | xlt }}</h4>
-                                        {% if ccdaOk %}
-                                            <a id="view-summary-go" class="btn btn-success mb-1" target="_blank" href="{{ web_root }}/ccdaservice/ccda_gateway.php?action=view&csrf_token_form={{ csrfUtils | attr_url }}">{{ 'View Summary of Care' | xlt }}</a>
-                                            <a id="download-summary-go" class="btn btn-success mb-1" href="{{ web_root }}/ccdaservice/ccda_gateway.php?action=dl&csrf_token_form={{ csrfUtils | attr_url }}">{{ 'Download Summary of Care' | xlt }}</a>
-                                        {% endif %}
-                                        {% if 'allow_custom_report' %}
-                                            <a id="create-report-go" class="btn btn-success mb-1" href="#reportcard" data-toggle="collapse" data-parent="#cardgroup" aria-expanded="false">{{ 'Custom Content Itemized Report' | xlt }}</a>
-                                        {% endif %}
-                                        {% if portal_onsite_document_download %}
-                                            <a id="download-documents-go" class="btn btn-success mb-1" href="#downloadcard" data-toggle="collapse" data-parent="#cardgroup" aria-expanded="false">{{ 'Download Medical Record Documents' | xlt }}</a>
-                                        {% endif %}
-                                    </div>
-                                </div>
-
-                                {% if isEasyPro %}
-                                    <div class="card d-flex mr-1 mb-1">
-                                        <div class="card-body">
-                                            <h4 class="card-title"><i class="fa fa-calendar-check mr-1"></i>{{ 'PRO Assessment' | xlt }}</h4>
-                                            <a id="appointments-go" class="btn btn-success mb-1" href="#procard" data-toggle="collapse" data-parent="#cardgroup" aria-expanded="false">{{ 'Patient Reported Outcomes' | xlt }}</a>
-                                        </div>
-                                    </div>
+                                {% if ccdaOk or 'allow_custom_report' or portal_onsite_document_download %}
+                                    {% include "portal/partial/_nav_icon.html.twig"
+                                        with {
+                                        url: "reports-list-card"|attr_url
+                                        , icon: "file-download"
+                                        , navText: "Medical Reports"|xl
+                                        , id: "reports-go"
+                                    } %}
                                 {% endif %}
-
+                                {% if isEasyPro %}
+                                    {% include "portal/partial/_nav_icon.html.twig"
+                                        with {
+                                        url: "procard"|attr_url
+                                        , icon: "flask-vial"
+                                        , navText: "PRO Assessment"|xl
+                                        , id: "easypro-go"
+                                    } %}
+                                {% endif %}
+                                <!-- Settings -->
+                                {% include "portal/partial/_nav_icon.html.twig"
+                                    with {
+                                    url: "settings-card"|attr_url
+                                    , icon: "gear"
+                                    , navText: "Settings"|xl
+                                    , id: "settings-go"
+                                } %}
+                                <!-- Help -->
+                                {% include "portal/partial/_nav_icon.html.twig"
+                                    with {
+                                    url: "help-card"|attr_url
+                                    , icon: "question-circle"
+                                    , navText: "Help"|xl
+                                    , id: "help-go"
+                                } %}
                                 {{ fireEvent(eventNames.dashboardInjectCard) }}
                             </div>
                         </div>
@@ -639,6 +647,8 @@
             </div>
         </div>
         {# End of quickstart-cards #}
+
+        <!-- Health Snapshot Card -->
         <div class="collapse overflow-auto" data-parent="#cardgroup" id="lists">
             <div class="card d-flex mr-1 mb-1">
                 <header class="card-header p-1 bg-dark text-light h3">{{ 'Health Snapshot (Medical Lists)' | xlt }}</header>
@@ -660,11 +670,15 @@
                     </div>
                     <div class="card">
                         <header class="card-header p-1 bg-dark text-light h5">{{ 'Current Medications' | xlt }}</header>
-                        <div id="medicationlist" class="card-body p-2 bg-light"></div>
+                        <div id="medicationlist" class="card-body p-2 bg-light">
+                            {% include "portal/partial/_alert_loading.html.twig" %}
+                        </div>
                     </div>
                     <div class="card">
                         <header class="card-header p-1 bg-dark text-light h5">{{ 'Active Prescriptions' | xlt }}</header>
-                        <div id="prescriptionlist" class="card-body p-2 bg-light"></div>
+                        <div id="prescriptionlist" class="card-body p-2 bg-light">
+                            {% include "portal/partial/_alert_loading.html.twig" %}
+                        </div>
                     </div>
                     <div class="card">
                         <header class="card-header p-1 bg-dark text-light h5">{{ 'Medication Allergy List' | xlt }}</header>
@@ -672,7 +686,9 @@
                     </div>
                     <div class="card">
                         <header class="card-header p-1 bg-dark text-light h5">{{ 'Current Problems List' | xlt }}</header>
-                        <div id="problemslist" class="card-body p-2 bg-light"></div>
+                        <div id="problemslist" class="card-body p-2 bg-light">
+                            {% include "portal/partial/_alert_loading.html.twig" %}
+                        </div>
                     </div>
                     {# <div class="card">
                 <header class="card-header p-1 bg-dark text-light">{{ 'Amendment List' | xlt }}</header>
@@ -680,21 +696,234 @@
             </div> #}
                     <div class="card">
                         <header class="card-header p-1 bg-dark text-light h5">{{ 'Lab Results' | xlt }}</header>
-                        <div id="labresults" class="card-body p-2 bg-light"></div>
+                        <div id="labresults" class="card-body p-2 bg-light">
+                            {% include "portal/partial/_alert_loading.html.twig" %}
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
 
+        <!-- Help Card -->
+        {% include "portal/partial/_help_card.html.twig" with {
+            id: "help-card"
+            ,title: "Dashboard Help"|xl
+            ,items: [
+                {
+                    title: "Clinical Documents"|xl
+                    ,icon: "file"
+                    ,description: "Clinical forms and documents that have been sent by your clinical staff to be filled out."|xl
+                    ,enabled: true
+                }
+                ,{
+                    title: "Appointments"|xl
+                    ,icon: "calendar-check"
+                    ,description: "View upcoming appointments and if allowed by your clinical staff make new appointments."|xl
+                    ,enabled: allow_portal_appointments
+                }
+                ,{
+                    title: "Make Payment"|xl
+                    ,icon: "wallet"
+                    ,description: ""|xl
+                    ,enabled: portal_two_payments
+                }
+                ,{
+                    title: "Secure Messaging"|xl
+                    ,icon: "envelope"
+                    ,description: "You can send and receive secure communications with your care team staff through this system."|xl
+                    ,enabled: true
+                }
+                ,{
+                    title: "Health Snapshot"|xl
+                    ,icon: "clipboard"
+                    ,description: "See your immunization, medications, active prescriptions, allergy list, current problems list, and lab results"|xl
+                    ,enabled: true
+                }
+                ,{
+                    title: "Profile"|xl
+                    ,icon: "user"
+                    ,description: "Review and edit your medical profile information.  This includes your basic demographics (name, address, emergency contact). You can also review your insurance information if you use a third party insurer to help pay for treatment of care."|xl
+                    ,enabled: true
+                }
+                ,{
+                    title: "Billing Summary"|xl
+                    ,icon: "credit-card"
+                    ,description: ""|xl
+                    ,enabled: portal_two_ledger
+                }
+                ,{
+                    title: "Medical Reports"|xl
+                    ,icon: "gear"
+                    ,description: "Setup your digital signature for signing your clinical documents, update your login credentials, or change application settings in the portal."|xl
+                    ,enabled: ccdaOk or 'allow_custom_report' or portal_onsite_document_download
+                }
+                ,{
+                    title: "PRO Assessment"|xl
+                    ,icon: "flask-vial"
+                    ,description: "Questionnaires/Assessments using the Patient-Reported Outcomes Measurement Information System (PROMIS)."|xl
+                    ,enabled: isEasyPro
+                }
+                ,{
+                    title: "Settings"|xl
+                    ,icon: "gear"
+                    ,description: "Setup your digital signature for signing your clinical documents, update your login credentials, or change application settings in the portal."|xl
+                    ,enabled: true
+                }
+            ]
+        } %}
+
+        <!-- Help Card Reports List -->
+        {% include "portal/partial/_help_card.html.twig" with {
+            id: "help-card-reports-list"
+            ,backButton: true
+            ,backButtonCard: "reports-list-card"
+            ,backButtonClass: "reports-list-back-btn"
+            ,title: "Medical Reports Help"|xl
+            ,items: [
+                {
+                    title: "View Summary of Care"|xl
+                    ,icon: "notes-medical"
+                    ,description: "View your Summary of Care document that includes a printable version of your healthcare information.  This document can be used to transfer your care to another healthcare facility. In technical terms it is called a C-CDA."|xl
+                    ,enabled: ccdaOk
+                }
+                ,{
+                    title: "Download Summary of Care"|xl
+                    ,icon: "notes-medical"
+                    ,description: "Download a copy of your Summary of Care document.  This document can be used to transfer your care to another healthcare facility. In technical terms it is called a C-CDA."|xl
+                    ,enabled: ccdaOk
+                }
+                ,{
+                    title: "Customized Medical History Report"|xl
+                    ,icon: "clipboard"
+                    ,description: "View, Print, or Download individual items of your medical history based upon your custom selections"|xl
+                    ,enabled: true
+                }
+                ,{
+                    title: "Download Medical Record Documents"|xl
+                    ,icon: "notes-medical"
+                    ,description: "Select stored documents in your medical file that have been uploaded by your clinical staff or yourself to be downloaded."|xl
+                    ,enabled: portal_onsite_document_download
+                }
+
+            ]
+        } %}
+
+        <!-- Reports List Card -->
+        <div class="card collapse overflow-auto" data-parent="#cardgroup" id="reports-list-card">
+            <header class="card-header p-1 bg-dark text-light h3">{{ 'Medical Reports' | xlt }}</header>
+            <div class="row no-gutters">
+                {% if ccdaOk %}
+                    {% include "portal/partial/_nav_icon.html.twig"
+                        with {
+                        url: web_root ~ "/ccdaservice/ccda_gateway.php?action=view&csrf_token_form=" ~ csrfUtils|attr_url
+                        , icon: "notes-medical"
+                        , navText: "View Summary of Care"|xl
+                        , id: "view-summary-go"
+                        , localLink: false
+                    } %}
+                    {% include "portal/partial/_nav_icon.html.twig"
+                        with {
+                        url: web_root ~ "/ccdaservice/ccda_gateway.php?action=dl&csrf_token_form=" ~ csrfUtils|attr_url
+                        , icon: "download"
+                        , navText: "Download Summary of Care"|xl
+                        , id: "download-summary-go"
+                        , localLink: false
+                    } %}
+                {% endif %}
+                {% if 'allow_custom_report' %}
+                    {% include "portal/partial/_nav_icon.html.twig"
+                        with {
+                        url: "reportcard"|attr_url
+                        , icon: "clipboard"
+                        , navText: "Customized Medical History Report"|xl
+                        , id: "create-report-go"
+                    } %}
+                {% endif %}
+                {% if portal_onsite_document_download %}
+                    {% include "portal/partial/_nav_icon.html.twig"
+                        with {
+                        url: "downloadcard"|attr_url
+                        , icon: "file-zipper"
+                        , navText: "Download Medical Record Documents"|xl
+                        , id: "download-documents-go"
+                    } %}
+                {% endif %}
+                {% include "portal/partial/_nav_icon.html.twig"
+                    with {
+                    url: "help-card-reports-list"|attr_url
+                    , icon: "question-circle"
+                    , navText: "Help"|xl
+                    , id: "help-reports-list-go"
+                } %}
+            </div>
+        </div>
+
+        <!-- Custom Itemised Report Card -->
         <div class="card collapse overflow-auto" data-parent="#cardgroup" id="reportcard">
-            <header class="card-header p-1 bg-dark text-light h3">{{ 'Custom Itemised Report' | xlt }}</header>
-            <div id="reports" class="card-body"></div>
+            <header class="card-header p-1 bg-dark text-light h3">
+                <a href="#reports-list-card"
+                     data-toggle="collapse" data-parent="#cardgroup" aria-expanded="false"
+                     class="reports-list-back-btn btn btn-light text-dark d-none"><i class="fa fa-arrow-left"></i> {{ "Back"|xlt }}</a>
+                {{ 'Custom Itemised Report' | xlt }}</header>
+            <div id="reports" class="card-body">{% include "portal/partial/_alert_loading.html.twig" %}</div>
         </div>
 
+        <!-- Settings Card -->
+        <div class="card collapse" data-parent="#cardgroup" id="settings-card">
+            <header class="card-header p-1 bg-dark text-light h3">{{ 'Settings' | xlt }}</header>
+            <div>
+                <!-- Signature -->
+                <div class="card d-flex mr-1 mb-1">
+                    <div class="card-body row">
+                        <h4 class="card-title d-flex align-items-center btn-link"><a role="button" href="#openSignModal" data-toggle="modal" data-parent="#cardgroup"><i class="fas fa-file-signature mr-1"></i>{{ 'Default Signature' | xlt }}</a></h4>
+                    </div>
+                </div>
+                <!-- Password -->
+                <div class="card d-flex mr-1 mb-1">
+                    <div class="card-body row">
+                        <h4 class="card-title d-flex align-items-center btn-link" role="button" onclick="changeCredentials(event)"><i class="fa fa-cog fa-fw mr-1"></i>{{ 'Manage Login Credentials' | xlt }}</h4>
+                    </div>
+                </div>
+                <!-- Theme -->
+                <div class="card d-flex mr-1 mb-1">
+                    <div class="card-body row">
+                        <h4 class="card-title d-flex align-items-center btn-link" data-toggle="collapse" data-target="#settings-content" role="button">
+                            <i class="fa fa-link mx-1"></i>{{ 'Select Theme' | xlt }}
+                        </h4>
+                        <div id="settings-content" class="collapse col-12">
+                            <div class="form-group">
+                                <div class="col">
+                                    <label class="" for='my_theme'>{{ 'Current Theme' | xlt }}</label>
+                                    <div class="input-group">
+                                        <select class='form-control' id='my_theme'>
+                                            {% for styleKey, styleValue in styleArray %}
+                                                {{ "<option value='" ~ styleKey | attr ~ "'" }}
+                                                {% if styleKey == current_theme %}
+                                                    {{ " selected" }}
+                                                {% endif %}
+                                                {{ ">" }}{{ styleValue | text }}{{ "</option>\n" }}
+                                            {% endfor %}
+                                        </select>
+                                        <div class="input-group-append">
+                                            <a class="btn btn-primary" href="./home.php" target="_parent">{{ 'Apply' | xlt }}</a>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Profile Card -->
         <div class="card collapse" data-parent="#cardgroup" id="profilecard">
-            <div id="profilereport" class="card-body p-2 bg-light"></div>
+            <div id="profilereport" class="card-body p-2 bg-light">
+                {% include "portal/partial/_alert_loading.html.twig" %}
+            </div>
         </div>
 
+        <!-- Secure Messages Card -->
         <div class="collapse" data-parent="#cardgroup" id="secure-msgs-card">
             <div class="card">
                 <div id="secure-msgs" class="card-body">
@@ -703,6 +932,7 @@
             </div>
         </div>
 
+        <!-- Appointments Card -->
         {% if allow_portal_appointments %}
             <div class="collapse mt-2 overflow-auto" data-parent="#cardgroup" id="appointmentcard">
                 <div class="container-fluid">
@@ -729,18 +959,25 @@
             </div>
         {% endif %}
 
+        <!-- Payments Card -->
         {% if portal_two_payments %}
             <div class="collapse overflow-auto" data-parent="#cardgroup" id="paymentcard">
                 <div class="card">
                     <header class="card-header p-1 bg-dark text-light h3">{{ 'Payments' | xlt }}</header>
-                    <div id="payment" class="card-body p-2 bg-light"></div>
+                    <div id="payment" class="card-body p-2 bg-light">{% include "portal/partial/_alert_loading.html.twig" %}</div>
                 </div>
             </div>
         {% endif %}
 
+        <!-- Download Documents Card -->
         {% if portal_onsite_document_download %}
             <div class="card collapse overflow-auto" data-parent="#cardgroup" id="downloadcard">
-                <header class="card-header p-1 bg-dark text-light h3">{{ 'Download Documents From Medical Record' | xlt }}</header>
+                <header class="card-header p-1 bg-dark text-light h3">
+                    <a href="#reports-list-card"
+                       data-toggle="collapse" data-parent="#cardgroup" aria-expanded="false"
+                       class="reports-list-back-btn btn btn-light text-dark d-none"><i class="fa fa-arrow-left"></i> {{ "Back"|xlt }}</a>
+                    {{ 'Download Documents From Medical Record' | xlt }}
+                </header>
                 <div id="docsdownload" class="card-body">
                     <div>
                         <iframe src="./get_patient_documents.php" class="w-100 vh-100 border-0"></iframe>
@@ -749,6 +986,7 @@
             </div>
         {% endif %}
 
+        <!-- Billing Summary Card -->
         {% if portal_two_ledger %}
             <div class="collapse overflow-auto" data-parent="#cardgroup" id="ledgercard">
                 <div class="card">
@@ -760,10 +998,11 @@
             </div>
         {% endif %}
 
+        <!-- Assessments PRO Card -->
         {% if isEasyPro %}
             <div class="card collapse overflow-auto" data-parent="#cardgroup" id="procard">
                 <header class="card-header p-1 bg-dark text-light h3">{{ 'Patient Reported Outcomes' | xlt }}</header>
-                <div id="pro" class="card-body p-2 bg-light"></div>
+                <div id="pro" class="card-body p-2 bg-light">{% include "portal/partial/_alert_loading.html.twig" %}</div>
             </div>
         {% endif %}
 

--- a/templates/portal/home.html.twig
+++ b/templates/portal/home.html.twig
@@ -875,7 +875,7 @@
                 <!-- Signature -->
                 <div class="card d-flex mr-1 mb-1">
                     <div class="card-body row">
-                        <h4 class="card-title d-flex align-items-center btn-link"><a role="button" href="#openSignModal" data-toggle="modal" data-parent="#cardgroup"><i class="fas fa-file-signature mr-1"></i>{{ 'Default Signature' | xlt }}</a></h4>
+                        <h4 class="card-title d-flex align-items-center btn-link"><a role="button" href="#openSignModal" data-toggle="modal" data-parent="#cardgroup"><i class="fas fa-file-signature mr-1"></i>{{ 'Default Digital Signature' | xlt }}</a></h4>
                     </div>
                 </div>
                 <!-- Password -->

--- a/templates/portal/partial/_alert_loading.html.twig
+++ b/templates/portal/partial/_alert_loading.html.twig
@@ -1,0 +1,1 @@
+<div class="alert alert-info"><h3>{{ "Loading..."|xlt }} <i class="wait fa fa-cog fa-spin ml-2"></i></h3></div>

--- a/templates/portal/partial/_help_card.html.twig
+++ b/templates/portal/partial/_help_card.html.twig
@@ -1,0 +1,25 @@
+{% set backButton = backButton is null ? false : backButton %}
+<div class="card collapse overflow-auto" data-parent="#cardgroup" id="{{ id|attr }}">
+    <header class="card-header p-1 bg-dark text-light h3">
+        {% if backButton %}
+            <a href="#{{ backButtonCard|attr_url }}"
+               data-toggle="collapse" data-parent="#cardgroup" aria-expanded="false"
+               class="{{ backButtonClass|attr }} btn btn-light text-dark d-none"><i class="fa fa-arrow-left"></i> {{ "Back"|xlt }}</a>
+        {% endif %}
+        {{ title|text }}
+    </header>
+    {% if items|length > 0 %}
+    <div class="list-group">
+        {% for item in items %}
+            {% if item.enabled %}
+                <a class="list-group-item list-group-item-action flex-column align-items-start">
+                    <div class="d-flex w-100 justify-content-between">
+                        <h5 class="mb-1"><i class="fa fa-2x fa-{{ item.icon|attr}} text-dark mr-1"></i>{{ item.title|text }}</h5>
+                    </div>
+                    <p class="mb-1">{{ item.description|text }}</p>
+                </a>
+            {% endif %}
+        {% endfor %}
+    </div>
+    {% endif %}
+</div>

--- a/templates/portal/partial/_nav_icon.html.twig
+++ b/templates/portal/partial/_nav_icon.html.twig
@@ -1,0 +1,23 @@
+{% set localLink = localLink is null ? true : localLink %}
+{% set cardGroup = cardGroup is null ? "cardgroup" : cardGroup %}
+
+<a id="{{ id|attr }}" class="col-lg-2 col-md-4 col-sm-6 col-6 card bg-light pl-sm-2 pr-sm-2 pl-0 pr-0 pt-2 pb-2 text-center text-decoration-none"
+   {% if localLink %}
+    data-toggle="collapse" data-parent="#{{ cardGroup|attr }}" aria-expanded="false"
+    href="#{{ url|attr_url }}"
+   {% else %}
+       {# Note url for urls that are not localLink must be escaped by the caller of this template to avoid double-escaping #}
+    href="{{ url }}"
+   {% endif %}
+>
+    <h1 class="card-image">
+        <i class="fa fa-2x fa-{{ icon|attr }} text-dark"></i>
+    </h1>
+    <div class="card-body pl-1 pr-1 pl-sm-3 pr-sm-3">
+        <button class="btn btn-success d-block w-100 text-light">
+            {% block navTextBlock %}
+            {{ navText | text }}
+            {% endblock %}
+        </button>
+    </div>
+</a>

--- a/templates/portal/partial/_nav_icon_secure_messaging.html.twig
+++ b/templates/portal/partial/_nav_icon_secure_messaging.html.twig
@@ -1,0 +1,5 @@
+{% extends "portal/partial/_nav_icon.html.twig" %}
+{% block navTextBlock %}
+    {{ 'Secure Messaging' | xlt }}
+    {% if newcnt > 0 %}<small><span class="badge-pill badge-danger ml-1">{{ newcnt ~ "(New)" | text }}</span></small>{% endif %}
+{% endblock %}


### PR DESCRIPTION
This fixes #7609.  This work has been sponsored by Open Plan IT and heavily builds upon what @sjpadgett has done with the portal single page app layout.

The issues referenced in the commit comments are for internal issues in the Open Plan IT project. 

Screenshots for the new design:
Desktop version:

Main home screen:

![Image](https://github.com/user-attachments/assets/55bfdfc5-59ad-462a-89db-7035246e755c)

Medical Reports Screen
![Image](https://github.com/user-attachments/assets/33af6d8d-34b8-4d4e-b692-f8150d889297)

Settings Screen
![Image](https://github.com/user-attachments/assets/ca0ef370-22ac-4dc7-8444-db46c3aa649e)

Dashboard Help Screen

![Image](https://github.com/user-attachments/assets/d79283fd-7868-463d-ad60-86a1b73762a1)

Medical Reports Help Screen
![Image](https://github.com/user-attachments/assets/d8d187d9-0a37-4e96-920b-17db7193202c)

Surface Pro:


![Image](https://github.com/user-attachments/assets/ce789d6b-3e40-4524-bb22-5affe4c75b81)

Ipad AIR


![Image](https://github.com/user-attachments/assets/02aa48c3-c0bc-424e-a195-f41648606b08)

iPhone XR


![Image](https://github.com/user-attachments/assets/d33c508f-3869-4c54-9797-289a940508aa)

Samsung Galaxy S8


![Image](https://github.com/user-attachments/assets/f84da3c1-e3b9-4102-a9a9-0d89778ab622)

