### PR TITLE
SDC FHIR Pain Management Questionnaires

### DIFF
--- a/contrib/portal_templates/assessments/SDC FHIR/After_Visit_Assessment.json
+++ b/contrib/portal_templates/assessments/SDC FHIR/After_Visit_Assessment.json
@@ -1,0 +1,673 @@
+{
+    "resourceType": "Questionnaire",
+    "meta": {
+        "profile": [
+            "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire|2.7",
+            "http://hl7.org/fhir/4.0/StructureDefinition/Questionnaire"
+        ],
+        "tag": [
+            {
+                "code": "generated: PEER"
+            }
+        ]
+    },
+    "status": "active",
+    "title": "After Visit Assessment",
+    "subjectType": [
+        "Patient",
+        "Person"
+    ],
+    "item": [
+        {
+            "type": "group",
+            "code": [],
+            "required": false,
+            "linkId": "/DM",
+            "prefix": "Shared Decision Making",
+            "text": " The next three questions measure how involved you were in decisions regarding your treatment.",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "SDMunderstand",
+                            "display": "How much effort was made to help\u00a0you understand your back pain?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/DM/SDMunderstand",
+                    "text": "How much effort was made to help\u00a0you understand your back pain?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "COR_1",
+                                "display": "no effort at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_2",
+                                "display": "1"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_3",
+                                "display": "2"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_4",
+                                "display": "3"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_5",
+                                "display": "4"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_6",
+                                "display": "5"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_7",
+                                "display": "6"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 6
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_8",
+                                "display": "7"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 7
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_9",
+                                "display": "8"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 8
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_10",
+                                "display": "maximal effort was made"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 9
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Thinking about your appointment at PEER Clinic:",
+                    "item": [
+                        {
+                            "text": "This question helps measure the shared decison making process between you and your doctor/care provider.",
+                            "type": "display",
+                            "linkId": "/DM/SDMunderstand-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "SDMlisten",
+                            "display": "How much effort was made to listen\u00a0to the things that matter most to\u00a0you about your back pain?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/DM/SDMlisten",
+                    "text": "How much effort was made to listen\u00a0to the things that matter most to\u00a0you about your back pain?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "COR_1",
+                                "display": "no effort at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_2",
+                                "display": "1"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_3",
+                                "display": "2"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_4",
+                                "display": "3"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_5",
+                                "display": "4"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_6",
+                                "display": "5"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_7",
+                                "display": "6"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 6
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_8",
+                                "display": "7"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 7
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_9",
+                                "display": "8"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 8
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_10",
+                                "display": "maximal effort was made"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 9
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Thinking about the appointments you have had so far for [back pain]:",
+                    "item": [
+                        {
+                            "text": "This question helps measure the shared decison making process between you and your doctor/care provider.",
+                            "type": "display",
+                            "linkId": "/DM/SDMlisten-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "SDMinclude",
+                            "display": "How much effort was made to include\u00a0what matters most to you in choosing\u00a0what to do next?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/DM/SDMinclude",
+                    "text": "How much effort was made to include\u00a0what matters most to you in choosing\u00a0what to do next?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "COR_1",
+                                "display": "no effort at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_2",
+                                "display": "1"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_3",
+                                "display": "2"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_4",
+                                "display": "3"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_5",
+                                "display": "4"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_6",
+                                "display": "5"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_7",
+                                "display": "6"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 6
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_8",
+                                "display": "7"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 7
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_9",
+                                "display": "8"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 8
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_10",
+                                "display": "maximal effort was made"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 9
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Thinking about the appointments you have had so far for [back pain]:",
+                    "item": [
+                        {
+                            "text": "This question helps measure the shared decison making process between you and your doctor/care provider.",
+                            "type": "display",
+                            "linkId": "/DM/SDMinclude-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "DM-score",
+                            "display": "Shared Decision Making Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "dm1_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/DM').item.where(linkId = '/DM/SDMunderstand').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/DM').item.where(linkId = '/DM/SDMunderstand').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "dm2_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/DM').item.where(linkId = '/DM/SDMlisten').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/DM').item.where(linkId = '/DM/SDMlisten').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "dm3_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/DM').item.where(linkId = '/DM/SDMinclude').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/DM').item.where(linkId = '/DM/SDMinclude').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "any_questions_answered",
+                                "language": "text/fhirpath",
+                                "expression": "%dm1_value.exists() or %dm2_value.exists() or %dm3_value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%any_questions_answered, iif(%dm1_value.exists(), %dm1_value, 0) + iif(%dm2_value.exists(), %dm2_value, 0) + iif(%dm3_value.exists(), %dm3_value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/DM/DM-score",
+                    "text": "Shared Decision Making Score"
+                }
+            ]
+        }
+    ],
+    "name": "After_Visit_Assessment"
+}

--- a/contrib/portal_templates/assessments/SDC FHIR/Back_Pain_History_Assessment.json
+++ b/contrib/portal_templates/assessments/SDC FHIR/Back_Pain_History_Assessment.json
@@ -1,0 +1,2166 @@
+{
+    "resourceType": "Questionnaire",
+    "meta": {
+        "profile": [
+            "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire|2.7",
+            "http://hl7.org/fhir/4.0/StructureDefinition/Questionnaire"
+        ],
+        "tag": [
+            {
+                "code": "generated: PEER"
+            }
+        ]
+    },
+    "status": "active",
+    "title": "Back Pain History Assessment",
+    "subjectType": [
+        "Patient",
+        "Person"
+    ],
+    "item": [
+        {
+            "type": "group",
+            "code": [],
+            "required": false,
+            "linkId": "/BP",
+            "prefix": "Back Pain History",
+            "text": "The next set of questions help provide comprehensive evaluation. \nThey require about 2 minutes. These queastions were developed by the National Institutes of Health Task Force on Research Standards\n for Chronic Low Back Pain. They are essential for comparing outcomes of patients with low back pain.",
+            "enableWhen": "",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS01",
+                            "display": "How long has back pain been an ongoing problem for you?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BP/MDS01",
+                    "text": "How long has back pain been an ongoing problem for you?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BCK_1",
+                                "display": "Less than 1 month"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BCK_2",
+                                "display": "1 to 3 months"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BCK_3",
+                                "display": "3 to 6 months"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BCK_4",
+                                "display": "6 to 12 months"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BCK_5",
+                                "display": "1 to 5 years"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BCK_6",
+                                "display": "More than 5 years"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 6
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": "",
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS01-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS02",
+                            "display": "How often has back pain been an ongoing problem for you?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BP/MDS02",
+                    "text": "How often has back pain been an ongoing problem for you?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BPF_1",
+                                "display": "Every day or nearly every day"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BPF_2",
+                                "display": "At least half the days"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BPF_3",
+                                "display": "Less than half the days"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BP/MDS01",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BCK_4"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS01",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BCK_5"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS01",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BCK_6"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS02-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS04",
+                            "display": "Do you have pain down your leg?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BP/MDS04",
+                    "text": "Do you have pain down your leg?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "LRP_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LRP_2",
+                                "display": "Yes, only the right side"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LRP_3",
+                                "display": "Yes, only on the left side"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LRP_4",
+                                "display": "Yes, both sides"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LRP_5",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "During the past 2 weeks",
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS04-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS04Side",
+                            "display": "Have you had pain, numbness or tingling below your knee?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BP/MDS04Side",
+                    "text": "Have you had pain, numbness or tingling below your knee?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "LRP_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LRP_2",
+                                "display": "Yes, only the right side"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LRP_3",
+                                "display": "Yes, only on the left side"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LRP_4",
+                                "display": "Yes, both sides"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LRP_5",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "During the past 2 weeks",
+                    "enableWhen": [
+                        {
+                            "question": "/BP/MDS04",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "LRP_2"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS04",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "LRP_3"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS04",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "LRP_4"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS04",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "LRP_5"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS04Side-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS06",
+                            "display": "Have you ever had a low-back operation?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BP/MDS06",
+                    "text": "Have you ever had a low-back operation?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BSY_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BSY_2",
+                                "display": "Yes, one operation"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BSY_3",
+                                "display": "Yes, more than one operation"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS06-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS07",
+                            "display": "When was your last back operation?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BP/MDS07",
+                    "text": "When was your last back operation?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "LBO_1",
+                                "display": "Less than 6 months ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LBO_2",
+                                "display": "Between 6 months and 1 year ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LBO_3",
+                                "display": "Between 1 and 2 years ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LBO_4",
+                                "display": "More than 2 years ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BP/MDS06",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BSY_2"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS06",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BSY_3"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS07-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS08",
+                            "display": "Did any of your back operations involve a spinal fusion? (also called an arthrodesis)",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BP/MDS08",
+                    "text": "Did any of your back operations involve a spinal fusion? (also called an arthrodesis)",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BP/MDS06",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BSY_2"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS06",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BSY_3"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS08-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13b",
+                            "display": "Have you ever had low back injection (such as epidural steroid injection, facet injection)?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BP/MDS13b",
+                    "text": "Have you ever had low back injection (such as epidural steroid injection, facet injection)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BIN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BIN_2",
+                                "display": "Yes, one injection"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BIN_3",
+                                "display": "Yes, more than one injection"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS13b-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13bWhen",
+                            "display": "When was your last injection?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BP/MDS13bWhen",
+                    "text": "When was your last injection?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "LBO_1",
+                                "display": "Less than 6 months ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LBO_2",
+                                "display": "Between 6 months and 1 year ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LBO_3",
+                                "display": "Between 1 and 2 years ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LBO_4",
+                                "display": "More than 2 years ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BP/MDS13b",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BIN_2"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS13b",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BIN_3"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS13bWhen-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13c",
+                            "display": "Have you ever had physical therapy for your back?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BP/MDS13c",
+                    "text": "Have you ever had physical therapy for your back?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NIH_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NIH_2",
+                                "display": "Yes, one series of treatments"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NIH_3",
+                                "display": "Yes, more than one series of treatments"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS13c-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13cWhen",
+                            "display": "When was your last session?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BP/MDS13cWhen",
+                    "text": "When was your last session?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "LBO_1",
+                                "display": "Less than 6 months ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LBO_2",
+                                "display": "Between 6 months and 1 year ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LBO_3",
+                                "display": "Between 1 and 2 years ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LBO_4",
+                                "display": "More than 2 years ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BP/MDS13c",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NIH_2"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS13c",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NIH_3"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS13cWhen-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13a",
+                            "display": "Have you ever used opioid pain killers? (prescription medications such as Vicodin, Lortab, Norco, hydrocodone, codeine, Tylenol #3 or #4, Fentanyl, Duragesic, MS Contin, Percocet, Tylox, OxyContin, oxycodone, methadone, tramadol, Ultram, Dilaudid)?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BP/MDS13a",
+                    "text": "Have you ever used opioid pain killers? (prescription medications such as Vicodin, Lortab, Norco, hydrocodone, codeine, Tylenol #3 or #4, Fentanyl, Duragesic, MS Contin, Percocet, Tylox, OxyContin, oxycodone, methadone, tramadol, Ultram, Dilaudid)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS13a-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13aCurrent",
+                            "display": "Are you using these medications currently?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BP/MDS13aCurrent",
+                    "text": "Are you using these medications currently?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BP/MDS13a",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_2"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS13a",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_3"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS13aCurrent-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13d",
+                            "display": "Have you ever had psychological counseling for pain coping skills, such as cognitive-behavioral therapy (CBT)?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BP/MDS13d",
+                    "text": "Have you ever had psychological counseling for pain coping skills, such as cognitive-behavioral therapy (CBT)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS13d-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS14",
+                            "display": "Have you had to take time off work?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BP/MDS14",
+                    "text": "Have you had to take time off work?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "TOF_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TOF_2",
+                                "display": "Yes, less than a month"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TOF_3",
+                                "display": "Yes, more than a month"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TOF_4",
+                                "display": "Does not apply"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": "",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BP/MDS14-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS15",
+                            "display": "Have you applied for disability?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BP/MDS15",
+                    "text": "Have you applied for disability?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "RTF_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RTF_2",
+                                "display": "Yes, workers compensation"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RTF_3",
+                                "display": "Yes, Social Security"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RTF_4",
+                                "display": "Yes, both workers comp and social security"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RTF_5",
+                                "display": "Does not apply"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BP/MDS14",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "TOF_2"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS14",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "TOF_3"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS14",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "TOF_4"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BP/MDS15-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "BP-score",
+                            "display": "Back Pain History Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp1_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS01').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS01').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp2_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS02').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS02').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp3_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS04').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS04').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp4_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS04Side').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS04Side').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp5_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS06').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS06').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp6_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS07').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS07').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp7_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS08').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS08').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp8_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13b').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13b').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp9_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13bWhen').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13bWhen').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp10_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13c').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13c').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp11_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13cWhen').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13cWhen').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp12_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13a').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13a').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp13_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13aCurrent').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13aCurrent').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp14_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13d').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13d').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp15_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS14').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS14').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp16_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS15').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS15').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "any_questions_answered",
+                                "language": "text/fhirpath",
+                                "expression": "%bp1_value.exists() or %bp2_value.exists() or %bp3_value.exists() or %bp4_value.exists() or %bp5_value.exists() or %bp6_value.exists() or %bp7_value.exists() or %bp8_value.exists() or %bp9_value.exists() or %bp10_value.exists() or %bp11_value.exists() or %bp12_value.exists() or %bp13_value.exists() or %bp14_value.exists() or %bp15_value.exists() or %bp16_value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%any_questions_answered, iif(%bp1_value.exists(), %bp1_value, 0) + iif(%bp2_value.exists(), %bp2_value, 0) + iif(%bp3_value.exists(), %bp3_value, 0) + iif(%bp4_value.exists(), %bp4_value, 0) + iif(%bp5_value.exists(), %bp5_value, 0) + iif(%bp6_value.exists(), %bp6_value, 0) + iif(%bp7_value.exists(), %bp7_value, 0) + iif(%bp8_value.exists(), %bp8_value, 0) + iif(%bp9_value.exists(), %bp9_value, 0) + iif(%bp10_value.exists(), %bp10_value, 0) + iif(%bp11_value.exists(), %bp11_value, 0) + iif(%bp12_value.exists(), %bp12_value, 0) + iif(%bp13_value.exists(), %bp13_value, 0) + iif(%bp14_value.exists(), %bp14_value, 0) + iif(%bp15_value.exists(), %bp15_value, 0) + iif(%bp16_value.exists(), %bp16_value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/BP-score",
+                    "text": "Back Pain History Score"
+                }
+            ]
+        }
+    ],
+    "name": "Back_Pain_History_Assessment"
+}

--- a/contrib/portal_templates/assessments/SDC FHIR/Back_Pain_Impact_Assessment.json
+++ b/contrib/portal_templates/assessments/SDC FHIR/Back_Pain_Impact_Assessment.json
@@ -1,0 +1,1082 @@
+{
+    "resourceType": "Questionnaire",
+    "meta": {
+        "profile": [
+            "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire|2.7",
+            "http://hl7.org/fhir/4.0/StructureDefinition/Questionnaire"
+        ],
+        "tag": [
+            {
+                "code": "generated: PEER"
+            }
+        ]
+    },
+    "status": "active",
+    "title": "Back Pain Impact Assessment",
+    "subjectType": [
+        "Patient",
+        "Person"
+    ],
+    "item": [
+        {
+            "type": "group",
+            "code": [],
+            "required": false,
+            "linkId": "/BI",
+            "prefix": "Back Pain Impact",
+            "text": "The National Institutes of Health Task Force on Research Standard for Chronic Low Back Pain recommended the next few questions to measure prior treatments, disability and goals. This section takes about 2 minutes.",
+            "enableWhen": "",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS15Injury",
+                            "display": "Do you feel there is a relationship between your back pain and any of the following?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BI/MDS15Injury",
+                    "text": "Do you feel there is a relationship between your back pain and any of the following?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "IJK_1",
+                                "display": "Employment"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "IJK_2",
+                                "display": "Auto accident"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "IJK_3",
+                                "display": "Other accident"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "IJK_4",
+                                "display": "Pregnancy"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "IJK_5",
+                                "display": "None of these"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/MDS15Injury-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS30",
+                            "display": "Are you involved in a lawsuit or legal claim related to you back problem?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BI/MDS30",
+                    "text": "Are you involved in a lawsuit or legal claim related to you back problem?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/MDS30-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS05a",
+                            "display": "How much have you been bothered by stomach pain?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BI/MDS05a",
+                    "text": "How much have you been bothered by stomach pain?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SPN_1",
+                                "display": "Not bothered at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SPN_2",
+                                "display": "Bothered a little"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SPN_3",
+                                "display": "Bothered a lot"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "During the past 4 weeks",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/MDS05a-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS05b",
+                            "display": "How much have you been bothered by headaches?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BI/MDS05b",
+                    "text": "How much have you been bothered by headaches?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SPN_1",
+                                "display": "Not bothered at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SPN_2",
+                                "display": "Bothered a little"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SPN_3",
+                                "display": "Bothered a lot"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "During the past 4 weeks",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/MDS05b-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS05c",
+                            "display": "How much have you been bothered by pain the joints in your arms or legs?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BI/MDS05c",
+                    "text": "How much have you been bothered by pain the joints in your arms or legs?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SPN_1",
+                                "display": "Not bothered at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SPN_2",
+                                "display": "Bothered a little"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SPN_3",
+                                "display": "Bothered a lot"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "During the past 4 weeks",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/MDS05c-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS05d",
+                            "display": "how much have you been bothered by widespread pain or pain in most of your body?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BI/MDS05d",
+                    "text": "how much have you been bothered by widespread pain or pain in most of your body?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SPN_1",
+                                "display": "Not bothered at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SPN_2",
+                                "display": "Bothered a little"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SPN_3",
+                                "display": "Bothered a lot"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "During the past 4 weeks",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/MDS05d-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS28",
+                            "display": "It's not really safe for a person with my back pain to be physically active.",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BI/MDS28",
+                    "text": "It's not really safe for a person with my back pain to be physically active.",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "AGD_1",
+                                "display": "Agree"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "AGD_2",
+                                "display": "Disagree"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Do you agree or disagree with this statement:",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/MDS28-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS29",
+                            "display": "I feel that my back pain is terrible and it's never going to get any better.",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BI/MDS29",
+                    "text": "I feel that my back pain is terrible and it's never going to get any better.",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "AGD_1",
+                                "display": "Agree"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "AGD_2",
+                                "display": "Disagree"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Do you agree or disagree with this statement:",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/MDS29-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "Goal",
+                            "display": "What is your treatment goal?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BI/Goal",
+                    "text": "What is your treatment goal?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "GOL_1",
+                                "display": "Become pain-free all of the time"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "GOL_2",
+                                "display": "Become pain-free on most days"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "GOL_3",
+                                "display": "Reduce pain enough so I can function"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/Goal-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "BI-score",
+                            "display": "Back Pain Impact Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi1_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS15Injury').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS15Injury').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi2_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS30').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS30').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi3_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS05a').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS05a').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi4_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS05b').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS05b').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi5_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS05c').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS05c').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi6_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS05d').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS05d').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi7_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS28').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS28').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi8_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS29').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS29').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi9_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/Goal').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/Goal').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "any_questions_answered",
+                                "language": "text/fhirpath",
+                                "expression": "%bi1_value.exists() or %bi2_value.exists() or %bi3_value.exists() or %bi4_value.exists() or %bi5_value.exists() or %bi6_value.exists() or %bi7_value.exists() or %bi8_value.exists() or %bi9_value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%any_questions_answered, iif(%bi1_value.exists(), %bi1_value, 0) + iif(%bi2_value.exists(), %bi2_value, 0) + iif(%bi3_value.exists(), %bi3_value, 0) + iif(%bi4_value.exists(), %bi4_value, 0) + iif(%bi5_value.exists(), %bi5_value, 0) + iif(%bi6_value.exists(), %bi6_value, 0) + iif(%bi7_value.exists(), %bi7_value, 0) + iif(%bi8_value.exists(), %bi8_value, 0) + iif(%bi9_value.exists(), %bi9_value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BI/BI-score",
+                    "text": "Back Pain Impact Score"
+                }
+            ]
+        }
+    ],
+    "name": "Back_Pain_Impact_Assessment"
+}

--- a/contrib/portal_templates/assessments/SDC FHIR/Back_Pain_Severity_Assessment.json
+++ b/contrib/portal_templates/assessments/SDC FHIR/Back_Pain_Severity_Assessment.json
@@ -1,0 +1,2477 @@
+{
+    "resourceType": "Questionnaire",
+    "meta": {
+        "profile": [
+            "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire|2.7",
+            "http://hl7.org/fhir/4.0/StructureDefinition/Questionnaire"
+        ],
+        "tag": [
+            {
+                "code": "generated: PEER"
+            }
+        ]
+    },
+    "status": "active",
+    "title": "Back Pain Severity Assessment",
+    "subjectType": [
+        "Patient",
+        "Person"
+    ],
+    "item": [
+        {
+            "type": "group",
+            "code": [],
+            "required": false,
+            "linkId": "/BS",
+            "prefix": "Back Pain Severity",
+            "text": "This questionnaire has been designed to give us information as to how your back pain is affecting your ability to manage in everyday life. It takes about 3 minutes. Please answer by checking ONE box in each section for the statement which best applies to you. We realize you may consider that two or more statements in any one section apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS03",
+                            "display": "How would you rate your low-back pain on average?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BS/MDS03",
+                    "text": "How would you rate your low-back pain on average?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NRS_1",
+                                "display": "0"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_2",
+                                "display": "1"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_3",
+                                "display": "2"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_4",
+                                "display": "3"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_5",
+                                "display": "4"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_6",
+                                "display": "5"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_7",
+                                "display": "6"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 6
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_8",
+                                "display": "7"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 7
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_9",
+                                "display": "8"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 8
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_10",
+                                "display": "9"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 9
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_11",
+                                "display": "10"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 10
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/MDS03-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI01",
+                            "display": "Pain Intensity",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BS/ODI01",
+                    "text": "Pain Intensity",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "ODI_1",
+                                "display": "I have no pain at the moment."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ODI_2",
+                                "display": "The pain is very mild at the moment."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ODI_3",
+                                "display": "The pain is moderate at the moment."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ODI_4",
+                                "display": "The pain is fairly severe at the moment."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ODI_5",
+                                "display": "The pain is very severe at the moment."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ODI_6",
+                                "display": "The pain is the worst imaginable at the moment."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI01-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI02",
+                            "display": "Personal Care (washing, dressing, etc.)",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BS/ODI02",
+                    "text": "Personal Care (washing, dressing, etc.)",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "OSW_1",
+                                "display": "I can do it without pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "OSW_2",
+                                "display": "I can do it but it causes pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "OSW_3",
+                                "display": "I am slow and careful."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "OSW_4",
+                                "display": "I need some help."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "OSW_5",
+                                "display": "I need help in most self-care."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "OSW_6",
+                                "display": "I do not get dressed and stay in bed."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI02-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI03",
+                            "display": "Lifting",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BS/ODI03",
+                    "text": "Lifting",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "LIF_1",
+                                "display": "I can lift heavy weights without pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LIF_2",
+                                "display": "I can lift heavy weights with pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LIF_3",
+                                "display": "I can lift heavy weights if conveniently positioned"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LIF_4",
+                                "display": "I can manage medium weights."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LIF_5",
+                                "display": "I can lift very light weights."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LIF_6",
+                                "display": "I cannot lift or carry anything at all."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI03-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI04",
+                            "display": "Walking",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BS/ODI04",
+                    "text": "Walking",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "WLK_1",
+                                "display": "Pain does not prevent me from walking any distance."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "WLK_2",
+                                "display": "Pain prevents me from walking more than 1 mile."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "WLK_3",
+                                "display": "Pain prevents me from walking more than 1/2 mile."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "WLK_4",
+                                "display": "Pain prevents me from walking more than 100 yards."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "WLK_5",
+                                "display": "I can only walk using a stick or crutches."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "WLK_6",
+                                "display": "I am in bed most of the time."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI04-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI05",
+                            "display": "Sitting",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BS/ODI05",
+                    "text": "Sitting",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SIT_1",
+                                "display": "I can sit in any chair as long as I like."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SIT_2",
+                                "display": "I can only sit in my favorite chair as long as I like."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SIT_3",
+                                "display": "Pain prevents me from sitting more than one hour."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SIT_4",
+                                "display": "Pain prevents me from sitting more than 30 minutes."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SIT_5",
+                                "display": "Pain prevents me from sitting more than 10 minutes."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SIT_6",
+                                "display": "Pain prevents me from sitting at all."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI05-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI06",
+                            "display": "Standing",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BS/ODI06",
+                    "text": "Standing",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "STD_1",
+                                "display": "I can stand as long as I want without pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "STD_2",
+                                "display": "I can stand as long as I want but it causes pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "STD_3",
+                                "display": "Pain prevents me from standing more than 1 hour."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "STD_4",
+                                "display": "Pain prevents me from standing more than 30 minutes."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "STD_5",
+                                "display": "Pain prevents me from standing more than 10 minutes."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "STD_6",
+                                "display": "Pain prevents me from standing at all."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI06-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI07",
+                            "display": "Sleeping",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BS/ODI07",
+                    "text": "Sleeping",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SLG_1",
+                                "display": "My sleep is never disturbed by pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLG_2",
+                                "display": "My sleep is occasionally disturbed by pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLG_3",
+                                "display": "Because of pain I have less than 6 hours sleep."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLG_4",
+                                "display": "Because of pain I have less than 4 hours sleep."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLG_5",
+                                "display": "Because of pain I have less than 2 hours sleep."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLG_6",
+                                "display": "Pain prevents me from sleeping at all."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI07-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI08",
+                            "display": "Sex Life (if applicable)",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BS/ODI08",
+                    "text": "Sex Life (if applicable)",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SEX_1",
+                                "display": "My sex life is normal and causes no extra pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SEX_2",
+                                "display": "My sex life is normal but causes some extra pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SEX_3",
+                                "display": "My sex life is nearly normal but is very painful."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SEX_4",
+                                "display": "My sex life is severely restricted by pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SEX_5",
+                                "display": "My sex life is nearly absent because of pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SEX_6",
+                                "display": "Pain prevents any sex life at all."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI08-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI09",
+                            "display": "Social Life",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BS/ODI09",
+                    "text": "Social Life",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SLK_1",
+                                "display": "My social life is normal and gives me no extra pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLK_2",
+                                "display": "My social life is normal but increases the degree of pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLK_3",
+                                "display": "Pain limits my more energetic interests, e.g., sport."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLK_4",
+                                "display": "Pain has restricted my social life and I do not go out as often."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLK_5",
+                                "display": "Pain has restricted my social life to my home."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLK_6",
+                                "display": "I have no social life because of pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI09-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI10",
+                            "display": "Traveling",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BS/ODI10",
+                    "text": "Traveling",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "TRL_1",
+                                "display": "I can travel anywhere without pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TRL_2",
+                                "display": "I can travel anywhere but it gives me extra pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TRL_3",
+                                "display": "Pain is bad but I manage journeys over 2 hours."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TRL_4",
+                                "display": "Pain is bad but I manage journeys less than 1 hour."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TRL_5",
+                                "display": "Pain restricts me to short necessary journeys under 30 minutes."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TRL_6",
+                                "display": "Pain prevents me from traveling except to receive treatment."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI10-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "BS-score",
+                            "display": "Back Pain Severity Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs1_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/MDS03').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/MDS03').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs2_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI01').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI01').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs3_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI02').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI02').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs4_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI03').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI03').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs5_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI04').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI04').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs6_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI05').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI05').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs7_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI06').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI06').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs8_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI07').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI07').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs9_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI08').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI08').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs10_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI09').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI09').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs11_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI10').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI10').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "any_questions_answered",
+                                "language": "text/fhirpath",
+                                "expression": "%bs1_value.exists() or %bs2_value.exists() or %bs3_value.exists() or %bs4_value.exists() or %bs5_value.exists() or %bs6_value.exists() or %bs7_value.exists() or %bs8_value.exists() or %bs9_value.exists() or %bs10_value.exists() or %bs11_value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%any_questions_answered, iif(%bs1_value.exists(), %bs1_value, 0) + iif(%bs2_value.exists(), %bs2_value, 0) + iif(%bs3_value.exists(), %bs3_value, 0) + iif(%bs4_value.exists(), %bs4_value, 0) + iif(%bs5_value.exists(), %bs5_value, 0) + iif(%bs6_value.exists(), %bs6_value, 0) + iif(%bs7_value.exists(), %bs7_value, 0) + iif(%bs8_value.exists(), %bs8_value, 0) + iif(%bs9_value.exists(), %bs9_value, 0) + iif(%bs10_value.exists(), %bs10_value, 0) + iif(%bs11_value.exists(), %bs11_value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/BS-score",
+                    "text": "Back Pain Severity Score"
+                }
+            ]
+        }
+    ],
+    "name": "Back_Pain_Severity_Assessment"
+}

