### PR TITLE
feat: update Oauth2KeyConfig for more logging and removing duplicated code

### DIFF
--- a/src/Common/Auth/OAuth2KeyConfig.php
+++ b/src/Common/Auth/OAuth2KeyConfig.php
@@ -9,7 +9,7 @@
  * @author    Brady Miller <brady.g.miller@gmail.com>
  * @author    Stephen Nielson <stephen@nielson.org>
  * @copyright Copyright (c) 2020-2025 Jerry Padgett <sjpadgett@gmail.com>
- * @copyright Copyright (c) 2020 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2020-2025 Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
@@ -17,7 +17,9 @@
 namespace OpenEMR\Common\Auth;
 
 use OpenEMR\Common\Crypto\CryptoGen;
+use OpenEMR\Common\Logging\EventAuditLogger;
 use OpenEMR\Common\Utils\RandomGenUtils;
+
 
 class OAuth2KeyConfig
 {
@@ -49,18 +51,20 @@ class OAuth2KeyConfig
             $siteDir = $GLOBALS['OE_SITE_DIR'];
         }
 
-        // Create a crypto object that will be used for for encryption/decryption
+        // Create a crypto object that will be used for encryption/decryption
         $this->cryptoGen = new CryptoGen();
         // verify and/or setup our key pairs.
         $this->privateKey = $siteDir . '/documents/certificates/oaprivate.key';
         $this->publicKey = $siteDir . '/documents/certificates/oapublic.key';
 
-        if ($this->verifyKeys() === false) {
+        // Create a Oauth2KeyMissing object that will track missing elements and used in below verifyKeys method and createOrRecreateKeys method
+        $oauth2KeyMissing = new OAuth2KeyMissing();
+        if ($this->verifyKeys($oauth2KeyMissing) === false) {
             try {
-                $this->recreateKeys();
+                $this->createOrRecreateKeys($oauth2KeyMissing);
             } catch (OAuth2KeyException $e) {
                 // if unable to recreate keys, then force exit
-                throw new OAuth2KeyException("Unable to recreate keys" . $e->getMessage());
+                throw new OAuth2KeyException("Unable to create/recreate oauth2 keys" . $e->getMessage());
             }
         }
     }
