### PR TITLE
Fixes #7814 empty procedures error.

### DIFF
--- a/src/Controllers/Portal/PortalPatientReportController.php
+++ b/src/Controllers/Portal/PortalPatientReportController.php
@@ -67,6 +67,10 @@ class PortalPatientReportController
                 'procedures' => []
             ];
         }
+        // nothing to do here
+        if (empty($proceduresById)) {
+            return [];
+        }
         $sql = "SELECT procedure_order_id, procedure_code, procedure_name FROM procedure_order_code " .
             "WHERE procedure_order_id IN (" . implode(",", array_keys($proceduresById)) . ") ORDER BY procedure_order_id, procedure_order_seq";
         $res = sqlStatement($sql);

--- a/templates/portal/partial/reports/patient_report/_procedure_orders.html.twig
+++ b/templates/portal/partial/reports/patient_report/_procedure_orders.html.twig
@@ -9,6 +9,7 @@
 *  @copyright Copyright (C) 2024 Open Plan IT Ltd. <support@openplanit.com>
 * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
 #}
+{% if procedureOrders|length > 0 %}
 <hr />
 <table class="table">
     <tr>
@@ -40,3 +41,4 @@
         </tr>
     {% endfor %}
 </table>
+{% endif %}


### PR DESCRIPTION
Made it so we handle the procedures list if there are no procedures present.

Fixes #7814.  Refactoring of the patient report page exposed a bug where if no procedures are present it blows up the portal.