### PR TITLE
Fix adjustments by removing unneeded toFixed() in validate().

### DIFF
--- a/interface/billing/sl_eob_invoice.php
+++ b/interface/billing/sl_eob_invoice.php
@@ -108,8 +108,8 @@ $info_msg = "";
                 };
                 let pfx = ename.substring(0, pfxlen);
                 let code = pfx.substring(pfx.indexOf('[') + 1, pfxlen - 1);
-                let cPay = parseFloat(f[pfx + '[pay]'].value).toFixed(2);
-                let cAdjust = parseFloat(f[pfx + '[adj]'].value).toFixed(2);
+                let cPay = parseFloat(f[pfx + '[pay]'].value);
+                let cAdjust = parseFloat(f[pfx + '[adj]'].value);
 
                 if ((cPay !== 0) || cAdjust !== 0) {
                     allempty = false;


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #8324

#### Short description of what this resolves:

This fixes requiring adjustment reasons for billing codes not being adjusted.

#### Changes proposed in this pull request:

The validate() function saves the adjustment amounts as fixed point strings, but then later compares them to numerical values.  Since the strings are discarded at the end of the function, we can skip the conversion to fixed point and get the expected behavior when comparing to numbers. 

#### Does your code include anything generated by an AI Engine? No

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.
