### PR TITLE
adding validation to time and duration for add edit event

### DIFF
--- a/interface/main/calendar/add_edit_event.php
+++ b/interface/main/calendar/add_edit_event.php
@@ -1065,11 +1065,16 @@ function set_display() {
             style_prefcat.display = '';
             f.form_apptstatus.style.display = 'none';
             f.form_prefcat.style.display = '';
+            f.form_duration.disabled = true;
+            f.form_duration.value = '';
+            document.getElementById('tdallday4').style.color = 'var(--gray)';
         } else {
             style_prefcat.display = 'none';
             style_apptstatus.display = '';
             f.form_prefcat.style.display = 'none';
             f.form_apptstatus.style.display = '';
+            f.form_duration.disabled = false;
+            document.getElementById('tdallday4').style.color = '';
         }
     }
 }
@@ -1091,27 +1096,37 @@ function set_category() {
 // radio buttons are clicked.
 function set_allday() {
     var f = document.forms[0];
+    var s = f.form_category;
     var color1 = 'var(--gray)';
     var color2 = 'var(--gray)';
-    var disabled2 = true;
+    var timeDisabled = true;
+    var durationDisabled = true;
     if (document.getElementById('rballday1').checked) {
         color1 = '';
     }
     if (document.getElementById('rballday2').checked) {
         color2 = '';
-        disabled2 = false;
+        timeDisabled = false;
+        if (s.selectedIndex >= 0) {
+            var catid = s.options[s.selectedIndex].value;
+            if (catid != '2') {
+                durationDisabled = false;
+            }
+        } else {
+            durationDisabled = false;
+        }
     }
     document.getElementById('tdallday1').style.color = color1;
     document.getElementById('tdallday2').style.color = color2;
     //document.getElementById('tdallday3').style.color = color2;
-    document.getElementById('tdallday4').style.color = color2;
+    // document.getElementById('tdallday4').style.color = color2;
     document.getElementById('tdallday5').style.color = color2;
-    f.form_hour.disabled = disabled2;
-    f.form_minute.disabled = disabled2;
+    f.form_hour.disabled = timeDisabled;
+    f.form_minute.disabled = timeDisabled;
     <?php if ($GLOBALS['time_display_format'] == 1) { ?>
-        f.form_ampm.disabled = disabled2;
+        f.form_ampm.disabled = durationDisabled;
     <?php } ?>
-    f.form_duration.disabled = disabled2;
+    f.form_duration.disabled = durationDisabled;
 }
 
 // Modify some visual attributes when the Repeat checkbox is clicked.
@@ -1832,6 +1847,8 @@ $(function () {
     $("#form_apptstatus").addClass('form-control-sm');
     $("#form_room").addClass('form-control-sm');
     $(".current a").addClass('active');
+
+    set_display();
 });
 
 function are_days_checked(){
@@ -1851,6 +1868,44 @@ function are_days_checked(){
 * */
 var collectvalidation = <?php echo $collectthis; ?>;
 function validateform(event,valu){
+    collectvalidation.form_hour = {
+        numericality: {
+            onlyInteger: true,
+            greaterThanOrEqualTo: 0,
+            lessThanOrEqualTo: 23,
+            message: "must be a valid hour (0-23)"
+        },
+        presence: {
+            allowEmpty: false,
+            message: "Hour is required"
+        }
+    };
+
+    collectvalidation.form_minute = {
+        numericality: {
+            onlyInteger: true,
+            greaterThanOrEqualTo: 0,
+            lessThanOrEqualTo: 59,
+            message: "must be a valid minute (0-59)"
+        },
+        presence: {
+            allowEmpty: false,
+            message: "Minute is required"
+        }
+    };
+
+    collectvalidation.form_duration = {
+        numericality: {
+            onlyInteger: true,
+            greaterThan: 0,
+            message: "must be a positive number"
+        },
+        presence: {
+            allowEmpty: false,
+            message: "Duration is required"
+        }
+    };
+
     $('#form_save').attr('disabled', true);
     //Make sure if days_every_week is checked that at least one weekday is checked.
     if($('#days_every_week').is(':checked') && !are_days_checked()){

--- a/interface/main/calendar/add_edit_event.php
+++ b/interface/main/calendar/add_edit_event.php
@@ -1873,7 +1873,7 @@ function validateform(event,valu){
             onlyInteger: true,
             greaterThanOrEqualTo: 0,
             lessThanOrEqualTo: 23,
-            message: "must be a valid hour (0-23)"
+            message: "must have a valid hour (0-23)"
         },
         presence: {
             allowEmpty: false,
@@ -1886,7 +1886,7 @@ function validateform(event,valu){
             onlyInteger: true,
             greaterThanOrEqualTo: 0,
             lessThanOrEqualTo: 59,
-            message: "must be a valid minute (0-59)"
+            message: "must have a valid minute (0-59)"
         },
         presence: {
             allowEmpty: false,
@@ -1898,7 +1898,7 @@ function validateform(event,valu){
         numericality: {
             onlyInteger: true,
             greaterThan: 0,
-            message: "must be a positive number"
+            message: "Must be a positive number"
         },
         presence: {
             allowEmpty: false,

--- a/library/validation/validation_script.js.php
+++ b/library/validation/validation_script.js.php
@@ -33,6 +33,22 @@ if ($use_validate_js) {
     <script src="<?php echo $GLOBALS['assets_static_relative'] ?>/moment/moment.js"></script>
     <script src="<?php echo $GLOBALS['rootdir'] ?>/../library/js/vendors/validate/validate_modified.js"></script>
     <script src="<?php echo $GLOBALS['rootdir'] ?>/../library/js/vendors/validate/validate_extend.js"></script>
+
+    <style type="text/css">
+    .error-message {
+        position: absolute;
+        z-index: 1000;
+        background-color: #fff;
+        border: 1px solid var(--danger);
+        border-radius: 4px;
+        padding: 6px 12px;
+        max-width: 250px;
+        white-space: normal;
+        box-shadow: 0 2px 5px rgba(0,0,0,0.2);
+        color: var(--danger);
+        margin-top: 5px;
+    }
+    </style>
     <?php
 }
 ?>
@@ -147,16 +163,12 @@ function submitme(new_validate,e,form_id, constraints) {
             function appendError(input, id, message){
 
                 //append 'span' tag for error massages if not exist
-                if($("#error_" + id).length == 0) {
-                    //If have another element after the input
-                    if($(input).next().length > 0) {
+                if ($("#error_" + id).length == 0) {
+                    // Create hidden error message
+                    var errorHtml = '<span class="error-message" id="error_' + id + '"></span>';
 
-                        $(input).next().after("<span id='error_" + id +"' class='error-message' '></span>");
-
-                    } else {
-                        $(input).after("<span id='error_" + id +"' class='error-message'></span>");
-
-                    }
+                    // Position after the input
+                    $(input).after(errorHtml);
                 }
                 //show error message
                 //Validate.js enables to overwrite the error messages by adding 'message' to constraints json. if you want to use your custom message instead
@@ -190,6 +202,15 @@ function submitme(new_validate,e,form_id, constraints) {
                     }
                 }
 
+                $(input).hover(
+                    function() {
+                        var $errorMsg = $("#error_" + id);
+                        $errorMsg.show();
+                    },
+                    function() {
+                        $("#error_" + id).hide();
+                    }
+                );
 
                 //bind hide function on focus/select again
                 $(input).on('click focus select', function(){
@@ -203,6 +224,7 @@ function submitme(new_validate,e,form_id, constraints) {
                     });
                 }
 
+                $("#error_" + id).hide();
             }
             /*
             * hide error message
@@ -210,7 +232,7 @@ function submitme(new_validate,e,form_id, constraints) {
             **/
             function hideErrors(input, id){
                 $(input).removeClass('error-border');
-                $("#error_" + id).text('');
+                $("#error_" + id).remove();
 
                 var parent_div = $(input).parents('div.tab');
                 if($(parent_div).is('div')) {

--- a/library/validation/validation_script.js.php
+++ b/library/validation/validation_script.js.php
@@ -247,6 +247,18 @@ function submitme(new_validate,e,form_id, constraints) {
                         return <?php echo xlj('Must be future date');?>;
                     case 'Recipient required unless status is Done':
                         return <?php echo xlj('Recipient required unless status is Done');?>;
+                    case 'must have a valid hour (0-23)':
+                        return <?php echo xlj('must have a valid hour (0-23)');?>;
+                    case 'Hour is required':
+                        return <?php echo xlj('Hour is required');?>;
+                    case 'must have a valid minute (0-59)':
+                        return <?php echo xlj('must have a valid minute (0-59)');?>;
+                    case 'Minute is required':
+                        return <?php echo xlj('Minute is required');?>;
+                    case 'Must be a positive number':
+                        return <?php echo xlj('Must be a positive number');?>;
+                    case 'Duration is required':
+                        return <?php echo xlj('Duration is required');?>;
                     default:
                        return <?php echo xlj('is not valid');?>;
                 }


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
--> https://github.com/openemr/openemr/issues/8185

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #8185

#### Short description of what this resolves:
No validation for time and duration fields on add edit event

#### Changes proposed in this pull request:
Added validation to time and duration fields on add edit event

#### Does your code include anything generated by an AI Engine? Yes / No
No

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.
