### PR TITLE
Fixing UI For Demographics Form On Big Screens

### DIFF
--- a/interface/patient_file/summary/demographics_full.php
+++ b/interface/patient_file/summary/demographics_full.php
@@ -417,48 +417,41 @@ $constraints = LBF_Validation::generate_validate_constraints("DEM");
 <input type='hidden' name='db_id' value="<?php echo attr($result['id']); ?>" />
 <input type="hidden" name="isSwapClicked" value="" />
 
-    <div class="container-fluid">
-        <div class="row">
-            <?php if (FormActionBarSettings::shouldDisplayTopActionBar()) { ?>
-            <div class="col-12">
-                <h2><?php echo xlt('Edit Current Patient');?></h2>
+<div class="container-xl">
+    <div class="row">
+        <div class="col-12">
+            <h2><?php echo xlt('Edit Current Patient');?></h2>
+        </div>
+        <?php if (FormActionBarSettings::shouldDisplayTopActionBar()) { ?>
+        <div class="col-12">
+            <div class="btn-group">
+                <button type="submit" class="btn btn-primary btn-save" id="submit_btn" disabled="disabled" value="<?php echo xla('Save'); ?>">
+                    <?php echo xlt('Save'); ?>
+                </button>
+                <a class="btn btn-secondary btn-cancel" href="demographics.php" onclick="top.restoreSession()">
+                    <?php echo xlt('Cancel'); ?>
+                </a>
             </div>
-            <div class="col-12">
-                <div class="btn-group">
-                    <button type="submit" class="btn btn-primary btn-save" id="submit_btn" disabled="disabled" value="<?php echo xla('Save'); ?>">
-                        <?php echo xlt('Save'); ?>
-                    </button>
-                    <a class="btn btn-secondary btn-cancel" href="demographics.php" onclick="top.restoreSession()">
-                        <?php echo xlt('Cancel'); ?>
-                    </a>
-                </div>
-                <hr>
+            <hr>
+        </div>
+        <?php } ?>
+    </div>
+
+    <div class="row">
+        <div class="col-12">
+            <div class="section-header">
+                <span class="text font-weight-bold"><?php echo xlt("Demographics")?></span>
             </div>
-            <?php } else { ?>
-            <div class="col-12">
-                <h2><?php echo xlt('Edit Current Patient');?></h2>
+            <ul class="tabNav">
+                <?php display_layout_tabs('DEM', $result, $result2); ?>
+            </ul>
+            <div class="tabContainer">
+                <?php display_layout_tabs_data_editable('DEM', $result, $result2); ?>
             </div>
-            <?php } ?>
         </div>
     </div>
-<?php
-$condition_str = '';
-?>
-<br />
-<div class='container-fluid demographicsEditContainer'>
-    <div class="section-header">
-        <span class="text font-weight-bold"><?php echo xlt("Demographics")?></span>
-    </div>
-    <ul class="tabNav">
-        <?php display_layout_tabs('DEM', $result, $result2); ?>
-    </ul>
 
-    <div class="tabContainer">
-        <?php display_layout_tabs_data_editable('DEM', $result, $result2); ?>
-    </div>
-</div>
-<?php if (FormActionBarSettings::shouldDisplayBottomActionBar()) { ?>
-<div class="container-fluid">
+    <?php if (FormActionBarSettings::shouldDisplayBottomActionBar()) { ?>
     <div class="row">
         <div class="col-12">
             <hr>
@@ -472,8 +465,8 @@ $condition_str = '';
             </div>
         </div>
     </div>
+    <?php } ?>
 </div>
-<?php } ?>
 </form>
 
 <br />

--- a/interface/patient_file/summary/demographics_full.php
+++ b/interface/patient_file/summary/demographics_full.php
@@ -417,7 +417,7 @@ $constraints = LBF_Validation::generate_validate_constraints("DEM");
 <input type='hidden' name='db_id' value="<?php echo attr($result['id']); ?>" />
 <input type="hidden" name="isSwapClicked" value="" />
 
-    <div class="container-xl">
+    <div class="container-fluid">
         <div class="row">
             <?php if (FormActionBarSettings::shouldDisplayTopActionBar()) { ?>
             <div class="col-12">
@@ -445,7 +445,7 @@ $constraints = LBF_Validation::generate_validate_constraints("DEM");
 $condition_str = '';
 ?>
 <br />
-<div class='container-xl demographicsEditContainer'>
+<div class='container-fluid demographicsEditContainer'>
     <div class="section-header">
         <span class="text font-weight-bold"><?php echo xlt("Demographics")?></span>
     </div>
@@ -458,7 +458,7 @@ $condition_str = '';
     </div>
 </div>
 <?php if (FormActionBarSettings::shouldDisplayBottomActionBar()) { ?>
-<div class="container-xl">
+<div class="container-fluid">
     <div class="row">
         <div class="col-12">
             <hr>


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
--> https://github.com/openemr/openemr/issues/8315

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #8315

#### Short description of what this resolves:
The label and buttons will now stay at where they should be regardless of display size:

<img width="966" alt="Screenshot 2025-04-28 at 4 48 21 PM" src="https://github.com/user-attachments/assets/c717a473-e5fd-492c-8f60-9ae6903d07f4" />

#### Changes proposed in this pull request:
Changed container-xl to container-fluid so the label, buttons, and demographics form each take up the entire width of the viewport

#### Does your code include anything generated by an AI Engine? Yes / No
No

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.