--- a/contrib/portal_templates/assessments/SDC FHIR/Follow_Up_Assessment.json
+++ b/contrib/portal_templates/assessments/SDC FHIR/Follow_Up_Assessment.json
@@ -1,0 +1,4670 @@
+{
+    "resourceType": "Questionnaire",
+    "meta": {
+        "profile": [
+            "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire|2.7",
+            "http://hl7.org/fhir/4.0/StructureDefinition/Questionnaire"
+        ],
+        "tag": [
+            {
+                "code": "generated: PEER"
+            }
+        ]
+    },
+    "status": "active",
+    "title": "Follow Up Assessment",
+    "subjectType": [
+        "Patient",
+        "Person"
+    ],
+    "item": [
+        {
+            "type": "group",
+            "code": [],
+            "required": false,
+            "linkId": "/PC",
+            "prefix": "PROMIS INTERFERENCE",
+            "text": "The next few questions help measure the level that pain interferes in daily activities.",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PAININ9",
+                            "display": "How much did pain interfere with your day to day activities?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PC/PAININ9",
+                    "text": "How much did pain interfere with your day to day activities?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NAA_1",
+                                "display": "Not at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_2",
+                                "display": "A little bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_3",
+                                "display": "Somewhat"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_4",
+                                "display": "Quite a bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_5",
+                                "display": "Very much"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Pain Interference score.",
+                            "type": "display",
+                            "linkId": "/PC/PAININ9-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PAININ22",
+                            "display": "How much did pain interfere with work around the home?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PC/PAININ22",
+                    "text": "How much did pain interfere with work around the home?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NAA_1",
+                                "display": "Not at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_2",
+                                "display": "A little bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_3",
+                                "display": "Somewhat"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_4",
+                                "display": "Quite a bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_5",
+                                "display": "Very much"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Pain Interference score.",
+                            "type": "display",
+                            "linkId": "/PC/PAININ22-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PAININ31",
+                            "display": "How much did pain interfere with your ability to participate in social activities?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PC/PAININ31",
+                    "text": "How much did pain interfere with your ability to participate in social activities?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NAA_1",
+                                "display": "Not at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_2",
+                                "display": "A little bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_3",
+                                "display": "Somewhat"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_4",
+                                "display": "Quite a bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_5",
+                                "display": "Very much"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Pain Interference score.",
+                            "type": "display",
+                            "linkId": "/PC/PAININ31-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PAININ34",
+                            "display": "How much did pain interfere with your household chores?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PC/PAININ34",
+                    "text": "How much did pain interfere with your household chores?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NAA_1",
+                                "display": "Not at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_2",
+                                "display": "A little bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_3",
+                                "display": "Somewhat"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_4",
+                                "display": "Quite a bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_5",
+                                "display": "Very much"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Pain Interference score.",
+                            "type": "display",
+                            "linkId": "/PC/PAININ34-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "PC-score",
+                            "display": "PROMIS INTERFERENCE Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pc5_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PC').item.where(linkId = '/PC/PAININ9').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PC').item.where(linkId = '/PC/PAININ9').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pc6_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PC').item.where(linkId = '/PC/PAININ22').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PC').item.where(linkId = '/PC/PAININ22').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pc7_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PC').item.where(linkId = '/PC/PAININ31').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PC').item.where(linkId = '/PC/PAININ31').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pc8_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PC').item.where(linkId = '/PC/PAININ34').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PC').item.where(linkId = '/PC/PAININ34').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "any_questions_answered",
+                                "language": "text/fhirpath",
+                                "expression": "%pc5_value.exists() or %pc6_value.exists() or %pc7_value.exists() or %pc8_value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%any_questions_answered, iif(%pc5_value.exists(), %pc5_value, 0) + iif(%pc6_value.exists(), %pc6_value, 0) + iif(%pc7_value.exists(), %pc7_value, 0) + iif(%pc8_value.exists(), %pc8_value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PC/PC-score",
+                    "text": "PROMIS INTERFERENCE Score"
+                }
+            ]
+        },
+        {
+            "type": "group",
+            "code": [],
+            "required": false,
+            "linkId": "/PP",
+            "prefix": "PROMIS PHYSICAL ACTIVITY",
+            "text": "The following five sections deal with pain. Please read each question and answer as well as you can. There is no right or wrong answer, only what is true for you. The next few questions help measure the level of your physical activity.",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PFA23",
+                            "display": "Are you able to go for a walk of at least 15 minutes?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PP/PFA23",
+                    "text": "Are you able to go for a walk of at least 15 minutes?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "DIF_1",
+                                "display": "Unable to do"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_2",
+                                "display": "With much difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_3",
+                                "display": "With some difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_4",
+                                "display": "With a little difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_5",
+                                "display": "Without any difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Physical Function score.",
+                            "type": "display",
+                            "linkId": "/PP/PFA23-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PFA21",
+                            "display": "Are you able to go up and down stairs at a normal pace?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PP/PFA21",
+                    "text": "Are you able to go up and down stairs at a normal pace?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "DIF_1",
+                                "display": "Unable to do"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_2",
+                                "display": "With much difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_3",
+                                "display": "With some difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_4",
+                                "display": "With a little difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_5",
+                                "display": "Without any difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Physical Function score.",
+                            "type": "display",
+                            "linkId": "/PP/PFA21-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PFA11",
+                            "display": "Are you able to do chores such as vacuuming or yard work?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PP/PFA11",
+                    "text": "Are you able to do chores such as vacuuming or yard work?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "DIF_1",
+                                "display": "Unable to do"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_2",
+                                "display": "With much difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_3",
+                                "display": "With some difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_4",
+                                "display": "With a little difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_5",
+                                "display": "Without any difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Physical Function score.",
+                            "type": "display",
+                            "linkId": "/PP/PFA11-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PFA53",
+                            "display": "Are you able to run errands and shop?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PP/PFA53",
+                    "text": "Are you able to run errands and shop?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "DIF_1",
+                                "display": "Unable to do"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_2",
+                                "display": "With much difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_3",
+                                "display": "With some difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_4",
+                                "display": "With a little difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_5",
+                                "display": "Without any difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Physical Function score.",
+                            "type": "display",
+                            "linkId": "/PP/PFA53-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "PP-score",
+                            "display": "PROMIS PHYSICAL ACTIVITY Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pp1_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA23').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA23').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pp2_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA21').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA21').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pp3_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA11').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA11').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pp4_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA53').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA53').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "any_questions_answered",
+                                "language": "text/fhirpath",
+                                "expression": "%pp1_value.exists() or %pp2_value.exists() or %pp3_value.exists() or %pp4_value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%any_questions_answered, iif(%pp1_value.exists(), %pp1_value, 0) + iif(%pp2_value.exists(), %pp2_value, 0) + iif(%pp3_value.exists(), %pp3_value, 0) + iif(%pp4_value.exists(), %pp4_value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PP/PP-score",
+                    "text": "PROMIS PHYSICAL ACTIVITY Score"
+                }
+            ]
+        },
+        {
+            "type": "group",
+            "code": [],
+            "required": false,
+            "linkId": "/BS",
+            "prefix": "Back Pain Severity",
+            "text": "This questionnaire has been designed to give us information as to how your back pain is affecting your ability to manage in everyday life. It takes about 3 minutes. Please answer by checking ONE box in each section for the statement which best applies to you. We realize you may consider that two or more statements in any one section apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS03",
+                            "display": "How would you rate your low-back pain on average?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/MDS03",
+                    "text": "How would you rate your low-back pain on average?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NRS_1",
+                                "display": "0"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_2",
+                                "display": "1"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_3",
+                                "display": "2"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_4",
+                                "display": "3"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_5",
+                                "display": "4"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_6",
+                                "display": "5"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_7",
+                                "display": "6"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 6
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_8",
+                                "display": "7"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 7
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_9",
+                                "display": "8"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 8
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_10",
+                                "display": "9"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 9
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_11",
+                                "display": "10"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 10
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/MDS03-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI01",
+                            "display": "Pain Intensity",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/ODI01",
+                    "text": "Pain Intensity",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "ODI_1",
+                                "display": "I have no pain at the moment."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ODI_2",
+                                "display": "The pain is very mild at the moment."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ODI_3",
+                                "display": "The pain is moderate at the moment."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ODI_4",
+                                "display": "The pain is fairly severe at the moment."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ODI_5",
+                                "display": "The pain is very severe at the moment."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ODI_6",
+                                "display": "The pain is the worst imaginable at the moment."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI01-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI02",
+                            "display": "Personal Care (washing, dressing, etc.)",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/ODI02",
+                    "text": "Personal Care (washing, dressing, etc.)",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "OSW_1",
+                                "display": "I can do it without pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "OSW_2",
+                                "display": "I can do it but it causes pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "OSW_3",
+                                "display": "I am slow and careful."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "OSW_4",
+                                "display": "I need some help."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "OSW_5",
+                                "display": "I need help in most self-care."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "OSW_6",
+                                "display": "I do not get dressed and stay in bed."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI02-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI03",
+                            "display": "Lifting",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/ODI03",
+                    "text": "Lifting",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "LIF_1",
+                                "display": "I can lift heavy weights without pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LIF_2",
+                                "display": "I can lift heavy weights with pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LIF_3",
+                                "display": "I can lift heavy weights if conveniently positioned"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LIF_4",
+                                "display": "I can manage medium weights."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LIF_5",
+                                "display": "I can lift very light weights."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LIF_6",
+                                "display": "I cannot lift or carry anything at all."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI03-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI04",
+                            "display": "Walking",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/ODI04",
+                    "text": "Walking",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "WLK_1",
+                                "display": "Pain does not prevent me from walking any distance."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "WLK_2",
+                                "display": "Pain prevents me from walking more than 1 mile."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "WLK_3",
+                                "display": "Pain prevents me from walking more than 1/2 mile."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "WLK_4",
+                                "display": "Pain prevents me from walking more than 100 yards."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "WLK_5",
+                                "display": "I can only walk using a stick or crutches."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "WLK_6",
+                                "display": "I am in bed most of the time."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI04-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI05",
+                            "display": "Sitting",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/ODI05",
+                    "text": "Sitting",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SIT_1",
+                                "display": "I can sit in any chair as long as I like."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SIT_2",
+                                "display": "I can only sit in my favorite chair as long as I like."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SIT_3",
+                                "display": "Pain prevents me from sitting more than one hour."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SIT_4",
+                                "display": "Pain prevents me from sitting more than 30 minutes."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SIT_5",
+                                "display": "Pain prevents me from sitting more than 10 minutes."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SIT_6",
+                                "display": "Pain prevents me from sitting at all."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI05-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI06",
+                            "display": "Standing",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/ODI06",
+                    "text": "Standing",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "STD_1",
+                                "display": "I can stand as long as I want without pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "STD_2",
+                                "display": "I can stand as long as I want but it causes pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "STD_3",
+                                "display": "Pain prevents me from standing more than 1 hour."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "STD_4",
+                                "display": "Pain prevents me from standing more than 30 minutes."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "STD_5",
+                                "display": "Pain prevents me from standing more than 10 minutes."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "STD_6",
+                                "display": "Pain prevents me from standing at all."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI06-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI07",
+                            "display": "Sleeping",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/ODI07",
+                    "text": "Sleeping",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SLG_1",
+                                "display": "My sleep is never disturbed by pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLG_2",
+                                "display": "My sleep is occasionally disturbed by pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLG_3",
+                                "display": "Because of pain I have less than 6 hours sleep."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLG_4",
+                                "display": "Because of pain I have less than 4 hours sleep."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLG_5",
+                                "display": "Because of pain I have less than 2 hours sleep."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLG_6",
+                                "display": "Pain prevents me from sleeping at all."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI07-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI08",
+                            "display": "Sex Life (if applicable)",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/ODI08",
+                    "text": "Sex Life (if applicable)",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SEX_1",
+                                "display": "My sex life is normal and causes no extra pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SEX_2",
+                                "display": "My sex life is normal but causes some extra pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SEX_3",
+                                "display": "My sex life is nearly normal but is very painful."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SEX_4",
+                                "display": "My sex life is severely restricted by pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SEX_5",
+                                "display": "My sex life is nearly absent because of pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SEX_6",
+                                "display": "Pain prevents any sex life at all."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI08-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI09",
+                            "display": "Social Life",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/ODI09",
+                    "text": "Social Life",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SLK_1",
+                                "display": "My social life is normal and gives me no extra pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLK_2",
+                                "display": "My social life is normal but increases the degree of pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLK_3",
+                                "display": "Pain limits my more energetic interests, e.g., sport."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLK_4",
+                                "display": "Pain has restricted my social life and I do not go out as often."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLK_5",
+                                "display": "Pain has restricted my social life to my home."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLK_6",
+                                "display": "I have no social life because of pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI09-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI10",
+                            "display": "Traveling",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/ODI10",
+                    "text": "Traveling",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "TRL_1",
+                                "display": "I can travel anywhere without pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TRL_2",
+                                "display": "I can travel anywhere but it gives me extra pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TRL_3",
+                                "display": "Pain is bad but I manage journeys over 2 hours."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TRL_4",
+                                "display": "Pain is bad but I manage journeys less than 1 hour."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TRL_5",
+                                "display": "Pain restricts me to short necessary journeys under 30 minutes."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TRL_6",
+                                "display": "Pain prevents me from traveling except to receive treatment."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI10-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "BS-score",
+                            "display": "Back Pain Severity Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs1_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/MDS03').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/MDS03').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs2_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI01').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI01').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs3_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI02').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI02').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs4_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI03').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI03').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs5_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI04').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI04').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs6_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI05').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI05').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs7_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI06').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI06').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs8_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI07').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI07').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs9_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI08').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI08').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs10_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI09').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI09').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs11_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI10').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI10').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "any_questions_answered",
+                                "language": "text/fhirpath",
+                                "expression": "%bs1_value.exists() or %bs2_value.exists() or %bs3_value.exists() or %bs4_value.exists() or %bs5_value.exists() or %bs6_value.exists() or %bs7_value.exists() or %bs8_value.exists() or %bs9_value.exists() or %bs10_value.exists() or %bs11_value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%any_questions_answered, iif(%bs1_value.exists(), %bs1_value, 0) + iif(%bs2_value.exists(), %bs2_value, 0) + iif(%bs3_value.exists(), %bs3_value, 0) + iif(%bs4_value.exists(), %bs4_value, 0) + iif(%bs5_value.exists(), %bs5_value, 0) + iif(%bs6_value.exists(), %bs6_value, 0) + iif(%bs7_value.exists(), %bs7_value, 0) + iif(%bs8_value.exists(), %bs8_value, 0) + iif(%bs9_value.exists(), %bs9_value, 0) + iif(%bs10_value.exists(), %bs10_value, 0) + iif(%bs11_value.exists(), %bs11_value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/BS-score",
+                    "text": "Back Pain Severity Score"
+                }
+            ]
+        },
+        {
+            "type": "group",
+            "code": [],
+            "required": false,
+            "linkId": "/SO",
+            "prefix": "Safety Outcomes",
+            "text": "The next eight questions help evaluate results of treatment.",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13aFollow",
+                            "display": "Are you currently using opioid pain killers? (prescription medications such as Vicodin, Lortab, Norco, hydrocodone, codeine, Tylenol #3 or #4, Fentanyl, Duragesic, MS Contin, Percocet, Tylox, OxyContin, oxycodone, methadone, tramadol, Ultram, Dilaudi",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SO/MDS13aFollow",
+                    "text": "Are you currently using opioid pain killers? (prescription medications such as Vicodin, Lortab, Norco, hydrocodone, codeine, Tylenol #3 or #4, Fentanyl, Duragesic, MS Contin, Percocet, Tylox, OxyContin, oxycodone, methadone, tramadol, Ultram, Dilaudi",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "This question helps measure results of back pain treatment.",
+                            "type": "display",
+                            "linkId": "/SO/MDS13aFollow-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ERvisitFollow",
+                            "display": "Have you had to go to an Emergency Room for any reason?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SO/ERvisitFollow",
+                    "text": "Have you had to go to an Emergency Room for any reason?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "ERV_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ERV_2",
+                                "display": "Yes, one visit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ERV_3",
+                                "display": "Yes, more than one visit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Since <DATE_OF_LAST_ASSESSMENT>",
+                    "item": [
+                        {
+                            "text": "This question helps measure results of back pain treatment.",
+                            "type": "display",
+                            "linkId": "/SO/ERvisitFollow-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS06Follow",
+                            "display": "Have you had a low-back operation?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SO/MDS06Follow",
+                    "text": "Have you had a low-back operation?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BSY_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BSY_2",
+                                "display": "Yes, one operation"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BSY_3",
+                                "display": "Yes, more than one operation"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Since <DATE_OF_LAST_ASSESSMENT>",
+                    "item": [
+                        {
+                            "text": "This question helps measure results of back pain treatment.",
+                            "type": "display",
+                            "linkId": "/SO/MDS06Follow-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13bFollow",
+                            "display": "Have you had low back injection (such as epidural steroid injection, facet injection)?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SO/MDS13bFollow",
+                    "text": "Have you had low back injection (such as epidural steroid injection, facet injection)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BIN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BIN_2",
+                                "display": "Yes, one injection"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BIN_3",
+                                "display": "Yes, more than one injection"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Since <DATE_OF_LAST_ASSESSMENT>",
+                    "item": [
+                        {
+                            "text": "This question helps measure results of back pain treatment.",
+                            "type": "display",
+                            "linkId": "/SO/MDS13bFollow-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13cFollow",
+                            "display": "Have you had physical therapy?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SO/MDS13cFollow",
+                    "text": "Have you had physical therapy?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NIH_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NIH_2",
+                                "display": "Yes, one series of treatments"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NIH_3",
+                                "display": "Yes, more than one series of treatments"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Since <DATE_OF_LAST_ASSESSMENT>",
+                    "item": [
+                        {
+                            "text": "This question helps measure results of back pain treatment.",
+                            "type": "display",
+                            "linkId": "/SO/MDS13cFollow-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13dFollow",
+                            "display": "Have you had psychological counseling for pain coping skills, such as cognitive-behavioral therapy (CBT)?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SO/MDS13dFollow",
+                    "text": "Have you had psychological counseling for pain coping skills, such as cognitive-behavioral therapy (CBT)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Since <DATE_OF_LAST_ASSESSMENT>",
+                    "item": [
+                        {
+                            "text": "This question helps measure results of back pain treatment.",
+                            "type": "display",
+                            "linkId": "/SO/MDS13dFollow-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS14Follow",
+                            "display": "Have you had to take time off work?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SO/MDS14Follow",
+                    "text": "Have you had to take time off work?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "TOF_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TOF_2",
+                                "display": "Yes, less than a month"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TOF_3",
+                                "display": "Yes, more than a month"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TOF_4",
+                                "display": "Does not apply"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Since <DATE_OF_LAST_ASSESSMENT>",
+                    "item": [
+                        {
+                            "text": "This question helps measure results of back pain treatment.",
+                            "type": "display",
+                            "linkId": "/SO/MDS14Follow-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS15Follow",
+                            "display": "Have you applied for disability?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SO/MDS15Follow",
+                    "text": "Have you applied for disability?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "RTF_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RTF_2",
+                                "display": "Yes, workers compensation"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RTF_3",
+                                "display": "Yes, Social Security"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RTF_4",
+                                "display": "Yes, both workers comp and social security"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RTF_5",
+                                "display": "Does not apply"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Since <DATE_OF_LAST_ASSESSMENT>",
+                    "enableWhen": "",
+                    "item": [
+                        {
+                            "text": "This question helps measure results of back pain treatment.",
+                            "type": "display",
+                            "linkId": "/SO/MDS15Follow-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "SO-score",
+                            "display": "Safety Outcomes Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "so1_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS13aFollow').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS13aFollow').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "so2_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SO').item.where(linkId = '/SO/ERvisitFollow').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SO').item.where(linkId = '/SO/ERvisitFollow').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "so3_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS06Follow').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS06Follow').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "so4_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS13bFollow').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS13bFollow').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "so5_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS13cFollow').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS13cFollow').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "so6_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS13dFollow').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS13dFollow').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "so7_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS14Follow').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS14Follow').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "so8_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS15Follow').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS15Follow').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "any_questions_answered",
+                                "language": "text/fhirpath",
+                                "expression": "%so1_value.exists() or %so2_value.exists() or %so3_value.exists() or %so4_value.exists() or %so5_value.exists() or %so6_value.exists() or %so7_value.exists() or %so8_value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%any_questions_answered, iif(%so1_value.exists(), %so1_value, 0) + iif(%so2_value.exists(), %so2_value, 0) + iif(%so3_value.exists(), %so3_value, 0) + iif(%so4_value.exists(), %so4_value, 0) + iif(%so5_value.exists(), %so5_value, 0) + iif(%so6_value.exists(), %so6_value, 0) + iif(%so7_value.exists(), %so7_value, 0) + iif(%so8_value.exists(), %so8_value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SO/SO-score",
+                    "text": "Safety Outcomes Score"
+                }
+            ]
+        }
+    ],
+    "name": "Follow_Up_Assessment"
+}

--- a/contrib/portal_templates/assessments/SDC FHIR/Full_Assessments.json
+++ b/contrib/portal_templates/assessments/SDC FHIR/Full_Assessments.json
@@ -1,0 +1,15779 @@
+{
+    "resourceType": "Questionnaire",
+    "meta": {
+        "profile": [
+            "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire|2.7",
+            "http://hl7.org/fhir/4.0/StructureDefinition/Questionnaire"
+        ],
+        "tag": [
+            {
+                "code": "generated: PEER"
+            }
+        ]
+    },
+    "status": "active",
+    "title": "Full Assessments",
+    "subjectType": [
+        "Patient",
+        "Person"
+    ],
+    "item": [
+        {
+            "type": "group",
+            "code": [],
+            "required": false,
+            "linkId": "/PP",
+            "prefix": "PROMIS PHYSICAL ACTIVITY",
+            "text": "The following five sections deal with pain. Please read each question and answer as well as you can. There is no right or wrong answer, only what is true for you. The next few questions help measure the level of your physical activity.",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PFA23",
+                            "display": "Are you able to go for a walk of at least 15 minutes?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PP/PFA23",
+                    "text": "Are you able to go for a walk of at least 15 minutes?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "DIF_1",
+                                "display": "Unable to do"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_2",
+                                "display": "With much difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_3",
+                                "display": "With some difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_4",
+                                "display": "With a little difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_5",
+                                "display": "Without any difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Physical Function score.",
+                            "type": "display",
+                            "linkId": "/PP/PFA23-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PFA21",
+                            "display": "Are you able to go up and down stairs at a normal pace?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PP/PFA21",
+                    "text": "Are you able to go up and down stairs at a normal pace?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "DIF_1",
+                                "display": "Unable to do"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_2",
+                                "display": "With much difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_3",
+                                "display": "With some difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_4",
+                                "display": "With a little difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_5",
+                                "display": "Without any difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Physical Function score.",
+                            "type": "display",
+                            "linkId": "/PP/PFA21-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PFA11",
+                            "display": "Are you able to do chores such as vacuuming or yard work?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PP/PFA11",
+                    "text": "Are you able to do chores such as vacuuming or yard work?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "DIF_1",
+                                "display": "Unable to do"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_2",
+                                "display": "With much difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_3",
+                                "display": "With some difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_4",
+                                "display": "With a little difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_5",
+                                "display": "Without any difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Physical Function score.",
+                            "type": "display",
+                            "linkId": "/PP/PFA11-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PFA53",
+                            "display": "Are you able to run errands and shop?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PP/PFA53",
+                    "text": "Are you able to run errands and shop?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "DIF_1",
+                                "display": "Unable to do"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_2",
+                                "display": "With much difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_3",
+                                "display": "With some difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_4",
+                                "display": "With a little difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_5",
+                                "display": "Without any difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Physical Function score.",
+                            "type": "display",
+                            "linkId": "/PP/PFA53-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "PP-score",
+                            "display": "PROMIS PHYSICAL ACTIVITY Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pp1_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA23').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA23').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pp2_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA21').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA21').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pp3_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA11').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA11').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pp4_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA53').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA53').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "any_questions_answered",
+                                "language": "text/fhirpath",
+                                "expression": "%pp1_value.exists() or %pp2_value.exists() or %pp3_value.exists() or %pp4_value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%any_questions_answered, iif(%pp1_value.exists(), %pp1_value, 0) + iif(%pp2_value.exists(), %pp2_value, 0) + iif(%pp3_value.exists(), %pp3_value, 0) + iif(%pp4_value.exists(), %pp4_value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PP/PP-score",
+                    "text": "PROMIS PHYSICAL ACTIVITY Score"
+                }
+            ]
+        },
+        {
+            "type": "group",
+            "code": [],
+            "required": false,
+            "linkId": "/PC",
+            "prefix": "PROMIS INTERFERENCE",
+            "text": "The next few questions help measure the level that pain interferes in daily activities.",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PAININ9",
+                            "display": "How much did pain interfere with your day to day activities?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PC/PAININ9",
+                    "text": "How much did pain interfere with your day to day activities?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NAA_1",
+                                "display": "Not at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_2",
+                                "display": "A little bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_3",
+                                "display": "Somewhat"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_4",
+                                "display": "Quite a bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_5",
+                                "display": "Very much"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Pain Interference score.",
+                            "type": "display",
+                            "linkId": "/PC/PAININ9-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PAININ22",
+                            "display": "How much did pain interfere with work around the home?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PC/PAININ22",
+                    "text": "How much did pain interfere with work around the home?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NAA_1",
+                                "display": "Not at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_2",
+                                "display": "A little bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_3",
+                                "display": "Somewhat"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_4",
+                                "display": "Quite a bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_5",
+                                "display": "Very much"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Pain Interference score.",
+                            "type": "display",
+                            "linkId": "/PC/PAININ22-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PAININ31",
+                            "display": "How much did pain interfere with your ability to participate in social activities?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PC/PAININ31",
+                    "text": "How much did pain interfere with your ability to participate in social activities?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NAA_1",
+                                "display": "Not at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_2",
+                                "display": "A little bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_3",
+                                "display": "Somewhat"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_4",
+                                "display": "Quite a bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_5",
+                                "display": "Very much"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Pain Interference score.",
+                            "type": "display",
+                            "linkId": "/PC/PAININ31-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PAININ34",
+                            "display": "How much did pain interfere with your household chores?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PC/PAININ34",
+                    "text": "How much did pain interfere with your household chores?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NAA_1",
+                                "display": "Not at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_2",
+                                "display": "A little bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_3",
+                                "display": "Somewhat"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_4",
+                                "display": "Quite a bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_5",
+                                "display": "Very much"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Pain Interference score.",
+                            "type": "display",
+                            "linkId": "/PC/PAININ34-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "PC-score",
+                            "display": "PROMIS INTERFERENCE Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pc5_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PC').item.where(linkId = '/PC/PAININ9').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PC').item.where(linkId = '/PC/PAININ9').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pc6_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PC').item.where(linkId = '/PC/PAININ22').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PC').item.where(linkId = '/PC/PAININ22').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pc7_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PC').item.where(linkId = '/PC/PAININ31').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PC').item.where(linkId = '/PC/PAININ31').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pc8_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PC').item.where(linkId = '/PC/PAININ34').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PC').item.where(linkId = '/PC/PAININ34').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "any_questions_answered",
+                                "language": "text/fhirpath",
+                                "expression": "%pc5_value.exists() or %pc6_value.exists() or %pc7_value.exists() or %pc8_value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%any_questions_answered, iif(%pc5_value.exists(), %pc5_value, 0) + iif(%pc6_value.exists(), %pc6_value, 0) + iif(%pc7_value.exists(), %pc7_value, 0) + iif(%pc8_value.exists(), %pc8_value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PC/PC-score",
+                    "text": "PROMIS INTERFERENCE Score"
+                }
+            ]
+        },
+        {
+            "type": "group",
+            "code": [],
+            "required": false,
+            "linkId": "/PS",
+            "prefix": "PROMIS SLEEP",
+            "text": "The next few questions help measure the level of your sleep habits.",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "Sleep116",
+                            "display": "My sleep was refreshing.",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PS/Sleep116",
+                    "text": "My sleep was refreshing.",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NAA_1",
+                                "display": "Not at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_2",
+                                "display": "A little bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_3",
+                                "display": "Somewhat"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_4",
+                                "display": "Quite a bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_5",
+                                "display": "Very much"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Pain Interference score.",
+                            "type": "display",
+                            "linkId": "/PS/Sleep116-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "Sleep20",
+                            "display": "I had a problem with my sleep.",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PS/Sleep20",
+                    "text": "I had a problem with my sleep.",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NAA_1",
+                                "display": "Not at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_2",
+                                "display": "A little bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_3",
+                                "display": "Somewhat"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_4",
+                                "display": "Quite a bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_5",
+                                "display": "Very much"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Sleep Disturbance score.",
+                            "type": "display",
+                            "linkId": "/PS/Sleep20-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "Sleep44",
+                            "display": "I had difficulty falling asleep.",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PS/Sleep44",
+                    "text": "I had difficulty falling asleep.",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NAA_1",
+                                "display": "Not at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_2",
+                                "display": "A little bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_3",
+                                "display": "Somewhat"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_4",
+                                "display": "Quite a bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_5",
+                                "display": "Very much"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Sleep Disturbance score.",
+                            "type": "display",
+                            "linkId": "/PS/Sleep44-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "Sleep109",
+                            "display": "My sleep quality was...",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PS/Sleep109",
+                    "text": "My sleep quality was...",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SLP_1",
+                                "display": "Very Good"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLP_2",
+                                "display": "Good"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLP_3",
+                                "display": "Fair"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLP_4",
+                                "display": "Poor"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLP_5",
+                                "display": "Very poor"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Sleep Disturbance score.",
+                            "type": "display",
+                            "linkId": "/PS/Sleep109-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "PS-score",
+                            "display": "PROMIS SLEEP Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "ps9_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PS').item.where(linkId = '/PS/Sleep116').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PS').item.where(linkId = '/PS/Sleep116').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "ps10_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PS').item.where(linkId = '/PS/Sleep20').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PS').item.where(linkId = '/PS/Sleep20').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "ps11_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PS').item.where(linkId = '/PS/Sleep44').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PS').item.where(linkId = '/PS/Sleep44').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "ps12_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PS').item.where(linkId = '/PS/Sleep109').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PS').item.where(linkId = '/PS/Sleep109').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "any_questions_answered",
+                                "language": "text/fhirpath",
+                                "expression": "%ps9_value.exists() or %ps10_value.exists() or %ps11_value.exists() or %ps12_value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%any_questions_answered, iif(%ps9_value.exists(), %ps9_value, 0) + iif(%ps10_value.exists(), %ps10_value, 0) + iif(%ps11_value.exists(), %ps11_value, 0) + iif(%ps12_value.exists(), %ps12_value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PS/PS-score",
+                    "text": "PROMIS SLEEP Score"
+                }
+            ]
+        },
+        {
+            "type": "group",
+            "code": [],
+            "required": false,
+            "linkId": "/PD",
+            "prefix": "PROMIS DEPRESSION",
+            "text": "The next few questions help measure the level of your depression.",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "EDDEP04",
+                            "display": "I felt worthless",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PD/EDDEP04",
+                    "text": "I felt worthless",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_1",
+                                "display": "Never"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_2",
+                                "display": "Rarely"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_3",
+                                "display": "Sometimes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_4",
+                                "display": "Often"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_5",
+                                "display": "Always"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Depression score.",
+                            "type": "display",
+                            "linkId": "/PD/EDDEP04-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "EDDEP06",
+                            "display": "I felt helpless",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PD/EDDEP06",
+                    "text": "I felt helpless",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_1",
+                                "display": "Never"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_2",
+                                "display": "Rarely"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_3",
+                                "display": "Sometimes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_4",
+                                "display": "Often"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_5",
+                                "display": "Always"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Depression score.",
+                            "type": "display",
+                            "linkId": "/PD/EDDEP06-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "EDDEP29",
+                            "display": "I felt depressed",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PD/EDDEP29",
+                    "text": "I felt depressed",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_1",
+                                "display": "Never"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_2",
+                                "display": "Rarely"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_3",
+                                "display": "Sometimes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_4",
+                                "display": "Often"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_5",
+                                "display": "Always"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Depression score.",
+                            "type": "display",
+                            "linkId": "/PD/EDDEP29-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "EDDEP41",
+                            "display": "I felt hopeless",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PD/EDDEP41",
+                    "text": "I felt hopeless",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_1",
+                                "display": "Never"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_2",
+                                "display": "Rarely"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_3",
+                                "display": "Sometimes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_4",
+                                "display": "Often"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_5",
+                                "display": "Always"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Depression score.",
+                            "type": "display",
+                            "linkId": "/PD/EDDEP41-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "PD-score",
+                            "display": "PROMIS DEPRESSION Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pd13_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PD').item.where(linkId = '/PD/EDDEP04').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PD').item.where(linkId = '/PD/EDDEP04').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pd14_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PD').item.where(linkId = '/PD/EDDEP06').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PD').item.where(linkId = '/PD/EDDEP06').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pd15_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PD').item.where(linkId = '/PD/EDDEP29').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PD').item.where(linkId = '/PD/EDDEP29').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pd16_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PD').item.where(linkId = '/PD/EDDEP41').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PD').item.where(linkId = '/PD/EDDEP41').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "any_questions_answered",
+                                "language": "text/fhirpath",
+                                "expression": "%pd13_value.exists() or %pd14_value.exists() or %pd15_value.exists() or %pd16_value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%any_questions_answered, iif(%pd13_value.exists(), %pd13_value, 0) + iif(%pd14_value.exists(), %pd14_value, 0) + iif(%pd15_value.exists(), %pd15_value, 0) + iif(%pd16_value.exists(), %pd16_value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PD/PD-score",
+                    "text": "PROMIS DEPRESSION Score"
+                }
+            ]
+        },
+        {
+            "type": "group",
+            "code": [],
+            "required": false,
+            "linkId": "/PA",
+            "prefix": "PROMIS ANXIETY",
+            "text": "The next few questions help measure the level of your anxiety.",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "EDANX01",
+                            "display": "I felt fearful",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PA/EDANX01",
+                    "text": "I felt fearful",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_1",
+                                "display": "Never"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_2",
+                                "display": "Rarely"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_3",
+                                "display": "Sometimes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_4",
+                                "display": "Often"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_5",
+                                "display": "Always"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Anxiety score.",
+                            "type": "display",
+                            "linkId": "/PA/EDANX01-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "EDANX40",
+                            "display": "I found it hard to focus on anything other than my anxiety",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PA/EDANX40",
+                    "text": "I found it hard to focus on anything other than my anxiety",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_1",
+                                "display": "Never"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_2",
+                                "display": "Rarely"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_3",
+                                "display": "Sometimes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_4",
+                                "display": "Often"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_5",
+                                "display": "Always"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Anxiety score.",
+                            "type": "display",
+                            "linkId": "/PA/EDANX40-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "EDANX41",
+                            "display": "My worries overwhelmed me",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PA/EDANX41",
+                    "text": "My worries overwhelmed me",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_1",
+                                "display": "Never"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_2",
+                                "display": "Rarely"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_3",
+                                "display": "Sometimes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_4",
+                                "display": "Often"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_5",
+                                "display": "Always"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Anxiety score.",
+                            "type": "display",
+                            "linkId": "/PA/EDANX41-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "EDANX53",
+                            "display": "I felt uneasy",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PA/EDANX53",
+                    "text": "I felt uneasy",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_1",
+                                "display": "Never"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_2",
+                                "display": "Rarely"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_3",
+                                "display": "Sometimes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_4",
+                                "display": "Often"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_5",
+                                "display": "Always"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Anxiety score.",
+                            "type": "display",
+                            "linkId": "/PA/EDANX53-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "PA-score",
+                            "display": "PROMIS ANXIETY Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pa17_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PA').item.where(linkId = '/PA/EDANX01').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PA').item.where(linkId = '/PA/EDANX01').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pa18_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PA').item.where(linkId = '/PA/EDANX40').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PA').item.where(linkId = '/PA/EDANX40').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pa19_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PA').item.where(linkId = '/PA/EDANX41').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PA').item.where(linkId = '/PA/EDANX41').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pa20_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PA').item.where(linkId = '/PA/EDANX53').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PA').item.where(linkId = '/PA/EDANX53').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "any_questions_answered",
+                                "language": "text/fhirpath",
+                                "expression": "%pa17_value.exists() or %pa18_value.exists() or %pa19_value.exists() or %pa20_value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%any_questions_answered, iif(%pa17_value.exists(), %pa17_value, 0) + iif(%pa18_value.exists(), %pa18_value, 0) + iif(%pa19_value.exists(), %pa19_value, 0) + iif(%pa20_value.exists(), %pa20_value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PA/PA-score",
+                    "text": "PROMIS ANXIETY Score"
+                }
+            ]
+        },
+        {
+            "type": "group",
+            "code": [],
+            "required": false,
+            "linkId": "/SF",
+            "prefix": "Social Factors",
+            "text": "The next few questions ask about social facotrs that may help select \nthe right treatment for you. This part will require about 2 minutes.",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS40bf",
+                            "display": "What is your weight? (pounds)",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SF/MDS40bf",
+                    "text": "What is your weight? (pounds)",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "PDS_1",
+                                "display": "<100lbs"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_2",
+                                "display": "100-120 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_3",
+                                "display": "121-140 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_4",
+                                "display": "141-160 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_5",
+                                "display": "161-180 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_6",
+                                "display": "181-200 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_7",
+                                "display": "201-220 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 6
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_8",
+                                "display": "221-240 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 7
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_9",
+                                "display": "241-260 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 8
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_10",
+                                "display": "261-280 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 9
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_11",
+                                "display": "281-300 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 10
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_12",
+                                "display": "more than 300 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 11
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "Weight is used to calculate BMI (body mass index). BMI can help select the right treatment for you. The question was developed by\n the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine \n if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/SF/MDS40bf-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "SF-score",
+                            "display": "Social Factors Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "sf1_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SF').item.where(linkId = '/SF/MDS40bf').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SF').item.where(linkId = '/SF/MDS40bf').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "any_questions_answered",
+                                "language": "text/fhirpath",
+                                "expression": "%sf1_value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%any_questions_answered, iif(%sf1_value.exists(), %sf1_value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SF/SF-score",
+                    "text": "Social Factors Score"
+                }
+            ]
+        },
+        {
+            "type": "group",
+            "code": [],
+            "required": false,
+            "linkId": "/MH",
+            "prefix": "Medical History",
+            "text": " The next few questions record important aspects of your medical history.",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComMI",
+                            "display": "Have you ever been treated for heart disease or been told you had a heart attack, or had procedures such as angioplasty, cardiac stents or bypass surgery?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComMI",
+                    "text": "Have you ever been treated for heart disease or been told you had a heart attack, or had procedures such as angioplasty, cardiac stents or bypass surgery?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "If you are considering active rehabilitation or surgery, please alert your care team of your risk of heart disease. History of heart attack or heart disease (CAD - Coronary Artery Disease) increases your risk of having heart attack with active rehabilitation or surgery.  Sharing this information with your surgical team will help them optimize your risk by adjusting your medications, surgical procedure, anesthesia and recovery plan.References: (1) Lee T H, et al. Derivation and prospective validation of a simple index for prediction of cardiac risk of major noncardiac surgery.Circulation. 1999;100:1043-1049 (2) Ford MK, et al. Systematic review: Prediction of perioperative cardiac complications and mortality by the RCRI. Annals of Internal Medicine. 2010;152(1):26-35",
+                            "type": "display",
+                            "linkId": "/MH/ComMI-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComCHF",
+                            "display": "Have you ever been treated for heart failure? You may have been short of breath and the doctor may have told you that you had fluid in your lungs or that your heart was not pumping well.",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComCHF",
+                    "text": "Have you ever been treated for heart failure? You may have been short of breath and the doctor may have told you that you had fluid in your lungs or that your heart was not pumping well.",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "Heart Failure due to a weak or stiff heart is important to recognize in order manage medications prescribed for your symptoms. If you are considering active rehabilitation or surgery, please alert your surgical team of your risk of heart failure. Heart failure may flare up after surgery.Preparing carefully for surgery may decrease the risk. References: (1) Healy KO, et al. Predictive outcome and long term mortality for Heart Failure patients undergoing intermediate and high risk non-cardiac surgery: Impact of Left ventricular Ejection Fraction. Congestive Heart Failure 2010;16:45-49. doi: 10.1111/j.1751-7133.2009.00130.x (2) Gupta PK, et al. Development and validation of a risk calculator for prediction of cardiac risk after surgery. Circulation. 2011 Jul 26;124(4):381-7. doi: 10.1161/CIRCULATIONAHA.110.015701 (3)Powell-Tuck J, et al. GIFTASUP - British Consensus Guidelines on Intravenous Fluid Therapy for Adult Surgical Patients. March 2011",
+                            "type": "display",
+                            "linkId": "/MH/ComCHF-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComPVD",
+                            "display": "Have you had an operation to unclog or bypass the arteries in your legs? ",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComPVD",
+                    "text": "Have you had an operation to unclog or bypass the arteries in your legs? ",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "If you are considering active rehabilitation or surgery, please alert your surgical team of circulation problems. Having a history of circulation problems (vascular disease, or peripheral arterial disease, PAD) increases your risk of blockages in your heart. It is relevant for planning for surgery and anesthesia, such as whether to use a tourniquet during knee replacement, and make other management decisions during and after surgery. References: (1)  Kiani S, et al. Peripheral arterial disease is associated with severe impairment of vascular function. Vascular Medicine. 2013 Apr; 18(2): 72-78  (2)Gokce N, et al. Risk stratification for postoperative cardiovascular events via noninvasive assessment of endothelial function: a prospective study. Circulation. 2002 Apr 2;105(13):1567-72    (3)  Smith DE, et al. Arterial complications and TKA. J Am Acad Orthop Surg 2001;9:253-257 (4) Dakka AM, et al. TKA in patients with PAD. Surgeon 2009 Dec; 7(6):362-5",
+                            "type": "display",
+                            "linkId": "/MH/ComPVD-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComDVT",
+                            "display": "Have you had ever been treated for blood clots in your legs or lungs, DVT, PE? ",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComDVT",
+                    "text": "Have you had ever been treated for blood clots in your legs or lungs, DVT, PE? ",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "If you are considering surgery please alert your surgical team to your risk of blood clots. It will help them investigate further and take precautions.",
+                            "type": "display",
+                            "linkId": "/MH/ComDVT-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComBleeding",
+                            "display": "Have you had ever been treated for bleeding problems? ",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComBleeding",
+                    "text": "Have you had ever been treated for bleeding problems? ",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "If you are considering surgery please alert your surgical team to your risk of bleeding. It will help them investigate further and take precautions.",
+                            "type": "display",
+                            "linkId": "/MH/ComBleeding-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComCVA",
+                            "display": "Have you ever been treated for a stroke, cerebrovascular accident, blood clot or bleeding in the brain, or transient ischemic attack (TIA)?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComCVA",
+                    "text": "Have you ever been treated for a stroke, cerebrovascular accident, blood clot or bleeding in the brain, or transient ischemic attack (TIA)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "If you are considering active rehabilitation or surgery please alert your surgical team to your risk of stroke, to help them investigate further and take precautions. Your risk of having another stroke (brain attack or CVA) or other serious events may be increased during and after surgery. References: (1)  Fleisher LA, et al. 2014 ACC/AHA Guideline on Perioperative Cardiovascular Evaluation and Management of Patients Undergoing Noncardiac Surgery, Journal of the American College of Cardiology (2014), doi: 10.1016/j.jacc.2014.07.944 (2)  Jorgensen ME, et al. Time elapsed after ischemic stroke and risk of adverse cardiovascular events and mortality following elective noncardiac surgery. JAMA. 2014 Jul;312(3):269-77 (3)  North American Symptomatic Carotid Endarterectomy Trial Collaborators. NewEngland Journal of Medicine. 1991;325(7):445 (4)  Kernan WN, et al. Guidelines for the prevention of stroke in patients with stroke and transient ischemic attack: a guideline for healthcare professionals from the American Heart Association/American Stroke Association. Stroke. 2014;45(7):2160",
+                            "type": "display",
+                            "linkId": "/MH/ComCVA-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComHemiplegia",
+                            "display": "Do you have difficulty moving an arm or leg as a result of the stroke or cerebrovascular accident?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComHemiplegia",
+                    "text": "Do you have difficulty moving an arm or leg as a result of the stroke or cerebrovascular accident?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/MH/ComCVA",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_2"
+                            }
+                        },
+                        {
+                            "question": "/MH/ComCVA",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_3"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "If you are considering surgery, muscle weakness or loss of sensation can affect your recovery from surgery and anesthesia, and change your rehabilitation plan.  References:  (1)  Mizner RL, et al. Preoperative Quadriceps strength predicts functional ability one year after TKA. Journal of Rheumatology 2005;32:1533-9   (2)  Charlson ME, et al. A new method of classifying prognostic comorbidity in longitudinal studies : Development and Validation. Journal of Chronic Disease 1987;40:373-383",
+                            "type": "display",
+                            "linkId": "/MH/ComHemiplegia-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComAsthma",
+                            "display": "Have you ever been diagnosed with or told that you have asthma? ",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComAsthma",
+                    "text": "Have you ever been diagnosed with or told that you have asthma? ",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "If you are considering surgery, please discuss this with your team to help them prepare for this risk. Asthma, COPD (emphysema, chronic bronchitis) can flare up after active rehabilitation or surgery.  History of lung disease may affect the type of anesthesia you receive, and your post-operative recovery. Reference: Tirumalasetty J, et al. Asthma, surgery, and general anesthesia: a review. Journal of Asthma 2006;43:251-4.",
+                            "type": "display",
+                            "linkId": "/MH/ComAsthma-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComAsthmaMed",
+                            "display": "Do you take medicines for your asthma?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComAsthmaMed",
+                    "text": "Do you take medicines for your asthma?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/MH/ComAsthma",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_2"
+                            }
+                        },
+                        {
+                            "question": "/MH/ComAsthma",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_3"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "If you are considering surgery, please discuss this with your team to help them prepare for this risk.  Asthma, COPD (emphysema, chronic bronchitis) can flare up after active rehabilitation or surgery.  History of lung disease may affect the type of anesthesia you receive, and your post-operative recovery. Reference:  Tirumalasetty J, et al. Asthma, surgery, and general anesthesia: a review. Journal of Asthma 2006;43:251-4.",
+                            "type": "display",
+                            "linkId": "/MH/ComAsthmaMed-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComCOPD",
+                            "display": "Do you have emphysema, chronic bronchitis, or chronic obstructive lung disease (COPD)? ",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComCOPD",
+                    "text": "Do you have emphysema, chronic bronchitis, or chronic obstructive lung disease (COPD)? ",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "Lung disease can affect anesthesia and recovery from active rehabilitation or surgery.  Asthma, COPD (emphysema, chronic bronchitis) can flare up after surgery.  If you are considering surgery, please discuss this with your team to help them prepare to address this risk and prevent problems.  References: (1) Smetana GW, Lawrence VA, Cornell JE. Preoperative pulmonary risk stratification for noncardiothoracic surgery: systematic review for the American College of Physicians. Annals of Internal Medicine. 2006;144:581-95  (2)  Qaseem A, Snow V, Fitterman N, et al., for the Clinical Efficacy Assessment Subcommittee of the American College of Physicians. Risk assessment for and strategies to reduce perioperative pulmonary complications for patients undergoing noncardiothoracic surgery: a guideline from the American College of Physicians. Annals of Internal Medicine. 2006; 144:575-80  (3) Fleischmann KE et al. Cardiac and noncardiac complications were strongly linked in patients undergoing noncardiac surgery.American Journal of Medicine. 2003;115:515-20",
+                            "type": "display",
+                            "linkId": "/MH/ComCOPD-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComOxygen",
+                            "display": "Do you take medicines for your lung disease, or use oxygen, or use a home breathing machine (CPAP machine)?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComOxygen",
+                    "text": "Do you take medicines for your lung disease, or use oxygen, or use a home breathing machine (CPAP machine)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/MH/ComCOPD",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_2"
+                            }
+                        },
+                        {
+                            "question": "/MH/ComCOPD",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_3"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "If you are considering surgery, you may have increased risk of needing to stay in the intensive care unit (ICU) after surgery and require a breathing machine (ventilator). This risk may be decreased by recommendations and individualized care from your anesthesia and surgical team. References:  (1)  Canet J et al. Prediction of postoperative pulmonary complications in a population-based surgical cohort. Anesthesiology. 2010;113(6):1338-50 (2) Memtsoudis SG, et al. Sleep apnea and total joint arthroplasty under various types of anesthesia: a population-based study of perioperative outcomes. Regional Anesthesia and Pain Medicine 2013;38:274-81",
+                            "type": "display",
+                            "linkId": "/MH/ComOxygen-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComGERD",
+                            "display": "Have you ever been diagnosed with or told that you have stomach ulcers, or peptic ulcer disease? ",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComGERD",
+                    "text": "Have you ever been diagnosed with or told that you have stomach ulcers, or peptic ulcer disease? ",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "A current or prior history of acid reflux, ulcers or gastritis increases your risk of blood loss and anemia. It may be relevant to the medications chosen to treat pain.  If you are considering surgery, it can affect the choice of medications to prevent blood clots after surgery.  References:  (1)  Singh JA, et al. Peptic ulcer disease and heart disease are associated with periprosthetic fractures after total hip replacement. Acta Orthopaedica 2012 Aug;83(4):353-9  (2) Madhusudhan TR, et al. Gastric protection and gastrointestinal bleeding with aspirin thromboprophylaxis in hip and knee joint replacements. Annals of the Royal College of Surgeons of England 2008 May;90(4):332-5",
+                            "type": "display",
+                            "linkId": "/MH/ComGERD-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComGERDdx",
+                            "display": "Has this condition been diagnosed by endoscopy where a doctor looks into your stomach through a scope or an upper GI or barium swallow study where you swallow chalky dye and then x-rays are taken?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComGERDdx",
+                    "text": "Has this condition been diagnosed by endoscopy where a doctor looks into your stomach through a scope or an upper GI or barium swallow study where you swallow chalky dye and then x-rays are taken?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/MH/ComGERD",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_2"
+                            }
+                        },
+                        {
+                            "question": "/MH/ComGERD",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_3"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "A current or prior history of ulcer increases your risk of blood loss and anemia and may be relevant to the medications chosen to prevent blood clots in the perioperative period. References: (1) Gralnek IM, et al. Management of acute bleeding from a peptic ulcer. N Engl J Med 2008; 359:928-937     (2) Hsu PI. New look at antiplatelet agent-related peptic ulcer: an update of prevention and treatment. Journal of Gastroenterology and Hepatology. 2012 Apr;27(4):654-61",
+                            "type": "display",
+                            "linkId": "/MH/ComGERDdx-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComDM",
+                            "display": "Have you ever been diagnosed with or treated for diabetes (high blood sugar)?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComDM",
+                    "text": "Have you ever been diagnosed with or treated for diabetes (high blood sugar)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "Diabetes affects medications used to treat your symptoms. If you are considering surgery, it increases risk of complications after surgery. Controlling diabetes before surgery and maintaining your blood sugars close to normal during and after surgery may decrease risk of major complications like infection. Reference:  Marchant MH, et al. The impact of glycemic control and diabetes mellitus on perioperative outcomes after total joint arthroplasty. Journal of Bone and Joint Surgery. 2009;91:1621-9",
+                            "type": "display",
+                            "linkId": "/MH/ComDM-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComDmeye",
+                            "display": "Has the diabetes caused any problems with your eyes, treated by an ophthalmologist (eye-doctor)?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComDmeye",
+                    "text": "Has the diabetes caused any problems with your eyes, treated by an ophthalmologist (eye-doctor)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/MH/ComDM",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_2"
+                            }
+                        },
+                        {
+                            "question": "/MH/ComDM",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_3"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "If diabetes has resulted in eye problems, there is greater risk of nerve problems (neuropathy), which can affect the surgical plan and outcome. Reference:  Parvizi J, et al. Total knee arthroplasty for neuropathic (Charcot) joints. Clinical Orthopaedics and Related Research. 2003;416:145-50",
+                            "type": "display",
+                            "linkId": "/MH/ComDmeye-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComDmkidney",
+                            "display": "Has the diabetes caused any problems with your kidneys?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComDmkidney",
+                    "text": "Has the diabetes caused any problems with your kidneys?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/MH/ComDM",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_2"
+                            }
+                        },
+                        {
+                            "question": "/MH/ComDM",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_3"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "If diabetes has resulted in kidney problems, there is greater risk for complication like kidney injury or failure after surgery. Reference:  National Kidney Foundation. KDOQI Clinical Practice Guideline for Diabetes and CKD: 2012 Update. Am J Kidney Dis. 2012 Nov; 60(5):850-86",
+                            "type": "display",
+                            "linkId": "/MH/ComDmkidney-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComKidney",
+                            "display": "Have you ever had problems with your kidneys (poor kidney function or blood tests show high creatinine)?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComKidney",
+                    "text": "Have you ever had problems with your kidneys (poor kidney function or blood tests show high creatinine)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "Kidney problems can play a vital role in choosing the medications prescribed for you, including contrast agents for imaging studies.  Poor kidney function can also affect the dosing of the medications.  If you are considering surgery, please alert your surgical and anesthesia teams. Kidney problems can increase risk of complications with surgery.References: (1) Memtsoudis SG, et al. Risk factors for perioperative mortality after lower extremity arthroplasties: A population based study of 6,901,324 patient discharges. J Arthroplasty. 2010 Jan;25(1):19-26. doi: 10.1016/j.arth.2008.11.010. Epub 2008 Dec 23  (2) Godin M, et al. Fluid balance in patients with acute kidney injury: Emerging concepts. Nephron Clinical Practice 2013;123:238-245 (2) Sawhney S, et al. Long term prognosis after acute kidney injury (AKI): What is the role of baseline kidney function and recovery? A systematic review. BMJ Open. 2015 Jan 6;5(1):e006497",
+                            "type": "display",
+                            "linkId": "/MH/ComKidney-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComDialysis",
+                            "display": "Have you used hemodialysis or peritoneal dialysis (kidney dialysis)?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComDialysis",
+                    "text": "Have you used hemodialysis or peritoneal dialysis (kidney dialysis)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/MH/ComKidney",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_2"
+                            }
+                        },
+                        {
+                            "question": "/MH/ComKidney",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_3"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "Patients on dialysis may need careful management of medications by nephrologist (kidney specialist). If you are considering surgery, additional dialysis may need to be arranged around the surgery date. References: (1) Afshar AH, et al. The validity of the VA surgical tool in predictig postoperative mortality in octogenarians. American Journal of Surgery. 2015 Feb;209(2):274-9  (2)  Shah H, et al. Perioperative management of peritoneal dialysis patients undergoing hernia surgery without the use of interim hemodialysis Peritoneal Dialysis International. 2006 Nov-Dec;26(6):684-7",
+                            "type": "display",
+                            "linkId": "/MH/ComDialysis-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComLiver",
+                            "display": "Have you ever been diagnosed with or treated for cirrhosis, or serious liver disease? ",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComLiver",
+                    "text": "Have you ever been diagnosed with or treated for cirrhosis, or serious liver disease? ",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "Liver disease or cirrhosis requires careful attention to medications prescribed for your treatment.  If you are considering surgery, liver disease increases the risk of infection, bleeding, confusion, and other complications. Please alert your surgical and anesthesia teams.They may need to adjust the techniques chosen and the postoperative plan. References: (1)  Tiberi JV, et al. Increased complication rates after hip and knee arthroplasty in patients with cirrhosis of the liver. Clin Orthop Relat Res (2014) 472:2774-2778  (2) Cohen SM, et al. Operative risk of total hip and knee arthroplasty in cirrhotic patients. Journal of Arthroplasty. 2005;20:460-466  (3) Shih LY, et al. Total knee arthroplasty in patients with liver cirrhosis. Journal of Bone and Joint Surgery, 2004 Feb; 86 (2): 335 -341",
+                            "type": "display",
+                            "linkId": "/MH/ComLiver-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComTransplant",
+                            "display": "Have you received a kidney, liver, lung or other transplant?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComTransplant",
+                    "text": "Have you received a kidney, liver, lung or other transplant?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "Transplant patients on anti-rejection meds may need dose adjustments, coordination of care with transplant team and close monitoring of their medications.  Reference:  Cavanaugh PK, et al.  Total Joint Arthroplasty in Transplant Recipients: In-Hospital Adverse Outcomes. J Arthroplasty. 2014 Dec 5. pii: S0883-5403(14)00913-9.",
+                            "type": "display",
+                            "linkId": "/MH/ComTransplant-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComCancer",
+                            "display": "Have you ever been diagnosed with or treated for cancer?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComCancer",
+                    "text": "Have you ever been diagnosed with or treated for cancer?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "A history of cancer is important for evaluation and treatment of your symptoms. If you are considering surgery, it can affect your risk of bleeding, infection, blood clots, and function of organs such as nerves, heart, lungs, liver or kidneys.  Please make sure your surgical team is aware of this. Cancer or its treatment may limit the benefits of surgery.  Also, some blood tests ordered before and after surgery will be expected to be abnormal in setting of cancer or its treatment. Please have your surgery and anesthesia teams coordinate carefully with your oncologist. References:  (1)  Dybvik E, et al. Long term risk for receiving a total hip replacement in cancer patients - A linkage study between the cancer register of Norway and the Norwegian arthroplasty register. Journal of Bone and Joint Surgery Br 2010;92-B:601 (2) Katz JN, et al. Elective palliative total hip replacement in a patient with lymphoma and advanced lung cancer. Arthritis and Rheumatology. 2008 Aug 15; 59(8): 1194-1196",
+                            "type": "display",
+                            "linkId": "/MH/ComCancer-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComMetastases",
+                            "display": "Has the cancer spread, or metastasized to other parts of your body?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComMetastases",
+                    "text": "Has the cancer spread, or metastasized to other parts of your body?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/MH/ComCancer",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_2"
+                            }
+                        },
+                        {
+                            "question": "/MH/ComCancer",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_3"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "Cancer may spread to bones and cause pain.  Surgery may be helpful for relief of pan, stabilization of the involved bone or joint, and to improve your quality of life.  If you are considering surgery, please have your surgery and anesthesia teams coordinate carefully with your oncologist. Reference:  Charlson ME, et al. A new method of classifying prognostic comorbidity in longitudinal studies : Development and Validation. Journal of Chronic Disease 1987;40:373-383.",
+                            "type": "display",
+                            "linkId": "/MH/ComMetastases-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComHIV",
+                            "display": "Have you ever been diagnosed with or treated for HIV/AIDS?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComHIV",
+                    "text": "Have you ever been diagnosed with or treated for HIV/AIDS?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "History of having HIV infection or AIDS is relevant to evaluation of your symptoms. It may affect the choice of medications prescribed for treating your symptoms.  If you are considering surgery, the medications used to treat HIV infection or AIDS can interact with anesthesia and surgical medications.  Untreated AIDS can lead to poor outcome including increased risk of infection after joint replacement and may need to be addressed before surgery.      Reference:  King Jr JT, et al. Thirty-Day Postoperative Mortality Among Individuals Wth HIV Infection Receiving Antiretroviral Therapy and Procedure-Matched, Uninfected Comparators. JAMA Surgery doi:10.1001/jamasurg.2014.2257 Published online February 25, 2015",
+                            "type": "display",
+                            "linkId": "/MH/ComHIV-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComIA",
+                            "display": "Do you have any rheumatic conditions like lupus, psoriasis, ankylosing spondylitis, or rheumatoid arthritis (a type of arthritis NOT related to the commonly diagnosed osteoarthritis)? ",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComIA",
+                    "text": "Do you have any rheumatic conditions like lupus, psoriasis, ankylosing spondylitis, or rheumatoid arthritis (a type of arthritis NOT related to the commonly diagnosed osteoarthritis)? ",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "Inflammatory conditions like rheumatic or autoimmune arthritis increase risk of complications from surgery such as infection. Careful management before surgery may decrease this risk.  Reference:  Howe CR, et al. Perioperative medication management for the patient with rheumatoid arthritis. Journal of the Academy of Orthopaedic Surgeons 2006;14:544-551. Grennan et al. Ann Rheum Dis. 2001;60:214-217.",
+                            "type": "display",
+                            "linkId": "/MH/ComIA-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComIAmed",
+                            "display": "Do you take medications for it regularly? ",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComIAmed",
+                    "text": "Do you take medications for it regularly? ",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/MH/ComIA",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_2"
+                            }
+                        },
+                        {
+                            "question": "/MH/ComIA",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_3"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "Some medications taken for rheumatoid arthritis increase the risk of infection and require careful adjustment before and after surgery. References: (1) Goodman SM, Figgie M. Lower extremity arthroplasty in patients with inflammatory arthritis: preoperative and perioperative management. J Am Acad Orthop Surg. 2013 Jun;21(6):355-63. doi: 10.5435/JAAOS-21-06-355 (2) Bongartz et al. Anti-TNF antibody therapy in rheumatoid arthritis and the risk of serious infections and malignancies: systematic review and meta-analysis of rare harmful effects in randomized controlled trials. JAMA. 2006; 295:2275-85",
+                            "type": "display",
+                            "linkId": "/MH/ComIAmed-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComOAKnee",
+                            "display": "Do you have arthritis in your knees?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComOAKnee",
+                    "text": "Do you have arthritis in your knees?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "If you are considering surgery, pain affecting other joint in your legs can complicate your recovery and limit the benefits you experience.  Reference: Coxib and traditional NSAID Trialists' (CNT) Collaboration.  Vascular and upper gastrointestinal effects of non-steroidal anti-infl ammatory drugs: meta-analyses of individual participant data from randomised trials. Lancet 2013; 382: 769-79",
+                            "type": "display",
+                            "linkId": "/MH/ComOAKnee-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComOAHip",
+                            "display": "Do you have arthritis in your hips?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComOAHip",
+                    "text": "Do you have arthritis in your hips?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "If you are considering surgery, pain affecting other joint in your legs can complicate your recovery and limit the benefits you experience. References:  Coxib and traditional NSAID Trialists' (CNT) Collaboration.  Vascular and upper gastrointestinal effects of non-steroidal anti-infl ammatory drugs: meta-analyses of individual participant data from randomised trials. Lancet 2013; 382: 769-79.",
+                            "type": "display",
+                            "linkId": "/MH/ComOAHip-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "MH-score",
+                            "display": "Medical History Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh1_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComMI').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComMI').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh2_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComCHF').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComCHF').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh3_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComPVD').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComPVD').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh4_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComDVT').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComDVT').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh5_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComBleeding').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComBleeding').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh6_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComCVA').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComCVA').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh7_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComHemiplegia').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComHemiplegia').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh8_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComAsthma').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComAsthma').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh9_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComAsthmaMed').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComAsthmaMed').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh10_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComCOPD').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComCOPD').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh11_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComOxygen').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComOxygen').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh12_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComGERD').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComGERD').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh13_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComGERDdx').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComGERDdx').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh14_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComDM').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComDM').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh15_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComDmeye').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComDmeye').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh16_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComDmkidney').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComDmkidney').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh17_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComKidney').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComKidney').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh18_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComDialysis').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComDialysis').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh19_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComLiver').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComLiver').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh20_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComTransplant').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComTransplant').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh21_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComCancer').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComCancer').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh22_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComMetastases').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComMetastases').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh23_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComHIV').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComHIV').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh24_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComIA').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComIA').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh25_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComIAmed').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComIAmed').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh26_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComOAKnee').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComOAKnee').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh27_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComOAHip').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComOAHip').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "any_questions_answered",
+                                "language": "text/fhirpath",
+                                "expression": "%mh1_value.exists() or %mh2_value.exists() or %mh3_value.exists() or %mh4_value.exists() or %mh5_value.exists() or %mh6_value.exists() or %mh7_value.exists() or %mh8_value.exists() or %mh9_value.exists() or %mh10_value.exists() or %mh11_value.exists() or %mh12_value.exists() or %mh13_value.exists() or %mh14_value.exists() or %mh15_value.exists() or %mh16_value.exists() or %mh17_value.exists() or %mh18_value.exists() or %mh19_value.exists() or %mh20_value.exists() or %mh21_value.exists() or %mh22_value.exists() or %mh23_value.exists() or %mh24_value.exists() or %mh25_value.exists() or %mh26_value.exists() or %mh27_value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%any_questions_answered, iif(%mh1_value.exists(), %mh1_value, 0) + iif(%mh2_value.exists(), %mh2_value, 0) + iif(%mh3_value.exists(), %mh3_value, 0) + iif(%mh4_value.exists(), %mh4_value, 0) + iif(%mh5_value.exists(), %mh5_value, 0) + iif(%mh6_value.exists(), %mh6_value, 0) + iif(%mh7_value.exists(), %mh7_value, 0) + iif(%mh8_value.exists(), %mh8_value, 0) + iif(%mh9_value.exists(), %mh9_value, 0) + iif(%mh10_value.exists(), %mh10_value, 0) + iif(%mh11_value.exists(), %mh11_value, 0) + iif(%mh12_value.exists(), %mh12_value, 0) + iif(%mh13_value.exists(), %mh13_value, 0) + iif(%mh14_value.exists(), %mh14_value, 0) + iif(%mh15_value.exists(), %mh15_value, 0) + iif(%mh16_value.exists(), %mh16_value, 0) + iif(%mh17_value.exists(), %mh17_value, 0) + iif(%mh18_value.exists(), %mh18_value, 0) + iif(%mh19_value.exists(), %mh19_value, 0) + iif(%mh20_value.exists(), %mh20_value, 0) + iif(%mh21_value.exists(), %mh21_value, 0) + iif(%mh22_value.exists(), %mh22_value, 0) + iif(%mh23_value.exists(), %mh23_value, 0) + iif(%mh24_value.exists(), %mh24_value, 0) + iif(%mh25_value.exists(), %mh25_value, 0) + iif(%mh26_value.exists(), %mh26_value, 0) + iif(%mh27_value.exists(), %mh27_value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/MH-score",
+                    "text": "Medical History Score"
+                }
+            ]
+        },
+        {
+            "type": "group",
+            "code": [],
+            "required": false,
+            "linkId": "/SC",
+            "prefix": "Social Factors",
+            "text": "The next few questions ask about social factors that may help select the right treatment for you. This part will require about 2 minutes",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS40afeet",
+                            "display": "How tall are you? Enter feet here and inches in the next question. For example, for 5 feet and 6 inches, please anwser 5 feet in this question and 6 inches in the next question)",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SC/MDS40afeet",
+                    "text": "How tall are you? Enter feet here and inches in the next question. For example, for 5 feet and 6 inches, please anwser 5 feet in this question and 6 inches in the next question)",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "FET_1",
+                                "display": "less than 4 feet"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FET_2",
+                                "display": "4 feet"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FET_3",
+                                "display": "5 feet"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FET_4",
+                                "display": "6 feet"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FET_5",
+                                "display": "more than 6 feet"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "Height is used to calculate BMI (body mass index). BMI can help select the right treatment for you. The question was developed by the National\n Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results \n of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/SC/MDS40afeet-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS40ainch",
+                            "display": "What is your height? (enter inches here)",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SC/MDS40ainch",
+                    "text": "What is your height? (enter inches here)",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "INC_1",
+                                "display": "0 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_2",
+                                "display": "1 inch"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_3",
+                                "display": "2 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_4",
+                                "display": "3 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_5",
+                                "display": "4 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_6",
+                                "display": "5 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_7",
+                                "display": "6 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 6
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_8",
+                                "display": "7 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 7
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_9",
+                                "display": "8 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 8
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_10",
+                                "display": "9 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 9
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_11",
+                                "display": "10 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 10
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_12",
+                                "display": "11 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 11
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "Height is used to calculate BMI (body mass index). BMI can help select the right treatment for you. The question was developed \nby the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if \nresults of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/SC/MDS40ainch-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS40b",
+                            "display": "What is your weight? (pounds)",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SC/MDS40b",
+                    "text": "What is your weight? (pounds)",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "PDS_1",
+                                "display": "<100lbs"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_2",
+                                "display": "100-120 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_3",
+                                "display": "121-140 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_4",
+                                "display": "141-160 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_5",
+                                "display": "161-180 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_6",
+                                "display": "181-200 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_7",
+                                "display": "201-220 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 6
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_8",
+                                "display": "221-240 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 7
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_9",
+                                "display": "241-260 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 8
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_10",
+                                "display": "261-280 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 9
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_11",
+                                "display": "281-300 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 10
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_12",
+                                "display": "more than 300 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 11
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "Weight is used to calculate BMI (body mass index). BMI can help select the right treatment for you. The question was developed by\n the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine \n if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/SC/MDS40b-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS39",
+                            "display": "How would you describe your cigarette smoking?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SC/MDS39",
+                    "text": "How would you describe your cigarette smoking?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SMK_1",
+                                "display": "Never smoked"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SMK_2",
+                                "display": "Current smoker"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SMK_3",
+                                "display": "Used to smoke, but have now quit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "Smoking can affect pain severity and also help choose the right treatment. The question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/SC/MDS39-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS31",
+                            "display": "Have you drunk or used drugs more than you meant to?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SC/MDS31",
+                    "text": "Have you drunk or used drugs more than you meant to?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "ALC_1",
+                                "display": "Never"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ALC_2",
+                                "display": "Rarely"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ALC_3",
+                                "display": "Sometimes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ALC_4",
+                                "display": "Often"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past year",
+                    "item": [
+                        {
+                            "text": "Alcohol use can influence risks of different treatments. The question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/SC/MDS31-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS32",
+                            "display": "Have you felt you wanted or needed to cut down on your drinking or drug use?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SC/MDS32",
+                    "text": "Have you felt you wanted or needed to cut down on your drinking or drug use?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "ALC_1",
+                                "display": "Never"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ALC_2",
+                                "display": "Rarely"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ALC_3",
+                                "display": "Sometimes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ALC_4",
+                                "display": "Often"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past year",
+                    "enableWhen": [
+                        {
+                            "question": "/SC/MDS31",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "ALC_2"
+                            }
+                        },
+                        {
+                            "question": "/SC/MDS31",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "ALC_3"
+                            }
+                        },
+                        {
+                            "question": "/SC/MDS31",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "ALC_4"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "Alcohol use can influence risks of different treatments. The question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/SC/MDS32-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS37",
+                            "display": "Employment Status:",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SC/MDS37",
+                    "text": "Employment Status:",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "EMP_1",
+                                "display": "Working now"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EMP_2",
+                                "display": "Sick leave"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EMP_3",
+                                "display": "Temporary disability"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EMP_4",
+                                "display": "Permanently disability"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EMP_5",
+                                "display": "Temporarily laid off"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EMP_6",
+                                "display": "Looking/unemployed"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 6
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EMP_7",
+                                "display": "Keeping house"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 7
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EMP_8",
+                                "display": "Student"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 8
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EMP_9",
+                                "display": "Retired"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 9
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EMP_10",
+                                "display": "Other"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 10
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "Work status is predicitive of outcomes. The question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/SC/MDS37-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS38",
+                            "display": "Select the highest education level attained",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SC/MDS38",
+                    "text": "Select the highest education level attained",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "EDU_1",
+                                "display": "No high school diploma"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EDU_2",
+                                "display": "High school or GED"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EDU_3",
+                                "display": "Some college, no degree"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EDU_4",
+                                "display": "Occupational program"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EDU_5",
+                                "display": "Associate degree"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EDU_6",
+                                "display": "Bachelors degree"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 6
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EDU_7",
+                                "display": "Masters degree"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 7
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EDU_8",
+                                "display": "Doctoral degree"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 8
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EDU_9",
+                                "display": "Prefer not to report"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "Education level is predicitive of outcomes. The question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/SC/MDS38-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS36",
+                            "display": "Choose the race with which you most closely identify",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SC/MDS36",
+                    "text": "Choose the race with which you most closely identify",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "RAC_1",
+                                "display": "American/Alaska Native"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RAC_2",
+                                "display": "Asian"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RAC_3",
+                                "display": "Black/African-American"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RAC_4",
+                                "display": "Hawaiian/Pacific Islander"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RAC_5",
+                                "display": "White"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RAC_6",
+                                "display": "Other"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 6
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RAC_7",
+                                "display": "Prefer not to answer"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "Race can be predicitive of outcomes. It can be associated to certain diagnoses and outcomes. The question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/SC/MDS36-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS35",
+                            "display": "Choose the ethnicity with which you most closely identify",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SC/MDS35",
+                    "text": "Choose the ethnicity with which you most closely identify",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "ETH_1",
+                                "display": "Hispanic or Latino"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ETH_2",
+                                "display": "Not Hispanic or Latino"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ETH_3",
+                                "display": "Unknown"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ETH_4",
+                                "display": "Prefer not to answer"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "Ethnicity may be predicitive of outcomes. It can be associated to certain diagnoses and outcomes. The question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/SC/MDS35-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "SC-score",
+                            "display": "Social Factors Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "sc1_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS40afeet').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS40afeet').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "sc2_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS40ainch').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS40ainch').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "sc3_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS40b').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS40b').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "sc4_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS39').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS39').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "sc5_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS31').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS31').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "sc6_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS32').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS32').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "sc7_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS37').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS37').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "sc8_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS38').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS38').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "sc9_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS36').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS36').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "sc10_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS35').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS35').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "any_questions_answered",
+                                "language": "text/fhirpath",
+                                "expression": "%sc1_value.exists() or %sc2_value.exists() or %sc3_value.exists() or %sc4_value.exists() or %sc5_value.exists() or %sc6_value.exists() or %sc7_value.exists() or %sc8_value.exists() or %sc9_value.exists() or %sc10_value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%any_questions_answered, iif(%sc1_value.exists(), %sc1_value, 0) + iif(%sc2_value.exists(), %sc2_value, 0) + iif(%sc3_value.exists(), %sc3_value, 0) + iif(%sc4_value.exists(), %sc4_value, 0) + iif(%sc5_value.exists(), %sc5_value, 0) + iif(%sc6_value.exists(), %sc6_value, 0) + iif(%sc7_value.exists(), %sc7_value, 0) + iif(%sc8_value.exists(), %sc8_value, 0) + iif(%sc9_value.exists(), %sc9_value, 0) + iif(%sc10_value.exists(), %sc10_value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SC/SC-score",
+                    "text": "Social Factors Score"
+                }
+            ]
+        },
+        {
+            "type": "group",
+            "code": [],
+            "required": false,
+            "linkId": "/BS",
+            "prefix": "Back Pain Severity",
+            "text": "This questionnaire has been designed to give us information as to how your back pain is affecting your ability to manage in everyday life. It takes about 3 minutes. Please answer by checking ONE box in each section for the statement which best applies to you. We realize you may consider that two or more statements in any one section apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS03",
+                            "display": "How would you rate your low-back pain on average?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/MDS03",
+                    "text": "How would you rate your low-back pain on average?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NRS_1",
+                                "display": "0"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_2",
+                                "display": "1"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_3",
+                                "display": "2"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_4",
+                                "display": "3"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_5",
+                                "display": "4"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_6",
+                                "display": "5"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_7",
+                                "display": "6"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 6
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_8",
+                                "display": "7"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 7
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_9",
+                                "display": "8"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 8
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_10",
+                                "display": "9"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 9
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_11",
+                                "display": "10"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 10
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/MDS03-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI01",
+                            "display": "Pain Intensity",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/ODI01",
+                    "text": "Pain Intensity",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "ODI_1",
+                                "display": "I have no pain at the moment."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ODI_2",
+                                "display": "The pain is very mild at the moment."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ODI_3",
+                                "display": "The pain is moderate at the moment."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ODI_4",
+                                "display": "The pain is fairly severe at the moment."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ODI_5",
+                                "display": "The pain is very severe at the moment."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ODI_6",
+                                "display": "The pain is the worst imaginable at the moment."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI01-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI02",
+                            "display": "Personal Care (washing, dressing, etc.)",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/ODI02",
+                    "text": "Personal Care (washing, dressing, etc.)",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "OSW_1",
+                                "display": "I can do it without pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "OSW_2",
+                                "display": "I can do it but it causes pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "OSW_3",
+                                "display": "I am slow and careful."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "OSW_4",
+                                "display": "I need some help."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "OSW_5",
+                                "display": "I need help in most self-care."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "OSW_6",
+                                "display": "I do not get dressed and stay in bed."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI02-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI03",
+                            "display": "Lifting",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/ODI03",
+                    "text": "Lifting",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "LIF_1",
+                                "display": "I can lift heavy weights without pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LIF_2",
+                                "display": "I can lift heavy weights with pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LIF_3",
+                                "display": "I can lift heavy weights if conveniently positioned"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LIF_4",
+                                "display": "I can manage medium weights."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LIF_5",
+                                "display": "I can lift very light weights."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LIF_6",
+                                "display": "I cannot lift or carry anything at all."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI03-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI04",
+                            "display": "Walking",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/ODI04",
+                    "text": "Walking",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "WLK_1",
+                                "display": "Pain does not prevent me from walking any distance."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "WLK_2",
+                                "display": "Pain prevents me from walking more than 1 mile."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "WLK_3",
+                                "display": "Pain prevents me from walking more than 1/2 mile."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "WLK_4",
+                                "display": "Pain prevents me from walking more than 100 yards."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "WLK_5",
+                                "display": "I can only walk using a stick or crutches."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "WLK_6",
+                                "display": "I am in bed most of the time."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI04-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI05",
+                            "display": "Sitting",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/ODI05",
+                    "text": "Sitting",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SIT_1",
+                                "display": "I can sit in any chair as long as I like."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SIT_2",
+                                "display": "I can only sit in my favorite chair as long as I like."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SIT_3",
+                                "display": "Pain prevents me from sitting more than one hour."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SIT_4",
+                                "display": "Pain prevents me from sitting more than 30 minutes."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SIT_5",
+                                "display": "Pain prevents me from sitting more than 10 minutes."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SIT_6",
+                                "display": "Pain prevents me from sitting at all."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI05-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI06",
+                            "display": "Standing",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/ODI06",
+                    "text": "Standing",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "STD_1",
+                                "display": "I can stand as long as I want without pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "STD_2",
+                                "display": "I can stand as long as I want but it causes pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "STD_3",
+                                "display": "Pain prevents me from standing more than 1 hour."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "STD_4",
+                                "display": "Pain prevents me from standing more than 30 minutes."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "STD_5",
+                                "display": "Pain prevents me from standing more than 10 minutes."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "STD_6",
+                                "display": "Pain prevents me from standing at all."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI06-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI07",
+                            "display": "Sleeping",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/ODI07",
+                    "text": "Sleeping",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SLG_1",
+                                "display": "My sleep is never disturbed by pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLG_2",
+                                "display": "My sleep is occasionally disturbed by pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLG_3",
+                                "display": "Because of pain I have less than 6 hours sleep."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLG_4",
+                                "display": "Because of pain I have less than 4 hours sleep."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLG_5",
+                                "display": "Because of pain I have less than 2 hours sleep."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLG_6",
+                                "display": "Pain prevents me from sleeping at all."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI07-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI08",
+                            "display": "Sex Life (if applicable)",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/ODI08",
+                    "text": "Sex Life (if applicable)",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SEX_1",
+                                "display": "My sex life is normal and causes no extra pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SEX_2",
+                                "display": "My sex life is normal but causes some extra pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SEX_3",
+                                "display": "My sex life is nearly normal but is very painful."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SEX_4",
+                                "display": "My sex life is severely restricted by pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SEX_5",
+                                "display": "My sex life is nearly absent because of pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SEX_6",
+                                "display": "Pain prevents any sex life at all."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI08-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI09",
+                            "display": "Social Life",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/ODI09",
+                    "text": "Social Life",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SLK_1",
+                                "display": "My social life is normal and gives me no extra pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLK_2",
+                                "display": "My social life is normal but increases the degree of pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLK_3",
+                                "display": "Pain limits my more energetic interests, e.g., sport."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLK_4",
+                                "display": "Pain has restricted my social life and I do not go out as often."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLK_5",
+                                "display": "Pain has restricted my social life to my home."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLK_6",
+                                "display": "I have no social life because of pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI09-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI10",
+                            "display": "Traveling",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/ODI10",
+                    "text": "Traveling",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "TRL_1",
+                                "display": "I can travel anywhere without pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TRL_2",
+                                "display": "I can travel anywhere but it gives me extra pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TRL_3",
+                                "display": "Pain is bad but I manage journeys over 2 hours."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TRL_4",
+                                "display": "Pain is bad but I manage journeys less than 1 hour."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TRL_5",
+                                "display": "Pain restricts me to short necessary journeys under 30 minutes."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TRL_6",
+                                "display": "Pain prevents me from traveling except to receive treatment."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI10-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "BS-score",
+                            "display": "Back Pain Severity Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs1_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/MDS03').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/MDS03').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs2_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI01').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI01').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs3_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI02').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI02').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs4_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI03').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI03').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs5_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI04').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI04').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs6_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI05').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI05').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs7_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI06').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI06').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs8_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI07').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI07').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs9_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI08').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI08').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs10_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI09').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI09').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs11_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI10').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI10').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "any_questions_answered",
+                                "language": "text/fhirpath",
+                                "expression": "%bs1_value.exists() or %bs2_value.exists() or %bs3_value.exists() or %bs4_value.exists() or %bs5_value.exists() or %bs6_value.exists() or %bs7_value.exists() or %bs8_value.exists() or %bs9_value.exists() or %bs10_value.exists() or %bs11_value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%any_questions_answered, iif(%bs1_value.exists(), %bs1_value, 0) + iif(%bs2_value.exists(), %bs2_value, 0) + iif(%bs3_value.exists(), %bs3_value, 0) + iif(%bs4_value.exists(), %bs4_value, 0) + iif(%bs5_value.exists(), %bs5_value, 0) + iif(%bs6_value.exists(), %bs6_value, 0) + iif(%bs7_value.exists(), %bs7_value, 0) + iif(%bs8_value.exists(), %bs8_value, 0) + iif(%bs9_value.exists(), %bs9_value, 0) + iif(%bs10_value.exists(), %bs10_value, 0) + iif(%bs11_value.exists(), %bs11_value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/BS-score",
+                    "text": "Back Pain Severity Score"
+                }
+            ]
+        },
+        {
+            "type": "group",
+            "code": [],
+            "required": false,
+            "linkId": "/BP",
+            "prefix": "Back Pain History",
+            "text": "The next set of questions help provide comprehensive evaluation. \nThey require about 2 minutes. These queastions were developed by the National Institutes of Health Task Force on Research Standards\n for Chronic Low Back Pain. They are essential for comparing outcomes of patients with low back pain.",
+            "enableWhen": [
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_2"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_3"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_4"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_5"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_6"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_7"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_8"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_9"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_10"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_11"
+                    }
+                }
+            ],
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS01",
+                            "display": "How long has back pain been an ongoing problem for you?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/MDS01",
+                    "text": "How long has back pain been an ongoing problem for you?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BCK_1",
+                                "display": "Less than 1 month"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BCK_2",
+                                "display": "1 to 3 months"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BCK_3",
+                                "display": "3 to 6 months"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BCK_4",
+                                "display": "6 to 12 months"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BCK_5",
+                                "display": "1 to 5 years"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BCK_6",
+                                "display": "More than 5 years"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 6
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS01-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS02",
+                            "display": "How often has back pain been an ongoing problem for you?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/MDS02",
+                    "text": "How often has back pain been an ongoing problem for you?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BPF_1",
+                                "display": "Every day or nearly every day"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BPF_2",
+                                "display": "At least half the days"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BPF_3",
+                                "display": "Less than half the days"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BP/MDS01",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BCK_4"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS01",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BCK_5"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS01",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BCK_6"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS02-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS04",
+                            "display": "Do you have pain down your leg?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/MDS04",
+                    "text": "Do you have pain down your leg?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "LRP_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LRP_2",
+                                "display": "Yes, only the right side"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LRP_3",
+                                "display": "Yes, only on the left side"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LRP_4",
+                                "display": "Yes, both sides"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LRP_5",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "During the past 2 weeks",
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS04-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS04Side",
+                            "display": "Have you had pain, numbness or tingling below your knee?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/MDS04Side",
+                    "text": "Have you had pain, numbness or tingling below your knee?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "LRP_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LRP_2",
+                                "display": "Yes, only the right side"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LRP_3",
+                                "display": "Yes, only on the left side"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LRP_4",
+                                "display": "Yes, both sides"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LRP_5",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "During the past 2 weeks",
+                    "enableWhen": [
+                        {
+                            "question": "/BP/MDS04",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "LRP_2"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS04",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "LRP_3"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS04",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "LRP_4"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS04",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "LRP_5"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS04Side-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS06",
+                            "display": "Have you ever had a low-back operation?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/MDS06",
+                    "text": "Have you ever had a low-back operation?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BSY_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BSY_2",
+                                "display": "Yes, one operation"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BSY_3",
+                                "display": "Yes, more than one operation"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS06-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS07",
+                            "display": "When was your last back operation?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/MDS07",
+                    "text": "When was your last back operation?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "LBO_1",
+                                "display": "Less than 6 months ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LBO_2",
+                                "display": "Between 6 months and 1 year ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LBO_3",
+                                "display": "Between 1 and 2 years ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LBO_4",
+                                "display": "More than 2 years ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BP/MDS06",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BSY_2"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS06",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BSY_3"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS07-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS08",
+                            "display": "Did any of your back operations involve a spinal fusion? (also called an arthrodesis)",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/MDS08",
+                    "text": "Did any of your back operations involve a spinal fusion? (also called an arthrodesis)",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BP/MDS06",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BSY_2"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS06",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BSY_3"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS08-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13b",
+                            "display": "Have you ever had low back injection (such as epidural steroid injection, facet injection)?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/MDS13b",
+                    "text": "Have you ever had low back injection (such as epidural steroid injection, facet injection)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BIN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BIN_2",
+                                "display": "Yes, one injection"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BIN_3",
+                                "display": "Yes, more than one injection"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS13b-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13bWhen",
+                            "display": "When was your last injection?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/MDS13bWhen",
+                    "text": "When was your last injection?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "LBO_1",
+                                "display": "Less than 6 months ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LBO_2",
+                                "display": "Between 6 months and 1 year ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LBO_3",
+                                "display": "Between 1 and 2 years ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LBO_4",
+                                "display": "More than 2 years ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BP/MDS13b",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BIN_2"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS13b",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BIN_3"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS13bWhen-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13c",
+                            "display": "Have you ever had physical therapy for your back?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/MDS13c",
+                    "text": "Have you ever had physical therapy for your back?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NIH_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NIH_2",
+                                "display": "Yes, one series of treatments"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NIH_3",
+                                "display": "Yes, more than one series of treatments"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS13c-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13cWhen",
+                            "display": "When was your last session?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/MDS13cWhen",
+                    "text": "When was your last session?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "LBO_1",
+                                "display": "Less than 6 months ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LBO_2",
+                                "display": "Between 6 months and 1 year ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LBO_3",
+                                "display": "Between 1 and 2 years ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LBO_4",
+                                "display": "More than 2 years ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BP/MDS13c",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NIH_2"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS13c",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NIH_3"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS13cWhen-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13a",
+                            "display": "Have you ever used opioid pain killers? (prescription medications such as Vicodin, Lortab, Norco, hydrocodone, codeine, Tylenol #3 or #4, Fentanyl, Duragesic, MS Contin, Percocet, Tylox, OxyContin, oxycodone, methadone, tramadol, Ultram, Dilaudid)?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/MDS13a",
+                    "text": "Have you ever used opioid pain killers? (prescription medications such as Vicodin, Lortab, Norco, hydrocodone, codeine, Tylenol #3 or #4, Fentanyl, Duragesic, MS Contin, Percocet, Tylox, OxyContin, oxycodone, methadone, tramadol, Ultram, Dilaudid)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS13a-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13aCurrent",
+                            "display": "Are you using these medications currently?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/MDS13aCurrent",
+                    "text": "Are you using these medications currently?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BP/MDS13a",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_2"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS13a",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_3"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS13aCurrent-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13d",
+                            "display": "Have you ever had psychological counseling for pain coping skills, such as cognitive-behavioral therapy (CBT)?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/MDS13d",
+                    "text": "Have you ever had psychological counseling for pain coping skills, such as cognitive-behavioral therapy (CBT)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS13d-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS14",
+                            "display": "Have you had to take time off work?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/MDS14",
+                    "text": "Have you had to take time off work?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "TOF_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TOF_2",
+                                "display": "Yes, less than a month"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TOF_3",
+                                "display": "Yes, more than a month"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TOF_4",
+                                "display": "Does not apply"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/SC/MDS37",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "EMP_2"
+                            }
+                        },
+                        {
+                            "question": "/SC/MDS37",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "EMP_3"
+                            }
+                        },
+                        {
+                            "question": "/SC/MDS37",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "EMP_4"
+                            }
+                        },
+                        {
+                            "question": "/SC/MDS37",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "EMP_5"
+                            }
+                        },
+                        {
+                            "question": "/SC/MDS37",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "EMP_6"
+                            }
+                        },
+                        {
+                            "question": "/SC/MDS37",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "EMP_7"
+                            }
+                        },
+                        {
+                            "question": "/SC/MDS37",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "EMP_8"
+                            }
+                        },
+                        {
+                            "question": "/SC/MDS37",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "EMP_9"
+                            }
+                        },
+                        {
+                            "question": "/SC/MDS37",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "EMP_10"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BP/MDS14-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS15",
+                            "display": "Have you applied for disability?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/MDS15",
+                    "text": "Have you applied for disability?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "RTF_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RTF_2",
+                                "display": "Yes, workers compensation"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RTF_3",
+                                "display": "Yes, Social Security"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RTF_4",
+                                "display": "Yes, both workers comp and social security"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RTF_5",
+                                "display": "Does not apply"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/BP/MDS14",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "TOF_2"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS14",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "TOF_3"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS14",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "TOF_4"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BP/MDS15-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "BP-score",
+                            "display": "Back Pain History Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp1_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS01').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS01').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp2_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS02').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS02').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp3_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS04').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS04').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp4_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS04Side').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS04Side').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp5_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS06').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS06').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp6_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS07').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS07').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp7_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS08').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS08').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp8_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13b').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13b').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp9_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13bWhen').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13bWhen').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp10_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13c').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13c').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp11_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13cWhen').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13cWhen').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp12_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13a').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13a').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp13_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13aCurrent').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13aCurrent').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp14_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13d').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13d').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp15_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS14').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS14').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp16_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS15').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS15').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "any_questions_answered",
+                                "language": "text/fhirpath",
+                                "expression": "%bp1_value.exists() or %bp2_value.exists() or %bp3_value.exists() or %bp4_value.exists() or %bp5_value.exists() or %bp6_value.exists() or %bp7_value.exists() or %bp8_value.exists() or %bp9_value.exists() or %bp10_value.exists() or %bp11_value.exists() or %bp12_value.exists() or %bp13_value.exists() or %bp14_value.exists() or %bp15_value.exists() or %bp16_value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%any_questions_answered, iif(%bp1_value.exists(), %bp1_value, 0) + iif(%bp2_value.exists(), %bp2_value, 0) + iif(%bp3_value.exists(), %bp3_value, 0) + iif(%bp4_value.exists(), %bp4_value, 0) + iif(%bp5_value.exists(), %bp5_value, 0) + iif(%bp6_value.exists(), %bp6_value, 0) + iif(%bp7_value.exists(), %bp7_value, 0) + iif(%bp8_value.exists(), %bp8_value, 0) + iif(%bp9_value.exists(), %bp9_value, 0) + iif(%bp10_value.exists(), %bp10_value, 0) + iif(%bp11_value.exists(), %bp11_value, 0) + iif(%bp12_value.exists(), %bp12_value, 0) + iif(%bp13_value.exists(), %bp13_value, 0) + iif(%bp14_value.exists(), %bp14_value, 0) + iif(%bp15_value.exists(), %bp15_value, 0) + iif(%bp16_value.exists(), %bp16_value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/BP-score",
+                    "text": "Back Pain History Score"
+                }
+            ]
+        },
+        {
+            "type": "group",
+            "code": [],
+            "required": false,
+            "linkId": "/BI",
+            "prefix": "Impact of Back Pain",
+            "text": "The National Institutes of Health Task Force on Research Standard for Chronic Low Back Pain recommended the next few questions to measure prior treatments, disability and goals. This section takes about 2 minutes.",
+            "enableWhen": [
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_2"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_3"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_4"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_5"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_6"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_7"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_8"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_9"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_10"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_11"
+                    }
+                }
+            ],
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS15Injury",
+                            "display": "Do you feel there is a relationship between your back pain and any of the following?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BI/MDS15Injury",
+                    "text": "Do you feel there is a relationship between your back pain and any of the following?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "IJK_1",
+                                "display": "Employment"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "IJK_2",
+                                "display": "Auto accident"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "IJK_3",
+                                "display": "Other accident"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "IJK_4",
+                                "display": "Pregnancy"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "IJK_5",
+                                "display": "None of these"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/MDS15Injury-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS30",
+                            "display": "Are you involved in a lawsuit or legal claim related to you back problem?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BI/MDS30",
+                    "text": "Are you involved in a lawsuit or legal claim related to you back problem?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/MDS30-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS05a",
+                            "display": "How much have you been bothered by stomach pain?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BI/MDS05a",
+                    "text": "How much have you been bothered by stomach pain?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SPN_1",
+                                "display": "Not bothered at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SPN_2",
+                                "display": "Bothered a little"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SPN_3",
+                                "display": "Bothered a lot"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "During the past 4 weeks",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/MDS05a-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS05b",
+                            "display": "How much have you been bothered by headaches?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BI/MDS05b",
+                    "text": "How much have you been bothered by headaches?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SPN_1",
+                                "display": "Not bothered at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SPN_2",
+                                "display": "Bothered a little"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SPN_3",
+                                "display": "Bothered a lot"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "During the past 4 weeks",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/MDS05b-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS05c",
+                            "display": "How much have you been bothered by pain the joints in your arms or legs?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BI/MDS05c",
+                    "text": "How much have you been bothered by pain the joints in your arms or legs?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SPN_1",
+                                "display": "Not bothered at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SPN_2",
+                                "display": "Bothered a little"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SPN_3",
+                                "display": "Bothered a lot"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "During the past 4 weeks",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/MDS05c-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS05d",
+                            "display": "how much have you been bothered by widespread pain or pain in most of your body?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BI/MDS05d",
+                    "text": "how much have you been bothered by widespread pain or pain in most of your body?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SPN_1",
+                                "display": "Not bothered at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SPN_2",
+                                "display": "Bothered a little"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SPN_3",
+                                "display": "Bothered a lot"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "During the past 4 weeks",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/MDS05d-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS28",
+                            "display": "It's not really safe for a person with my back pain to be physically active.",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BI/MDS28",
+                    "text": "It's not really safe for a person with my back pain to be physically active.",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "AGD_1",
+                                "display": "Agree"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "AGD_2",
+                                "display": "Disagree"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Do you agree or disagree with this statement:",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/MDS28-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS29",
+                            "display": "I feel that my back pain is terrible and it's never going to get any better.",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BI/MDS29",
+                    "text": "I feel that my back pain is terrible and it's never going to get any better.",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "AGD_1",
+                                "display": "Agree"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "AGD_2",
+                                "display": "Disagree"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Do you agree or disagree with this statement:",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/MDS29-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "Goal",
+                            "display": "What is your treatment goal?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BI/Goal",
+                    "text": "What is your treatment goal?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "GOL_1",
+                                "display": "Become pain-free all of the time"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "GOL_2",
+                                "display": "Become pain-free on most days"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "GOL_3",
+                                "display": "Reduce pain enough so I can function"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/Goal-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "BI-score",
+                            "display": "Impact of Back Pain Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi1_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS15Injury').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS15Injury').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi2_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS30').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS30').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi3_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS05a').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS05a').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi4_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS05b').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS05b').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi5_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS05c').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS05c').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi6_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS05d').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS05d').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi7_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS28').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS28').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi8_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS29').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS29').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi9_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/Goal').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/Goal').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "any_questions_answered",
+                                "language": "text/fhirpath",
+                                "expression": "%bi1_value.exists() or %bi2_value.exists() or %bi3_value.exists() or %bi4_value.exists() or %bi5_value.exists() or %bi6_value.exists() or %bi7_value.exists() or %bi8_value.exists() or %bi9_value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%any_questions_answered, iif(%bi1_value.exists(), %bi1_value, 0) + iif(%bi2_value.exists(), %bi2_value, 0) + iif(%bi3_value.exists(), %bi3_value, 0) + iif(%bi4_value.exists(), %bi4_value, 0) + iif(%bi5_value.exists(), %bi5_value, 0) + iif(%bi6_value.exists(), %bi6_value, 0) + iif(%bi7_value.exists(), %bi7_value, 0) + iif(%bi8_value.exists(), %bi8_value, 0) + iif(%bi9_value.exists(), %bi9_value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BI/BI-score",
+                    "text": "Impact of Back Pain Score"
+                }
+            ]
+        },
+        {
+            "type": "group",
+            "code": [],
+            "required": false,
+            "linkId": "/SO",
+            "prefix": "Safety Outcomes",
+            "text": "The next eight questions help evaluate results of treatment.",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13aFollow",
+                            "display": "Are you currently using opioid pain killers? (prescription medications such as Vicodin, Lortab, Norco, hydrocodone, codeine, Tylenol #3 or #4, Fentanyl, Duragesic, MS Contin, Percocet, Tylox, OxyContin, oxycodone, methadone, tramadol, Ultram, Dilaudi",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SO/MDS13aFollow",
+                    "text": "Are you currently using opioid pain killers? (prescription medications such as Vicodin, Lortab, Norco, hydrocodone, codeine, Tylenol #3 or #4, Fentanyl, Duragesic, MS Contin, Percocet, Tylox, OxyContin, oxycodone, methadone, tramadol, Ultram, Dilaudi",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "This question helps measure results of back pain treatment.",
+                            "type": "display",
+                            "linkId": "/SO/MDS13aFollow-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ERvisitFollow",
+                            "display": "Have you had to go to an Emergency Room for any reason?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SO/ERvisitFollow",
+                    "text": "Have you had to go to an Emergency Room for any reason?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "ERV_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ERV_2",
+                                "display": "Yes, one visit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ERV_3",
+                                "display": "Yes, more than one visit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Since <DATE_OF_LAST_ASSESSMENT>",
+                    "item": [
+                        {
+                            "text": "This question helps measure results of back pain treatment.",
+                            "type": "display",
+                            "linkId": "/SO/ERvisitFollow-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS06Follow",
+                            "display": "Have you had a low-back operation?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SO/MDS06Follow",
+                    "text": "Have you had a low-back operation?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BSY_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BSY_2",
+                                "display": "Yes, one operation"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BSY_3",
+                                "display": "Yes, more than one operation"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Since <DATE_OF_LAST_ASSESSMENT>",
+                    "item": [
+                        {
+                            "text": "This question helps measure results of back pain treatment.",
+                            "type": "display",
+                            "linkId": "/SO/MDS06Follow-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13bFollow",
+                            "display": "Have you had low back injection (such as epidural steroid injection, facet injection)?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SO/MDS13bFollow",
+                    "text": "Have you had low back injection (such as epidural steroid injection, facet injection)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BIN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BIN_2",
+                                "display": "Yes, one injection"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BIN_3",
+                                "display": "Yes, more than one injection"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Since <DATE_OF_LAST_ASSESSMENT>",
+                    "item": [
+                        {
+                            "text": "This question helps measure results of back pain treatment.",
+                            "type": "display",
+                            "linkId": "/SO/MDS13bFollow-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13cFollow",
+                            "display": "Have you had physical therapy?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SO/MDS13cFollow",
+                    "text": "Have you had physical therapy?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NIH_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NIH_2",
+                                "display": "Yes, one series of treatments"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NIH_3",
+                                "display": "Yes, more than one series of treatments"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Since <DATE_OF_LAST_ASSESSMENT>",
+                    "item": [
+                        {
+                            "text": "This question helps measure results of back pain treatment.",
+                            "type": "display",
+                            "linkId": "/SO/MDS13cFollow-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13dFollow",
+                            "display": "Have you had psychological counseling for pain coping skills, such as cognitive-behavioral therapy (CBT)?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SO/MDS13dFollow",
+                    "text": "Have you had psychological counseling for pain coping skills, such as cognitive-behavioral therapy (CBT)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Since <DATE_OF_LAST_ASSESSMENT>",
+                    "item": [
+                        {
+                            "text": "This question helps measure results of back pain treatment.",
+                            "type": "display",
+                            "linkId": "/SO/MDS13dFollow-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS14Follow",
+                            "display": "Have you had to take time off work?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SO/MDS14Follow",
+                    "text": "Have you had to take time off work?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "TOF_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TOF_2",
+                                "display": "Yes, less than a month"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TOF_3",
+                                "display": "Yes, more than a month"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TOF_4",
+                                "display": "Does not apply"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Since <DATE_OF_LAST_ASSESSMENT>",
+                    "item": [
+                        {
+                            "text": "This question helps measure results of back pain treatment.",
+                            "type": "display",
+                            "linkId": "/SO/MDS14Follow-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS15Follow",
+                            "display": "Have you applied for disability?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SO/MDS15Follow",
+                    "text": "Have you applied for disability?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "RTF_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RTF_2",
+                                "display": "Yes, workers compensation"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RTF_3",
+                                "display": "Yes, Social Security"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RTF_4",
+                                "display": "Yes, both workers comp and social security"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RTF_5",
+                                "display": "Does not apply"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Since <DATE_OF_LAST_ASSESSMENT>",
+                    "enableWhen": [
+                        {
+                            "question": "/BP/MDS15",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "RTF_2"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS15",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "RTF_3"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS15",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "RTF_4"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS15",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "RTF_5"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question helps measure results of back pain treatment.",
+                            "type": "display",
+                            "linkId": "/SO/MDS15Follow-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "SO-score",
+                            "display": "Safety Outcomes Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "so1_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS13aFollow').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS13aFollow').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "so2_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SO').item.where(linkId = '/SO/ERvisitFollow').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SO').item.where(linkId = '/SO/ERvisitFollow').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "so3_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS06Follow').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS06Follow').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "so4_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS13bFollow').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS13bFollow').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "so5_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS13cFollow').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS13cFollow').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "so6_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS13dFollow').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS13dFollow').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "so7_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS14Follow').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS14Follow').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "so8_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS15Follow').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS15Follow').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "any_questions_answered",
+                                "language": "text/fhirpath",
+                                "expression": "%so1_value.exists() or %so2_value.exists() or %so3_value.exists() or %so4_value.exists() or %so5_value.exists() or %so6_value.exists() or %so7_value.exists() or %so8_value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%any_questions_answered, iif(%so1_value.exists(), %so1_value, 0) + iif(%so2_value.exists(), %so2_value, 0) + iif(%so3_value.exists(), %so3_value, 0) + iif(%so4_value.exists(), %so4_value, 0) + iif(%so5_value.exists(), %so5_value, 0) + iif(%so6_value.exists(), %so6_value, 0) + iif(%so7_value.exists(), %so7_value, 0) + iif(%so8_value.exists(), %so8_value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SO/SO-score",
+                    "text": "Safety Outcomes Score"
+                }
+            ]
+        },
+        {
+            "type": "group",
+            "code": [],
+            "required": false,
+            "linkId": "/DM",
+            "prefix": "Shared Decision Making",
+            "text": " The next three questions measure how involved you were in decisions regarding your treatment.",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "SDMunderstand",
+                            "display": "How much effort was made to help\u00a0you understand your back pain?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/DM/SDMunderstand",
+                    "text": "How much effort was made to help\u00a0you understand your back pain?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "COR_1",
+                                "display": "no effort at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_2",
+                                "display": "1"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_3",
+                                "display": "2"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_4",
+                                "display": "3"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_5",
+                                "display": "4"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_6",
+                                "display": "5"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_7",
+                                "display": "6"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 6
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_8",
+                                "display": "7"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 7
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_9",
+                                "display": "8"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 8
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_10",
+                                "display": "maximal effort was made"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 9
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Thinking about your appointment at PEER Clinic:",
+                    "item": [
+                        {
+                            "text": "This question helps measure the shared decison making process between you and your doctor/care provider.",
+                            "type": "display",
+                            "linkId": "/DM/SDMunderstand-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "SDMlisten",
+                            "display": "How much effort was made to listen\u00a0to the things that matter most to\u00a0you about your back pain?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/DM/SDMlisten",
+                    "text": "How much effort was made to listen\u00a0to the things that matter most to\u00a0you about your back pain?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "COR_1",
+                                "display": "no effort at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_2",
+                                "display": "1"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_3",
+                                "display": "2"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_4",
+                                "display": "3"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_5",
+                                "display": "4"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_6",
+                                "display": "5"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_7",
+                                "display": "6"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 6
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_8",
+                                "display": "7"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 7
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_9",
+                                "display": "8"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 8
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_10",
+                                "display": "maximal effort was made"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 9
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Thinking about the appointments you have had so far for [back pain]:",
+                    "item": [
+                        {
+                            "text": "This question helps measure the shared decison making process between you and your doctor/care provider.",
+                            "type": "display",
+                            "linkId": "/DM/SDMlisten-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "SDMinclude",
+                            "display": "How much effort was made to include\u00a0what matters most to you in choosing\u00a0what to do next?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/DM/SDMinclude",
+                    "text": "How much effort was made to include\u00a0what matters most to you in choosing\u00a0what to do next?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "COR_1",
+                                "display": "no effort at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_2",
+                                "display": "1"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_3",
+                                "display": "2"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_4",
+                                "display": "3"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_5",
+                                "display": "4"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_6",
+                                "display": "5"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_7",
+                                "display": "6"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 6
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_8",
+                                "display": "7"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 7
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_9",
+                                "display": "8"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 8
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_10",
+                                "display": "maximal effort was made"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 9
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Thinking about the appointments you have had so far for [back pain]:",
+                    "item": [
+                        {
+                            "text": "This question helps measure the shared decison making process between you and your doctor/care provider.",
+                            "type": "display",
+                            "linkId": "/DM/SDMinclude-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "DM-score",
+                            "display": "Shared Decision Making Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "dm1_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/DM').item.where(linkId = '/DM/SDMunderstand').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/DM').item.where(linkId = '/DM/SDMunderstand').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "dm2_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/DM').item.where(linkId = '/DM/SDMlisten').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/DM').item.where(linkId = '/DM/SDMlisten').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "dm3_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/DM').item.where(linkId = '/DM/SDMinclude').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/DM').item.where(linkId = '/DM/SDMinclude').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "any_questions_answered",
+                                "language": "text/fhirpath",
+                                "expression": "%dm1_value.exists() or %dm2_value.exists() or %dm3_value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%any_questions_answered, iif(%dm1_value.exists(), %dm1_value, 0) + iif(%dm2_value.exists(), %dm2_value, 0) + iif(%dm3_value.exists(), %dm3_value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/DM/DM-score",
+                    "text": "Shared Decision Making Score"
+                }
+            ]
+        }
+    ],
+    "name": "Full_Assessments"
+}

--- a/contrib/portal_templates/assessments/SDC FHIR/Impact_of_Back_Pain_Assessment.json
+++ b/contrib/portal_templates/assessments/SDC FHIR/Impact_of_Back_Pain_Assessment.json
@@ -1,0 +1,1082 @@
+{
+    "resourceType": "Questionnaire",
+    "meta": {
+        "profile": [
+            "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire|2.7",
+            "http://hl7.org/fhir/4.0/StructureDefinition/Questionnaire"
+        ],
+        "tag": [
+            {
+                "code": "generated: PEER"
+            }
+        ]
+    },
+    "status": "active",
+    "title": "Impact of Back Pain Assessment",
+    "subjectType": [
+        "Patient",
+        "Person"
+    ],
+    "item": [
+        {
+            "type": "group",
+            "code": [],
+            "required": false,
+            "linkId": "/BI",
+            "prefix": "Impact of Back Pain",
+            "text": "The National Institutes of Health Task Force on Research Standard for Chronic Low Back Pain recommended the next few questions to measure prior treatments, disability and goals. This section takes about 2 minutes.",
+            "enableWhen": "",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS15Injury",
+                            "display": "Do you feel there is a relationship between your back pain and any of the following?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BI/MDS15Injury",
+                    "text": "Do you feel there is a relationship between your back pain and any of the following?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "IJK_1",
+                                "display": "Employment"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "IJK_2",
+                                "display": "Auto accident"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "IJK_3",
+                                "display": "Other accident"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "IJK_4",
+                                "display": "Pregnancy"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "IJK_5",
+                                "display": "None of these"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/MDS15Injury-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS30",
+                            "display": "Are you involved in a lawsuit or legal claim related to you back problem?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BI/MDS30",
+                    "text": "Are you involved in a lawsuit or legal claim related to you back problem?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/MDS30-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS05a",
+                            "display": "How much have you been bothered by stomach pain?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BI/MDS05a",
+                    "text": "How much have you been bothered by stomach pain?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SPN_1",
+                                "display": "Not bothered at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SPN_2",
+                                "display": "Bothered a little"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SPN_3",
+                                "display": "Bothered a lot"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "During the past 4 weeks",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/MDS05a-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS05b",
+                            "display": "How much have you been bothered by headaches?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BI/MDS05b",
+                    "text": "How much have you been bothered by headaches?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SPN_1",
+                                "display": "Not bothered at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SPN_2",
+                                "display": "Bothered a little"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SPN_3",
+                                "display": "Bothered a lot"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "During the past 4 weeks",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/MDS05b-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS05c",
+                            "display": "How much have you been bothered by pain the joints in your arms or legs?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BI/MDS05c",
+                    "text": "How much have you been bothered by pain the joints in your arms or legs?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SPN_1",
+                                "display": "Not bothered at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SPN_2",
+                                "display": "Bothered a little"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SPN_3",
+                                "display": "Bothered a lot"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "During the past 4 weeks",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/MDS05c-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS05d",
+                            "display": "how much have you been bothered by widespread pain or pain in most of your body?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BI/MDS05d",
+                    "text": "how much have you been bothered by widespread pain or pain in most of your body?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SPN_1",
+                                "display": "Not bothered at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SPN_2",
+                                "display": "Bothered a little"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SPN_3",
+                                "display": "Bothered a lot"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "During the past 4 weeks",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/MDS05d-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS28",
+                            "display": "It's not really safe for a person with my back pain to be physically active.",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BI/MDS28",
+                    "text": "It's not really safe for a person with my back pain to be physically active.",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "AGD_1",
+                                "display": "Agree"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "AGD_2",
+                                "display": "Disagree"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Do you agree or disagree with this statement:",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/MDS28-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS29",
+                            "display": "I feel that my back pain is terrible and it's never going to get any better.",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BI/MDS29",
+                    "text": "I feel that my back pain is terrible and it's never going to get any better.",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "AGD_1",
+                                "display": "Agree"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "AGD_2",
+                                "display": "Disagree"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Do you agree or disagree with this statement:",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/MDS29-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "Goal",
+                            "display": "What is your treatment goal?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/BI/Goal",
+                    "text": "What is your treatment goal?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "GOL_1",
+                                "display": "Become pain-free all of the time"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "GOL_2",
+                                "display": "Become pain-free on most days"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "GOL_3",
+                                "display": "Reduce pain enough so I can function"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/Goal-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "BI-score",
+                            "display": "Impact of Back Pain Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi1_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS15Injury').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS15Injury').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi2_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS30').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS30').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi3_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS05a').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS05a').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi4_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS05b').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS05b').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi5_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS05c').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS05c').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi6_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS05d').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS05d').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi7_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS28').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS28').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi8_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS29').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS29').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi9_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/Goal').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/Goal').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "any_questions_answered",
+                                "language": "text/fhirpath",
+                                "expression": "%bi1_value.exists() or %bi2_value.exists() or %bi3_value.exists() or %bi4_value.exists() or %bi5_value.exists() or %bi6_value.exists() or %bi7_value.exists() or %bi8_value.exists() or %bi9_value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%any_questions_answered, iif(%bi1_value.exists(), %bi1_value, 0) + iif(%bi2_value.exists(), %bi2_value, 0) + iif(%bi3_value.exists(), %bi3_value, 0) + iif(%bi4_value.exists(), %bi4_value, 0) + iif(%bi5_value.exists(), %bi5_value, 0) + iif(%bi6_value.exists(), %bi6_value, 0) + iif(%bi7_value.exists(), %bi7_value, 0) + iif(%bi8_value.exists(), %bi8_value, 0) + iif(%bi9_value.exists(), %bi9_value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BI/BI-score",
+                    "text": "Impact of Back Pain Score"
+                }
+            ]
+        }
+    ],
+    "name": "Impact_of_Back_Pain_Assessment"
+}

--- a/contrib/portal_templates/assessments/SDC FHIR/Medical_History_Assessment.json
+++ b/contrib/portal_templates/assessments/SDC FHIR/Medical_History_Assessment.json
@@ -1,0 +1,3205 @@
+{
+    "resourceType": "Questionnaire",
+    "meta": {
+        "profile": [
+            "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire|2.7",
+            "http://hl7.org/fhir/4.0/StructureDefinition/Questionnaire"
+        ],
+        "tag": [
+            {
+                "code": "generated: PEER"
+            }
+        ]
+    },
+    "status": "active",
+    "title": "Medical History Assessment",
+    "subjectType": [
+        "Patient",
+        "Person"
+    ],
+    "item": [
+        {
+            "type": "group",
+            "code": [],
+            "required": false,
+            "linkId": "/MH",
+            "prefix": "Medical History",
+            "text": " The next few questions record important aspects of your medical history.",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComMI",
+                            "display": "Have you ever been treated for heart disease or been told you had a heart attack, or had procedures such as angioplasty, cardiac stents or bypass surgery?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/MH/ComMI",
+                    "text": "Have you ever been treated for heart disease or been told you had a heart attack, or had procedures such as angioplasty, cardiac stents or bypass surgery?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "If you are considering active rehabilitation or surgery, please alert your care team of your risk of heart disease. History of heart attack or heart disease (CAD - Coronary Artery Disease) increases your risk of having heart attack with active rehabilitation or surgery.  Sharing this information with your surgical team will help them optimize your risk by adjusting your medications, surgical procedure, anesthesia and recovery plan.References: (1) Lee T H, et al. Derivation and prospective validation of a simple index for prediction of cardiac risk of major noncardiac surgery.Circulation. 1999;100:1043-1049 (2) Ford MK, et al. Systematic review: Prediction of perioperative cardiac complications and mortality by the RCRI. Annals of Internal Medicine. 2010;152(1):26-35",
+                            "type": "display",
+                            "linkId": "/MH/ComMI-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComCHF",
+                            "display": "Have you ever been treated for heart failure? You may have been short of breath and the doctor may have told you that you had fluid in your lungs or that your heart was not pumping well.",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/MH/ComCHF",
+                    "text": "Have you ever been treated for heart failure? You may have been short of breath and the doctor may have told you that you had fluid in your lungs or that your heart was not pumping well.",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "Heart Failure due to a weak or stiff heart is important to recognize in order manage medications prescribed for your symptoms. If you are considering active rehabilitation or surgery, please alert your surgical team of your risk of heart failure. Heart failure may flare up after surgery.Preparing carefully for surgery may decrease the risk. References: (1) Healy KO, et al. Predictive outcome and long term mortality for Heart Failure patients undergoing intermediate and high risk non-cardiac surgery: Impact of Left ventricular Ejection Fraction. Congestive Heart Failure 2010;16:45-49. doi: 10.1111/j.1751-7133.2009.00130.x (2) Gupta PK, et al. Development and validation of a risk calculator for prediction of cardiac risk after surgery. Circulation. 2011 Jul 26;124(4):381-7. doi: 10.1161/CIRCULATIONAHA.110.015701 (3)Powell-Tuck J, et al. GIFTASUP - British Consensus Guidelines on Intravenous Fluid Therapy for Adult Surgical Patients. March 2011",
+                            "type": "display",
+                            "linkId": "/MH/ComCHF-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComPVD",
+                            "display": "Have you had an operation to unclog or bypass the arteries in your legs? ",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/MH/ComPVD",
+                    "text": "Have you had an operation to unclog or bypass the arteries in your legs? ",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "If you are considering active rehabilitation or surgery, please alert your surgical team of circulation problems. Having a history of circulation problems (vascular disease, or peripheral arterial disease, PAD) increases your risk of blockages in your heart. It is relevant for planning for surgery and anesthesia, such as whether to use a tourniquet during knee replacement, and make other management decisions during and after surgery. References: (1)  Kiani S, et al. Peripheral arterial disease is associated with severe impairment of vascular function. Vascular Medicine. 2013 Apr; 18(2): 72-78  (2)Gokce N, et al. Risk stratification for postoperative cardiovascular events via noninvasive assessment of endothelial function: a prospective study. Circulation. 2002 Apr 2;105(13):1567-72    (3)  Smith DE, et al. Arterial complications and TKA. J Am Acad Orthop Surg 2001;9:253-257 (4) Dakka AM, et al. TKA in patients with PAD. Surgeon 2009 Dec; 7(6):362-5",
+                            "type": "display",
+                            "linkId": "/MH/ComPVD-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComDVT",
+                            "display": "Have you had ever been treated for blood clots in your legs or lungs, DVT, PE? ",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/MH/ComDVT",
+                    "text": "Have you had ever been treated for blood clots in your legs or lungs, DVT, PE? ",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "If you are considering surgery please alert your surgical team to your risk of blood clots. It will help them investigate further and take precautions.",
+                            "type": "display",
+                            "linkId": "/MH/ComDVT-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComBleeding",
+                            "display": "Have you had ever been treated for bleeding problems? ",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/MH/ComBleeding",
+                    "text": "Have you had ever been treated for bleeding problems? ",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "If you are considering surgery please alert your surgical team to your risk of bleeding. It will help them investigate further and take precautions.",
+                            "type": "display",
+                            "linkId": "/MH/ComBleeding-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComCVA",
+                            "display": "Have you ever been treated for a stroke, cerebrovascular accident, blood clot or bleeding in the brain, or transient ischemic attack (TIA)?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/MH/ComCVA",
+                    "text": "Have you ever been treated for a stroke, cerebrovascular accident, blood clot or bleeding in the brain, or transient ischemic attack (TIA)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "If you are considering active rehabilitation or surgery please alert your surgical team to your risk of stroke, to help them investigate further and take precautions. Your risk of having another stroke (brain attack or CVA) or other serious events may be increased during and after surgery. References: (1)  Fleisher LA, et al. 2014 ACC/AHA Guideline on Perioperative Cardiovascular Evaluation and Management of Patients Undergoing Noncardiac Surgery, Journal of the American College of Cardiology (2014), doi: 10.1016/j.jacc.2014.07.944 (2)  Jorgensen ME, et al. Time elapsed after ischemic stroke and risk of adverse cardiovascular events and mortality following elective noncardiac surgery. JAMA. 2014 Jul;312(3):269-77 (3)  North American Symptomatic Carotid Endarterectomy Trial Collaborators. NewEngland Journal of Medicine. 1991;325(7):445 (4)  Kernan WN, et al. Guidelines for the prevention of stroke in patients with stroke and transient ischemic attack: a guideline for healthcare professionals from the American Heart Association/American Stroke Association. Stroke. 2014;45(7):2160",
+                            "type": "display",
+                            "linkId": "/MH/ComCVA-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComHemiplegia",
+                            "display": "Do you have difficulty moving an arm or leg as a result of the stroke or cerebrovascular accident?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/MH/ComHemiplegia",
+                    "text": "Do you have difficulty moving an arm or leg as a result of the stroke or cerebrovascular accident?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/MH/ComCVA",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_2"
+                            }
+                        },
+                        {
+                            "question": "/MH/ComCVA",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_3"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "If you are considering surgery, muscle weakness or loss of sensation can affect your recovery from surgery and anesthesia, and change your rehabilitation plan.  References:  (1)  Mizner RL, et al. Preoperative Quadriceps strength predicts functional ability one year after TKA. Journal of Rheumatology 2005;32:1533-9   (2)  Charlson ME, et al. A new method of classifying prognostic comorbidity in longitudinal studies : Development and Validation. Journal of Chronic Disease 1987;40:373-383",
+                            "type": "display",
+                            "linkId": "/MH/ComHemiplegia-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComAsthma",
+                            "display": "Have you ever been diagnosed with or told that you have asthma? ",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/MH/ComAsthma",
+                    "text": "Have you ever been diagnosed with or told that you have asthma? ",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "If you are considering surgery, please discuss this with your team to help them prepare for this risk. Asthma, COPD (emphysema, chronic bronchitis) can flare up after active rehabilitation or surgery.  History of lung disease may affect the type of anesthesia you receive, and your post-operative recovery. Reference: Tirumalasetty J, et al. Asthma, surgery, and general anesthesia: a review. Journal of Asthma 2006;43:251-4.",
+                            "type": "display",
+                            "linkId": "/MH/ComAsthma-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComAsthmaMed",
+                            "display": "Do you take medicines for your asthma?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/MH/ComAsthmaMed",
+                    "text": "Do you take medicines for your asthma?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/MH/ComAsthma",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_2"
+                            }
+                        },
+                        {
+                            "question": "/MH/ComAsthma",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_3"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "If you are considering surgery, please discuss this with your team to help them prepare for this risk.  Asthma, COPD (emphysema, chronic bronchitis) can flare up after active rehabilitation or surgery.  History of lung disease may affect the type of anesthesia you receive, and your post-operative recovery. Reference:  Tirumalasetty J, et al. Asthma, surgery, and general anesthesia: a review. Journal of Asthma 2006;43:251-4.",
+                            "type": "display",
+                            "linkId": "/MH/ComAsthmaMed-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComCOPD",
+                            "display": "Do you have emphysema, chronic bronchitis, or chronic obstructive lung disease (COPD)? ",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/MH/ComCOPD",
+                    "text": "Do you have emphysema, chronic bronchitis, or chronic obstructive lung disease (COPD)? ",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "Lung disease can affect anesthesia and recovery from active rehabilitation or surgery.  Asthma, COPD (emphysema, chronic bronchitis) can flare up after surgery.  If you are considering surgery, please discuss this with your team to help them prepare to address this risk and prevent problems.  References: (1) Smetana GW, Lawrence VA, Cornell JE. Preoperative pulmonary risk stratification for noncardiothoracic surgery: systematic review for the American College of Physicians. Annals of Internal Medicine. 2006;144:581-95  (2)  Qaseem A, Snow V, Fitterman N, et al., for the Clinical Efficacy Assessment Subcommittee of the American College of Physicians. Risk assessment for and strategies to reduce perioperative pulmonary complications for patients undergoing noncardiothoracic surgery: a guideline from the American College of Physicians. Annals of Internal Medicine. 2006; 144:575-80  (3) Fleischmann KE et al. Cardiac and noncardiac complications were strongly linked in patients undergoing noncardiac surgery.American Journal of Medicine. 2003;115:515-20",
+                            "type": "display",
+                            "linkId": "/MH/ComCOPD-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComOxygen",
+                            "display": "Do you take medicines for your lung disease, or use oxygen, or use a home breathing machine (CPAP machine)?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/MH/ComOxygen",
+                    "text": "Do you take medicines for your lung disease, or use oxygen, or use a home breathing machine (CPAP machine)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/MH/ComCOPD",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_2"
+                            }
+                        },
+                        {
+                            "question": "/MH/ComCOPD",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_3"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "If you are considering surgery, you may have increased risk of needing to stay in the intensive care unit (ICU) after surgery and require a breathing machine (ventilator). This risk may be decreased by recommendations and individualized care from your anesthesia and surgical team. References:  (1)  Canet J et al. Prediction of postoperative pulmonary complications in a population-based surgical cohort. Anesthesiology. 2010;113(6):1338-50 (2) Memtsoudis SG, et al. Sleep apnea and total joint arthroplasty under various types of anesthesia: a population-based study of perioperative outcomes. Regional Anesthesia and Pain Medicine 2013;38:274-81",
+                            "type": "display",
+                            "linkId": "/MH/ComOxygen-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComGERD",
+                            "display": "Have you ever been diagnosed with or told that you have stomach ulcers, or peptic ulcer disease? ",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/MH/ComGERD",
+                    "text": "Have you ever been diagnosed with or told that you have stomach ulcers, or peptic ulcer disease? ",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "A current or prior history of acid reflux, ulcers or gastritis increases your risk of blood loss and anemia. It may be relevant to the medications chosen to treat pain.  If you are considering surgery, it can affect the choice of medications to prevent blood clots after surgery.  References:  (1)  Singh JA, et al. Peptic ulcer disease and heart disease are associated with periprosthetic fractures after total hip replacement. Acta Orthopaedica 2012 Aug;83(4):353-9  (2) Madhusudhan TR, et al. Gastric protection and gastrointestinal bleeding with aspirin thromboprophylaxis in hip and knee joint replacements. Annals of the Royal College of Surgeons of England 2008 May;90(4):332-5",
+                            "type": "display",
+                            "linkId": "/MH/ComGERD-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComGERDdx",
+                            "display": "Has this condition been diagnosed by endoscopy where a doctor looks into your stomach through a scope or an upper GI or barium swallow study where you swallow chalky dye and then x-rays are taken?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/MH/ComGERDdx",
+                    "text": "Has this condition been diagnosed by endoscopy where a doctor looks into your stomach through a scope or an upper GI or barium swallow study where you swallow chalky dye and then x-rays are taken?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/MH/ComGERD",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_2"
+                            }
+                        },
+                        {
+                            "question": "/MH/ComGERD",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_3"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "A current or prior history of ulcer increases your risk of blood loss and anemia and may be relevant to the medications chosen to prevent blood clots in the perioperative period. References: (1) Gralnek IM, et al. Management of acute bleeding from a peptic ulcer. N Engl J Med 2008; 359:928-937     (2) Hsu PI. New look at antiplatelet agent-related peptic ulcer: an update of prevention and treatment. Journal of Gastroenterology and Hepatology. 2012 Apr;27(4):654-61",
+                            "type": "display",
+                            "linkId": "/MH/ComGERDdx-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComDM",
+                            "display": "Have you ever been diagnosed with or treated for diabetes (high blood sugar)?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/MH/ComDM",
+                    "text": "Have you ever been diagnosed with or treated for diabetes (high blood sugar)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "Diabetes affects medications used to treat your symptoms. If you are considering surgery, it increases risk of complications after surgery. Controlling diabetes before surgery and maintaining your blood sugars close to normal during and after surgery may decrease risk of major complications like infection. Reference:  Marchant MH, et al. The impact of glycemic control and diabetes mellitus on perioperative outcomes after total joint arthroplasty. Journal of Bone and Joint Surgery. 2009;91:1621-9",
+                            "type": "display",
+                            "linkId": "/MH/ComDM-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComDmeye",
+                            "display": "Has the diabetes caused any problems with your eyes, treated by an ophthalmologist (eye-doctor)?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/MH/ComDmeye",
+                    "text": "Has the diabetes caused any problems with your eyes, treated by an ophthalmologist (eye-doctor)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/MH/ComDM",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_2"
+                            }
+                        },
+                        {
+                            "question": "/MH/ComDM",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_3"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "If diabetes has resulted in eye problems, there is greater risk of nerve problems (neuropathy), which can affect the surgical plan and outcome. Reference:  Parvizi J, et al. Total knee arthroplasty for neuropathic (Charcot) joints. Clinical Orthopaedics and Related Research. 2003;416:145-50",
+                            "type": "display",
+                            "linkId": "/MH/ComDmeye-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComDmkidney",
+                            "display": "Has the diabetes caused any problems with your kidneys?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/MH/ComDmkidney",
+                    "text": "Has the diabetes caused any problems with your kidneys?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/MH/ComDM",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_2"
+                            }
+                        },
+                        {
+                            "question": "/MH/ComDM",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_3"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "If diabetes has resulted in kidney problems, there is greater risk for complication like kidney injury or failure after surgery. Reference:  National Kidney Foundation. KDOQI Clinical Practice Guideline for Diabetes and CKD: 2012 Update. Am J Kidney Dis. 2012 Nov; 60(5):850-86",
+                            "type": "display",
+                            "linkId": "/MH/ComDmkidney-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComKidney",
+                            "display": "Have you ever had problems with your kidneys (poor kidney function or blood tests show high creatinine)?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/MH/ComKidney",
+                    "text": "Have you ever had problems with your kidneys (poor kidney function or blood tests show high creatinine)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "Kidney problems can play a vital role in choosing the medications prescribed for you, including contrast agents for imaging studies.  Poor kidney function can also affect the dosing of the medications.  If you are considering surgery, please alert your surgical and anesthesia teams. Kidney problems can increase risk of complications with surgery.References: (1) Memtsoudis SG, et al. Risk factors for perioperative mortality after lower extremity arthroplasties: A population based study of 6,901,324 patient discharges. J Arthroplasty. 2010 Jan;25(1):19-26. doi: 10.1016/j.arth.2008.11.010. Epub 2008 Dec 23  (2) Godin M, et al. Fluid balance in patients with acute kidney injury: Emerging concepts. Nephron Clinical Practice 2013;123:238-245 (2) Sawhney S, et al. Long term prognosis after acute kidney injury (AKI): What is the role of baseline kidney function and recovery? A systematic review. BMJ Open. 2015 Jan 6;5(1):e006497",
+                            "type": "display",
+                            "linkId": "/MH/ComKidney-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComDialysis",
+                            "display": "Have you used hemodialysis or peritoneal dialysis (kidney dialysis)?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/MH/ComDialysis",
+                    "text": "Have you used hemodialysis or peritoneal dialysis (kidney dialysis)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/MH/ComKidney",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_2"
+                            }
+                        },
+                        {
+                            "question": "/MH/ComKidney",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_3"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "Patients on dialysis may need careful management of medications by nephrologist (kidney specialist). If you are considering surgery, additional dialysis may need to be arranged around the surgery date. References: (1) Afshar AH, et al. The validity of the VA surgical tool in predictig postoperative mortality in octogenarians. American Journal of Surgery. 2015 Feb;209(2):274-9  (2)  Shah H, et al. Perioperative management of peritoneal dialysis patients undergoing hernia surgery without the use of interim hemodialysis Peritoneal Dialysis International. 2006 Nov-Dec;26(6):684-7",
+                            "type": "display",
+                            "linkId": "/MH/ComDialysis-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComLiver",
+                            "display": "Have you ever been diagnosed with or treated for cirrhosis, or serious liver disease? ",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/MH/ComLiver",
+                    "text": "Have you ever been diagnosed with or treated for cirrhosis, or serious liver disease? ",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "Liver disease or cirrhosis requires careful attention to medications prescribed for your treatment.  If you are considering surgery, liver disease increases the risk of infection, bleeding, confusion, and other complications. Please alert your surgical and anesthesia teams.They may need to adjust the techniques chosen and the postoperative plan. References: (1)  Tiberi JV, et al. Increased complication rates after hip and knee arthroplasty in patients with cirrhosis of the liver. Clin Orthop Relat Res (2014) 472:2774-2778  (2) Cohen SM, et al. Operative risk of total hip and knee arthroplasty in cirrhotic patients. Journal of Arthroplasty. 2005;20:460-466  (3) Shih LY, et al. Total knee arthroplasty in patients with liver cirrhosis. Journal of Bone and Joint Surgery, 2004 Feb; 86 (2): 335 -341",
+                            "type": "display",
+                            "linkId": "/MH/ComLiver-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComTransplant",
+                            "display": "Have you received a kidney, liver, lung or other transplant?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/MH/ComTransplant",
+                    "text": "Have you received a kidney, liver, lung or other transplant?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "Transplant patients on anti-rejection meds may need dose adjustments, coordination of care with transplant team and close monitoring of their medications.  Reference:  Cavanaugh PK, et al.  Total Joint Arthroplasty in Transplant Recipients: In-Hospital Adverse Outcomes. J Arthroplasty. 2014 Dec 5. pii: S0883-5403(14)00913-9.",
+                            "type": "display",
+                            "linkId": "/MH/ComTransplant-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComCancer",
+                            "display": "Have you ever been diagnosed with or treated for cancer?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/MH/ComCancer",
+                    "text": "Have you ever been diagnosed with or treated for cancer?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "A history of cancer is important for evaluation and treatment of your symptoms. If you are considering surgery, it can affect your risk of bleeding, infection, blood clots, and function of organs such as nerves, heart, lungs, liver or kidneys.  Please make sure your surgical team is aware of this. Cancer or its treatment may limit the benefits of surgery.  Also, some blood tests ordered before and after surgery will be expected to be abnormal in setting of cancer or its treatment. Please have your surgery and anesthesia teams coordinate carefully with your oncologist. References:  (1)  Dybvik E, et al. Long term risk for receiving a total hip replacement in cancer patients - A linkage study between the cancer register of Norway and the Norwegian arthroplasty register. Journal of Bone and Joint Surgery Br 2010;92-B:601 (2) Katz JN, et al. Elective palliative total hip replacement in a patient with lymphoma and advanced lung cancer. Arthritis and Rheumatology. 2008 Aug 15; 59(8): 1194-1196",
+                            "type": "display",
+                            "linkId": "/MH/ComCancer-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComMetastases",
+                            "display": "Has the cancer spread, or metastasized to other parts of your body?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/MH/ComMetastases",
+                    "text": "Has the cancer spread, or metastasized to other parts of your body?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/MH/ComCancer",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_2"
+                            }
+                        },
+                        {
+                            "question": "/MH/ComCancer",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_3"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "Cancer may spread to bones and cause pain.  Surgery may be helpful for relief of pan, stabilization of the involved bone or joint, and to improve your quality of life.  If you are considering surgery, please have your surgery and anesthesia teams coordinate carefully with your oncologist. Reference:  Charlson ME, et al. A new method of classifying prognostic comorbidity in longitudinal studies : Development and Validation. Journal of Chronic Disease 1987;40:373-383.",
+                            "type": "display",
+                            "linkId": "/MH/ComMetastases-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComHIV",
+                            "display": "Have you ever been diagnosed with or treated for HIV/AIDS?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/MH/ComHIV",
+                    "text": "Have you ever been diagnosed with or treated for HIV/AIDS?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "History of having HIV infection or AIDS is relevant to evaluation of your symptoms. It may affect the choice of medications prescribed for treating your symptoms.  If you are considering surgery, the medications used to treat HIV infection or AIDS can interact with anesthesia and surgical medications.  Untreated AIDS can lead to poor outcome including increased risk of infection after joint replacement and may need to be addressed before surgery.      Reference:  King Jr JT, et al. Thirty-Day Postoperative Mortality Among Individuals Wth HIV Infection Receiving Antiretroviral Therapy and Procedure-Matched, Uninfected Comparators. JAMA Surgery doi:10.1001/jamasurg.2014.2257 Published online February 25, 2015",
+                            "type": "display",
+                            "linkId": "/MH/ComHIV-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComIA",
+                            "display": "Do you have any rheumatic conditions like lupus, psoriasis, ankylosing spondylitis, or rheumatoid arthritis (a type of arthritis NOT related to the commonly diagnosed osteoarthritis)? ",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/MH/ComIA",
+                    "text": "Do you have any rheumatic conditions like lupus, psoriasis, ankylosing spondylitis, or rheumatoid arthritis (a type of arthritis NOT related to the commonly diagnosed osteoarthritis)? ",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "Inflammatory conditions like rheumatic or autoimmune arthritis increase risk of complications from surgery such as infection. Careful management before surgery may decrease this risk.  Reference:  Howe CR, et al. Perioperative medication management for the patient with rheumatoid arthritis. Journal of the Academy of Orthopaedic Surgeons 2006;14:544-551. Grennan et al. Ann Rheum Dis. 2001;60:214-217.",
+                            "type": "display",
+                            "linkId": "/MH/ComIA-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComIAmed",
+                            "display": "Do you take medications for it regularly? ",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/MH/ComIAmed",
+                    "text": "Do you take medications for it regularly? ",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "enableWhen": [
+                        {
+                            "question": "/MH/ComIA",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_2"
+                            }
+                        },
+                        {
+                            "question": "/MH/ComIA",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_3"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "Some medications taken for rheumatoid arthritis increase the risk of infection and require careful adjustment before and after surgery. References: (1) Goodman SM, Figgie M. Lower extremity arthroplasty in patients with inflammatory arthritis: preoperative and perioperative management. J Am Acad Orthop Surg. 2013 Jun;21(6):355-63. doi: 10.5435/JAAOS-21-06-355 (2) Bongartz et al. Anti-TNF antibody therapy in rheumatoid arthritis and the risk of serious infections and malignancies: systematic review and meta-analysis of rare harmful effects in randomized controlled trials. JAMA. 2006; 295:2275-85",
+                            "type": "display",
+                            "linkId": "/MH/ComIAmed-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComOAKnee",
+                            "display": "Do you have arthritis in your knees?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/MH/ComOAKnee",
+                    "text": "Do you have arthritis in your knees?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "If you are considering surgery, pain affecting other joint in your legs can complicate your recovery and limit the benefits you experience.  Reference: Coxib and traditional NSAID Trialists' (CNT) Collaboration.  Vascular and upper gastrointestinal effects of non-steroidal anti-infl ammatory drugs: meta-analyses of individual participant data from randomised trials. Lancet 2013; 382: 769-79",
+                            "type": "display",
+                            "linkId": "/MH/ComOAKnee-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComOAHip",
+                            "display": "Do you have arthritis in your hips?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/MH/ComOAHip",
+                    "text": "Do you have arthritis in your hips?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "If you are considering surgery, pain affecting other joint in your legs can complicate your recovery and limit the benefits you experience. References:  Coxib and traditional NSAID Trialists' (CNT) Collaboration.  Vascular and upper gastrointestinal effects of non-steroidal anti-infl ammatory drugs: meta-analyses of individual participant data from randomised trials. Lancet 2013; 382: 769-79.",
+                            "type": "display",
+                            "linkId": "/MH/ComOAHip-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "MH-score",
+                            "display": "Medical History Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh1_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComMI').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComMI').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh2_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComCHF').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComCHF').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh3_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComPVD').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComPVD').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh4_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComDVT').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComDVT').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh5_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComBleeding').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComBleeding').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh6_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComCVA').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComCVA').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh7_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComHemiplegia').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComHemiplegia').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh8_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComAsthma').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComAsthma').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh9_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComAsthmaMed').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComAsthmaMed').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh10_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComCOPD').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComCOPD').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh11_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComOxygen').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComOxygen').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh12_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComGERD').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComGERD').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh13_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComGERDdx').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComGERDdx').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh14_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComDM').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComDM').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh15_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComDmeye').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComDmeye').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh16_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComDmkidney').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComDmkidney').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh17_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComKidney').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComKidney').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh18_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComDialysis').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComDialysis').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh19_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComLiver').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComLiver').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh20_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComTransplant').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComTransplant').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh21_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComCancer').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComCancer').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh22_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComMetastases').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComMetastases').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh23_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComHIV').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComHIV').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh24_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComIA').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComIA').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh25_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComIAmed').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComIAmed').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh26_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComOAKnee').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComOAKnee').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh27_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComOAHip').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComOAHip').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "any_questions_answered",
+                                "language": "text/fhirpath",
+                                "expression": "%mh1_value.exists() or %mh2_value.exists() or %mh3_value.exists() or %mh4_value.exists() or %mh5_value.exists() or %mh6_value.exists() or %mh7_value.exists() or %mh8_value.exists() or %mh9_value.exists() or %mh10_value.exists() or %mh11_value.exists() or %mh12_value.exists() or %mh13_value.exists() or %mh14_value.exists() or %mh15_value.exists() or %mh16_value.exists() or %mh17_value.exists() or %mh18_value.exists() or %mh19_value.exists() or %mh20_value.exists() or %mh21_value.exists() or %mh22_value.exists() or %mh23_value.exists() or %mh24_value.exists() or %mh25_value.exists() or %mh26_value.exists() or %mh27_value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%any_questions_answered, iif(%mh1_value.exists(), %mh1_value, 0) + iif(%mh2_value.exists(), %mh2_value, 0) + iif(%mh3_value.exists(), %mh3_value, 0) + iif(%mh4_value.exists(), %mh4_value, 0) + iif(%mh5_value.exists(), %mh5_value, 0) + iif(%mh6_value.exists(), %mh6_value, 0) + iif(%mh7_value.exists(), %mh7_value, 0) + iif(%mh8_value.exists(), %mh8_value, 0) + iif(%mh9_value.exists(), %mh9_value, 0) + iif(%mh10_value.exists(), %mh10_value, 0) + iif(%mh11_value.exists(), %mh11_value, 0) + iif(%mh12_value.exists(), %mh12_value, 0) + iif(%mh13_value.exists(), %mh13_value, 0) + iif(%mh14_value.exists(), %mh14_value, 0) + iif(%mh15_value.exists(), %mh15_value, 0) + iif(%mh16_value.exists(), %mh16_value, 0) + iif(%mh17_value.exists(), %mh17_value, 0) + iif(%mh18_value.exists(), %mh18_value, 0) + iif(%mh19_value.exists(), %mh19_value, 0) + iif(%mh20_value.exists(), %mh20_value, 0) + iif(%mh21_value.exists(), %mh21_value, 0) + iif(%mh22_value.exists(), %mh22_value, 0) + iif(%mh23_value.exists(), %mh23_value, 0) + iif(%mh24_value.exists(), %mh24_value, 0) + iif(%mh25_value.exists(), %mh25_value, 0) + iif(%mh26_value.exists(), %mh26_value, 0) + iif(%mh27_value.exists(), %mh27_value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/MH-score",
+                    "text": "Medical History Score"
+                }
+            ]
+        }
+    ],
+    "name": "Medical_History_Assessment"
+}

