### PR TITLE
display correct name when 'choices' group name is changed

### DIFF
--- a/src/Common/Twig/TwigExtension.php
+++ b/src/Common/Twig/TwigExtension.php
@@ -327,6 +327,12 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
                 }
             ),
             new TwigFilter(
+                'xlLayoutLabel',
+                function ($string) {
+                    return xl_layout_label($string);
+                }
+            ),
+            new TwigFilter(
                 'xlListLabel',
                 function ($string) {
                     return xl_list_label($string);

--- a/src/Patient/Cards/PortalCard.php
+++ b/src/Patient/Cards/PortalCard.php
@@ -64,16 +64,16 @@ class PortalCard extends CardModel
         $this->opts['templateVariables']['appendedInjection'] = $dispatchResult->getAppendedInjection();
     }
 
-    // used in portal.html.twig and card_base.html.twig
+    // used in twigs
     private function setOpts()
     {
         global $GLOBALS;
         global $pid;
         // RM get name for 'choices' group, i.e. group 4 in 'layout_gropu_properties' table in db
         $sql = "SELECT grp_title FROM layout_group_properties WHERE grp_group_id = 4 AND grp_form_id = 'DEM'";
-        $res = sqlStatement ($sql);
+        $res = sqlStatement($sql);
         $nrow = sqlFetchArray($res);
-        $groupName = ($nrow['grp_title']  !=='' ? $nrow['grp_title'] : 'Choices');
+        $groupName = ($nrow['grp_title']  !== '' ? $nrow['grp_title'] : 'Choices');
 
         $this->opts = [
             'acl' => ['patients', 'demo'],

--- a/src/Patient/Cards/PortalCard.php
+++ b/src/Patient/Cards/PortalCard.php
@@ -85,7 +85,7 @@ class PortalCard extends CardModel
             'identifier' => self::CARD_ID,
             'title' => xl('Patient Portal') . ' / ' . xl('API Access'),
             'templateVariables' => [
-                'allowpp' => (xl('Allow Patient Portal in Demographics') . ' ' . xl_layout_label($groupName)),
+               'allowpp' => $groupName,
                 'isPortalEnabled' => isPortalEnabled(),
                 'isPortalSiteAddressValid' => isPortalSiteAddressValid(),
                 'isPortalAllowed' => isPortalAllowed($pid),

--- a/src/Patient/Cards/PortalCard.php
+++ b/src/Patient/Cards/PortalCard.php
@@ -64,10 +64,17 @@ class PortalCard extends CardModel
         $this->opts['templateVariables']['appendedInjection'] = $dispatchResult->getAppendedInjection();
     }
 
+    // used in portal.html.twig and card_base.html.twig
     private function setOpts()
     {
         global $GLOBALS;
         global $pid;
+        // RM get name for 'choices' group, i.e. group 4 in 'layout_gropu_properties' table in db
+        $sql = "SELECT grp_title FROM layout_group_properties WHERE grp_group_id = 4 AND grp_form_id = 'DEM'";
+        $res = sqlStatement ($sql);
+        $nrow = sqlFetchArray($res);
+        $groupName = ($nrow['grp_title']  !=='' ? $nrow['grp_title'] : 'Choices');
+
         $this->opts = [
             'acl' => ['patients', 'demo'],
             'initiallyCollapsed' => (getUserSetting(self::CARD_ID . '_expand') == 0),
@@ -78,6 +85,7 @@ class PortalCard extends CardModel
             'identifier' => self::CARD_ID,
             'title' => xl('Patient Portal') . ' / ' . xl('API Access'),
             'templateVariables' => [
+                'allowpp' => xl('Allow Patient Portal in Demographics ' . $groupName),
                 'isPortalEnabled' => isPortalEnabled(),
                 'isPortalSiteAddressValid' => isPortalSiteAddressValid(),
                 'isPortalAllowed' => isPortalAllowed($pid),

--- a/src/Patient/Cards/PortalCard.php
+++ b/src/Patient/Cards/PortalCard.php
@@ -85,7 +85,7 @@ class PortalCard extends CardModel
             'identifier' => self::CARD_ID,
             'title' => xl('Patient Portal') . ' / ' . xl('API Access'),
             'templateVariables' => [
-                'allowpp' => xl('Allow Patient Portal in Demographics ' . $groupName),
+                'allowpp' => (xl('Allow Patient Portal in Demographics') . ' ' . xl_layout_label($groupName)),
                 'isPortalEnabled' => isPortalEnabled(),
                 'isPortalSiteAddressValid' => isPortalSiteAddressValid(),
                 'isPortalAllowed' => isPortalAllowed($pid),

--- a/templates/patient/partials/portal.html.twig
+++ b/templates/patient/partials/portal.html.twig
@@ -33,7 +33,7 @@ The Patient Portal card for the Medical Record Dashboard
     {% if isPortalAllowed == false %}
         <div class="alert alert-warning" role="alert">
             <p class="font-weight-bold">{{  "Portal Access"|xlt }}</p>
-            <p> {{ allowpp }} </p>
+            <p> {{ "Allow Patient Portal in Demographic"|xlt }} {{ allowpp|xlLayoutLabel|text }} </p>
         </div>
     {% elseif isContactEmail == false and isEnforceSigninEmailPortal == true %}
             <div class="alert alert-warning" role="alert">

--- a/templates/patient/partials/portal.html.twig
+++ b/templates/patient/partials/portal.html.twig
@@ -33,7 +33,7 @@ The Patient Portal card for the Medical Record Dashboard
     {% if isPortalAllowed == false %}
         <div class="alert alert-warning" role="alert">
             <p class="font-weight-bold">{{  "Portal Access"|xlt }}</p>
-            <p> {{ "Allow Patient Portal in Demographics Choices."|xlt }} </p>
+            <p> {{ allowpp }} </p>
         </div>
     {% elseif isContactEmail == false and isEnforceSigninEmailPortal == true %}
             <div class="alert alert-warning" role="alert">


### PR DESCRIPTION
 
Fixes #7670

#### Short description of what this resolves:
patient portal card on dashboard mentions 'demographics choices' even if the group has been renamed to something other than choices 

#### Changes proposed in this pull request:
PostalCard.php now looks for the group's name (group 4) in the db and uses the new name - or reverts to 'Choices' if the group name is not returned