### PR TITLE
if allow_patient_portal is YES set portal login user name if necessary

### DIFF
--- a/src/Services/PatientService.php
+++ b/src/Services/PatientService.php
@@ -245,7 +245,20 @@ class PatientService extends BaseService
             // need to save off our care team
             $this->saveCareTeamHistory($data, $dataBeforeUpdate['care_team_provider'], $dataBeforeUpdate['care_team_facility']);
         }
-
+        // RM if  'allow_patient_portal' is YES, make sure portal login username has been created
+        if ($data['allow_patient_portal'] == 'YES' ) {
+            // we're about to set it to YES, so make sure credentials have been created
+            $sql = "SELECT portal_login_username, portal_username FROM patient_access_onsite WHERE pid = ?";
+            $sqlget = sqlStatement($sql, $data['pid']);
+            $names = sqlFetchArray($sqlget);
+            if ($names['portal_login_username'] == ""){
+                //RM - create a portal login username, as it's empty at the moment - use Account Name - portal_username in db
+                $sql =  "UPDATE patient_access_onsite SET portal_login_username = ?  WHERE pid = ?";
+                $update_parameters ['portal_login_username'] = $names['portal_username'];
+                $update_parameters ['pid'] = $data['pid'];
+                $sqlres = sqlStatement($sql,$update_parameters);
+            }
+        }
         if ($sqlResult) {
             // Tell subscribers that a new patient has been updated
             $patientUpdatedEvent = new PatientUpdatedEvent($dataBeforeUpdate, $data);


### PR DESCRIPTION
 if allow_patient_portal is YES check 'portal login user name' - if not already set - set it to 'portal user name' - otherwise it can get stuck empty, i.e. one can't give it a value.

Fixes #7643

#### Short description of what this resolves:
if portal login user name is empty it can get stuck with no value, and no way to enter a value, under some undefined conditions. 

#### Changes proposed in this pull request:
when the demographic form is saved, check if 'allow patient portal' has the value 'YES', and if so check that 'portal login user name' has a value and if not set it to the same string as 'portal user name' 