--- a/contrib/portal_templates/assessments/SDC FHIR/PROMIS_Anxiety_Assessment.json
+++ b/contrib/portal_templates/assessments/SDC FHIR/PROMIS_Anxiety_Assessment.json
@@ -1,0 +1,627 @@
+{
+    "resourceType": "Questionnaire",
+    "meta": {
+        "profile": [
+            "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire|2.7",
+            "http://hl7.org/fhir/4.0/StructureDefinition/Questionnaire"
+        ],
+        "tag": [
+            {
+                "code": "generated: PEER"
+            }
+        ]
+    },
+    "status": "active",
+    "title": "PROMIS ANXIETY Assessment",
+    "subjectType": [
+        "Patient",
+        "Person"
+    ],
+    "item": [
+        {
+            "type": "group",
+            "code": [],
+            "required": false,
+            "linkId": "/PA",
+            "prefix": "PROMIS ANXIETY",
+            "text": "The next few questions help measure the level of your anxiety.",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "EDANX01",
+                            "display": "I felt fearful",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/PA/EDANX01",
+                    "text": "I felt fearful",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_1",
+                                "display": "Never"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_2",
+                                "display": "Rarely"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_3",
+                                "display": "Sometimes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_4",
+                                "display": "Often"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_5",
+                                "display": "Always"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Anxiety score.",
+                            "type": "display",
+                            "linkId": "/PA/EDANX01-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "EDANX40",
+                            "display": "I found it hard to focus on anything other than my anxiety",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/PA/EDANX40",
+                    "text": "I found it hard to focus on anything other than my anxiety",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_1",
+                                "display": "Never"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_2",
+                                "display": "Rarely"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_3",
+                                "display": "Sometimes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_4",
+                                "display": "Often"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_5",
+                                "display": "Always"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Anxiety score.",
+                            "type": "display",
+                            "linkId": "/PA/EDANX40-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "EDANX41",
+                            "display": "My worries overwhelmed me",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/PA/EDANX41",
+                    "text": "My worries overwhelmed me",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_1",
+                                "display": "Never"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_2",
+                                "display": "Rarely"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_3",
+                                "display": "Sometimes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_4",
+                                "display": "Often"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_5",
+                                "display": "Always"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Anxiety score.",
+                            "type": "display",
+                            "linkId": "/PA/EDANX41-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "EDANX53",
+                            "display": "I felt uneasy",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/PA/EDANX53",
+                    "text": "I felt uneasy",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_1",
+                                "display": "Never"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_2",
+                                "display": "Rarely"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_3",
+                                "display": "Sometimes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_4",
+                                "display": "Often"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_5",
+                                "display": "Always"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Anxiety score.",
+                            "type": "display",
+                            "linkId": "/PA/EDANX53-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "PA-score",
+                            "display": "PROMIS ANXIETY Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pa17_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PA').item.where(linkId = '/PA/EDANX01').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PA').item.where(linkId = '/PA/EDANX01').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pa18_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PA').item.where(linkId = '/PA/EDANX40').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PA').item.where(linkId = '/PA/EDANX40').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pa19_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PA').item.where(linkId = '/PA/EDANX41').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PA').item.where(linkId = '/PA/EDANX41').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pa20_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PA').item.where(linkId = '/PA/EDANX53').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PA').item.where(linkId = '/PA/EDANX53').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "any_questions_answered",
+                                "language": "text/fhirpath",
+                                "expression": "%pa17_value.exists() or %pa18_value.exists() or %pa19_value.exists() or %pa20_value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%any_questions_answered, iif(%pa17_value.exists(), %pa17_value, 0) + iif(%pa18_value.exists(), %pa18_value, 0) + iif(%pa19_value.exists(), %pa19_value, 0) + iif(%pa20_value.exists(), %pa20_value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PA/PA-score",
+                    "text": "PROMIS ANXIETY Score"
+                }
+            ]
+        }
+    ],
+    "name": "PROMIS_ANXIETY_Assessment"
+}

