### PR TITLE
fixing issue of allow_custom_report being treated as a string instead…

### DIFF
--- a/templates/portal/home.html.twig
+++ b/templates/portal/home.html.twig
@@ -604,7 +604,7 @@
                                     } %}
                                 {% endif %}
                                 <!-- Reports -->
-                                {% if ccdaOk or 'allow_custom_report' or portal_onsite_document_download %}
+                                {% if ccdaOk or allow_custom_report or portal_onsite_document_download %}
                                     {% include "portal/partial/_nav_icon.html.twig"
                                         with {
                                         url: "reports-list-card"|attr_url
@@ -709,7 +709,7 @@
                     title: "Medical Reports"|xl
                     ,icon: "gear"
                     ,description: "Setup your digital signature for signing your clinical documents, update your login credentials, or change application settings in the portal."|xl
-                    ,enabled: ccdaOk or 'allow_custom_report' or portal_onsite_document_download
+                    ,enabled: ccdaOk or allow_custom_report or portal_onsite_document_download
                 }
                 ,{
                     title: "PRO Assessment"|xl
@@ -784,7 +784,7 @@
                         , localLink: false
                     } %}
                 {% endif %}
-                {% if 'allow_custom_report' %}
+                {% if allow_custom_report %}
                     {% include "portal/partial/_nav_icon.html.twig"
                         with {
                         url: "reportcard"|attr_url


### PR DESCRIPTION
… of global

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
--> https://github.com/openemr/openemr/issues/8178

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #8178

#### Short description of what this resolves:
The allow_custom_report global had quotations around them, which caused it to be treated as a string instead of a global. Which causes the check to show medical reports to be invalid - the report will be shown regardless of the value of the global. 

#### Changes proposed in this pull request:
The allow_custom_report global now has no quotations around them, meaning they should now be treated as a global. 

#### Does your code include anything generated by an AI Engine? Yes / No
No

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.
