### PR TITLE
chore: update easy dev docs to ensure have most recent dockers for alternate php versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,10 @@ You will need a "local" version of OpenEMR to make changes to the source code. T
 8. To ensure you are using the most recent dockers, recommend running below set of commands intermittently:
     ```console
     docker pull openemr/openemr:flex
+    docker pull openemr/openemr:flex-3.17
+    docker pull openemr/openemr:flex-3.18
+    docker pull openemr/openemr:flex-3.20
+    docker pull openemr/openemr:flex-3.21
     docker pull mariadb:11.4
     docker pull phpmyadmin/phpmyadmin
     docker pull couchdb


### PR DESCRIPTION
update easy dev docs to ensure have most recent dockers for alternate php versions