### PR TITLE
Fixes #7646 portal update page title tag

### DIFF
--- a/templates/portal/home.html.twig
+++ b/templates/portal/home.html.twig
@@ -135,9 +135,21 @@
             }
         };
 
+        function updateWindowTitle(element) {
+            if (element && element.dataset && element.dataset.windowTitle) {
+                let textNode = document.createElement("div");
+                textNode.innerText = element.dataset.windowTitle;
+                document.title = textNode.innerText;
+            } else {
+                // if we don't have a valid element we are going to reset to our home page
+                document.title = {{ pagetitle|js_escape }};
+            }
+        }
+
         $(function () {
             $('#topNav [data-parent="#cardgroup"]').on('click', (e) => {
                 persist($(e.target).attr('href'), false);
+                updateWindowTitle(e.target);
             });
 
             $('#quickstart-card [data-parent="#cardgroup"]' +
@@ -146,6 +158,7 @@
                 // we use currentTarget so we grab the event with the original data-parent, if there are buttons or
                 // other stuff inside we want to go to the href.
                 persist($(e.currentTarget).attr('href'), false);
+                updateWindowTitle(e.currentTarget);
                 return true;
             });
 

--- a/templates/portal/home.html.twig
+++ b/templates/portal/home.html.twig
@@ -270,6 +270,8 @@
             // Persist last card used for returns for actions.
             let gowhere = {{ whereto | js_escape }};
             $(gowhere).collapse('show');
+            // grab the navigation element that we persisted, if there is no element we default to our page title
+            updateWindowTitle(document.querySelector("a[href='" + gowhere + "']"));
             // update home button in case our last location is the quickstart
             updateDashboardHomeButton();
 

--- a/templates/portal/partial/_nav_icon.html.twig
+++ b/templates/portal/partial/_nav_icon.html.twig
@@ -9,6 +9,11 @@
        {# Note url for urls that are not localLink must be escaped by the caller of this template to avoid double-escaping #}
     href="{{ url }}"
    {% endif %}
+   {# windowTitle is used to update the current webpage's title property whenever a card is toggled to be displayed.
+        Note the window title is sanitized to be text only in javascript.  #}
+   {% if navText %}
+    data-window-title="{{ navText|attr }}"
+   {% endif %}
 >
     <h1 class="card-image">
         <i class="fa fa-2x fa-{{ icon|attr }} text-dark"></i>


### PR DESCRIPTION
Made it so the patient portal will update the page title tag whenever the single page app navigates to a new 'page'. I do this whenever the page is persisted.

If the user comes back to the dashboard page it reverts to the default page title set in the home.php file.

Fixes #7646