### PR TITLE
Fixes #7907 load forms from a module

### DIFF
--- a/interface/patient_file/encounter/forms.php
+++ b/interface/patient_file/encounter/forms.php
@@ -33,8 +33,8 @@ use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Core\Header;
-use OpenEMR\Events\Encounter\EncounterMenuEvent;
 use OpenEMR\Events\Encounter\EncounterFormsListRenderEvent;
+use OpenEMR\Events\Encounter\EncounterMenuEvent;
 use OpenEMR\Common\Forms\FormLocator;
 use OpenEMR\Common\Forms\FormReportRenderer;
 

--- a/interface/patient_file/encounter/forms.php
+++ b/interface/patient_file/encounter/forms.php
@@ -13,6 +13,14 @@
  */
 
 require_once(__DIR__ . "/../../globals.php");
+/**
+ * @global $srcdir
+ * @global $attendant_type
+ * @global $therapy_group
+ * @global $pid
+ * @global $userauthorized
+ * @global $rootdir
+ */
 require_once("$srcdir/encounter.inc.php");
 require_once("$srcdir/group.inc.php");
 require_once("$srcdir/patient.inc.php");
@@ -26,10 +34,13 @@ use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Core\Header;
 use OpenEMR\Events\Encounter\EncounterMenuEvent;
+use OpenEMR\Events\Encounter\EncounterFormsListRenderEvent;
+use OpenEMR\Common\Forms\FormLocator;
+use OpenEMR\Common\Forms\FormReportRenderer;
+
 use OpenEMR\Services\EncounterService;
 use OpenEMR\Services\UserService;
 use Symfony\Component\EventDispatcher\EventDispatcher;
-use OpenEMR\Events\Encounter\EncounterFormsListRenderEvent;
 
 $expand_default = (int)$GLOBALS['expand_form'] ? 'show' : 'hide';
 $reviewMode = false;
@@ -56,7 +67,8 @@ if ($GLOBALS['kernel']->getEventDispatcher() instanceof EventDispatcher) {
 } else {
     throw new Exception("Could not get EventDispatcher from kernel", 1);
 }
-
+// instantiate the locator at the beginning so our file caching can be re-used.
+$formLocator = new FormLocator();
 ?>
 <!DOCTYPE html>
 <html>
