### PR TITLE
Fixes #7621 validation save errors w/ translations

### DIFF
--- a/library/js/utility.js
+++ b/library/js/utility.js
@@ -15,8 +15,7 @@
 // This calls the i18next.t function that has been set up in main.php, portal/base.html.twig, etc.
 function xl(string) {
     // safety check if for some reason the i18next is not included.
-    // if (top.i18next && typeof top.i18next.t == 'function') {
-    if (typeof top.i18next.t == 'function') {
+    if (top.i18next && typeof top.i18next.t == 'function') {
         return top.i18next.t(string);
     } else {
         // Unable to find the i18next.t function, so log error

--- a/library/js/utility.js
+++ b/library/js/utility.js
@@ -12,8 +12,10 @@
 /* We should really try to keep this library jQuery free ie javaScript only! */
 
 // Translation function
-// This calls the i18next.t function that has been set up in main.php
+// This calls the i18next.t function that has been set up in main.php, portal/base.html.twig, etc.
 function xl(string) {
+    // safety check if for some reason the i18next is not included.
+    // if (top.i18next && typeof top.i18next.t == 'function') {
     if (typeof top.i18next.t == 'function') {
         return top.i18next.t(string);
     } else {

--- a/portal/home.php
+++ b/portal/home.php
@@ -27,6 +27,7 @@ use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Events\PatientPortal\AppointmentFilterEvent;
 use OpenEMR\Events\PatientPortal\RenderEvent;
 use OpenEMR\Services\LogoService;
+use OpenEMR\Services\Utils\TranslationService;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
 use Twig\Error\SyntaxError;
@@ -46,16 +47,7 @@ $logoService = new LogoService();
 
 
 // Get language definitions for js
-$language = $_SESSION['language_choice'] ?? '1'; // defaults english
-$sql = "SELECT c.constant_name, d.definition FROM lang_definitions as d
-        JOIN lang_constants AS c ON d.cons_id = c.cons_id
-        WHERE d.lang_id = ?";
-$tarns = sqlStatement($sql, $language);
-$language_defs = array();
-while ($row = SqlFetchArray($tarns)) {
-    $language_defs[$row['constant_name']] = $row['definition'];
-}
-
+$language_defs = TranslationService::getLanguageDefinitionsForSession();
 $whereto = $_SESSION['whereto'] ?? null;
 
 $user = $_SESSION['sessionUser'] ?? 'portal user';

--- a/portal/patient/libs/Controller/OnsiteDocumentController.php
+++ b/portal/patient/libs/Controller/OnsiteDocumentController.php
@@ -13,6 +13,7 @@
 /** import supporting libraries */
 
 use OpenEMR\Services\DocumentTemplates\DocumentTemplateRender;
+use OpenEMR\Services\Utils\TranslationService;
 
 require_once("AppBasePortalController.php");
 require_once("Model/OnsiteDocument.php");
@@ -75,6 +76,9 @@ class OnsiteDocumentController extends AppBasePortalController
         unset($_GET['auto_render_name']);
         unset($_GET['audit_render_id']);
 
+        $language_defs = TranslationService::getLanguageDefinitionsForSession();
+
+        $this->Assign("language_defs", $language_defs);
         $this->Assign('doc_edit', $doc_edit);
         $this->Assign('recid', $recid);
         $this->Assign('help_id', $help_id);

--- a/portal/patient/templates/OnsiteDocumentListView.tpl.php
+++ b/portal/patient/templates/OnsiteDocumentListView.tpl.php
@@ -93,9 +93,9 @@ $templateService = new DocumentTemplateService();
     echo "<script>var formNamesWhitelist=" . json_encode(CoreFormToPortalUtility::getListPortalCompliantEncounterForms()) . ";</script>";
 
     if ($is_portal) {
-        Header::setupHeader(['no_main-theme', 'portal-theme', 'datetime-picker']);
+        Header::setupHeader(['no_main-theme', 'portal-theme', 'datetime-picker', 'i18next']);
     } else {
-        Header::setupHeader(['datetime-picker']);
+        Header::setupHeader(['datetime-picker', 'i18next']);
     }
     ?>
     <link rel="stylesheet" href="<?php echo $GLOBALS['web_root']; ?>/portal/sign/css/signer_modal.css?v=<?php echo $GLOBALS['v_js_includes']; ?>">
@@ -111,7 +111,20 @@ $templateService = new DocumentTemplateService();
         $LAB.script("<?php echo $GLOBALS['assets_static_relative']; ?>/underscore/underscore-min.js").script("<?php echo $GLOBALS['assets_static_relative']; ?>/moment/moment.js").script(
             "<?php echo $GLOBALS['assets_static_relative']; ?>/backbone/backbone-min.js").script("<?php echo $GLOBALS['web_root']; ?>/portal/patient/scripts/app.js?v=<?php echo $GLOBALS['v_js_includes']; ?>").script(
             "<?php echo $GLOBALS['web_root']; ?>/portal/patient/scripts/model.js?v=<?php echo $GLOBALS['v_js_includes']; ?>").wait().script(
-            "<?php echo $GLOBALS['web_root']; ?>/portal/patient/scripts/view.js?v=<?php echo $GLOBALS['v_js_includes']; ?>").wait()
+            "<?php echo $GLOBALS['web_root']; ?>/portal/patient/scripts/view.js?v=<?php echo $GLOBALS['v_js_includes']; ?>").wait();
+        i18next.init({
+            lng: 'selected',
+            debug: false,
+            nsSeparator: false,
+            keySeparator: false,
+            resources: {
+                selected: {
+                    translation: <?php echo js_escape($this->language_defs ?? []); ?>
+                }
+            }
+        }).catch(error => {
+            console.log(error.message);
+        });
     </script>
     <style>
       @media print {

--- a/src/Services/Utils/TranslationService.php
+++ b/src/Services/Utils/TranslationService.php
@@ -8,7 +8,7 @@
  * @author    Jerry Padgett <sjpadgett@gmail.com>
  * @author    Stephen Nielson <snielson@discoverandchange.com>
  * @copyright Copyright (c) 2016-2024 Jerry Padgett <sjpadgett@gmail.com>
- * @copyright Copyright (c) 2024 Open Plan IT. <pete@openplanit.com>
+ * @copyright Copyright (c) 2024 Open Plan IT Ltd. <support@openplanit.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 

--- a/src/Services/Utils/TranslationService.php
+++ b/src/Services/Utils/TranslationService.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Helper class for dealing with language translations.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Jerry Padgett <sjpadgett@gmail.com>
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2016-2024 Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright Copyright (c) 2024 Open Plan IT. <pete@openplanit.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Services\Utils;
+
+class TranslationService
+{
+    public static function getLanguageDefinitionsForSession()
+    {
+        $language = $_SESSION['language_choice'] ?? '1'; // defaults english
+        return self::getLanguageDefinitionsForLanguage($language);
+    }
+
+    public static function getLanguageDefinitionsForLanguage(int $languageId)
+    {
+        $sql = "SELECT c.constant_name, d.definition FROM lang_definitions as d
+        JOIN lang_constants AS c ON d.cons_id = c.cons_id
+        WHERE d.lang_id = ?";
+        $tarns = sqlStatement($sql, $languageId);
+        $language_defs = array();
+        while ($row = SqlFetchArray($tarns)) {
+            $language_defs[$row['constant_name']] = $row['definition'];
+        }
+        return $language_defs;
+    }
+}


### PR DESCRIPTION
The translation system was not setup in the OnSiteDocumentController and a bug in utility.js would blow up preventing the questionnaire from saving.  I added more safety checks to the xl translation function. Injected the language translations into the OnSiteDocumentController and abstracted the language definition retrievals into a service utility class.

Fixes #7621 