### PR TITLE
Feature add persist token portal login and Whereto redirect (#8088)

### DIFF
--- a/interface/modules/custom_modules/oe-module-faxsms/library/api_onetime.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/library/api_onetime.php
@@ -6,22 +6,31 @@
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Jerry Padgett <sjpadgett@gmail.com>
- * @copyright Copyright (c) 2023 Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright Copyright (c)2023-2025 Jerry Padgett <sjpadgett@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General public License 3
  */
 
 require_once(__DIR__ . "/../../../../globals.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Events\Messaging\SendNotificationEvent;
 use OpenEMR\Services\PatientPortalService;
 
-if (!CsrfUtils::verifyCsrfToken($_POST["csrf_token_form"], 'contact-form')) {
+if (!CsrfUtils::verifyCsrfToken($_REQUEST["csrf_token_form"], 'contact-form')) {
     CsrfUtils::csrfNotVerified();
 }
 
 if (isset($_REQUEST['sendOneTime'])) {
     try {
-        $rtn = doOnetimeDocumentRequest();
+        doOnetimeDocumentRequest();
+    } catch (Exception $e) {
+        die($e->getMessage());
+    }
+}
+
+if (isset($_REQUEST['sendInvoiceOneTime'])) {
+    try {
+        doOnetimeInvoiceRequest();
     } catch (Exception $e) {
         die($e->getMessage());
     }
@@ -30,7 +39,50 @@ if (isset($_REQUEST['sendOneTime'])) {
 /**
  * @throws Exception
  */
-function doOnetimeDocumentRequest()
+function doOnetimeInvoiceRequest(): void
+{
+    $service = new PatientPortalService();
+    // auto allow if a portal user else must be an admin
+    if (!$service::isPortalUser()) {
+        // default is admin documents
+        if (!$service::verifyAcl()) {
+            throw new Exception(xlt("Error! Not authorised. You must be an authorised portal user or admin."));
+        }
+    }
+    $ot_pid = $_REQUEST['pid'] ?? 0;
+    if (!empty($ot_pid)) {
+        $patient = $service->getPatientDetails($ot_pid);
+    } else {
+        throw new Exception(xlt("Error! Missing patient id."));
+    }
+    $message = "Dear " . $patient['fname'] . ' ' . $patient['lname'] . ",\n";
+    $message .= xlt("Please review your current invoice by clinking the link to automatically redirect to your billing account portal. Use this PIN to complete authorization");
+    $data = [
+        'pid' => $ot_pid,
+        'expiry_interval' => "P14D",
+        'text_message' => $message,
+        'html_message' => "",
+        'redirect_url' => $GLOBALS['web_root'] . "/portal/home.php?site=" . urlencode($_SESSION['site_id']) . "&landOn=MakePayment",
+        'phone' => $patient['phone'] ?? '',
+        'email' => $patient['email'] ?? '',
+        'actions' => [
+            'enforce_onetime_use' => true,
+            'enforce_auth_pin' => true,
+            'extend_portal_visit' => false,
+        ]
+    ];
+    try {
+        $rtn = $GLOBALS["kernel"]->getEventDispatcher()
+            ->dispatch(new SendNotificationEvent($data['pid'], $data, 'email'), SendNotificationEvent::SEND_NOTIFICATION_SERVICE_UNIVERSAL_ONETIME);
+    } catch (Exception $e) {
+        die($e->getMessage());
+    }
+}
+
+/**
+ * @throws Exception
+ */
+function doOnetimeDocumentRequest(): void
 {
     $service = new PatientPortalService();
     // auto allow if a portal user else must be an admin

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php
@@ -17,6 +17,7 @@ use OpenEMR\Common\Auth\OneTimeAuth;
 use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Events\Messaging\SendNotificationEvent;
 use OpenEMR\Modules\FaxSMS\Controller\AppDispatch;
+use PHPMailer\PHPMailer\Exception;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -44,6 +45,7 @@ class NotificationEventListener implements EventSubscriberInterface
         return [
             SendNotificationEvent::SEND_NOTIFICATION_BY_SERVICE => 'onNotifyEvent',
             SendNotificationEvent::SEND_NOTIFICATION_SERVICE_ONETIME => 'onNotifyDocumentRenderOneTime',
+            SendNotificationEvent::SEND_NOTIFICATION_SERVICE_UNIVERSAL_ONETIME => 'onNotifyPortalPaymentOneTime',
         ];
     }
 
@@ -55,6 +57,7 @@ class NotificationEventListener implements EventSubscriberInterface
     {
         $eventDispatcher->addListener('sendNotification.send', [$this, 'onNotifySendEvent']);
         $eventDispatcher->addListener('sendNotification.service.onetime', [$this, 'onNotifyDocumentRenderOneTime']);
+        $eventDispatcher->addListener('sendNotification.service.universal.onetime', [$this, 'onNotifyUniversalOneTime']);
         $eventDispatcher->addListener(SendNotificationEvent::ACTIONS_RENDER_NOTIFICATION_POST, [$this, 'notificationButton']);
         $eventDispatcher->addListener(SendNotificationEvent::JAVASCRIPT_READY_NOTIFICATION_POST, [$this, 'notificationDialogFunction']);
     }
@@ -66,7 +69,7 @@ class NotificationEventListener implements EventSubscriberInterface
      * @return string
      * @throws \Exception
      */
-    public function onNotifyDocumentRenderOneTime(SendNotificationEvent $event)
+    public function onNotifyDocumentRenderOneTime(SendNotificationEvent $event): string
     {
         $status = 'Starting request.' . ' ';
         $site_id = ($_SESSION['site_id'] ?? null) ?: 'default';
@@ -105,7 +108,7 @@ class NotificationEventListener implements EventSubscriberInterface
         }
 
         if ($patient['hipaa_allowsms'] == 'YES' && $includeSMS) {
-            $status .= "Sending SMS to " .  text($recipientPhone) . ': ';
+            $status .= "Sending SMS to " . text($recipientPhone) . ': ';
             $clientApp = AppDispatch::getApiService('sms');
             $status_api = $clientApp->sendSMS(
                 $recipientPhone,
@@ -127,6 +130,111 @@ class NotificationEventListener implements EventSubscriberInterface
         ) {
             $status .= "Sending email to " . text($recipientEmail) . ': ';
             $status .= text($this->emailNotification($recipientEmail, $html_message));
+        }
+        $status .= "\n";
+        echo(nl2br($status)); //preserve html for alert status
+        return 'okay';
+    }
+
+    /**
+     * Send a token for universal onetime/token.
+     * Example: Payment link.
+     * $data = [
+     *   'pid' => $e_pid,
+     *   'expiry_interval' => "P2D", // valid for 2 days.
+     *   'text_message' => "Please make a payment for your appointment.",
+     *   'html_message' => "",
+     *   'redirect_url' => $GLOBALS['web_root'] . "/portal/home.php?site=" . urlencode($_SESSION['site_id']) . "&landOn=MakePayment",
+     *   'actions' => [
+     *      'enforce_onetime_use' => true,
+     *      'enforce_auth_pin' => true,
+     *     ]
+     * ];
+     * // Dispatch the event. In this case, the onetime is created and emailed to the recipient.
+     * $GLOBALS["kernel"]->getEventDispatcher()->dispatch(new SendNotificationEvent($e_pid, $data), SendNotificationEvent::SEND_NOTIFICATION_SERVICE_UNIVERSAL_ONETIME);
+     *
+     * @param SendNotificationEvent $event
+     * @return string
+     * @throws \Exception
+     */
+    public function onNotifyUniversalOneTime(SendNotificationEvent $event): string
+    {
+        // TODO: Move Implement onNotifyUniversalOneTime() method
+        $status = 'Starting request.' . ' ';
+        $site_id = ($_SESSION['site_id'] ?? null) ?: 'default';
+        $pid = $event->getPid();
+        $defaultUrl = $GLOBALS['web_root'] . "/portal/home.php?site=" . urlencode($site_id) . "&landOn=MakePayment";
+        $redirectURL = $data['redirect_url'] ?? $defaultUrl;
+        $data = $event->getEventData() ?? [];
+        $patient = $event->fetchPatientDetails($pid);
+
+        $recipientEmail = $data['email'] ?? $patient['email'];
+        $recipientPhone = $patient['phone'];
+        $sendMethod = $event->getSendNotificationMethod();
+        $includeSMS = ($sendMethod == 'sms' || $sendMethod == 'both') && $this->isSmsEnabled;
+        $includeEmail = $sendMethod == 'email' || $sendMethod == 'both';
+        // default actions.
+        $actionDefaults = [
+            'enforce_onetime_use' => false, // Enforces the onetime token to be used only once.
+            'extend_portal_visit' => true, // Extends the portal visit by not forcing logout redirect.
+            'enforce_auth_pin' => false, // Requires the pin to be entered.
+            'max_access_count' => 0, // 0 = unlimited.
+        ];
+        $actions = array_merge($actionDefaults, $data['actions'] ?? []); // from event data.
+
+        $text_message = $data['text_message'] ?? xl("Click link to run application.");
+        $html_message = $data['html_message'] ?? '';
+
+        $parameters = [
+            'pid' => $pid,
+            'redirect_link' => $redirectURL,
+            'email' => '',
+            'expiry_interval' => $data['expiry_interval'] ?? 'PT60M',
+            'actions' => $actions,
+        ];
+        // get token.
+        $service = new OneTimeAuth();
+        $oneTime = $service->createPortalOneTime($parameters); // create the token.
+
+        if (!isset($oneTime['encoded_link'])) {
+            (new SystemLogger())->errorLogCaller("Failed to generate encoded_link with onetime service");
+            return 'Failed! Redirect link.';
+        }
+
+        $status .= "Send Method: $sendMethod\n";
+
+        $canned = "\n\n" . xlt("PIN") . ": " . $oneTime['pin'] ?? '';
+        $canned .= "\n" . xlt("Link") . ": " . $oneTime['encoded_link'];
+        $canned .= "\n" . xlt("If you are not automatically redirected after clicking, please copy and then paste the link into your browser's address bar.");
+        $canned .= "\n" . xlt("Thank you for your attention.");
+        $text_message .= $canned;
+        if (empty($html_message)) {
+            $html_message = "<html><body><div class='wrapper'><p>" . nl2br($text_message) . "</p></div></body></html>";
+        }
+
+        if ($patient['hipaa_allowsms'] == 'YES' && $includeSMS) {
+            $status .= "Sending SMS to " . text($recipientPhone) . ': ';
+            $clientApp = AppDispatch::getApiService('sms');
+            $status_api = $clientApp->sendSMS(
+                $recipientPhone,
+                "",
+                $text_message,
+                $recipientPhone
+            );
+            if ($status_api !== true) {
+                $status .= text($status_api);
+            } else {
+                $status .= xlt("Message sent.");
+            }
+        }
+        $status .= "\n";
+        if (
+            !empty($recipientEmail)
+            && ($includeEmail)
+            && ($patient['hipaa_allowemail'] == 'YES')
+        ) {
+            $status .= "Sending email to " . text($recipientEmail) . ': ';
+            $status .= text($this->emailNotification($recipientEmail, $html_message)); // TODO use mail client
         }
         $status .= "\n";
         echo (nl2br($status)); //preserve html for alert status
@@ -169,11 +277,7 @@ class NotificationEventListener implements EventSubscriberInterface
             }
         }
 
-        if (
-            !empty($patient['email'])
-            && ($data['include_email'] ?? false)
-            && ($patient['hipaa_allowemail'] == 'YES')
-        ) {
+        if (!empty($patient['email']) && ($data['include_email'] ?? false) && ($patient['hipaa_allowemail'] == 'YES')) {
             $status .= $this->emailNotification($patient['email'], $message);
         }
         return $status;
@@ -187,33 +291,43 @@ class NotificationEventListener implements EventSubscriberInterface
      */
     public function emailNotification($email, $content, $file = null): string
     {
-        $from_name = ($user['fname'] ?? '') . ' ' . ($user['lname'] ?? '');
-        $mail = new MyMailer(true);
-        $smtpEnabled = $mail::isConfigured();
-        if (!$smtpEnabled) {
-            return 'Error: ' . xlt("Mail was not sent. A SMTP client is not set up in Config Notifications!.");
+        $send = '';
+        try {
+            $from_name = ($user['fname'] ?? '') . ' ' . ($user['lname'] ?? '');
+            $mail = new MyMailer(true);
+            $smtpEnabled = $mail::isConfigured();
+            if (!$smtpEnabled) {
+                return 'Error: ' . xlt("Mail was not sent. A SMTP client is not set up in Config Notifications!.");
+            }
+            $isHtml = (stripos($content, '<html') !== false) || (stripos($content, '<body') !== false);
+            if (!$isHtml) {
+                $html = "<html><body><div class='wrapper'>" . nl2br($content) . "</div></body></html>";
+            } else {
+                $html = $content;
+            }
+            $from_name = text($from_name);
+            $from = $GLOBALS["practice_return_email_path"];
+            $mail->addReplyTo($from, $from_name);
+            $mail->setFrom($from, $from);
+            $to = $email;
+            $to_name = $email;
+            $mail->addAddress($to, $to_name);
+            $subject = xl("Your clinic asks for your attention.");
+            $mail->Subject = $subject;
+            $mail->msgHTML($html);
+            $mail->isHTML(true);
+            if (!empty($file)) {
+                $mail->addAttachment($file);
+            }
+            $send = $mail->Send();
+            $mail->smtpClose();
+            if (!$send) {
+                error_log("Failed to send email: " . $mail->ErrorInfo);
+            }
+        } catch (Exception $e) {
+            error_log("Failed to send email: " . $e->getMessage());
         }
-        $isHtml = (stripos($content, '<html') !== false) || (stripos($content, '<body') !== false);
-        if (!$isHtml) {
-            $html = "<html><body><div class='wrapper'>" . nl2br($content) . "</div></body></html>";
-        } else {
-            $html = $content;
-        }
-        $from_name = text($from_name);
-        $from = $GLOBALS["practice_return_email_path"];
-        $mail->AddReplyTo($from, $from_name);
-        $mail->SetFrom($from, $from);
-        $to = $email;
-        $to_name = $email;
-        $mail->AddAddress($to, $to_name);
-        $subject = xl("Your clinic asks for your attention.");
-        $mail->Subject = $subject;
-        $mail->MsgHTML($html);
-        $mail->IsHTML(true);
-        if (!empty($file)) {
-            $mail->AddAttachment($file);
-        }
-        return $mail->Send();
+        return $send ? xlt("Email sent.") : xlt("Email failed to send.");
     }
 
     /**
@@ -236,6 +350,21 @@ class NotificationEventListener implements EventSubscriberInterface
             <?php echo attr_js($template); ?>,
             <?php echo attr_js(json_encode($details)); ?>
                 );" value="true"><?php echo $buttonName; ?></button>
+    <?php }
+
+    /**
+     * Available button to use.
+     * @param SendNotificationEvent $notificationEvent
+     * @return void
+     */
+    public function universalSubmitButton(SendNotificationEvent $notificationEvent): void
+    {
+        $e_pid = $notificationEvent->getPid();
+        $p_data = $notificationEvent->fetchPatientDetails($e_pid);
+        $eData = $notificationEvent->getEventData();
+        $buttonName = $eData['button_name'] ?? xlt('Submit');
+        ?>
+        <button type="button" class="btn btn-success btn-sm btn-send-msg" onclick="sendUniversalNotification(<?php echo attr_js($e_pid) ?>)"><?php echo $buttonName; ?></button>
     <?php }
 
     /**
@@ -270,17 +399,16 @@ class NotificationEventListener implements EventSubscriberInterface
         $modal_size_height = $e['modal_size_height'] ?? '';
         ?>
         function sendNotification(pid, docName, docId, details) {
-            let btnClose = <?php echo xlj("Cancel"); ?>;
-            let title = <?php echo xlj("Send Message"); ?>;
-            let url = top.webroot_url + '<?php echo $url_part; ?>' + encodeURIComponent(pid) +
-                '&title=' + encodeURIComponent(docName) + '&template_id=' + encodeURIComponent(docId) +
-                '&details=' + encodeURIComponent(details);
-            dlgopen(url, '', '<?php echo attr($modal); ?>', '<?php echo attr($modal_height); ?>', '', title, {
-                buttons: [{text: btnClose, close: true, style: 'secondary'}],
-                sizeHeight: '<?php echo attr($modal_size_height); ?>',
-                allowDrag: true,
-                allowResize: true,
-            });
+        let btnClose = <?php echo xlj("Cancel"); ?>;
+        let title = <?php echo xlj("Send Message"); ?>;
+        let url = top.webroot_url + '<?php echo $url_part; ?>' + encodeURIComponent(pid) + '&title=' + encodeURIComponent(docName) +
+        '&template_id=' + encodeURIComponent(docId) + '&details=' + encodeURIComponent(details);
+        dlgopen(url, '', '<?php echo attr($modal); ?>', '<?php echo attr($modal_height); ?>', '', title, {
+        buttons: [{text: btnClose, close: true, style: 'secondary'}],
+        sizeHeight: '<?php echo attr($modal_size_height); ?>',
+        allowDrag: true,
+        allowResize: true,
+        });
         }
     <?php }
 }

--- a/portal/home.php
+++ b/portal/home.php
@@ -45,12 +45,37 @@ if (!isset($_SESSION['portal_init'])) {
     $_SESSION['portal_init'] = true;
 }
 
-$logoService = new LogoService();
+// Example https://localhost/openemr/portal/index.php?site=default&landOn=BillingSummary
+// landOn query is used to redirect to a specific section of the portal.
+$landOnHref = [
+    'ClinicalDocuments' => '#onsitedocuments',
+    'Appointments' => '#appointmentcard',
+    'MakePayment' => '#paymentcard',
+    'SecureMessaging' => '#secure-msgs-card',
+    'HealthSnapshot' => '#lists',
+    'Profile' => '#profilecard',
+    'BillingSummary' => '#ledgercard',
+    'MedicalReports' => '#reports-list-card',
+    'PROAssessment' => '#procard',
+    'Settings' => '#settings-card',
+    'Help' => '#help-card',
+    'Logout' => '#logout.php'
+];
+// redirect using the interface query landOn or last page visited
+// TODO sjp - qualify if redirect feature is enabled!
+$whereto = $_SESSION['whereto'] ?? null;
+// set the landOn session variable to the redirected card.
+$landWhere = $_SESSION['landOn'] = $_REQUEST['landOn'] ?? null;
+// Set the landOn href query from lookup.
+$where = $landOnHref[$landWhere] ?? null;
+if (!empty($where)) {
+    $_SESSION['whereto'] = $where;
+}
 
+$logoService = new LogoService();
 
 // Get language definitions for js
 $language_defs = TranslationService::getLanguageDefinitionsForSession();
-$whereto = $_SESSION['whereto'] ?? null;
 
 $user = $_SESSION['sessionUser'] ?? 'portal user';
 $result = getPatientData($pid);
@@ -323,7 +348,7 @@ try {
     $filteredEvent = $GLOBALS['kernel']->getEventDispatcher()->dispatch($patientReportEvent, PatientReportFilterEvent::FILTER_PORTAL_HEALTHSNAPSHOT_TWIG_DATA);
     $data = [
         'user' => $user,
-        'whereto' => $_SESSION['whereto'] ?? null ?: ($whereto ?? '#quickstart-card'),
+        'whereto' => ($_SESSION['whereto'] ?? null) ?: ($whereto ?? '#quickstart-card'),
         'result' => $result,
         'msgs' => $msgs,
         'msgcnt' => $msgcnt,
@@ -366,6 +391,7 @@ try {
         'dateDisplayFormat' => $GLOBALS['date_display_format'],
         'timezone' => $GLOBALS['gbl_time_zone'] ?? '',
         'assetVersion' => $GLOBALS['v_js_includes'],
+        'extendVisit' => $_SESSION['portal_visit_extended'] ?? 1,
         'eventNames' => [
             'sectionRenderPost' => RenderEvent::EVENT_SECTION_RENDER_POST,
             'scriptsRenderPre' => RenderEvent::EVENT_SCRIPTS_RENDER_PRE,

--- a/sql/7_0_2-to-7_0_3_upgrade.sql
+++ b/sql/7_0_2-to-7_0_3_upgrade.sql
@@ -334,3 +334,15 @@ ALTER TABLE sct2_description
     ADD INDEX idx_active_term (active, term),
     ADD FULLTEXT INDEX ft_term (term);
 #EndIf
+
+#IfMissingColumn onetime_auth scope
+ALTER TABLE `onetime_auth` ADD `scope` tinytext COMMENT 'context scope for this token';
+#EndIf
+
+#IfMissingColumn onetime_auth profile
+ALTER TABLE `onetime_auth` ADD `profile` tinytext COMMENT 'scopes profile for this token';
+#EndIf
+
+#IfMissingColumn onetime_auth onetime_actions
+ALTER TABLE `onetime_auth` ADD `onetime_actions` text COMMENT 'JSON array of actions that can be performed with this token';
+#EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -13367,6 +13367,9 @@ CREATE TABLE `onetime_auth` (
     `expires` int(11) DEFAULT NULL,
     `date_created` datetime DEFAULT current_timestamp(),
     `last_accessed` datetime DEFAULT NULL,
+    `scope` tinytext COMMENT 'context scope for this token',
+    `profile` tinytext COMMENT 'profile of scope for this token',
+    `onetime_actions` text COMMENT 'JSON array of actions that can be performed with this token',
     PRIMARY KEY (`id`),
     KEY `pid` (`pid`,`onetime_token`(255))
 ) ENGINE=InnoDB;

--- a/src/Common/Auth/OneTimeAuth.php
+++ b/src/Common/Auth/OneTimeAuth.php
@@ -31,14 +31,16 @@ class OneTimeAuth
 {
     private $scope;
     private $context;
+    private $profile;
     private $cryptoGen;
     private $systemLogger;
 
-    public function __construct($context = 'portal', $scope = 'redirect')
+    public function __construct($context = 'portal', $scope = 'redirect', $profile = 'default')
     {
         // scope = portal/service tasks (reset, register). context = portal, patient etc.
-        $this->scope = $scope;
         $this->context = $context;
+        $this->scope = $scope;
+        $this->profile = $profile;
         $this->cryptoGen = new CryptoGen();
         $this->systemLogger = new SystemLogger();
     }
@@ -51,12 +53,20 @@ class OneTimeAuth
      *
      *   $p[
      *   'pid' => '', // required for most onetime auth
-     *   'target_link' => '', // Onetime endpoint
-     *   'redirect_link' => '', // Where to redirect the user after auth
+     *   'target_link' => '', // Onetime endpoint.
+     *   'redirect_link' => '', // Where to redirect the user after auth.
      *   'enabled_datetime' => 'NOW', // Use a datetime if wish to enable for a future date.
-     *   'expiry_interval' => 'PT15M', // Always PTxx{Sec,Min,Day} PeriodTime
-     *   'email' => '']
+     *   'expiry_interval' => 'PT15M', // Always PTxx{Sec,Min,Day} PeriodTime.
+     *   'email' => '', // Email to send the onetime pin to.
+     *   // Array of actions to be stored within encrypted token and retrieved in decodePortalOneTime() then passed to authorization.
+     *   'actions' => [
+     *        'enforce_onetime_use' => true, // Enforces the onetime token to be used only once.
+     *        'extend_portal_visit' => false, // Extends the portal visit by not forcing logout redirect.
+     *        'enforce_auth_pin' => false, // Requires the pin to be entered.
+     *        'max_access_count' => 0, // 0 = unlimited.
+     *     ]
      */
+
     public function createPortalOneTime(array $p, bool $encrypt_redirect = false): array|bool
     {
         $redirect_token = null;
@@ -97,13 +107,16 @@ class OneTimeAuth
             throw new RuntimeException($err);
         }
 
+        $actions = ($p['actions'] ?? []);
+        // Create the encoded link and return the onetime token data set
         $rtn['encoded_link'] = $this->encodeLink($site_addr, $token_encrypt, $redirect_token);
         $rtn['onetime_token'] = $token_encrypt;
         $rtn['redirect_token'] = $redirect_token;
         $rtn['pin'] = $pin;
         $rtn['email'] = $email;
 
-        $save = $this->insertOnetime($passed_in_pid, $pin, $token_raw, $redirect_raw, $expiry->format('U'));
+        // Save the onetime token to the database
+        $save = $this->insertOnetime($passed_in_pid, $pin, $token_raw, $redirect_raw, $expiry->format('U'), $this->scope, $this->profile, $actions);
         if (empty($save)) {
             $err = xlt("Onetime save failed!");
             $this->systemLogger->error($err);
@@ -121,7 +134,7 @@ class OneTimeAuth
      * @return array
      * @throws OneTimeAuthExpiredException
      */
-    public function decodePortalOneTime($onetime_token, $redirect_token = null): array
+    public function decodePortalOneTime($onetime_token, $redirect_token = null, $logUpdate = true): array
     {
         $auth = false;
         $rtn = [];
@@ -173,6 +186,7 @@ class OneTimeAuth
                 $this->systemLogger->debug("Redirect token decrypted: pid = " . $redirect_array['pid'] . " redirect = " . $redirect);
             }
         }
+
         $rtn['pid'] = $auth['pid'];
         $rtn['pin'] = $t_info['onetime_pin'];
         $rtn['redirect'] = $redirect;
@@ -180,9 +194,12 @@ class OneTimeAuth
         $rtn['login_username'] = $auth['portal_login_username'];
         $rtn['portal_pwd'] = $auth['portal_pwd'];
         $rtn['onetime_decrypted'] = $one_time;
+        $rtn['actions'] = $t_info['onetime_actions'] ?? [];
 
-        $this->updateOnetime($auth['pid'], $one_time);
-        $this->systemLogger->debug("Onetime successfully decoded. $one_time");
+        if ($logUpdate) {
+            $this->updateOnetime($auth['pid'], $one_time);
+            $this->systemLogger->debug("Onetime successfully decoded. $one_time");
+        }
 
         return $rtn;
     }
@@ -246,11 +263,11 @@ class OneTimeAuth
      * @param $expires
      * @return int
      */
-    public function insertOnetime($pid, $onetime_pin, $onetime_token, $redirect_url, $expires): int
+    public function insertOnetime($pid, $onetime_pin, $onetime_token, $redirect_url, $expires, $scope = '', $profile = '', $actions = []): int
     {
-        $bind = [$pid, $_SESSION['authUserID'] ?? null, $this->context, $onetime_pin, $onetime_token, $redirect_url, $expires];
-
-        $sql = "INSERT INTO `onetime_auth` (`id`, `pid`, `create_user_id`, `context`, `onetime_pin`, `onetime_token`, `redirect_url`, `expires`, `date_created`) VALUES (NULL, ?, ?, ?, ?, ?, ?, ?, current_timestamp())";
+        $actions = json_encode($actions);
+        $bind = [$pid, $_SESSION['authUserID'] ?? null, $this->context, $onetime_pin, $onetime_token, $redirect_url, $expires, $scope, $profile, $actions];
+        $sql = "INSERT INTO `onetime_auth` (`id`, `pid`, `create_user_id`, `context`, `onetime_pin`, `onetime_token`, `redirect_url`, `expires`, `date_created`, `scope`, `profile`, `onetime_actions`) VALUES (NULL, ?, ?, ?, ?, ?, ?, ?, current_timestamp(), ?, ?, ?)";
 
         return sqlInsert($sql, $bind);
     }
@@ -282,8 +299,9 @@ class OneTimeAuth
             $bind = [$pid, $token];
             $sql = "SELECT * FROM `onetime_auth` WHERE `pid` = ? AND `onetime_token` = ? LIMIT 1";
         }
-
-        return sqlQuery($sql, $bind);
+        $data = sqlQuery($sql, $bind);
+        $data['onetime_actions'] = json_decode($data['onetime_actions'] ?? [], true);
+        return $data;
     }
 
     /**
@@ -293,7 +311,20 @@ class OneTimeAuth
      */
     public function processOnetime($token, $redirect_token): array
     {
-        $auth = $this->decodePortalOneTime($token, $redirect_token);
+        try {
+            $auth = $this->decodePortalOneTime($token, $redirect_token);
+            if ($auth["actions"]["enforce_auth_pin"]) {
+                $this->systemLogger->debug("Pin auth required");
+                if ($auth['pin'] != $_POST['login_pin'] ?? null) {
+                    $this->systemLogger->error("Failed Pin auth");
+                    throw new OneTimeAuthException(xlt("Pin Authentication Failed! Contact administrator."));
+                }
+            }
+        } catch (OneTimeAuthExpiredException $e) {
+            $this->systemLogger->error("Failed " . $e->getMessage());
+            unset($auth);
+            throw new OneTimeAuthException(xlt("Decode Authentication Failed! Contact administrator."));
+        }
         if (!empty($auth['error'] ?? null)) {
             $this->systemLogger->error("Failed " . $auth['error']);
             unset($auth);
@@ -309,6 +340,7 @@ class OneTimeAuth
         $_SESSION['redirect_target'] = $auth['redirect'];
         $_SESSION['onetime'] = $auth['portal_pwd'];
         $_SESSION['patient_portal_onsite_two'] = 1;
+        $_SESSION['onetime_actions'] = $auth['actions'];
 
         // set up the other variables needed for the session interaction
         // this was taken from portal/get_patient_info.php
@@ -326,8 +358,11 @@ class OneTimeAuth
         // Set up the csrf private_key (for the patient portal)
         //  Note this key always remains private and never leaves server session. It is used to create
         //  the csrf tokens.
+
+        $extend = $auth['actions']['extend_portal_visit'] ? 1 : 0;
+        $_SESSION['portal_visit_extended'] = $extend;
+
         CsrfUtils::setupCsrfKey();
-        // $auth['redirect'] .= "&me=" . session_id();
         header('Location: ' . $auth['redirect']);
         // allows logging and any other processing to be handled on the return
         return $auth;

--- a/src/Events/Messaging/SendNotificationEvent.php
+++ b/src/Events/Messaging/SendNotificationEvent.php
@@ -7,7 +7,7 @@
  * @link      http://www.open-emr.org
  *
  * @author    Jerry Padgett <sjpadgett@gmail.com>
- * @copyright Copyright (c) 2023-2024 Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright Copyright (c) 2023-2025 Jerry Padgett <sjpadgett@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -30,20 +30,59 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 class SendNotificationEvent extends Event
 {
-    const ACTIONS_RENDER_NOTIFICATION_POST = 'sendNotification.actions.render.post';
-    const JAVASCRIPT_READY_NOTIFICATION_POST = 'sendNotification.javascript.load.post';
+    const ACTIONS_RENDER_NOTIFICATION_POST = 'sendNotification.actions.render.post'; // button
+    const JAVASCRIPT_READY_NOTIFICATION_POST = 'sendNotification.javascript.load.post'; // javascript load
     const SEND_NOTIFICATION_BY_SERVICE = 'sendNotification.send';
     const SEND_NOTIFICATION_SERVICE_ONETIME = 'sendNotification.service.onetime';
+    const ACTIONS_RENDER_NOTIFICATION_UNIVERSAL = 'sendNotification.actions.render.universal'; // button
+    const JAVASCRIPT_LOAD_NOTIFICATION_UNIVERSAL = 'sendNotification.javascript.load.universal';
+    const SEND_NOTIFICATION_SERVICE_UNIVERSAL_ONETIME = 'sendNotification.service.universal.onetime';
 
-    private mixed $pid;
-    private array|bool $patientDetails;
     private mixed $eventData;
+    private array|bool $patientDetails;
+    private mixed $pid;
+    private string|null $sendNotificationMethod;
 
-    public function __construct($pid, $data = [])
+    public function __construct($pid, $data = [], $sendMethod = 'both') // 'both', 'sms', 'email'
     {
         $this->pid = $pid ?? 0;
-        $this->eventData = $data;
+        $this->setEventData($data);
+        $this->setSendNotificationMethod($sendMethod);
+        $this->setPatientDetails($this->pid);
+    }
+
+    /**
+     * @param string $sendNotificationMethod
+     * @return SendNotificationEvent
+     */
+    public function setSendNotificationMethod(string $sendNotificationMethod)
+    {
+        $this->sendNotificationMethod = $sendNotificationMethod;
+    }
+
+    /**
+     * @param array|bool $pid
+     * @return void
+     */
+    public function setPatientDetails($pid): void
+    {
         $this->patientDetails = $this->fetchPatientDetails($pid);
+    }
+
+    /**
+     * @return array|bool
+     */
+    public function getPatientDetails(): bool|array
+    {
+        return $this->patientDetails;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSendNotificationMethod(): string
+    {
+        return $this->sendNotificationMethod;
     }
 
     /**
@@ -62,10 +101,15 @@ class SendNotificationEvent extends Event
         return $this->eventData ?? [];
     }
 
+    public function setEventData($data)
+    {
+        $this->eventData = $data;
+    }
+
     /**
      * @return bool|string
      */
-    public function getEncodedPatientDetails(): bool|string
+    public function getEncodedPatientDetails()
     {
         return json_encode($this->patientDetails);
     }
@@ -79,12 +123,12 @@ class SendNotificationEvent extends Event
     }
 
     /**
-     * @param $sect
-     * @param $v
-     * @param $u
+     * @param string $sect
+     * @param string $v
+     * @param string $u
      * @return bool
      */
-    public function verifyAcl($sect = 'patients', $v = 'docs', $u = ''): bool
+    public function verifyAcl(string $sect = 'patients', string $v = 'docs', string $u = ''): bool
     {
         return AclMain::aclCheckCore($sect, $v, $u);
     }

--- a/templates/portal/header.html.twig
+++ b/templates/portal/header.html.twig
@@ -7,9 +7,11 @@
         <span class="navbar-toggler-icon"></span>
     </button>
     {% endif %}
+    {% if extendVisit %}
     <a class="btn btn-outline-primary" id="quickstart_dashboard" href="#quickstart-card" data-toggle="collapse" data-parent="#cardgroup" aria-expanded="true">
         <i class="ml-1 fas fa-tasks mr-1"></i>{{ 'Dashboard' | xlt }}
     </a>
+    {% endif %}
     {% if navMenu|length > 0 %}
     <div class="collapse navbar-collapse justify-content-end" id="nav">
         <ul class="navbar-nav mt-2 mt-lg-0">

--- a/templates/portal/home.html.twig
+++ b/templates/portal/home.html.twig
@@ -8,7 +8,7 @@
  * @author    Shiqiang Tao <StrongTSQ@gmail.com>
  * @author    Ben Marte <benmarte@gmail.com>
  * @author    Stephen Nielson <snielson@discoverandchange.com>
- * @copyright Copyright (c) 2016-2024 Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright Copyright (c) 2016-2025 Jerry Padgett <sjpadgett@gmail.com>
  * @copyright Copyright (c) 2019-2021 Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2020 Shiqiang Tao <StrongTSQ@gmail.com>
  * @copyright Copyright (c) 2021 Ben Marte <benmarte@gmail.com>
@@ -56,6 +56,27 @@
 
       .navbar-nav .dropdown:hover .dropdown-menu {
         display: block;
+      }
+
+      @media (max-width: 768px) {
+        .jumbotron {
+          padding: 1rem;
+        }
+        .card {
+          margin-bottom: 1rem;
+        }
+        .navbar-nav .dropdown-menu {
+          position: static;
+          float: none;
+          width: 100%;
+          text-align: center;
+        }
+        .navbar-nav .dropdown-menu a {
+          padding: 10px;
+        }
+        .card-body {
+          padding: 10px;
+        }
       }
     </style>
     <script>

--- a/templates/portal/login/autologin.html.twig
+++ b/templates/portal/login/autologin.html.twig
@@ -29,17 +29,32 @@
         <header class="card-header bg-primary text-light">
             <h1>{{ 'Authenticating Login Session' | xlt }}</h1>
         </header>
+        {% if pin_required == 1 %}
+        <h5 class="m-5">{{ "Enter PIN to authenticate your session"|xlt }}</h5>
+        {% else %}
         <h5 class="m-5">{{ "Please wait while we authenticate your session"|xlt }}</h5>
+        {% endif %}
         <form method="POST" id="autologinform" action="{{ action }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token|attr }}" />
             <input type="hidden" name="service_auth" value="{{ service_auth|attr }}" />
             <input type="hidden" name="target" value="{{ target|attr_url }}" />
+            {% if pin_required %}
+            <label for="login_pin">{{ "PIN Required value"|xlt }}</label>
+            <input type="text" class="text-center m-1" maxlength="6" id="login_pin" name="login_pin" value="" />
+            <input class="btn btn-sm btn-primary" type="submit" name="autoLoginSubmit" value="{{ "Authorize and Go To Destination"|xla }}" />
+            {% else %}
             <input class="btn btn-lg btn-primary" type="submit" name="autoLoginSubmit" value="{{ "Go To Destination"|xla }}" />
+            {% endif %}
         </form>
+        {% if pin_required %}
+        <p>{{ "You are Required to confirm access by entering the companion PIN."|xlt }} {{ target|text }}</p>
+        {% else %}
         <p>{{ "If you have not been redirected in a few seconds click the button above"|xlt }}</p>
         <p>{{ "You will be sent to the following web page"|xlt }} {{ target|text }}</p>
+        {% endif %}
     </div>
     <script>
+        const pinRequired = {{ pin_required|js_escape }};
         (function() {
             window.addEventListener("DOMContentLoaded", function() {
                 let form = window.document.getElementById("autologinform");
@@ -47,7 +62,13 @@
                     console.error("Failed to find autologinform");
                     return;
                 }
-                form.submit(); // submit the form as soon as we load to start the session
+                // if pin is not required, submit the form immediately
+                // otherwise, wait for the user to enter the pin and submit the form.
+                // The pin will be validated on the server side before redirect.
+                // he action must be set in the onetime create actions.
+                if (!pinRequired) {
+                    form.submit(); // submit the form as soon as we load to start the session}
+                }
             });
         })(window);
     </script>

--- a/version.php
+++ b/version.php
@@ -17,7 +17,7 @@
 $v_major = '7';
 $v_minor = '0';
 $v_patch = '3';
-$v_tag   = '-dev'; // minor revision number, should be empty for production releases
+$v_tag   = ''; // minor revision number, should be empty for production releases
 
 // A real patch identifier. This is incremented when we release a patch for a
 // production release. Note the above $v_patch variable is a misnomer and actually
@@ -28,7 +28,7 @@ $v_realpatch = '0';
 // is a database change in the course of development.  It is used
 // internally to determine when a database upgrade is needed.
 //
-$v_database = 505;
+$v_database = 506;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
* Feature add persist token portal login and Whereto redirect add new session var to track URL landOn query to redirect.

* refactor onetime tokens and wrapper to add an actions array to onetime_auth add new universal onetime event and listener onNotifyUniversalOneTime(SendNotificationEvent $event).

* streamline event and onetime listener handling. add scope and profile for onetime contexts

* implement pin collection for onetime login enforce visit page only. removes Dashboard button so can't goto that page.

* cleanup and set defaults

* update 7.0.2 to 7.0.3 sql.

* More cleanup

* escape

(cherry picked from commit 30af554f207296cfe9429f99bf4a6d0bff048986)

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:


#### Changes proposed in this pull request:

#### Does your code include anything generated by an AI Engine? Yes / No

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.
