### PR TITLE
Tab Identifier Service

### DIFF
--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -62,6 +62,19 @@ use OpenEMR\Services\PatientIssuesService;
 use OpenEMR\Services\PatientService;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
+/** @var TabIdentifierService $tabIdentifierService */
+$tabIdentifierService = $GLOBALS['kernel']->getContainer();
+// Retrieve the session service
+/** @var SessionInterface $session */
+$browserTabSession = $tabIdentifierService->get(SessionInterface::class);
+
+// Retrieve the TabIdentifierService
+/** @var TabIdentifierService $tabIdentifierService */
+$tabIdentifierService = $tabIdentifierService->get(TabIdentifierService::class);
+
+// Use the services
+$tabToken = $tabIdentifierService->generateTabIdentifier();
+
 // Reset the previous name flag to allow normal operation.
 // This is set in new.php so we can prevent new previous name from being added i.e no pid available.
 OpenEMR\Common\Session\SessionUtil::setSession('disablePreviousNameAdds', 0);

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -50,6 +50,13 @@ class Kernel
             $definition = new Definition(EventDispatcher::class, [new Reference('service_container')]);
             $definition->setPublic(true);
             $builder->setDefinition('event_dispatcher', $definition);
+            // Register the Session service
+            $builder->register(SessionInterface::class, Session::class)
+                ->setPublic(true);
+            // Register other services (e.g., TabIdentifierService)
+            $builder->register(\OpenEMR\Services\Tabs\TabIdentifierService::class)
+                ->addArgument(new Reference(SessionInterface::class))
+                ->setPublic(true);
             $builder->compile();
             $this->container = $builder;
         }

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -14,6 +14,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 /**
  * Class Kernel.
@@ -72,7 +74,14 @@ class Kernel
         if (!$this->container) {
             $this->prepareContainer();
         }
+        // Register the Session service
+        $this->container->register(SessionInterface::class, Session::class)
+            ->setPublic(true);
 
+        // Register other services (e.g., TabIdentifierService)
+        $this->container->register(\OpenEMR\Services\Tabs\TabIdentifierService::class)
+            ->addArgument(new Reference(SessionInterface::class))
+            ->setPublic(true);
         return $this->container;
     }
 

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -26,6 +26,7 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
  * @package OpenEMR
  * @subpackage Core
  * @author Robert Down <robertdown@live.com>
+ * @author Sherwin Gaddis <sherwingaddis@gmail.com> (2025) added TabIdentifierService  to the container
  * @copyright Copyright (c) 2017-2022 Robert Down
  */
 class Kernel

--- a/src/Services/Tabs/TabIdentifierService.php
+++ b/src/Services/Tabs/TabIdentifierService.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace OpenEMR\Services\Tabs;
+
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+class TabIdentifierService
+{
+    private SessionInterface $session;
+
+    public function __construct(SessionInterface $session)
+    {
+        $this->session = $session;
+
+        if (!$this->session->isStarted()) {
+            $this->session->start();
+        }
+    }
+
+    public function generateTabIdentifier(): string
+    {
+        $tabIdentifier = bin2hex(random_bytes(16));
+        $this->session->set('tabContexts.' . $tabIdentifier, []);
+        return $tabIdentifier;
+    }
+
+    public function getTabData(string $tabIdentifier): ?array
+    {
+        return $this->session->get('tabContexts.' . $tabIdentifier, null);
+    }
+
+    public function setTabData(string $tabIdentifier, array $data): void
+    {
+        $this->session->set('tabContexts.' . $tabIdentifier, $data);
+    }
+}
+

--- a/src/Services/Tabs/TabIdentifierService.php
+++ b/src/Services/Tabs/TabIdentifierService.php
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ * OpenEMR <https://open-emr.org>.
+ * Code written by ChatGPTo4 <https://www.chatgpt.com/>
+ * Code distributed under the GNU General Public License (GPL).
+ * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
 namespace OpenEMR\Services\Tabs;
 
 use Symfony\Component\HttpFoundation\Session\SessionInterface;

--- a/src/Services/Tabs/TabIdentifierService.php
+++ b/src/Services/Tabs/TabIdentifierService.php
@@ -41,4 +41,3 @@ class TabIdentifierService
         $this->session->set('tabContexts.' . $tabIdentifier, $data);
     }
 }
-


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #7943

#### Short description of what this resolves:
Nothing. This is a foundation to the bigger task of having multiple browser tabs open and encapsulation patient data with in the browser session.

#### Changes proposed in this pull request:
Adding the Symfony Session Interface to the Kernel

#### Does your code include anything generated by an AI Engine? Yes / No
Yes

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.
