### PR TITLE
Correct mismatched Review and Donate globals on About page

### DIFF
--- a/interface/main/about_page.php
+++ b/interface/main/about_page.php
@@ -58,8 +58,8 @@ $viewArgs = [
     'userManualHref' => $userManual,
     'onlineSupportLink' => $GLOBALS['online_support_link'] ?? false,
     'displayAcknowledgements' => $GLOBALS['display_acknowledgements'],
-    'displayDonations' => $GLOBALS['display_review_link'],
-    'displayReview' => $GLOBALS['display_donations_link'],
+    'displayReview' => $GLOBALS['display_review_link'],
+    'displayDonations' => $GLOBALS['display_donations_link'],
 ];
 
 echo $t->render('core/about.html.twig', $viewArgs);


### PR DESCRIPTION
Fixes https://github.com/openemr/openemr/issues/8204

#### Short description of what this resolves:

Fixes issue where the global setting "Display the Review link on the About page" controls the visibility of the "Donate" link and the global setting "Display the Donations link on the About page" controls the visibility of the "Write a Review" link.

#### Changes proposed in this pull request:

Simple typo correction

#### Does your code include anything generated by an AI Engine?

No
