### PR TITLE
Fixes api sorting, pagination problems #8127,#8128

### DIFF
--- a/src/RestControllers/RestControllerHelper.php
+++ b/src/RestControllers/RestControllerHelper.php
@@ -151,6 +151,10 @@ class RestControllerHelper
                 // cleanup _limit and _offset
                 unset($getParams['_limit']);
                 unset($getParams['_offset']);
+                // cleanup a mod_rewrite piece so the URL is nicer.
+                if (isset($getParams['_REWRITE_COMMAND'])) {
+                    unset($getParams['_REWRITE_COMMAND']);
+                }
                 $queryParams = http_build_query($getParams);
 
                 $pagination->setSearchUri($bundleUrl . '?' . $queryParams);

--- a/src/Services/FHIR/FhirServiceBase.php
+++ b/src/Services/FHIR/FhirServiceBase.php
@@ -219,6 +219,7 @@ abstract class FhirServiceBase implements IResourceSearchableService, IResourceR
             if (isset($oeSearchParameters['_config'])) {
                 $searchConfig = SearchQueryConfig::createFhirConfigFromSearchParams($oeSearchParameters['_config']);
                 $fhirSearchResult->setPagination($searchConfig->getPagination());
+                unset($oeSearchParameters['_config']); // clear out the config so we don't break the search
                 $oeSearchResult = $this->searchForOpenEMRRecordsWithConfig($oeSearchParameters, $searchConfig);
             } else {
                 $oeSearchResult = $this->searchForOpenEMRRecords($oeSearchParameters);

--- a/src/Services/FHIR/Traits/ResourceServiceSearchTrait.php
+++ b/src/Services/FHIR/Traits/ResourceServiceSearchTrait.php
@@ -54,7 +54,8 @@ trait ResourceServiceSearchTrait
                         $hasSort = true;
                     }
                     $config[$fhirSearchField] = $searchValue;
-                    $oeSearchParameters['config'] = $config;
+                    $oeSearchParameters['_config'] = $config;
+                    continue;
                 }
                 // format: <field>{:modifier1|:modifier2}={comparator1|comparator2}[value1{,value2}]
                 // field is the FHIR search field
@@ -75,7 +76,7 @@ trait ResourceServiceSearchTrait
 
         // now that we've created all of our fields, let's go through and create our sort
         if ($hasSort) {
-            $oeSearchParameters['config']['_sort'] = $this->createSortParameter($fhirSearchParameters['_sort']);
+            $oeSearchParameters['_config']['_sort'] = $this->createSortParameter($fhirSearchParameters['_sort']);
         }
 
         // we make sure if we are a resource that deals with patient data and we are in a patient bound context that
@@ -97,7 +98,7 @@ trait ResourceServiceSearchTrait
         $sortFields = explode(',', $sort);
         $searchFactory = $this->getSearchFieldFactory();
         foreach ($sortFields as $key => $sortField) {
-            $isDescending = $sortField[0] ?? '' === '-';
+            $isDescending = ($sortField[0] ?? '') === '-';
             if ($isDescending) {
                 $sortField = substr($sortField, 1);
             }

--- a/src/Services/Search/SearchQueryConfig.php
+++ b/src/Services/Search/SearchQueryConfig.php
@@ -64,7 +64,9 @@ class SearchQueryConfig
     public static function createConfigFromQueryParams($queryParams)
     {
         $config = new SearchQueryConfig();
-        $config->pagination = new QueryPagination(intval($queryParams['_limit'] ?? 0), intval($queryParams['_offset'] ?? 0));
+        // some clients use _limit, but currently FHIR TU uses _maxresults for the same purpose, so we will handle both
+        $limit = $queryParams['_maxresults'] ?? $queryParams['_limit'] ?? 0;
+        $config->pagination = new QueryPagination(intval($limit), intval($queryParams['_offset'] ?? 0));
 
         if (!empty($queryParams['_sort'])) {
             $fields = explode(",", $queryParams['_sort']);

--- a/src/Validators/ProcessingResult.php
+++ b/src/Validators/ProcessingResult.php
@@ -136,7 +136,7 @@ class ProcessingResult
     public function addData($newData)
     {
         $count = count($this->data);
-        $limit = min(0, $this->getPagination()->getLimit());
+        $limit = max(0, $this->getPagination()->getLimit());
         if ($limit === 0 || $count < $this->getPagination()->getLimit()) {
             array_push($this->data, $newData);
         } else {


### PR DESCRIPTION
Removed _REWRITE_COMMAND from pagination links as its extraneous information that's not needed.

Fixed bug where FHIR resources were not properly handling the search config parameters.

Fixed a bug where pagination was not actually limiting the results to the specified _limit parameter.  Also added support for FHIR TU _maxresults parameter in addition to supporting experimental clients that use _limit.  Fixes #8128.

Fixed bug where sort fields were always set to be descending (ie search field date treated as search field -date).  Fixes #8127.

Many of these bugs were introduced in the original paging/sorting PR in  #6801 