### PR TITLE
Fixes #7654 see appointments availability

### DIFF
--- a/portal/add_edit_event_user.php
+++ b/portal/add_edit_event_user.php
@@ -737,7 +737,7 @@ if ($userid) {
                             ?>
                         </select>
                         <div class="text-right">
-                            <input type='button' class='btn btn-success' value='<?php echo xla('Openings'); ?>' onclick='find_available()' />
+                            <input type='button' class='btn btn-success' value='<?php echo xla('See Availability'); ?>' onclick='find_available()' />
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
This fixes #7654 changes the verbiage Openings to be "See Availability" to make it more clear to both US and EU audiences of what this button does.