### PR TITLE
Fixes #7608 appointment localized dates

### DIFF
--- a/portal/add_edit_event_user.php
+++ b/portal/add_edit_event_user.php
@@ -87,6 +87,8 @@ if ($date) {
 } else {
     $date = date("Y-m-d");
 }
+// internationalize the date
+$date = oeFormatShortDate($date);
 
 //
 $starttimem = '00';
@@ -549,7 +551,7 @@ $row = array();
 // If we are editing an existing event, then get its data.
 if ($eid) {
     $row = sqlQuery("SELECT * FROM openemr_postcalendar_events WHERE pc_eid = ?", array($eid));
-    $date = $row['pc_eventDate'];
+    $date = oeFormatShortDate($row['pc_eventDate']);
     $userid = $row['pc_aid'];
     $patientid = $row['pc_pid'];
     $starttimeh = substr($row['pc_startTime'], 0, 2) + 0;
@@ -686,7 +688,7 @@ if ($userid) {
                     </div>
                     <div class="input-group col-12 col-md-6">
                         <label class="mr-2" for="form_date"><?php echo xlt('Date'); ?>:</label>
-                        <input class="form-control mb-1" type='text' name='form_date' readonly id='form_date' value='<?php echo (isset($eid) && $eid) ? attr($row['pc_eventDate']) : attr($date); ?>' />
+                        <input class="form-control mb-1" type='text' name='form_date' readonly id='form_date' value='<?php echo (isset($eid) && $eid) ? attr(oeFormatShortDate($row['pc_eventDate'])) : attr($date); ?>' />
                     </div>
                 </div>
                 <div class="row">
@@ -758,7 +760,9 @@ if ($userid) {
         <script>
             function change_provider() {
                 var f = document.forms.namedItem("theaddform");
-                f.form_date.value = '';
+                // use today's date but reset everything else when changing providers so we can
+                // search on availability.
+                f.form_date.value = window.top.oeFormatters.I18NDateFormat(new Date());
                 f.form_hour.value = '';
                 f.form_minute.value = '';
             }
@@ -808,9 +812,9 @@ if ($userid) {
             // This is for callback by the find-available popup.
             function setappt(year, mon, mday, hours, minutes) {
                 var f = document.forms.namedItem("theaddform");
-                f.form_date.value = '' + year + '-' +
-                    ('' + (mon + 100)).substring(1) + '-' +
-                    ('' + (mday + 100)).substring(1);
+                // note that month is 0 based, 0-11 so need to subtract 1 as the api caller is 1 based (1-12)
+                let date= new Date(year, mon-1, mday, hours, minutes);
+                f.form_date.value = window.top.oeFormatters.I18NDateFormat(date);
                 f.form_ampm.selectedIndex = (hours > 12) ? 1 : 0;
                 if (hours == 0) {
                     f.form_hour.value = 12;

--- a/portal/find_appt_popup_user.php
+++ b/portal/find_appt_popup_user.php
@@ -53,6 +53,7 @@ require_once("$srcdir/patient.inc.php");
 require_once(dirname(__FILE__) . "/../library/appointments.inc.php");
 
 use OpenEMR\Core\Header;
+use OpenEMR\Services\Utils\DateFormatterUtils;
 
 $input_catid = $_REQUEST['catid'];
 
@@ -123,14 +124,8 @@ if ($_REQUEST['searchdays'] ?? null) {
 }
 
 // Get a start date.
-if (
-    $_REQUEST['startdate'] && preg_match(
-        "/(\d\d\d\d)\D*(\d\d)\D*(\d\d)/",
-        $_REQUEST['startdate'],
-        $matches
-    )
-) {
-    $sdate = $matches[1] . '-' . $matches[2] . '-' . $matches[3];
+if (!empty($_REQUEST['startdate'])) {
+    $sdate = DateFormatterUtils::DateToYYYYMMDD($_REQUEST['startdate']);
 } else {
     $sdate = date("Y-m-d");
 }
@@ -287,7 +282,7 @@ if ($_REQUEST['providerid']) {
             <div class="form-row mx-0 align-items-center">
                 <label for="startdate" class="col-1 mx-2 col-form-label"><?php echo xlt('Start date:'); ?></label>
                 <div class="col-auto">
-                    <input type='text' class='datepicker form-control' name='startdate' id='startdate' size='10' value='<?php echo attr($sdate); ?>' title='yyyy-mm-dd starting date for search' />
+                    <input type='text' class='datepicker form-control' name='startdate' id='startdate' size='10' value='<?php echo attr(DateFormatterUtils::oeFormatShortDate($sdate)); ?>' title='starting date for search' />
                 </div>
                 <label for="searchdays" class="col-auto col-form-label"><?php echo xlt('for'); ?></label>
                 <div class="col-auto">
@@ -410,7 +405,7 @@ if ($_REQUEST['providerid']) {
 
             $('.datepicker').datetimepicker({
                 <?php $datetimepicker_timepicker = false; ?>
-                <?php $datetimepicker_formatInput = false; ?>
+                <?php $datetimepicker_formatInput = true; ?>
                 <?php require($GLOBALS['srcdir'] . '/js/xl/jquery-datetimepicker-2-5-4.js.php'); ?>
                 <?php // can add any additional javascript settings to datetimepicker here; need to prepend first setting with a comma ?>
             });

--- a/portal/home.php
+++ b/portal/home.php
@@ -108,7 +108,7 @@ if ($appts) {
         }
 
         $formattedRecord = [
-            'appointmentDate' => $dayname . ', ' . $row['pc_eventDate'] . ' ' . $disphour . ':' . $dispmin . ' ' . $dispampm,
+            'appointmentDate' => $dayname . ', ' . oeFormatShortDate($row['pc_eventDate']) . ' ' . $disphour . ':' . $dispmin . ' ' . $dispampm,
             'appointmentType' => xl('Type') . ': ' . $row['pc_catname'],
             'provider' => xl('Provider') . ': ' . $row['ufname'] . ' ' . $row['ulname'],
             'status' => xl('Status') . ': ' . $status_title,

--- a/templates/portal/base.html.twig
+++ b/templates/portal/base.html.twig
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     {% block head %}
-        {{ setupHeader(['no_main-theme', 'portal-theme', 'datetime-picker', 'i18next']) }}
+        {{ setupHeader(['no_main-theme', 'portal-theme', 'datetime-picker', 'i18next', 'il8formatting']) }}
     {% endblock %}
 
     <title>{% block pagetitle %}{{ "Home"|xlt }}{% endblock %}</title>

--- a/templates/portal/home.html.twig
+++ b/templates/portal/home.html.twig
@@ -8,15 +8,18 @@
     <script src="../portal/sign/assets/signature_pad.umd.js?v={{ assetVersion | attr_url }}"></script>
     <script src="../portal/sign/assets/signer_api.js?v={{ assetVersion | attr_url }}"></script>
 
-    {% if payment_gateway == 'Stripe' %}
-        <script src="https://js.stripe.com/v3/"></script>
-    {% endif %}
+    {% if portal_two_payments %}
+        {# We don't include anything for payments if we don't have payments enabled #}
+        {% if payment_gateway == 'Stripe' %}
+            <script src="https://js.stripe.com/v3/"></script>
+        {% endif %}
 
-    {% if payment_gateway == 'AuthorizeNet' %}
-        {% if gateway_mode_production %}
-            <script src="https://js.authorize.net/v1/Accept.js"></script>
-        {% else %}
-            <script src="https://jstest.authorize.net/v1/Accept.js"></script>
+        {% if payment_gateway == 'AuthorizeNet' %}
+            {% if gateway_mode_production %}
+                <script src="https://js.authorize.net/v1/Accept.js"></script>
+            {% else %}
+                <script src="https://jstest.authorize.net/v1/Accept.js"></script>
+            {% endif %}
         {% endif %}
     {% endif %}
     <style>


### PR DESCRIPTION
Fixes #7608 appointment localized dates.

This fixes the appointment localized date issue showing in the new
appointment screen. I add the localization js library to the
add_edit_event_user.php script and also handle the localization when it
comes back in the find_appt_popup script.

Also changed default behavior to retain today's date in the date field
if you switch providers in the appointment popup dialog.

Work sponsored by Open Plan IT.