### PR TITLE
Fixes #7590 wrongful use of break tag

### DIFF
--- a/gacl/docs/manual.html
+++ b/gacl/docs/manual.html
@@ -238,12 +238,16 @@
 				font-size: 12pt;
 			}
 		}
+		.image-space {
+			content: ' ';
+    		display: block;
+		}
 	</style>
 </head>
 
 <body dir="ltr">
 	<div class="container">
-		<p class="text-center" style="margin-top: 1rem; line-height: 100%; page-break-after: avoid;">
+		<p class="text-center image-space" style="margin-top: 1rem; line-height: 100%; page-break-after: avoid;">
 			<img src="manual_html_m54d0ced8.png" id="Graphic6" class="img-responsive d-block ml-auto" width="165" height="45" alt="phpGACL Logo" />
 			<br style="clear: right;" /><br /><br />
 		</p>

--- a/gacl/docs/manual.html
+++ b/gacl/docs/manual.html
@@ -249,7 +249,6 @@
 	<div class="container">
 		<p class="text-center image-space" style="margin-top: 1rem; line-height: 100%; page-break-after: avoid;">
 			<img src="manual_html_m54d0ced8.png" id="Graphic6" class="img-responsive d-block ml-auto" width="165" height="45" alt="phpGACL Logo" />
-			<br style="clear: right;" /><br /><br />
 		</p>
 		<p class="text-center" style="margin-top: 1rem; line-height: 100%; page-break-after: avoid;">
 			<span class="font4">


### PR DESCRIPTION
This fixes issue [#7590 ](https://github.com/openemr/openemr/issues/7590)

This issue resolves the wrongful use of a break element/tag in line 248 of the file (gacl/docs/manual.html).

Content separation should be done using CSS as it has better semantics, accessibility and responsiveness. 

--

To fix this issue, I removed the break tag on Line 248. I created a new CSS selector called "image-space" and then applied that class to the paragraph tag (now line 250) about the image to achieve the same effect.