### PR TITLE
fixing keyword processing issue in calendar search

### DIFF
--- a/interface/main/calendar/includes/pnAPI.php
+++ b/interface/main/calendar/includes/pnAPI.php
@@ -410,42 +410,6 @@ function pnVarCleanFromInput()
 }
 
 /**
- * clean user input, but just for strings
- * <br />
- * Gets a global variable, cleaning it up to try to ensure that
- * hack attacks don't work
- * @param $string - the string to clean
- * @returns string
- * @return $cleaned - $string after being cleaned
- */
-function pnStringCleanFromInput($string)
-{
-    // If string is empty, return empty string
-    if (empty($string)) {
-        return '';
-    }
-
-    // Define patterns to remove potentially harmful HTML/script elements
-    $search = array(
-        '|</?\s*SCRIPT.*?>|si',
-        '|</?\s*FRAME.*?>|si',
-        '|</?\s*OBJECT.*?>|si',
-        '|</?\s*META.*?>|si',
-        '|</?\s*APPLET.*?>|si',
-        '|</?\s*LINK.*?>|si',
-        '|</?\s*IFRAME.*?>|si',
-        '|STYLE\s*=\s*"[^"]*"|si'
-    );
-
-    // Replace harmful patterns with empty string
-    $cleaned = preg_replace($search, '', $string);
-    $cleaned = strip_tags($cleaned);
-    $cleaned = htmlspecialchars($cleaned, ENT_QUOTES, 'UTF-8');
-
-    return $cleaned;
-}
-
-/**
  * ready user output
  * <br />
  * Gets a variable, cleaning it up such that the text is

--- a/interface/main/calendar/includes/pnAPI.php
+++ b/interface/main/calendar/includes/pnAPI.php
@@ -410,6 +410,42 @@ function pnVarCleanFromInput()
 }
 
 /**
+ * clean user input, but just for strings
+ * <br />
+ * Gets a global variable, cleaning it up to try to ensure that
+ * hack attacks don't work
+ * @param $string - the string to clean
+ * @returns string
+ * @return $cleaned - $string after being cleaned
+ */
+function pnStringCleanFromInput($string)
+{
+    // If string is empty, return empty string
+    if (empty($string)) {
+        return '';
+    }
+
+    // Define patterns to remove potentially harmful HTML/script elements
+    $search = array(
+        '|</?\s*SCRIPT.*?>|si',
+        '|</?\s*FRAME.*?>|si',
+        '|</?\s*OBJECT.*?>|si',
+        '|</?\s*META.*?>|si',
+        '|</?\s*APPLET.*?>|si',
+        '|</?\s*LINK.*?>|si',
+        '|</?\s*IFRAME.*?>|si',
+        '|STYLE\s*=\s*"[^"]*"|si'
+    );
+
+    // Replace harmful patterns with empty string
+    $cleaned = preg_replace($search, '', $string);
+    $cleaned = strip_tags($cleaned);
+    $cleaned = htmlspecialchars($cleaned, ENT_QUOTES, 'UTF-8');
+
+    return $cleaned;
+}
+
+/**
  * ready user output
  * <br />
  * Gets a variable, cleaning it up such that the text is

--- a/interface/main/calendar/modules/PostCalendar/pnuser.php
+++ b/interface/main/calendar/modules/PostCalendar/pnuser.php
@@ -122,7 +122,7 @@ function postcalendar_user_display($args)
 function postcalendar_user_search()
 {
     $tpl = new pcSmarty();
-    $k = isset($_REQUEST['pc_keywords']) ? pnVarCleanFromInput($_REQUEST['pc_keywords']) : '';
+    $k = !empty($_REQUEST['pc_keywords']) ? pnStringCleanFromInput($_REQUEST['pc_keywords']) : '';
     $k_andor = pnVarCleanFromInput('pc_keywords_andor');
     $pc_category = pnVarCleanFromInput('pc_category');
     $pc_facility = pnVarCleanFromInput('pc_facility');

--- a/interface/main/calendar/modules/PostCalendar/pnuser.php
+++ b/interface/main/calendar/modules/PostCalendar/pnuser.php
@@ -122,7 +122,7 @@ function postcalendar_user_display($args)
 function postcalendar_user_search()
 {
     $tpl = new pcSmarty();
-    $k = !empty($_REQUEST['pc_keywords']) ? pnStringCleanFromInput($_REQUEST['pc_keywords']) : '';
+    $k = pnVarCleanFromInput('pc_keywords') ?? '';
     $k_andor = pnVarCleanFromInput('pc_keywords_andor');
     $pc_category = pnVarCleanFromInput('pc_category');
     $pc_facility = pnVarCleanFromInput('pc_facility');


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
--> https://github.com/openemr/openemr/issues/8239

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes # 8239

#### Short description of what this resolves:
Calendar search Keywords field not working

#### Changes proposed in this pull request:
The Keywords field currently gets cleaned in the **pnVarCleanFromInput** function and since the Keywords field is just a string, it does not get processed properly and returns null. 

I added a new function, **pnStringCleanFromInput**, which properly cleans string inputs. 

#### Does your code include anything generated by an AI Engine? Yes / No
No

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.
