### PR TITLE
POSTSEG vs RETINA

### DIFF
--- a/interface/forms/eye_mag/js/eye_base.php
+++ b/interface/forms/eye_mag/js/eye_base.php
@@ -2864,7 +2864,7 @@ $(function () {
 
                   // set display functions for Draw panel appearance
                   // for each DRAW area, if the value AREA_DRAW = 1, show it.
-                  var zones = ["PMH","HPI","EXT","ANTSEG","POSTSEG","NEURO","IMPPLAN"];
+                  var zones = ["PMH","HPI","EXT","ANTSEG","RETINA","NEURO","IMPPLAN"];
                   for (index = '0'; index < zones.length; ++index) {
                     if ($("#PREFS_"+zones[index]+"_RIGHT").val() =='DRAW') {
                         show_DRAW_section(zones[index]);


### PR DESCRIPTION
fixes #8151 

When the Eye Form loads it will display the Form as the authID/current user prefers (based on the last time they used the form) - which panels are open by default, which are closed, minus or plus cylinder, Draw/quick picks panel open, whole sections of exam hidden, etc.  Some people will never use the Neuro section, so it is hidden. Others want the Retina Draw panel to display by default, others will want the Glaucoma Fee Sheet to display on opening the form.  Each time a panel is changed, that UI choice is stored as the current preference and subsequent Eye Forms will open/display the same way for that user.  This change fixes a bug where the RETINA section was not honoring preferences, because it was mis-labelled as POSTSEG.  Now all is well.
