### PR TITLE
alter document api response body to include file name and hash

### DIFF
--- a/src/Services/DocumentService.php
+++ b/src/Services/DocumentService.php
@@ -101,7 +101,7 @@ class DocumentService extends BaseService
 
         $categoryId = $this->getLastIdOfPath($path);
 
-        $documentsSql  = " SELECT doc.url, doc.id, doc.mimetype, doc.docdate";
+        $documentsSql  = " SELECT doc.id, doc.mimetype, doc.docdate, doc.name, doc.hash";
         $documentsSql .= " FROM documents doc";
         $documentsSql .= " JOIN categories_to_documents ctd on ctd.document_id = doc.id";
         $documentsSql .= " WHERE ctd.category_id = ? and doc.foreign_id = ? and doc.deleted = 0";
@@ -111,7 +111,8 @@ class DocumentService extends BaseService
         $fileResults = array();
         while ($row = sqlFetchArray($documentResults)) {
             array_push($fileResults, array(
-                "filename" => basename($row["url"]),
+                "filename" => $row["name"],
+                "hash" => $row["hash"],
                 "id" =>  $row["id"],
                 "mimetype" =>  $row["mimetype"],
                 "docdate" =>  $row["docdate"]

--- a/src/Services/DocumentService.php
+++ b/src/Services/DocumentService.php
@@ -158,12 +158,12 @@ class DocumentService extends BaseService
 
     public function getFile($pid, $did)
     {
-        $filenameSql = sqlQuery("SELECT `url`, `mimetype` FROM `documents` WHERE `id` = ? AND `foreign_id` = ? AND `deleted` = 0", [$did, $pid]);
+        $filenameSql = sqlQuery("SELECT `name`, `mimetype` FROM `documents` WHERE `id` = ? AND `foreign_id` = ? AND `deleted` = 0", [$did, $pid]);
 
-        if (empty(basename($filenameSql['url']))) {
+        if (empty($filenameSql['name'])) {
             $filename = "unknownName";
         } else {
-            $filename = basename($filenameSql['url']);
+            $filename = $filenameSql['name'];
         }
 
         $obj = new \C_Document();


### PR DESCRIPTION
Fixes #8304

#### Short description of what this resolves:
Return the filename as it is stored in the database in the documents api.

#### Changes proposed in this pull request:
Don't use the file path basename but get the name field from the documents table.

I also added the hash field to the api, this makes preventing duplicate uploads a lot easier.


#### Does your code include anything generated by an AI Engine?  No

