### PR TITLE
Show e-sign amendment. Fixes #8205

### DIFF
--- a/library/ESign/Signature.php
+++ b/library/ESign/Signature.php
@@ -53,6 +53,8 @@ class Signature implements SignatureIF
         $uid,
         $firstName,
         $lastName,
+        $suffix,
+        $valedictory,
         $datetime,
         $hash,
         $amendment = null,
@@ -65,6 +67,8 @@ class Signature implements SignatureIF
         $this->uid = $uid;
         $this->firstName = $firstName;
         $this->lastName = $lastName;
+        $this->suffix = $suffix;
+        $this->valedictory = $valedictory;
         $this->datetime = $datetime;
         $this->hash = $hash;
         $this->amendment = $amendment;


### PR DESCRIPTION
Fixes #8205 show the e-sign amendment.

The constructor order for the signature is off due to the addition of the suffix/valedictory tags which throws off the values of everything else.