--- a/contrib/portal_templates/assessments/SDC FHIR/PROMIS_Depression_Assessment.json
+++ b/contrib/portal_templates/assessments/SDC FHIR/PROMIS_Depression_Assessment.json
@@ -1,0 +1,627 @@
+{
+    "resourceType": "Questionnaire",
+    "meta": {
+        "profile": [
+            "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire|2.7",
+            "http://hl7.org/fhir/4.0/StructureDefinition/Questionnaire"
+        ],
+        "tag": [
+            {
+                "code": "generated: PEER"
+            }
+        ]
+    },
+    "status": "active",
+    "title": "PROMIS DEPRESSION Assessment",
+    "subjectType": [
+        "Patient",
+        "Person"
+    ],
+    "item": [
+        {
+            "type": "group",
+            "code": [],
+            "required": false,
+            "linkId": "/PD",
+            "prefix": "PROMIS DEPRESSION",
+            "text": "The next few questions help measure the level of your depression.",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "EDDEP04",
+                            "display": "I felt worthless",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/PD/EDDEP04",
+                    "text": "I felt worthless",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_1",
+                                "display": "Never"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_2",
+                                "display": "Rarely"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_3",
+                                "display": "Sometimes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_4",
+                                "display": "Often"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_5",
+                                "display": "Always"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Depression score.",
+                            "type": "display",
+                            "linkId": "/PD/EDDEP04-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "EDDEP06",
+                            "display": "I felt helpless",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/PD/EDDEP06",
+                    "text": "I felt helpless",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_1",
+                                "display": "Never"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_2",
+                                "display": "Rarely"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_3",
+                                "display": "Sometimes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_4",
+                                "display": "Often"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_5",
+                                "display": "Always"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Depression score.",
+                            "type": "display",
+                            "linkId": "/PD/EDDEP06-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "EDDEP29",
+                            "display": "I felt depressed",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/PD/EDDEP29",
+                    "text": "I felt depressed",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_1",
+                                "display": "Never"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_2",
+                                "display": "Rarely"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_3",
+                                "display": "Sometimes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_4",
+                                "display": "Often"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_5",
+                                "display": "Always"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Depression score.",
+                            "type": "display",
+                            "linkId": "/PD/EDDEP29-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "EDDEP41",
+                            "display": "I felt hopeless",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/PD/EDDEP41",
+                    "text": "I felt hopeless",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_1",
+                                "display": "Never"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_2",
+                                "display": "Rarely"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_3",
+                                "display": "Sometimes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_4",
+                                "display": "Often"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_5",
+                                "display": "Always"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Depression score.",
+                            "type": "display",
+                            "linkId": "/PD/EDDEP41-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "PD-score",
+                            "display": "PROMIS DEPRESSION Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pd13_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PD').item.where(linkId = '/PD/EDDEP04').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PD').item.where(linkId = '/PD/EDDEP04').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pd14_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PD').item.where(linkId = '/PD/EDDEP06').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PD').item.where(linkId = '/PD/EDDEP06').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pd15_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PD').item.where(linkId = '/PD/EDDEP29').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PD').item.where(linkId = '/PD/EDDEP29').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pd16_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PD').item.where(linkId = '/PD/EDDEP41').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PD').item.where(linkId = '/PD/EDDEP41').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "any_questions_answered",
+                                "language": "text/fhirpath",
+                                "expression": "%pd13_value.exists() or %pd14_value.exists() or %pd15_value.exists() or %pd16_value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%any_questions_answered, iif(%pd13_value.exists(), %pd13_value, 0) + iif(%pd14_value.exists(), %pd14_value, 0) + iif(%pd15_value.exists(), %pd15_value, 0) + iif(%pd16_value.exists(), %pd16_value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PD/PD-score",
+                    "text": "PROMIS DEPRESSION Score"
+                }
+            ]
+        }
+    ],
+    "name": "PROMIS_DEPRESSION_Assessment"
+}

