### PR TITLE
check registration status before continuing tests

### DIFF
--- a/tests/Tests/Api/ApiTestClient.php
+++ b/tests/Tests/Api/ApiTestClient.php
@@ -139,7 +139,14 @@ class ApiTestClient
             "scope" => $scope
         ];
         $clientResponse = $this->post($authURL . '/registration', $clientBody);
-        $clientResponseBody = json_decode($clientResponse->getBody());
+        if ($clientResponse->getStatusCode() >= 400) {
+            throw new \RuntimeException("Client registration failed with status code: " . $clientResponse->getStatusCode());
+        }
+        $clientResponseBodyRaw = $clientResponse->getBody();
+        $clientResponseBody = json_decode($clientResponseBodyRaw);
+        if ($clientResponseBody === null) {
+            throw new \RuntimeException("Client registration response could not be decoded");
+        }
         $this->client_id = $clientResponseBody->client_id;
         $this->client_secret = $clientResponseBody->client_secret;
         // we need to enable the app otherwise we can't use it.


### PR DESCRIPTION
#### Short description of what this resolves:

API testing is a little tricky because you have to determine whether to debug the client (tests) or the server. In my current case, it is useful to be able to distinguish getting an HTTP status code indicating failure from a successful one that still fails.

#### Changes proposed in this pull request:

Provides a little more debugging context when registration fails during api testing.

#### Does your code include anything generated by an AI Engine? Yes / No

No

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.

N/A
