### PR TITLE
Improving reminder forms

### DIFF
--- a/interface/main/dated_reminders/dated_reminders_add.php
+++ b/interface/main/dated_reminders/dated_reminders_add.php
@@ -445,7 +445,14 @@ if (isset($this_message['pid'])) {
             </div>
 
             <div class="col-12 mt-4">
+                <div class="card">
+                    <div class="card-header bg-primary text-white">
+                        <h5 class="mb-0"><?php echo xlt('Messages Sent Today') ?></h5>
+                    </div>
+                    <div class="card-body p-0">
                         <?php
+                        $_GET['sentBy'] = array($_SESSION['authUserID']);
+                        $_GET['sd'] = oeFormatShortDate();
                         $TempRemindersArray = logRemindersArray();
                         $remindersArray = array();
                         foreach ($TempRemindersArray as $RA) {
@@ -456,47 +463,39 @@ if (isset($this_message['pid'])) {
                             $remindersArray[$RA['messageID']]['dDate'] = $RA['dDate'];
                         }
 
+                        if (empty($remindersArray)) {
+                            echo '<div class="alert alert-info text-center m-3">' . xlt('No Messages Found') . '</div>';
+                        } else {
+                            echo '<div class="table-responsive">
+                                <table class="table table-striped table-hover" id="logTable">
+                                    <thead class="thead-light">
+                                    <tr>
+                                        <th>' . xlt('ID') . '</th>
+                                        <th>' . xlt('To{{Destination}}') . '</th>
+                                        <th>' . xlt('Patient') . '</th>
+                                        <th>' . xlt('Message') . '</th>
+                                        <th>' . xlt('Due Date') . '</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>';
+
+                            foreach ($remindersArray as $RA) {
+                                echo '<tr>
+                                    <td>' . text($RA['messageID']) . '</td>
+                                    <td>' . text($RA['ToName']) . '</td>
+                                    <td>' . text($RA['PatientName']) . '</td>
+                                    <td>' . text($RA['message']) . '</td>
+                                    <td>' . text(oeFormatShortDate($RA['dDate'])) . '</td>
+                                    </tr>';
+                            }
+
+                            echo '</tbody></table></div>';
+                        }
+                        ?>
+                    </div>
                 </div>
             </div>
-    <div class="table-responsive">
-    <?php
-        $_GET['sentBy'] = array($_SESSION['authUserID']);
-        $_GET['sd'] = oeFormatShortDate();
-        $TempRemindersArray = logRemindersArray();
-        $remindersArray = array();
-    foreach ($TempRemindersArray as $RA) {
-        $remindersArray[$RA['messageID']]['messageID'] = $RA['messageID'];
-        $remindersArray[$RA['messageID']]['ToName'] = ((!empty($remindersArray[$RA['messageID']]['ToName'])) ? $remindersArray[$RA['messageID']]['ToName'] . ', ' . ($RA['ToName'] ?? '') : ($RA['ToName'] ?? ''));
-        $remindersArray[$RA['messageID']]['PatientName'] = $RA['PatientName'];
-        $remindersArray[$RA['messageID']]['message'] = $RA['message'];
-        $remindersArray[$RA['messageID']]['dDate'] = $RA['dDate'];
-    }
-
-        echo '<h4>' . xlt('Messages You have sent Today') . '</h4>';
-        echo '<table class="table table-bordered table-hover" id="logTable">
-                <thead>
-                  <tr>
-                    <th>' . xlt('ID') . '</th>
-                    <th>' . xlt('To{{Destination}}') . '</th>
-                    <th>' . xlt('Patient') . '</th>
-                    <th>' . xlt('Message') . '</th>
-                    <th>' . xlt('Due Date') . '</th>
-                  </tr>
-                </thead>
-                <tbody>';
-
-    foreach ($remindersArray as $RA) {
-        echo '<tr class="heading">
-                  <td>' . text($RA['messageID']) . '</td>
-                  <td>' . text($RA['ToName']) . '</td>
-                  <td>' . text($RA['PatientName']) . '</td>
-                  <td>' . text($RA['message']) . '</td>
-                  <td>' . text(oeFormatShortDate($RA['dDate'])) . '</td>
-                </tr>';
-    }
-
-        echo '</tbody></table></fieldset><div>';
-    ?>
+        </div>
     </div><!--end of container div-->
   <script>
     $(function () {

--- a/interface/main/dated_reminders/dated_reminders_add.php
+++ b/interface/main/dated_reminders/dated_reminders_add.php
@@ -432,6 +432,14 @@ if (isset($this_message['pid'])) {
                                 </div>
                             </div>
                         </div>
+                        <div class="card-footer">
+                            <button type='submit' class='btn btn-primary' name="sendButton" id="sendButton" value="<?php echo xla('Send This Message');?>" onclick='return this.clicked = true;'>
+                                <i class="fa fa-paper-plane mr-1"></i><?php echo xlt('Send This Message'); ?>
+                            </button>
+                            <button type="reset" class="btn btn-secondary ml-1">
+                                <i class="fa fa-eraser mr-1"></i><?php echo xlt('Reset') ?>
+                            </button>
+                        </div>
                     </form>
                 </div>
             </div>

--- a/interface/main/dated_reminders/dated_reminders_add.php
+++ b/interface/main/dated_reminders/dated_reminders_add.php
@@ -306,60 +306,138 @@ if (isset($this_message['pid'])) {
 <div id="overDiv" style="position:absolute; visibility:hidden; z-index:1000;"></div>
 
     <div class="container">
-        <h4><?php echo attr($reminder_title) ?></h4>
-        <form id="addDR"  class="form-horizontal" id="newMessage" method="post" onsubmit="return top.restoreSession()">
-            <input type="hidden" name="csrf_token_form" value="<?php echo attr(CsrfUtils::collectCsrfToken()); ?>" />
+        <div class="row">
+            <div class="col-12 mb-3">
+                <div class="card">
+                    <div class="card-header bg-primary text-white">
+                        <h5 class="mb-0"><?php echo attr($reminder_title) ?></h5>
+                    </div>
+                    <div class="card-body">
+                        <form id="addDR" class="form-horizontal" method="post" onsubmit="return top.restoreSession()">
+                            <input type="hidden" name="csrf_token_form" value="<?php echo attr(CsrfUtils::collectCsrfToken()); ?>" />
 
-            <fieldset id='error-info' class='oe-error-modal' style="display: none">
-                <div class="text-center" id="errorMessage"></div>
-            </fieldset>
+                            <fieldset id='error-info' class='oe-error-modal' style="display: none">
+                                <div class="text-center" id="errorMessage"></div>
+                            </fieldset>
 
+                            <div class="section-header mb-2" style="max-width: 100%; box-sizing: border-box; overflow: hidden;">
+                                <h6 class="text-muted"><?php echo xlt('Message Recipients');?></h6>
+                            </div>
 
-            <div class="form-group mt-3">
-                <label for="patientName"><?php echo xlt('Link To Patient') ?>: <i id="link-tooltip" class="fa fa-info-circle text-primary" aria-hidden="true" data-original-title="" title=""></i></label>
-                <input type='text' id='patientName' name='patientName' class='form-control' value='<?php echo ($patientID > 0 ? attr(getPatName($patientID)) : xla('Click to select patient')); ?>' onclick='sel_patient()' title='<?php xla('Click to select patient'); ?>' readonly />
-                <input type="hidden" name="PatientID" id="PatientID" value="<?php echo (isset($patientID) ? attr($patientID) : 0) ?>" />
-                <button type="button" class="btn btn-secondary btn-undo mt-2" <?php echo ($patientID > 0 ? '' : 'style="display:none"') ?> id="removePatient"><?php echo xlt('unlink patient') ?></button>
-            </div>
+                            <div class="form-group">
+                                <label for="patientName">
+                                    <?php echo xlt('Link To Patient') ?>:
+                                    <i id="link-tooltip" class="fa fa-info-circle text-primary ml-1" aria-hidden="true" data-original-title="" title=""></i>
+                                </label>
+                                <input type='text' id='patientName' name='patientName' class='form-control' value='<?php echo ($patientID > 0 ? attr(getPatName($patientID)) : xla('Click to select patient')); ?>' onclick='sel_patient()' title='<?php xla('Click to select patient'); ?>' readonly />
+                                <input type="hidden" name="PatientID" id="PatientID" value="<?php echo (isset($patientID) ? attr($patientID) : 0) ?>" />
+                                <button type="button" class="btn btn-sm btn-outline-secondary mt-2" <?php echo ($patientID > 0 ? '' : 'style="display:none"') ?> id="removePatient">
+                                    <i class="fa fa-unlink mr-1"></i><?php echo xlt('Unlink Patient') ?>
+                                </button>
+                            </div>
 
-            <div class="form-group mt-3">
-                <label for="patientName">
-                    <?php echo xlt('Send to') ?>:
-                    <br />
-                    <?php echo xlt('([ctrl] + click to select multiple recipients)'); ?>
-                </label>
-                <select class="form-control" id="sendTo" name="sendTo[]" multiple="multiple">
-                    <option value="<?php echo attr(intval($_SESSION['authUserID'])); ?>"><?php echo xlt('Myself') ?></option>
-                        <?php //
-                        $uSQL = sqlStatement('SELECT id, fname,	mname, lname  FROM  `users` WHERE  `active` = 1 AND `facility_id` > 0 AND id != ?', array(intval($_SESSION['authUserID'])));
-                        for ($i = 2; $uRow = sqlFetchArray($uSQL); $i++) {
-                            echo '<option value="' . attr($uRow['id']) . '">' . text($uRow['fname'] . ' ' . $uRow['mname'] . ' ' . $uRow['lname']) . '</option>';
-                        }
-                        ?>
-                </select>
-                <a class="btn btn-secondary btn-save mt-2" style="cursor: pointer" onclick="selectAll();"><?php echo xlt('Select all') ?></a>
-            </div>
+                            <div class="form-group mt-3">
+                                <label for="sendTo">
+                                    <?php echo xlt('Send To') ?>:
+                                    <small class="text-muted">
+                                        <?php echo xlt('([ctrl] + click or [cmd] + click on Mac to select multiple)'); ?>
+                                    </small>
+                                </label>
+                                <select class="form-control" id="sendTo" name="sendTo[]" multiple="multiple">
+                                    <option value="<?php echo attr(intval($_SESSION['authUserID'])); ?>"><?php echo xlt('Myself') ?></option>
+                                    <?php //
+                                    $uSQL = sqlStatement('SELECT id, fname, mname, lname FROM `users` WHERE `active` = 1 AND `facility_id` > 0 AND id != ?', array(intval($_SESSION['authUserID'])));
+                                    for ($i = 2; $uRow = sqlFetchArray($uSQL); $i++) {
+                                        echo '<option value="' . attr($uRow['id']) . '">' . text($uRow['fname'] . ' ' . $uRow['mname'] . ' ' . $uRow['lname']) . '</option>';
+                                    }
+                                    ?>
+                                </select>
+                                <button type="button" class="btn btn-sm btn-outline-secondary mt-2" onclick="selectAll();">
+                                    <i class="fa fa-users mr-1"></i><?php echo xlt('Select All') ?>
+                                </button>
+                            </div>
 
-            <div class="form-group mt-3">
-                <div class="checkbox">
-                    <label>
-                        <input type="checkbox" name="sendSeperately" id="sendSeperately" title="<?php echo xla('Selecting this will create a message that needs to be processed by each recipient individually (this is not a group task).') ?>" />  <i id="select-tooltip" class="fa fa-info-circle text-primary" aria-hidden="true" data-original-title="" title=""></i> <?php echo xlt('Each recipient must set their own messages as completed.') ?>
-                    </label>
+                            <div class="form-group">
+                                <div class="custom-control custom-checkbox">
+                                    <input type="checkbox" class="custom-control-input" name="sendSeperately" id="sendSeperately" title="<?php echo xla('Selecting this will create a message that needs to be processed by each recipient individually (this is not a group task).') ?>" />
+                                    <label class="custom-control-label" for="sendSeperately">
+                                        <?php echo xlt('Each recipient must set their own messages as completed.') ?>
+                                        <i id="select-tooltip" class="fa fa-info-circle text-primary ml-1" aria-hidden="true" data-original-title="" title=""></i>
+                                    </label>
+                                </div>
+                            </div>
+
+                            <div class="section-header mt-4 mb-2" style="max-width: 100%; box-sizing: border-box; overflow: hidden;">
+                                <h6 class="text-muted"><?php echo xlt('Due Date & Priority');?></h6>
+                            </div>
+
+                            <div class="form-group row">
+                                <div class="col-12 col-md-5">
+                                    <label for="dueDate"><?php echo xlt('Due Date') ?>:</label>
+                                    <input type='text' class='datepicker form-control' name='dueDate' id="dueDate" value="<?php echo ($this_message['dueDate'] == '' ? oeFormatShortDate() : attr(oeFormatShortDate($this_message['dueDate']))); ?>" title='<?php echo attr(DateFormatRead('validateJS')) ?>'>
+                                </div>
+                                <div class="col-12 col-md-2">
+                                    <label class="d-none d-md-block">&nbsp;</label>
+                                    <div class="text-center mt-md-2"><?php echo xlt('OR') ?></div>
+                                </div>
+                                <div class="col-12 col-md-5">
+                                    <label for="timeSpan"><?php echo xlt('Select a Time Span') ?>:</label>
+                                    <select id="timeSpan" class="form-control">
+                                        <option value="__BLANK__"> -- <?php echo xlt('Select a Time Span') ?> -- </option>
+                                        <?php
+                                        $optionTxt = '';
+                                        foreach ($dateRanges as $val => $txt) {
+                                            $optionTxt .= '<option value="' . attr($val) . '">' . text($txt) . '</option>';
+                                        }
+                                        echo $optionTxt;
+                                        ?>
+                                    </select>
+                                </div>
+                            </div>
+
+                            <div class="form-group mt-3">
+                                <label for="priority"><?php echo xlt('Priority') ?>:</label>
+                                <div class="mt-2">
+                                    <div class="custom-control custom-radio custom-control-inline">
+                                        <input <?php echo ($this_message['message_priority'] == 3 ? 'checked="checked"' : '') ?> type="radio" class="custom-control-input" name="priority" id="priority_3" value='3'>
+                                        <label class="custom-control-label" for="priority_3"><strong><?php echo xlt('Low{{Priority}}') ?></strong></label>
+                                    </div>
+                                    <div class="custom-control custom-radio custom-control-inline">
+                                        <input <?php echo ($this_message['message_priority'] == 2 ? 'checked="checked"' : '') ?> type="radio" class="custom-control-input" name="priority" id="priority_2" value='2'>
+                                        <label class="custom-control-label" for="priority_2"><strong><?php echo xlt('Medium{{Priority}}') ?></strong></label>
+                                    </div>
+                                    <div class="custom-control custom-radio custom-control-inline">
+                                        <input <?php echo ($this_message['message_priority'] == 1 ? 'checked="checked"' : '') ?> type="radio" class="custom-control-input" name="priority" id="priority_1" value='1'>
+                                        <label class="custom-control-label" for="priority_1"><strong><?php echo xlt('High{{Priority}}') ?></strong></label>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="section-header mt-4 mb-2" style="max-width: 100%; box-sizing: border-box; overflow: hidden;">
+                                <h6 class="text-muted"><?php echo xlt('Message Content');?></h6>
+                            </div>
+
+                            <div class="form-group">
+                                <label for="message"><?php echo xlt('Type Your Message Here');?>:</label>
+                                <textarea onKeyDown="limitText(this.form.message,this.form.countdown,<?php echo attr(addslashes($max_reminder_words)); ?>);"
+                                        onKeyUp="limitText(this.form.message,this.form.countdown,<?php echo attr(addslashes($max_reminder_words)); ?>);"
+                                        class="form-control" rows="5" name="message" id="message"
+                                        placeholder="<?php echo xla('Maximum characters') ?> : <?php echo attr($max_reminder_words); ?>"><?php echo text($this_message['dr_message_text'] ?? '');?></textarea>
+
+                                <div class="form-row mt-2">
+                                    <label class="col-form-label" for="countdown"><?php echo xlt('Characters Remaining') ?>:</label>
+                                    <div class="col-2">
+                                        <input class="form-control form-control-sm" readonly type="text" name="countdown" id="countdown" value="<?php echo attr($max_reminder_words); ?>" />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </form>
                 </div>
             </div>
 
-                </div>
-                <div class="col-2">
-                    <label for="">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</label>
-                    <div class="text-center"><?php echo xlt('OR') ?></div>
-                </div>
-                <div class="col-5">
-                    <label for="timeSpan"><?php echo xlt('Select a Time Span') ?>:</label>
             <div class="col-12 mt-4">
                         <?php
-                        $optionTxt = '';
-                        foreach ($dateRanges as $val => $txt) {
-                            $optionTxt .= '<option value="' . attr($val) . '">' . text($txt) . '</option>';
                         $TempRemindersArray = logRemindersArray();
                         $remindersArray = array();
                         foreach ($TempRemindersArray as $RA) {
@@ -369,20 +447,9 @@ if (isset($this_message['pid'])) {
                             $remindersArray[$RA['messageID']]['message'] = $RA['message'];
                             $remindersArray[$RA['messageID']]['dDate'] = $RA['dDate'];
                         }
-                    <label class="radio-inline"><input type="radio" name="optradio" class="d-none" /><input <?php echo ($this_message['message_priority'] == 1 ? 'checked="checked"' : '') ?> type="radio" name="priority" id="priority_1" value='1'><strong><?php echo xlt('High{{Priority}}') ?></strong>
-            <div class="form-group mt-3">
-                <label class="text-right" for="message"><?php echo xlt('Type Your message here');?>:</label>
-                <textarea onKeyDown="limitText(this.form.message,this.form.countdown,<?php echo attr(addslashes($max_reminder_words)); ?>);" onKeyUp="limitText(this.form.message,this.form.countdown,<?php echo attr(addslashes($max_reminder_words)); ?>);" class="form-control text-left" rows="5" name="message" id="message" placeholder="<?php echo xla('Maximum characters') ?> : <?php echo attr($max_reminder_words); ?>"><?php echo text($this_message['dr_message_text'] ?? '');?></textarea>
-            </div>
 
-            <div class="form-row mt-3">
-                <label class="col-form-label col" for="countdown"><?php echo xlt('Characters Remaining') ?>:</label>
-                <div class="col-2">
-                    <input class="form-control" readonly type="text" name="countdown" id="countdown" value="<?php echo attr($max_reminder_words); ?>" />
                 </div>
             </div>
-            <button type='submit' class='btn btn-primary btn-send-msg' name="sendButton" id="sendButton" value="<?php echo xla('Send This Message');?>"  onclick='return this.clicked = true;'><?php echo xlt('Send This Message'); ?></button>
-        </form>
     <div class="table-responsive">
     <?php
         $_GET['sentBy'] = array($_SESSION['authUserID']);

--- a/interface/main/dated_reminders/dated_reminders_add.php
+++ b/interface/main/dated_reminders/dated_reminders_add.php
@@ -419,8 +419,8 @@ if (isset($this_message['pid'])) {
 
                             <div class="form-group">
                                 <label for="message"><?php echo xlt('Type Your Message Here');?>:</label>
-                                <textarea onKeyDown="limitText(this.form.message,this.form.countdown,<?php echo attr(addslashes($max_reminder_words)); ?>);"
-                                        onKeyUp="limitText(this.form.message,this.form.countdown,<?php echo attr(addslashes($max_reminder_words)); ?>);"
+                                <textarea onKeyDown="limitText(this.form.message,this.form.countdown,<?php echo attr_js($max_reminder_words); ?>);"
+                                        onKeyUp="limitText(this.form.message,this.form.countdown,<?php echo attr_js($max_reminder_words); ?>);"
                                         class="form-control" rows="5" name="message" id="message"
                                         placeholder="<?php echo xla('Maximum characters') ?> : <?php echo attr($max_reminder_words); ?>"><?php echo text($this_message['dr_message_text'] ?? '');?></textarea>
 

--- a/interface/main/dated_reminders/dated_reminders_add.php
+++ b/interface/main/dated_reminders/dated_reminders_add.php
@@ -211,7 +211,7 @@ if (isset($this_message['pid'])) {
           // todo : check if they are all numeric , no rush as this is checked in the php after the post
 
           if (!$("#sendTo option:selected").length){
-             errorMessage = errorMessage + '* <?php echo xla('Please Select A Recipient') ?><br />';
+             errorMessage = errorMessage + '* <?php echo xla('Please select a recipient') ?><br />';
           }
 
 
@@ -348,10 +348,6 @@ if (isset($this_message['pid'])) {
                 </div>
             </div>
 
-            <div class="form-group row mt-3">
-                <div class="col-5">
-                    <label for="dueDate"><?php echo xlt('Due Date') ?>:</label>
-                    <input type='text' class='datepicker form-control' name='dueDate' id="dueDate" value="<?php echo ($this_message['dueDate'] == '' ? oeFormatShortDate() : attr(oeFormatShortDate($this_message['dueDate']))); ?>" title='<?php echo attr(DateFormatRead('validateJS')) ?>'>
                 </div>
                 <div class="col-2">
                     <label for="">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</label>
@@ -359,33 +355,21 @@ if (isset($this_message['pid'])) {
                 </div>
                 <div class="col-5">
                     <label for="timeSpan"><?php echo xlt('Select a Time Span') ?>:</label>
-                    <select id="timeSpan" class="form-control">
-                        <option value="__BLANK__"> -- <?php echo xlt('Select a Time Span') ?> -- </option>
+            <div class="col-12 mt-4">
                         <?php
                         $optionTxt = '';
                         foreach ($dateRanges as $val => $txt) {
                             $optionTxt .= '<option value="' . attr($val) . '">' . text($txt) . '</option>';
+                        $TempRemindersArray = logRemindersArray();
+                        $remindersArray = array();
+                        foreach ($TempRemindersArray as $RA) {
+                            $remindersArray[$RA['messageID']]['messageID'] = $RA['messageID'];
+                            $remindersArray[$RA['messageID']]['ToName'] = ((!empty($remindersArray[$RA['messageID']]['ToName'])) ? $remindersArray[$RA['messageID']]['ToName'] . ', ' . ($RA['ToName'] ?? '') : ($RA['ToName'] ?? ''));
+                            $remindersArray[$RA['messageID']]['PatientName'] = $RA['PatientName'];
+                            $remindersArray[$RA['messageID']]['message'] = $RA['message'];
+                            $remindersArray[$RA['messageID']]['dDate'] = $RA['dDate'];
                         }
-                        echo $optionTxt;
-                        ?>
-                    </select>
-                </div>
-            </div>
-
-            <div class="form-group row mt-3">
-                <div class="col-2 text-right">
-                    <label for="priority"><?php echo xlt('Priority') ?>:</label>
-                </div>
-                <div class="col-10">
-                    <label class="radio-inline"><input <?php echo ($this_message['message_priority'] == 3 ? 'checked="checked"' : '') ?> type="radio" name="priority" id="priority_3" value='3'><strong><?php echo xlt('Low{{Priority}}') ?></strong>
-                    </label>
-                    <label class="radio-inline"><input type="radio" name="optradio" class="d-none" /><input <?php echo ($this_message['message_priority'] == 2 ? 'checked="checked"' : '') ?> type="radio" name="priority" id="priority_2" value='2'><strong><?php echo xlt('Medium{{Priority}}') ?></strong>
-                    </label>
                     <label class="radio-inline"><input type="radio" name="optradio" class="d-none" /><input <?php echo ($this_message['message_priority'] == 1 ? 'checked="checked"' : '') ?> type="radio" name="priority" id="priority_1" value='1'><strong><?php echo xlt('High{{Priority}}') ?></strong>
-                    </label>
-                </div>
-            </div>
-
             <div class="form-group mt-3">
                 <label class="text-right" for="message"><?php echo xlt('Type Your message here');?>:</label>
                 <textarea onKeyDown="limitText(this.form.message,this.form.countdown,<?php echo attr(addslashes($max_reminder_words)); ?>);" onKeyUp="limitText(this.form.message,this.form.countdown,<?php echo attr(addslashes($max_reminder_words)); ?>);" class="form-control text-left" rows="5" name="message" id="message" placeholder="<?php echo xla('Maximum characters') ?> : <?php echo attr($max_reminder_words); ?>"><?php echo text($this_message['dr_message_text'] ?? '');?></textarea>

--- a/interface/main/dated_reminders/dated_reminders_log.php
+++ b/interface/main/dated_reminders/dated_reminders_log.php
@@ -148,68 +148,90 @@ if ($_GET) {
         }
         ?>
         <div class="row">
-            <div class="col-12">
-                <h2><?php echo xlt('Dated Message Log');?> &nbsp;<i id="show_hide" class="fa fa-eye-slash fa-2x small" data-toggle="tooltip" data-placement="top" title="<?php echo xla('Click to Hide Filters'); ?>"></i></h2>
+            <div class="col-12 mb-2">
+                <h2 class="title">
+                    <?php echo xlt('Dated Message Log'); ?>
+                    <i id="show_hide" class="fa fa-eye-slash ml-2" data-toggle="tooltip" data-placement="top" title="<?php echo xla('Click to Hide Filters'); ?>"></i>
+                </h2>
             </div>
-            <div class="col-12 hideaway">
+            <div class="col-12 filter-section mb-3">
                 <form method="get" id="logForm" onsubmit="return top.restoreSession()">
                     <input type="hidden" name="csrf_token_form" value="<?php echo attr(CsrfUtils::collectCsrfToken()); ?>" />
-                    <fieldset>
-                        <legend><?php echo xlt('Filters') ?></legend>
-                        <h5><?php echo xlt('Date The Message Was Sent');?></h5>
-                        <div class="form-group row">
-                            <div class="col-12 col-md-6">
-                                <label class="col-form-label" for="sd"><?php echo xlt('Start Date') ?>:</label>
-                                <input id="sd" type="text" class='form-control datepicker' name="sd" value="" title='<?php echo attr(DateFormatRead('validateJS')) ?>'>
-                            </div>
-                            <div class="col-12 col-md-6">
-                                <label class="col-form-label" for="ed"><?php echo xlt('End Date') ?>:</label>
-                                <input id="ed" type="text" class='form-control datepicker' name="ed" value="" title='<?php echo attr(DateFormatRead('validateJS')) ?>'>
-                            </div>
+                    <div class="card">
+                        <div class="card-header bg-primary text-white">
+                            <h5 class="mb-0"><?php echo xlt('Filters') ?></h5>
                         </div>
-                        <div class="form-group row">
-                            <div class="col-12 col-md-6">
-                                <label class="col-form-label" for="sentBy"><?php echo xlt('Sent By, Leave Blank For All');?>:</label>
-                                <select class="form-control" id="sentBy" name="sentBy[]" multiple="multiple">
-                                    <option value="<?php echo attr(intval($_SESSION['authUserID'])); ?>"><?php echo xlt('Myself') ?></option>
-                                    <?php
-                                    if ($isAdmin) {
-                                        foreach ($allUsers as $user) {
-                                            echo '<option value="' . attr($user['id']) . '">' . text($user['fname'] . ' ' . $user['mname'] . ' ' . $user['lname']) . '</option>';
+                        <div class="card-body">
+                            <div class="section-header mb-2">
+                                <h6 class="text-muted"><?php echo xlt('Message Date Range');?></h6>
+                            </div>
+                            <div class="form-group row">
+                                <div class="col-12 col-md-6">
+                                    <label class="col-form-label" for="sd"><?php echo xlt('Start Date') ?>:</label>
+                                    <input id="sd" type="text" class='form-control datepicker' name="sd" value="" title='<?php echo attr(DateFormatRead('validateJS')) ?>'>
+                                </div>
+                                <div class="col-12 col-md-6">
+                                    <label class="col-form-label" for="ed"><?php echo xlt('End Date') ?>:</label>
+                                    <input id="ed" type="text" class='form-control datepicker' name="ed" value="" title='<?php echo attr(DateFormatRead('validateJS')) ?>'>
+                                </div>
+                            </div>
+
+                            <div class="section-header mt-4 mb-2">
+                                <h6 class="text-muted"><?php echo xlt('Message Participants');?></h6>
+                            </div>
+                            <div class="form-group row">
+                                <div class="col-12 col-md-6">
+                                    <label class="col-form-label" for="sentBy">
+                                        <?php echo xlt('Sent By');?>:
+                                        <small class="text-muted"><?php echo xlt('Leave blank for all'); ?></small>
+                                    </label>
+                                    <select class="form-control" id="sentBy" name="sentBy[]" multiple="multiple">
+                                        <option value="<?php echo attr(intval($_SESSION['authUserID'])); ?>"><?php echo xlt('Myself') ?></option>
+                                        <?php
+                                        if ($isAdmin) {
+                                            foreach ($allUsers as $user) {
+                                                echo '<option value="' . attr($user['id']) . '">' . text($user['fname'] . ' ' . $user['mname'] . ' ' . $user['lname']) . '</option>';
+                                            }
                                         }
-                                    }
-                                    ?>
-                                </select>
-                            </div>
-                            <div class="col-12 col-md-6">
-                                <label class="col-form-label" for="sentBy"><?php echo xlt('Sent To, Leave Blank For All') ?>:</label>
-                                <select class="form-control" id="sentTo" name="sentTo[]" multiple="multiple">
-                                    <option value="<?php echo attr(intval($_SESSION['authUserID'])); ?>"><?php echo xlt('Myself') ?></option>
-                                    <?php
-                                    if ($isAdmin) {
-                                        foreach ($allUsers as $user) {
-                                            echo '<option value="' . attr($user['id']) . '">' . text($user['fname'] . ' ' . $user['mname'] . ' ' . $user['lname']) . '</option>';
+                                        ?>
+                                    </select>
+                                    <small class="form-text text-muted">
+                                        <?php echo xlt('([ctrl] + click or [cmd] + click on Mac to select multiple)'); ?>
+                                    </small>
+                                </div>
+                                <div class="col-12 col-md-6">
+                                    <label class="col-form-label" for="sentTo">
+                                        <?php echo xlt('Sent To');?>:
+                                        <small class="text-muted"><?php echo xlt('Leave blank for all'); ?></small>
+                                    </label>
+                                    <select class="form-control" id="sentTo" name="sentTo[]" multiple="multiple">
+                                        <option value="<?php echo attr(intval($_SESSION['authUserID'])); ?>"><?php echo xlt('Myself') ?></option>
+                                        <?php
+                                        if ($isAdmin) {
+                                            foreach ($allUsers as $user) {
+                                                echo '<option value="' . attr($user['id']) . '">' . text($user['fname'] . ' ' . $user['mname'] . ' ' . $user['lname']) . '</option>';
+                                            }
                                         }
-                                    }
-                                    ?>
-                                </select>
+                                        ?>
+                                    </select>
+                                    <small class="form-text text-muted">
+                                        <?php echo xlt('([ctrl] + click or [cmd] + click on Mac to select multiple)'); ?>
+                                    </small>
+                                </div>
                             </div>
-                        </div>
-                        <div class="form-group row">
-                            <div class="checkbox">
-                                <label>
-                                    <input type="checkbox" name="processed" id="processed"><?php echo xlt('Processed') ?>
-                                </label>
-                                <label>
-                                    <input type="checkbox" name="pending" id="pending"><?php echo xlt('Pending') ?>
-                                </label>
+
+                            <div class="section-header mt-4 mb-2">
+                                <h6 class="text-muted"><?php echo xlt('Message Status');?></h6>
                             </div>
-                        </div>
-                    </fieldset>
-                    <div class="form-group row">
-                        <div class="col-sm-12 position-override">
-                            <div class="btn-group form-group" role="group">
-                                <button type="button" value="Refresh" id="submitForm" class="btn btn-secondary btn-refresh" ><?php echo xlt('Refresh') ?></button>
+                            <div class="form-group">
+                                <div class="custom-control custom-checkbox custom-control-inline">
+                                    <input type="checkbox" class="custom-control-input" name="processed" id="processed">
+                                    <label class="custom-control-label" for="processed"><?php echo xlt('Processed') ?></label>
+                                </div>
+                                <div class="custom-control custom-checkbox custom-control-inline">
+                                    <input type="checkbox" class="custom-control-input" name="pending" id="pending">
+                                    <label class="custom-control-label" for="pending"><?php echo xlt('Pending') ?></label>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/interface/main/dated_reminders/dated_reminders_log.php
+++ b/interface/main/dated_reminders/dated_reminders_log.php
@@ -35,23 +35,6 @@ if ($_GET) {
         }
     }
 
-    echo '  <div class="col-12">
-            <h4>' . xlt('Click and drag bottom right corner to resize this display') . '</h4>
-            <table class="table table-bordered"  id="logTable">
-                <thead>
-                  <tr>
-                    <th>' . xlt('ID') . '</th>
-                    <th>' . xlt('Sent Date') . '</th>
-                    <th>' . xlt('From') . '</th>
-                    <th>' . xlt('To{{Destination}}') . '</th>
-                    <th>' . xlt('Patient') . '</th>
-                    <th>' . xlt('Message') . '</th>
-                    <th>' . xlt('Due Date') . '</th>
-                    <th>' . xlt('Processed Date') . '</th>
-                    <th>' . xlt('Processed By') . '</th>
-                  </tr>
-                </thead>
-                <tbody>';
     $remindersArray = array();
     $TempRemindersArray = logRemindersArray();
     foreach ($TempRemindersArray as $RA) {
@@ -66,21 +49,57 @@ if ($_GET) {
         $remindersArray[$RA['messageID']]['fromName'] = $RA['fromName'];
     }
 
-    foreach ($remindersArray as $RA) {
-        echo '<tr class="heading">
-              <td>' . text($RA['messageID']) . '</td>
-              <td>' . text(oeFormatDateTime($RA['sDate'])) . '</td>
-              <td>' . text($RA['fromName']) . '</td>
-              <td>' . text($RA['ToName']) . '</td>
-              <td>' . text($RA['PatientName']) . '</td>
-              <td>' . text($RA['message']) . '</td>
-              <td>' . text(oeFormatShortDate($RA['dDate'])) . '</td>
-              <td>' . text(oeFormatDateTime($RA['pDate'])) . '</td>
-              <td>' . text($RA['processedByName']) . '</td>
-            </tr>';
+    echo '<div class="row">
+            <div class="col-12 results-section mb-3">';
+
+    if (empty($remindersArray)) {
+        echo '<div class="alert alert-info text-center mt-3 mb-3">' . xlt('No Messages Found') . '</div>';
+    } else {
+        echo '<div class="card mt-3 mb-3">
+                <div class="card-header bg-primary text-white">
+                    <h5 class="mb-0">' . xlt('Message Results') . '</h5>
+                </div>
+                <div class="card-body p-0">
+                    <div class="table-responsive">
+                        <table class="table table-striped table-hover" id="logTable">
+                            <thead class="thead-light">
+                                <tr>
+                                    <th>' . xlt('ID') . '</th>
+                                    <th>' . xlt('Sent Date') . '</th>
+                                    <th>' . xlt('From') . '</th>
+                                    <th>' . xlt('To{{Destination}}') . '</th>
+                                    <th>' . xlt('Patient') . '</th>
+                                    <th>' . xlt('Message') . '</th>
+                                    <th>' . xlt('Due Date') . '</th>
+                                    <th>' . xlt('Processed Date') . '</th>
+                                    <th>' . xlt('Processed By') . '</th>
+                                </tr>
+                            </thead>
+                            <tbody>';
+
+        foreach ($remindersArray as $RA) {
+            echo '<tr>
+                    <td>' . text($RA['messageID']) . '</td>
+                    <td>' . text(oeFormatDateTime($RA['sDate'])) . '</td>
+                    <td>' . text($RA['fromName']) . '</td>
+                    <td>' . text($RA['ToName']) . '</td>
+                    <td>' . text($RA['PatientName']) . '</td>
+                    <td>' . text($RA['message']) . '</td>
+                    <td>' . text(oeFormatShortDate($RA['dDate'])) . '</td>
+                    <td>' . text(oeFormatDateTime($RA['pDate'])) . '</td>
+                    <td>' . text($RA['processedByName']) . '</td>
+                </tr>';
+        }
+
+        echo '</tbody>
+            </table>
+            </div>
+        </div>
+        </div>';
     }
 
-    echo '</tbody></table></div>';
+    echo '</div>
+        </div>';
 
     die;
 }

--- a/interface/main/dated_reminders/dated_reminders_log.php
+++ b/interface/main/dated_reminders/dated_reminders_log.php
@@ -234,6 +234,14 @@ if ($_GET) {
                                 </div>
                             </div>
                         </div>
+                        <div class="card-footer">
+                            <button type="button" id="submitForm" class="btn btn-primary">
+                                <i class="fa fa-refresh mr-1"></i><?php echo xlt('Apply Filters') ?>
+                            </button>
+                            <button type="reset" class="btn btn-secondary ml-1">
+                                <i class="fa fa-eraser mr-1"></i><?php echo xlt('Reset') ?>
+                            </button>
+                        </div>
                     </div>
                 </form>
             </div>

--- a/interface/main/dated_reminders/dated_reminders_log.php
+++ b/interface/main/dated_reminders/dated_reminders_log.php
@@ -21,9 +21,9 @@
     $isAdmin = AclMain::aclCheckCore('admin', 'users');
 ?>
 <?php
-  /*
+/*
     -------------------  HANDLE POST ---------------------
-  */
+*/
 if ($_GET) {
     if (!CsrfUtils::verifyCsrfToken($_GET["csrf_token_form"])) {
         CsrfUtils::csrfNotVerified();

--- a/interface/main/dated_reminders/dated_reminders_log.php
+++ b/interface/main/dated_reminders/dated_reminders_log.php
@@ -142,7 +142,7 @@ if ($_GET) {
         <div id="overDiv" style="position:absolute; visibility:hidden; z-index:1000;"></div>
         <?php
         $allUsers = array();
-        $uSQL = sqlStatement('SELECT id, fname,	mname, lname  FROM  `users` WHERE  `active` = 1 AND `facility_id` > 0 AND id != ?', array(intval($_SESSION['authUserID'])));
+        $uSQL = sqlStatement('SELECT id, fname, mname, lname FROM `users` WHERE `active` = 1 AND `facility_id` > 0 AND id != ?', array(intval($_SESSION['authUserID'])));
         for ($i = 0; $uRow = sqlFetchArray($uSQL); $i++) {
             $allUsers[] = $uRow;
         }

--- a/interface/main/dated_reminders/dated_reminders_log.php
+++ b/interface/main/dated_reminders/dated_reminders_log.php
@@ -243,11 +243,12 @@ if ($_GET) {
         </div>
     </div><!--end of container div-->
     <script>
-       $('#show_hide').click(function() {
+        $('#show_hide').click(function() {
             var elementTitle = $('#show_hide').prop('title');
             var hideTitle = '<?php echo xla('Click to Hide Filters'); ?>';
             var showTitle = '<?php echo xla('Click to Show Filters'); ?>';
-            $('.hideaway').toggle('1000');
+
+            $('.filter-section').toggle('1000');
             $(this).toggleClass('fa-eye-slash fa-eye');
             if (elementTitle == hideTitle) {
                 elementTitle = showTitle;


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
--> https://github.com/openemr/openemr/issues/8307

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #8307 

#### Short description of what this resolves:
The bad usability of the two forms in Reminders

#### Changes proposed in this pull request:
1. Use consistent colored top cards, make each card the same width
2. Added Reset buttons
3. Added “No Messages Found” text in place of the existing table header
4. Separated filters into sections:
    * Dated Message Log form:
        * Message Date Range
        * Message Participants
        * Message Status
    * Send a Reminder form:
        * Message Recipients
        * Due Date & Priority
        * Message Content
5. Added muted help text / made existing help text muted

#### Does your code include anything generated by an AI Engine? Yes / No
No

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.