--- a/contrib/portal_templates/assessments/SDC FHIR/PROMIS_Interference_Assessment.json
+++ b/contrib/portal_templates/assessments/SDC FHIR/PROMIS_Interference_Assessment.json
@@ -1,0 +1,627 @@
+{
+    "resourceType": "Questionnaire",
+    "meta": {
+        "profile": [
+            "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire|2.7",
+            "http://hl7.org/fhir/4.0/StructureDefinition/Questionnaire"
+        ],
+        "tag": [
+            {
+                "code": "generated: PEER"
+            }
+        ]
+    },
+    "status": "active",
+    "title": "PROMIS INTERFERENCE Assessment",
+    "subjectType": [
+        "Patient",
+        "Person"
+    ],
+    "item": [
+        {
+            "type": "group",
+            "code": [],
+            "required": false,
+            "linkId": "/PC",
+            "prefix": "PROMIS INTERFERENCE",
+            "text": "The next few questions help measure the level that pain interferes in daily activities.",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PAININ9",
+                            "display": "How much did pain interfere with your day to day activities?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/PC/PAININ9",
+                    "text": "How much did pain interfere with your day to day activities?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NAA_1",
+                                "display": "Not at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_2",
+                                "display": "A little bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_3",
+                                "display": "Somewhat"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_4",
+                                "display": "Quite a bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_5",
+                                "display": "Very much"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Pain Interference score.",
+                            "type": "display",
+                            "linkId": "/PC/PAININ9-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PAININ22",
+                            "display": "How much did pain interfere with work around the home?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/PC/PAININ22",
+                    "text": "How much did pain interfere with work around the home?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NAA_1",
+                                "display": "Not at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_2",
+                                "display": "A little bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_3",
+                                "display": "Somewhat"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_4",
+                                "display": "Quite a bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_5",
+                                "display": "Very much"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Pain Interference score.",
+                            "type": "display",
+                            "linkId": "/PC/PAININ22-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PAININ31",
+                            "display": "How much did pain interfere with your ability to participate in social activities?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/PC/PAININ31",
+                    "text": "How much did pain interfere with your ability to participate in social activities?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NAA_1",
+                                "display": "Not at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_2",
+                                "display": "A little bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_3",
+                                "display": "Somewhat"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_4",
+                                "display": "Quite a bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_5",
+                                "display": "Very much"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Pain Interference score.",
+                            "type": "display",
+                            "linkId": "/PC/PAININ31-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PAININ34",
+                            "display": "How much did pain interfere with your household chores?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/PC/PAININ34",
+                    "text": "How much did pain interfere with your household chores?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NAA_1",
+                                "display": "Not at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_2",
+                                "display": "A little bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_3",
+                                "display": "Somewhat"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_4",
+                                "display": "Quite a bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_5",
+                                "display": "Very much"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Pain Interference score.",
+                            "type": "display",
+                            "linkId": "/PC/PAININ34-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "PC-score",
+                            "display": "PROMIS INTERFERENCE Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pc5_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PC').item.where(linkId = '/PC/PAININ9').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PC').item.where(linkId = '/PC/PAININ9').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pc6_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PC').item.where(linkId = '/PC/PAININ22').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PC').item.where(linkId = '/PC/PAININ22').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pc7_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PC').item.where(linkId = '/PC/PAININ31').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PC').item.where(linkId = '/PC/PAININ31').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pc8_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PC').item.where(linkId = '/PC/PAININ34').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PC').item.where(linkId = '/PC/PAININ34').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "any_questions_answered",
+                                "language": "text/fhirpath",
+                                "expression": "%pc5_value.exists() or %pc6_value.exists() or %pc7_value.exists() or %pc8_value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%any_questions_answered, iif(%pc5_value.exists(), %pc5_value, 0) + iif(%pc6_value.exists(), %pc6_value, 0) + iif(%pc7_value.exists(), %pc7_value, 0) + iif(%pc8_value.exists(), %pc8_value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PC/PC-score",
+                    "text": "PROMIS INTERFERENCE Score"
+                }
+            ]
+        }
+    ],
+    "name": "PROMIS_INTERFERENCE_Assessment"
+}

--- a/contrib/portal_templates/assessments/SDC FHIR/PROMIS_Physical_Activity_Assessment.json
+++ b/contrib/portal_templates/assessments/SDC FHIR/PROMIS_Physical_Activity_Assessment.json
@@ -1,0 +1,627 @@
+{
+    "resourceType": "Questionnaire",
+    "meta": {
+        "profile": [
+            "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire|2.7",
+            "http://hl7.org/fhir/4.0/StructureDefinition/Questionnaire"
+        ],
+        "tag": [
+            {
+                "code": "generated: PEER"
+            }
+        ]
+    },
+    "status": "active",
+    "title": "PROMIS PHYSICAL ACTIVITY Assessment",
+    "subjectType": [
+        "Patient",
+        "Person"
+    ],
+    "item": [
+        {
+            "type": "group",
+            "code": [],
+            "required": false,
+            "linkId": "/PP",
+            "prefix": "PROMIS PHYSICAL ACTIVITY",
+            "text": "The following five sections deal with pain. Please read each question and answer as well as you can. There is no right or wrong answer, only what is true for you. The next few questions help measure the level of your physical activity.",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PFA23",
+                            "display": "Are you able to go for a walk of at least 15 minutes?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/PP/PFA23",
+                    "text": "Are you able to go for a walk of at least 15 minutes?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "DIF_1",
+                                "display": "Unable to do"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_2",
+                                "display": "With much difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_3",
+                                "display": "With some difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_4",
+                                "display": "With a little difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_5",
+                                "display": "Without any difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Physical Function score.",
+                            "type": "display",
+                            "linkId": "/PP/PFA23-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PFA21",
+                            "display": "Are you able to go up and down stairs at a normal pace?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/PP/PFA21",
+                    "text": "Are you able to go up and down stairs at a normal pace?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "DIF_1",
+                                "display": "Unable to do"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_2",
+                                "display": "With much difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_3",
+                                "display": "With some difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_4",
+                                "display": "With a little difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_5",
+                                "display": "Without any difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Physical Function score.",
+                            "type": "display",
+                            "linkId": "/PP/PFA21-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PFA11",
+                            "display": "Are you able to do chores such as vacuuming or yard work?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/PP/PFA11",
+                    "text": "Are you able to do chores such as vacuuming or yard work?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "DIF_1",
+                                "display": "Unable to do"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_2",
+                                "display": "With much difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_3",
+                                "display": "With some difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_4",
+                                "display": "With a little difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_5",
+                                "display": "Without any difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Physical Function score.",
+                            "type": "display",
+                            "linkId": "/PP/PFA11-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PFA53",
+                            "display": "Are you able to run errands and shop?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/PP/PFA53",
+                    "text": "Are you able to run errands and shop?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "DIF_1",
+                                "display": "Unable to do"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_2",
+                                "display": "With much difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_3",
+                                "display": "With some difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_4",
+                                "display": "With a little difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_5",
+                                "display": "Without any difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Physical Function score.",
+                            "type": "display",
+                            "linkId": "/PP/PFA53-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "PP-score",
+                            "display": "PROMIS PHYSICAL ACTIVITY Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pp1_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA23').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA23').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pp2_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA21').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA21').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pp3_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA11').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA11').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pp4_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA53').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA53').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "any_questions_answered",
+                                "language": "text/fhirpath",
+                                "expression": "%pp1_value.exists() or %pp2_value.exists() or %pp3_value.exists() or %pp4_value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%any_questions_answered, iif(%pp1_value.exists(), %pp1_value, 0) + iif(%pp2_value.exists(), %pp2_value, 0) + iif(%pp3_value.exists(), %pp3_value, 0) + iif(%pp4_value.exists(), %pp4_value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PP/PP-score",
+                    "text": "PROMIS PHYSICAL ACTIVITY Score"
+                }
+            ]
+        }
+    ],
+    "name": "PROMIS_PHYSICAL_ACTIVITY_Assessment"
+}

