### PR TITLE
fix: x12837 billing 5 or 9 digit zip check

### DIFF
--- a/src/Billing/Claim.php
+++ b/src/Billing/Claim.php
@@ -1677,7 +1677,7 @@ class Claim
 
     public function referrerMiddleName()
     {
-        return $this->x12Clean(trim($this->referrer['mname']));
+        return $this->x12Clean(trim($this->referrer['mname'] ?? ''));
     }
 
     public function referrerNPI()

--- a/src/Billing/X125010837P.php
+++ b/src/Billing/X125010837P.php
@@ -1223,7 +1223,7 @@ class X125010837P
             if (
                 !(
                     (strlen($claim->insuredZip($ins)) == 5)
-                    || (strlen($claim->insuredZip($ins) == 9))
+                    || (strlen($claim->insuredZip($ins)) == 9)
                 )
             ) {
                 $log .= "*** Other insco insured zip is not 5 or 9 digits.\n";
@@ -1285,7 +1285,7 @@ class X125010837P
             if (
                 !(
                     (strlen($claim->payerZip($ins)) == 5)
-                    || (strlen($claim->payerZip() == 9))
+                    || (strlen($claim->payerZip($ins)) == 9)
                 )
             ) {
                 $log .= "*** Other payer zip is not 5 or 9 digits.\n";

--- a/src/Services/FormService.php
+++ b/src/Services/FormService.php
@@ -48,6 +48,7 @@ class FormService
 
         $res = sqlStatement($sql, $arraySqlBind);
 
+        $all = [];
         for ($iter = 0; $row = sqlFetchArray($res); $iter++) {
             $all[$iter] = $row;
         }


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #7759 
also fixes an empty array and warning 

#### Short description of what this resolves:


#### Changes proposed in this pull request:

#### Does your code include anything generated by an AI Engine? Yes / No

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.
