### PR TITLE
adding minimum height for all appts under 15 minutes for all categories

### DIFF
--- a/interface/main/calendar/modules/PostCalendar/pntemplates/default/views/day/ajax_template.html
+++ b/interface/main/calendar/modules/PostCalendar/pntemplates/default/views/day/ajax_template.html
@@ -658,10 +658,10 @@ foreach ($providers as $provider) {
             $eEndInterval = $eMinDiff / $interval;
             // times the interval height
             $eHeight = $eEndInterval * $timeslotHeightVal;
-            if($event['catid']==3)
+            // For all categories: ensure minimum height for zero-duration events
+            if($eEndInterval <= 15 / $interval)
             {
-                // An "OUT" that is "zero duration" still needs height so we can click it.
-                $eHeight = $eEndInterval==0 ? $timeslotHeightVal : $eHeight ;
+                $eHeight = $timeslotHeightVal;
             }
             $evtHeight = $eHeight.$timeslotHeightUnit;
 


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
--> https://github.com/openemr/openemr/issues/8146

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #8146 

#### Short description of what this resolves:
Appointments with a duration of 0 minute used to be unclickable, now they have a minimum height and are clickable. 
#### Changes proposed in this pull request:
Appointments that are under 15 minutes will now have a minimum height. 
#### Does your code include anything generated by an AI Engine? Yes / No
No
#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.
