### PR TITLE
rel-703 Fix token parsing&trusted user display #8111,#8110 (#8113)

### DIFF
--- a/src/FHIR/SMART/ClientAdminController.php
+++ b/src/FHIR/SMART/ClientAdminController.php
@@ -474,6 +474,7 @@ class ClientAdminController
                     ,'tokenObj' => $tokenObject
                 ];
             }
+            $user['accessTokens'] = $accessTokenList;
             $user['refreshTokens'] = $refreshTokenList;
             $trustedUsersList[] = [
                 'link' => $this->getActionUrl(['edit', $client->getIdentifier(), self::REVOKE_TRUSTED_USER, $user['user_id']])
@@ -809,7 +810,7 @@ class ClientAdminController
     private function parseTokenAction(Request $request)
     {
         $parts = null;
-        $token = $request->query->get('token', null);
+        $token = $request->request->get('token', null);
         $actionUrl = $this->getActionUrl([self::TOKEN_TOOLS_ACTION, self::PARSE_TOKEN_ACTION]);
         $textSetting = [
                 'value' => $token

--- a/templates/interface/smart/admin-client/edit.html.twig
+++ b/templates/interface/smart/admin-client/edit.html.twig
@@ -81,7 +81,7 @@
                         </div>
                     </div>
                     {% endif %}
-                    {% for trustedUser in trustedUsersList %}
+                    {% for trustedUser in trustedUsers %}
                     <div class="card m-3">
                         <div class="card-header">
                             <h4 class="text-center">{{ trustedUser.user.display_name|text }}
@@ -150,7 +150,7 @@
                                             {{ "Action"|xlt }}
                                         </div>
                                     </div>
-                                    {% if trustedUser.accessTokens|length <= 0 %}
+                                    {% if trustedUser.user.accessTokens|length <= 0 %}
                                     <div class="row">
                                         <div class="col">
                                             <div class="alert alert-info text-center">
@@ -159,8 +159,8 @@
                                         </div>
                                     </div>
                                     {% endif %}
-                                    {% if trustedUser.accessTokens|length > 0 %}
-                                    {% for accessToken in trustedUser.accessTokens %}
+                                    {% if trustedUser.user.accessTokens|length > 0 %}
+                                    {% for accessToken in trustedUser.user.accessTokens %}
                                     <div class="row">
                                         <div class="col-3">
                                             {{ accessToken.tokenObj.token|text }}
@@ -202,7 +202,7 @@
                                             {{ "Action"|xlt }}
                                         </div>
                                     </div>
-                                    {% if trustedUser.refreshTokens|length <= 0 %}
+                                    {% if trustedUser.user.refreshTokens|length <= 0 %}
                                     <div class="row">
                                         <div class="col">
                                             <div class="alert alert-info text-center">
@@ -211,8 +211,8 @@
                                         </div>
                                     </div>
                                     {% endif %}
-                                    {% if trustedUser.refreshTokens|length > 0 %}
-                                    {% for refreshToken in trustedUser.refreshTokens %}
+                                    {% if trustedUser.user.refreshTokens|length > 0 %}
+                                    {% for refreshToken in trustedUser.user.refreshTokens %}
                                     <div class="row">
                                         <div class="col-7">
                                             {{ refreshToken.tokenObj.token|text }}


### PR DESCRIPTION
The token parsing was not being received due to a use of the query param when its parameter is posted.

The trustedUsers array was skipped over with the twig refactor as part of the b11 dsi work.

Fixes #8111
Fixes #8110