### PR TITLE
fix: support nginx based testing ci dockers for testing nodejs stuff

### DIFF
--- a/docker/library/dockers/dev-php-fpm-8-1-redis/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-1-redis/Dockerfile
@@ -11,6 +11,10 @@
 #
 FROM php:8.1-fpm-buster
 
+# set environment setting to let OpenEMR CI know that unable to test nodejs related stuff since this
+#  environment can not support a high enough nodejs version.
+ENV UNABLE_SUPPORT_OPENEMR_NODEJS = True
+
 # Update
 RUN apt-get update
 

--- a/docker/library/dockers/dev-php-fpm-8-1/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-1/Dockerfile
@@ -11,6 +11,10 @@
 #
 FROM php:8.1-fpm-buster
 
+# set environment setting to let OpenEMR CI know that unable to test nodejs related stuff since this
+#  environment can not support a high enough nodejs version.
+ENV UNABLE_SUPPORT_OPENEMR_NODEJS = True
+
 # Update
 RUN apt-get update
 

--- a/docker/library/dockers/dev-php-fpm-8-2-redis/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-2-redis/Dockerfile
@@ -11,6 +11,10 @@
 #
 FROM php:8.2-fpm-buster
 
+# set environment setting to let OpenEMR CI know that unable to test nodejs related stuff since this
+#  environment can not support a high enough nodejs version.
+ENV UNABLE_SUPPORT_OPENEMR_NODEJS = True
+
 # Update
 RUN apt-get update
 

--- a/docker/library/dockers/dev-php-fpm-8-2/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-2/Dockerfile
@@ -11,6 +11,10 @@
 #
 FROM php:8.2-fpm-buster
 
+# set environment setting to let OpenEMR CI know that unable to test nodejs related stuff since this
+#  environment can not support a high enough nodejs version.
+ENV UNABLE_SUPPORT_OPENEMR_NODEJS = True
+
 # Update
 RUN apt-get update
 

--- a/docker/library/dockers/dev-php-fpm-8-4-redis/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-4-redis/Dockerfile
@@ -9,7 +9,7 @@
 # php-fpm Dockerfile build for openemr development docker environment
 # This docker is hosted here: https://hub.docker.com/r/openemr/dev-php-fpm/ <tag is 7.2>
 #
-FROM openemr/dev-php-fpm:pre-build-dev-84
+FROM php:8.4-rc-fpm
 
 # Update
 RUN apt-get update

--- a/docker/library/dockers/dev-php-fpm-8-4/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-4/Dockerfile
@@ -9,7 +9,7 @@
 # php-fpm Dockerfile build for openemr development docker environment
 # This docker is hosted here: https://hub.docker.com/r/openemr/dev-php-fpm/ <tag is 7.2>
 #
-FROM openemr/dev-php-fpm:pre-build-dev-84
+FROM php:8.4-rc-fpm
 
 # Update
 RUN apt-get update


### PR DESCRIPTION
support nginx based testing ci dockers for testing nodejs stuff