### PR TITLE
Fix SMS and email appointment reminder notifications

### DIFF
--- a/interface/batchcom/smsnotification.php
+++ b/interface/batchcom/smsnotification.php
@@ -59,7 +59,7 @@ if (!empty($_POST['form_action']) && ($_POST['form_action'] == 'save')) {
         $sql_value = " (?, ?, ?, ?, ?, ?, ?) ";
         $values = array($_POST['notification_id'], $_POST['sms_gateway_type'],
                         $_POST['provider_name'], $_POST['message'],
-                        '', '', 'SMS');
+                        $_POST['sender'], '', 'SMS');
         $query = "REPLACE INTO `automatic_notification` $sql_text VALUES $sql_value";
         //echo $query;
         $id = sqlInsert($query, $values);
@@ -79,6 +79,7 @@ if ($result) {
     $notification_id = $result['notification_id'];
     $sms_gateway_type = $result['sms_gateway_type'];
     $provider_name = $result['provider_name'];
+    $sender = $result['email_sender'];
     $message = $result['message'];
 } else {
     $sql_msg = xl('Missing SMS config record');
@@ -118,7 +119,7 @@ $sms_gateway = array ('CLICKATELL','TMB4');
             <input type="hidden" name="type" value="SMS">
             <input type="hidden" name="notification_id" value="<?php echo attr($notification_id); ?>">
             <div class="row">
-                <div class="col-md-6 form-group">
+                <div class="col-md-4 form-group">
                     <label for="sms_gateway_type"><?php echo xlt('SMS Gateway') ?>:</label>
                     <select name="sms_gateway_type" class="form-control">
                         <option value=""><?php echo xlt('Select SMS Gateway'); ?></option>
@@ -134,7 +135,11 @@ $sms_gateway = array ('CLICKATELL','TMB4');
                         <?php }?>
                     </select>
                 </div>
-                <div class="col-md-6 form-group">
+                <div class="col-md-4 form-group">
+                    <label for="sender"><?php echo xlt('Sending Number'); ?>:</label>
+                    <input class="form-control" type="text" name="sender" size="20" value="<?php echo attr($sender); ?>" placeholder="<?php xla('sender number'); ?>">
+                </div>
+                <div class="col-md-4 form-group">
                     <label for="provider_name"><?php echo xlt('Name of Provider'); ?>:</label>
                     <input class="form-control" type="text" name="provider_name" size="40" value="<?php echo attr($provider_name); ?>" placeholder="<?php xla('provider name'); ?>">
                 </div>

--- a/modules/sms_email_reminder/cron_email_notification.php
+++ b/modules/sms_email_reminder/cron_email_notification.php
@@ -15,8 +15,10 @@
 exit;
 
 // larry :: hack add for command line version
-$_SERVER['REQUEST_URI'] = $_SERVER['PHP_SELF'];
-$_SERVER['SERVER_NAME'] = 'localhost';
+if (!array_key_exists('REQUEST_URI', $_SERVER)) {
+    $_SERVER['REQUEST_URI'] = $_SERVER['PHP_SELF'];
+    $_SERVER['SERVER_NAME'] = 'localhost';
+}
 $backpic = "";
 
 // email notification

--- a/modules/sms_email_reminder/cron_email_notification.php
+++ b/modules/sms_email_reminder/cron_email_notification.php
@@ -71,13 +71,13 @@ for ($p = 0; $p < count($db_patient); $p++) {
         cron_InsertNotificationLogEntry($TYPE, $prow, $db_email_msg);
 
         //set message
-        $db_email_msg['message'] = cron_setmessage($prow, $db_email_msg);
+        $content = cron_setmessage($prow, $db_email_msg);
 
         // send mail to patinet
         cron_SendMail(
             $prow['email'],
             $db_email_msg['email_subject'],
-            $db_email_msg['message'],
+            $content,
             $db_email_msg['email_sender']
         );
 
@@ -85,7 +85,7 @@ for ($p = 0; $p < count($db_patient); $p++) {
         cron_updateentry($TYPE, $prow['pid'], $prow['pc_eid']);
 
         $strMsg .= " || ALERT SENT SUCCESSFULLY TO " . $prow['email'];
-        $strMsg .= "\n" . $patient_info . "\n" . $smsgateway_info . "\n" . $data_info . "\n" . $db_email_msg['message'];
+        $strMsg .= "\n" . $patient_info . "\n" . $smsgateway_info . "\n" . $data_info . "\n" . $content;
     }
 
     WriteLog($strMsg);

--- a/modules/sms_email_reminder/cron_functions.php
+++ b/modules/sms_email_reminder/cron_functions.php
@@ -5,8 +5,6 @@
 // scripts to notify events
 ////////////////////////////////////////////////////////////////////
 
-use MyMailer;
-
 // larry :: somne global to be defined here
 global $smsgateway_info;
 global $patient_info;

--- a/modules/sms_email_reminder/cron_functions.php
+++ b/modules/sms_email_reminder/cron_functions.php
@@ -133,10 +133,10 @@ function cron_SendMail($to, $subject, $vBody, $from)
                 $vBody
             )
         ) {
-            echo "Message sent to " . text($to) . " OK.\n";
+            //echo "Message sent to " . text($to) . " OK.\n";
             $mstatus = true;
         } else {
-             echo "Cound not send the message to " . text($to) . ".\nError: " . text($smtp->error) . "\n";
+             //echo "Cound not send the message to " . text($to) . ".\nError: " . text($smtp->error) . "\n";
              $mstatus = false;
         }
 

--- a/modules/sms_email_reminder/cron_sms_notification.php
+++ b/modules/sms_email_reminder/cron_sms_notification.php
@@ -115,7 +115,7 @@ for ($p = 0; $p < count($db_patient); $p++) {
         }
 
         // larry :: debug
