### PR TITLE
Display an alert for emailing of statements

### DIFF
--- a/interface/billing/sl_eob_search.php
+++ b/interface/billing/sl_eob_search.php
@@ -12,9 +12,11 @@
  * @author    Roberto Vasquez <robertogagliotta@gmail.com>
  * @author    Jerry Padgett <sjpadgett@gmail.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Sherwin Gaddis <sherwingaddis@gmail.com>
  * @copyright Copyright (c) 2005-2020 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2018-2020 Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2018-2020 Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright Copyright (c) 2025 Sherwin Gaddis <sherwingaddis@gmail.com> (add alert for email status)
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -773,10 +775,8 @@ if (
 <body>
 <div>
     <?php
-    if ($emailStatementStatus) {
+    if ($emailStatementStatus && $_REQUEST['form_email']) {
         echo "<script> alert(" . xlj('Email Sent Successfully') . ");\n</script>";
-    } elseif (!$emailStatementStatus) {
-        echo "<script> alert(" . xlj('Email Failed to Send') . ");\n</script>";
     }
     ?>
 </div>

--- a/interface/billing/sl_eob_search.php
+++ b/interface/billing/sl_eob_search.php
@@ -57,6 +57,7 @@ $eracount = 0;
 $g_posting_adj_disable = $GLOBALS['posting_adj_disable'] ? 'checked' : '';
 $posting_adj_disable = prevSetting('sl_eob_search.', 'posting_adj_disable', 'posting_adj_disable', $g_posting_adj_disable);
 $form_cb = false;
+$emailStatementStatus = false;
 
 /* Load dependencies only if we need them */
 if (!empty($GLOBALS['portal_onsite_two_enable'])) {
@@ -257,7 +258,7 @@ function upload_file_to_client_email($ppid, $file_to_send)
         $countline++;
     }
 
-    emailLogin($ppid, $message);
+    return emailLogin($ppid, $message);
 }
 
 function upload_file_to_client_pdf($file_to_send, $aPatFirstName = '', $aPatID = null, $flagCFN = false)
@@ -610,7 +611,7 @@ if (
     } elseif ($_REQUEST['form_pdf']) {
         upload_file_to_client_pdf($STMT_TEMP_FILE, $aPatientFirstName, $aPatientID, $usePatientNamePdf);
     } elseif ($_REQUEST['form_email']) {
-        upload_file_to_client_email($stmt['pid'], $STMT_TEMP_FILE);
+        $emailStatementStatus = upload_file_to_client_email($stmt['pid'], $STMT_TEMP_FILE);
     } elseif ($_REQUEST['form_portalnotify']) {
         if ($alertmsg == "") {
             $alertmsg = xl('Sending Invoice to Patient Portal Completed');
@@ -770,6 +771,15 @@ if (
 </head>
 
 <body>
+<div>
+    <?php
+    if ($emailStatementStatus) {
+        echo "<script> alert(" . xlj('Email Sent Successfully') . ");\n</script>";
+    } elseif (!$emailStatementStatus) {
+        echo "<script> alert(" . xlj('Email Failed to Send') . ");\n</script>";
+    }
+    ?>
+</div>
 <div id="container_div" class="<?php echo attr($oemr_ui->oeContainer()); ?> mt-3">
     <div class="row">
         <div class="col-12">


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #8016

#### Short description of what this resolves:
Throws and alert when emailing statements to patients. The alert shows that statements failed or succeeded. 


#### Does your code include anything generated by an AI Engine? No

