### PR TITLE
Feat Fixes #7650 portal credential settings update

### DIFF
--- a/portal/account/index_reset.php
+++ b/portal/account/index_reset.php
@@ -114,10 +114,7 @@ $vars = [
 ];
 try {
     echo (new TwigContainer(null, $GLOBALS['kernel']))->getTwig()->render("portal/portal-credentials-settings.html.twig", $vars);
-}
-catch (\Exception $exception) {
+} catch (\Exception $exception) {
     (new \OpenEMR\Common\Logging\SystemLogger())->errorLogCaller($exception->getMessage(), ['trace' => $exception->getTraceAsString()]);
     die(xlt("Failed to render twig file"));
 }
-
-?>

--- a/templates/portal/home.html.twig
+++ b/templates/portal/home.html.twig
@@ -317,7 +317,7 @@
         }
 
         function changeCredentials(e) {
-            title = {{ 'Please Enter New Credentials' | xlj }};
+            title = {{ 'Manage Login Credentials' | xlj }};
             dlgopen("./account/index_reset.php", '', 900, 750, null, title, {});
         }
 

--- a/templates/portal/portal-credentials-settings.html.twig
+++ b/templates/portal/portal-credentials-settings.html.twig
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{{ 'Change Portal Credentials'|xlt }}</title>
+    {{ setupHeader(['no_main-theme', 'portal-theme', 'opener']) }}
+    {% if isSubmit %}
+        <script>dlgclose();</script>
+    {% endif %}
+    <script>
+        function checkUserName() {
+            let vacct = document.getElementById('uname').value;
+            let vsuname = document.getElementById('login_uname').value;
+            let data = {
+                'action': 'userIsUnique',
+                'account': vacct,
+                'loginUname': vsuname
+            };
+            $.ajax({
+                type: 'GET',
+                url: './account.php',
+                data: data
+            }).done(function (rtn) {
+                if (rtn === '1') {
+                    return true;
+                }
+                alert({{ 'Log In Name is unavailable. Try again!'|xlj }});
+                return false;
+            });
+        }
+
+        function process_new_pass() {
+            if (document.getElementById('login_uname').value != document.getElementById('confirm_uname').value) {
+                alert({{ 'The Username fields are not the same.'|xlj }});
+                return false;
+            }
+            if (document.getElementById('pass_new').value != document.getElementById('pass_new_confirm').value) {
+                alert({{ 'The new password fields are not the same.'|xlj }});
+                return false;
+            }
+            if (document.getElementById('pass_current').value == document.getElementById('pass_new_confirm').value) {
+                if (!confirm({{ 'The new password is the same as the current password. Click Okay to accept anyway.'|xlj }})) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    </script>
+    <style>
+        .table > tbody > tr > td {
+            border-top: 0px;
+        }
+    </style>
+</head>
+<body>
+<div class="container-fluid">
+    <form action="" method="POST" onsubmit="return process_new_pass()">
+        <div class="row">
+            <div class="col-12">
+                <div class="alert alert-info">
+                    <p>{{ 'Use this form to change your login Password, Username or Both.'|xlt }}</p>
+                    <p>{{ 'For example, to change your current Password, enter and use your current Username and enter new Password. You must still confirm Password and Username regardless.'|xlt }}</p>
+                </div>
+                <input class="d-none" type="text" name="dummyuname" />
+                <input class="d-none" type="password" name="dummypassword" />
+                {{ csrfToken("portal_index_reset", "csrf_token_form") }}
+            </div>
+        </div>
+        <table class="table table-sm" style="border-bottom:0px;width:100%">
+            <tr>
+                <td width="35%"><strong>{{ 'Portal Account ID for reference'|xlt }}</strong></td>
+                <td><input class="form-control" name="uname" id="uname" type="text" readonly
+                           value="{{ auth.portal_username|attr }}" /></td>
+            </tr>
+            <tr>
+                <td><strong>{{ 'Change or Keep Existing Username'|xlt }}</strong></td>
+                <td><input class="form-control" name="login_uname" id="login_uname" type="text" required onblur="checkUserName()"
+                           title="{{ 'Change or keep current. Enter a minimum of 8 characters. Recommended to include symbols and numbers but not required.'|xla }}" pattern=".{8,}"
+                           value="{{ auth.portal_login_username|attr }}" />
+                </td>
+            </tr>
+            <tr>
+            <tr>
+                <td><strong>{{ 'Confirm Above Username'|xlt }}</strong></td>
+                <td><input class="form-control" name="confirm_uname" id="confirm_uname" type="text" required
+                           title="{{ 'You must confirm this Username.'|xla }}"
+                           autocomplete="none" pattern=".{8,80}" value="" />
+                </td>
+            </tr>
+            </tr>
+            <tr>
+                <td><strong>{{ 'Current Password to Authorize Changes'|xlt }}</strong></td>
+                <td>
+                    <input class="form-control" name="pass_current" id="pass_current" type="password" required
+                           placeholder="{{ 'Enter your current password used to login.'|xla }}"
+                           title="{{ 'Enter your existing current password used to login.'|xla }}"
+                           pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}" />
+                </td>
+            </tr>
+            <tr>
+                <td><strong>{{ 'Change or Keep Existing Password'|xlt }}</strong></td>
+                <td>
+                    <input class="form-control" name="pass_new" id="pass_new" type="password" required
+                           placeholder="{{ 'Minimum length is 8 with upper,lowercase,numbers mix'|xla }}"
+                           title="{{ 'You must enter a new or reenter current password to keep it. Even for Username change.'|xla }}"
+                           pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}" />
+                </td>
+            </tr>
+            <tr>
+                <td><strong>{{ 'Confirm Password'|xlt }}</strong></td>
+                <td>
+                    <input class="form-control" name="pass_new_confirm" id="pass_new_confirm" type="password"
+                           pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}" autocomplete="none" />
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2"><br /><input class="btn btn-primary float-right" type="submit" name="submit" value="{{ 'Save'|xla }}" /></td>
+            </tr>
+        </table>
+        <div><strong>{{ '* ' ~ 'All credential fields are case sensitive!'|xlt }}</strong></div>
+    </form>
+</div><!-- container -->
+</body>
+</html>

