### PR TITLE
Correctly replace invalid code unit sequences

### DIFF
--- a/library/options.inc.php
+++ b/library/options.inc.php
@@ -2440,9 +2440,9 @@ function generate_display_field($frow, $currvalue)
             }
         }
     } elseif ($data_type == 2) { // simple text field
-        $s = nl2br(htmlspecialchars($currvalue, ENT_NOQUOTES));
+        $s = nl2br(htmlspecialchars($currvalue, ENT_NOQUOTES | ENT_SUBSTITUTE));
     } elseif ($data_type == 3) { // long or multi-line text field
-        $s = nl2br(htmlspecialchars($currvalue, ENT_NOQUOTES));
+        $s = nl2br(htmlspecialchars($currvalue, ENT_NOQUOTES | ENT_SUBSTITUTE));
     } elseif ($data_type == 4) { // date
         $asof = ''; //not used here, but set to prevent a php warning when call optionalAge
         $s = '';


### PR DESCRIPTION
When trying to generate a report for an LBF form with a long text field containing invalid characters, an empty string is returned and the data is missing from the report.

This simply adds `ENT_SUBSTITUTE` which will do substitution instead of returning the empty string.