### PR TITLE
Refactor Vitals form save

### DIFF
--- a/interface/forms/vitals/templates/vitals/vitals.html.twig
+++ b/interface/forms/vitals/templates/vitals/vitals.html.twig
@@ -17,7 +17,7 @@
         'weight_input_usa': window.xl("Weight") + ' (' + window.xl("lbs") + ')'
         ,'weight_input_metric': window.xl("Weight") + ' (' + window.xl("kg") + ')'
         ,'height_input_usa': window.xl("Height/Length") + ' (' + window.xl("in") + ')'
-        ,'height_input_usa_metric': window.xl("Height/Length") + ' (' + window.xl("cm") + ')'
+        ,'height_input_metric': window.xl("Height/Length") + ' (' + window.xl("cm") + ')'
         ,'bps_input': window.xl("BP Systolic")
         ,'bpd_input': window.xl("BP Diastolic")
         ,'validateFailed': window.xl("Please correct the value(s) before proceeding!")

--- a/interface/forms/vitals/templates/vitals/vitals.html.twig
+++ b/interface/forms/vitals/templates/vitals/vitals.html.twig
@@ -14,10 +14,10 @@
 <script src="{{ FORM_ACTION|attr }}/interface/forms/vitals/vitals.js?v={{ assetVersion|attr_url }}" type="text/javascript"></script>
 <script>
     let vitalsTranslations = {
-        'weight_input': window.xl("Weight") + ' (' + window.xl("lbs") + ')'
+        'weight_input_usa': window.xl("Weight") + ' (' + window.xl("lbs") + ')'
         ,'weight_input_metric': window.xl("Weight") + ' (' + window.xl("kg") + ')'
-        ,'height_input': window.xl("Height/Length") + ' (' + window.xl("in") + ')'
-        ,'height_input_metric': window.xl("Height/Length") + ' (' + window.xl("cm") + ')'
+        ,'height_input_usa': window.xl("Height/Length") + ' (' + window.xl("in") + ')'
+        ,'height_input_usa_metric': window.xl("Height/Length") + ' (' + window.xl("cm") + ')'
         ,'bps_input': window.xl("BP Systolic")
         ,'bpd_input': window.xl("BP Diastolic")
         ,'validateFailed': window.xl("Please correct the value(s) before proceeding!")
@@ -192,7 +192,7 @@ $(function () {
 
 function ShowGrowthchart(doPDF) {
     // get values from the current form elements
-    vitals[0] = formdate+'-'+$("#height_input").val()+'-'+$("#weight_input").val()+'-'+$("#head_circ_input").val();
+    vitals[0] = formdate+'-'+$("#height_input_usa").val()+'-'+$("#weight_input_usa").val()+'-'+$("#head_circ_input_usa").val();
     // build the data string
     var datastring = "";
     for(let i=0; i<vitals.length; i++) {

--- a/interface/forms/vitals/vitals.js
+++ b/interface/forms/vitals/vitals.js
@@ -15,7 +15,7 @@
     function vitalsFormSubmitted() {
         var invalid = "";
 
-        var elementsToValidate = ['weight_input', 'weight_input_metric', 'height_input', 'height_input_metric', 'bps_input', 'bpd_input'];
+        var elementsToValidate = ['weight_input_usa', 'weight_input_metric', 'height_input_usa', 'height_input_usa_metric', 'bps_input', 'bpd_input'];
 
         for (var i = 0; i < elementsToValidate.length; i++) {
             var current_elem_id = elementsToValidate[i];
@@ -84,7 +84,7 @@
             inputConv.value = "";
         }
 
-        if (targetSaveUnit == "weight_input" || targetSaveUnit == "height_input") {
+        if (targetSaveUnit == "weight_input_usa" || targetSaveUnit == "height_input_usa") {
             calculateBMI();
         }
     }
@@ -95,7 +95,16 @@
             console.error("Failed to find vitalsForm DOM Node");
             return;
         }
-        vitalsForm.addEventListener('submit', vitalsFormSubmitted);
+        document.getElementById('vitalsForm').addEventListener('submit', function(event) {
+            if (!vitalsFormSubmitted()) {
+                event.preventDefault(); // stop the form from submitting
+                let firstErrorElement = document.querySelector('.error');
+                if (firstErrorElement) {
+                    firstErrorElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                }
+                return false;
+            }
+        });
 
         // we want to setup our reason code widgets
         if (oeUI.reasonCodeWidget) {
@@ -276,14 +285,14 @@ function calculateBMI() {
 
     let precision = vitalsGetPrecision(bmiNode, 2);
 
-    let heightNode = document.getElementById("height_input");
+    let heightNode = document.getElementById("height_input_usa");
     if (!heightNode) {
-        console.error("Failed to find node with id height_input");
+        console.error("Failed to find node with id height_input_usa");
         return;
     }
-    let weightNode = document.getElementById("weight_input");
+    let weightNode = document.getElementById("weight_input_usa");
     if (!weightNode) {
-        console.error("Failed to find node with id weight_input");
+        console.error("Failed to find node with id weight_input_usa");
         return;
     }
     var height = parseFloat(heightNode.value);

--- a/interface/forms/vitals/vitals.js
+++ b/interface/forms/vitals/vitals.js
@@ -15,7 +15,7 @@
     function vitalsFormSubmitted() {
         var invalid = "";
 
-        var elementsToValidate = ['weight_input_usa', 'weight_input_metric', 'height_input_usa', 'height_input_usa_metric', 'bps_input', 'bpd_input'];
+        var elementsToValidate = ['weight_input_usa', 'weight_input_metric', 'height_input_usa', 'height_input_metric', 'bps_input', 'bpd_input'];
 
         for (var i = 0; i < elementsToValidate.length; i++) {
             var current_elem_id = elementsToValidate[i];

--- a/src/Services/Traits/ServiceEventTrait.php
+++ b/src/Services/Traits/ServiceEventTrait.php
@@ -9,7 +9,7 @@ trait ServiceEventTrait
     /**
      *
      * @param string $type The type of save event to dispatch
-     * @param $saveData The history data to send in the event
+     * @param array $saveData The history data to send in the event
      * @return array
      */
     private function dispatchSaveEvent(string $type, $saveData)

--- a/src/Services/VitalsService.php
+++ b/src/Services/VitalsService.php
@@ -356,7 +356,6 @@ class VitalsService extends BaseService
             }
             $isInsert = true;
             $sqlOperation = "INSERT INTO ";
-            // use our generate_id function here for us to create a new id
             $vitalsData['id'] = null;
             $vitalsData['uuid'] = UuidRegistry::getRegistryForTable(self::TABLE_VITALS)->createUuid();
         } else {

--- a/src/Services/VitalsService.php
+++ b/src/Services/VitalsService.php
@@ -388,7 +388,7 @@ class VitalsService extends BaseService
                 $vitalsData['id'] = $id;
                 // add new forms entry with new form_vital reference.
                 \addForm($vitalsData['eid'], "Vitals", $id, "vitals", $vitalsData['pid'], $vitalsData['authorized']);
-            } else { // unsure if will ever gets here.
+            } else { // unsure if will ever get here.
                 throw new \InvalidArgumentException("Insert new record failed.");
             }
         } else { // update
@@ -404,9 +404,7 @@ class VitalsService extends BaseService
         $updatedDetails = [];
         foreach ($details as $column => $detail) {
             $detail['form_id'] = $vitalsData['id'];
-            // $updatedDetails[$column] = $this->saveVitalDetails($detail); // TODO: sjp IMO this is a bug, didn't make sense to me
-            $this->saveVitalDetails($detail); // save the detail record
-            $updatedDetails[$column] = $detail; // update the details array with the saved record
+            $updatedDetails[$column] = $this->saveVitalDetails($detail);
         }
         $vitalsData['details'] = $updatedDetails;
         $vitalsData = $this->dispatchSaveEvent(ServiceSaveEvent::EVENT_POST_SAVE, $vitalsData);
@@ -506,8 +504,11 @@ class VitalsService extends BaseService
         if (!empty($id)) {
             $sql .= " WHERE `id` = ? ";
             $values[] = $id;
+            QueryUtils::sqlStatementThrowException($sql, $values);
+        } else {
+            $vitalDetails['id'] = QueryUtils::sqlInsert($sql, $values);
         }
-        QueryUtils::sqlStatementThrowException($sql, $values);
+        return $vitalDetails;
     }
 
     public function getVitalsForPatientEncounter($pid, $eid)

--- a/src/Services/VitalsService.php
+++ b/src/Services/VitalsService.php
@@ -392,12 +392,12 @@ class VitalsService extends BaseService
                 throw new \InvalidArgumentException("Insert new record failed.");
             }
         } else { // update
-        if (!empty($id)) {
-            $sql .= " WHERE `id` = ? ";
-            $values[] = $id;
-            $vitalsData['id'] = $id;
-        }
-        QueryUtils::sqlStatementThrowException($sql, $values);
+            if (!empty($id)) {
+                $sql .= " WHERE `id` = ? ";
+                $values[] = $id;
+                $vitalsData['id'] = $id;
+            }
+            QueryUtils::sqlStatementThrowException($sql, $values);
         }
 
         // now go through and update all of our vital details


### PR DESCRIPTION
refactor saveVitalsArray to create new form_vitals first to get new id then create the forms record. Removes the reliance on sequence value. fix doc block entry for event trait.

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #8051 
Fixes #7857 
#### Short description of what this resolves:
On new vitals form save and for the sake of pure logic create the form_vital form first to get the record id from table to use in the new encounter forms record.


#### Changes proposed in this pull request:
refactor saveVitalsArray to create new form_vitals first to get new id then create the forms record. Removes the reliance on sequence value. fix doc block entry for event trait.