### PR TITLE
rel-703 Fix dsi window launch w/ unescaped action #8103 (#8114)

### DIFF
--- a/library/js/utility.js
+++ b/library/js/utility.js
@@ -577,7 +577,8 @@ if (typeof top.userDebug !== 'undefined' && (top.userDebug === '1' || top.userDe
                 };
                 window.top.addEventListener('message', windowMessageHandler);
 
-                let url = webroot + '/interface/smart/admin-client.php?action=external-cdr/cdr-info&serviceId=' + encodeURIComponent(dsi)
+                let url = webroot + '/interface/smart/admin-client.php?action=' + encodeURIComponent("external-cdr/cdr-info")
+                    + '&serviceId=' + encodeURIComponent(dsi)
                     + "&csrf_token=" + encodeURIComponent(csrfToken);
                 let title = node.dataset.smartName || JSON.stringify(xl("Smart App"));
                 // we allow external dialog's  here because that is what a SMART app is

--- a/src/FHIR/SMART/ClientAdminController.php
+++ b/src/FHIR/SMART/ClientAdminController.php
@@ -648,7 +648,6 @@ class ClientAdminController
                             <?php echo text($title); ?>
                             <a class="btn btn-secondary btn-sm float-right" href="<?php echo attr($this->getActionUrl([self::TOKEN_TOOLS_ACTION])); ?>" onclick="top.restoreSession()"><?php echo xlt("Token Tools"); ?></a>
                             <a class="btn btn-secondary btn-sm float-right mr-2" href="<?php echo $GLOBALS['webroot']; ?>/interface/smart/register-app.php" onclick="top.restoreSession()"><?php echo xlt("Register New App"); ?></a>
-                            <a class="btn btn-secondary btn-sm float-right mr-2" href="<?php echo attr($this->getActionUrl([RouteController::EXTERNAL_CDR_ACTION])); ?>" onclick="top.restoreSession()"><?php echo xlt("External CDR"); ?></a>
                         </h2>
                     </div>
                 </div>


### PR DESCRIPTION
* Fix dsi window launch w/ unescaped action #8103

This fixes #8103 on windows and other browsers that don't like a forward slash in a query parameter. Was missing the encoding of the action.

Fixes #8103

* Remove leftover button from old cdr implementation

Originally had the external CDR built so you could go to a list of CDR services and see them.  However, I consolidated them into the clients list pieces and we no longer need to go the CDR external list page as that got removed.  The old button was still showing up under the tools so removing that option.