--- a/templates/portal/portal-credentials-settings.html.twig
+++ b/templates/portal/portal-credentials-settings.html.twig
@@ -3,13 +3,15 @@
 <head>
     <title>{{ 'Change Portal Credentials'|xlt }}</title>
     {{ setupHeader(['no_main-theme', 'portal-theme', 'opener']) }}
-    {% if isSubmit %}
-        <script>dlgclose();</script>
-    {% endif %}
     <script>
         function checkUserName() {
             let vacct = document.getElementById('uname').value;
             let vsuname = document.getElementById('login_uname').value;
+            let validation = validateUsername();
+            // no point in hitting the server if we don't have a valid username
+            if (!validation.isValid) {
+                return false;
+            }
             let data = {
                 'action': 'userIsUnique',
                 'account': vacct,
@@ -23,9 +25,34 @@
                 if (rtn === '1') {
                     return true;
                 }
-                alert({{ 'Log In Name is unavailable. Try again!'|xlj }});
+                alert({{ 'Username is unavailable. Try again!'|xlj }});
                 return false;
             });
+        }
+
+        function validateUsername() {
+            let newUsername = document.getElementById('login_uname').value;
+            let existingUsername = {{ auth.portal_login_username|js_escape }};
+            let confirmUsername = document.getElementById('confirm_uname').value;
+            let validation = {
+                usernameMatch: true
+                ,usernameChanged: false
+                ,validUsername: true
+                ,isValid: true
+            };
+            if (existingUsername != newUsername) {
+                validation.usernameChanged = true;
+            }
+            if (existingUsername != newUsername
+                && newUsername != confirmUsername) {
+                validation.usernameMatch = false;
+                validation.isValid = false;
+            }
+            if (newUsername == "") {
+                validation.validUsername = false;
+                validation.isValid = false;
+            }
+            return validation;
         }
 
         function process_new_pass() {
@@ -33,25 +60,38 @@
             let existingUsername = {{ auth.portal_login_username|js_escape }};
             let confirmUsername = document.getElementById('confirm_uname').value;
             // has to be changed, can't be empty
-            if (existingUsername != newUsername
-                && newUsername != confirmUsername) {
+            let validationUsername = validateUsername();
+            if (!validationUsername.usernameMatch) {
                 alert({{ 'The Username fields are not the same.'|xlj }});
                 return false;
-            } else if (confirmUsername == "") {
+            }
+            if (!validationUsername.validUsername) {
                 alert({{ 'The Username must not be empty.'|xlj }});
+                return false;
             }
 
             // if empty string... not changing passwords
             let newPass = document.getElementById('pass_new').value;
             let newPassConfirm = document.getElementById('pass_new_confirm').value;
+            let currentPassConfirm = document.getElementById('pass_current').value;
             if (newPass != newPassConfirm) {
                 alert({{ 'The new password fields are not the same.'|xlj }});
                 return false;
             }
-            if (newPass == newPassConfirm) {
+            if (currentPassConfirm == "") {
+                alert({{"You must enter your current Account Password to authorize these changes to your Account Credentials"|xlj }});
+                return false;
+            }
+
+            if (currentPassConfirm == newPassConfirm) {
                 if (!confirm({{ 'The new password is the same as the current password. Click Okay to accept anyway.'|xlj }})) {
                     return false;
                 }
+            }
+
+            if (newPass == "" && !validationUsername.usernameChanged) {
+                alert({{ 'Nothing was changed.'|xlj }});
+                return false;
             }
             return true;
         }
@@ -59,11 +99,35 @@
 </head>
 <body>
 <div class="container-fluid">
+    {% if isSubmit and isSaved %}
+    <script>
+        setTimeout(function() {
+            dlgclose();
+        }, 3000);
+    </script>
+    <div class="alert alert-success">
+        <p>{{ "Account Credentials Successfully Updated"|xlt }}</p>
+        <p>{{ "This dialog window will close automatically in a few seconds"|xlt }}</p>
+    </div>
+    {% else %}
     <form action="" method="POST" onsubmit="return process_new_pass()">
         <input class="d-none" type="text" name="dummyuname" />
         <input class="d-none" type="password" name="dummypassword" />
         {{ csrfToken("portal_index_reset", "csrf_token_form") }}
 
+        {% if isSubmit and not isSaved %}
+        <div class="row no-gutters mb-2">
+            <div class="col-12">
+                <div class="alert alert-danger">
+                    {% if errMsg is not empty %}
+                        {{ errMsg|text }}
+                    {% else %}
+                        {{ "A system error occured - try again or contact your healthcare support staff"|xlt }}
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+        {% endif %}
         <div class="row no-gutters mb-2">
             <div class="col-12 card">
                 <div class="card-header">
@@ -75,7 +139,7 @@
                             <strong>{{ 'Change Username'|xlt }}</strong>
                         </div>
                         <div class="col-md-9 col-12">
-                            <input class="form-control" name="login_uname" id="login_uname" type="text" required onblur="checkUserName()"
+                            <input class="form-control" name="login_uname" id="login_uname" type="text" onblur="checkUserName()"
                                    title="{{ 'Enter a minimum of 8 characters. Recommended to include symbols and numbers but not required.'|xla }}" pattern=".{8,}"
                                    value="{{ auth.portal_login_username|attr }}" />
                         </div>
@@ -85,9 +149,9 @@
                             <strong>{{ 'Confirm Username'|xlt }}</strong>
                         </div>
                         <div class="col-md-9 col-12">
-                            <input class="form-control" name="confirm_uname" id="confirm_uname" type="text" required
+                            <input class="form-control" name="confirm_uname" id="confirm_uname" type="text"
                                    title="{{ 'You must confirm this Username.'|xla }}"
-                                   autocomplete="none" pattern=".{8,80}" value="" />
+                                   autocomplete="none" pattern=".{8,80}" value="" onblur="checkUserName()" />
                         </div>
                         <div class="col-12 col-md-9 offset-md-3 font-italic">
                             {{ "Enter a minimum of 8 characters. Recommended to include symbols and numbers but not required."|xlt}}
@@ -108,7 +172,7 @@
                             <strong>{{ 'Change Password'|xlt }}</strong>
                         </div>
                         <div class="col-md-9 col-12">
-                            <input class="form-control" name="pass_new" id="pass_new" type="password" required
+                            <input class="form-control" name="pass_new" id="pass_new" type="password"
                                    placeholder=""
                                    title="{{ 'You must enter a new or reenter current password to keep it. Even for Username change.'|xla }}"
                                    pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}" />
@@ -134,11 +198,11 @@
             <div class="col-12">
                 <div class="alert alert-danger">
                     {# it looks nicer just to have the text be in the input but screen-readers won't display placeholder text reliably #}
-                    <h6 class="font-weight-bold"><i class="fa fa-triangle-exclamation"></i> {{ 'Enter your current password to authorize these changes'|xlt }}</h6>
+                    <h6 class="font-weight-bold"><i class="fa fa-triangle-exclamation"></i> {{ 'Enter your current Account Password to authorize these changes'|xlt }}</h6>
                     {# Note we don't via JS validate the current password just in case security requirements have changed #}
-                    <input class="form-control" name="pass_current" id="pass_current" type="password" required
+                    <input class="form-control" name="pass_current" id="pass_current" type="password"
                            placeholder="{{ 'Current password'|xla }}"
-                           title="{{ 'Enter your existing current password used to login.'|xla }}" />
+                           title="{{ 'Enter your current Account Password used to login.'|xla }}" />
                 </div>
             </div>
         </div>
@@ -151,16 +215,22 @@
             <details class="col-12 alert alert-info">
                 <summary class="h5 text-center"><span class="btn-link">{{ "Help"|xlt }}</span> <i class="fa fa-info-circle fa"></i></summary>
                 <div class="container-fluid">
-                    <div clas="row">
+                    <div class="row">
                         <div class="col-12">
-                            <p>{{ 'Use this form to change your login Password, Username or Both.'|xlt }}</p>
-                            <p>{{ 'For example, to change your current Password, enter and use your current Username and enter new Password. You must still confirm Password and Username regardless.'|xlt }}</p>
+                            <p>{{ 'Use this form to change your Account Username, Account Password, or both.'|xlt }}</p>
+                            <p>{{ 'You can change your current Account Password by entering a new Account Password and then entering the same Account Password into the Confirm Password field'|xlt }}</p>
+                            <p>{{ 'You can change your current Account Username by entering a new Account Username and then entering the same Account Username into the Confirm Username field'|xlt }}</p>
+                            <p>{{ 'Any change to your Account Username or Account Password requires you to enter in your current Account Password into the Confirm Current Password field.'|xlt }}</p>
                         </div>
                     </div>
                     <div class="row mb-2">
                         <div class="col-12">
-                            {{ "For additional questions you can contact your healthcare support staff."|xlt }}
-                            {{ "The following fields can be used to help your support staff locate your account."|xlt }}
+                            <p>
+                                {{ "For additional help or questions you can contact your healthcare support staff."|xlt }}
+                            </p>
+                            <p>
+                                {{ "The following fields can be used to help your support staff locate your account."|xlt }}
+                            </p>
                         </div>
                     </div>
                     <div class="row mb-2">
@@ -186,5 +256,6 @@
         </div>
     </form>
 </div><!-- container -->
+{% endif %}
 </body>
 </html>

--- a/templates/portal/portal-credentials-settings.html.twig
+++ b/templates/portal/portal-credentials-settings.html.twig
@@ -29,15 +29,26 @@
         }
 
         function process_new_pass() {
-            if (document.getElementById('login_uname').value != document.getElementById('confirm_uname').value) {
+            let newUsername = document.getElementById('login_uname').value;
+            let existingUsername = {{ auth.portal_login_username|js_escape }};
+            let confirmUsername = document.getElementById('confirm_uname').value;
+            // has to be changed, can't be empty
+            if (existingUsername != newUsername
+                && newUsername != confirmUsername) {
                 alert({{ 'The Username fields are not the same.'|xlj }});
                 return false;
+            } else if (confirmUsername == "") {
+                alert({{ 'The Username must not be empty.'|xlj }});
             }
-            if (document.getElementById('pass_new').value != document.getElementById('pass_new_confirm').value) {
+
+            // if empty string... not changing passwords
+            let newPass = document.getElementById('pass_new').value;
+            let newPassConfirm = document.getElementById('pass_new_confirm').value;
+            if (newPass != newPassConfirm) {
                 alert({{ 'The new password fields are not the same.'|xlj }});
                 return false;
             }
-            if (document.getElementById('pass_current').value == document.getElementById('pass_new_confirm').value) {
+            if (newPass == newPassConfirm) {
                 if (!confirm({{ 'The new password is the same as the current password. Click Okay to accept anyway.'|xlj }})) {
                     return false;
                 }
@@ -45,78 +56,134 @@
             return true;
         }
     </script>
-    <style>
-        .table > tbody > tr > td {
-            border-top: 0px;
-        }
-    </style>
 </head>
 <body>
 <div class="container-fluid">
     <form action="" method="POST" onsubmit="return process_new_pass()">
-        <div class="row">
-            <div class="col-12">
-                <div class="alert alert-info">
-                    <p>{{ 'Use this form to change your login Password, Username or Both.'|xlt }}</p>
-                    <p>{{ 'For example, to change your current Password, enter and use your current Username and enter new Password. You must still confirm Password and Username regardless.'|xlt }}</p>
+        <input class="d-none" type="text" name="dummyuname" />
+        <input class="d-none" type="password" name="dummypassword" />
+        {{ csrfToken("portal_index_reset", "csrf_token_form") }}
+
+        <div class="row no-gutters mb-2">
+            <div class="col-12 card">
+                <div class="card-header">
+                    <h5 class="text-center">{{ "Account Username"|xlt }} <i class="fa fa-info-circle text-info" title="{{ "Your username is case sensitive"|xla }}"></i></h5>
                 </div>
-                <input class="d-none" type="text" name="dummyuname" />
-                <input class="d-none" type="password" name="dummypassword" />
-                {{ csrfToken("portal_index_reset", "csrf_token_form") }}
+                <div class="card-body">
+                    <div class="row mb-2">
+                        <div class="col-md-3 col-12">
+                            <strong>{{ 'Change Username'|xlt }}</strong>
+                        </div>
+                        <div class="col-md-9 col-12">
+                            <input class="form-control" name="login_uname" id="login_uname" type="text" required onblur="checkUserName()"
+                                   title="{{ 'Enter a minimum of 8 characters. Recommended to include symbols and numbers but not required.'|xla }}" pattern=".{8,}"
+                                   value="{{ auth.portal_login_username|attr }}" />
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-3 col-12">
+                            <strong>{{ 'Confirm Username'|xlt }}</strong>
+                        </div>
+                        <div class="col-md-9 col-12">
+                            <input class="form-control" name="confirm_uname" id="confirm_uname" type="text" required
+                                   title="{{ 'You must confirm this Username.'|xla }}"
+                                   autocomplete="none" pattern=".{8,80}" value="" />
+                        </div>
+                        <div class="col-12 col-md-9 offset-md-3 font-italic">
+                            {{ "Enter a minimum of 8 characters. Recommended to include symbols and numbers but not required."|xlt}}
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
-        <table class="table table-sm" style="border-bottom:0px;width:100%">
-            <tr>
-                <td width="35%"><strong>{{ 'Portal Account ID for reference'|xlt }}</strong></td>
-                <td><input class="form-control" name="uname" id="uname" type="text" readonly
-                           value="{{ auth.portal_username|attr }}" /></td>
-            </tr>
-            <tr>
-                <td><strong>{{ 'Change or Keep Existing Username'|xlt }}</strong></td>
-                <td><input class="form-control" name="login_uname" id="login_uname" type="text" required onblur="checkUserName()"
-                           title="{{ 'Change or keep current. Enter a minimum of 8 characters. Recommended to include symbols and numbers but not required.'|xla }}" pattern=".{8,}"
-                           value="{{ auth.portal_login_username|attr }}" />
-                </td>
-            </tr>
-            <tr>
-            <tr>
-                <td><strong>{{ 'Confirm Above Username'|xlt }}</strong></td>
-                <td><input class="form-control" name="confirm_uname" id="confirm_uname" type="text" required
-                           title="{{ 'You must confirm this Username.'|xla }}"
-                           autocomplete="none" pattern=".{8,80}" value="" />
-                </td>
-            </tr>
-            </tr>
-            <tr>
-                <td><strong>{{ 'Current Password to Authorize Changes'|xlt }}</strong></td>
-                <td>
+        <div class="row no-gutters">
+            <div class="col-12 card">
+                <div class="card-header">
+                    <h5 class="text-center">{{ "Account Password"|xlt }}  <i class="fa fa-info-circle text-info" title="{{ "Your password is case sensitive"|xla }}"></i></h5>
+                </div>
+                <div class="card-body">
+
+                    <div class="row mb-2">
+                        <div class="col-md-3 col-12">
+                            <strong>{{ 'Change Password'|xlt }}</strong>
+                        </div>
+                        <div class="col-md-9 col-12">
+                            <input class="form-control" name="pass_new" id="pass_new" type="password" required
+                                   placeholder=""
+                                   title="{{ 'You must enter a new or reenter current password to keep it. Even for Username change.'|xla }}"
+                                   pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}" />
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-3 col-12">
+                            <strong>{{ 'Confirm Password'|xlt }}</strong>
+                        </div>
+                        <div class="col-md-9 col-12">
+                            <input class="form-control" name="pass_new_confirm" id="pass_new_confirm" type="password"
+                                   pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}" autocomplete="none" />
+                        </div>
+                        <div class="col-12 col-md-9 offset-md-3 font-italic">
+                            {{ "Password must be at least 8 characters with at least one uppercase,one lowercase,and one number."|xlt}}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="row mt-2">
+            <div class="col-12">
+                <div class="alert alert-danger">
+                    {# it looks nicer just to have the text be in the input but screen-readers won't display placeholder text reliably #}
+                    <h6 class="font-weight-bold"><i class="fa fa-triangle-exclamation"></i> {{ 'Enter your current password to authorize these changes'|xlt }}</h6>
+                    {# Note we don't via JS validate the current password just in case security requirements have changed #}
                     <input class="form-control" name="pass_current" id="pass_current" type="password" required
-                           placeholder="{{ 'Enter your current password used to login.'|xla }}"
-                           title="{{ 'Enter your existing current password used to login.'|xla }}"
-                           pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}" />
-                </td>
-            </tr>
-            <tr>
-                <td><strong>{{ 'Change or Keep Existing Password'|xlt }}</strong></td>
-                <td>
-                    <input class="form-control" name="pass_new" id="pass_new" type="password" required
-                           placeholder="{{ 'Minimum length is 8 with upper,lowercase,numbers mix'|xla }}"
-                           title="{{ 'You must enter a new or reenter current password to keep it. Even for Username change.'|xla }}"
-                           pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}" />
-                </td>
-            </tr>
-            <tr>
-                <td><strong>{{ 'Confirm Password'|xlt }}</strong></td>
-                <td>
-                    <input class="form-control" name="pass_new_confirm" id="pass_new_confirm" type="password"
-                           pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}" autocomplete="none" />
-                </td>
-            </tr>
-            <tr>
-                <td colspan="2"><br /><input class="btn btn-primary float-right" type="submit" name="submit" value="{{ 'Save'|xla }}" /></td>
-            </tr>
-        </table>
-        <div><strong>{{ '* ' ~ 'All credential fields are case sensitive!'|xlt }}</strong></div>
+                           placeholder="{{ 'Current password'|xla }}"
+                           title="{{ 'Enter your existing current password used to login.'|xla }}" />
+                </div>
+            </div>
+        </div>
+        <div class="row mb-2">
+            <div class="col-12">
+                <input class="btn btn-primary" type="submit" name="submit" value="{{ 'Save'|xla }}" />
+            </div>
+        </div>
+        <div class="row no-gutters">
+            <details class="col-12 alert alert-info">
+                <summary class="h5 text-center"><span class="btn-link">{{ "Help"|xlt }}</span> <i class="fa fa-info-circle fa"></i></summary>
+                <div class="container-fluid">
+                    <div clas="row">
+                        <div class="col-12">
+                            <p>{{ 'Use this form to change your login Password, Username or Both.'|xlt }}</p>
+                            <p>{{ 'For example, to change your current Password, enter and use your current Username and enter new Password. You must still confirm Password and Username regardless.'|xlt }}</p>
+                        </div>
+                    </div>
+                    <div class="row mb-2">
+                        <div class="col-12">
+                            {{ "For additional questions you can contact your healthcare support staff."|xlt }}
+                            {{ "The following fields can be used to help your support staff locate your account."|xlt }}
+                        </div>
+                    </div>
+                    <div class="row mb-2">
+                        <div class="col-md-4 col-12">
+                            <strong>{{ 'Portal Account ID for reference'|xlt }}</strong>
+                        </div>
+                        <div class="col-md-8 col-12">
+                            <input class="form-control" name="uname" id="uname" type="text" readonly
+                                   value="{{ auth.portal_username|attr }}" />
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-4 col-12">
+                            <strong>{{ 'Patient Identifier'|xlt }} (pid)</strong>
+                        </div>
+                        <div class="col-md-8 col-12">
+                            <input class="form-control" name="pid" id="pid" type="text" readonly
+                                   value="{{ pid|attr }}" />
+                        </div>
+                    </div>
+                </div>
+            </details>
+        </div>
     </form>
 </div><!-- container -->
 </body>

--- a/templates/portal/portal-credentials-settings.html.twig
+++ b/templates/portal/portal-credentials-settings.html.twig
@@ -174,7 +174,7 @@
                         <div class="col-md-9 col-12">
                             <input class="form-control" name="pass_new" id="pass_new" type="password"
                                    placeholder=""
-                                   title="{{ 'You must enter a new or reenter current password to keep it. Even for Username change.'|xla }}"
+                                   title="{{ 'Password must be at least 8 characters with at least one uppercase,one lowercase,and one number.'|xla }}"
                                    pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}" />
                         </div>
                     </div>


### PR DESCRIPTION
Fixes #7650.

Twigified the update credentials page.  Improved the UX and made the username/password updates be independent of each other.

Page now looks like this:
![image](https://github.com/user-attachments/assets/b1ae190b-c1e1-48a3-8d60-1a8a5a17fdf2)


Also added some help instructions as well.