### PR TITLE
Utility import_ccda Fixes

### DIFF
--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php
@@ -274,7 +274,9 @@ class CarecoordinationTable extends AbstractTableGateway
             $index = 0;
             foreach ($xml['recordTarget']['patientRole']['patient']['name'] as $i => $iValue) {
                 if ($iValue['use'] === 'L') {
-                    $index = $i;
+                    if (!$i) { // only grab first legal name
+                        $index = $i;
+                    }
                 }
                 if ($iValue['given'][0]['qualifier'] ?? '' === 'BR') {
                     $this->documentData['field_name_value_array']['patient_data'][1]['birth_fname'] = $iValue['given'][0]['_'] ?? null;
@@ -1125,7 +1127,7 @@ class CarecoordinationTable extends AbstractTableGateway
     // hmm, can't find where this is used.
 
     /**
-     * @param $document_id
+     * @param      $document_id
      * @return void
      * @throws Exception
      */

--- a/src/Services/Cda/CdaComponentParseHelpers.php
+++ b/src/Services/Cda/CdaComponentParseHelpers.php
@@ -168,7 +168,7 @@ class CdaComponentParseHelpers
         $lastName = $patientData['names'][0]['family'];
         $dob = date("Y-m-d", strtotime($patientData['dob']));
         $phone = preg_replace('/\D/', '', $patientData['phones'][0]);
-        $address = implode(" ", $patientData['address']['street']);
+        $address = trim($patientData['address']['street'][0] ?? '');
 
         $sql = "SELECT pid, fname, lname, DOB, phone_home, phone_cell, phone_biz, street, city, state, postal_code
             FROM patient_data


### PR DESCRIPTION
fix duplicate check to continue logic.
fix parse for current legal name if more than one. i.e. previous name. 
relax address to one line in duplicate check
show a dot per import for a run status

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #
