### PR TITLE
fix: fixes wrong prescription provider being recorded

### DIFF
--- a/templates/prescription/general_edit.html.twig
+++ b/templates/prescription/general_edit.html.twig
@@ -157,7 +157,7 @@
             <label>{{'Provider'|xlt}}</label>
             <select class="input sm form-control" name="provider_id">
                 {% for providerId, providerName in prescription.provider.utility_provider_array() %}
-                    <option value="{{ provider.id|attr }}" {% if providerId == prescription.provider.get_id() %} selected="selected" {% endif %}>{{ providerName|text }}</option>
+                    <option value="{{ providerId|attr }}" {% if providerId == prescription.provider.get_id() %} selected="selected" {% endif %}>{{ providerName|text }}</option>
                 {% endfor %}
             </select>
             <input type="hidden" name="patient_id" value="{{prescription.patient.id|attr}}" />


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #7916

#### Short description of what this resolves:
Fixes a variable name typo which resulted in the current user rather than the selected provider being recorded as the provider on prescription

#### Changes proposed in this pull request:
Changing the variable name provider.id on line 160 to the correct one of providerId

#### Does your code include anything generated by an AI Engine? Yes / No
no
#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.
