### PR TITLE
Add payor information for FHIR Coverage Endpoint

### DIFF
--- a/src/Services/InsuranceService.php
+++ b/src/Services/InsuranceService.php
@@ -74,12 +74,25 @@ class InsuranceService extends BaseService
     public function search($search, $isAndCondition = true)
     {
         $sql = "SELECT `insurance_data`.*,
-                       `puuid`
+                       `puuid`,
+                       `insureruuid`
                 FROM `insurance_data`
                 LEFT JOIN (
                     SELECT
+                    CONCAT_WS('-',
+                        HEX(SUBSTRING(`uuid`, 1, 4)),
+                        HEX(SUBSTRING(`uuid`, 5, 2)),
+                        HEX(SUBSTRING(`uuid`, 7, 2)),
+                        HEX(SUBSTRING(`uuid`, 9, 2)),
+                        HEX(SUBSTRING(`uuid`, 11, 6))
+                    ) AS `insureruuid`,
+                    `id` AS `insurerid`
+                    FROM `insurance_companies` 
+                    ) `insurance_company_data` ON `insurance_data`.`provider` = `insurance_company_data`.`insurerid` 
+                LEFT JOIN (
+                    SELECT
                     `pid` AS `patient_data_pid`,
-                    `uuid` as `puuid`
+                    `uuid` AS `puuid`
                     FROM `patient_data`
                 ) `patient_data` ON `insurance_data`.`pid` = `patient_data`.`patient_data_pid` ";
 

--- a/src/Services/InsuranceService.php
+++ b/src/Services/InsuranceService.php
@@ -57,7 +57,7 @@ class InsuranceService extends BaseService
 
     public function getUuidFields(): array
     {
-        return ['uuid', 'puuid'];
+        return ['uuid', 'puuid', 'insureruuid'];
     }
 
     public function validate($data)
@@ -79,13 +79,7 @@ class InsuranceService extends BaseService
                 FROM `insurance_data`
                 LEFT JOIN (
                     SELECT
-                    CONCAT_WS('-',
-                        HEX(SUBSTRING(`uuid`, 1, 4)),
-                        HEX(SUBSTRING(`uuid`, 5, 2)),
-                        HEX(SUBSTRING(`uuid`, 7, 2)),
-                        HEX(SUBSTRING(`uuid`, 9, 2)),
-                        HEX(SUBSTRING(`uuid`, 11, 6))
-                    ) AS `insureruuid`,
+                    `uuid` AS `insureruuid`,
                     `id` AS `insurerid`
                     FROM `insurance_companies` 
                     ) `insurance_company_data` ON `insurance_data`.`provider` = `insurance_company_data`.`insurerid` 


### PR DESCRIPTION
Fixes #7684 

#### Short description of what this resolves:
This PR simply adds to the query when searching for coverage to actually pull the associated `insurance_companies` entity, if present.
