### PR TITLE
Fix Dicom Viewer 404 image load

### DIFF
--- a/library/dicom_frame.php
+++ b/library/dicom_frame.php
@@ -44,6 +44,7 @@ if ($web_path) {
 $twig = (new TwigContainer(null, $GLOBALS['kernel']))->getTwig();
 echo $twig->render("dicom/dicom-viewer.html.twig", [
     'assets_static_relative' => $GLOBALS['assets_static_relative']
+    ,'web_root' => $web_root
     ,'web_path' => $web_path
     ,'state_url' => $state_url ?? null
     ,'docid' => $docid ?? null


### PR DESCRIPTION
twig template missing web_root var init

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #8065 

#### Short description of what this resolves:
image loading

