### PR TITLE
Fixes #7707, #7708 health snapshot, custom report

### DIFF
--- a/interface/patient_file/report/patient_report.php
+++ b/interface/patient_file/report/patient_report.php
@@ -2,6 +2,8 @@
 
 /**
  * Patient report
+ * TODO: Note that this file can be refactored to re-use shared code with the portal_patient_report.php file
+ * that file has been refactored to use twig templates and this file could be reworked to re-use much of that code
  *
  * @package   OpenEMR
  * @link      http://www.open-emr.org

--- a/interface/super/edit_globals.php
+++ b/interface/super/edit_globals.php
@@ -498,7 +498,7 @@ $apiUrl = $serverConfig->getInternalBaseApiUrl();
                                             }
                                             if ($fldtype == GlobalSetting::DATA_TYPE_HTML_DISPLAY_SECTION) {
                                                 // if the field is an html display box we want to take over the entire real estate so we will continue from here.
-                                                include_once 'templates/field_html_display_section.php';
+                                                include 'templates/field_html_display_section.php';
                                                 ++$i; // make sure we advance the iterator here...
                                                 continue;
                                             }

--- a/portal/home.php
+++ b/portal/home.php
@@ -31,6 +31,8 @@ use OpenEMR\Services\Utils\TranslationService;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
 use Twig\Error\SyntaxError;
+use OpenEMR\Events\PatientReport\PatientReportFilterEvent;
+use OpenEMR\Common\Logging\SystemLogger;
 
 if (isset($_SESSION['register']) && $_SESSION['register'] === true) {
     require_once(__DIR__ . '/../src/Common/Session/SessionUtil.php');
@@ -312,7 +314,14 @@ $styleArray = collectStyles();
 // Render Home Page
 $twig = (new TwigContainer('', $GLOBALS['kernel']))->getTwig();
 try {
-    echo $twig->render('portal/home.html.twig', [
+    $healthSnapshot = [
+        'immunizationRecords' => $immunRecords,
+        'patientID' => $pid
+    ];
+    $patientReportEvent = new PatientReportFilterEvent();
+    $patientReportEvent->setDataElement('healthSnapshot', $healthSnapshot);
+    $filteredEvent = $GLOBALS['kernel']->getEventDispatcher()->dispatch($patientReportEvent, PatientReportFilterEvent::FILTER_PORTAL_HEALTHSNAPSHOT_TWIG_DATA);
+    $data = [
         'user' => $user,
         'whereto' => $_SESSION['whereto'] ?? null ?: ($whereto ?? '#quickstart-card'),
         'result' => $result,
@@ -352,7 +361,7 @@ try {
         'styleArray' => $styleArray,
         'ccdaOk' => $ccdaOk,
         'allow_custom_report' => $GLOBALS['allow_custom_report'] ?? '0',
-        'immunRecords' => $immunRecords,
+        'healthSnapshot' => $filteredEvent->getDataElement('healthSnapshot'),
         'languageDirection' => $_SESSION['language_direction'] ?? 'ltr',
         'dateDisplayFormat' => $GLOBALS['date_display_format'],
         'timezone' => $GLOBALS['gbl_time_zone'] ?? '',
@@ -363,8 +372,13 @@ try {
             'dashboardInjectCard' => RenderEvent::EVENT_DASHBOARD_INJECT_CARD,
             'dashboardRenderScripts' => RenderEvent::EVENT_DASHBOARD_RENDER_SCRIPTS
         ]
-    ]);
+    ];
+
+    echo $twig->render('portal/home.html.twig', $data);
 } catch (LoaderError | RuntimeError | SyntaxError $e) {
     OpenEMR\Common\Session\SessionUtil::portalSessionCookieDestroy();
+    if ($e instanceof SyntaxError) {
+        (new SystemLogger())->error($e->getMessage(), ['file' => $e->getFile(), 'trace' => $e->getTraceAsString()]);
+    }
     die(text($e->getMessage()));
 }

--- a/portal/home.php
+++ b/portal/home.php
@@ -24,15 +24,15 @@ require_once(__DIR__ . '/../library/appointments.inc.php');
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Events\PatientPortal\AppointmentFilterEvent;
+use OpenEMR\Events\PatientReport\PatientReportFilterEvent;
 use OpenEMR\Events\PatientPortal\RenderEvent;
 use OpenEMR\Services\LogoService;
 use OpenEMR\Services\Utils\TranslationService;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
 use Twig\Error\SyntaxError;
-use OpenEMR\Events\PatientReport\PatientReportFilterEvent;
-use OpenEMR\Common\Logging\SystemLogger;
 
 if (isset($_SESSION['register']) && $_SESSION['register'] === true) {
     require_once(__DIR__ . '/../src/Common/Session/SessionUtil.php');

--- a/portal/report/portal_patient_report.php
+++ b/portal/report/portal_patient_report.php
@@ -131,12 +131,10 @@ try {
     $updatedEvent = $GLOBALS['kernel']->getEventDispatcher()->dispatch($event, PatientReportFilterEvent::FILTER_PORTAL_TWIG_DATA);
     $updatedData  = $event->getDataAsArray();
     echo $twig->render("portal/portal_patient_report.html.twig", $updatedData);
-}
-catch (SyntaxError $exception) {
+} catch (SyntaxError $exception) {
     (new SystemLogger())->error($exception->getMessage(), ['trace' => $exception->getTraceAsString(), 'file' => $exception->getFile()]);
     echo $twig->render("error/general_http_error.html.twig", []);
-}
-catch (\Exception $exception) {
+} catch (\Exception $exception) {
     (new SystemLogger())->error($exception->getMessage(), ['trace' => $exception->getTraceAsString()]);
     echo $twig->render("error/general_http_error.html.twig", []);
 }

--- a/portal/report/portal_patient_report.php
+++ b/portal/report/portal_patient_report.php
@@ -42,8 +42,8 @@ require_once("$srcdir/patient.inc.php");
 
 use OpenEMR\Core\Header;
 use OpenEMR\Common\Logging\SystemLogger;
-use OpenEMR\Controllers\Portal\PortalPatientReportController;
 use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\Controllers\Portal\PortalPatientReportController;
 use OpenEMR\Events\PatientReport\PatientReportFilterEvent;
 use Twig\Error\SyntaxError;
 

--- a/portal/report/portal_patient_report.php
+++ b/portal/report/portal_patient_report.php
@@ -7,8 +7,10 @@
  * @link      https://www.open-emr.org
  * @author    Jerry Padgett <sjpadgett@gmail.com>
  * @author    Brady Miller <brady@sparmy.com>
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
  * @copyright Copyright (c) 2016-2020 Jerry Padgett <sjpadgett@gmail.com>
  * @copyright Copyright (c) 2019 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (C) 2024 Open Plan IT Ltd. <support@openplanit.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -39,6 +41,11 @@ require_once("$srcdir/forms.inc.php");
 require_once("$srcdir/patient.inc.php");
 
 use OpenEMR\Core\Header;
+use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Controllers\Portal\PortalPatientReportController;
+use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\Events\PatientReport\PatientReportFilterEvent;
+use Twig\Error\SyntaxError;
 
 // get various authorization levels
 $auth_notes_a = true; //AclMain::aclCheckCore('encounters', 'notes_a');
@@ -50,733 +57,87 @@ $auth_med = true; //AclMain::aclCheckCore('patients'  , 'med');
 $auth_demo = true; //AclMain::aclCheckCore('patients'  , 'demo');
 
 $ignoreAuth_onsite_portal = true;
-?>
 
-<?php Header::setupAssets('textformat'); ?>
-
-<style>
-    input[type="checkbox"],
-    input[type="radio"] {
-        margin: 0 5px 5px;
-        line-height: normal;
-    }
-
-    #patient_reports {
-        width: 100%;
-    }
-
-    #patient_reports .issues {
-        padding-right: 30px;
-    }
-
-    #patient_reports .issues table {
-        margin: 10px 0 10px 0;
-    }
-
-    #patient_reports .issues td {
-        padding: 2px;
-    }
-
-    #patient_reports .encounters td {
-        padding: 2px;
-    }
-
-    #patient_reports .encounter_forms {
-        margin: 5px 15px 5px 15px;
-    }
-
-    #patient_reports td {
-        vertical-align: top;
-    }
-
-    #patient_reports ul {
-        list-style: none;
-    }
-
-    /*=============================================================
-    * Report - Custom
-    * seen as the patient report (portal_custom_report.php)
-    *============================================================*/
-    #report_custom {
-        width: 100%;
-    }
-
-    #report_custom hr {
-        border: 2px dotted #000;
-    }
-
-    #report_custom .billing {
-        margin: 5px;
-        padding: 5px;
-    }
-
-    #report_custom h1 {
-        font-size: 120%;
-        margin: 0 0 5px 0;
-        padding: 0;
-    }
-
-    #report_custom .immunizations {
-        margin: 5px;
-        padding: 5px;
-    }
-
-    #report_custom .notes {
-        margin: 5px;
-        padding: 5px;
-    }
-
-    #report_custom .transactions {
-        margin: 5px;
-        padding: 5px;
-    }
-
-    #report_custom .communications {
-        margin: 5px;
-        padding: 5px;
-    }
-
-    #report_custom .documents {
-        margin: 5px;
-        padding: 5px;
-    }
-
-    #report_custom .demographics {
-        margin: 5px;
-        padding: 5px;
-    }
-
-    #report_custom .insurance {
-        margin: 5px;
-        padding: 5px;
-    }
-
-    #report_custom .history {
-        margin: 5px;
-        padding: 5px;
-    }
-
-    #report_custom .issue {
-        margin-left: 20px;
-    }
-
-    #report_custom .issue_type {
-        font-weight: bold;
-        padding: 5px 0 5px 0;
-    }
-
-    #report_custom .issue_diag {
-        margin: 0 20px 0 20px;
-    }
-
-    #report_custom .encounter {
-        width: 100%;
-        border-top: 2px dotted #000;
-        padding: 10px 5px 10px 5px;
-        margin-top: 10px;
-    }
-
-    #report_custom .encounter h1 {
-        font-size: 140%;
-        margin: 0;
-        padding: 0;
-    }
-
-    #report_custom .encounter_form {
-        margin: 10px;
-        padding: 10px;
-        border-top: 1px solid #808080;
-    }
-
-    #addressbook_list tr.evenrow {
-        background-color: #ddddff;
-    }
-
-    #addressbook_list tr.oddrow {
-        background-color: #ffffff;
-    }
-
-    tr.odd,
-    td.even {
-        background-color: #ffffff !important;
-    }
-</style>
-<script>
-    function checkAll(check) {
-        var f = document.forms['report_form'];
-        for (var i = 0; i < f.elements.length; ++i) {
-            if (f.elements[i].type == 'checkbox') f.elements[i].checked = check;
-        }
-        return false;
-    }
-
-    function show_date_fun() {
-        if (document.getElementById('show_date').checked == true) {
-            document.getElementById('date_div').style.display = '';
-        } else {
-            document.getElementById('date_div').style.display = 'none';
-        }
-        return;
-    }
-
-    var mypcc = <?php echo js_escape($GLOBALS['phone_country_code']); ?>;
-</script>
-
-<body class="body_top">
-    <div id="patient_reports"> <!-- large outer DIV -->
-        <form name='report_form' id="report_form" method='post' action='./report/portal_custom_report.php'>
-            <span class='card-heading'><?php echo xlt('Patient Report'); ?></span>&nbsp;&nbsp;
-            <a class="link_submit" href="#" onclick="return checkAll(true)"><?php echo xlt('Check All'); ?></a>
-            |
-            <a class="link_submit" href="#" onclick="return checkAll(false)"><?php echo xlt('Clear All'); ?></a>
-            <p>
-            <table class="table includes">
-                <tr>
-                    <td class='text'>
-                        <input type='checkbox' name='include_demographics' id='include_demographics' value="demographics" checked><?php echo xlt('Demographics'); ?><br />
-                        <input type='checkbox' name='include_history' id='include_history' value="history"><?php echo xlt('History'); ?><br />
-                        <input type='checkbox' name='include_insurance' id='include_insurance' value="insurance"><?php echo xlt('Insurance'); ?><br />
-                        <input type='checkbox' name='include_billing' id='include_billing' value="billing"
-                            <?php if (!$GLOBALS['simplified_demographics']) {
-                                echo 'checked';
-                            } ?>><?php echo xlt('Billing'); ?><br />
-                    </td>
-                    <td class='text'>
-
-                        <input type='checkbox' name='include_allergies' id='include_allergies' value="allergies">Allergies<br />
-                        <input type='checkbox' name='include_medications' id='include_medications' value="medications">Medications<br />
-
-                        <input type='checkbox' name='include_immunizations' id='include_immunizations' value="immunizations"><?php echo xlt('Immunizations'); ?><br />
-
-                        <input type='checkbox' name='include_medical_problems' id='include_medical_problems' value="medical_problems">Medical Problems<br />
-
-                        <input type='checkbox' name='include_notes' id='include_notes' value="notes"><?php echo xlt('Patient Notes'); ?><br />
-                        <input type='checkbox' name='include_transactions' id='include_transactions' value="transactions"><?php echo xlt('Transactions'); ?><br />
-                        <input type='checkbox' name='include_batchcom' id='include_batchcom' value="batchcom"><?php echo xlt('Communications'); ?><br />
-                    </td>
-                </tr>
-            </table>
-
-            <input type='hidden' name='pdf' value='0'>
-            <br />
-            <table class="issues_encounters_forms table">
-                <tr>
-                    <!-- Issues -->
-                    <td class='text'>
-                        <div class="issues">
-                            <span class='bold'><?php echo xlt('Issues'); ?>:</span>
-                            <br />
-                            <br />
-
-                            <table>
-
-                                <?php
-                                // get issues
-                                $pres = sqlStatement("SELECT * FROM lists WHERE pid = ? " .
-                                    "ORDER BY type, begdate", [$pid]);
-                                $lasttype = "";
-                                while ($prow = sqlFetchArray($pres)) {
-                                    if ($lasttype != $prow['type']) {
-                                        $lasttype = $prow['type'];
-
-                                        /****
-                                         * $disptype = $lasttype;
-                                         * switch ($lasttype) {
-                                         * case "allergy"        : $disptype = "Allergies"       ; break;
-                                         * case "problem"        :
-                                         * case "medical_problem": $disptype = "Medical Problems"; break;
-                                         * case "medication"     : $disptype = "Medications"     ; break;
-                                         * case "surgery"        : $disptype = "Surgeries"       ; break;
-                                         * }
-                                         ****/
-                                        $disptype = $ISSUE_TYPES[$lasttype][0];
-
-                                        echo " <tr>\n";
-                                        echo "  <td colspan='4' class='bold'><b>" . text($disptype) . "</b></td>\n";
-                                        echo " </tr>\n";
-                                    }
-
-                                    $rowid = $prow['id'];
-                                    $disptitle = trim($prow['title']) ? $prow['title'] : "[Missing Title]";
-
-                                    $ieres = sqlStatement("SELECT encounter FROM issue_encounter WHERE " .
-                                        "pid = ? AND list_id = ?", [$pid, $rowid]);
-
-                                    echo "    <tr class='text'>\n";
-                                    echo "     <td>&nbsp;</td>\n";
-                                    echo "     <td>";
-                                    echo "<input type='checkbox' name='issue_" . attr($rowid) . "' id='issue_" . attr($rowid) . "' class='issuecheckbox' value='/";
-                                    while ($ierow = sqlFetchArray($ieres)) {
-                                        echo text($ierow['encounter']) . "/";
-                                    }
-
-                                    echo "' />" . text($disptitle) . "</td>\n";
-                                    echo "     <td>" . text($prow['begdate']);
-
-                                    if ($prow['enddate']) {
-                                        echo " - " . text($prow['enddate']);
-                                    } else {
-                                        echo " Active";
-                                    }
-                                    echo "</td>\n";
-                                    echo "</tr>\n";
-                                }
-                                ?>
-                            </table>
-                            <?php //endif; // end of Issues output ?>
-                        </div> <!-- end issues DIV -->
-                    </td>
-                    <!-- Encounters and Forms -->
-                    <td class='text'>
-                        <div class='encounters'>
-                            <span class='bold'><?php echo xlt('Encounters & Forms'); ?>:</span>
-                            <br /><br />
-
-                            <?php if (!($auth_notes_a || $auth_notes || $auth_coding_a || $auth_coding || $auth_med || $auth_relaxed)) : ?>
-                                (Encounters not authorized)
-                            <?php else : ?>
-                                <?php
-
-                                $isfirst = 1;
-                                $res = sqlStatement("SELECT forms.encounter, forms.form_id, forms.form_name, " .
-                                    "forms.formdir, forms.date AS fdate, form_encounter.date " .
-                                    ",form_encounter.reason " .
-                                    "FROM forms, form_encounter WHERE " .
-                                    "forms.pid = ? AND form_encounter.pid = ? AND " .
-                                    "form_encounter.encounter = forms.encounter " .
-                                    " AND forms.deleted=0 " . // --JRM--
-                                    "ORDER BY form_encounter.date DESC, fdate ASC", [$pid, $pid]);
-                                $res2 = sqlStatement("SELECT name FROM registry ORDER BY priority");
-                                $html_strings = array();
-                                $registry_form_name = array();
-                                while ($result2 = sqlFetchArray($res2)) {
-                                    array_push($registry_form_name, trim($result2['name']));
-                                }
-
-                                while ($result = sqlFetchArray($res)) {
-                                    if ($result["form_name"] == "New Patient Encounter") {
-                                        if ($isfirst == 0) {
-                                            foreach ($registry_form_name as $var) {
-                                                if ($toprint = ($html_strings[$var] ?? '')) {
-                                                    foreach ($toprint as $var) {
-                                                        print $var;
-                                                    }
-                                                }
-                                            }
-
-                                            $html_strings = array();
-                                            echo "</div>\n"; // end DIV encounter_forms
-                                            echo "</div>\n\n";  //end DIV encounter_data
-                                            echo "<br />";
-                                        }
-
-                                        $isfirst = 0;
-                                        echo "<div class='encounter_data'>\n";
-                                        echo "<input type=checkbox " .
-                                            " name='" . attr($result["formdir"]) . "_" . attr($result["form_id"]) . "'" .
-                                            " id='" . attr($result["formdir"]) . "_" . attr($result["form_id"]) . "'" .
-                                            " value='" . attr($result["encounter"]) . "'" .
-                                            " class='encounter'" .
-                                            " >";
-
-                                        // show encounter reason, not just 'New Encounter'
-                                        // trim to a reasonable length for display purposes --cfapress
-                                        $maxReasonLength = 20;
-                                        if (strlen($result["reason"]) > $maxReasonLength) {
-                                            $result['reason'] = substr($result['reason'], 0, $maxReasonLength) . " ... ";
-                                        }
-
-                                        echo attr($result["reason"]) .
-                                            " (" . date("Y-m-d", strtotime($result["date"])) .
-                                            ")\n";
-                                        echo "<div class='encounter_forms'>\n";
-                                    } else {
-                                        $form_name = trim($result["form_name"]);
-                                        //if form name is not in registry, look for the closest match by
-                                        // finding a registry name which is  at the start of the form name.
-                                        //this is to allow for forms to put additional helpful information
-                                        //in the database in the same string as their form name after the name
-                                        $form_name_found_flag = 0;
-                                        foreach ($registry_form_name as $var) {
-                                            if ($var == $form_name) {
-                                                $form_name_found_flag = 1;
-                                            }
-                                        }
-
-                                        // if the form does not match precisely with any names in the registry, now see if any front partial matches
-                                        // and change $form_name appropriately so it will print above in $toprint = $html_strings[$var]
-                                        if (!$form_name_found_flag) {
-                                            foreach ($registry_form_name as $var) {
-                                                if (strpos($form_name, $var) == 0) {
-                                                    $form_name = $var;
-                                                }
-                                            }
-                                        }
-
-                                        if (!is_array($html_strings[$form_name] ?? null)) {
-                                            $html_strings[$form_name] = array();
-                                        }
-
-                                        array_push($html_strings[$form_name], "<input type='checkbox' " .
-                                            " name='" . attr($result["formdir"]) . "_" . attr($result["form_id"]) . "'" .
-                                            " id='" . attr($result["formdir"]) . "_" . attr($result["form_id"]) . "'" .
-                                            " value='" . attr($result["encounter"]) . "'" .
-                                            " class='encounter_form' " .
-                                            ">" . text(xl_form_title($result["form_name"])) . "<br />\n");
-                                    }
-                                }
-
-                                foreach ($registry_form_name as $var) {
-                                    if ($toprint = $html_strings[$var] ?? null) {
-                                        foreach ($toprint as $var) {
-                                            print $var;
-                                        }
-                                    }
-                                }
-                                ?>
-
-                            <?php endif; ?>
-
-                        </div> <!-- end encounters DIV -->
-                    </td>
-                </tr>
-            </table>
-
-            <!-- Procedure Orders -->
-            <hr />
-            <table border="0" cellpadding="0" cellspacing="0">
-                <tr>
-                    <td class='bold'><?php echo xlt('Procedures'); ?>&nbsp;&nbsp;</td>
-                    <td class='text'><?php echo xlt('Order Date'); ?>&nbsp;&nbsp;</td>
-                    <td class='text'><?php echo xlt('Encounter Date'); ?>&nbsp;&nbsp;</td>
-                    <td class='text'><?php echo xlt('Order Descriptions'); ?></td>
-                </tr>
-                <?php
-                $res = sqlStatement(
-                    "SELECT po.procedure_order_id, po.date_ordered, fe.date " .
-                    "FROM procedure_order AS po " .
-                    "LEFT JOIN forms AS f ON f.pid = po.patient_id AND f.formdir = 'procedure_order' AND " .
-                    "f.form_id = po.procedure_order_id AND f.deleted = 0 " .
-                    "LEFT JOIN form_encounter AS fe ON fe.pid = f.pid AND fe.encounter = f.encounter " .
-                    "WHERE po.patient_id = ? " .
-                    "ORDER BY po.date_ordered DESC, po.procedure_order_id DESC",
-                    array($pid)
-                );
-                while ($row = sqlFetchArray($res)) {
-                    $poid = $row['procedure_order_id'];
-                    echo " <tr>\n";
-                    echo "  <td align='center' class='text'>" .
-                        "<input type='checkbox' name='procedures[]' value='" . attr($poid) . "' />&nbsp;&nbsp;</td>\n";
-                    echo "  <td class='text'>" . text(oeFormatShortDate($row['date_ordered'])) . "&nbsp;&nbsp;</td>\n";
-                    echo "  <td class='text'>" . text(oeFormatShortDate($row['date'])) . "&nbsp;&nbsp;</td>\n";
-                    echo "  <td class='text'>";
-                    $opres = sqlStatement(
-                        "SELECT procedure_code, procedure_name FROM procedure_order_code " .
-                        "WHERE procedure_order_id = ? ORDER BY procedure_order_seq",
-                        array($poid)
-                    );
-                    while ($oprow = sqlFetchArray($opres)) {
-                        $tmp = $oprow['procedure_name'];
-                        if (empty($tmp)) {
-                            $tmp = $oprow['procedure_code'];
-                        }
-
-                        echo text($tmp) . "<br />";
-                    }
-
-                    echo "</td>\n";
-                    echo " </tr>\n";
-                }
-                ?>
-            </table>
-
-            <hr />
-            <span class="bold"><?php echo xlt('Documents'); ?></span>:<br />
-            <ul>
-                <?php
-                // show available documents
-                $db = $GLOBALS['adodb']['db'];
-                $sql = "SELECT d.id, d.url, d.name as document_name, c.name FROM documents AS d " .
-                    "LEFT JOIN categories_to_documents AS ctd ON d.id=ctd.document_id " .
-                    "LEFT JOIN categories AS c ON c.id = ctd.category_id WHERE " .
-                    "d.foreign_id = ? AND d.deleted = 0";
-                $result = $db->Execute($sql, [$pid]);
-                if ($db->ErrorMsg()) {
-                    echo $db->ErrorMsg();
-                }
-
-                while ($result && !$result->EOF) {
-                    $fname = basename($result->fields['url']);
-                    $extension = strtolower(substr($fname, strrpos($fname, ".")));
-                    if ($extension !== '.zip' && $extension !== '.dcm') {
-                        echo "<li class='bold'>";
-                        echo '<input type="checkbox" name="documents[]" value="' .
-                            $result->fields['id'] . '">';
-                        echo '&nbsp;&nbsp;<i>' . text(xl_document_category($result->fields['name'])) . "</i>";
-                        echo '&nbsp;&nbsp;' . xlt('Name') . ': <i>' . text(basename($result->fields['url'])) . "</i>";
-                        echo '</li>';
-                    }
-
-                    $result->MoveNext();
-                }
-                ?>
-            </ul>
-        </form>
-
-        <input type="button" class="genreport" value="<?php echo xla('Generate Report'); ?>" />&nbsp;
-        <input type="button" class="genpdfrep" value="<?php echo xla('Download PDF'); ?>" />&nbsp;
-
-    </div>  <!-- close patient_reports DIV -->
-    <script>
-        initReport = function () {
-            $("body").on("click", ".genreport", function () {
-                document.report_form.pdf.value = 0;
-                showCustom();
-
-                return false;
-            });
-            $(".genpdfrep").click(function () {
-                document.report_form.pdf.value = 1;
-                $("#report_form").submit();
-            });
-            $(".genportal").click(function () {
-                document.report_form.pdf.value = 2;
-                $("#report_form").submit();
-            });
-            $("#genfullreport").click(function () {
-                location.href = '<?php echo (!empty($returnurl)) ? "$rootdir/patient_file/encounter/$returnurl" : '';?>';
-            });
-//$("#printform").click(function() { PrintForm(); });
-            $(".issuecheckbox").click(function () {
-                issueClick(this);
-            });
-
-// check/uncheck all Forms of an encounter
-            $(".encounter").click(function () {
-                SelectForms(this);
-            });
-
-            function showCustom() {
-                var formval = $("#report_form").serializeArray();
-                var title = <?php echo xlj("Custom Report") ?>;
-                var params = {
-                    sizeHeight: 'full',
-                    size: 'modal-lg',
-                    title: title,
-                    type: "POST",
-                    url: './report/portal_custom_report.php',
-                    data: formval
-                };
-
-// returns a promise after dialog inits. Just an empty fulfill for an example.
-// Could do an alert or confirm etc.
-                return dialog.ajax(params).then(function (dialog) {
-                    $('div.modal-body', dialog).addClass('overflow-auto');
-                });
-            }
-
-            $(".generateCCR").click(
-                function () {
-                    if (document.getElementById('show_date').checked == true) {
-                        if (document.getElementById('Start').value == '' || document.getElementById('End').value == '') {
-                            alert(<?php echo xlj('Please select a start date and end date'); ?>);
-                            return false;
-                        }
-                    }
-                    var ccrAction = document.getElementsByName('ccrAction');
-                    ccrAction[0].value = 'generate';
-                    var raw = document.getElementsByName('raw');
-                    raw[0].value = 'no';
-
-                    ccr_form.setAttribute("target", "_blank");
-                    $("#ccr_form").submit();
-                    ccr_form.setAttribute("target", "");
-                });
-            $(".generateCCR_raw").click(
-                function () {
-                    var ccrAction = document.getElementsByName('ccrAction');
-                    ccrAction[0].value = 'generate';
-                    var raw = document.getElementsByName('raw');
-                    raw[0].value = 'yes';
-
-                    ccr_form.setAttribute("target", "_blank");
-                    $("#ccr_form").submit();
-                    ccr_form.setAttribute("target", "");
-                });
-            $(".generateCCR_download_h").click(
-                function () {
-                    var ccrAction = document.getElementsByName('ccrAction');
-                    ccrAction[0].value = 'generate';
-                    var raw = document.getElementsByName('raw');
-                    raw[0].value = 'hybrid';
-
-                    $("#ccr_form").submit();
-                });
-            $(".generateCCR_download_p").click(
-                function () {
-                    if (document.getElementById('show_date').checked === true) {
-                        if (document.getElementById('Start').value === '' || document.getElementById('End').value === '') {
-                            alert(<?php echo xlj('Please select a start date and end date'); ?>);
-                            return false;
-                        }
-                    }
-                    var ccrAction = document.getElementsByName('ccrAction');
-                    ccrAction[0].value = 'generate';
-                    var raw = document.getElementsByName('raw');
-                    raw[0].value = 'pure';
-
-                    $("#ccr_form").submit();
-                });
-            $(".viewCCD").click(
-                function () {
-                    var ccrAction = document.getElementsByName('ccrAction');
-                    ccrAction[0].value = 'viewccd';
-                    var raw = document.getElementsByName('raw');
-                    raw[0].value = 'no';
-
-                    ccr_form.setAttribute("target", "_blank");
-                    $("#ccr_form").submit();
-                    ccr_form.setAttribute("target", "");
-                });
-            $(".viewCCD_raw").click(
-                function () {
-                    var ccrAction = document.getElementsByName('ccrAction');
-                    ccrAction[0].value = 'viewccd';
-                    var raw = document.getElementsByName('raw');
-                    raw[0].value = 'yes';
-
-                    ccr_form.setAttribute("target", "_blank");
-                    $("#ccr_form").submit();
-                    ccr_form.setAttribute("target", "");
-                });
-            $(".viewCCD_download").click(
-                function () {
-                    var ccrAction = document.getElementsByName('ccrAction');
-                    ccrAction[0].value = 'viewccd';
-                    var raw = document.getElementsByName('raw');
-                    raw[0].value = 'pure';
-                    $("#ccr_form").submit();
-                });
-            <?php if ($GLOBALS['phimail_enable'] == true && $GLOBALS['phimail_ccr_enable'] == true) { ?>
-            $(".viewCCR_send_dialog").click(
-                function () {
-                    $("#ccr_send_dialog").toggle();
-                });
-            $(".viewCCR_transmit").click(
-                function () {
-                    $(".viewCCR_transmit").attr('disabled', 'disabled');
-                    var ccrAction = document.getElementsByName('ccrAction');
-                    ccrAction[0].value = 'generate';
-                    var ccrRecipient = $("#ccr_send_to").val();
-                    var raw = document.getElementsByName('raw');
-                    raw[0].value = 'send ' + ccrRecipient;
-                    if (ccrRecipient === "") {
-                        $("#ccr_send_message").html("<?php
-                            echo xla('Please enter a valid Direct Address above.'); ?>");
-                        $("#ccr_send_result").show();
-                    } else {
-                        $(".viewCCR_transmit").attr('disabled', 'disabled');
-                        $("#ccr_send_message").html("<?php
-                            echo xla('Working... this may take a minute.'); ?>");
-                        $("#ccr_send_result").show();
-                        var action = $("#ccr_form").attr('action');
-                        $.post(action, {ccrAction: 'generate', raw: 'send ' + ccrRecipient, requested_by: 'user'},
-                            function (data) {
-                                if (data === "SUCCESS") {
-                                    $("#ccr_send_message").html("<?php
-                                        echo xla('Your message was submitted for delivery to');
-                                    ?> " + ccrRecipient);
-                                    $("#ccr_send_to").val("");
-                                } else {
-                                    $("#ccr_send_message").html(data);
-                                }
-                                $(".viewCCR_transmit").removeAttr('disabled');
-                            });
-                    }
-                });
-            <?php }
-
-            if ($GLOBALS['phimail_enable'] == true && $GLOBALS['phimail_ccd_enable'] == true) { ?>
-            $(".viewCCD_send_dialog").click(
-                function () {
-                    $("#ccd_send_dialog").toggle();
-                });
-            $(".viewCCD_transmit").click(
-                function () {
-                    $(".viewCCD_transmit").attr('disabled', 'disabled');
-                    var ccrAction = document.getElementsByName('ccrAction');
-                    ccrAction[0].value = 'viewccd';
-                    var ccdRecipient = $("#ccd_send_to").val();
-                    var raw = document.getElementsByName('raw');
-                    raw[0].value = 'send ' + ccdRecipient;
-                    if (ccdRecipient === "") {
-                        $("#ccd_send_message").html("<?php
-                            echo xla('Please enter a valid Direct Address above.'); ?>");
-                        $("#ccd_send_result").show();
-                    } else {
-                        $(".viewCCD_transmit").attr('disabled', 'disabled');
-                        $("#ccd_send_message").html("<?php
-                            echo xla('Working... this may take a minute.'); ?>");
-                        $("#ccd_send_result").show();
-                        var action = $("#ccr_form").attr('action');
-                        $.post(action, {ccrAction: 'viewccd', raw: 'send ' + ccdRecipient, requested_by: 'user'},
-                            function (data) {
-                                if (data === "SUCCESS") {
-                                    $("#ccd_send_message").html("<?php
-                                        echo xla('Your message was submitted for delivery to');
-                                    ?> " + ccdRecipient);
-                                    $("#ccd_send_to").val("");
-                                } else {
-                                    $("#ccd_send_message").html(data);
-                                }
-                                $(".viewCCD_transmit").removeAttr('disabled');
-                            });
-                    }
-                });
-            <?php } ?>
-        }; // end initReport
-
-        $(function () {
-
-            initReport();
-
-            $('.datepicker').datetimepicker({
-                <?php $datetimepicker_timepicker = false; ?>
-                <?php $datetimepicker_formatInput = false; ?>
-                <?php require($GLOBALS['srcdir'] . '/js/xl/jquery-datetimepicker-2-5-4.js.php'); ?>
-            });
-        });
-
-        // select/deselect the Forms related to the selected Encounter
-        // (it ain't pretty code folks)
-        var SelectForms = function (selectedEncounter) {
-            if ($(selectedEncounter).prop("checked")) {
-                $(selectedEncounter).parent().children().each(function (i, obj) {
-                    $(this).children().each(function (i, obj) {
-                        $(this).prop("checked", true);
-                    });
-                });
-            } else {
-                $(selectedEncounter).parent().children().each(function (i, obj) {
-                    $(this).children().each(function (i, obj) {
-                        $(this).prop("checked", false);
-                    });
-                });
-            }
-        }
-
-        // When an issue is checked, auto-check all the related encounters and forms
-        function issueClick(issue) {
-// do nothing when unchecked
-            if (!$(issue).prop("checked")) return;
-
-            $("#report_form :checkbox").each(function (i, obj) {
-                if ($(issue).val().indexOf('/' + $(this).val() + '/') >= 0) {
-                    $(this).prop("checked", true);
-                }
-
-            });
-        }
-
-    </script>
-
+$portalPatientReportController = new PortalPatientReportController();
+$twig = (new TwigContainer(null, $GLOBALS['kernel']))->getTwig();
+
+$issues = [];
+$data = [];
+try {
+    $data['phone_country_code'] = $GLOBALS['phone_country_code'] ?? '';
+    $data['returnurl'] = (!empty($returnurl)) ? "$rootdir/patient_file/encounter/$returnurl" : '';
+    $data['issues'] = $portalPatientReportController->getIssues($ISSUE_TYPES, $pid);
+    $data['encounters'] = $portalPatientReportController->getEncounters($pid);
+    $data['procedureOrders'] = $portalPatientReportController->getProcedureOrders($pid);
+    $data['documents'] = $portalPatientReportController->getDocuments($pid);
+    $data['phimail_enable'] = $GLOBALS['phimail_enable'] ?? false;
+    $data['phimail_ccr_enable'] = $GLOBALS['phimail_ccr_enable'] ?? false;
+    $data['phimail_ccd_enable'] = $GLOBALS['phimail_ccd_enable'] ?? false;
+    $data['sections'] = [
+        'demographics' => [
+            'selected' => true
+            ,'label' => xl('Demographics')
+        ]
+        ,'history' => [
+            'selected' => false
+            ,'label' => xl('History')
+        ]
+        ,'insurance' => [
+            'selected' => false
+            ,'label' => xl('Insurance')
+        ]
+        ,'billing' => [
+            'selected' => $GLOBALS['simplified_demographics'] ? false : true
+            ,'label' => xl('Billing')
+        ]
+        ,'allergies' => [
+            'selected' => false
+            ,'label' => xl('Allergies')
+        ]
+        ,'medications' => [
+            'selected' => false
+            ,'label' => xl('Medications')
+        ]
+        ,'immunizations' => [
+            'selected' => false
+            ,'label' => xl('Immunizations')
+        ]
+        ,'medical_problems' => [
+            'selected' => false
+            ,'label' => xl('Medical Problems')
+        ]
+        ,'notes' => [
+            'selected' => false
+            ,'label' => xl('Patient Notes')
+        ]
+        ,'transactions' => [
+            'selected' => false
+            ,'label' => xl('Transactions')
+        ]
+        ,'batchcom' => [
+            'selected' => false
+            ,'label' => xl('Communications')
+        ]
+    ];
+    // what sections display can be controlled by the following two arrays
+    $data['section_one'] = [
+        'demographics', 'history', 'insurance', 'billing'
+    ];
+    $data['section_two'] = [
+        'allergies', 'medications', 'immunizations', 'medical_problems', 'notes', 'transactions', 'batchcom'
+    ];
+    $event = new PatientReportFilterEvent();
+    $event->populateData($data);
+    $updatedEvent = $GLOBALS['kernel']->getEventDispatcher()->dispatch($event, PatientReportFilterEvent::FILTER_PORTAL_TWIG_DATA);
+    $updatedData  = $event->getDataAsArray();
+    echo $twig->render("portal/portal_patient_report.html.twig", $updatedData);
+}
+catch (SyntaxError $exception) {
+    (new SystemLogger())->error($exception->getMessage(), ['trace' => $exception->getTraceAsString(), 'file' => $exception->getFile()]);
+    echo $twig->render("error/general_http_error.html.twig", []);
+}
+catch (\Exception $exception) {
+    (new SystemLogger())->error($exception->getMessage(), ['trace' => $exception->getTraceAsString()]);
+    echo $twig->render("error/general_http_error.html.twig", []);
+}
+die();

--- a/src/Controllers/Portal/PortalPatientReportController.php
+++ b/src/Controllers/Portal/PortalPatientReportController.php
@@ -1,5 +1,17 @@
 <?php
 
+/**
+ * PortalPatientReportController class file - holds helper methods for retrieving data with the custom patient report
+ * in the portal_patient_report.php file.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ *
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (C) 2024 Open Plan IT Ltd. <support@openplanit.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
 namespace OpenEMR\Controllers\Portal;
 
 use OpenEMR\Common\Database\QueryUtils;

--- a/src/Controllers/Portal/PortalPatientReportController.php
+++ b/src/Controllers/Portal/PortalPatientReportController.php
@@ -6,7 +6,8 @@ use OpenEMR\Common\Database\QueryUtils;
 
 class PortalPatientReportController
 {
-    public function getDocuments($pid) {
+    public function getDocuments($pid)
+    {
 
         // show available documents
         $db = $GLOBALS['adodb']['db'];
@@ -69,7 +70,8 @@ class PortalPatientReportController
         return $procedures;
     }
 
-    public function getIssues(array $ISSUE_TYPES, int $pid) {
+    public function getIssues(array $ISSUE_TYPES, int $pid)
+    {
         $issuesByType = [];
         // get issues
         $pres = sqlStatement("SELECT lists.* FROM lists "
@@ -118,7 +120,8 @@ class PortalPatientReportController
         }
         return $issuesByType;
     }
-    public function getEncounters($pid) {
+    public function getEncounters($pid)
+    {
 
         $isfirst = 1;
         $res = sqlStatement("SELECT forms.encounter, forms.form_id, forms.form_name, " .
@@ -160,7 +163,6 @@ class PortalPatientReportController
                 $encounter['date'] = date("Y-m-d", strtotime($result["date"]));
                 $encountersByDate[] = $encounterId;
                 $encountersByEncounter[$encounterId] = $encounter;
-
             } else {
                 $form_name = trim($result["form_name"]);
                 // TODO: @adunsulag we need to investigate why procedure order form saves
@@ -199,7 +201,7 @@ class PortalPatientReportController
                 ];
             }
         }
-        $encounters = array_map(function($encounterId) use ($encountersByEncounter) {
+        $encounters = array_map(function ($encounterId) use ($encountersByEncounter) {
             return $encountersByEncounter[$encounterId];
         }, $encountersByDate);
         return $encounters;

--- a/src/Controllers/Portal/PortalPatientReportController.php
+++ b/src/Controllers/Portal/PortalPatientReportController.php
@@ -22,7 +22,6 @@ class PortalPatientReportController
     {
 
         // show available documents
-        $db = $GLOBALS['adodb']['db'];
         $sql = "SELECT d.id, d.url, d.name as document_name, c.name FROM documents AS d " .
             "LEFT JOIN categories_to_documents AS ctd ON d.id=ctd.document_id " .
             "LEFT JOIN categories AS c ON c.id = ctd.category_id WHERE " .

--- a/src/Controllers/Portal/PortalPatientReportController.php
+++ b/src/Controllers/Portal/PortalPatientReportController.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace OpenEMR\Controllers\Portal;
+
+use OpenEMR\Common\Database\QueryUtils;
+
+class PortalPatientReportController
+{
+    public function getDocuments($pid) {
+
+        // show available documents
+        $db = $GLOBALS['adodb']['db'];
+        $sql = "SELECT d.id, d.url, d.name as document_name, c.name FROM documents AS d " .
+            "LEFT JOIN categories_to_documents AS ctd ON d.id=ctd.document_id " .
+            "LEFT JOIN categories AS c ON c.id = ctd.category_id WHERE " .
+            "d.foreign_id = ? AND d.deleted = 0";
+        $records = QueryUtils::sqlStatementThrowException($sql, [$pid]);
+        $documents = [];
+        foreach ($records as $record) {
+            $fname = basename($record['url']);
+            $extension = strtolower(substr($fname, strrpos($fname, ".")));
+            if ($extension !== '.zip' && $extension !== '.dcm') {
+                $documents[] = [
+                    'id' => $record['id'],
+                    'url' => basename($record['url']),
+                    'name' => $record['document_name'],
+                    'category' => xl_document_category($record['name'])
+                ];
+            }
+        }
+        return $documents;
+    }
+    public function getProcedureOrders($pid)
+    {
+        $res = sqlStatement(
+            "SELECT po.procedure_order_id, po.date_ordered, fe.date " .
+            "FROM procedure_order AS po " .
+            "LEFT JOIN forms AS f ON f.pid = po.patient_id AND f.formdir = 'procedure_order' AND " .
+            "f.form_id = po.procedure_order_id AND f.deleted = 0 " .
+            "LEFT JOIN form_encounter AS fe ON fe.pid = f.pid AND fe.encounter = f.encounter " .
+            "WHERE po.patient_id = ? " .
+            "ORDER BY po.date_ordered DESC, po.procedure_order_id DESC",
+            array($pid)
+        );
+        $procedures = [];
+        $proceduresById = [];
+        $index = 0;
+        while ($row = sqlFetchArray($res)) {
+            $poid = $row['procedure_order_id'];
+            $proceduresById[$poid] = $index++;
+            $procedures[] = [
+                'id' => $poid,
+                'date_ordered' => $row['date_ordered'],
+                'date' => $row['date'],
+                'procedures' => []
+            ];
+        }
+        $sql = "SELECT procedure_order_id, procedure_code, procedure_name FROM procedure_order_code " .
+            "WHERE procedure_order_id IN (" . implode(",", array_keys($proceduresById)) . ") ORDER BY procedure_order_id, procedure_order_seq";
+        $res = sqlStatement($sql);
+        while ($row = sqlFetchArray($res)) {
+            $poid = $row['procedure_order_id'];
+            $index = $proceduresById[$poid];
+            $procedures[$index]['procedures'][] = [
+                'code' => $row['procedure_code'],
+                'name' => $row['procedure_name']
+            ];
+        }
+        return $procedures;
+    }
+
+    public function getIssues(array $ISSUE_TYPES, int $pid) {
+        $issuesByType = [];
+        // get issues
+        $pres = sqlStatement("SELECT lists.* FROM lists "
+        . " WHERE lists.pid = ? " .
+            "ORDER BY lists.type, lists.begdate", [$pid]);
+        $lasttype = "";
+        $lastEncounter = null;
+        $issuesIndex = 0;
+        $issuesByTypeMap = [];
+        while ($prow = sqlFetchArray($pres)) {
+            if ($lasttype != $prow['type']) {
+                $lasttype = $prow['type'];
+
+                if (empty($issuesByType[$lasttype])) {
+                    $issuesByType[$lasttype] = [
+                        'type' => $lasttype,
+                        'display' => $ISSUE_TYPES[$lasttype][0],
+                        'issues' => []
+                    ];
+                }
+                $issuesIndex = 0;
+            }
+            $rowid = $prow['id'];
+            $disptitle = trim($prow['title']) ? $prow['title'] : "[Missing Title]";
+
+
+            $issuesByTypeMap[$lasttype][$rowid] = $issuesIndex;
+            $issuesByType[$lasttype]['issues'][$issuesIndex++] = [
+                'id' => $rowid,
+                'title' => $disptitle,
+                'begdate' => $prow['begdate'],
+                'enddate' => $prow['enddate'],
+                'status' => !empty($prow['enddate']) ? 'inactive' : 'active',
+                'encounters' => []
+            ];
+        }
+        // now populate encounters
+        $ieres = sqlStatement("SELECT encounter,list_id,lists.type FROM issue_encounter JOIN lists ON lists.id = list_id "
+            . " AND issue_encounter.pid = lists.pid WHERE " .
+            "lists.pid = ?", [$pid]);
+        while ($ierow = sqlFetchArray($ieres)) {
+            $listId = $ierow['list_id'];
+            $encounter = $ierow['encounter'];
+            $issuesIndex = $issuesByTypeMap[$ierow['type']][$listId];
+            $issuesByType[$ierow['type']]['issues'][$issuesIndex]['encounters'][] = $encounter;
+        }
+        return $issuesByType;
+    }
+    public function getEncounters($pid) {
+
+        $isfirst = 1;
+        $res = sqlStatement("SELECT forms.encounter, forms.form_id, forms.form_name, " .
+            "forms.formdir, forms.date AS fdate, form_encounter.date " .
+            ",form_encounter.reason " .
+            "FROM forms, form_encounter WHERE " .
+            "forms.pid = ? AND form_encounter.pid = ? AND " .
+            "form_encounter.encounter = forms.encounter " .
+            " AND forms.deleted=0 " . // --JRM--
+            "ORDER BY form_encounter.date DESC, fdate ASC", [$pid, $pid]);
+        $res2 = sqlStatement("SELECT name FROM registry ORDER BY priority");
+        $encountersByDate = [];
+        $encountersByEncounter = [];
+        $html_strings = array();
+        $registry_form_name = array();
+        while ($result2 = sqlFetchArray($res2)) {
+            array_push($registry_form_name, trim($result2['name']));
+        }
+
+        $encounter = null;
+        while ($result = sqlFetchArray($res)) {
+            $encounterId = $result['encounter'];
+            if ($result["form_name"] == "New Patient Encounter") {
+                $encounter = [
+                    'formdir' => $result["formdir"]
+                    ,'form_id' => $result["form_id"]
+                    ,'encounter' => $result["encounter"]
+                    ,'display' => ''
+                    ,'forms' => []
+                ];
+                // show encounter reason, not just 'New Encounter'
+                // trim to a reasonable length for display purposes --cfapress
+                $maxReasonLength = 20;
+                if (strlen($result["reason"]) > $maxReasonLength) {
+                    $encounter['display'] = substr($result['reason'], 0, $maxReasonLength) . " ... ";
+                } else {
+                    $encounter['display'] = $result['reason'] ?? '';
+                }
+                $encounter['date'] = date("Y-m-d", strtotime($result["date"]));
+                $encountersByDate[] = $encounterId;
+                $encountersByEncounter[$encounterId] = $encounter;
+
+            } else {
+                $form_name = trim($result["form_name"]);
+                // TODO: @adunsulag we need to investigate why procedure order form saves
+                // its name as this way.. so odd.
+                if ($form_name === '-procedure') {
+                    $form_name = 'Procedure Order';
+                }
+                //if form name is not in registry, look for the closest match by
+                // finding a registry name which is  at the start of the form name.
+                //this is to allow for forms to put additional helpful information
+                //in the database in the same string as their form name after the name
+                $form_name_found_flag = 0;
+                foreach ($registry_form_name as $var) {
+                    if ($var == $form_name) {
+                        $form_name_found_flag = 1;
+                    }
+                }
+
+                // if the form does not match precisely with any names in the registry, now see if any front partial matches
+                // and change $form_name appropriately so it will print above in $toprint = $html_strings[$var]
+                if (!$form_name_found_flag) {
+                    foreach ($registry_form_name as $var) {
+                        if (strpos($form_name, $var) === 0) {
+                            $form_name = $var;
+                        }
+                    }
+                }
+                if (empty($encountersByEncounter[$encounterId]['forms'][$form_name])) {
+                    $encountersByEncounter[$encounterId]['forms'][$form_name] = [];
+                }
+                $encountersByEncounter[$encounterId]['forms'][$form_name][] = [
+                    'formdir' => $result['formdir']
+                    , 'form_id' => $result['form_id']
+                    , 'encounter' => $result['encounter']
+                    , 'display' => xl_form_title($form_name)
+                ];
+            }
+        }
+        $encounters = array_map(function($encounterId) use ($encountersByEncounter) {
+            return $encountersByEncounter[$encounterId];
+        }, $encountersByDate);
+        return $encounters;
+    }
+}

--- a/src/Events/PatientReport/PatientReportFilterEvent.php
+++ b/src/Events/PatientReport/PatientReportFilterEvent.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * PatientReportFilterEvent handls the filtering of data in the patient report for both the portal and the patient report.
+ *
+ * The class hides the implementation details of the underlying data allowing the event to change implementations
+ * as needed.
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ *
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (C) 2024 Open Plan IT Ltd. <support@openplanit.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\PatientReport;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+class PatientReportFilterEvent extends Event
+{
+    /**
+     * This event fires just before the data elements are sent into the patient portal's patient report twig template.
+     * It allows the listener to modify the data elements that are sent in (hiding/showing sections, etc).
+     */
+    const FILTER_PORTAL_TWIG_DATA = 'patientReport.filter.portal.twig.data';
+    const FILTER_PORTAL_HEALTHSNAPSHOT_TWIG_DATA = 'home.filter.portal.healthsnapshot.twig.data';
+
+    /**
+     * @var array $data The data elements that are being filtered by this array.
+     */
+    private array $data;
+
+    public function __construct()
+    {
+        $this->data = [];
+    }
+
+    /**
+     * Populates the data elements for this filtered event.
+     * @param array $data
+     */
+    public function populateData(array $data): void
+    {
+       $this->clearData();
+       foreach ($data as $key => $value) {
+           $this->setDataElement($key, $value);
+       }
+    }
+
+    /**
+     * Sets the data elements that are being filtered by this array.
+     * @param int|string $key
+     * @param mixed $data
+     */
+    public function setDataElement(int|string $key, mixed $data): void
+    {
+        $this->data[$key] = $data;
+    }
+
+    public function getDataElement(int|string $key) : mixed
+    {
+        return $this->data[$key];
+    }
+
+    /**
+     * Removes a data element from the filtered data.
+     * @param int|string $key
+     * @return void
+     */
+    public function removeDataElement(int|string $key) {
+        unset($this->data[$key]);
+    }
+
+    /**
+     * Removes the data elements from the filtered data.
+     * @return void
+     */
+    public function clearData() {
+        $this->data = [];
+    }
+
+    public function getDataAsArray(): array
+    {
+        return $this->data;
+    }
+}

--- a/src/Events/PatientReport/PatientReportFilterEvent.php
+++ b/src/Events/PatientReport/PatientReportFilterEvent.php
@@ -42,10 +42,10 @@ class PatientReportFilterEvent extends Event
      */
     public function populateData(array $data): void
     {
-       $this->clearData();
-       foreach ($data as $key => $value) {
-           $this->setDataElement($key, $value);
-       }
+        $this->clearData();
+        foreach ($data as $key => $value) {
+            $this->setDataElement($key, $value);
+        }
     }
 
     /**
@@ -58,7 +58,7 @@ class PatientReportFilterEvent extends Event
         $this->data[$key] = $data;
     }
 
-    public function getDataElement(int|string $key) : mixed
+    public function getDataElement(int|string $key): mixed
     {
         return $this->data[$key];
     }
@@ -68,7 +68,8 @@ class PatientReportFilterEvent extends Event
      * @param int|string $key
      * @return void
      */
-    public function removeDataElement(int|string $key) {
+    public function removeDataElement(int|string $key)
+    {
         unset($this->data[$key]);
     }
 
@@ -76,7 +77,8 @@ class PatientReportFilterEvent extends Event
      * Removes the data elements from the filtered data.
      * @return void
      */
-    public function clearData() {
+    public function clearData()
+    {
         $this->data = [];
     }
 

--- a/templates/portal/home.html.twig
+++ b/templates/portal/home.html.twig
@@ -1,3 +1,20 @@
+{#
+* home.html.twig
+*
+* @package   OpenEMR
+* @link      https://www.open-emr.org
+ * @author    Jerry Padgett <sjpadgett@gmail.com>
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Shiqiang Tao <StrongTSQ@gmail.com>
+ * @author    Ben Marte <benmarte@gmail.com>
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2016-2024 Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright Copyright (c) 2019-2021 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2020 Shiqiang Tao <StrongTSQ@gmail.com>
+ * @copyright Copyright (c) 2021 Ben Marte <benmarte@gmail.com>
+*  @copyright Copyright (C) 2024 Open Plan IT Ltd. <support@openplanit.com>
+* @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+#}
 {% extends "portal/base.html.twig" %}
 
 {% block head %}
@@ -195,24 +212,6 @@
                 $("#editDems").click(function () {
                     showProfileModal()
                 });
-            });
-
-            $("#medicationlist").load("./get_medications.php", {}, function () {
-            });
-
-            $("#prescriptionlist").load("./get_prescriptions.php", {}, function () {
-            });
-
-            $("#labresults").load("./get_lab_results.php", {}, function () {
-            });
-
-            /* $("#amendmentslist").load("./get_amendments.php", {}, function () {
-             });*/
-
-            $("#problemslist").load("./get_problems.php", {}, function () {
-            });
-
-            $("#allergylist").load("./get_allergies.php", {}, function () {
             });
 
             $("#reports").load("./report/portal_patient_report.php?pid=" + {{ patientID | js_url }}, {}, function () {
@@ -635,60 +634,7 @@
         {# End of quickstart-cards #}
 
         <!-- Health Snapshot Card -->
-        <div class="collapse overflow-auto" data-parent="#cardgroup" id="lists">
-            <div class="card d-flex mr-1 mb-1">
-                <header class="card-header p-1 bg-dark text-light h3">{{ 'Health Snapshot (Medical Lists)' | xlt }}</header>
-                <div class="card-body">
-                    <div class="card">
-                        <header class="card-header p-1 bg-dark text-light h5">{{ 'Patient Immunization' | xlt }}</header>
-                        <div class="card-body border">
-                            {% for record in immunRecords %}
-                                <div>
-                                    {{ record.administered_formatted | xlt }} :
-                                    {{ record.code_text | xlt }} :
-                                    {{ record.note | xlt }} :
-                                    {{ record.completion_status | xlt }}
-                                </div>
-                            {% else %}
-                                <p>{{ 'No records found.' | xlt }}</p>
-                            {% endfor %}
-                        </div>
-                    </div>
-                    <div class="card">
-                        <header class="card-header p-1 bg-dark text-light h5">{{ 'Current Medications' | xlt }}</header>
-                        <div id="medicationlist" class="card-body p-2 bg-light">
-                            {% include "portal/partial/_alert_loading.html.twig" %}
-                        </div>
-                    </div>
-                    <div class="card">
-                        <header class="card-header p-1 bg-dark text-light h5">{{ 'Active Prescriptions' | xlt }}</header>
-                        <div id="prescriptionlist" class="card-body p-2 bg-light">
-                            {% include "portal/partial/_alert_loading.html.twig" %}
-                        </div>
-                    </div>
-                    <div class="card">
-                        <header class="card-header p-1 bg-dark text-light h5">{{ 'Medication Allergy List' | xlt }}</header>
-                        <div id="allergylist" class="card-body p-2 bg-light"></div>
-                    </div>
-                    <div class="card">
-                        <header class="card-header p-1 bg-dark text-light h5">{{ 'Current Problems List' | xlt }}</header>
-                        <div id="problemslist" class="card-body p-2 bg-light">
-                            {% include "portal/partial/_alert_loading.html.twig" %}
-                        </div>
-                    </div>
-                    {# <div class="card">
-                <header class="card-header p-1 bg-dark text-light">{{ 'Amendment List' | xlt }}</header>
-                <div id="amendmentslist" class="card-body p-2 bg-light"></div>
-            </div> #}
-                    <div class="card">
-                        <header class="card-header p-1 bg-dark text-light h5">{{ 'Lab Results' | xlt }}</header>
-                        <div id="labresults" class="card-body p-2 bg-light">
-                            {% include "portal/partial/_alert_loading.html.twig" %}
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
+        {% include "portal/partial/cards/_health_snapshot_card.html.twig" with {healthSnapshot: healthSnapshot}%}
 
         <!-- Help Card -->
         {% include "portal/partial/_help_card.html.twig" with {

--- a/templates/portal/partial/cards/_health_snapshot_allergylist_card.html.twig
+++ b/templates/portal/partial/cards/_health_snapshot_allergylist_card.html.twig
@@ -1,0 +1,15 @@
+{#
+* _health_snapshot_allergylist_card.html.twig
+*
+* @package   OpenEMR
+* @link      https://www.open-emr.org
+* @author    Jerry Padgett <sjpadgett@gmail.com>
+* @author    Stephen Nielson <snielson@discoverandchange.com>
+* @copyright Copyright (c) 2016-2024 Jerry Padgett <sjpadgett@gmail.com>
+*  @copyright Copyright (C) 2024 Open Plan IT Ltd. <support@openplanit.com>
+* @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+#}
+<div class="card">
+    <header class="card-header p-1 bg-dark text-light h5">{{ 'Medication Allergy List' | xlt }}</header>
+    <div id="allergylist" class="card-body p-2 bg-light"></div>
+</div>

--- a/templates/portal/partial/cards/_health_snapshot_card.html.twig
+++ b/templates/portal/partial/cards/_health_snapshot_card.html.twig
@@ -1,0 +1,27 @@
+{#
+* _health_snapshot_card.html.twig
+*
+* @package   OpenEMR
+* @link      https://www.open-emr.org
+* @author    Jerry Padgett <sjpadgett@gmail.com>
+* @author    Stephen Nielson <snielson@discoverandchange.com>
+* @copyright Copyright (c) 2016-2024 Jerry Padgett <sjpadgett@gmail.com>
+*  @copyright Copyright (C) 2024 Open Plan IT Ltd. <support@openplanit.com>
+* @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+#}
+<!-- Health Snapshot Card -->
+<div class="collapse overflow-auto" data-parent="#cardgroup" id="lists">
+    <div class="card d-flex mr-1 mb-1">
+        <header class="card-header p-1 bg-dark text-light h3">{{ 'Health Snapshot (Medical Lists)' | xlt }}</header>
+        <div class="card-body">
+            {% include "portal/partial/cards/_health_snapshot_immunization_card.html.twig" with {immunizationRecords: healthSnapshot.immunizationRecords} %}
+            {% include "portal/partial/cards/_health_snapshot_medicationlist_card.html.twig" %}
+            {% include "portal/partial/cards/_health_snapshot_prescriptionlist_card.html.twig" %}
+            {% include "portal/partial/cards/_health_snapshot_allergylist_card.html.twig" %}
+            {% include "portal/partial/cards/_health_snapshot_problemslist_card.html.twig" %}
+            {# {% include "portal/partial/cards/_health_snapshot_amendmentslist_card.html.twig" %} #}
+            {% include "portal/partial/cards/_health_snapshot_labresults_card.html.twig" %}
+        </div>
+    </div>
+</div>
+{% include "portal/partial/cards/_health_snapshot_scripts.html.twig" %}

--- a/templates/portal/partial/cards/_health_snapshot_immunization_card.html.twig
+++ b/templates/portal/partial/cards/_health_snapshot_immunization_card.html.twig
@@ -1,0 +1,26 @@
+{#
+* _health_snapshot_immunization_card.html.twig
+*
+* @package   OpenEMR
+* @link      https://www.open-emr.org
+* @author    Jerry Padgett <sjpadgett@gmail.com>
+* @author    Stephen Nielson <snielson@discoverandchange.com>
+* @copyright Copyright (c) 2016-2024 Jerry Padgett <sjpadgett@gmail.com>
+*  @copyright Copyright (C) 2024 Open Plan IT Ltd. <support@openplanit.com>
+* @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+#}
+<div class="card">
+    <header class="card-header p-1 bg-dark text-light h5">{{ 'Patient Immunization' | xlt }}</header>
+    <div class="card-body border">
+        {% for record in immunizationRecords %}
+            <div>
+                {{ record.administered_formatted | xlt }} :
+                {{ record.code_text | xlt }} :
+                {{ record.note | xlt }} :
+                {{ record.completion_status | xlt }}
+            </div>
+        {% else %}
+            <p>{{ 'No records found.' | xlt }}</p>
+        {% endfor %}
+    </div>
+</div>

--- a/templates/portal/partial/cards/_health_snapshot_labresults_card.html.twig
+++ b/templates/portal/partial/cards/_health_snapshot_labresults_card.html.twig
@@ -1,0 +1,17 @@
+{#
+* _health_snapshot_labresults_card.html.twig
+*
+* @package   OpenEMR
+* @link      https://www.open-emr.org
+* @author    Jerry Padgett <sjpadgett@gmail.com>
+* @author    Stephen Nielson <snielson@discoverandchange.com>
+* @copyright Copyright (c) 2016-2024 Jerry Padgett <sjpadgett@gmail.com>
+*  @copyright Copyright (C) 2024 Open Plan IT Ltd. <support@openplanit.com>
+* @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+#}
+<div class="card">
+    <header class="card-header p-1 bg-dark text-light h5">{{ 'Lab Results' | xlt }}</header>
+    <div id="labresults" class="card-body p-2 bg-light">
+        {% include "portal/partial/_alert_loading.html.twig" %}
+    </div>
+</div>

--- a/templates/portal/partial/cards/_health_snapshot_medicationlist_card.html.twig
+++ b/templates/portal/partial/cards/_health_snapshot_medicationlist_card.html.twig
@@ -1,0 +1,17 @@
+{#
+* _health_snapshot_medicationlist_card.html.twig
+*
+* @package   OpenEMR
+* @link      https://www.open-emr.org
+* @author    Jerry Padgett <sjpadgett@gmail.com>
+* @author    Stephen Nielson <snielson@discoverandchange.com>
+* @copyright Copyright (c) 2016-2024 Jerry Padgett <sjpadgett@gmail.com>
+*  @copyright Copyright (C) 2024 Open Plan IT Ltd. <support@openplanit.com>
+* @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+#}
+<div class="card">
+    <header class="card-header p-1 bg-dark text-light h5">{{ 'Current Medications' | xlt }}</header>
+    <div id="medicationlist" class="card-body p-2 bg-light">
+        {% include "portal/partial/_alert_loading.html.twig" %}
+    </div>
+</div>

--- a/templates/portal/partial/cards/_health_snapshot_prescriptionlist_card.html.twig
+++ b/templates/portal/partial/cards/_health_snapshot_prescriptionlist_card.html.twig
@@ -1,0 +1,17 @@
+{#
+* _health_snapshot_prescriptionlist_card.html.twig
+*
+* @package   OpenEMR
+* @link      https://www.open-emr.org
+* @author    Jerry Padgett <sjpadgett@gmail.com>
+* @author    Stephen Nielson <snielson@discoverandchange.com>
+* @copyright Copyright (c) 2016-2024 Jerry Padgett <sjpadgett@gmail.com>
+*  @copyright Copyright (C) 2024 Open Plan IT Ltd. <support@openplanit.com>
+* @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+#}
+<div class="card">
+    <header class="card-header p-1 bg-dark text-light h5">{{ 'Active Prescriptions' | xlt }}</header>
+    <div id="prescriptionlist" class="card-body p-2 bg-light">
+        {% include "portal/partial/_alert_loading.html.twig" %}
+    </div>
+</div>

--- a/templates/portal/partial/cards/_health_snapshot_problemslist_card.html.twig
+++ b/templates/portal/partial/cards/_health_snapshot_problemslist_card.html.twig
@@ -1,0 +1,17 @@
+{#
+* _health_snapshot_problemslist_card.html.twig
+*
+* @package   OpenEMR
+* @link      https://www.open-emr.org
+* @author    Jerry Padgett <sjpadgett@gmail.com>
+* @author    Stephen Nielson <snielson@discoverandchange.com>
+* @copyright Copyright (c) 2016-2024 Jerry Padgett <sjpadgett@gmail.com>
+*  @copyright Copyright (C) 2024 Open Plan IT Ltd. <support@openplanit.com>
+* @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+#}
+<div class="card">
+    <header class="card-header p-1 bg-dark text-light h5">{{ 'Current Problems List' | xlt }}</header>
+    <div id="problemslist" class="card-body p-2 bg-light">
+        {% include "portal/partial/_alert_loading.html.twig" %}
+    </div>
+</div>

--- a/templates/portal/partial/cards/_health_snapshot_scripts.html.twig
+++ b/templates/portal/partial/cards/_health_snapshot_scripts.html.twig
@@ -1,0 +1,36 @@
+{#
+ * _health_snapshot_scripts.html.twig
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Jerry Padgett <sjpadgett@gmail.com>
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2016-2024 Jerry Padgett <sjpadgett@gmail.com>
+*  @copyright Copyright (C) 2024 Open Plan IT Ltd. <support@openplanit.com>
+* @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+#}
+<script>
+    (function() {
+        window.document.addEventListener("DOMContentLoaded", function() {
+
+            $("#medicationlist").load("./get_medications.php", {}, function () {
+            });
+
+            $("#prescriptionlist").load("./get_prescriptions.php", {}, function () {
+            });
+
+            $("#labresults").load("./get_lab_results.php", {}, function () {
+            });
+
+            /* $("#amendmentslist").load("./get_amendments.php", {}, function () {
+             });*/
+
+            $("#problemslist").load("./get_problems.php", {}, function () {
+            });
+
+            $("#allergylist").load("./get_allergies.php", {}, function () {
+            });
+        });
+    })(window);
+</script>
+{% include "portal/partial/cards/_health_snapshot_scripts_post.html.twig" %}

--- a/templates/portal/partial/cards/_health_snapshot_scripts_post.html.twig
+++ b/templates/portal/partial/cards/_health_snapshot_scripts_post.html.twig
@@ -1,0 +1,1 @@
+{# Module writers can override this template to do any custom scripts they need to do in the health snapshot screen #}

--- a/templates/portal/partial/reports/patient_report/_body_scripts.html.twig
+++ b/templates/portal/partial/reports/patient_report/_body_scripts.html.twig
@@ -1,0 +1,274 @@
+{#
+* _body_scripts.html.twig
+*
+* @package   OpenEMR
+* @link      https://www.open-emr.org
+* @author    Jerry Padgett <sjpadgett@gmail.com>
+* @author    Stephen Nielson <snielson@discoverandchange.com>
+* @copyright Copyright (c) 2016-2024 Jerry Padgett <sjpadgett@gmail.com>
+*  @copyright Copyright (C) 2024 Open Plan IT Ltd. <support@openplanit.com>
+* @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+#}
+<script>
+    function checkAll(check) {
+        var f = document.forms['report_form'];
+        for (var i = 0; i < f.elements.length; ++i) {
+            if (f.elements[i].type == 'checkbox') f.elements[i].checked = check;
+        }
+        return false;
+    }
+
+    function show_date_fun() {
+        if (document.getElementById('show_date').checked == true) {
+            document.getElementById('date_div').style.display = '';
+        } else {
+            document.getElementById('date_div').style.display = 'none';
+        }
+        return;
+    }
+
+    var mypcc = {{ phone_country_code|js_escape }};
+    initReport = function () {
+        $("body").on("click", ".genreport", function () {
+            document.report_form.pdf.value = 0;
+            showCustom();
+
+            return false;
+        });
+        $(".genpdfrep").click(function () {
+            document.report_form.pdf.value = 1;
+            $("#report_form").submit();
+        });
+        $(".genportal").click(function () {
+            document.report_form.pdf.value = 2;
+            $("#report_form").submit();
+        });
+        $("#genfullreport").click(function () {
+            location.href = {{ returnurl|json_encode }};
+        });
+//$("#printform").click(function() { PrintForm(); });
+        $(".issuecheckbox").click(function () {
+            issueClick(this);
+        });
+
+// check/uncheck all Forms of an encounter
+        $(".encounter").click(function () {
+            SelectForms(this);
+        });
+
+        function showCustom() {
+            var formval = $("#report_form").serializeArray();
+            var title = {{ "Custom Report"|xlj }};
+            var params = {
+                sizeHeight: 'full',
+                size: 'modal-lg',
+                title: title,
+                type: "POST",
+                url: './report/portal_custom_report.php',
+                data: formval
+            };
+
+// returns a promise after dialog inits. Just an empty fulfill for an example.
+// Could do an alert or confirm etc.
+            return dialog.ajax(params).then(function (dialog) {
+                $('div.modal-body', dialog).addClass('overflow-auto');
+            });
+        }
+
+        $(".generateCCR").click(
+            function () {
+                if (document.getElementById('show_date').checked == true) {
+                    if (document.getElementById('Start').value == '' || document.getElementById('End').value == '') {
+                        alert({{ 'Please select a start date and end date'|xlj }});
+                        return false;
+                    }
+                }
+                var ccrAction = document.getElementsByName('ccrAction');
+                ccrAction[0].value = 'generate';
+                var raw = document.getElementsByName('raw');
+                raw[0].value = 'no';
+
+                ccr_form.setAttribute("target", "_blank");
+                $("#ccr_form").submit();
+                ccr_form.setAttribute("target", "");
+            });
+        $(".generateCCR_raw").click(
+            function () {
+                var ccrAction = document.getElementsByName('ccrAction');
+                ccrAction[0].value = 'generate';
+                var raw = document.getElementsByName('raw');
+                raw[0].value = 'yes';
+
+                ccr_form.setAttribute("target", "_blank");
+                $("#ccr_form").submit();
+                ccr_form.setAttribute("target", "");
+            });
+        $(".generateCCR_download_h").click(
+            function () {
+                var ccrAction = document.getElementsByName('ccrAction');
+                ccrAction[0].value = 'generate';
+                var raw = document.getElementsByName('raw');
+                raw[0].value = 'hybrid';
+
+                $("#ccr_form").submit();
+            });
+        $(".generateCCR_download_p").click(
+            function () {
+                if (document.getElementById('show_date').checked === true) {
+                    if (document.getElementById('Start').value === '' || document.getElementById('End').value === '') {
+                        alert({{'Please select a start date and end date'|xlj }});
+                        return false;
+                    }
+                }
+                var ccrAction = document.getElementsByName('ccrAction');
+                ccrAction[0].value = 'generate';
+                var raw = document.getElementsByName('raw');
+                raw[0].value = 'pure';
+
+                $("#ccr_form").submit();
+            });
+        $(".viewCCD").click(
+            function () {
+                var ccrAction = document.getElementsByName('ccrAction');
+                ccrAction[0].value = 'viewccd';
+                var raw = document.getElementsByName('raw');
+                raw[0].value = 'no';
+
+                ccr_form.setAttribute("target", "_blank");
+                $("#ccr_form").submit();
+                ccr_form.setAttribute("target", "");
+            });
+        $(".viewCCD_raw").click(
+            function () {
+                var ccrAction = document.getElementsByName('ccrAction');
+                ccrAction[0].value = 'viewccd';
+                var raw = document.getElementsByName('raw');
+                raw[0].value = 'yes';
+
+                ccr_form.setAttribute("target", "_blank");
+                $("#ccr_form").submit();
+                ccr_form.setAttribute("target", "");
+            });
+        $(".viewCCD_download").click(
+            function () {
+                var ccrAction = document.getElementsByName('ccrAction');
+                ccrAction[0].value = 'viewccd';
+                var raw = document.getElementsByName('raw');
+                raw[0].value = 'pure';
+                $("#ccr_form").submit();
+            });
+        {% if phimail_enable and phimail_ccr_enable %}
+        $(".viewCCR_send_dialog").click(
+            function () {
+                $("#ccr_send_dialog").toggle();
+            });
+        $(".viewCCR_transmit").click(
+            function () {
+                $(".viewCCR_transmit").attr('disabled', 'disabled');
+                var ccrAction = document.getElementsByName('ccrAction');
+                ccrAction[0].value = 'generate';
+                var ccrRecipient = $("#ccr_send_to").val();
+                var raw = document.getElementsByName('raw');
+                raw[0].value = 'send ' + ccrRecipient;
+                if (ccrRecipient === "") {
+                    $("#ccr_send_message").html("{{ 'Please enter a valid Direct Address above.'|xla }}");
+                    $("#ccr_send_result").show();
+                } else {
+                    $(".viewCCR_transmit").attr('disabled', 'disabled');
+                    $("#ccr_send_message").html("{{ 'Working... this may take a minute.'|xla }}");
+                    $("#ccr_send_result").show();
+                    var action = $("#ccr_form").attr('action');
+                    $.post(action, {ccrAction: 'generate', raw: 'send ' + ccrRecipient, requested_by: 'user'},
+                        function (data) {
+                            if (data === "SUCCESS") {
+                                $("#ccr_send_message").html("{{ 'Your message was submitted for delivery to'|xla }} "
+                                    + ccrRecipient);
+                                $("#ccr_send_to").val("");
+                            } else {
+                                $("#ccr_send_message").html(data);
+                            }
+                            $(".viewCCR_transmit").removeAttr('disabled');
+                        });
+                }
+            });
+        {% endif %}
+
+        {% if phimail_enable and phimail_ccd_enable %}
+        $(".viewCCD_send_dialog").click(
+            function () {
+                $("#ccd_send_dialog").toggle();
+            });
+        $(".viewCCD_transmit").click(
+            function () {
+                $(".viewCCD_transmit").attr('disabled', 'disabled');
+                var ccrAction = document.getElementsByName('ccrAction');
+                ccrAction[0].value = 'viewccd';
+                var ccdRecipient = $("#ccd_send_to").val();
+                var raw = document.getElementsByName('raw');
+                raw[0].value = 'send ' + ccdRecipient;
+                if (ccdRecipient === "") {
+                    $("#ccd_send_message").text("{{ 'Please enter a valid Direct Address above.'|xla }}");
+                    $("#ccd_send_result").show();
+                } else {
+                    $(".viewCCD_transmit").attr('disabled', 'disabled');
+                    $("#ccd_send_message").text("{{ 'Working... this may take a minute.'|xla }}");
+                    $("#ccd_send_result").show();
+                    var action = $("#ccr_form").attr('action');
+                    $.post(action, {ccrAction: 'viewccd', raw: 'send ' + ccdRecipient, requested_by: 'user'},
+                        function (data) {
+                            if (data === "SUCCESS") {
+                                $("#ccd_send_message").text("{{ 'Your message was submitted for delivery to'|xla }} "
+                                    + ccdRecipient);
+                                $("#ccd_send_to").val("");
+                            } else {
+                                $("#ccd_send_message").text(data);
+                            }
+                            $(".viewCCD_transmit").removeAttr('disabled');
+                        });
+                }
+            });
+        {% endif %}
+    }; // end initReport
+
+    $(function () {
+
+        initReport();
+
+        datetimepickerTranslated('.datepicker', {
+            timepicker: false
+            , formatInput: false
+        });
+    });
+
+    // select/deselect the Forms related to the selected Encounter
+    // (it ain't pretty code folks)
+    var SelectForms = function (selectedEncounter) {
+        if ($(selectedEncounter).prop("checked")) {
+            $(selectedEncounter).parent().children().each(function (i, obj) {
+                $(this).children().each(function (i, obj) {
+                    $(this).prop("checked", true);
+                });
+            });
+        } else {
+            $(selectedEncounter).parent().children().each(function (i, obj) {
+                $(this).children().each(function (i, obj) {
+                    $(this).prop("checked", false);
+                });
+            });
+        }
+    }
+
+    // When an issue is checked, auto-check all the related encounters and forms
+    function issueClick(issue) {
+// do nothing when unchecked
+        if (!$(issue).prop("checked")) return;
+
+        $("#report_form :checkbox").each(function (i, obj) {
+            if ($(issue).val().indexOf('/' + $(this).val() + '/') >= 0) {
+                $(this).prop("checked", true);
+            }
+
+        });
+    }
+
+</script>

--- a/templates/portal/partial/reports/patient_report/_documents.html.twig
+++ b/templates/portal/partial/reports/patient_report/_documents.html.twig
@@ -1,0 +1,24 @@
+{#
+* _documents.html.twig
+*
+* @package   OpenEMR
+* @link      https://www.open-emr.org
+* @author    Jerry Padgett <sjpadgett@gmail.com>
+* @author    Stephen Nielson <snielson@discoverandchange.com>
+* @copyright Copyright (c) 2016-2024 Jerry Padgett <sjpadgett@gmail.com>
+*  @copyright Copyright (C) 2024 Open Plan IT Ltd. <support@openplanit.com>
+* @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+#}
+<hr />
+<span class="bold">{{ 'Documents'|xlt }}</span>:<br />
+<ul>
+    {% for document in documents %}
+        <li class='bold'>
+            <label>
+                <input type="checkbox" name="documents[]" value="{{ document.id|attr }}" />
+                &nbsp;&nbsp;<i>{{ document.category|text }}</i>
+                &nbsp;&nbsp;{{ "Name"|xlt}}: <i>{{ document.url|text }}</i>
+            </label>
+        </li>
+    {% endfor %}
+</ul>

--- a/templates/portal/partial/reports/patient_report/_head.html.twig
+++ b/templates/portal/partial/reports/patient_report/_head.html.twig
@@ -1,0 +1,159 @@
+{#
+* _head.html.twig
+*
+* @package   OpenEMR
+* @link      https://www.open-emr.org
+* @author    Jerry Padgett <sjpadgett@gmail.com>
+* @author    Stephen Nielson <snielson@discoverandchange.com>
+* @copyright Copyright (c) 2016-2024 Jerry Padgett <sjpadgett@gmail.com>
+*  @copyright Copyright (C) 2024 Open Plan IT Ltd. <support@openplanit.com>
+* @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+#}
+{{ setupHeader(['textformat', 'datetime-picker','datetime-picker-translated']) }}
+<style>
+    input[type="checkbox"],
+    input[type="radio"] {
+        margin: 0 5px 5px;
+        line-height: normal;
+    }
+
+    #patient_reports {
+        width: 100%;
+    }
+
+    #patient_reports .issues {
+        padding-right: 30px;
+    }
+
+    #patient_reports .issues table {
+        margin: 10px 0 10px 0;
+    }
+
+    #patient_reports .issues td {
+        padding: 2px;
+    }
+
+    #patient_reports .encounters td {
+        padding: 2px;
+    }
+
+    #patient_reports .encounter_forms {
+        margin: 5px 15px 5px 15px;
+    }
+
+    #patient_reports td {
+        vertical-align: top;
+    }
+
+    #patient_reports ul {
+        list-style: none;
+    }
+
+    /*=============================================================
+    * Report - Custom
+    * seen as the patient report (portal_custom_report.php)
+    *============================================================*/
+    #report_custom {
+        width: 100%;
+    }
+
+    #report_custom hr {
+        border: 2px dotted #000;
+    }
+
+    #report_custom .billing {
+        margin: 5px;
+        padding: 5px;
+    }
+
+    #report_custom h1 {
+        font-size: 120%;
+        margin: 0 0 5px 0;
+        padding: 0;
+    }
+
+    #report_custom .immunizations {
+        margin: 5px;
+        padding: 5px;
+    }
+
+    #report_custom .notes {
+        margin: 5px;
+        padding: 5px;
+    }
+
+    #report_custom .transactions {
+        margin: 5px;
+        padding: 5px;
+    }
+
+    #report_custom .communications {
+        margin: 5px;
+        padding: 5px;
+    }
+
+    #report_custom .documents {
+        margin: 5px;
+        padding: 5px;
+    }
+
+    #report_custom .demographics {
+        margin: 5px;
+        padding: 5px;
+    }
+
+    #report_custom .insurance {
+        margin: 5px;
+        padding: 5px;
+    }
+
+    #report_custom .history {
+        margin: 5px;
+        padding: 5px;
+    }
+
+    #report_custom .issue {
+        margin-left: 20px;
+    }
+
+    #report_custom .issue_type {
+        font-weight: bold;
+        padding: 5px 0 5px 0;
+    }
+
+    #report_custom .issue_diag {
+        margin: 0 20px 0 20px;
+    }
+
+    #report_custom .encounter {
+        width: 100%;
+        border-top: 2px dotted #000;
+        padding: 10px 5px 10px 5px;
+        margin-top: 10px;
+    }
+
+    #report_custom .encounter h1 {
+        font-size: 140%;
+        margin: 0;
+        padding: 0;
+    }
+
+    #report_custom .encounter_form {
+        margin: 10px;
+        padding: 10px;
+        border-top: 1px solid #808080;
+    }
+
+    #addressbook_list tr.evenrow {
+        background-color: #ddddff;
+    }
+
+    #addressbook_list tr.oddrow {
+        background-color: #ffffff;
+    }
+
+    tr.odd,
+    td.even {
+        background-color: #ffffff !important;
+    }
+</style>

