### PR TITLE
fix: allow viewing of fee sheet items if billing.billed is null

### DIFF
--- a/src/Billing/BillingReport.php
+++ b/src/Billing/BillingReport.php
@@ -43,7 +43,7 @@ class BillingReport
                     $billstring .= ' AND ' . "billing.billed = '1'";
                 } elseif (strpos($criteria_value, "billing.billed|=|0") !== false) {
                     //3 is an error condition
-                    $billstring .= ' AND ' . "(billing.billed = '0' or (billing.billed = '1' and billing.bill_process = '3'))";
+                    $billstring .= ' AND ' . "(billing.billed = '0' OR billing.billed IS NULL OR (billing.billed = '1' AND billing.bill_process = '3'))";
                 } elseif (strpos($criteria_value, "billing.billed|=|7") !== false) {
                     $billstring .= ' AND ' . "billing.bill_process = '7'";
                 } elseif (strpos($criteria_value, "billing.id|=|null") !== false) {


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #7807 

#### Short description of what this resolves:


#### Changes proposed in this pull request:

#### Does your code include anything generated by an AI Engine? Yes / No

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.
