### PR TITLE
correct checking of memory_limit in setup.php

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -1492,7 +1492,26 @@ STP4TOP;
                     $post_max_size = ini_get('post_max_size');
                     $post_max_size_style = $post_max_size < 30 ? 'text-danger' : '';
                     $memory_limit = ini_get('memory_limit');
-                    $memory_limit_style = $memory_limit < 256 ? 'text-danger' : '';
+                    // Convert from shorthand to M
+                    if (preg_match('/^(\d+)([KMG]?)$/', $memory_limit, $matches)) {
+                        switch ($matches[2]) {
+                            case 'K':
+                                $memory_limit_mb = intdiv($matches[1], 1024);
+                                break;
+                            case 'M':
+                                $memory_limit_mb = (int)$matches[1];
+                                break;
+                            case 'G':
+                                $memory_limit_mb = $matches[1] * 1024;
+                                break;
+                            case '':
+                                $memory_limit_mb = intdiv($matches[1], 1024 * 1024);
+                                break;
+                        }
+                    } else {
+                        $memory_limit_mb = intdiv($memory_limit, 1024 * 1024);
+                    }
+                    $memory_limit_style = $memory_limit_mb < 512 ? 'text-danger' : '';
                     $mysqli_allow_local_infile = ini_get('mysqli.allow_local_infile') ? 'On' : 'Off';
                     $mysqli_allow_local_infile_style = (strcmp($mysqli_allow_local_infile, 'On')  === 0) ? '' : 'text-danger';
 
@@ -1540,7 +1559,7 @@ STP4TOP;
                                 </tr>
                                 <tr>
                                     <td>memory_limit</td>
-                                    <td>at least 256M</td>
+                                    <td>at least 512M</td>
                                     <td class='" . attr($memory_limit_style) . "'>" . text($memory_limit) . "</td>
                                 </tr>
                                 <tr>
@@ -1793,7 +1812,8 @@ FRM;
                                         <button type='submit' value='Continue'><b>Proceed to Step 1</b></button>
                                     </form>
 FRM;
-                        echo $form . "\r\n";                        }
+                        echo $form . "\r\n";
+                    }
             }
                         $bot = <<<BOT
                                     </div>


### PR DESCRIPTION
#### Short description of what this resolves:

Corrects setup.php's comparison of `memory_limit` so it doesn't flag inappropriate values.


#### Changes proposed in this pull request:

- Update `memory_limit` from 256M to 512M to be consistent with `Documentation/INSTALL`
- Convert the ini value to M before the comparison, to avoid erroneously flagging 1G as too little, or 1024K as enough.

#### Does your code include anything generated by an AI Engine? Yes / No

No

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.
