### PR TITLE
updated US CDC website link to current immunization VIS page

### DIFF
--- a/ccdaservice/package-lock.json
+++ b/ccdaservice/package-lock.json
@@ -2601,7 +2601,6 @@
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "oe-blue-button-generate": {
-	    "name": "oe-blue-button-generate",
             "version": "1.5.10",
             "license": "Apache-2.0",
             "devDependencies": {},

--- a/interface/patient_file/summary/immunizations.php
+++ b/interface/patient_file/summary/immunizations.php
@@ -465,7 +465,7 @@ tr.selected {
                     <div class="form-group mt-3">
                         <label>
                             <?php echo xlt('Date of VIS Statement'); ?>
-                            (<a href="https://www.cdc.gov/vaccines/pubs/vis/default.htm" title="<?php echo xla('Help'); ?>" rel="noopener" target="_blank">?</a>)
+                            (<a href="https://www.cdc.gov/vaccines/hcp/vis/current-vis.html" title="<?php echo xla('Help'); ?>" rel="noopener" target="_blank">?</a>)
                         </label>
                         <input type='text' size='10' class='datepicker  form-control' name="vis_date" id="vis_date"
                             value='<?php echo (!empty($vis_date)) ? attr($vis_date) : date('Y-m-d'); ?>'


### PR DESCRIPTION
This PR addresses Issue #7844 

Updates the "Help" link on the immunization entry form to the current US CDC page: https://www.cdc.gov/vaccines/hcp/vis/current-vis.html

Additional clarifications and changes may be needed to ensure this link is appropriately localized per original issue author's request. 

Does your code include anything generated by an AI Engine? No
