### PR TITLE
Fix type error in add_edit_lot file

### DIFF
--- a/interface/drugs/add_edit_lot.php
+++ b/interface/drugs/add_edit_lot.php
@@ -128,8 +128,8 @@ function genWarehouseList($tag_name, $currvalue, $title, $class = '')
     return $count;
 }
 
-$drug_id = $_REQUEST['drug'] + 0;
-$lot_id  = $_REQUEST['lot'] + 0;
+$drug_id = (int)$_REQUEST['drug'];
+$lot_id  = (int)$_REQUEST['lot'];
 $info_msg = "";
 
 $form_trans_type = intval(isset($_POST['form_trans_type']) ? $_POST['form_trans_type'] : '0');


### PR DESCRIPTION

Fixes #7304

#### Short description of what this resolves:
Fix type casting error in add_edit_lot.php file.

#### Changes proposed in this pull request:
Add type casting for $drug_id and $lot_id on line 131 and 132 and removed the "+ 0"