### PR TITLE
#7914 - Fix for contacts being empty or string

### DIFF
--- a/src/FHIR/SMART/ClientAdminController.php
+++ b/src/FHIR/SMART/ClientAdminController.php
@@ -391,7 +391,7 @@ class ClientAdminController
             'contacts' => [
                 'type' => 'text'
                 ,'label' => xl("Contacts")
-                ,'value' => implode("|", $client->getContacts())
+                ,'value' => is_array($client->getContacts()) ? implode("|", $client->getContacts()) : ''
             ],
             'registrationDate' => [
                 'type' => 'text'


### PR DESCRIPTION
fixes issues #7914 which prevents edit form from loading when contacts is empty

,'value' => is_array($client->getContacts()) ? implode("|", $client->getContacts()) : ''