--- a/contrib/portal_templates/assessments/SDC FHIR/PROMIS_Physical_Function_Assessment.json
+++ b/contrib/portal_templates/assessments/SDC FHIR/PROMIS_Physical_Function_Assessment.json
@@ -1,0 +1,627 @@
+{
+    "resourceType": "Questionnaire",
+    "meta": {
+        "profile": [
+            "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire|2.7",
+            "http://hl7.org/fhir/4.0/StructureDefinition/Questionnaire"
+        ],
+        "tag": [
+            {
+                "code": "generated: PEER"
+            }
+        ]
+    },
+    "status": "active",
+    "title": "PROMIS Physical Function Assessment",
+    "subjectType": [
+        "Patient",
+        "Person"
+    ],
+    "item": [
+        {
+            "type": "group",
+            "code": [],
+            "required": false,
+            "linkId": "/PP",
+            "prefix": "PROMIS Physical Function",
+            "text": "The following five sections deal with pain. Please read each question and answer as well as you can. There is no right or wrong answer, only what is true for you. The next few questions help measure the level of your physical activity.",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PFA23",
+                            "display": "Are you able to go for a walk of at least 15 minutes?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/PP/PFA23",
+                    "text": "Are you able to go for a walk of at least 15 minutes?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "DIF_1",
+                                "display": "Unable to do"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_2",
+                                "display": "With much difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_3",
+                                "display": "With some difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_4",
+                                "display": "With a little difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_5",
+                                "display": "Without any difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Physical Function score.",
+                            "type": "display",
+                            "linkId": "/PP/PFA23-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PFA21",
+                            "display": "Are you able to go up and down stairs at a normal pace?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/PP/PFA21",
+                    "text": "Are you able to go up and down stairs at a normal pace?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "DIF_1",
+                                "display": "Unable to do"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_2",
+                                "display": "With much difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_3",
+                                "display": "With some difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_4",
+                                "display": "With a little difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_5",
+                                "display": "Without any difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Physical Function score.",
+                            "type": "display",
+                            "linkId": "/PP/PFA21-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PFA11",
+                            "display": "Are you able to do chores such as vacuuming or yard work?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/PP/PFA11",
+                    "text": "Are you able to do chores such as vacuuming or yard work?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "DIF_1",
+                                "display": "Unable to do"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_2",
+                                "display": "With much difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_3",
+                                "display": "With some difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_4",
+                                "display": "With a little difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_5",
+                                "display": "Without any difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Physical Function score.",
+                            "type": "display",
+                            "linkId": "/PP/PFA11-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PFA53",
+                            "display": "Are you able to run errands and shop?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/PP/PFA53",
+                    "text": "Are you able to run errands and shop?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "DIF_1",
+                                "display": "Unable to do"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_2",
+                                "display": "With much difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_3",
+                                "display": "With some difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_4",
+                                "display": "With a little difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_5",
+                                "display": "Without any difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Physical Function score.",
+                            "type": "display",
+                            "linkId": "/PP/PFA53-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "PP-score",
+                            "display": "PROMIS Physical Function Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pp1_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA23').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA23').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pp2_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA21').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA21').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pp3_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA11').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA11').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pp4_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA53').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA53').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "any_questions_answered",
+                                "language": "text/fhirpath",
+                                "expression": "%pp1_value.exists() or %pp2_value.exists() or %pp3_value.exists() or %pp4_value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%any_questions_answered, iif(%pp1_value.exists(), %pp1_value, 0) + iif(%pp2_value.exists(), %pp2_value, 0) + iif(%pp3_value.exists(), %pp3_value, 0) + iif(%pp4_value.exists(), %pp4_value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PP/PP-score",
+                    "text": "PROMIS Physical Function Score"
+                }
+            ]
+        }
+    ],
+    "name": "PROMIS_Physical_Function_Assessment"
+}

--- a/contrib/portal_templates/assessments/SDC FHIR/PROMIS_Sleep_Assessment.json
+++ b/contrib/portal_templates/assessments/SDC FHIR/PROMIS_Sleep_Assessment.json
@@ -1,0 +1,627 @@
+{
+    "resourceType": "Questionnaire",
+    "meta": {
+        "profile": [
+            "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire|2.7",
+            "http://hl7.org/fhir/4.0/StructureDefinition/Questionnaire"
+        ],
+        "tag": [
+            {
+                "code": "generated: PEER"
+            }
+        ]
+    },
+    "status": "active",
+    "title": "PROMIS SLEEP Assessment",
+    "subjectType": [
+        "Patient",
+        "Person"
+    ],
+    "item": [
+        {
+            "type": "group",
+            "code": [],
+            "required": false,
+            "linkId": "/PS",
+            "prefix": "PROMIS SLEEP",
+            "text": "The next few questions help measure the level of your sleep habits.",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "Sleep116",
+                            "display": "My sleep was refreshing.",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/PS/Sleep116",
+                    "text": "My sleep was refreshing.",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NAA_1",
+                                "display": "Not at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_2",
+                                "display": "A little bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_3",
+                                "display": "Somewhat"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_4",
+                                "display": "Quite a bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_5",
+                                "display": "Very much"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Pain Interference score.",
+                            "type": "display",
+                            "linkId": "/PS/Sleep116-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "Sleep20",
+                            "display": "I had a problem with my sleep.",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/PS/Sleep20",
+                    "text": "I had a problem with my sleep.",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NAA_1",
+                                "display": "Not at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_2",
+                                "display": "A little bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_3",
+                                "display": "Somewhat"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_4",
+                                "display": "Quite a bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_5",
+                                "display": "Very much"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Sleep Disturbance score.",
+                            "type": "display",
+                            "linkId": "/PS/Sleep20-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "Sleep44",
+                            "display": "I had difficulty falling asleep.",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/PS/Sleep44",
+                    "text": "I had difficulty falling asleep.",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NAA_1",
+                                "display": "Not at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_2",
+                                "display": "A little bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_3",
+                                "display": "Somewhat"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_4",
+                                "display": "Quite a bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_5",
+                                "display": "Very much"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Sleep Disturbance score.",
+                            "type": "display",
+                            "linkId": "/PS/Sleep44-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "Sleep109",
+                            "display": "My sleep quality was...",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/PS/Sleep109",
+                    "text": "My sleep quality was...",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SLP_1",
+                                "display": "Very Good"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLP_2",
+                                "display": "Good"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLP_3",
+                                "display": "Fair"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLP_4",
+                                "display": "Poor"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLP_5",
+                                "display": "Very poor"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Sleep Disturbance score.",
+                            "type": "display",
+                            "linkId": "/PS/Sleep109-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "PS-score",
+                            "display": "PROMIS SLEEP Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "ps9_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PS').item.where(linkId = '/PS/Sleep116').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PS').item.where(linkId = '/PS/Sleep116').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "ps10_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PS').item.where(linkId = '/PS/Sleep20').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PS').item.where(linkId = '/PS/Sleep20').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "ps11_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PS').item.where(linkId = '/PS/Sleep44').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PS').item.where(linkId = '/PS/Sleep44').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "ps12_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PS').item.where(linkId = '/PS/Sleep109').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PS').item.where(linkId = '/PS/Sleep109').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "any_questions_answered",
+                                "language": "text/fhirpath",
+                                "expression": "%ps9_value.exists() or %ps10_value.exists() or %ps11_value.exists() or %ps12_value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%any_questions_answered, iif(%ps9_value.exists(), %ps9_value, 0) + iif(%ps10_value.exists(), %ps10_value, 0) + iif(%ps11_value.exists(), %ps11_value, 0) + iif(%ps12_value.exists(), %ps12_value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PS/PS-score",
+                    "text": "PROMIS SLEEP Score"
+                }
+            ]
+        }
+    ],
+    "name": "PROMIS_SLEEP_Assessment"
+}