-        echo "\nDEBUG :: sms was sent to= " . text($prow['phone_cell']) .
+        //echo "\nDEBUG :: sms was sent to= " . text($prow['phone_cell']) .
                     " \nsender= " . text($db_email_msg['email_sender']) .
                     " \nsbj= " . text($db_email_msg['email_subject']) .
                     " \nmsg= " . text($content) . "\n";

--- a/modules/sms_email_reminder/cron_sms_notification.php
+++ b/modules/sms_email_reminder/cron_sms_notification.php
@@ -13,8 +13,10 @@
 exit;
 
 // larry :: hack add for command line version
-$_SERVER['REQUEST_URI'] = $_SERVER['PHP_SELF'];
-$_SERVER['SERVER_NAME'] = 'localhost';
+if (!array_key_exists('REQUEST_URI', $_SERVER)) {
+    $_SERVER['REQUEST_URI'] = $_SERVER['PHP_SELF'];
+    $_SERVER['SERVER_NAME'] = 'localhost';
+}
 $backpic = "";
 
 // email notification

--- a/modules/sms_email_reminder/cron_sms_notification.php
+++ b/modules/sms_email_reminder/cron_sms_notification.php
@@ -102,14 +102,14 @@ for ($p = 0; $p < count($db_patient); $p++) {
         cron_InsertNotificationLogEntry($TYPE, $prow, $db_email_msg);
 
         //set message
-        $db_email_msg['message'] = cron_setmessage($prow, $db_email_msg);
+        $content = cron_setmessage($prow, $db_email_msg);
 
         // send sms to patinet - if not in test mode
         if ($bTestRun == 0) {
             cron_SendSMS(
                 $prow['phone_cell'],
                 $db_email_msg['email_subject'],
-                $db_email_msg['message'],
+                $content,
                 $db_email_msg['email_sender']
             );
         }
@@ -118,13 +118,13 @@ for ($p = 0; $p < count($db_patient); $p++) {
         echo "\nDEBUG :: sms was sent to= " . text($prow['phone_cell']) .
                     " \nsender= " . text($db_email_msg['email_sender']) .
                     " \nsbj= " . text($db_email_msg['email_subject']) .
-                    " \nmsg= " . text($db_email_msg['message']) . "\n";
+                    " \nmsg= " . text($content) . "\n";
 
         //update entry >> pc_sendalertsms='Yes'
         cron_updateentry($TYPE, $prow['pid'], $prow['pc_eid']);
 
         $strMsg .= " || ALERT SENT SUCCESSFULLY TO " . $prow['phone_cell'];
-        $strMsg .= "\n" . $patient_info . "\n" . $smsgateway_info . "\n" . $data_info . "\n" . $db_email_msg['message'];
+        $strMsg .= "\n" . $patient_info . "\n" . $smsgateway_info . "\n" . $data_info . "\n" . $content;
     }
 
     // write logs for every reminder sent

--- a/modules/sms_email_reminder/sms_clickatell.php
+++ b/modules/sms_email_reminder/sms_clickatell.php
@@ -26,7 +26,7 @@
  * <code>
  * <?php
  * require_once ("sms_api.php");
- * $mysms = new sms();
+ * $mysms = new sms("username", "password", "api_key");
  * echo $mysms->session;
  * echo $mysms->getbalance();
  * // $mysms->token_pay("1234567890123456"); //spend voucher with SMS credits
@@ -120,8 +120,12 @@ class sms
     * @return object New SMS object.
     * @access public
     */
-    function __construct()
+    function __construct($strUser, $strPass, $strApiId)
     {
+        $this->user = $strUser;
+        $this->password = $strPass;
+        $this->api_id = $strApiId;
+
         if ($this->use_ssl) {
             $this->base   = "http://api.clickatell.com/http";
             $this->base_s = "https://api.clickatell.com/http";


### PR DESCRIPTION
Fixes #7822

#### Short description of what this resolves:
This fixes (Clickatell) SMS notifications and (Google Workspaces) email notifications.

#### Changes proposed in this pull request:
**Only set SERVER_NAME if it was not already set** - the scripts included logic to set a SERVER_NAME and REQUEST_URI to hardcoded values.  This would support invoking the scripts directly.  However, it will overwrite legitimate values if the scripts were instead invoked through the web server.  This caused later integration with MyMailer to fail due to the hostname being rejected by the SMTP server.  Instead, only set these if they were not already set.

**Store formatted messages in local variable** - when sending messages, the message format was updated in place.  If multiple notifications were sent, this would result in subsequent messages being sent with the formatted content of the first.  Instead, store the formatted message in a local variable.

**Don't echo potential PII in notification sending output** - the scripts included echo statements for debugging.  Since the scripts are served without a login requirement through the web server, this could expose PII - names, email addresses, phone numbers.  Comment out these statements; the actions will still be logged.

**Use MyMailer for sending appointment email reminders** - other places use the `MyMailer` class for sending emails.  The notification scripts used a different mechanism, expecting different configuration values.  Change the script to use `MyMailer`, instead.

**Use passed in values for user, password, API key** - the username, password, and API key were already being passed in to the Clickatell SMS class, but not used.  Use those values.

**Update Clickatell integration to use new API** - The API used in the Clickatell integration is no longer supported for new customers.  This updates it to use the [current API](https://docs.clickatell.com/channels/sms-channels/sms-api-reference/#tag/SMS-API/operation/sendMessageHTTP).  The new API requires a sending phone number, so it adds that field to the configuration page (the `email_sender` value was already being passed through).

All of these changes are being used and working on a live instance.

#### Does your code include anything generated by an AI Engine? No