@@ -86,116 +90,81 @@ class OAuth2KeyConfig
     }
 
     /**
-     * Configures the public and private keys for OpenEMR OAuth2.  If they do not exist it generates them.
+     * Configures and verifies the encryption key, passphrase, public key and private key for OpenEMR OAuth2.
+     *  (note the existence of all these needed pieces have already been verified in the constructor, however
+     *   to be safe will also check this here)
      *
      * @throws OAuth2KeyException
      */
     public function configKeyPairs(): void
     {
-        // encryption key
+        //  collect the encryption key from database (confirm existence) and ensure it can by properly decrypted
         $eKey = sqlQueryNoLog("SELECT `name`, `value` FROM `keys` WHERE `name` = 'oauth2key'");
-        if (!empty($eKey['name']) && ($eKey['name'] === 'oauth2key')) {
-            // collect the encryption key from database
+        if (!empty($eKey['name']) && ($eKey['name'] == 'oauth2key')) {
             $this->oaEncryptionKey = $this->cryptoGen->decryptStandard($eKey['value']);
             if (empty($this->oaEncryptionKey)) {
+                // if decrypted key is empty, then critical error and must log and exit
                 if (($_ENV['OPENEMR__ENVIRONMENT'] ?? '') === 'dev') {
-                    // delete corrupted key if doesn't exist to regenerate on next attempt.
-                    sqlStatementNoLog("DELETE FROM `keys` WHERE `name` = 'oauth2key'");
+                    // Special case for developers. Delete all the oauth2 keys, which will force the keys to be recreated at next attempt.
+                    // TODO: see if this mechanism is still required
+                    $this->deleteKeys();
                 }
-                // if decrypted key is empty, then critical error and must exit
-                throw new OAuth2KeyException("oauth2 key problem after decrypted. Key is invalid, Try to restore the file key in sites from a backup.");
+                EventAuditLogger::instance()->newEvent("oauth2", ($_SESSION['authUser'] ?? ''), ($_SESSION['authProvider'] ?? ''), 0, "oauth2 ConfigKeyPairs: oauth2 encryption key was blank after it was decrypted");
+                throw new OAuth2KeyException("oauth2 encryption key was blank after it was decrypted");
             }
         } else {
-            // create a encryption key and store it in database
-            $this->oaEncryptionKey = RandomGenUtils::produceRandomBytes(32);
-            if (empty($this->oaEncryptionKey)) {
-                // if empty, then force exit
-                throw new OAuth2KeyException("random generator broken during oauth2 encryption key generation");
-            }
-            $this->oaEncryptionKey = base64_encode($this->oaEncryptionKey);
-            if (empty($this->oaEncryptionKey)) {
-                // if empty, then force exit
-                throw new OAuth2KeyException("base64 encoding broken during oauth2 encryption key generation");
-            }
-            sqlStatementNoLog("INSERT INTO `keys` (`name`, `value`) VALUES ('oauth2key', ?)", [$this->cryptoGen->encryptStandard($this->oaEncryptionKey)]);
+            // oauth2key is missing so must log and exit
+            EventAuditLogger::instance()->newEvent("oauth2", ($_SESSION['authUser'] ?? ''), ($_SESSION['authProvider'] ?? ''), 0, "oauth2 ConfigKeyPairs: oauth2 encryption key is missing");
+            throw new OAuth2KeyException("oauth2 encryption key is missing");
         }
-        // private key
-        if (!file_exists($this->privateKey)) {
-            // create the private/public key pair (store in filesystem) with a random passphrase (store in database)
-            // first, create the passphrase (removing any prior passphrases)
-            sqlStatementNoLog("DELETE FROM `keys` WHERE `name` = 'oauth2passphrase'");
-            $this->passphrase = RandomGenUtils::produceRandomString(60, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
+        // collect the passphrase from database (confirm existence) and ensure it can by properly decrypted
+        $pKey = sqlQueryNoLog("SELECT `name`, `value` FROM `keys` WHERE `name` = 'oauth2passphrase'");
+        if (!empty($pKey['name']) && ($pKey['name'] == 'oauth2passphrase')) {
+            $this->passphrase = $this->cryptoGen->decryptStandard($pKey['value']);
             if (empty($this->passphrase)) {
-                // if empty, then force exit
-                throw new OAuth2KeyException("random generator broken during oauth2 key passphrase generation");
-            }
-            // second, create and store the private/public key pair
-            $keysConfig = [
-                "default_md" => "sha256",
-                "private_key_type" => OPENSSL_KEYTYPE_RSA,
-                "private_key_bits" => 2048,
-                "encrypt_key" => true,
-                "encrypt_key_cipher" => OPENSSL_CIPHER_AES_256_CBC
-            ];
-            $msg = getenv('OPENSSL_CONF');
-
-            $keys = openssl_pkey_new($keysConfig);
-            if ($keys === false) {
-                while ($msg = openssl_error_string()) {
-                    $msg_error .= $msg . "\n";
-                }
-                error_log($msg_error);
-                // if unable to create keys, then force exit
-                throw new OAuth2KeyException("key generation broken during oauth2");
-            }
-            $privkey = '';
-            openssl_pkey_export($keys, $privkey, $this->passphrase, $keysConfig);
-            $pubkey = openssl_pkey_get_details($keys);
-            $pubkey = $pubkey["key"];
-            if (empty($privkey) || empty($pubkey)) {
-                // if unable to construct keys, then force exit
-                throw new OAuth2KeyException("key construction broken during oauth2");
-            }
-            // third, store the keys on drive and store the passphrase in the database
-            file_put_contents($this->privateKey, $privkey);
-            chmod($this->privateKey, 0640);
-            file_put_contents($this->publicKey, $pubkey);
-            chmod($this->publicKey, 0660);
-            sqlStatementNoLog("INSERT INTO `keys` (`name`, `value`) VALUES ('oauth2passphrase', ?)", [$this->cryptoGen->encryptStandard($this->passphrase)]);
-        }
-        // confirm existence of passphrase
-        $pkey = sqlQueryNoLog("SELECT `name`, `value` FROM `keys` WHERE `name` = 'oauth2passphrase'");
-        if (!empty($pkey['name']) && ($pkey['name'] == 'oauth2passphrase')) {
-            $this->passphrase = $this->cryptoGen->decryptStandard($pkey['value']);
-            if (empty($this->passphrase)) {
-                // if decrypted pssphrase is empty, then critical error and must exit
+                // if decrypted pssphrase is empty, then critical error and must log and exit
+                EventAuditLogger::instance()->newEvent("oauth2", ($_SESSION['authUser'] ?? ''), ($_SESSION['authProvider'] ?? ''), 0, "oauth2 ConfigKeyPairs: oauth2 passphrase was blank after it was decrypted");
                 throw new OAuth2KeyException("oauth2 passphrase was blank after it was decrypted");
             }
         } else {
-            // oauth2passphrase is missing so must exit
+            // oauth2passphrase is missing so must log and exit
+            EventAuditLogger::instance()->newEvent("oauth2", ($_SESSION['authUser'] ?? ''), ($_SESSION['authProvider'] ?? ''), 0, "oauth2 ConfigKeyPairs: oauth2 passphrase is missing");
             throw new OAuth2KeyException("oauth2 passphrase is missing");
         }
         // confirm existence of key pair
         if (!file_exists($this->privateKey) || !file_exists($this->publicKey)) {
-            // key pair is missing so must exit
+            // key pair is missing so must log and exit
+            EventAuditLogger::instance()->newEvent("oauth2", ($_SESSION['authUser'] ?? ''), ($_SESSION['authProvider'] ?? ''), 0, "oauth2 ConfigKeyPairs: oauth2 keypair is missing");
             throw new OAuth2KeyException("oauth2 keypair is missing");
         }
     }
 
-
-    public function verifyKeys(): bool
+    private function verifyKeys(OAuth2KeyMissing &$oauth2KeyMissing): bool
     {
         $eKey = sqlQueryNoLog("SELECT `name`, `value` FROM `keys` WHERE `name` = 'oauth2key'");
         $pKey = sqlQueryNoLog("SELECT `name`, `value` FROM `keys` WHERE `name` = 'oauth2passphrase'");
 
         if (!$eKey || !$pKey || !file_exists($this->privateKey) || !file_exists($this->publicKey)) {
+            // $oauth2KeyMissing will be used in the createOrRecreateKeys method to determine what is missing
+            if (!$eKey) {
+                $oauth2KeyMissing->setEncryptionKeyMissing();
+            }
+            if (!$pKey) {
+                $oauth2KeyMissing->setPassphraseMissing();
+            }
+            if (!file_exists($this->privateKey)) {
+                $oauth2KeyMissing->setPrivateKeyMissing();
+            }
+            if (!file_exists($this->publicKey)) {
+                $oauth2KeyMissing->setPublicKeyMissing();
+            }
             return false;
         }
 
         return true;
     }
 
-    public function deleteKeys(): void
+    private function deleteKeys(): void
     {
         sqlStatementNoLog("DELETE FROM `keys` WHERE `name` = 'oauth2key'");
         sqlStatementNoLog("DELETE FROM `keys` WHERE `name` = 'oauth2passphrase'");
@@ -208,24 +177,34 @@ class OAuth2KeyConfig
         }
     }
 
-    public function recreateKeys(): bool
+    private function createOrRecreateKeys(OAuth2KeyMissing &$oauth2KeyMissing): void
     {
+        $createNew = $oauth2KeyMissing->isMissingAll();
+        if ($createNew) {
+            $logLabel = "Attempt create the first oauth2 keys: ";
+        } else {
+            $logLabel = "Missing oauth2 keys (" . $oauth2KeyMissing->isMissingToString() . "), so attempt remove and recreate all the oauth2 keys: ";
+        }
+
         $this->deleteKeys();
 
         $this->oaEncryptionKey = RandomGenUtils::produceRandomBytes(32);
         if (empty($this->oaEncryptionKey)) {
-            // if empty, then force exit
+            // if empty, then log and force exit
+            EventAuditLogger::instance()->newEvent("oauth2", ($_SESSION['authUser'] ?? ''), ($_SESSION['authProvider'] ?? ''), 0, $logLabel . "random generator broken during oauth2 encryption key generation");
             throw new OAuth2KeyException("random generator broken during oauth2 encryption key generation");
         }
         $this->oaEncryptionKey = base64_encode($this->oaEncryptionKey);
         if (empty($this->oaEncryptionKey)) {
-            // if empty, then force exit
+            // if empty, then log and force exit
+            EventAuditLogger::instance()->newEvent("oauth2", ($_SESSION['authUser'] ?? ''), ($_SESSION['authProvider'] ?? ''), 0, $logLabel . "base64 encoding broken during oauth2 encryption key generation");
             throw new OAuth2KeyException("base64 encoding broken during oauth2 encryption key generation");
         }
         sqlStatementNoLog("INSERT INTO `keys` (`name`, `value`) VALUES ('oauth2key', ?)", [$this->cryptoGen->encryptStandard($this->oaEncryptionKey)]);
         $this->passphrase = RandomGenUtils::produceRandomString(60, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
         if (empty($this->passphrase)) {
-            // if empty, then force exit
+            // if empty, then log and force exit
+            EventAuditLogger::instance()->newEvent("oauth2", ($_SESSION['authUser'] ?? ''), ($_SESSION['authProvider'] ?? ''), 0, $logLabel . "random generator broken during oauth2 key passphrase generation");
             throw new OAuth2KeyException("random generator broken during oauth2 key passphrase generation");
         }
         $keysConfig = [
@@ -243,6 +222,7 @@ class OAuth2KeyConfig
             }
             error_log($msg_error);
             // if unable to create keys, then force exit
+            EventAuditLogger::instance()->newEvent("oauth2", ($_SESSION['authUser'] ?? ''), ($_SESSION['authProvider'] ?? ''), 0, $logLabel . "key generation broken OPEN_SSL: $msgEnv" . $msg_error);
             throw new OAuth2KeyException("key generation broken OPEN_SSL: $msgEnv" . $msg_error);
         }
         $privkey = '';
@@ -251,6 +231,7 @@ class OAuth2KeyConfig
         $pubkey = $pubkey["key"];
         if (empty($privkey) || empty($pubkey)) {
             // if unable to construct keys, then force exit
+            EventAuditLogger::instance()->newEvent("oauth2", ($_SESSION['authUser'] ?? ''), ($_SESSION['authProvider'] ?? ''), 0, $logLabel . "key construction broken during oauth2");
             throw new OAuth2KeyException("key construction broken during oauth2");
         }
 
@@ -259,6 +240,6 @@ class OAuth2KeyConfig
         file_put_contents($this->publicKey, $pubkey);
         chmod($this->publicKey, 0660);
         sqlStatementNoLog("INSERT INTO `keys` (`name`, `value`) VALUES ('oauth2passphrase', ?)", [$this->cryptoGen->encryptStandard($this->passphrase)]);
-        return true;
+        EventAuditLogger::instance()->newEvent("oauth2", ($_SESSION['authUser'] ?? ''), ($_SESSION['authProvider'] ?? ''), 1, $logLabel . "Successful");
     }
 }

--- a/src/Common/Auth/OAuth2KeyConfig.php
+++ b/src/Common/Auth/OAuth2KeyConfig.php
@@ -20,7 +20,6 @@ use OpenEMR\Common\Crypto\CryptoGen;
 use OpenEMR\Common\Logging\EventAuditLogger;
 use OpenEMR\Common\Utils\RandomGenUtils;
 
-
 class OAuth2KeyConfig
 {
     /**

--- a/src/Common/Auth/OAuth2KeyConfig.php
+++ b/src/Common/Auth/OAuth2KeyConfig.php
@@ -107,9 +107,10 @@ class OAuth2KeyConfig
                 if (($_ENV['OPENEMR__ENVIRONMENT'] ?? '') === 'dev') {
                     // Special case for developers. Delete all the oauth2 keys, which will force the keys to be recreated at next attempt.
                     // TODO: see if this mechanism is still required
+                    $devModeLog = " (in development mode, so will delete all oauth2 keys, and should all be recreated at next attempt)";
                     $this->deleteKeys();
                 }
-                EventAuditLogger::instance()->newEvent("oauth2", ($_SESSION['authUser'] ?? ''), ($_SESSION['authProvider'] ?? ''), 0, "oauth2 ConfigKeyPairs: oauth2 encryption key was blank after it was decrypted");
+                EventAuditLogger::instance()->newEvent("oauth2", ($_SESSION['authUser'] ?? ''), ($_SESSION['authProvider'] ?? ''), 0, "oauth2 ConfigKeyPairs: oauth2 encryption key was blank after it was decrypted" . ($devModeLog ?? ''));
                 throw new OAuth2KeyException("oauth2 encryption key was blank after it was decrypted");
             }
         } else {

--- a/src/Common/Auth/OAuth2KeyMissing.php
+++ b/src/Common/Auth/OAuth2KeyMissing.php
@@ -2,6 +2,7 @@
 
 /**
  * OAuth2KeyMissing.php is responsible for tracking missing OAuth2 keys.
+ *
  * @package   openemr
  * @link      https://www.open-emr.org
  * @author    Brady Miller <brady.g.miller@gmail.com>
@@ -59,5 +60,13 @@ class OAuth2KeyMissing
             $missing .= 'private key, ';
         }
         return rtrim($missing, ', ');
+    }
+
+    public function reset(): void
+    {
+        $this->encryptionKeyMissing = false;
+        $this->passphraseMissing = false;
+        $this->publicKeyMissing = false;
+        $this->privateKeyMissing = false;
     }
 }

--- a/src/Common/Auth/OAuth2KeyMissing.php
+++ b/src/Common/Auth/OAuth2KeyMissing.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * OAuth2KeyMissing.php is responsible for tracking missing OAuth2 keys.
+ * @package   openemr
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2020-2025 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Common\Auth;
+
+class OAuth2KeyMissing
+{
+    private bool $encryptionKeyMissing = false;
+    private bool $passphraseMissing = false;
+    private bool $publicKeyMissing = false;
+    private bool $privateKeyMissing = false;
+
+    public function setEncryptionKeyMissing(): void
+    {
+        $this->encryptionKeyMissing = true;
+    }
+
+    public function setPassphraseMissing(): void
+    {
+        $this->passphraseMissing = true;
+    }
+
+    public function setPublicKeyMissing(): void
+    {
+        $this->publicKeyMissing = true;
+    }
+
+    public function setPrivateKeyMissing(): void
+    {
+        $this->privateKeyMissing = true;
+    }
+
+    public function isMissingAll(): bool
+    {
+        return $this->encryptionKeyMissing && $this->passphraseMissing && $this->publicKeyMissing && $this->privateKeyMissing;
+    }
+
+    public function isMissingToString(): string
+    {
+        $missing = '';
+        if ($this->encryptionKeyMissing) {
+            $missing .= 'encryption key, ';
+        }
+        if ($this->passphraseMissing) {
+            $missing .= 'passphrase, ';
+        }
+        if ($this->publicKeyMissing) {
+            $missing .= 'public key, ';
+        }
+        if ($this->privateKeyMissing) {
+            $missing .= 'private key, ';
+        }
+        return rtrim($missing, ', ');
+    }
+}


### PR DESCRIPTION
Update Oauth2KeyConfig for more logging and removing duplicated code

Prelim testing ok. Still more testing to do.

Here is what the log shows with some of the testing (so can track what is happening to the oauth2 stuff; ideally should only be created once and then set, but if need to autocreate-them for some reason then can follow what is going on in the log to problem solve the issue (since recreating oauth2 stuff will break all api tokens, will be good to know can problem solve from log when this is happening)).
![image](https://github.com/user-attachments/assets/840d9f1b-0733-4905-9e88-8cc92c51e708)
