### PR TITLE
appointments report csv file header row does not match report headers

### DIFF
--- a/interface/reports/appointments_report.php
+++ b/interface/reports/appointments_report.php
@@ -464,8 +464,19 @@ if (!empty($_POST['form_refresh']) || !empty($_POST['form_orderby'])) {
     $appointments = sortAppointments($appointments, $form_orderby);
     if (!empty($_POST['form_csvexport'])) {
         // include provider as well
-          $fields = ['ufname','ulname','pc_eventDate', 'pc_startTime', 'fname', 'lname', 'DOB'];
-           $spreadsheet = new SpreadSheetService($appointments, $fields, 'appts');
+        //  $fields = ['ufname','ulname','pc_eventDate', 'pc_startTime', 'fname', 'lname', 'DOB'];
+        // RM generate csv file with same column headers row as used in the report itself
+           $fields = ['Provider','Date', 'Time', 'Patient', 'DOB'];
+
+              for ($i = 0; $i < count($appointments); ++$i) {
+              $appointments[$i]["Provider"] = $appointments[$i]["ulname"] . ',' . $appointments[$i]["ufname"] . ' ' .  $appointments[$i]["umname"] ;
+              $csvfields[$i]["Provider"] = $appointments[$i]["Provider"] ;
+              $csvfields[$i]["Date"] = $appointments[$i]["pc_eventDate"] ;
+              $csvfields[$i]["Time"] = $appointments[$i]["pc_startTime"] ;
+              $csvfields[$i]["Patient"] = $appointments[$i]["fname"] . " " .  $appointments[$i]["lname"] ;
+              $csvfields[$i]["DOB"] = $appointments[$i]["DOB"] ;
+           }
+           $spreadsheet = new SpreadSheetService($csvfields, $fields, 'appts');
         if (!empty($spreadsheet->buildSpreadsheet())) {
             $spreadsheet->downloadSpreadsheet('Csv');
         }

--- a/interface/reports/appointments_report.php
+++ b/interface/reports/appointments_report.php
@@ -466,17 +466,16 @@ if (!empty($_POST['form_refresh']) || !empty($_POST['form_orderby'])) {
         // include provider as well
         //  $fields = ['ufname','ulname','pc_eventDate', 'pc_startTime', 'fname', 'lname', 'DOB'];
         // RM generate csv file with same column headers row as used in the report itself
-           $fields = ['Provider','Date', 'Time', 'Patient', 'DOB'];
-
-              for ($i = 0; $i < count($appointments); ++$i) {
+        $fields = ['Provider','Date', 'Time', 'Patient', 'DOB'];
+        for ($i = 0; $i < count($appointments); ++$i) {
               $appointments[$i]["Provider"] = $appointments[$i]["ulname"] . ',' . $appointments[$i]["ufname"] . ' ' .  $appointments[$i]["umname"] ;
               $csvfields[$i]["Provider"] = $appointments[$i]["Provider"] ;
               $csvfields[$i]["Date"] = $appointments[$i]["pc_eventDate"] ;
               $csvfields[$i]["Time"] = $appointments[$i]["pc_startTime"] ;
               $csvfields[$i]["Patient"] = $appointments[$i]["fname"] . " " .  $appointments[$i]["lname"] ;
               $csvfields[$i]["DOB"] = $appointments[$i]["DOB"] ;
-           }
-           $spreadsheet = new SpreadSheetService($csvfields, $fields, 'appts');
+          }
+        $spreadsheet = new SpreadSheetService($csvfields, $fields, 'appts');
         if (!empty($spreadsheet->buildSpreadsheet())) {
             $spreadsheet->downloadSpreadsheet('Csv');
         }

--- a/interface/reports/appointments_report.php
+++ b/interface/reports/appointments_report.php
@@ -474,7 +474,7 @@ if (!empty($_POST['form_refresh']) || !empty($_POST['form_orderby'])) {
               $csvfields[$i]["Time"] = $appointments[$i]["pc_startTime"] ;
               $csvfields[$i]["Patient"] = $appointments[$i]["fname"] . " " .  $appointments[$i]["lname"] ;
               $csvfields[$i]["DOB"] = $appointments[$i]["DOB"] ;
-          }
+        }
         $spreadsheet = new SpreadSheetService($csvfields, $fields, 'appts');
         if (!empty($spreadsheet->buildSpreadsheet())) {
             $spreadsheet->downloadSpreadsheet('Csv');


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #8010

#### Short description of what this resolves:
row 1 of the csv file, which contains column headings, now matches the headings used in the report itself

#### Changes proposed in this pull request:
a new array is generated with the csv data and with row 1, the headers, matching the report (rather than db field names)

#### Does your code include anything generated by an AI Engine? Yes / No
no

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.
