### PR TITLE
Feat openemr fix #7699 #7698 setup header

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -7,10 +7,20 @@
 # assets: Top-level key name (Required)
 #     asset-short-name: Short name
 #         basePath: %assets_static_relative%/full/path/to/deepest/common/file
-#         script: null filename or null
+#         script: null filename or null or array of filenames or array of objects
 #         link: jquery-ui.min.css filename or null
 #         autoload: true (defaults to false)
 #         loadInFile: relative path to file, load always in specific file (defaults to false) for custom assets.
+
+# Example scripts config can be in the following format
+# script: null
+# script: filename.js
+# script: - filename1.js
+#         - filename2.js
+# script: - src: filename1.js
+#           type: module
+#         - src: filename2.js
+#           type: text/javascript
 assets:
     jquery:
         basePath: '%assets_static_relative%/jquery/dist/'
@@ -274,3 +284,31 @@ assets:
     dompurify:
         basePath: '%assets_static_relative%/'
         script: dompurify/dist/purify.js
+    questionnaires:
+        basePath: '%webroot%/interface/forms/questionnaire_assessments/'
+        script:
+            - src: lforms/webcomponent/assets/lib/zone.min.js
+              type: module
+            - src: lforms/webcomponent/runtime.js
+              type: module
+            - src: lforms/webcomponent/polyfills.js
+              type: module
+            - src: lforms/webcomponent/main.js
+              type: module
+            - src: lforms/fhir/R4/lformsFHIR.min.js
+              type: module
+        link: /assets/styles/styles_openemr_lforms.css
+    questionnaires-lform:
+        basePath: '%webroot%/interface/forms/questionnaire_assessments/'
+        script:
+            -   src: lforms/webcomponent/assets/lib/zone.min.js
+                type: module
+            -   src: lforms/webcomponent/runtime.js
+                type: module
+            -   src: lforms/webcomponent/polyfills.js
+                type: module
+            -   src: lforms/webcomponent/main.js
+                type: module
+            -   src: lforms/fhir/R4/lformsFHIR.min.js
+                type: module
+        link: /assets/styles/styles_openemr_lforms.css


### PR DESCRIPTION
Made it so the config.yaml file can now have an object syntax to specify
additional attributes to add to the script tag such as the type syntax
that will be output in the HTML.

Fixes https://github.com/openemr/openemr/issues/7698

Added the questionnaire and questionnaire-lforms configuration option
that can be used in the setupHeader syntax to be able to embed
questionnaires into the form.

Fixes https://github.com/openemr/openemr/issues/7699

This work allows the questionnaire to be embedded in the setupHeader twig function
```
{% block header %}
    {{ setupHeader(['questionnaires']) }}
{% endblock %}
```

Then the questionnaire can be rendered in the twig fairly easily:
```
{% block contents %}
   <div id="formContainer"></div>
   <div class="container-fluid">
        <div class="row">
            <div class="col-12">
                <button id="saveBtn" class="btn btn-primary">{{ "Save"|xlt }}</button>
            </div>
        </div>
    </div>
    <script>
        let questionnaire = {{ questionnaire|json_encode|raw }};
        document.addEventListener('DOMContentLoaded', function() {
            if (!LForms) {
                console.error('LForms is not loaded');
                return;
            } else {
                console.log('LForms is loaded');
                console.log("questionnaire is ", questionnaire);
            }
            LForms.Util.addFormToPage(questionnaire, 'formContainer');

            document.getElementById('saveBtn').addEventListener('click', function() {
                let form = LForms.Util.getFormFHIRData('QuestionnaireResponse', 'R4');
                console.log('form data is ', form);
            });
        });
    </script>
{% endblock %}
```