--- a/contrib/portal_templates/assessments/SDC FHIR/Pain_Initial_Assessment.json
+++ b/contrib/portal_templates/assessments/SDC FHIR/Pain_Initial_Assessment.json
@@ -1,0 +1,13724 @@
+{
+    "resourceType": "Questionnaire",
+    "meta": {
+        "profile": [
+            "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire|2.7",
+            "http://hl7.org/fhir/4.0/StructureDefinition/Questionnaire",
+        ],
+        "tag": [
+            {
+                "code": "generated: PEER"
+            }
+        ]
+    },
+    "version": "2.0.0",
+    "name": "Pain_Initial_Assessment",
+    "title": "Pain Initial Assessment",
+    "status": "active",
+    "subjectType": [
+        "Patient",
+        "Person"
+    ],
+    "date": "2025-02-01",
+    "approvalDate": "2025-02-03",
+    "lastReviewDate": "2025-02-03",
+    "item": [
+        {
+            "type": "group",
+            "required": false,
+            "linkId": "/PP",
+            "prefix": "PROMIS PHYSICAL ACTIVITY",
+            "text": "The following five sections deal with pain. Please read each question and answer as well as you can. There is no right or wrong answer, only what is true for you. The next few questions help measure the level of your physical activity.",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PFA23",
+                            "display": "Are you able to go for a walk of at least 15 minutes?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PP/PFA23",
+                    "text": "Are you able to go for a walk of at least 15 minutes?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "DIF_1",
+                                "display": "Unable to do"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_2",
+                                "display": "With much difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_3",
+                                "display": "With some difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_4",
+                                "display": "With a little difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_5",
+                                "display": "Without any difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Physical Function score.",
+                            "type": "display",
+                            "linkId": "/PP/PFA23-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PFA21",
+                            "display": "Are you able to go up and down stairs at a normal pace?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PP/PFA21",
+                    "text": "Are you able to go up and down stairs at a normal pace?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "DIF_1",
+                                "display": "Unable to do"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_2",
+                                "display": "With much difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_3",
+                                "display": "With some difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_4",
+                                "display": "With a little difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_5",
+                                "display": "Without any difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Physical Function score.",
+                            "type": "display",
+                            "linkId": "/PP/PFA21-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PFA11",
+                            "display": "Are you able to do chores such as vacuuming or yard work?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PP/PFA11",
+                    "text": "Are you able to do chores such as vacuuming or yard work?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "DIF_1",
+                                "display": "Unable to do"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_2",
+                                "display": "With much difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_3",
+                                "display": "With some difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_4",
+                                "display": "With a little difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_5",
+                                "display": "Without any difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Physical Function score.",
+                            "type": "display",
+                            "linkId": "/PP/PFA11-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PFA53",
+                            "display": "Are you able to run errands and shop?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PP/PFA53",
+                    "text": "Are you able to run errands and shop?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "DIF_1",
+                                "display": "Unable to do"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_2",
+                                "display": "With much difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_3",
+                                "display": "With some difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_4",
+                                "display": "With a little difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "DIF_5",
+                                "display": "Without any difficulty"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Physical Function score.",
+                            "type": "display",
+                            "linkId": "/PP/PFA53-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "PP-score",
+                            "display": "PROMIS PHYSICAL ACTIVITY Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pp1value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA23').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA23').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pp2value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA21').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA21').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pp3value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA11').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA11').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pp4value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA53').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PP').item.where(linkId = '/PP/PFA53').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "anyquestionsanswered",
+                                "language": "text/fhirpath",
+                                "expression": "%pp1value.exists() or %pp2value.exists() or %pp3value.exists() or %pp4value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%anyquestionsanswered, iif(%pp1value.exists(), %pp1value, 0) + iif(%pp2value.exists(), %pp2value, 0) + iif(%pp3value.exists(), %pp3value, 0) + iif(%pp4value.exists(), %pp4value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PP/PP-score",
+                    "text": "PROMIS PHYSICAL ACTIVITY Score"
+                }
+            ]
+        },
+        {
+            "type": "group",
+            "required": false,
+            "linkId": "/PC",
+            "prefix": "PROMIS INTERFERENCE",
+            "text": "The next few questions help measure the level that pain interferes in daily activities.",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PAININ9",
+                            "display": "How much did pain interfere with your day to day activities?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PC/PAININ9",
+                    "text": "How much did pain interfere with your day to day activities?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NAA_1",
+                                "display": "Not at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_2",
+                                "display": "A little bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_3",
+                                "display": "Somewhat"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_4",
+                                "display": "Quite a bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_5",
+                                "display": "Very much"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Pain Interference score.",
+                            "type": "display",
+                            "linkId": "/PC/PAININ9-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PAININ22",
+                            "display": "How much did pain interfere with work around the home?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PC/PAININ22",
+                    "text": "How much did pain interfere with work around the home?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NAA_1",
+                                "display": "Not at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_2",
+                                "display": "A little bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_3",
+                                "display": "Somewhat"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_4",
+                                "display": "Quite a bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_5",
+                                "display": "Very much"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Pain Interference score.",
+                            "type": "display",
+                            "linkId": "/PC/PAININ22-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PAININ31",
+                            "display": "How much did pain interfere with your ability to participate in social activities?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PC/PAININ31",
+                    "text": "How much did pain interfere with your ability to participate in social activities?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NAA_1",
+                                "display": "Not at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_2",
+                                "display": "A little bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_3",
+                                "display": "Somewhat"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_4",
+                                "display": "Quite a bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_5",
+                                "display": "Very much"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Pain Interference score.",
+                            "type": "display",
+                            "linkId": "/PC/PAININ31-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "PAININ34",
+                            "display": "How much did pain interfere with your household chores?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PC/PAININ34",
+                    "text": "How much did pain interfere with your household chores?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NAA_1",
+                                "display": "Not at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_2",
+                                "display": "A little bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_3",
+                                "display": "Somewhat"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_4",
+                                "display": "Quite a bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_5",
+                                "display": "Very much"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Pain Interference score.",
+                            "type": "display",
+                            "linkId": "/PC/PAININ34-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "PC-score",
+                            "display": "PROMIS INTERFERENCE Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pc5value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PC').item.where(linkId = '/PC/PAININ9').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PC').item.where(linkId = '/PC/PAININ9').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pc6value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PC').item.where(linkId = '/PC/PAININ22').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PC').item.where(linkId = '/PC/PAININ22').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pc7value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PC').item.where(linkId = '/PC/PAININ31').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PC').item.where(linkId = '/PC/PAININ31').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pc8value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PC').item.where(linkId = '/PC/PAININ34').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PC').item.where(linkId = '/PC/PAININ34').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "anyquestionsanswered",
+                                "language": "text/fhirpath",
+                                "expression": "%pc5value.exists() or %pc6value.exists() or %pc7value.exists() or %pc8value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%anyquestionsanswered, iif(%pc5value.exists(), %pc5value, 0) + iif(%pc6value.exists(), %pc6value, 0) + iif(%pc7value.exists(), %pc7value, 0) + iif(%pc8value.exists(), %pc8value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PC/PC-score",
+                    "text": "PROMIS INTERFERENCE Score"
+                }
+            ]
+        },
+        {
+            "type": "group",
+            "required": false,
+            "linkId": "/PS",
+            "prefix": "PROMIS SLEEP",
+            "text": "The next few questions help measure the level of your sleep habits.",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "Sleep116",
+                            "display": "My sleep was refreshing.",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PS/Sleep116",
+                    "text": "My sleep was refreshing.",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NAA_1",
+                                "display": "Not at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_2",
+                                "display": "A little bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_3",
+                                "display": "Somewhat"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_4",
+                                "display": "Quite a bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_5",
+                                "display": "Very much"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Pain Interference score.",
+                            "type": "display",
+                            "linkId": "/PS/Sleep116-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "Sleep20",
+                            "display": "I had a problem with my sleep.",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PS/Sleep20",
+                    "text": "I had a problem with my sleep.",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NAA_1",
+                                "display": "Not at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_2",
+                                "display": "A little bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_3",
+                                "display": "Somewhat"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_4",
+                                "display": "Quite a bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_5",
+                                "display": "Very much"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Sleep Disturbance score.",
+                            "type": "display",
+                            "linkId": "/PS/Sleep20-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "Sleep44",
+                            "display": "I had difficulty falling asleep.",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PS/Sleep44",
+                    "text": "I had difficulty falling asleep.",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NAA_1",
+                                "display": "Not at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_2",
+                                "display": "A little bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_3",
+                                "display": "Somewhat"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_4",
+                                "display": "Quite a bit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NAA_5",
+                                "display": "Very much"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Sleep Disturbance score.",
+                            "type": "display",
+                            "linkId": "/PS/Sleep44-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "Sleep109",
+                            "display": "My sleep quality was...",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PS/Sleep109",
+                    "text": "My sleep quality was...",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SLP_1",
+                                "display": "Very Good"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLP_2",
+                                "display": "Good"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLP_3",
+                                "display": "Fair"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLP_4",
+                                "display": "Poor"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLP_5",
+                                "display": "Very poor"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Sleep Disturbance score.",
+                            "type": "display",
+                            "linkId": "/PS/Sleep109-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "PS-score",
+                            "display": "PROMIS SLEEP Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "ps9value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PS').item.where(linkId = '/PS/Sleep116').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PS').item.where(linkId = '/PS/Sleep116').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "ps10value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PS').item.where(linkId = '/PS/Sleep20').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PS').item.where(linkId = '/PS/Sleep20').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "ps11value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PS').item.where(linkId = '/PS/Sleep44').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PS').item.where(linkId = '/PS/Sleep44').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "ps12value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PS').item.where(linkId = '/PS/Sleep109').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PS').item.where(linkId = '/PS/Sleep109').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "anyquestionsanswered",
+                                "language": "text/fhirpath",
+                                "expression": "%ps9value.exists() or %ps10value.exists() or %ps11value.exists() or %ps12value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%anyquestionsanswered, iif(%ps9value.exists(), %ps9value, 0) + iif(%ps10value.exists(), %ps10value, 0) + iif(%ps11value.exists(), %ps11value, 0) + iif(%ps12value.exists(), %ps12value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PS/PS-score",
+                    "text": "PROMIS SLEEP Score"
+                }
+            ]
+        },
+        {
+            "type": "group",
+            "required": false,
+            "linkId": "/PD",
+            "prefix": "PROMIS DEPRESSION",
+            "text": "The next few questions help measure the level of your depression.",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "EDDEP04",
+                            "display": "I felt worthless",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PD/EDDEP04",
+                    "text": "I felt worthless",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_1",
+                                "display": "Never"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_2",
+                                "display": "Rarely"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_3",
+                                "display": "Sometimes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_4",
+                                "display": "Often"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_5",
+                                "display": "Always"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Depression score.",
+                            "type": "display",
+                            "linkId": "/PD/EDDEP04-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "EDDEP06",
+                            "display": "I felt helpless",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PD/EDDEP06",
+                    "text": "I felt helpless",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_1",
+                                "display": "Never"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_2",
+                                "display": "Rarely"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_3",
+                                "display": "Sometimes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_4",
+                                "display": "Often"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_5",
+                                "display": "Always"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Depression score.",
+                            "type": "display",
+                            "linkId": "/PD/EDDEP06-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "EDDEP29",
+                            "display": "I felt depressed",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PD/EDDEP29",
+                    "text": "I felt depressed",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_1",
+                                "display": "Never"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_2",
+                                "display": "Rarely"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_3",
+                                "display": "Sometimes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_4",
+                                "display": "Often"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_5",
+                                "display": "Always"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Depression score.",
+                            "type": "display",
+                            "linkId": "/PD/EDDEP29-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "EDDEP41",
+                            "display": "I felt hopeless",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PD/EDDEP41",
+                    "text": "I felt hopeless",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_1",
+                                "display": "Never"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_2",
+                                "display": "Rarely"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_3",
+                                "display": "Sometimes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_4",
+                                "display": "Often"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_5",
+                                "display": "Always"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Depression score.",
+                            "type": "display",
+                            "linkId": "/PD/EDDEP41-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "PD-score",
+                            "display": "PROMIS DEPRESSION Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pd13value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PD').item.where(linkId = '/PD/EDDEP04').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PD').item.where(linkId = '/PD/EDDEP04').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pd14value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PD').item.where(linkId = '/PD/EDDEP06').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PD').item.where(linkId = '/PD/EDDEP06').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pd15value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PD').item.where(linkId = '/PD/EDDEP29').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PD').item.where(linkId = '/PD/EDDEP29').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pd16value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PD').item.where(linkId = '/PD/EDDEP41').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PD').item.where(linkId = '/PD/EDDEP41').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "anyquestionsanswered",
+                                "language": "text/fhirpath",
+                                "expression": "%pd13value.exists() or %pd14value.exists() or %pd15value.exists() or %pd16value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%anyquestionsanswered, iif(%pd13value.exists(), %pd13value, 0) + iif(%pd14value.exists(), %pd14value, 0) + iif(%pd15value.exists(), %pd15value, 0) + iif(%pd16value.exists(), %pd16value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PD/PD-score",
+                    "text": "PROMIS DEPRESSION Score"
+                }
+            ]
+        },
+        {
+            "type": "group",
+            "required": false,
+            "linkId": "/PA",
+            "prefix": "PROMIS ANXIETY",
+            "text": "The next few questions help measure the level of your anxiety.",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "EDANX01",
+                            "display": "I felt fearful",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PA/EDANX01",
+                    "text": "I felt fearful",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_1",
+                                "display": "Never"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_2",
+                                "display": "Rarely"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_3",
+                                "display": "Sometimes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_4",
+                                "display": "Often"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_5",
+                                "display": "Always"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Anxiety score.",
+                            "type": "display",
+                            "linkId": "/PA/EDANX01-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "EDANX40",
+                            "display": "I found it hard to focus on anything other than my anxiety",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PA/EDANX40",
+                    "text": "I found it hard to focus on anything other than my anxiety",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_1",
+                                "display": "Never"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_2",
+                                "display": "Rarely"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_3",
+                                "display": "Sometimes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_4",
+                                "display": "Often"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_5",
+                                "display": "Always"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Anxiety score.",
+                            "type": "display",
+                            "linkId": "/PA/EDANX40-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "EDANX41",
+                            "display": "My worries overwhelmed me",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PA/EDANX41",
+                    "text": "My worries overwhelmed me",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_1",
+                                "display": "Never"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_2",
+                                "display": "Rarely"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_3",
+                                "display": "Sometimes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_4",
+                                "display": "Often"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_5",
+                                "display": "Always"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Anxiety score.",
+                            "type": "display",
+                            "linkId": "/PA/EDANX41-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "EDANX53",
+                            "display": "I felt uneasy",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PA/EDANX53",
+                    "text": "I felt uneasy",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_1",
+                                "display": "Never"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_2",
+                                "display": "Rarely"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_3",
+                                "display": "Sometimes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_4",
+                                "display": "Often"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FRQ_5",
+                                "display": "Always"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "These questions were developed by scientists at the National Institutes of Health (NIH). They are part of the NIH Patient Reported Outcomes Measurement Information System (PROMIS) Computer Adaptive Test (CAT). This qiestion is part of  PROMIS Anxiety score.",
+                            "type": "display",
+                            "linkId": "/PA/EDANX53-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "PA-score",
+                            "display": "PROMIS ANXIETY Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pa17value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PA').item.where(linkId = '/PA/EDANX01').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PA').item.where(linkId = '/PA/EDANX01').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pa18value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PA').item.where(linkId = '/PA/EDANX40').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PA').item.where(linkId = '/PA/EDANX40').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pa19value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PA').item.where(linkId = '/PA/EDANX41').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PA').item.where(linkId = '/PA/EDANX41').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "pa20value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/PA').item.where(linkId = '/PA/EDANX53').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/PA').item.where(linkId = '/PA/EDANX53').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "anyquestionsanswered",
+                                "language": "text/fhirpath",
+                                "expression": "%pa17value.exists() or %pa18value.exists() or %pa19value.exists() or %pa20value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%anyquestionsanswered, iif(%pa17value.exists(), %pa17value, 0) + iif(%pa18value.exists(), %pa18value, 0) + iif(%pa19value.exists(), %pa19value, 0) + iif(%pa20value.exists(), %pa20value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/PA/PA-score",
+                    "text": "PROMIS ANXIETY Score"
+                }
+            ]
+        },
+        {
+            "type": "group",
+            "required": false,
+            "linkId": "/SC",
+            "prefix": "Social Factors",
+            "text": "The next few questions ask about social factors that may help select the right treatment for you. This part will require about 2 minutes",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS40afeet",
+                            "display": "How tall are you? Enter feet here and inches in the next question. For example, for 5 feet and 6 inches, please anwser 5 feet in this question and 6 inches in the next question)",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SC/MDS40afeet",
+                    "text": "How tall are you? Enter feet here and inches in the next question. For example, for 5 feet and 6 inches, please anwser 5 feet in this question and 6 inches in the next question)",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "FET_1",
+                                "display": "less than 4 feet"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FET_2",
+                                "display": "4 feet"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FET_3",
+                                "display": "5 feet"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FET_4",
+                                "display": "6 feet"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FET_5",
+                                "display": "more than 6 feet"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "Height is used to calculate BMI (body mass index). BMI can help select the right treatment for you. The question was developed by the National\n Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results \n of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/SC/MDS40afeet-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS40ainch",
+                            "display": "What is your height? (enter inches here)",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SC/MDS40ainch",
+                    "text": "What is your height? (enter inches here)",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "INC_1",
+                                "display": "0 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_2",
+                                "display": "1 inch"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_3",
+                                "display": "2 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_4",
+                                "display": "3 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_5",
+                                "display": "4 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_6",
+                                "display": "5 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_7",
+                                "display": "6 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 6
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_8",
+                                "display": "7 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 7
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_9",
+                                "display": "8 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 8
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_10",
+                                "display": "9 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 9
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_11",
+                                "display": "10 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 10
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_12",
+                                "display": "11 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 11
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "Height is used to calculate BMI (body mass index). BMI can help select the right treatment for you. The question was developed \nby the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if \nresults of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/SC/MDS40ainch-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS40b",
+                            "display": "What is your weight? (pounds)",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SC/MDS40b",
+                    "text": "What is your weight? (pounds)",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "PDS_1",
+                                "display": "<100lbs"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_2",
+                                "display": "100-120 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_3",
+                                "display": "121-140 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_4",
+                                "display": "141-160 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_5",
+                                "display": "161-180 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_6",
+                                "display": "181-200 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_7",
+                                "display": "201-220 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 6
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_8",
+                                "display": "221-240 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 7
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_9",
+                                "display": "241-260 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 8
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_10",
+                                "display": "261-280 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 9
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_11",
+                                "display": "281-300 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 10
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_12",
+                                "display": "more than 300 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 11
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "Weight is used to calculate BMI (body mass index). BMI can help select the right treatment for you. The question was developed by\n the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine \n if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/SC/MDS40b-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS39",
+                            "display": "How would you describe your cigarette smoking?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SC/MDS39",
+                    "text": "How would you describe your cigarette smoking?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SMK_1",
+                                "display": "Never smoked"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SMK_2",
+                                "display": "Current smoker"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SMK_3",
+                                "display": "Used to smoke, but have now quit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "Smoking can affect pain severity and also help choose the right treatment. The question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/SC/MDS39-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS31",
+                            "display": "Have you drunk or used drugs more than you meant to?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SC/MDS31",
+                    "text": "Have you drunk or used drugs more than you meant to?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "ALC_1",
+                                "display": "Never"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ALC_2",
+                                "display": "Rarely"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ALC_3",
+                                "display": "Sometimes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ALC_4",
+                                "display": "Often"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past year",
+                    "item": [
+                        {
+                            "text": "Alcohol use can influence risks of different treatments. The question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/SC/MDS31-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS32",
+                            "display": "Have you felt you wanted or needed to cut down on your drinking or drug use?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SC/MDS32",
+                    "text": "Have you felt you wanted or needed to cut down on your drinking or drug use?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "ALC_1",
+                                "display": "Never"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ALC_2",
+                                "display": "Rarely"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ALC_3",
+                                "display": "Sometimes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ALC_4",
+                                "display": "Often"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past year",
+                    "enableWhen": [
+                        {
+                            "question": "/SC/MDS31",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "ALC_2"
+                            }
+                        },
+                        {
+                            "question": "/SC/MDS31",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "ALC_3"
+                            }
+                        },
+                        {
+                            "question": "/SC/MDS31",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "ALC_4"
+                            }
+                        }
+                    ],
+                    "enableBehavior": "any",
+                    "item": [
+                        {
+                            "text": "Alcohol use can influence risks of different treatments. The question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/SC/MDS32-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS37",
+                            "display": "Employment Status:",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SC/MDS37",
+                    "text": "Employment Status:",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "EMP_1",
+                                "display": "Working now"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EMP_2",
+                                "display": "Sick leave"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EMP_3",
+                                "display": "Temporary disability"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EMP_4",
+                                "display": "Permanently disability"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EMP_5",
+                                "display": "Temporarily laid off"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EMP_6",
+                                "display": "Looking/unemployed"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 6
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EMP_7",
+                                "display": "Keeping house"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 7
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EMP_8",
+                                "display": "Student"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 8
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EMP_9",
+                                "display": "Retired"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 9
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EMP_10",
+                                "display": "Other"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 10
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "Work status is predicitive of outcomes. The question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/SC/MDS37-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS38",
+                            "display": "Select the highest education level attained",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SC/MDS38",
+                    "text": "Select the highest education level attained",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "EDU_1",
+                                "display": "No high school diploma"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EDU_2",
+                                "display": "High school or GED"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EDU_3",
+                                "display": "Some college, no degree"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EDU_4",
+                                "display": "Occupational program"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EDU_5",
+                                "display": "Associate degree"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EDU_6",
+                                "display": "Bachelors degree"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 6
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EDU_7",
+                                "display": "Masters degree"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 7
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EDU_8",
+                                "display": "Doctoral degree"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 8
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EDU_9",
+                                "display": "Prefer not to report"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "Education level is predicitive of outcomes. The question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/SC/MDS38-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS36",
+                            "display": "Choose the race with which you most closely identify",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SC/MDS36",
+                    "text": "Choose the race with which you most closely identify",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "RAC_1",
+                                "display": "American/Alaska Native"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RAC_2",
+                                "display": "Asian"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RAC_3",
+                                "display": "Black/African-American"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RAC_4",
+                                "display": "Hawaiian/Pacific Islander"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RAC_5",
+                                "display": "White"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RAC_6",
+                                "display": "Other"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 6
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RAC_7",
+                                "display": "Prefer not to answer"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "Race can be predicitive of outcomes. It can be associated to certain diagnoses and outcomes. The question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/SC/MDS36-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS35",
+                            "display": "Choose the ethnicity with which you most closely identify",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SC/MDS35",
+                    "text": "Choose the ethnicity with which you most closely identify",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "ETH_1",
+                                "display": "Hispanic or Latino"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ETH_2",
+                                "display": "Not Hispanic or Latino"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ETH_3",
+                                "display": "Unknown"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ETH_4",
+                                "display": "Prefer not to answer"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "Ethnicity may be predicitive of outcomes. It can be associated to certain diagnoses and outcomes. The question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/SC/MDS35-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "SC-score",
+                            "display": "Social Factors Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "sc1value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS40afeet').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS40afeet').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "sc2value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS40ainch').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS40ainch').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "sc3value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS40b').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS40b').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "sc4value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS39').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS39').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "sc5value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS31').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS31').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "sc6value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS32').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS32').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "sc7value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS37').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS37').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "sc8value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS38').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS38').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "sc9value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS36').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS36').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "sc10value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS35').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS35').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "anyquestionsanswered",
+                                "language": "text/fhirpath",
+                                "expression": "%sc1value.exists() or %sc2value.exists() or %sc3value.exists() or %sc4value.exists() or %sc5value.exists() or %sc6value.exists() or %sc7value.exists() or %sc8value.exists() or %sc9value.exists() or %sc10value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%anyquestionsanswered, iif(%sc1value.exists(), %sc1value, 0) + iif(%sc2value.exists(), %sc2value, 0) + iif(%sc3value.exists(), %sc3value, 0) + iif(%sc4value.exists(), %sc4value, 0) + iif(%sc5value.exists(), %sc5value, 0) + iif(%sc6value.exists(), %sc6value, 0) + iif(%sc7value.exists(), %sc7value, 0) + iif(%sc8value.exists(), %sc8value, 0) + iif(%sc9value.exists(), %sc9value, 0) + iif(%sc10value.exists(), %sc10value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SC/SC-score",
+                    "text": "Social Factors Score"
+                }
+            ]
+        },
+        {
+            "type": "group",
+            "required": false,
+            "linkId": "/MH",
+            "prefix": "Medical History",
+            "text": " The next few questions record important aspects of your medical history.",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComMI",
+                            "display": "Have you ever been treated for heart disease or been told you had a heart attack, or had procedures such as angioplasty, cardiac stents or bypass surgery?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComMI",
+                    "text": "Have you ever been treated for heart disease or been told you had a heart attack, or had procedures such as angioplasty, cardiac stents or bypass surgery?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "If you are considering active rehabilitation or surgery, please alert your care team of your risk of heart disease. History of heart attack or heart disease (CAD - Coronary Artery Disease) increases your risk of having heart attack with active rehabilitation or surgery.  Sharing this information with your surgical team will help them optimize your risk by adjusting your medications, surgical procedure, anesthesia and recovery plan.References: (1) Lee T H, et al. Derivation and prospective validation of a simple index for prediction of cardiac risk of major noncardiac surgery.Circulation. 1999;100:1043-1049 (2) Ford MK, et al. Systematic review: Prediction of perioperative cardiac complications and mortality by the RCRI. Annals of Internal Medicine. 2010;152(1):26-35",
+                            "type": "display",
+                            "linkId": "/MH/ComMI-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComCHF",
+                            "display": "Have you ever been treated for heart failure? You may have been short of breath and the doctor may have told you that you had fluid in your lungs or that your heart was not pumping well.",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComCHF",
+                    "text": "Have you ever been treated for heart failure? You may have been short of breath and the doctor may have told you that you had fluid in your lungs or that your heart was not pumping well.",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "Heart Failure due to a weak or stiff heart is important to recognize in order manage medications prescribed for your symptoms. If you are considering active rehabilitation or surgery, please alert your surgical team of your risk of heart failure. Heart failure may flare up after surgery.Preparing carefully for surgery may decrease the risk. References: (1) Healy KO, et al. Predictive outcome and long term mortality for Heart Failure patients undergoing intermediate and high risk non-cardiac surgery: Impact of Left ventricular Ejection Fraction. Congestive Heart Failure 2010;16:45-49. doi: 10.1111/j.1751-7133.2009.00130.x (2) Gupta PK, et al. Development and validation of a risk calculator for prediction of cardiac risk after surgery. Circulation. 2011 Jul 26;124(4):381-7. doi: 10.1161/CIRCULATIONAHA.110.015701 (3)Powell-Tuck J, et al. GIFTASUP - British Consensus Guidelines on Intravenous Fluid Therapy for Adult Surgical Patients. March 2011",
+                            "type": "display",
+                            "linkId": "/MH/ComCHF-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComPVD",
+                            "display": "Have you had an operation to unclog or bypass the arteries in your legs? ",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComPVD",
+                    "text": "Have you had an operation to unclog or bypass the arteries in your legs? ",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "If you are considering active rehabilitation or surgery, please alert your surgical team of circulation problems. Having a history of circulation problems (vascular disease, or peripheral arterial disease, PAD) increases your risk of blockages in your heart. It is relevant for planning for surgery and anesthesia, such as whether to use a tourniquet during knee replacement, and make other management decisions during and after surgery. References: (1)  Kiani S, et al. Peripheral arterial disease is associated with severe impairment of vascular function. Vascular Medicine. 2013 Apr; 18(2): 72-78  (2)Gokce N, et al. Risk stratification for postoperative cardiovascular events via noninvasive assessment of endothelial function: a prospective study. Circulation. 2002 Apr 2;105(13):1567-72    (3)  Smith DE, et al. Arterial complications and TKA. J Am Acad Orthop Surg 2001;9:253-257 (4) Dakka AM, et al. TKA in patients with PAD. Surgeon 2009 Dec; 7(6):362-5",
+                            "type": "display",
+                            "linkId": "/MH/ComPVD-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComDVT",
+                            "display": "Have you had ever been treated for blood clots in your legs or lungs, DVT, PE? ",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComDVT",
+                    "text": "Have you had ever been treated for blood clots in your legs or lungs, DVT, PE? ",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "If you are considering surgery please alert your surgical team to your risk of blood clots. It will help them investigate further and take precautions.",
+                            "type": "display",
+                            "linkId": "/MH/ComDVT-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComBleeding",
+                            "display": "Have you had ever been treated for bleeding problems? ",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComBleeding",
+                    "text": "Have you had ever been treated for bleeding problems? ",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "If you are considering surgery please alert your surgical team to your risk of bleeding. It will help them investigate further and take precautions.",
+                            "type": "display",
+                            "linkId": "/MH/ComBleeding-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComCVA",
+                            "display": "Have you ever been treated for a stroke, cerebrovascular accident, blood clot or bleeding in the brain, or transient ischemic attack (TIA)?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComCVA",
+                    "text": "Have you ever been treated for a stroke, cerebrovascular accident, blood clot or bleeding in the brain, or transient ischemic attack (TIA)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "If you are considering active rehabilitation or surgery please alert your surgical team to your risk of stroke, to help them investigate further and take precautions. Your risk of having another stroke (brain attack or CVA) or other serious events may be increased during and after surgery. References: (1)  Fleisher LA, et al. 2014 ACC/AHA Guideline on Perioperative Cardiovascular Evaluation and Management of Patients Undergoing Noncardiac Surgery, Journal of the American College of Cardiology (2014), doi: 10.1016/j.jacc.2014.07.944 (2)  Jorgensen ME, et al. Time elapsed after ischemic stroke and risk of adverse cardiovascular events and mortality following elective noncardiac surgery. JAMA. 2014 Jul;312(3):269-77 (3)  North American Symptomatic Carotid Endarterectomy Trial Collaborators. NewEngland Journal of Medicine. 1991;325(7):445 (4)  Kernan WN, et al. Guidelines for the prevention of stroke in patients with stroke and transient ischemic attack: a guideline for healthcare professionals from the American Heart Association/American Stroke Association. Stroke. 2014;45(7):2160",
+                            "type": "display",
+                            "linkId": "/MH/ComCVA-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComHemiplegia",
+                            "display": "Do you have difficulty moving an arm or leg as a result of the stroke or cerebrovascular accident?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComHemiplegia",
+                    "text": "Do you have difficulty moving an arm or leg as a result of the stroke or cerebrovascular accident?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "enableWhen": [
+                        {
+                            "question": "/MH/ComCVA",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_2"
+                            }
+                        },
+                        {
+                            "question": "/MH/ComCVA",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_3"
+                            }
+                        }
+                    ],
+                    "enableBehavior": "any",
+                    "item": [
+                        {
+                            "text": "If you are considering surgery, muscle weakness or loss of sensation can affect your recovery from surgery and anesthesia, and change your rehabilitation plan.  References:  (1)  Mizner RL, et al. Preoperative Quadriceps strength predicts functional ability one year after TKA. Journal of Rheumatology 2005;32:1533-9   (2)  Charlson ME, et al. A new method of classifying prognostic comorbidity in longitudinal studies : Development and Validation. Journal of Chronic Disease 1987;40:373-383",
+                            "type": "display",
+                            "linkId": "/MH/ComHemiplegia-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComAsthma",
+                            "display": "Have you ever been diagnosed with or told that you have asthma? ",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComAsthma",
+                    "text": "Have you ever been diagnosed with or told that you have asthma? ",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "If you are considering surgery, please discuss this with your team to help them prepare for this risk. Asthma, COPD (emphysema, chronic bronchitis) can flare up after active rehabilitation or surgery.  History of lung disease may affect the type of anesthesia you receive, and your post-operative recovery. Reference: Tirumalasetty J, et al. Asthma, surgery, and general anesthesia: a review. Journal of Asthma 2006;43:251-4.",
+                            "type": "display",
+                            "linkId": "/MH/ComAsthma-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComAsthmaMed",
+                            "display": "Do you take medicines for your asthma?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComAsthmaMed",
+                    "text": "Do you take medicines for your asthma?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "enableWhen": [
+                        {
+                            "question": "/MH/ComAsthma",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_2"
+                            }
+                        },
+                        {
+                            "question": "/MH/ComAsthma",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_3"
+                            }
+                        }
+                    ],
+                    "enableBehavior": "any",
+                    "item": [
+                        {
+                            "text": "If you are considering surgery, please discuss this with your team to help them prepare for this risk.  Asthma, COPD (emphysema, chronic bronchitis) can flare up after active rehabilitation or surgery.  History of lung disease may affect the type of anesthesia you receive, and your post-operative recovery. Reference:  Tirumalasetty J, et al. Asthma, surgery, and general anesthesia: a review. Journal of Asthma 2006;43:251-4.",
+                            "type": "display",
+                            "linkId": "/MH/ComAsthmaMed-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComCOPD",
+                            "display": "Do you have emphysema, chronic bronchitis, or chronic obstructive lung disease (COPD)? ",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComCOPD",
+                    "text": "Do you have emphysema, chronic bronchitis, or chronic obstructive lung disease (COPD)? ",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "Lung disease can affect anesthesia and recovery from active rehabilitation or surgery.  Asthma, COPD (emphysema, chronic bronchitis) can flare up after surgery.  If you are considering surgery, please discuss this with your team to help them prepare to address this risk and prevent problems.  References: (1) Smetana GW, Lawrence VA, Cornell JE. Preoperative pulmonary risk stratification for noncardiothoracic surgery: systematic review for the American College of Physicians. Annals of Internal Medicine. 2006;144:581-95  (2)  Qaseem A, Snow V, Fitterman N, et al., for the Clinical Efficacy Assessment Subcommittee of the American College of Physicians. Risk assessment for and strategies to reduce perioperative pulmonary complications for patients undergoing noncardiothoracic surgery: a guideline from the American College of Physicians. Annals of Internal Medicine. 2006; 144:575-80  (3) Fleischmann KE et al. Cardiac and noncardiac complications were strongly linked in patients undergoing noncardiac surgery.American Journal of Medicine. 2003;115:515-20",
+                            "type": "display",
+                            "linkId": "/MH/ComCOPD-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComOxygen",
+                            "display": "Do you take medicines for your lung disease, or use oxygen, or use a home breathing machine (CPAP machine)?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComOxygen",
+                    "text": "Do you take medicines for your lung disease, or use oxygen, or use a home breathing machine (CPAP machine)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "enableWhen": [
+                        {
+                            "question": "/MH/ComCOPD",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_2"
+                            }
+                        },
+                        {
+                            "question": "/MH/ComCOPD",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_3"
+                            }
+                        }
+                    ],
+                    "enableBehavior": "any",
+                    "item": [
+                        {
+                            "text": "If you are considering surgery, you may have increased risk of needing to stay in the intensive care unit (ICU) after surgery and require a breathing machine (ventilator). This risk may be decreased by recommendations and individualized care from your anesthesia and surgical team. References:  (1)  Canet J et al. Prediction of postoperative pulmonary complications in a population-based surgical cohort. Anesthesiology. 2010;113(6):1338-50 (2) Memtsoudis SG, et al. Sleep apnea and total joint arthroplasty under various types of anesthesia: a population-based study of perioperative outcomes. Regional Anesthesia and Pain Medicine 2013;38:274-81",
+                            "type": "display",
+                            "linkId": "/MH/ComOxygen-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComGERD",
+                            "display": "Have you ever been diagnosed with or told that you have stomach ulcers, or peptic ulcer disease? ",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComGERD",
+                    "text": "Have you ever been diagnosed with or told that you have stomach ulcers, or peptic ulcer disease? ",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "A current or prior history of acid reflux, ulcers or gastritis increases your risk of blood loss and anemia. It may be relevant to the medications chosen to treat pain.  If you are considering surgery, it can affect the choice of medications to prevent blood clots after surgery.  References:  (1)  Singh JA, et al. Peptic ulcer disease and heart disease are associated with periprosthetic fractures after total hip replacement. Acta Orthopaedica 2012 Aug;83(4):353-9  (2) Madhusudhan TR, et al. Gastric protection and gastrointestinal bleeding with aspirin thromboprophylaxis in hip and knee joint replacements. Annals of the Royal College of Surgeons of England 2008 May;90(4):332-5",
+                            "type": "display",
+                            "linkId": "/MH/ComGERD-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComGERDdx",
+                            "display": "Has this condition been diagnosed by endoscopy where a doctor looks into your stomach through a scope or an upper GI or barium swallow study where you swallow chalky dye and then x-rays are taken?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComGERDdx",
+                    "text": "Has this condition been diagnosed by endoscopy where a doctor looks into your stomach through a scope or an upper GI or barium swallow study where you swallow chalky dye and then x-rays are taken?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "enableWhen": [
+                        {
+                            "question": "/MH/ComGERD",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_2"
+                            }
+                        },
+                        {
+                            "question": "/MH/ComGERD",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_3"
+                            }
+                        }
+                    ],
+                    "enableBehavior": "any",
+                    "item": [
+                        {
+                            "text": "A current or prior history of ulcer increases your risk of blood loss and anemia and may be relevant to the medications chosen to prevent blood clots in the perioperative period. References: (1) Gralnek IM, et al. Management of acute bleeding from a peptic ulcer. N Engl J Med 2008; 359:928-937     (2) Hsu PI. New look at antiplatelet agent-related peptic ulcer: an update of prevention and treatment. Journal of Gastroenterology and Hepatology. 2012 Apr;27(4):654-61",
+                            "type": "display",
+                            "linkId": "/MH/ComGERDdx-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComDM",
+                            "display": "Have you ever been diagnosed with or treated for diabetes (high blood sugar)?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComDM",
+                    "text": "Have you ever been diagnosed with or treated for diabetes (high blood sugar)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "Diabetes affects medications used to treat your symptoms. If you are considering surgery, it increases risk of complications after surgery. Controlling diabetes before surgery and maintaining your blood sugars close to normal during and after surgery may decrease risk of major complications like infection. Reference:  Marchant MH, et al. The impact of glycemic control and diabetes mellitus on perioperative outcomes after total joint arthroplasty. Journal of Bone and Joint Surgery. 2009;91:1621-9",
+                            "type": "display",
+                            "linkId": "/MH/ComDM-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComDmeye",
+                            "display": "Has the diabetes caused any problems with your eyes, treated by an ophthalmologist (eye-doctor)?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComDmeye",
+                    "text": "Has the diabetes caused any problems with your eyes, treated by an ophthalmologist (eye-doctor)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "enableWhen": [
+                        {
+                            "question": "/MH/ComDM",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_2"
+                            }
+                        },
+                        {
+                            "question": "/MH/ComDM",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_3"
+                            }
+                        }
+                    ],
+                    "enableBehavior": "any",
+                    "item": [
+                        {
+                            "text": "If diabetes has resulted in eye problems, there is greater risk of nerve problems (neuropathy), which can affect the surgical plan and outcome. Reference:  Parvizi J, et al. Total knee arthroplasty for neuropathic (Charcot) joints. Clinical Orthopaedics and Related Research. 2003;416:145-50",
+                            "type": "display",
+                            "linkId": "/MH/ComDmeye-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComDmkidney",
+                            "display": "Has the diabetes caused any problems with your kidneys?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComDmkidney",
+                    "text": "Has the diabetes caused any problems with your kidneys?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "enableWhen": [
+                        {
+                            "question": "/MH/ComDM",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_2"
+                            }
+                        },
+                        {
+                            "question": "/MH/ComDM",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_3"
+                            }
+                        }
+                    ],
+                    "enableBehavior": "any",
+                    "item": [
+                        {
+                            "text": "If diabetes has resulted in kidney problems, there is greater risk for complication like kidney injury or failure after surgery. Reference:  National Kidney Foundation. KDOQI Clinical Practice Guideline for Diabetes and CKD: 2012 Update. Am J Kidney Dis. 2012 Nov; 60(5):850-86",
+                            "type": "display",
+                            "linkId": "/MH/ComDmkidney-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComKidney",
+                            "display": "Have you ever had problems with your kidneys (poor kidney function or blood tests show high creatinine)?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComKidney",
+                    "text": "Have you ever had problems with your kidneys (poor kidney function or blood tests show high creatinine)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "Kidney problems can play a vital role in choosing the medications prescribed for you, including contrast agents for imaging studies.  Poor kidney function can also affect the dosing of the medications.  If you are considering surgery, please alert your surgical and anesthesia teams. Kidney problems can increase risk of complications with surgery.References: (1) Memtsoudis SG, et al. Risk factors for perioperative mortality after lower extremity arthroplasties: A population based study of 6,901,324 patient discharges. J Arthroplasty. 2010 Jan;25(1):19-26. doi: 10.1016/j.arth.2008.11.010. Epub 2008 Dec 23  (2) Godin M, et al. Fluid balance in patients with acute kidney injury: Emerging concepts. Nephron Clinical Practice 2013;123:238-245 (2) Sawhney S, et al. Long term prognosis after acute kidney injury (AKI): What is the role of baseline kidney function and recovery? A systematic review. BMJ Open. 2015 Jan 6;5(1):e006497",
+                            "type": "display",
+                            "linkId": "/MH/ComKidney-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComDialysis",
+                            "display": "Have you used hemodialysis or peritoneal dialysis (kidney dialysis)?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComDialysis",
+                    "text": "Have you used hemodialysis or peritoneal dialysis (kidney dialysis)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "enableWhen": [
+                        {
+                            "question": "/MH/ComKidney",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_2"
+                            }
+                        },
+                        {
+                            "question": "/MH/ComKidney",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_3"
+                            }
+                        }
+                    ],
+                    "enableBehavior": "any",
+                    "item": [
+                        {
+                            "text": "Patients on dialysis may need careful management of medications by nephrologist (kidney specialist). If you are considering surgery, additional dialysis may need to be arranged around the surgery date. References: (1) Afshar AH, et al. The validity of the VA surgical tool in predictig postoperative mortality in octogenarians. American Journal of Surgery. 2015 Feb;209(2):274-9  (2)  Shah H, et al. Perioperative management of peritoneal dialysis patients undergoing hernia surgery without the use of interim hemodialysis Peritoneal Dialysis International. 2006 Nov-Dec;26(6):684-7",
+                            "type": "display",
+                            "linkId": "/MH/ComDialysis-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComLiver",
+                            "display": "Have you ever been diagnosed with or treated for cirrhosis, or serious liver disease? ",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComLiver",
+                    "text": "Have you ever been diagnosed with or treated for cirrhosis, or serious liver disease? ",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "Liver disease or cirrhosis requires careful attention to medications prescribed for your treatment.  If you are considering surgery, liver disease increases the risk of infection, bleeding, confusion, and other complications. Please alert your surgical and anesthesia teams.They may need to adjust the techniques chosen and the postoperative plan. References: (1)  Tiberi JV, et al. Increased complication rates after hip and knee arthroplasty in patients with cirrhosis of the liver. Clin Orthop Relat Res (2014) 472:2774-2778  (2) Cohen SM, et al. Operative risk of total hip and knee arthroplasty in cirrhotic patients. Journal of Arthroplasty. 2005;20:460-466  (3) Shih LY, et al. Total knee arthroplasty in patients with liver cirrhosis. Journal of Bone and Joint Surgery, 2004 Feb; 86 (2): 335 -341",
+                            "type": "display",
+                            "linkId": "/MH/ComLiver-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComTransplant",
+                            "display": "Have you received a kidney, liver, lung or other transplant?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComTransplant",
+                    "text": "Have you received a kidney, liver, lung or other transplant?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "Transplant patients on anti-rejection meds may need dose adjustments, coordination of care with transplant team and close monitoring of their medications.  Reference:  Cavanaugh PK, et al.  Total Joint Arthroplasty in Transplant Recipients: In-Hospital Adverse Outcomes. J Arthroplasty. 2014 Dec 5. pii: S0883-5403(14)00913-9.",
+                            "type": "display",
+                            "linkId": "/MH/ComTransplant-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComCancer",
+                            "display": "Have you ever been diagnosed with or treated for cancer?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComCancer",
+                    "text": "Have you ever been diagnosed with or treated for cancer?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "A history of cancer is important for evaluation and treatment of your symptoms. If you are considering surgery, it can affect your risk of bleeding, infection, blood clots, and function of organs such as nerves, heart, lungs, liver or kidneys.  Please make sure your surgical team is aware of this. Cancer or its treatment may limit the benefits of surgery.  Also, some blood tests ordered before and after surgery will be expected to be abnormal in setting of cancer or its treatment. Please have your surgery and anesthesia teams coordinate carefully with your oncologist. References:  (1)  Dybvik E, et al. Long term risk for receiving a total hip replacement in cancer patients - A linkage study between the cancer register of Norway and the Norwegian arthroplasty register. Journal of Bone and Joint Surgery Br 2010;92-B:601 (2) Katz JN, et al. Elective palliative total hip replacement in a patient with lymphoma and advanced lung cancer. Arthritis and Rheumatology. 2008 Aug 15; 59(8): 1194-1196",
+                            "type": "display",
+                            "linkId": "/MH/ComCancer-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComMetastases",
+                            "display": "Has the cancer spread, or metastasized to other parts of your body?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComMetastases",
+                    "text": "Has the cancer spread, or metastasized to other parts of your body?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "enableWhen": [
+                        {
+                            "question": "/MH/ComCancer",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_2"
+                            }
+                        },
+                        {
+                            "question": "/MH/ComCancer",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_3"
+                            }
+                        }
+                    ],
+                    "enableBehavior": "any",
+                    "item": [
+                        {
+                            "text": "Cancer may spread to bones and cause pain.  Surgery may be helpful for relief of pan, stabilization of the involved bone or joint, and to improve your quality of life.  If you are considering surgery, please have your surgery and anesthesia teams coordinate carefully with your oncologist. Reference:  Charlson ME, et al. A new method of classifying prognostic comorbidity in longitudinal studies : Development and Validation. Journal of Chronic Disease 1987;40:373-383.",
+                            "type": "display",
+                            "linkId": "/MH/ComMetastases-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComHIV",
+                            "display": "Have you ever been diagnosed with or treated for HIV/AIDS?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComHIV",
+                    "text": "Have you ever been diagnosed with or treated for HIV/AIDS?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "History of having HIV infection or AIDS is relevant to evaluation of your symptoms. It may affect the choice of medications prescribed for treating your symptoms.  If you are considering surgery, the medications used to treat HIV infection or AIDS can interact with anesthesia and surgical medications.  Untreated AIDS can lead to poor outcome including increased risk of infection after joint replacement and may need to be addressed before surgery.      Reference:  King Jr JT, et al. Thirty-Day Postoperative Mortality Among Individuals Wth HIV Infection Receiving Antiretroviral Therapy and Procedure-Matched, Uninfected Comparators. JAMA Surgery doi:10.1001/jamasurg.2014.2257 Published online February 25, 2015",
+                            "type": "display",
+                            "linkId": "/MH/ComHIV-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComIA",
+                            "display": "Do you have any rheumatic conditions like lupus, psoriasis, ankylosing spondylitis, or rheumatoid arthritis (a type of arthritis NOT related to the commonly diagnosed osteoarthritis)? ",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComIA",
+                    "text": "Do you have any rheumatic conditions like lupus, psoriasis, ankylosing spondylitis, or rheumatoid arthritis (a type of arthritis NOT related to the commonly diagnosed osteoarthritis)? ",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "Inflammatory conditions like rheumatic or autoimmune arthritis increase risk of complications from surgery such as infection. Careful management before surgery may decrease this risk.  Reference:  Howe CR, et al. Perioperative medication management for the patient with rheumatoid arthritis. Journal of the Academy of Orthopaedic Surgeons 2006;14:544-551. Grennan et al. Ann Rheum Dis. 2001;60:214-217.",
+                            "type": "display",
+                            "linkId": "/MH/ComIA-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComIAmed",
+                            "display": "Do you take medications for it regularly? ",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComIAmed",
+                    "text": "Do you take medications for it regularly? ",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "enableWhen": [
+                        {
+                            "question": "/MH/ComIA",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_2"
+                            }
+                        },
+                        {
+                            "question": "/MH/ComIA",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_3"
+                            }
+                        }
+                    ],
+                    "enableBehavior": "any",
+                    "item": [
+                        {
+                            "text": "Some medications taken for rheumatoid arthritis increase the risk of infection and require careful adjustment before and after surgery. References: (1) Goodman SM, Figgie M. Lower extremity arthroplasty in patients with inflammatory arthritis: preoperative and perioperative management. J Am Acad Orthop Surg. 2013 Jun;21(6):355-63. doi: 10.5435/JAAOS-21-06-355 (2) Bongartz et al. Anti-TNF antibody therapy in rheumatoid arthritis and the risk of serious infections and malignancies: systematic review and meta-analysis of rare harmful effects in randomized controlled trials. JAMA. 2006; 295:2275-85",
+                            "type": "display",
+                            "linkId": "/MH/ComIAmed-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComOAKnee",
+                            "display": "Do you have arthritis in your knees?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComOAKnee",
+                    "text": "Do you have arthritis in your knees?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "If you are considering surgery, pain affecting other joint in your legs can complicate your recovery and limit the benefits you experience.  Reference: Coxib and traditional NSAID Trialists' (CNT) Collaboration.  Vascular and upper gastrointestinal effects of non-steroidal anti-infl ammatory drugs: meta-analyses of individual participant data from randomised trials. Lancet 2013; 382: 769-79",
+                            "type": "display",
+                            "linkId": "/MH/ComOAKnee-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ComOAHip",
+                            "display": "Do you have arthritis in your hips?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/ComOAHip",
+                    "text": "Do you have arthritis in your hips?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "If you are considering surgery, pain affecting other joint in your legs can complicate your recovery and limit the benefits you experience. References:  Coxib and traditional NSAID Trialists' (CNT) Collaboration.  Vascular and upper gastrointestinal effects of non-steroidal anti-infl ammatory drugs: meta-analyses of individual participant data from randomised trials. Lancet 2013; 382: 769-79.",
+                            "type": "display",
+                            "linkId": "/MH/ComOAHip-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "MH-score",
+                            "display": "Medical History Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh1value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComMI').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComMI').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh2value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComCHF').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComCHF').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh3value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComPVD').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComPVD').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh4value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComDVT').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComDVT').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh5value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComBleeding').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComBleeding').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh6value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComCVA').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComCVA').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh7value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComHemiplegia').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComHemiplegia').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh8value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComAsthma').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComAsthma').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh9value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComAsthmaMed').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComAsthmaMed').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh10value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComCOPD').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComCOPD').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh11value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComOxygen').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComOxygen').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh12value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComGERD').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComGERD').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh13value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComGERDdx').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComGERDdx').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh14value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComDM').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComDM').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh15value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComDmeye').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComDmeye').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh16value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComDmkidney').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComDmkidney').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh17value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComKidney').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComKidney').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh18value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComDialysis').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComDialysis').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh19value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComLiver').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComLiver').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh20value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComTransplant').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComTransplant').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh21value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComCancer').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComCancer').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh22value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComMetastases').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComMetastases').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh23value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComHIV').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComHIV').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh24value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComIA').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComIA').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh25value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComIAmed').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComIAmed').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh26value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComOAKnee').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComOAKnee').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "mh27value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/MH').item.where(linkId = '/MH/ComOAHip').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/MH').item.where(linkId = '/MH/ComOAHip').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "anyquestionsanswered",
+                                "language": "text/fhirpath",
+                                "expression": "%mh1value.exists() or %mh2value.exists() or %mh3value.exists() or %mh4value.exists() or %mh5value.exists() or %mh6value.exists() or %mh7value.exists() or %mh8value.exists() or %mh9value.exists() or %mh10value.exists() or %mh11value.exists() or %mh12value.exists() or %mh13value.exists() or %mh14value.exists() or %mh15value.exists() or %mh16value.exists() or %mh17value.exists() or %mh18value.exists() or %mh19value.exists() or %mh20value.exists() or %mh21value.exists() or %mh22value.exists() or %mh23value.exists() or %mh24value.exists() or %mh25value.exists() or %mh26value.exists() or %mh27value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%anyquestionsanswered, iif(%mh1value.exists(), %mh1value, 0) + iif(%mh2value.exists(), %mh2value, 0) + iif(%mh3value.exists(), %mh3value, 0) + iif(%mh4value.exists(), %mh4value, 0) + iif(%mh5value.exists(), %mh5value, 0) + iif(%mh6value.exists(), %mh6value, 0) + iif(%mh7value.exists(), %mh7value, 0) + iif(%mh8value.exists(), %mh8value, 0) + iif(%mh9value.exists(), %mh9value, 0) + iif(%mh10value.exists(), %mh10value, 0) + iif(%mh11value.exists(), %mh11value, 0) + iif(%mh12value.exists(), %mh12value, 0) + iif(%mh13value.exists(), %mh13value, 0) + iif(%mh14value.exists(), %mh14value, 0) + iif(%mh15value.exists(), %mh15value, 0) + iif(%mh16value.exists(), %mh16value, 0) + iif(%mh17value.exists(), %mh17value, 0) + iif(%mh18value.exists(), %mh18value, 0) + iif(%mh19value.exists(), %mh19value, 0) + iif(%mh20value.exists(), %mh20value, 0) + iif(%mh21value.exists(), %mh21value, 0) + iif(%mh22value.exists(), %mh22value, 0) + iif(%mh23value.exists(), %mh23value, 0) + iif(%mh24value.exists(), %mh24value, 0) + iif(%mh25value.exists(), %mh25value, 0) + iif(%mh26value.exists(), %mh26value, 0) + iif(%mh27value.exists(), %mh27value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/MH/MH-score",
+                    "text": "Medical History Score"
+                }
+            ]
+        },
+        {
+            "type": "group",
+            "required": false,
+            "linkId": "/BS",
+            "prefix": "Back Pain Severity",
+            "text": "This questionnaire has been designed to give us information as to how your back pain is affecting your ability to manage in everyday life. It takes about 3 minutes. Please answer by checking ONE box in each section for the statement which best applies to you. We realize you may consider that two or more statements in any one section apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS03",
+                            "display": "How would you rate your low-back pain on average?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/MDS03",
+                    "text": "How would you rate your low-back pain on average?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NRS_1",
+                                "display": "0"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_2",
+                                "display": "1"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_3",
+                                "display": "2"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_4",
+                                "display": "3"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_5",
+                                "display": "4"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_6",
+                                "display": "5"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_7",
+                                "display": "6"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 6
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_8",
+                                "display": "7"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 7
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_9",
+                                "display": "8"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 8
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_10",
+                                "display": "9"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 9
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NRS_11",
+                                "display": "10"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 10
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past 7 days",
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/MDS03-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI01",
+                            "display": "Pain Intensity",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/ODI01",
+                    "text": "Pain Intensity",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "ODI_1",
+                                "display": "I have no pain at the moment."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ODI_2",
+                                "display": "The pain is very mild at the moment."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ODI_3",
+                                "display": "The pain is moderate at the moment."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ODI_4",
+                                "display": "The pain is fairly severe at the moment."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ODI_5",
+                                "display": "The pain is very severe at the moment."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ODI_6",
+                                "display": "The pain is the worst imaginable at the moment."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "enableBehavior": "any",
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI01-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI02",
+                            "display": "Personal Care (washing, dressing, etc.)",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/ODI02",
+                    "text": "Personal Care (washing, dressing, etc.)",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "OSW_1",
+                                "display": "I can do it without pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "OSW_2",
+                                "display": "I can do it but it causes pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "OSW_3",
+                                "display": "I am slow and careful."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "OSW_4",
+                                "display": "I need some help."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "OSW_5",
+                                "display": "I need help in most self-care."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "OSW_6",
+                                "display": "I do not get dressed and stay in bed."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "enableBehavior": "any",
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI02-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI03",
+                            "display": "Lifting",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/ODI03",
+                    "text": "Lifting",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "LIF_1",
+                                "display": "I can lift heavy weights without pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LIF_2",
+                                "display": "I can lift heavy weights with pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LIF_3",
+                                "display": "I can lift heavy weights if conveniently positioned"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LIF_4",
+                                "display": "I can manage medium weights."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LIF_5",
+                                "display": "I can lift very light weights."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LIF_6",
+                                "display": "I cannot lift or carry anything at all."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "enableBehavior": "any",
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI03-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI04",
+                            "display": "Walking",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/ODI04",
+                    "text": "Walking",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "WLK_1",
+                                "display": "Pain does not prevent me from walking any distance."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "WLK_2",
+                                "display": "Pain prevents me from walking more than 1 mile."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "WLK_3",
+                                "display": "Pain prevents me from walking more than 1/2 mile."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "WLK_4",
+                                "display": "Pain prevents me from walking more than 100 yards."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "WLK_5",
+                                "display": "I can only walk using a stick or crutches."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "WLK_6",
+                                "display": "I am in bed most of the time."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "enableBehavior": "any",
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI04-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI05",
+                            "display": "Sitting",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/ODI05",
+                    "text": "Sitting",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SIT_1",
+                                "display": "I can sit in any chair as long as I like."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SIT_2",
+                                "display": "I can only sit in my favorite chair as long as I like."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SIT_3",
+                                "display": "Pain prevents me from sitting more than one hour."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SIT_4",
+                                "display": "Pain prevents me from sitting more than 30 minutes."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SIT_5",
+                                "display": "Pain prevents me from sitting more than 10 minutes."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SIT_6",
+                                "display": "Pain prevents me from sitting at all."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "enableBehavior": "any",
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI05-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI06",
+                            "display": "Standing",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/ODI06",
+                    "text": "Standing",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "STD_1",
+                                "display": "I can stand as long as I want without pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "STD_2",
+                                "display": "I can stand as long as I want but it causes pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "STD_3",
+                                "display": "Pain prevents me from standing more than 1 hour."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "STD_4",
+                                "display": "Pain prevents me from standing more than 30 minutes."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "STD_5",
+                                "display": "Pain prevents me from standing more than 10 minutes."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "STD_6",
+                                "display": "Pain prevents me from standing at all."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "enableBehavior": "any",
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI06-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI07",
+                            "display": "Sleeping",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/ODI07",
+                    "text": "Sleeping",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SLG_1",
+                                "display": "My sleep is never disturbed by pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLG_2",
+                                "display": "My sleep is occasionally disturbed by pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLG_3",
+                                "display": "Because of pain I have less than 6 hours sleep."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLG_4",
+                                "display": "Because of pain I have less than 4 hours sleep."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLG_5",
+                                "display": "Because of pain I have less than 2 hours sleep."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLG_6",
+                                "display": "Pain prevents me from sleeping at all."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "enableBehavior": "any",
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI07-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI08",
+                            "display": "Sex Life (if applicable)",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/ODI08",
+                    "text": "Sex Life (if applicable)",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SEX_1",
+                                "display": "My sex life is normal and causes no extra pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SEX_2",
+                                "display": "My sex life is normal but causes some extra pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SEX_3",
+                                "display": "My sex life is nearly normal but is very painful."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SEX_4",
+                                "display": "My sex life is severely restricted by pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SEX_5",
+                                "display": "My sex life is nearly absent because of pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SEX_6",
+                                "display": "Pain prevents any sex life at all."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "enableBehavior": "any",
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI08-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI09",
+                            "display": "Social Life",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/ODI09",
+                    "text": "Social Life",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SLK_1",
+                                "display": "My social life is normal and gives me no extra pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLK_2",
+                                "display": "My social life is normal but increases the degree of pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLK_3",
+                                "display": "Pain limits my more energetic interests, e.g., sport."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLK_4",
+                                "display": "Pain has restricted my social life and I do not go out as often."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLK_5",
+                                "display": "Pain has restricted my social life to my home."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SLK_6",
+                                "display": "I have no social life because of pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "enableBehavior": "any",
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI09-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ODI10",
+                            "display": "Traveling",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/ODI10",
+                    "text": "Traveling",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "TRL_1",
+                                "display": "I can travel anywhere without pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TRL_2",
+                                "display": "I can travel anywhere but it gives me extra pain."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TRL_3",
+                                "display": "Pain is bad but I manage journeys over 2 hours."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TRL_4",
+                                "display": "Pain is bad but I manage journeys less than 1 hour."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TRL_5",
+                                "display": "Pain restricts me to short necessary journeys under 30 minutes."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TRL_6",
+                                "display": "Pain prevents me from traveling except to receive treatment."
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        }
+                    ],
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "enableBehavior": "any",
+                    "item": [
+                        {
+                            "text": "This question is part of the Oswestry Disability Questionnaire. It measures how much your back pain is affecting your ability to manage in everyday life. Please answer by checking ONE box for the statement which best applies to you. We realize you may consider that two or more statements may apply, but please just mark the box that indicates the statement which most clearly describes your problem.",
+                            "type": "display",
+                            "linkId": "/BS/ODI10-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "BS-score",
+                            "display": "Back Pain Severity Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs1value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/MDS03').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/MDS03').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs2value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI01').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI01').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs3value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI02').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI02').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs4value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI03').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI03').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs5value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI04').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI04').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs6value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI05').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI05').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs7value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI06').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI06').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs8value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI07').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI07').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs9value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI08').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI08').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs10value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI09').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI09').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bs11value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI10').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BS').item.where(linkId = '/BS/ODI10').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "anyquestionsanswered",
+                                "language": "text/fhirpath",
+                                "expression": "%bs1value.exists() or %bs2value.exists() or %bs3value.exists() or %bs4value.exists() or %bs5value.exists() or %bs6value.exists() or %bs7value.exists() or %bs8value.exists() or %bs9value.exists() or %bs10value.exists() or %bs11value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%anyquestionsanswered, iif(%bs1value.exists(), %bs1value, 0) + iif(%bs2value.exists(), %bs2value, 0) + iif(%bs3value.exists(), %bs3value, 0) + iif(%bs4value.exists(), %bs4value, 0) + iif(%bs5value.exists(), %bs5value, 0) + iif(%bs6value.exists(), %bs6value, 0) + iif(%bs7value.exists(), %bs7value, 0) + iif(%bs8value.exists(), %bs8value, 0) + iif(%bs9value.exists(), %bs9value, 0) + iif(%bs10value.exists(), %bs10value, 0) + iif(%bs11value.exists(), %bs11value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BS/BS-score",
+                    "text": "Back Pain Severity Score"
+                }
+            ]
+        },
+        {
+            "type": "group",
+            "required": false,
+            "linkId": "/BP",
+            "prefix": "Back Pain History",
+            "text": "The next set of questions help provide comprehensive evaluation. \nThey require about 2 minutes. These queastions were developed by the National Institutes of Health Task Force on Research Standards\n for Chronic Low Back Pain. They are essential for comparing outcomes of patients with low back pain.",
+            "enableWhen": [
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_2"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_3"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_4"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_5"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_6"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_7"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_8"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_9"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_10"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_11"
+                    }
+                }
+            ],
+            "enableBehavior": "any",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS01",
+                            "display": "How long has back pain been an ongoing problem for you?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/MDS01",
+                    "text": "How long has back pain been an ongoing problem for you?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BCK_1",
+                                "display": "Less than 1 month"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BCK_2",
+                                "display": "1 to 3 months"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BCK_3",
+                                "display": "3 to 6 months"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BCK_4",
+                                "display": "6 to 12 months"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BCK_5",
+                                "display": "1 to 5 years"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BCK_6",
+                                "display": "More than 5 years"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 6
+                                }
+                            ]
+                        }
+                    ],
+                    "enableWhen": [
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_2"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_3"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_4"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_5"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_6"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_7"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_8"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_9"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_10"
+                            }
+                        },
+                        {
+                            "question": "/BS/MDS03",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NRS_11"
+                            }
+                        }
+                    ],
+                    "enableBehavior": "any",
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS01-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS02",
+                            "display": "How often has back pain been an ongoing problem for you?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/MDS02",
+                    "text": "How often has back pain been an ongoing problem for you?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BPF_1",
+                                "display": "Every day or nearly every day"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BPF_2",
+                                "display": "At least half the days"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BPF_3",
+                                "display": "Less than half the days"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        }
+                    ],
+                    "enableWhen": [
+                        {
+                            "question": "/BP/MDS01",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BCK_4"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS01",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BCK_5"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS01",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BCK_6"
+                            }
+                        }
+                    ],
+                    "enableBehavior": "any",
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS02-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS04",
+                            "display": "Do you have pain down your leg?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/MDS04",
+                    "text": "Do you have pain down your leg?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "LRP_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LRP_2",
+                                "display": "Yes, only the right side"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LRP_3",
+                                "display": "Yes, only on the left side"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LRP_4",
+                                "display": "Yes, both sides"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LRP_5",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "During the past 2 weeks",
+                    "enableBehavior": "any",
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS04-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS04Side",
+                            "display": "Have you had pain, numbness or tingling below your knee?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/MDS04Side",
+                    "text": "Have you had pain, numbness or tingling below your knee?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "LRP_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LRP_2",
+                                "display": "Yes, only the right side"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LRP_3",
+                                "display": "Yes, only on the left side"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LRP_4",
+                                "display": "Yes, both sides"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LRP_5",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "During the past 2 weeks",
+                    "enableWhen": [
+                        {
+                            "question": "/BP/MDS04",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "LRP_2"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS04",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "LRP_3"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS04",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "LRP_4"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS04",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "LRP_5"
+                            }
+                        }
+                    ],
+                    "enableBehavior": "any",
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS04Side-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS06",
+                            "display": "Have you ever had a low-back operation?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/MDS06",
+                    "text": "Have you ever had a low-back operation?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BSY_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BSY_2",
+                                "display": "Yes, one operation"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BSY_3",
+                                "display": "Yes, more than one operation"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS06-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS07",
+                            "display": "When was your last back operation?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/MDS07",
+                    "text": "When was your last back operation?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "LBO_1",
+                                "display": "Less than 6 months ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LBO_2",
+                                "display": "Between 6 months and 1 year ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LBO_3",
+                                "display": "Between 1 and 2 years ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LBO_4",
+                                "display": "More than 2 years ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        }
+                    ],
+                    "enableWhen": [
+                        {
+                            "question": "/BP/MDS06",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BSY_2"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS06",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BSY_3"
+                            }
+                        }
+                    ],
+                    "enableBehavior": "any",
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS07-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS08",
+                            "display": "Did any of your back operations involve a spinal fusion? (also called an arthrodesis)",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/MDS08",
+                    "text": "Did any of your back operations involve a spinal fusion? (also called an arthrodesis)",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "enableWhen": [
+                        {
+                            "question": "/BP/MDS06",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BSY_2"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS06",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BSY_3"
+                            }
+                        }
+                    ],
+                    "enableBehavior": "any",
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS08-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13b",
+                            "display": "Have you ever had low back injection (such as epidural steroid injection, facet injection)?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/MDS13b",
+                    "text": "Have you ever had low back injection (such as epidural steroid injection, facet injection)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BIN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BIN_2",
+                                "display": "Yes, one injection"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BIN_3",
+                                "display": "Yes, more than one injection"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS13b-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13bWhen",
+                            "display": "When was your last injection?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/MDS13bWhen",
+                    "text": "When was your last injection?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "LBO_1",
+                                "display": "Less than 6 months ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LBO_2",
+                                "display": "Between 6 months and 1 year ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LBO_3",
+                                "display": "Between 1 and 2 years ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LBO_4",
+                                "display": "More than 2 years ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        }
+                    ],
+                    "enableWhen": [
+                        {
+                            "question": "/BP/MDS13b",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BIN_2"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS13b",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BIN_3"
+                            }
+                        }
+                    ],
+                    "enableBehavior": "any",
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS13bWhen-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13c",
+                            "display": "Have you ever had physical therapy for your back?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/MDS13c",
+                    "text": "Have you ever had physical therapy for your back?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NIH_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NIH_2",
+                                "display": "Yes, one series of treatments"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NIH_3",
+                                "display": "Yes, more than one series of treatments"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS13c-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13cWhen",
+                            "display": "When was your last session?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/MDS13cWhen",
+                    "text": "When was your last session?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "LBO_1",
+                                "display": "Less than 6 months ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LBO_2",
+                                "display": "Between 6 months and 1 year ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LBO_3",
+                                "display": "Between 1 and 2 years ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "LBO_4",
+                                "display": "More than 2 years ago"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        }
+                    ],
+                    "enableWhen": [
+                        {
+                            "question": "/BP/MDS13c",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NIH_2"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS13c",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "NIH_3"
+                            }
+                        }
+                    ],
+                    "enableBehavior": "any",
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS13cWhen-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13a",
+                            "display": "Have you ever used opioid pain killers? (prescription medications such as Vicodin, Lortab, Norco, hydrocodone, codeine, Tylenol #3 or #4, Fentanyl, Duragesic, MS Contin, Percocet, Tylox, OxyContin, oxycodone, methadone, tramadol, Ultram, Dilaudid)?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/MDS13a",
+                    "text": "Have you ever used opioid pain killers? (prescription medications such as Vicodin, Lortab, Norco, hydrocodone, codeine, Tylenol #3 or #4, Fentanyl, Duragesic, MS Contin, Percocet, Tylox, OxyContin, oxycodone, methadone, tramadol, Ultram, Dilaudid)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS13a-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13aCurrent",
+                            "display": "Are you using these medications currently?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/MDS13aCurrent",
+                    "text": "Are you using these medications currently?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "enableWhen": [
+                        {
+                            "question": "/BP/MDS13a",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_2"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS13a",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "BFN_3"
+                            }
+                        }
+                    ],
+                    "enableBehavior": "any",
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS13aCurrent-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13d",
+                            "display": "Have you ever had psychological counseling for pain coping skills, such as cognitive-behavioral therapy (CBT)?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/MDS13d",
+                    "text": "Have you ever had psychological counseling for pain coping skills, such as cognitive-behavioral therapy (CBT)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "This question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/BP/MDS13d-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS14",
+                            "display": "Have you had to take time off work?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/MDS14",
+                    "text": "Have you had to take time off work?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "TOF_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TOF_2",
+                                "display": "Yes, less than a month"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TOF_3",
+                                "display": "Yes, more than a month"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TOF_4",
+                                "display": "Does not apply"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BP/MDS14-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS15",
+                            "display": "Have you applied for disability?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/MDS15",
+                    "text": "Have you applied for disability?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "RTF_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RTF_2",
+                                "display": "Yes, workers compensation"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RTF_3",
+                                "display": "Yes, Social Security"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RTF_4",
+                                "display": "Yes, both workers comp and social security"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RTF_5",
+                                "display": "Does not apply"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        }
+                    ],
+                    "enableWhen": [
+                        {
+                            "question": "/BP/MDS14",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "TOF_2"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS14",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "TOF_3"
+                            }
+                        },
+                        {
+                            "question": "/BP/MDS14",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "TOF_4"
+                            }
+                        }
+                    ],
+                    "enableBehavior": "any",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BP/MDS15-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "BP-score",
+                            "display": "Back Pain History Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp1value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS01').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS01').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp2value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS02').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS02').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp3value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS04').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS04').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp4value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS04Side').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS04Side').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp5value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS06').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS06').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp6value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS07').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS07').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp7value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS08').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS08').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp8value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13b').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13b').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp9value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13bWhen').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13bWhen').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp10value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13c').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13c').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp11value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13cWhen').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13cWhen').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp12value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13a').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13a').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp13value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13aCurrent').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13aCurrent').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp14value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13d').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS13d').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp15value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS14').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS14').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bp16value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS15').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BP').item.where(linkId = '/BP/MDS15').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "anyquestionsanswered",
+                                "language": "text/fhirpath",
+                                "expression": "%bp1value.exists() or %bp2value.exists() or %bp3value.exists() or %bp4value.exists() or %bp5value.exists() or %bp6value.exists() or %bp7value.exists() or %bp8value.exists() or %bp9value.exists() or %bp10value.exists() or %bp11value.exists() or %bp12value.exists() or %bp13value.exists() or %bp14value.exists() or %bp15value.exists() or %bp16value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%anyquestionsanswered, iif(%bp1value.exists(), %bp1value, 0) + iif(%bp2value.exists(), %bp2value, 0) + iif(%bp3value.exists(), %bp3value, 0) + iif(%bp4value.exists(), %bp4value, 0) + iif(%bp5value.exists(), %bp5value, 0) + iif(%bp6value.exists(), %bp6value, 0) + iif(%bp7value.exists(), %bp7value, 0) + iif(%bp8value.exists(), %bp8value, 0) + iif(%bp9value.exists(), %bp9value, 0) + iif(%bp10value.exists(), %bp10value, 0) + iif(%bp11value.exists(), %bp11value, 0) + iif(%bp12value.exists(), %bp12value, 0) + iif(%bp13value.exists(), %bp13value, 0) + iif(%bp14value.exists(), %bp14value, 0) + iif(%bp15value.exists(), %bp15value, 0) + iif(%bp16value.exists(), %bp16value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BP/BP-score",
+                    "text": "Back Pain History Score"
+                }
+            ]
+        },
+        {
+            "type": "group",
+            "required": false,
+            "linkId": "/BI",
+            "prefix": "Impact of Back Pain",
+            "text": "The National Institutes of Health Task Force on Research Standard for Chronic Low Back Pain recommended the next few questions to measure prior treatments, disability and goals. This section takes about 2 minutes.",
+            "enableWhen": [
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_2"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_3"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_4"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_5"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_6"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_7"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_8"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_9"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_10"
+                    }
+                },
+                {
+                    "question": "/BS/MDS03",
+                    "operator": "=",
+                    "answerCoding": {
+                        "code": "NRS_11"
+                    }
+                }
+            ],
+            "enableBehavior": "any",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS15Injury",
+                            "display": "Do you feel there is a relationship between your back pain and any of the following?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BI/MDS15Injury",
+                    "text": "Do you feel there is a relationship between your back pain and any of the following?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "IJK_1",
+                                "display": "Employment"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "IJK_2",
+                                "display": "Auto accident"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "IJK_3",
+                                "display": "Other accident"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "IJK_4",
+                                "display": "Pregnancy"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "IJK_5",
+                                "display": "None of these"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/MDS15Injury-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS30",
+                            "display": "Are you involved in a lawsuit or legal claim related to you back problem?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BI/MDS30",
+                    "text": "Are you involved in a lawsuit or legal claim related to you back problem?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/MDS30-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS05a",
+                            "display": "How much have you been bothered by stomach pain?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BI/MDS05a",
+                    "text": "How much have you been bothered by stomach pain?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SPN_1",
+                                "display": "Not bothered at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SPN_2",
+                                "display": "Bothered a little"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SPN_3",
+                                "display": "Bothered a lot"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "During the past 4 weeks",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/MDS05a-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS05b",
+                            "display": "How much have you been bothered by headaches?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BI/MDS05b",
+                    "text": "How much have you been bothered by headaches?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SPN_1",
+                                "display": "Not bothered at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SPN_2",
+                                "display": "Bothered a little"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SPN_3",
+                                "display": "Bothered a lot"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "During the past 4 weeks",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/MDS05b-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS05c",
+                            "display": "How much have you been bothered by pain the joints in your arms or legs?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BI/MDS05c",
+                    "text": "How much have you been bothered by pain the joints in your arms or legs?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SPN_1",
+                                "display": "Not bothered at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SPN_2",
+                                "display": "Bothered a little"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SPN_3",
+                                "display": "Bothered a lot"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "During the past 4 weeks",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/MDS05c-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS05d",
+                            "display": "how much have you been bothered by widespread pain or pain in most of your body?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BI/MDS05d",
+                    "text": "how much have you been bothered by widespread pain or pain in most of your body?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SPN_1",
+                                "display": "Not bothered at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SPN_2",
+                                "display": "Bothered a little"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SPN_3",
+                                "display": "Bothered a lot"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "During the past 4 weeks",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/MDS05d-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS28",
+                            "display": "It's not really safe for a person with my back pain to be physically active.",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BI/MDS28",
+                    "text": "It's not really safe for a person with my back pain to be physically active.",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "AGD_1",
+                                "display": "Agree"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "AGD_2",
+                                "display": "Disagree"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Do you agree or disagree with this statement:",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/MDS28-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS29",
+                            "display": "I feel that my back pain is terrible and it's never going to get any better.",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BI/MDS29",
+                    "text": "I feel that my back pain is terrible and it's never going to get any better.",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "AGD_1",
+                                "display": "Agree"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "AGD_2",
+                                "display": "Disagree"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Do you agree or disagree with this statement:",
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/MDS29-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "Goal",
+                            "display": "What is your treatment goal?",
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0360"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BI/Goal",
+                    "text": "What is your treatment goal?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "GOL_1",
+                                "display": "Become pain-free all of the time"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "GOL_2",
+                                "display": "Become pain-free on most days"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "GOL_3",
+                                "display": "Reduce pain enough so I can function"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "The National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain recommended this question as part of the minimum data set for back pain.",
+                            "type": "display",
+                            "linkId": "/BI/Goal-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "BI-score",
+                            "display": "Impact of Back Pain Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi1value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS15Injury').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS15Injury').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi2value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS30').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS30').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi3value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS05a').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS05a').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi4value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS05b').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS05b').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi5value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS05c').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS05c').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi6value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS05d').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS05d').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi7value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS28').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS28').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi8value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS29').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/MDS29').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "bi9value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/BI').item.where(linkId = '/BI/Goal').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/BI').item.where(linkId = '/BI/Goal').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "anyquestionsanswered",
+                                "language": "text/fhirpath",
+                                "expression": "%bi1value.exists() or %bi2value.exists() or %bi3value.exists() or %bi4value.exists() or %bi5value.exists() or %bi6value.exists() or %bi7value.exists() or %bi8value.exists() or %bi9value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%anyquestionsanswered, iif(%bi1value.exists(), %bi1value, 0) + iif(%bi2value.exists(), %bi2value, 0) + iif(%bi3value.exists(), %bi3value, 0) + iif(%bi4value.exists(), %bi4value, 0) + iif(%bi5value.exists(), %bi5value, 0) + iif(%bi6value.exists(), %bi6value, 0) + iif(%bi7value.exists(), %bi7value, 0) + iif(%bi8value.exists(), %bi8value, 0) + iif(%bi9value.exists(), %bi9value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/BI/BI-score",
+                    "text": "Impact of Back Pain Score"
+                }
+            ]
+        }
+    ]
+}

