### PR TITLE
Fixes #8262 default facility to respect care team

### DIFF
--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -4316,7 +4316,7 @@ $GLOBALS_METADATA = array(
         ],
 
         'set_service_facility_encounter' => array(
-            xl('Set Service Facility in Encounter'),
+            xl('Set Service Facility in Encounter To First Care Team Facility'),
             'bool',                           // data type
             '0',                              // default = false
             xl('This feature will allow the default service facility to be selected by the care team facility in Choices.')


### PR DESCRIPTION
Brought back in the default facility in order to respect the Set Service Facility care team setting.

Fixed the care team setting so it uses the first care team setting in the patient demographics.  Before it would break if there were multiple care team settings.

Relabeled the Set Service Facility care team setting label so it is more clear of what is happening.

Fixes #8262