### PR TITLE
Encounter form menu - keep on top of any reports

### DIFF
--- a/templates/encounter/forms/navbar.html.twig
+++ b/templates/encounter/forms/navbar.html.twig
@@ -16,7 +16,7 @@
                         <a class="nav-link dropdown-toggle" href="#" id="category_{{ category|attr }}" role="button" data-toggle="dropdown" aria-expanded="false">
                             {{ category|text }}
                         </a>
-                        <div class="dropdown-menu" aria-labelledby="category_{{ category|attr }}">
+                        <div class="dropdown-menu" aria-labelledby="category_{{ category|attr }}" style="z-index:9999;">
                             {% for item in details.children %}
                                 {% set display = (item.menu_name is defined) ? item.menu_name : item.displayText %}
                                 {% if item.onclick is defined %}


### PR DESCRIPTION
 

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #7897

#### Short description of what this resolves:
the forms drop down menus in an encounter summary appear behind a clinical notes report. this ensures the menu would always be on the top of other items

#### Changes proposed in this pull request:
the drop down menu's z-index is set to '9999'
#### Does your code include anything generated by an AI Engine? Yes / No
no
#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.
