### PR TITLE
changing prefcat title to Exclusive Category and add description to a…

### DIFF
--- a/interface/main/calendar/add_edit_event.php
+++ b/interface/main/calendar/add_edit_event.php
@@ -1706,7 +1706,10 @@ function isRegularRepeat($repeat)
 <div class="form-row mx-2">
     <div class="col-sm form-group">
         <label id='title_apptstatus'><?php echo xlt('Status'); ?>:</label>
-        <label id='title_prefcat' class='font-weight-bold' style='display:none'><?php echo xlt('Pref Cat'); ?>:</label>
+        <label id='title_prefcat' class='font-weight-bold' style='display:none'>
+            <?php echo xlt('Exclusive Category'); ?>:
+            <i class="text-muted font-weight-normal ml-1"><?php echo xlt('(If selected, you will only be shown as available for this category)'); ?></i>
+        </label>
         <?php
         if ($_GET['group'] != true) {
             generate_form_field(array('data_type' => 1, 'field_id' => 'apptstatus', 'list_id' => 'apptstat', 'empty_title' => 'SKIP'), ($row['pc_apptstatus'] ?? null));


### PR DESCRIPTION
…void misleading

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
--> https://github.com/openemr/openemr/issues/7689

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #7689

#### Short description of what this resolves:
While having this pref cat feature can definitely be useful in the real world, with providers that might only want to accept a certain event category for certain time frames, I think the title is quite misleading and can cause real problems. In the future I think it will be useful to have a project to make this drop down multi-select, but this should be a good temporary fix to avoid unintended filtering of availability. 

#### Changes proposed in this pull request:
Changed the title **"Pref Cat"** to **"Exclusive Category"** and added a description next to it. 

#### Does your code include anything generated by an AI Engine? Yes / No
No

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.
