### PR TITLE
CCDA Fixes

### DIFF
--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php
@@ -33,6 +33,7 @@ use OpenEMR\Services\Cda\CdaValidateDocuments;
 use OpenEMR\Services\Cda\XmlExtended;
 use OpenEMR\Services\CodeTypesService;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use function PHPUnit\Framework\throwException;
 
 class CarecoordinationTable extends AbstractTableGateway
 {
@@ -228,7 +229,7 @@ class CarecoordinationTable extends AbstractTableGateway
             $xml_to_array = new XmlExtended();
             $xml = $xml_to_array->fromString($this->conditionedXmlContent);
         } catch (Exception $e) {
-            die($e->getMessage());
+            throw new Exception($e->getMessage());
         }
         // Document various sectional components
         $components = $xml['component']['structuredBody']['component'];
@@ -2322,13 +2323,13 @@ class CarecoordinationTable extends AbstractTableGateway
      * @return string Cleaned XML content.
      * @throws Exception If the input XML is invalid or cannot be parsed.
      */
-    function cleanCcdaXmlContent(string $xmlContent, bool $removeBr = false): string
+    function cleanCcdaXmlContent(string $xmlContent, bool $replaceBr = false): string
     {
         // Handle <br/> tags if required
-        if ($removeBr) {
-            $xmlContent = preg_replace('/<br\s*\/?>/', '', $xmlContent); // Remove <br/>
+        if ($replaceBr) {
+            $xmlContent = preg_replace('/<\/?br\s*\/?>/i', '', $xmlContent);
         } else {
-            $xmlContent = preg_replace('/<br\s*\/?>/', "\n", $xmlContent); // Replace <br/> with newline
+           $xmlContent = preg_replace('/<\/?br\s*\/?>/i', '\n', $xmlContent); // Replace <br/> with newline
         }
         $xmlContent = preg_replace('/\xC2\xA0/', '', $xmlContent);
         $xmlContent = str_replace('Â', '', $xmlContent);


### PR DESCRIPTION
remove all forms of br in XML

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:
`<br />` can mess up parsing of narratives and lists so I remove. In this case I missed the invalid XHTML `<br></br>`
I also validate XML using DOMDocument() and convert to UTF-8 if needed.
After all the different versions of XML from other vendors, I've found not validating XML caused headaches that were difficult to track down.

#### Changes proposed in this pull request:
Remove all parts of the element

#### Does your code include anything generated by an AI Engine? No
