### PR TITLE
add ability to configure two logos on portal login page

### DIFF
--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -3232,6 +3232,30 @@ $GLOBALS_METADATA = array(
             '1',
             xl('UnCheck to not show insurances in Profile.')
         ),
+
+        'show_portal_primary_logo' => [
+            xl('Show Primary Logo on portal login page'),
+            'bool',
+            '1',
+            xl('Show primary logo on login'),
+        ],
+
+        'extra_portal_logo_login' => array(
+            xl('Show Secondary Logo on portal  Login page'),
+            'bool',                           // data type
+            '0',                              // default = false
+            xl('Show Secondary Logo on Login')
+        ),
+
+        'secondary_portal_logo_position' => [
+            xl('Order of the Secondary logo'),
+            [
+                'first' => xl('First Position'),
+                'second' => xl('Second Position'),
+            ],
+            'second',
+            xl('Place the secondary logo first, or second'),
+        ],
     ),
 
     // Connectors Tab

--- a/portal/index.php
+++ b/portal/index.php
@@ -51,6 +51,7 @@ use OpenEMR\Services\LogoService;
 $landingpage = "index.php?site=" . urlencode($_SESSION['site_id']);
 $logoService = new LogoService();
 $logoSrc = $logoService->getLogo("portal/login/primary");
+$logo2ndSrc = $logoService->getLogo("portal/login/secondary","logoHSE.png"); /*rm - add secondary logo */
 
 // allow both get and post redirect params here... everything will be sanitized in get_patient_info.php before we
 // actually do anything with the redirect
@@ -550,7 +551,24 @@ if (!(isset($_SESSION['password_update']) || (!empty($GLOBALS['portal_two_pass_r
         <?php } else {
             ?> <!-- Main logon -->
         <div class="container-xl p-1">
-            <div class="img-fluid text-center"><img class="login-logo" src='<?php echo $logoSrc; ?>'></div>
+        <!-- Optionally show two logos, and in either order -->
+        <?php if($GLOBALS['secondary_portal_logo_position'] == 'second'){ ?>
+              <?php if ($GLOBALS['show_portal_primary_logo']) { ?>
+                <div class="img-fluid text-center"><img class="login-logo" src='<?php echo $logoSrc; ?>'></div>
+              <?php } ?>
+              <?php if ($GLOBALS['extra_portal_logo_login']) { ?>
+                <div class="img-fluid text-center"><img class="login-logo" src='<?php echo $logo2ndSrc; ?>'></div>
+              <?php } ?>
+        <?php } else {
+               if($GLOBALS['secondary_portal_logo_position'] == 'first'){ ?>
+                  <?php if ($GLOBALS['extra_portal_logo_login']) { ?>
+                        <div class="img-fluid text-center"><img class="login-logo" src='<?php echo $logo2ndSrc; ?>'></div>
+                  <?php } ?>
+                   <?php if ($GLOBALS['show_portal_primary_logo']) { ?>
+                       <div class="img-fluid text-center"><img class="login-logo" src='<?php echo $logoSrc; ?>'></div>
+                   <?php } ?>
+               <?php  } ?>
+          <?php } ?>
             <legend class="text-center bg-light text-dark pt-2 py-1"><h2><?php echo $GLOBALS['openemr_name'] . ' ' . xlt('Portal Login'); ?></h2></legend>
             <form class="mx-1" action="get_patient_info.php" method="POST" onsubmit="return process()">
                 <?php if (isset($redirectUrl)) { ?>


### PR DESCRIPTION
 
Fixes #7710

#### Short description of what this resolves:
enable one to have two logos on the portal login page, configure which to display and in which order

#### Changes proposed in this pull request:
add 3 configuration items to  admin -> config -> portal 
![Screenshot from 2024-09-11 16-42-37](https://github.com/user-attachments/assets/f4b2329d-9d1d-4c08-8fdb-ef89f53cd10b)
and then display zero, one or two logos and if two in either order

add the directory openemr/public/images/logos/portal/login/secondary - in which to place the secondary image