--- a/contrib/portal_templates/assessments/SDC FHIR/Safety_Outcomes_Assessment.json
+++ b/contrib/portal_templates/assessments/SDC FHIR/Safety_Outcomes_Assessment.json
@@ -1,0 +1,1008 @@
+{
+    "resourceType": "Questionnaire",
+    "meta": {
+        "profile": [
+            "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire|2.7",
+            "http://hl7.org/fhir/4.0/StructureDefinition/Questionnaire"
+        ],
+        "tag": [
+            {
+                "code": "generated: PEER"
+            }
+        ]
+    },
+    "status": "active",
+    "title": "Safety Outcomes Assessment",
+    "subjectType": [
+        "Patient",
+        "Person"
+    ],
+    "item": [
+        {
+            "type": "group",
+            "code": [],
+            "required": false,
+            "linkId": "/SO",
+            "prefix": "Safety Outcomes",
+            "text": "The next eight questions help evaluate results of treatment.",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13aFollow",
+                            "display": "Are you currently using opioid pain killers? (prescription medications such as Vicodin, Lortab, Norco, hydrocodone, codeine, Tylenol #3 or #4, Fentanyl, Duragesic, MS Contin, Percocet, Tylox, OxyContin, oxycodone, methadone, tramadol, Ultram, Dilaudi",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/SO/MDS13aFollow",
+                    "text": "Are you currently using opioid pain killers? (prescription medications such as Vicodin, Lortab, Norco, hydrocodone, codeine, Tylenol #3 or #4, Fentanyl, Duragesic, MS Contin, Percocet, Tylox, OxyContin, oxycodone, methadone, tramadol, Ultram, Dilaudi",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "This question helps measure results of back pain treatment.",
+                            "type": "display",
+                            "linkId": "/SO/MDS13aFollow-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "ERvisitFollow",
+                            "display": "Have you had to go to an Emergency Room for any reason?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/SO/ERvisitFollow",
+                    "text": "Have you had to go to an Emergency Room for any reason?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "ERV_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ERV_2",
+                                "display": "Yes, one visit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ERV_3",
+                                "display": "Yes, more than one visit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Since <DATE_OF_LAST_ASSESSMENT>",
+                    "item": [
+                        {
+                            "text": "This question helps measure results of back pain treatment.",
+                            "type": "display",
+                            "linkId": "/SO/ERvisitFollow-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS06Follow",
+                            "display": "Have you had a low-back operation?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/SO/MDS06Follow",
+                    "text": "Have you had a low-back operation?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BSY_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BSY_2",
+                                "display": "Yes, one operation"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BSY_3",
+                                "display": "Yes, more than one operation"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Since <DATE_OF_LAST_ASSESSMENT>",
+                    "item": [
+                        {
+                            "text": "This question helps measure results of back pain treatment.",
+                            "type": "display",
+                            "linkId": "/SO/MDS06Follow-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13bFollow",
+                            "display": "Have you had low back injection (such as epidural steroid injection, facet injection)?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/SO/MDS13bFollow",
+                    "text": "Have you had low back injection (such as epidural steroid injection, facet injection)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BIN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BIN_2",
+                                "display": "Yes, one injection"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BIN_3",
+                                "display": "Yes, more than one injection"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Since <DATE_OF_LAST_ASSESSMENT>",
+                    "item": [
+                        {
+                            "text": "This question helps measure results of back pain treatment.",
+                            "type": "display",
+                            "linkId": "/SO/MDS13bFollow-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13cFollow",
+                            "display": "Have you had physical therapy?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/SO/MDS13cFollow",
+                    "text": "Have you had physical therapy?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "NIH_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NIH_2",
+                                "display": "Yes, one series of treatments"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "NIH_3",
+                                "display": "Yes, more than one series of treatments"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Since <DATE_OF_LAST_ASSESSMENT>",
+                    "item": [
+                        {
+                            "text": "This question helps measure results of back pain treatment.",
+                            "type": "display",
+                            "linkId": "/SO/MDS13cFollow-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS13dFollow",
+                            "display": "Have you had psychological counseling for pain coping skills, such as cognitive-behavioral therapy (CBT)?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/SO/MDS13dFollow",
+                    "text": "Have you had psychological counseling for pain coping skills, such as cognitive-behavioral therapy (CBT)?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "BFN_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_2",
+                                "display": "Yes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "BFN_3",
+                                "display": "Not sure"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Since <DATE_OF_LAST_ASSESSMENT>",
+                    "item": [
+                        {
+                            "text": "This question helps measure results of back pain treatment.",
+                            "type": "display",
+                            "linkId": "/SO/MDS13dFollow-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS14Follow",
+                            "display": "Have you had to take time off work?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/SO/MDS14Follow",
+                    "text": "Have you had to take time off work?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "TOF_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TOF_2",
+                                "display": "Yes, less than a month"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TOF_3",
+                                "display": "Yes, more than a month"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "TOF_4",
+                                "display": "Does not apply"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Since <DATE_OF_LAST_ASSESSMENT>",
+                    "item": [
+                        {
+                            "text": "This question helps measure results of back pain treatment.",
+                            "type": "display",
+                            "linkId": "/SO/MDS14Follow-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS15Follow",
+                            "display": "Have you applied for disability?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/SO/MDS15Follow",
+                    "text": "Have you applied for disability?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "RTF_1",
+                                "display": "No"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RTF_2",
+                                "display": "Yes, workers compensation"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RTF_3",
+                                "display": "Yes, Social Security"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RTF_4",
+                                "display": "Yes, both workers comp and social security"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RTF_5",
+                                "display": "Does not apply"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Since <DATE_OF_LAST_ASSESSMENT>",
+                    "enableWhen": "",
+                    "item": [
+                        {
+                            "text": "This question helps measure results of back pain treatment.",
+                            "type": "display",
+                            "linkId": "/SO/MDS15Follow-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "SO-score",
+                            "display": "Safety Outcomes Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "so1_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS13aFollow').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS13aFollow').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "so2_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SO').item.where(linkId = '/SO/ERvisitFollow').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SO').item.where(linkId = '/SO/ERvisitFollow').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "so3_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS06Follow').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS06Follow').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "so4_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS13bFollow').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS13bFollow').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "so5_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS13cFollow').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS13cFollow').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "so6_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS13dFollow').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS13dFollow').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "so7_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS14Follow').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS14Follow').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "so8_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS15Follow').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SO').item.where(linkId = '/SO/MDS15Follow').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "any_questions_answered",
+                                "language": "text/fhirpath",
+                                "expression": "%so1_value.exists() or %so2_value.exists() or %so3_value.exists() or %so4_value.exists() or %so5_value.exists() or %so6_value.exists() or %so7_value.exists() or %so8_value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%any_questions_answered, iif(%so1_value.exists(), %so1_value, 0) + iif(%so2_value.exists(), %so2_value, 0) + iif(%so3_value.exists(), %so3_value, 0) + iif(%so4_value.exists(), %so4_value, 0) + iif(%so5_value.exists(), %so5_value, 0) + iif(%so6_value.exists(), %so6_value, 0) + iif(%so7_value.exists(), %so7_value, 0) + iif(%so8_value.exists(), %so8_value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SO/SO-score",
+                    "text": "Safety Outcomes Score"
+                }
+            ]
+        }
+    ],
+    "name": "Safety_Outcomes_Assessment"
+}

--- a/contrib/portal_templates/assessments/SDC FHIR/Shared_Decision_Making_Assessment.json
+++ b/contrib/portal_templates/assessments/SDC FHIR/Shared_Decision_Making_Assessment.json
@@ -1,0 +1,673 @@
+{
+    "resourceType": "Questionnaire",
+    "meta": {
+        "profile": [
+            "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire|2.7",
+            "http://hl7.org/fhir/4.0/StructureDefinition/Questionnaire"
+        ],
+        "tag": [
+            {
+                "code": "generated: PEER"
+            }
+        ]
+    },
+    "status": "active",
+    "title": "Shared Decision Making Assessment",
+    "subjectType": [
+        "Patient",
+        "Person"
+    ],
+    "item": [
+        {
+            "type": "group",
+            "code": [],
+            "required": false,
+            "linkId": "/DM",
+            "prefix": "Shared Decision Making",
+            "text": " The next three questions measure how involved you were in decisions regarding your treatment.",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "SDMunderstand",
+                            "display": "How much effort was made to help\u00a0you understand your back pain?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/DM/SDMunderstand",
+                    "text": "How much effort was made to help\u00a0you understand your back pain?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "COR_1",
+                                "display": "no effort at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_2",
+                                "display": "1"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_3",
+                                "display": "2"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_4",
+                                "display": "3"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_5",
+                                "display": "4"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_6",
+                                "display": "5"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_7",
+                                "display": "6"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 6
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_8",
+                                "display": "7"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 7
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_9",
+                                "display": "8"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 8
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_10",
+                                "display": "maximal effort was made"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 9
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Thinking about your appointment at PEER Clinic:",
+                    "item": [
+                        {
+                            "text": "This question helps measure the shared decison making process between you and your doctor/care provider.",
+                            "type": "display",
+                            "linkId": "/DM/SDMunderstand-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "SDMlisten",
+                            "display": "How much effort was made to listen\u00a0to the things that matter most to\u00a0you about your back pain?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/DM/SDMlisten",
+                    "text": "How much effort was made to listen\u00a0to the things that matter most to\u00a0you about your back pain?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "COR_1",
+                                "display": "no effort at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_2",
+                                "display": "1"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_3",
+                                "display": "2"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_4",
+                                "display": "3"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_5",
+                                "display": "4"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_6",
+                                "display": "5"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_7",
+                                "display": "6"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 6
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_8",
+                                "display": "7"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 7
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_9",
+                                "display": "8"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 8
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_10",
+                                "display": "maximal effort was made"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 9
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Thinking about the appointments you have had so far for [back pain]:",
+                    "item": [
+                        {
+                            "text": "This question helps measure the shared decison making process between you and your doctor/care provider.",
+                            "type": "display",
+                            "linkId": "/DM/SDMlisten-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "SDMinclude",
+                            "display": "How much effort was made to include\u00a0what matters most to you in choosing\u00a0what to do next?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/DM/SDMinclude",
+                    "text": "How much effort was made to include\u00a0what matters most to you in choosing\u00a0what to do next?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "COR_1",
+                                "display": "no effort at all"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_2",
+                                "display": "1"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_3",
+                                "display": "2"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_4",
+                                "display": "3"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_5",
+                                "display": "4"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_6",
+                                "display": "5"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_7",
+                                "display": "6"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 6
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_8",
+                                "display": "7"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 7
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_9",
+                                "display": "8"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 8
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "COR_10",
+                                "display": "maximal effort was made"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 9
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "Thinking about the appointments you have had so far for [back pain]:",
+                    "item": [
+                        {
+                            "text": "This question helps measure the shared decison making process between you and your doctor/care provider.",
+                            "type": "display",
+                            "linkId": "/DM/SDMinclude-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "DM-score",
+                            "display": "Shared Decision Making Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "dm1_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/DM').item.where(linkId = '/DM/SDMunderstand').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/DM').item.where(linkId = '/DM/SDMunderstand').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "dm2_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/DM').item.where(linkId = '/DM/SDMlisten').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/DM').item.where(linkId = '/DM/SDMlisten').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "dm3_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/DM').item.where(linkId = '/DM/SDMinclude').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/DM').item.where(linkId = '/DM/SDMinclude').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "any_questions_answered",
+                                "language": "text/fhirpath",
+                                "expression": "%dm1_value.exists() or %dm2_value.exists() or %dm3_value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%any_questions_answered, iif(%dm1_value.exists(), %dm1_value, 0) + iif(%dm2_value.exists(), %dm2_value, 0) + iif(%dm3_value.exists(), %dm3_value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/DM/DM-score",
+                    "text": "Shared Decision Making Score"
+                }
+            ]
+        }
+    ],
+    "name": "Shared_Decision_Making_Assessment"
+}

--- a/contrib/portal_templates/assessments/SDC FHIR/Social_Factors_Assessment.json
+++ b/contrib/portal_templates/assessments/SDC FHIR/Social_Factors_Assessment.json
@@ -1,0 +1,1694 @@
+{
+    "resourceType": "Questionnaire",
+    "meta": {
+        "profile": [
+            "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire|2.7",
+            "http://hl7.org/fhir/4.0/StructureDefinition/Questionnaire"
+        ],
+        "tag": [
+            {
+                "code": "generated: PEER"
+            }
+        ]
+    },
+    "status": "active",
+    "title": "Social Factors Assessment",
+    "subjectType": [
+        "Patient",
+        "Person"
+    ],
+    "item": [
+        {
+            "type": "group",
+            "code": [],
+            "required": false,
+            "linkId": "/SC",
+            "prefix": "Social Factors",
+            "text": "The next few questions ask about social factors that may help select the right treatment for you. This part will require about 2 minutes",
+            "item": [
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS40afeet",
+                            "display": "How tall are you? Enter feet here and inches in the next question. For example, for 5 feet and 6 inches, please anwser 5 feet in this question and 6 inches in the next question)",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/SC/MDS40afeet",
+                    "text": "How tall are you? Enter feet here and inches in the next question. For example, for 5 feet and 6 inches, please anwser 5 feet in this question and 6 inches in the next question)",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "FET_1",
+                                "display": "less than 4 feet"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FET_2",
+                                "display": "4 feet"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FET_3",
+                                "display": "5 feet"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FET_4",
+                                "display": "6 feet"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "FET_5",
+                                "display": "more than 6 feet"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "Height is used to calculate BMI (body mass index). BMI can help select the right treatment for you. The question was developed by the National\n Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results \n of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/SC/MDS40afeet-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS40ainch",
+                            "display": "What is your height? (enter inches here)",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/SC/MDS40ainch",
+                    "text": "What is your height? (enter inches here)",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "INC_1",
+                                "display": "0 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_2",
+                                "display": "1 inch"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_3",
+                                "display": "2 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_4",
+                                "display": "3 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_5",
+                                "display": "4 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_6",
+                                "display": "5 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_7",
+                                "display": "6 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 6
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_8",
+                                "display": "7 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 7
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_9",
+                                "display": "8 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 8
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_10",
+                                "display": "9 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 9
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_11",
+                                "display": "10 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 10
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "INC_12",
+                                "display": "11 inches"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 11
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "Height is used to calculate BMI (body mass index). BMI can help select the right treatment for you. The question was developed \nby the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if \nresults of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/SC/MDS40ainch-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS40b",
+                            "display": "What is your weight? (pounds)",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/SC/MDS40b",
+                    "text": "What is your weight? (pounds)",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "PDS_1",
+                                "display": "<100lbs"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_2",
+                                "display": "100-120 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_3",
+                                "display": "121-140 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_4",
+                                "display": "141-160 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_5",
+                                "display": "161-180 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_6",
+                                "display": "181-200 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_7",
+                                "display": "201-220 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 6
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_8",
+                                "display": "221-240 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 7
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_9",
+                                "display": "241-260 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 8
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_10",
+                                "display": "261-280 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 9
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_11",
+                                "display": "281-300 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 10
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "PDS_12",
+                                "display": "more than 300 pounds"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 11
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "Weight is used to calculate BMI (body mass index). BMI can help select the right treatment for you. The question was developed by\n the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine \n if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/SC/MDS40b-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS39",
+                            "display": "How would you describe your cigarette smoking?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/SC/MDS39",
+                    "text": "How would you describe your cigarette smoking?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "SMK_1",
+                                "display": "Never smoked"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SMK_2",
+                                "display": "Current smoker"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "SMK_3",
+                                "display": "Used to smoke, but have now quit"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "Smoking can affect pain severity and also help choose the right treatment. The question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/SC/MDS39-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS31",
+                            "display": "Have you drunk or used drugs more than you meant to?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/SC/MDS31",
+                    "text": "Have you drunk or used drugs more than you meant to?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "ALC_1",
+                                "display": "Never"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ALC_2",
+                                "display": "Rarely"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ALC_3",
+                                "display": "Sometimes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ALC_4",
+                                "display": "Often"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past year",
+                    "item": [
+                        {
+                            "text": "Alcohol use can influence risks of different treatments. The question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/SC/MDS31-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS32",
+                            "display": "Have you felt you wanted or needed to cut down on your drinking or drug use?",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/SC/MDS32",
+                    "text": "Have you felt you wanted or needed to cut down on your drinking or drug use?",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "ALC_1",
+                                "display": "Never"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ALC_2",
+                                "display": "Rarely"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ALC_3",
+                                "display": "Sometimes"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ALC_4",
+                                "display": "Often"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "In the past year",
+                    "enableWhen": [
+                        {
+                            "question": "/SC/MDS31",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "ALC_2"
+                            }
+                        },
+                        {
+                            "question": "/SC/MDS31",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "ALC_3"
+                            }
+                        },
+                        {
+                            "question": "/SC/MDS31",
+                            "operator": "=",
+                            "answerCoding": {
+                                "code": "ALC_4"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "text": "Alcohol use can influence risks of different treatments. The question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/SC/MDS32-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS37",
+                            "display": "Employment Status:",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/SC/MDS37",
+                    "text": "Employment Status:",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "EMP_1",
+                                "display": "Working now"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EMP_2",
+                                "display": "Sick leave"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EMP_3",
+                                "display": "Temporary disability"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EMP_4",
+                                "display": "Permanently disability"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EMP_5",
+                                "display": "Temporarily laid off"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EMP_6",
+                                "display": "Looking/unemployed"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 6
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EMP_7",
+                                "display": "Keeping house"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 7
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EMP_8",
+                                "display": "Student"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 8
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EMP_9",
+                                "display": "Retired"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 9
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EMP_10",
+                                "display": "Other"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 10
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "Work status is predicitive of outcomes. The question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/SC/MDS37-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS38",
+                            "display": "Select the highest education level attained",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/SC/MDS38",
+                    "text": "Select the highest education level attained",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "EDU_1",
+                                "display": "No high school diploma"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EDU_2",
+                                "display": "High school or GED"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EDU_3",
+                                "display": "Some college, no degree"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EDU_4",
+                                "display": "Occupational program"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EDU_5",
+                                "display": "Associate degree"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EDU_6",
+                                "display": "Bachelors degree"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 6
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EDU_7",
+                                "display": "Masters degree"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 7
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EDU_8",
+                                "display": "Doctoral degree"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 8
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "EDU_9",
+                                "display": "Prefer not to report"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "Education level is predicitive of outcomes. The question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/SC/MDS38-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS36",
+                            "display": "Choose the race with which you most closely identify",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/SC/MDS36",
+                    "text": "Choose the race with which you most closely identify",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "RAC_1",
+                                "display": "American/Alaska Native"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RAC_2",
+                                "display": "Asian"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RAC_3",
+                                "display": "Black/African-American"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RAC_4",
+                                "display": "Hawaiian/Pacific Islander"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RAC_5",
+                                "display": "White"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 5
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RAC_6",
+                                "display": "Other"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 6
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "RAC_7",
+                                "display": "Prefer not to answer"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "Race can be predicitive of outcomes. It can be associated to certain diagnoses and outcomes. The question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/SC/MDS36-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "choice",
+                    "code": [
+                        {
+                            "code": "MDS35",
+                            "display": "Choose the ethnicity with which you most closely identify",
+                            "system": "http://hl7.org/fhir/StructureDefinition/code"
+                        }
+                    ],
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "radio-button",
+                                        "display": "Radio Button"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "required": true,
+                    "linkId": "/SC/MDS35",
+                    "text": "Choose the ethnicity with which you most closely identify",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "ETH_1",
+                                "display": "Hispanic or Latino"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ETH_2",
+                                "display": "Not Hispanic or Latino"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ETH_3",
+                                "display": "Unknown"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ]
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "ETH_4",
+                                "display": "Prefer not to answer"
+                            },
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 4
+                                }
+                            ]
+                        }
+                    ],
+                    "prefix": "",
+                    "item": [
+                        {
+                            "text": "Ethnicity may be predicitive of outcomes. It can be associated to certain diagnoses and outcomes. The question was developed by the National Institutes of Health Task Force on Research Standards for Chronic Low Back Pain. Your response helps determine if results of research on back pain apply to you.",
+                            "type": "display",
+                            "linkId": "/SC/MDS35-help",
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "text": "Help-Button",
+                                        "coding": [
+                                            {
+                                                "code": "help",
+                                                "display": "Help-Button",
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "decimal",
+                    "code": [
+                        {
+                            "code": "SC-score",
+                            "display": "Social Factors Score"
+                        }
+                    ],
+                    "readOnly": true,
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "scoreExt",
+                                "language": "text/fhirpath",
+                                "expression": "'http://hl7.org/fhir/StructureDefinition/ordinalValue'"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationLinkPeriod",
+                            "valueDuration": {
+                                "value": 100,
+                                "unit": "year",
+                                "system": "http://unitsofmeasure.org",
+                                "code": "a"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                            "valueBoolean": true
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                            "valueCoding": {
+                                "display": "{score}"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "sc1_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS40afeet').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS40afeet').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "sc2_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS40ainch').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS40ainch').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "sc3_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS40b').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS40b').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "sc4_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS39').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS39').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "sc5_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS31').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS31').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "sc6_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS32').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS32').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "sc7_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS37').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS37').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "sc8_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS38').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS38').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "sc9_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS36').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS36').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "sc10_value",
+                                "language": "text/fhirpath",
+                                "expression": "%questionnaire.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS35').answerOption.where(valueCoding.code=%resource.item.where(linkId = '/SC').item.where(linkId = '/SC/MDS35').answer.valueCoding.code).extension.where(url=%scoreExt).valueDecimal"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                            "valueExpression": {
+                                "name": "any_questions_answered",
+                                "language": "text/fhirpath",
+                                "expression": "%sc1_value.exists() or %sc2_value.exists() or %sc3_value.exists() or %sc4_value.exists() or %sc5_value.exists() or %sc6_value.exists() or %sc7_value.exists() or %sc8_value.exists() or %sc9_value.exists() or %sc10_value.exists()"
+                            }
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                            "valueExpression": {
+                                "description": "Total score calculation",
+                                "language": "text/fhirpath",
+                                "expression": "iif(%any_questions_answered, iif(%sc1_value.exists(), %sc1_value, 0) + iif(%sc2_value.exists(), %sc2_value, 0) + iif(%sc3_value.exists(), %sc3_value, 0) + iif(%sc4_value.exists(), %sc4_value, 0) + iif(%sc5_value.exists(), %sc5_value, 0) + iif(%sc6_value.exists(), %sc6_value, 0) + iif(%sc7_value.exists(), %sc7_value, 0) + iif(%sc8_value.exists(), %sc8_value, 0) + iif(%sc9_value.exists(), %sc9_value, 0) + iif(%sc10_value.exists(), %sc10_value, 0), {})"
+                            }
+                        }
+                    ],
+                    "required": false,
+                    "linkId": "/SC/SC-score",
+                    "text": "Social Factors Score"
+                }
+            ]
+        }
+    ],
+    "name": "Social_Factors_Assessment"
+}


### PR DESCRIPTION
Numerous Questionnaires for pain management.
The three questionnaire set  After_Visit_Assessment.json, Follow_Up_Assessment.json and Pain_Initial_Assessment allows complete pain evaluation. To use import from Portal Dashboard to templates and Questionnaire Resource.

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #7971

#### Short description of what this resolve
All forms need re validation since last SDC release. I've already have done the Pain Initial Assessment.
