### PR TITLE
Fixes #8173 date format encounter bug

### DIFF
--- a/interface/billing/billing_tracker.php
+++ b/interface/billing/billing_tracker.php
@@ -36,7 +36,7 @@ if (!AclMain::aclCheckCore('acct', 'eob', '', 'write') && !AclMain::aclCheckCore
 ?>
 <html>
 <head>
-    <?php Header::setupHeader(['datatables', 'datatables-colreorder', 'datatables-dt', 'datatables-bs', 'i18formatting']); ?>
+    <?php Header::setupHeader(['datatables', 'datatables-colreorder', 'datatables-dt', 'datatables-bs']); ?>
     <title><?php echo xlt("Claim File Tracker"); ?></title>
     <style>
         table.dataTable td.details-control:before {
@@ -104,8 +104,8 @@ if (!AclMain::aclCheckCore('acct', 'eob', '', 'write') && !AclMain::aclCheckCore
                             return data;
                         }
                     },
-                    { 
-                        "data": "created_at", 
+                    {
+                        "data": "created_at",
                         "render": function(data, type, row, meta) {
                             // Build the URL so the user can download the claim batch file
                             if (type === 'display') {
@@ -115,7 +115,7 @@ if (!AclMain::aclCheckCore('acct', 'eob', '', 'write') && !AclMain::aclCheckCore
                             return data;
                         }
                     },
-                    { 
+                    {
                         "data": "updated_at",
                         "render": function(data, type, row, meta) {
                             // Build the URL so the user can download the claim batch file

--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -98,6 +98,7 @@ $twig = (new TwigContainer(null, $GLOBALS['kernel']))->getTwig();
         jsGlobals.enable_group_therapy = <?php echo js_escape($GLOBALS['enable_group_therapy']); ?>;
         jsGlobals.languageDirection = jsLanguageDirection;
         jsGlobals.date_display_format = <?php echo js_escape($GLOBALS['date_display_format']); ?>;
+        jsGlobals.time_display_format = <?php echo js_escape($GLOBALS['time_display_format']); ?>;
         jsGlobals.timezone = <?php echo js_escape($GLOBALS['gbl_time_zone'] ?? ''); ?>;
         jsGlobals.assetVersion = <?php echo js_escape($GLOBALS['v_js_includes']); ?>;
         var WindowTitleAddPatient = <?php echo ($GLOBALS['window_title_add_patient_name'] ? 'true' : 'false' ); ?>;
@@ -261,7 +262,7 @@ $twig = (new TwigContainer(null, $GLOBALS['kernel']))->getTwig();
         }
     </script>
 
-    <?php Header::setupHeader(['knockout', 'tabs-theme', 'i18next', 'hotkeys']); ?>
+    <?php Header::setupHeader(['knockout', 'tabs-theme', 'i18next', 'hotkeys', 'i18formatting']); ?>
     <script>
         // set up global translations for js
         function setupI18n(lang_id) {

--- a/library/js/xl/formatting.js
+++ b/library/js/xl/formatting.js
@@ -76,10 +76,11 @@
         const format = typeof date_display_format !== 'undefined' ? date_display_format : 0;
 
         let formatted;
+        // uses php-date-formatter library which in turn uses the php datetime format @see https://www.php.net/manual/en/datetime.format.php
         if (format === 1) {
-            formatted = seconds ? "h:mm:ss a" : "h:mm a";
-        } else { // (format === 0)
-            formatted = seconds ? "HH:mm:ss" : "HH:mm";
+            formatted = seconds ? "h:i:s a" : "h:i a";
+        } else { // (format === 0) 24hour time
+            formatted = seconds ? "H:i:s" : "H:i";
         }
         return formatted;
     }

--- a/portal/home.php
+++ b/portal/home.php
@@ -364,6 +364,7 @@ try {
         'healthSnapshot' => $filteredEvent->getDataElement('healthSnapshot'),
         'languageDirection' => $_SESSION['language_direction'] ?? 'ltr',
         'dateDisplayFormat' => $GLOBALS['date_display_format'],
+        'timeDisplayFormat' => $GLOBALS['time_display_format'],
         'timezone' => $GLOBALS['gbl_time_zone'] ?? '',
         'assetVersion' => $GLOBALS['v_js_includes'],
         'eventNames' => [

--- a/templates/core/base.html.twig
+++ b/templates/core/base.html.twig
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     {% block head %}
-        {{ setupHeader(['i18next', 'il8formatting']) }}
+        {{ setupHeader(['i18next', 'i18formatting']) }}
     {% endblock %}
 
     <title>{% block pagetitle %}

--- a/templates/patient/insurance/insurance_edit.html.twig
+++ b/templates/patient/insurance/insurance_edit.html.twig
@@ -11,7 +11,7 @@ files for editing and adding new insurance policies for a patient.
 <html>
 <head>
     <title>{% block title %}{{ "Insurance Edit"|xlt }}{% endblock %}</title>
-    {{ setupHeader(['common','select2', 'erx', 'select2-translated', 'i18formatting', 'datetime-picker', 'datetime-picker-translated' ]) }}
+    {{ setupHeader(['common','select2', 'erx', 'select2-translated','datetime-picker', 'datetime-picker-translated' ]) }}
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
     {% block scripts %}
     {% endblock %}

--- a/templates/portal/home.html.twig
+++ b/templates/portal/home.html.twig
@@ -75,6 +75,7 @@
         var jsGlobals = {
             languageDirection: jsLanguageDirection,
             date_display_format: {{ dateDisplayFormat | js_escape }},
+            time_display_format: {{ timeDisplayFormat | js_escape }},
             timezone: {{ timezone | js_escape }},
             assetVersion: {{ assetVersion | js_escape }}
         };


### PR DESCRIPTION
Fixes #8173.

Formatting library was missing the time_display_format in the jsGlobals so time formatting was messed up.

Also had a wierd bug where sub-frames that loaded the i18formatting library would end up stomping on the global values of i18formatting but when the script was unloaded the browser appears to go and remove the references to those values so the functions would end up undefined.

I ended up defining the formatting library in the main entry points (main.php and in the portal/home.php) so the functions always exist.  I then removed the library loads from any of the sub-frames to avoid the behavior.  billing_tracker.php, insurance_edit, and the encounter stuff appears to be the only things impacted.

@stephenwaite I don't have any data setup for the x12 auto sftp claim tracking pieces that would impact billing_tracker.php.  Any chance when you have some free time to pull this down and verify I haven't broken anything.  Best way to check is to turn the date local format to 'dd/mm/yyyy' and just make sure the date selector formats properly.