### PR TITLE
fix: edi segment count for ordering provider

### DIFF
--- a/src/Billing/X125010837P.php
+++ b/src/Billing/X125010837P.php
@@ -1522,8 +1522,10 @@ class X125010837P
                     "*" . "XX" .
                     "*" . $claim->ordererNPI() . "~\n";
                 $out .= "N3" . "*" . $claim->ordererStreet() . "~\n";
+                $edicount++;
                 $out .= "N4" . "*" . $claim->ordererCity() . "*" .
                     $claim->ordererState() . "*" . $claim->ordererZip() . "~\n";
+                $edicount++;
             }
 
             // Segment NM1 (Referring Provider Name) omitted.

--- a/src/Billing/X125010837P.php
+++ b/src/Billing/X125010837P.php
@@ -1521,11 +1521,11 @@ class X125010837P
                     "*" .
                     "*" . "XX" .
                     "*" . $claim->ordererNPI() . "~\n";
+                $edicount++;
                 $out .= "N3" . "*" . $claim->ordererStreet() . "~\n";
                 $edicount++;
                 $out .= "N4" . "*" . $claim->ordererCity() . "*" .
                     $claim->ordererState() . "*" . $claim->ordererZip() . "~\n";
-                $edicount++;
             }
 
             // Segment NM1 (Referring Provider Name) omitted.

--- a/src/Billing/X125010837P.php
+++ b/src/Billing/X125010837P.php
@@ -1521,9 +1521,9 @@ class X125010837P
                     "*" .
                     "*" . "XX" .
                     "*" . $claim->ordererNPI() . "~\n";
-                $edicount++;
+                ++$edicount;
                 $out .= "N3" . "*" . $claim->ordererStreet() . "~\n";
-                $edicount++;
+                ++$edicount;
                 $out .= "N4" . "*" . $claim->ordererCity() . "*" .
                     $claim->ordererState() . "*" . $claim->ordererZip() . "~\n";
             }


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #7921

thanks @darkdecoy
#### Short description of what this resolves:


#### Changes proposed in this pull request:

#### Does your code include anything generated by an AI Engine? Yes / No

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.