@@ -970,22 +982,9 @@ if (
 
         // Use the form's report.php for display.  Forms with names starting with LBF
         // are list-based forms sharing a single collection of code.
-        //
-        if (substr($formdir, 0, 3) == 'LBF') {
-            include_once($GLOBALS['incdir'] . "/forms/LBF/report.php");
-            lbf_report($attendant_id, $encounter, 2, $iter['form_id'], $formdir, true);
-        } else {
-            if (file_exists($GLOBALS['incdir'] . "/forms/$formdir/report.php")) {
-                include_once($GLOBALS['incdir'] . "/forms/$formdir/report.php");
-                if (function_exists($formdir . "_report")) {
-                    call_user_func($formdir . "_report", $attendant_id, $encounter, 2, $iter['form_id']);
-                } else {
-                    (new \OpenEMR\Common\Logging\SystemLogger())->errorLogCaller("form is missing report function", ['formdir' => $formdir]);
-                }
-            } else {
-                (new \OpenEMR\Common\Logging\SystemLogger())->errorLogCaller("form is missing report.php file", ['formdir' => $formdir]);
-            }
-        }
+        $reportRenderer = new FormReportRenderer($formLocator);
+        $reportColumns = 2;
+        $reportRenderer->renderReport($formdir, 'forms.php', $attendant_id, $encounter, $reportColumns, $iter['form_id']);
 
         if ($esign->isLogViewable()) {
             $esign->renderLog();

--- a/interface/patient_file/encounter/load_form.php
+++ b/interface/patient_file/encounter/load_form.php
@@ -16,12 +16,21 @@ require_once("../../globals.php");
 require_once("../../../library/registry.inc.php");
 
 use OpenEMR\Common\Acl\AclMain;
+use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Common\Forms\FormLocator;
 use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\Events\Encounter\LoadEncounterFormFilterEvent;
+use OpenEMR\Core\ModulesApplication;
 
-if (substr($_GET["formname"], 0, 3) === 'LBF') {
-    // Use the List Based Forms engine for all LBFxxxxx forms.
-    include_once("$incdir/forms/LBF/new.php");
-} else {
+check_file_dir_name($_GET['formname']);
+/**
+ * @gloal $incdir the include directory
+ */
+$incdir = $incdir ?? "";
+
+$pageName = "new.php";
+$isLBF = false;
+if (!str_starts_with($_GET["formname"], 'LBF')) {
     if ((!empty($_GET['pid'])) && ($_GET['pid'] > 0)) {
         $pid = $_GET['pid'];
         $encounter = $_GET['encounter'];
@@ -37,9 +46,10 @@ if (substr($_GET["formname"], 0, 3) === 'LBF') {
         echo (new TwigContainer(null, $GLOBALS['kernel']))->getTwig()->render('core/unauthorized.html.twig', ['pageTitle' => $formLabel]);
         exit;
     }
-
-    include_once("$incdir/forms/" . $_GET["formname"] . "/new.php");
 }
+$formLocator = new FormLocator();
+$file = $formLocator->findFile($_GET['formname'], 'view.php', 'load_form.php');
+require_once($file);
 
 if (!empty($GLOBALS['text_templates_enabled']) && !($_GET['formname'] == 'fee_sheet')) { ?>
     <script src="<?php echo $GLOBALS['web_root'] ?>/library/js/CustomTemplateLoader.js"></script>

--- a/interface/patient_file/encounter/load_form.php
+++ b/interface/patient_file/encounter/load_form.php
@@ -16,20 +16,15 @@ require_once("../../globals.php");
 require_once("../../../library/registry.inc.php");
 
 use OpenEMR\Common\Acl\AclMain;
-use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Common\Forms\FormLocator;
 use OpenEMR\Common\Twig\TwigContainer;
-use OpenEMR\Events\Encounter\LoadEncounterFormFilterEvent;
-use OpenEMR\Core\ModulesApplication;
 
-check_file_dir_name($_GET['formname']);
 /**
  * @gloal $incdir the include directory
  */
 $incdir = $incdir ?? "";
 
 $pageName = "new.php";
-$isLBF = false;
 if (!str_starts_with($_GET["formname"], 'LBF')) {
     if ((!empty($_GET['pid'])) && ($_GET['pid'] > 0)) {
         $pid = $_GET['pid'];
@@ -48,7 +43,7 @@ if (!str_starts_with($_GET["formname"], 'LBF')) {
     }
 }
 $formLocator = new FormLocator();
-$file = $formLocator->findFile($_GET['formname'], 'view.php', 'load_form.php');
+$file = $formLocator->findFile($_GET['formname'], $pageName, 'load_form.php');
 require_once($file);
 
 if (!empty($GLOBALS['text_templates_enabled']) && !($_GET['formname'] == 'fee_sheet')) { ?>

--- a/interface/patient_file/encounter/view_form.php
+++ b/interface/patient_file/encounter/view_form.php
@@ -7,27 +7,75 @@
  * @link      http://www.open-emr.org
  * @author    Brady Miller <brady.g.miller@gmail.com>
  * @author    Jerry Padgett <sjpadgett@gmail.com>
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
  * @copyright Copyright (c) 2018 Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2019 Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright Copyright (c) 2024 Sophisticated Acquisitions <sophisticated.acquisitions@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
 require_once("../../globals.php");
 
+use OpenEMR\Common\Acl\AclMain;
+use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\Core\ModulesApplication;
+use OpenEMR\Events\Encounter\LoadEncounterFormFilterEvent;
+
 $clean_id = sanitizeNumber($_GET["id"]);
 
+$pageName = 'view.php';
+$isLBF = false;
+/**
+ * @global $incdir
+ */
 if (substr($_GET["formname"], 0, 3) === 'LBF') {
+    $dir = "$incdir/forms/LBF/";
+    $isLBF = true;
     // Use the List Based Forms engine for all LBFxxxxx forms.
-    include_once("$incdir/forms/LBF/view.php");
 } else {
+    if ((!empty($_GET['pid'])) && ($_GET['pid'] > 0)) {
+        $pid = $_GET['pid'];
+        $encounter = $_GET['encounter'];
+    }
+
     // ensure the path variable has no illegal characters
     check_file_dir_name($_GET["formname"]);
 
-    include_once("$incdir/forms/" . $_GET["formname"] . "/view.php");
+    // ensure authorized to see the form
+    if (!AclMain::aclCheckForm($_GET["formname"])) {
+        $formLabel = xl_form_title(getRegistryEntryByDirectory($_GET["formname"], 'name')['name'] ?? '');
+        $formLabel = (!empty($formLabel)) ? $formLabel : $_GET["formname"];
+        echo (new TwigContainer(null, $GLOBALS['kernel']))->getTwig()->render('core/unauthorized.html.twig', ['pageTitle' => $formLabel]);
+        exit;
+    }
+    $dir = "$incdir/forms/" . $_GET["formname"] . "/";
 }
 
-$id = $clean_id;
+$encounterLoadFormEvent = new LoadEncounterFormFilterEvent($_GET["formname"], $dir, $pageName);
+$encounterLoadFormEvent->setPid($pid ?? null);
+$encounterLoadFormEvent->setEncounter($encounter ?? null);
+$encounterLoadFormEvent->setIsLayoutBasedForm($isLBF);
+$event = $GLOBALS['kernel']->getContainer()->get('event_dispatcher')->dispatch($encounterLoadFormEvent, LoadEncounterFormFilterEvent::EVENT_NAME);
+$formDirToInclude = $dir . $pageName;
+if (
+    $event instanceof LoadEncounterFormFilterEvent
+    && $event->getFormIncludePath() !== null
+    && $event->getFormIncludePath() != $formDirToInclude
+) {
+    // currently we do not allow rerouting from one form to another, the event ONLY allows inclusion within the modules
+    if (ModulesApplication::isSafeModuleFileForInclude($event->getFormIncludePath())) {
+        $formDirToInclude = $event->getFormIncludePath();
+    } else {
+        (new SystemLogger())->errorLogCaller(
+            "Module attempted to load a file outside of its directory",
+            ['file' => $event->getFormIncludePath(), 'formdir' => $event->getFormName()]
+        );
+    }
+}
+include_once($formDirToInclude);
 
+$id = $clean_id;
 if (!empty($GLOBALS['text_templates_enabled'])) { ?>
     <script src="<?php echo $GLOBALS['web_root'] ?>/library/js/CustomTemplateLoader.js"></script>
 <?php } ?>

--- a/interface/patient_file/history/encounters_ajax.php
+++ b/interface/patient_file/history/encounters_ajax.php
@@ -16,6 +16,7 @@ require_once("../../globals.php");
 require_once("$srcdir/forms.inc.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Forms\FormReportRenderer;
 
 if (!CsrfUtils::verifyCsrfToken($_GET["csrf_token_form"])) {
     CsrfUtils::csrfNotVerified();
@@ -32,16 +33,5 @@ $formid   = $_GET['formid'] + 0;
 if (!hasFormPermission($formname)) {
     exit;
 }
-
-if (substr($formname, 0, 3) == 'LBF') {
-    include_once("{$GLOBALS['incdir']}/forms/LBF/report.php");
-    lbf_report($ptid, $encid, 2, $formid, $formname);
-} else {
-    include_once("{$GLOBALS['incdir']}/forms/$formname/report.php");
-    $report_function = $formname . '_report';
-    if (!function_exists($report_function)) {
-        exit;
-    }
-
-    call_user_func($report_function, $ptid, $encid, 2, $formid);
-}
+$formReportRenderer = new FormReportRenderer();
+$formReportRenderer->renderReport($formname, "encounters_ajax.php", $ptid, $encid, 2, $formid);

--- a/interface/patient_file/report/custom_report.php
+++ b/interface/patient_file/report/custom_report.php
@@ -30,12 +30,12 @@ require_once($GLOBALS['fileroot'] . "/controllers/C_Document.class.php");
 use ESign\Api;
 use Mpdf\Mpdf;
 use OpenEMR\Common\Acl\AclMain;
+use OpenEMR\Common\Forms\FormReportRenderer;
 use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Core\Header;
 use OpenEMR\MedicalDevice\MedicalDevice;
 use OpenEMR\Pdf\Config_Mpdf;
 use OpenEMR\Services\FacilityService;
-use OpenEMR\Common\Forms\FormReportRenderer;
 
 if (!AclMain::aclCheckCore('patients', 'pat_rep')) {
     echo (new TwigContainer(null, $GLOBALS['kernel']))->getTwig()->render('core/unauthorized.html.twig', ['pageTitle' => xl("Custom Report")]);

--- a/src/Common/Forms/FormLocator.php
+++ b/src/Common/Forms/FormLocator.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * This class is used to locate the form files for the encounter forms.
+ * @package openemr
+ * @license   There are segments of code in this file that have been generated via Claude.ai and are licensed as Public Domain.  They have been marked with a header and footer.
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2025 Discover and Change, Inc. <snielson@discoverandchange.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+// AI GENERATED CODE: HEADER START
+namespace OpenEMR\Common\Forms;
+
+use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Core\ModulesApplication;
+use OpenEMR\Events\Encounter\LoadEncounterFormFilterEvent;
+
+class FormLocator
+{
+    private array $pathCache = [];
+    private string $fileRoot;
+    private SystemLogger $logger;
+
+    // AI GENERATED CODE: HEADER END
+    public function __construct(?SystemLogger $logger = null)
+    {
+        if (!$logger) {
+            $logger = new SystemLogger();
+        }
+        $this->logger = $logger;
+    // AI GENERATED CODE: HEADER START
+        $this->fileRoot = $GLOBALS['fileroot'];
+    }
+
+    public function findFile(string $formDir, string $fileName, string $page): string
+    {
+        $cacheKey = $this->buildCacheKey($formDir, $fileName, $page);
+
+        if (isset($this->pathCache[$cacheKey])) {
+            return $this->pathCache[$cacheKey];
+        }
+
+        $path = $this->locateFile($formDir, $fileName, $page);
+        $this->pathCache[$cacheKey] = $path;
+
+        return $path;
+    }
+
+    private function buildCacheKey(string $formDir, string $fileName, string $page): string
+    {
+        return implode(':', [$formDir, $fileName, $page]);
+    }
+
+    private function locateFile(string $formDir, string $fileName, string $page): string
+    {
+        $isLBF = substr($formDir, 0, 3) === 'LBF';
+        $basePath = $isLBF ? "/interface/forms/LBF/" : "/interface/forms/{$formDir}/";
+        $initialPath = $this->fileRoot . $basePath;
+        $initialFilename = $initialPath . $fileName;
+        $event = new LoadEncounterFormFilterEvent($formDir, $initialPath, $fileName);
+        $event->setIsLayoutBasedForm($isLBF);
+
+        // AI GENERATED CODE: HEADER END
+        $filteredEvent = $GLOBALS['kernel']->getEventDispatcher()->dispatch($event, LoadEncounterFormFilterEvent::EVENT_NAME);
+
+        $finalPath = $filteredEvent->getFormIncludePath();
+        if ($finalPath != $initialFilename) {
+            if (ModulesApplication::isSafeModuleFileForInclude($finalPath)) {
+                return $finalPath;
+            } else {
+                $this->logger->errorLogCaller(
+                    "Module attempted to load a file outside of its directory",
+                    ['file' => $event->getFormIncludePath(), 'formdir' => $event->getFormName()]
+                );
+            }
+        }
+        if (!file_exists($finalPath)) {
+            $this->logger->errorLogCaller("form is missing report.php file", ['file' => $finalPath, 'formdir' => $formDir]);
+        }
+        // AI GENERATED CODE: HEADER START
+
+        return $finalPath;
+    }
+}

--- a/src/Common/Forms/FormReportRenderer.php
+++ b/src/Common/Forms/FormReportRenderer.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This class is used to render the report for the encounter forms. It takes into account any module
+ * forms and will render the report for the form.
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2025 Discover and Change, Inc. <snielson@discoverandchange.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Common\Forms;
+
+use OpenEMR\Common\Logging\SystemLogger;
+
+class FormReportRenderer
+{
+    private SystemLogger $logger;
+    private FormLocator $locator;
+    public function __construct(?FormLocator $locator = null, ?SystemLogger $logger = null)
+    {
+        $this->locator = $locator ?? new FormLocator();
+        $this->logger = $logger ?? new SystemLogger();
+    }
+
+    public function renderReport(string $formDir, string $page, $attendant_id, $encounter, $columns, $formId, $noWrap = true)
+    {
+        $isLBF = str_starts_with($formDir, 'LBF');
+        $formLocator = new FormLocator();
+        $formPath = $formLocator->findFile($formDir, 'report.php', $page);
+        include $formPath;
+        if ($isLBF) {
+            lbf_report($attendant_id, $encounter, $columns, $formId, $formDir, $noWrap);
+        } else {
+            if (function_exists($formDir . "_report")) {
+                call_user_func($formDir . "_report", $attendant_id, $encounter, $columns, $formId);
+            } else {
+                $this->logger->errorLogCaller("form is missing report function", ['formdir' => $formDir, 'formId' => $formId]);
+            }
+        }
+    }
+}

--- a/src/Core/ModulesApplication.php
+++ b/src/Core/ModulesApplication.php
@@ -188,6 +188,23 @@ class ModulesApplication
     }
 
     /**
+     * Checks to make sure the file originates in a module directory and is safe to include.
+     * @param $file
+     * @return bool
+     */
+    public static function isSafeModuleFileForInclude($file)
+    {
+        $realpath = realpath($file);
+        $moduleRootLocation = realpath($GLOBALS['fileroot'] . DIRECTORY_SEPARATOR . 'interface' . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR);
+
+        // make sure we haven't left our root path ie interface folder
+        if (strpos($realpath, $moduleRootLocation) === 0 && file_exists($realpath) && strpos($realpath, ".php") !== false) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * Given a list of module files (javascript, css, etc) make sure they are locked down to be just inside the modules
      * folder.  The intent is to prevent module writers from including files outside the modules installation directory.
      * If the file exists and is inside the modules installation path it will be returned.  Otherwise it is filtered out

--- a/src/Events/Encounter/LoadEncounterFormFilterEvent.php
+++ b/src/Events/Encounter/LoadEncounterFormFilterEvent.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * LoadEncounterFormFilterEvent.php
+ *
+ * This event handles the filtering of forms that are loaded for an encounter.  This event is triggered
+ * in the view_form.php, load_form.php, and forms.php files for encounter forms.
+ *
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2024 Sophisticated Acquisitions <sophisticated.acquisitions@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Events\Encounter;
+
+class LoadEncounterFormFilterEvent
+{
+    const EVENT_NAME = 'encounter.load_form_filter';
+    private $formName;
+    private $dir;
+    private $pageName;
+    private ?int $pid;
+    private ?int $encounter;
+    private bool $isLBF = false;
+
+    /**
+     * @param mixed $formname
+     * @param string $dir
+     * @param string $pageName
+     */
+    public function __construct(string $formname, string $dir, string $pageName)
+    {
+        // if the directory does not exist in the core filesystem we set the dir initially knowing it will be
+        // incorrect but we will validate it later
+        $this->dir = $dir;
+        $this->pageName = $pageName;
+        $this->setFormName($formname);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getFormName()
+    {
+        return $this->formName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPageName(): string
+    {
+        return $this->pageName;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getPid(): ?int
+    {
+        return $this->pid;
+    }
+
+    /**
+     * @param int|null $pid
+     */
+    public function setPid(?int $pid): void
+    {
+        $this->pid = $pid;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getDir()
+    {
+        return $this->dir;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getEncounter(): ?int
+    {
+        return $this->encounter;
+    }
+
+    /**
+     * @param int|null $encounter
+     */
+    public function setEncounter(?int $encounter): void
+    {
+        $this->encounter = $encounter;
+    }
+
+    /**
+     * Will die if form name is invalid characters
+     * @param mixed $formName
+     */
+    public function setFormName(string $formName): void
+    {
+        check_file_dir_name($formName);
+        $this->formName = $formName;
+    }
+
+    /**
+     * @param mixed $pageName
+     */
+    public function setPageName(string $pageName): void
+    {
+        $this->pageName = $pageName;
+    }
+
+    /**
+     * @param string $dir  The directory as a string (note the path will be concatenated to $GLOBALS['fileroot']
+     * @throws \InvalidArgumentException if the path is invalid or does not exist.  Paths must currently be within the /interface/forms/ directory or the /interface/modules/ directory
+     */
+    public function setDir(string $dir): void
+    {
+        $this->validatePath($dir);
+        $this->dir = $dir;
+    }
+
+    public function getFormIncludePath()
+    {
+        return $this->dir . $this->pageName;
+    }
+
+    private function validatePath($path)
+    {
+        $path = realpath($path);
+        // for now we will lock this down to just the forms directory or to the modules directory
+        $inModules = strpos($path, $GLOBALS['fileroot'] . '/interface/modules/') === 0;
+        $inForms = strpos($path, $GLOBALS['fileroot'] . '/interface/forms/') === 0;
+        if (!(($inModules || $inForms) && file_exists($path))) {
+            throw new \InvalidArgumentException('Invalid path');
+        }
+    }
+
+    public function setIsLayoutBasedForm(bool $isLBF)
+    {
+        $this->isLBF = $isLBF;
+    }
+    public function isLayoutBasedForm(): bool
+    {
+        return $this->isLBF;
+    }
+}


### PR DESCRIPTION
This implements the loading of a form from a module using events.  This allows the module writer to customize the directory of an existing form or to implement their own forms.

It assumes that forms will be added to the registry via the module's table.sql.  It does NOT modify the forms administration piece.  That is still a work in progress.

I implemented also a FormLocator class for finding the paths for a form and caching the file.  Caching is based upon the formdir, page request (visit.php, report,php, new.php), and the current report page.

The report renderer got added everywhere that the LBF / standard forms are rendered.

Also added a safety mechanism to the ModulesApplication to make sure a module can only include files that are inside the module.

Added a new event LoadEncounterFormFilterEvent that gets fired whenever an encounter form is going to be loaded that module writers can hook into.

Fixes #7907

#### Does your code include anything generated by an AI Engine? Yes