### PR TITLE
Update eye_base.php

### DIFF
--- a/interface/forms/eye_mag/js/eye_base.php
+++ b/interface/forms/eye_mag/js/eye_base.php
@@ -2178,7 +2178,10 @@ function showpnotes(docid) {
 function getTimeStamp() {
     var now = new Date();
     var AMPM = now.getHours() >= 12 ? 'PM' : 'AM';
-    return now.getHours() + ':' + ((now.getMinutes() < 10) ? ("0" + now.getMinutes()) : (now.getMinutes())) + AMPM;
+    var hours = now.getHours();
+    var minutes = now.getMinutes();
+    minutes = minutes < 10 ? '0' + minutes : minutes;
+    return hours + ':' + minutes + " " + AMPM;
 }
 
 /**


### PR DESCRIPTION
The IOPDATE timestamps were not being properly handled.  The IOPPOSTTIME wasn't being stored either.  The displayed versions of time have to be converted to a mysql "time" format 00:00:00 for the DB.  This is easier than changing the DB field type and safer, perhaps even the correct fix.  Look forward to the review.