--- a/templates/portal/partial/reports/patient_report/_issues_encounters.html.twig
+++ b/templates/portal/partial/reports/patient_report/_issues_encounters.html.twig
@@ -1,0 +1,37 @@
+{#
+* _issues_encounters.html.twig
+*
+* @package   OpenEMR
+* @link      https://www.open-emr.org
+* @author    Jerry Padgett <sjpadgett@gmail.com>
+* @author    Stephen Nielson <snielson@discoverandchange.com>
+* @copyright Copyright (c) 2016-2024 Jerry Padgett <sjpadgett@gmail.com>
+*  @copyright Copyright (C) 2024 Open Plan IT Ltd. <support@openplanit.com>
+* @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+#}
+<div class="issues">
+    <span class='bold'>{{ "Issues"|xlt }}:</span>
+    <br /><br />
+    <table>
+        {% for disptype,issuesCategory in issues %}
+        <tr>
+            <td colspan='4' class='bold'><b>{{ issuesCategory.display|text }}</b></td>
+        </tr>
+        {% for issue in issuesCategory.issues %}
+        <tr class='text'>
+            <td>&nbsp;</td>
+            <td>
+                <label class="d-block" for='issue_{{ issue.id|attr }}'>
+                    <input type='checkbox' name='issue_{{ issue.id|attr }}' id='issue_{{ issue.id|attr }}' class='issuecheckbox' value='/{{ issue.encounter|join("/")|text }}' />
+                    {{ issue.title|text }}
+                </label>
+            </td>
+            <td><label for='issue_{{ issue.id|attr }}' class="d-block">{{ issue.begdate|text }}
+                {% if issue.status == 'active' %}{{ "Active"|xlt }}{% else %}{{ issue.enddate|text }}{% endif %}
+            </label>
+            </td>
+        </tr>
+        {% endfor %}
+        {% endfor %}
+    </table>
+</div>

--- a/templates/portal/partial/reports/patient_report/_issues_encounters.html.twig
+++ b/templates/portal/partial/reports/patient_report/_issues_encounters.html.twig
@@ -22,7 +22,7 @@
             <td>&nbsp;</td>
             <td>
                 <label class="d-block" for='issue_{{ issue.id|attr }}'>
-                    <input type='checkbox' name='issue_{{ issue.id|attr }}' id='issue_{{ issue.id|attr }}' class='issuecheckbox' value='/{{ issue.encounter|join("/")|text }}' />
+                    <input type='checkbox' name='issue_{{ issue.id|attr }}' id='issue_{{ issue.id|attr }}' class='issuecheckbox' value='/{{ issue.encounter|join("/")|attr }}' />
                     {{ issue.title|text }}
                 </label>
             </td>

--- a/templates/portal/partial/reports/patient_report/_issues_encounters_form.html.twig
+++ b/templates/portal/partial/reports/patient_report/_issues_encounters_form.html.twig
@@ -33,7 +33,7 @@
                         <label>
                             <input type="checkbox" name="{{ form.formdir|attr }}_{{ form.form_id|attr }}"
                                    id="{{ form.formdir|attr }}_{{ form.form_id|attr }}"
-                                   value="{{ form.encounter|attr }}" class="encounter_form">{{ form.display|attr }} ({{ form.date|date("Y-m-d")|attr }})
+                                   value="{{ form.encounter|attr }}" class="encounter_form">{{ form.display|text }} ({{ form.date|date("Y-m-d")|text }})
                         </label>
                         <br />
                         {% endfor %}

--- a/templates/portal/partial/reports/patient_report/_issues_encounters_form.html.twig
+++ b/templates/portal/partial/reports/patient_report/_issues_encounters_form.html.twig
@@ -1,0 +1,47 @@
+{#
+* _issues_encounters_form.html.twig
+*
+* @package   OpenEMR
+* @link      https://www.open-emr.org
+* @author    Jerry Padgett <sjpadgett@gmail.com>
+* @author    Stephen Nielson <snielson@discoverandchange.com>
+* @copyright Copyright (c) 2016-2024 Jerry Padgett <sjpadgett@gmail.com>
+*  @copyright Copyright (C) 2024 Open Plan IT Ltd. <support@openplanit.com>
+* @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+#}
+<table class="issues_encounters_forms table">
+    <tr>
+        <!-- Issues -->
+        <td class='text'>
+            {% include "portal/partial/reports/patient_report/_issues_encounters.html.twig" %}
+        </td>
+        <!-- Encounters and Forms -->
+        <td class='text'>
+            <div class='encounters'>
+                <span class='bold'>{{ "Encounters & Forms"|xlt }}:</span>
+                <br /><br />
+                {% for encounter in encounters %}
+                <div class='encounter_data'>
+                    <label>
+                        <input type='checkbox' name='{{ encounter.formdir|attr }}_{{ encounter.form_id|attr }}'
+                               id='{{ encounter.formdir|attr }}_{{ encounter.form_id|attr }}'
+                               value='{{ encounter.encounter|attr }}' class='encounter'>{{ encounter.display|text }} ({{ form.date|date("Y-m-d") }})
+                    </label>
+                    <div class='encounter_forms'>
+                        {% for formName,formList in encounter.forms %}
+                        {% for form in formList %}
+                        <label>
+                            <input type="checkbox" name="{{ form.formdir|attr }}_{{ form.form_id|attr }}"
+                                   id="{{ form.formdir|attr }}_{{ form.form_id|attr }}"
+                                   value="{{ form.encounter|attr }}" class="encounter_form">{{ form.display|attr }} ({{ form.date|date("Y-m-d")|attr }})
+                        </label>
+                        <br />
+                        {% endfor %}
+                        {% endfor %}
+                    </div> <!-- end encounter_forms -->
+                </div> <!-- end encounter_data -->
+                {% endfor %}
+            </div>
+        </td>
+    </tr>
+</table>

--- a/templates/portal/partial/reports/patient_report/_procedure_orders.html.twig
+++ b/templates/portal/partial/reports/patient_report/_procedure_orders.html.twig
@@ -1,0 +1,42 @@
+{#
+* _procedure_orders.html.twig
+*
+* @package   OpenEMR
+* @link      https://www.open-emr.org
+* @author    Jerry Padgett <sjpadgett@gmail.com>
+* @author    Stephen Nielson <snielson@discoverandchange.com>
+* @copyright Copyright (c) 2016-2024 Jerry Padgett <sjpadgett@gmail.com>
+*  @copyright Copyright (C) 2024 Open Plan IT Ltd. <support@openplanit.com>
+* @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+#}
+<hr />
+<table class="table">
+    <tr>
+        <td class='bold'>{{ 'Procedures'|xlt }}&nbsp;&nbsp;</td>
+        <td class='text'>{{ 'Order Date'|xlt }}&nbsp;&nbsp;</td>
+        <td class='text'>{{ 'Encounter Date'|xlt }}&nbsp;&nbsp;</td>
+        <td class='text'>{{ 'Order Descriptions'|xlt }}</td>
+    </tr>
+    {% for row in procedureOrders %}
+        <tr>
+            <td class='text text-left'>
+                <label class="d-block"><input id="procedure_{{ id|attr }}" type='checkbox' name='procedures[]' value='{{ row.id|attr }}' />&nbsp;&nbsp;
+                </label>
+            </td>
+            <td class='text'><label class="d-block" for="procedure_{{ id|attr }}">{{ row.date_ordered|shortDate|text }}&nbsp;&nbsp;</label></td>
+            <td class='text'><label class="d-block" for="procedure_{{ id|attr }}">{{ row.date|shortDate|text }}</label></td>
+            <td class='text'>
+                <label class="d-block" for="procedure_{{ id|attr }}">
+                    {% for procedure in row.procedures %}
+                        {% if procedure.name is empty %}
+                            {{ procedure.code|text }}
+                        {% else %}
+                            {{ procedure.name|text }}
+                        {% endif %}
+                        <br />
+                    {% endfor %}
+                </label>
+            </td>
+        </tr>
+    {% endfor %}
+</table>

--- a/templates/portal/partial/reports/patient_report/_section_list.html.twig
+++ b/templates/portal/partial/reports/patient_report/_section_list.html.twig
@@ -1,0 +1,31 @@
+{#
+* _section_list.html.twig
+*
+* @package   OpenEMR
+* @link      https://www.open-emr.org
+* @author    Jerry Padgett <sjpadgett@gmail.com>
+* @author    Stephen Nielson <snielson@discoverandchange.com>
+* @copyright Copyright (c) 2016-2024 Jerry Padgett <sjpadgett@gmail.com>
+*  @copyright Copyright (C) 2024 Open Plan IT Ltd. <support@openplanit.com>
+* @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+#}
+<table class="table includes">
+    <tr>
+        {% if section_one|length > 0 %}
+        <td class='text'>
+            {% for sectionId in section_one %}
+            {% include 'portal/partial/reports/patient_report/_section_list_item.html.twig'
+                with {sectionId: sectionId, section: sections[sectionId] } %}
+            {% endfor %}
+        </td>
+        {% endif %}
+        {% if section_two|length > 0 %}
+        <td class='text'>
+            {% for sectionId in section_two %}
+                {% include 'portal/partial/reports/patient_report/_section_list_item.html.twig'
+                    with {sectionId: sectionId, section: sections[sectionId] } %}
+            {% endfor %}
+        </td>
+        {% endif %}
+    </tr>
+</table>

--- a/templates/portal/partial/reports/patient_report/_section_list_item.html.twig
+++ b/templates/portal/partial/reports/patient_report/_section_list_item.html.twig
@@ -1,0 +1,11 @@
+{#
+* _section_list_item.html.twig
+*
+* @package   OpenEMR
+* @link      https://www.open-emr.org
+* @author    Stephen Nielson <snielson@discoverandchange.com>
+*  @copyright Copyright (C) 2024 Open Plan IT Ltd. <support@openplanit.com>
+* @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+#}
+<input type='checkbox' name='include_{{ sectionId|attr }}' id='include_{{ sectionId|attr }}' value="{{ sectionId|attr }}"
+    {% if section.selected %}checked{% endif %}>{{ section.label|text }}<br />

--- a/templates/portal/portal_patient_report.html.twig
+++ b/templates/portal/portal_patient_report.html.twig
@@ -1,0 +1,48 @@
+{#
+* portal_patient_report.html.twig
+*
+* @package   OpenEMR
+* @link      https://www.open-emr.org
+* @author    Jerry Padgett <sjpadgett@gmail.com>
+* @author    Brady Miller <brady@sparmy.com>
+* @author    Stephen Nielson <snielson@discoverandchange.com>
+* @copyright Copyright (c) 2016-2020 Jerry Padgett <sjpadgett@gmail.com>
+* @copyright Copyright (c) 2019 Brady Miller <brady.g.miller@gmail.com>
+* @copyright Copyright (C) 2024 Open Plan IT Ltd. <support@openplanit.com>
+* @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+#}
+<html>
+<head>
+    {% include "portal/partial/reports/patient_report/_head.html.twig" %}
+</head>
+<body class="body_top">
+<div id="patient_reports"> <!-- large outer DIV -->
+    <form name='report_form' id="report_form" method='post' action='./report/portal_custom_report.php'>
+        <span class='card-heading'>{{ "Patient Report"|xlt }}</span>&nbsp;&nbsp;
+        <a class="link_submit" href="#" onclick="return checkAll(true)">{{ "Check All"|xlt }}</a> |
+        <a class="link_submit" href="#" onclick="return checkAll(false)">{{ "Clear All"|xlt }}</a>
+
+        {% include "portal/partial/reports/patient_report/_section_list.html.twig"  %}
+
+        <input type='hidden' name='pdf' value='0'>
+        <br />
+        {% include "portal/partial/reports/patient_report/_issues_encounters_form.html.twig" with {encounters: encounters, issues: issues} %}
+
+        <!-- Procedure Orders -->
+        {% include "portal/partial/reports/patient_report/_procedure_orders.html.twig" with {procedureOrders: procedureOrders} %}
+
+        {% include "portal/partial/reports/patient_report/_documents.html.twig" with {documents: documents} %}
+
+    </form>
+    <input type="button" class="genreport" value="{{ 'Generate Report'|xla }}" />&nbsp;
+    <input type="button" class="genpdfrep" value="{{ 'Download PDF'|xla }}" />&nbsp;
+</div>  <!-- close patient_reports DIV -->
+{% include "portal/partial/reports/patient_report/_body_scripts.html.twig"
+    with {
+        phimail_enable: phimail_enable
+        ,phimail_ccd_enable: phimail_ccd_enable
+        ,phone_country_code: phone_country_code
+    }
+%}
+</body>
+</html>


### PR DESCRIPTION
Made it so the custom report foudn in patient_report.php uses twig and also has a filter event for customizing the data that gets passed into the report selection system.  This allows module writers to extend the interface and add data or hide sections as needed.

Did the same thing with the health snapshot to allow pieces of the snapshot to be overridden by twig templates.

This work was done to facilitate a module that wanted to have flags to hide/show different parts of the reports and health snapshot as they pilot test these areas with their patients.

Fixes #7707
Fixes #7708