### PR TITLE
added confirmation when switching tabs in insurance edit, when there …

### DIFF
--- a/library/js/oeUI/insurance/EditPolicyScreenController.js
+++ b/library/js/oeUI/insurance/EditPolicyScreenController.js
@@ -478,7 +478,6 @@ export class EditPolicyScreenController
         }
     }
 
-
     #setupInsuranceTypeNavigation() {
         // grab nav-link-insurance-type elements and setup click handlers for them
         // when the user clicks on one of them we need to hide all the tabs and show the one they clicked on
@@ -490,6 +489,17 @@ export class EditPolicyScreenController
                     // cancel the evt so we don't navigate to a new page
                     evt.preventDefault();
                     evt.stopPropagation();
+
+                    // Check if there are unsaved changes
+                    if (this.hasDataToSave()) {
+                        // If there are unsaved changes, show a confirmation dialog
+                        if (!confirm(window.top.xl("You have unsaved changes. Do you want to proceed without saving?"))) {
+                            // User clicked cancel, so don't change tabs
+                            return;
+                        }
+                        // If user confirmed, continue with tab change but reset any changes
+                        this.resetSaveData();
+                    }
 
                     this.__selectedInsuranceTypeTab = evt.target.dataset.type;
                     // need to default to the top insurance in the list


### PR DESCRIPTION
…are unsaved changes

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->https://github.com/openemr/openemr/issues/8116

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #8116 

#### Short description of what this resolves:
User inputted data does not persist when switching tabs on the insurance edit page. 

#### Changes proposed in this pull request:
Added a confirmation popup when the user tries to switch tabs with unsaved data. 
#### Does your code include anything generated by an AI Engine? Yes / No
No
#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.
