### PR TITLE
rel-703 Fixes #8105 collapsing home dashboard (#8107)

### DIFF
--- a/library/user.inc.php
+++ b/library/user.inc.php
@@ -35,7 +35,7 @@ function effectiveUser($user)
  */
 function getUserSetting($label, $user = null, $defaultUser = 0)
 {
-    return UserSettingsService::effectiveUser($label, $user, $defaultUser);
+    return UserSettingsService::getUserSetting($label, $user, $defaultUser);
 }
 
 /**


### PR DESCRIPTION
Looks like the home dashboard page was not collapsing properly due to a bug in the refactor of cac171e where the wrong function was being called.

Fixes #8105