### PR TITLE
fix: registration modal fix to ensure complete decoupling

### DIFF
--- a/_rest_routes.inc.php
+++ b/_rest_routes.inc.php
@@ -146,7 +146,7 @@
  *              "user/practitioner.write": "Write practitioners the user has access to (api:oemr)",
  *              "user/prescription.read": "Read prescriptions the user has access to (api:oemr)",
  *              "user/procedure.read": "Read procedures the user has access to (api:oemr)",
-*               "user/product.read": "Read procedures the user has access to (api:oemr)",
+*               "user/product.read": "Read the email registration status of OpenEMR (api:oemr)",
  *              "user/soap_note.read": "Read soap notes the user has access to (api:oemr)",
  *              "user/soap_note.write": "Write soap notes the user has access to (api:oemr)",
  *              "user/surgery.read": "Read surgeries the user has access to (api:oemr)",

--- a/apis/dispatch.php
+++ b/apis/dispatch.php
@@ -414,9 +414,9 @@ if ($dispatchResult === false) {
 try {
     (new TelemetryService())->trackApiRequestEvent([
         'eventType' => 'API',
-        'eventLabel' => json_encode($GLOBALS['oauth_scopes'] ?? []),
-        'eventUrl' => $resource,
-        'eventTarget' => $restRequest->getRequestMethod() . ' ' . $_SESSION['api'],
+        'eventLabel' => strtoupper($_SESSION['api'] ?? 'UNKNOWN'),
+        'eventUrl' => $restRequest->getRequestMethod() . ' ' . $resource,
+        'eventTarget' => json_encode($GLOBALS['oauth_scopes'] ?? []),
     ]);
     exit;
 } catch (\Exception $e) {

--- a/interface/main/about_page.php
+++ b/interface/main/about_page.php
@@ -36,7 +36,7 @@ $userManual = ($GLOBALS['user_manual_link'] === '')
     : $GLOBALS['user_manual_link'];
 
 // Collect registered email, if applicable
-$emailRegistered = (new ProductRegistrationService())->getProductStatus()['email'] ?? '';
+$emailRegistered = (new ProductRegistrationService())->getRegistrationEmail() ?? '';
 
 $viewArgs = [
     'onlineSupportHref' => $GLOBALS["online_support_link"],

--- a/interface/main/tabs/js/tabs_view_model.js
+++ b/interface/main/tabs/js/tabs_view_model.js
@@ -347,7 +347,7 @@ function menuActionClick(data,evt)
         navigateTab(webroot_url + dataurl, data.target, function () {
             activateTabByName(data.target,true);
             // Send telemetry event. This is sent after the tab is activated to ensure the tab is visible.
-            if (top.allowTelemetry) {
+            if (top.telemetryEnabled) {
                 reportMenuClickData(data);
             }
         },xl("Loading") + " " + dataLabel);

--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -37,7 +37,7 @@ $logoService = new LogoService();
 $menuLogo = $logoService->getLogo('core/menu/primary/');
 // Registration status and options.
 $productRegistration = new ProductRegistrationService();
-$product_row = $productRegistration->getProductStatus();
+$product_row = $productRegistration->getProductDialogStatus();
 $allowRegisterDialog = $product_row['allowRegisterDialog'] ?? 0;
 $allowTelemetry = $product_row['allowTelemetry'] ?? null; // for dialog
 $allowEmail = $product_row['allowEmail'] ?? null; // for dialog

--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -122,7 +122,7 @@ $twig = (new TwigContainer(null, $GLOBALS['kernel']))->getTwig();
     const isSms = "<?php echo !empty($GLOBALS['oefax_enable_sms'] ?? null); ?>";
     const isFax = "<?php echo !empty($GLOBALS['oefax_enable_fax']) ?? null?>";
     const isServicesOther = (isSms || isFax);
-    const allowTelemetry = <?php echo js_escape(TelemetryService::isTelemetryEnabled()); ?>;
+    var telemetryEnabled = <?php echo js_escape(TelemetryService::isTelemetryEnabled()); ?>;
 
     /**
      * Async function to get session value from the server

--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -30,6 +30,7 @@ use OpenEMR\Events\Main\Tabs\RenderEvent;
 use OpenEMR\Menu\MainMenuRole;
 use OpenEMR\Services\LogoService;
 use OpenEMR\Services\ProductRegistrationService;
+use OpenEMR\Telemetry\TelemetryService;
 use Symfony\Component\Filesystem\Path;
 
 $logoService = new LogoService();
@@ -38,8 +39,8 @@ $menuLogo = $logoService->getLogo('core/menu/primary/');
 $productRegistration = new ProductRegistrationService();
 $product_row = $productRegistration->getProductStatus();
 $allowRegisterDialog = $product_row['allowRegisterDialog'] ?? 0;
-$allowTelemetry = $product_row['allowTelemetry'] ?? null;
-$allowEmail = $product_row['allowEmail'] ?? null;
+$allowTelemetry = $product_row['allowTelemetry'] ?? null; // for dialog
+$allowEmail = $product_row['allowEmail'] ?? null; // for dialog
 // If running unit tests, then disable the registration dialog
 if ($_SESSION['testing_mode'] ?? false) {
     $allowRegisterDialog = false;
@@ -121,7 +122,7 @@ $twig = (new TwigContainer(null, $GLOBALS['kernel']))->getTwig();
     const isSms = "<?php echo !empty($GLOBALS['oefax_enable_sms'] ?? null); ?>";
     const isFax = "<?php echo !empty($GLOBALS['oefax_enable_fax']) ?? null?>";
     const isServicesOther = (isSms || isFax);
-    const allowTelemetry = <?php echo js_escape($allowTelemetry); ?>;
+    const allowTelemetry = <?php echo js_escape(TelemetryService::isTelemetryEnabled()); ?>;
 
     /**
      * Async function to get session value from the server

--- a/interface/product_registration/product_registration_controller.js
+++ b/interface/product_registration/product_registration_controller.js
@@ -22,7 +22,7 @@ function ProductRegistrationController() {
     };
     const _registrationCreatedHandler = function (data) {
         // If telemetry is enabled, set the telemetryEnabled flag
-        if (data && typeof data === 'object' && data.hasOwnProperty('telemetry_enabled') && data.telemetry_enabled) {
+        if (data && typeof data === 'object' && Object.prototype.hasOwnProperty.call(data, 'telemetry_enabled') && data.telemetry_enabled) {
             top.telemetryEnabled = 1;
         }
         _closeModal();

--- a/interface/product_registration/product_registration_controller.js
+++ b/interface/product_registration/product_registration_controller.js
@@ -21,6 +21,10 @@ function ProductRegistrationController() {
         $('.product-registration-modal .message').text(error);
     };
     const _registrationCreatedHandler = function (data) {
+        // If telemetry is enabled, set the telemetryEnabled flag
+        if (data && typeof data === 'object' && data.hasOwnProperty('telemetry_enabled') && data.telemetry_enabled) {
+            top.telemetryEnabled = 1;
+        }
         _closeModal();
     };
     const _formCancellationHandler = function () {

--- a/interface/product_registration/product_registration_controller.php
+++ b/interface/product_registration/product_registration_controller.php
@@ -24,7 +24,7 @@ $method = $_SERVER['REQUEST_METHOD'];
 
 if ($method === 'GET') {
     // retrieve if allowRegisterDialog
-    $allowRegisterDialog = (new ProductRegistrationService())->getProductStatus()['allowRegisterDialog'] ?? 0;
+    $allowRegisterDialog = (new ProductRegistrationService())->getProductDialogStatus()['allowRegisterDialog'] ?? 0;
     echo json_encode(["allowRegisterDialog" => $allowRegisterDialog]);
     exit;
 }
@@ -32,7 +32,7 @@ if ($method === 'GET') {
 // Process form submission
 if ($method === 'POST') {
     // Figure out which elements are going to be updated
-    $productRegistration = (new ProductRegistrationService())->getProductStatus();
+    $productRegistration = (new ProductRegistrationService())->getProductDialogStatus();
     $allowEmail = $productRegistration['allowEmail'] ?? null;
     $allowTelemetry = $productRegistration['allowTelemetry'] ?? null;
 

--- a/interface/product_registration/product_registration_controller.php
+++ b/interface/product_registration/product_registration_controller.php
@@ -141,7 +141,7 @@ if ($method === 'POST') {
             } else {
                 $backgroundTaskManager->deleteTelemetryTask();
             }
-            echo json_encode(["success" => true, "email" => $email]);
+            echo json_encode(["success" => true, "email" => $email, "telemetry_enabled" => ($telemetry_disabled == 0)]);
         } else {
             http_response_code(500);
             echo json_encode(["message" => xlt("Failed to update registration")]);

--- a/interface/product_registration/product_registration_controller.php
+++ b/interface/product_registration/product_registration_controller.php
@@ -141,7 +141,11 @@ if ($method === 'POST') {
             } else {
                 $backgroundTaskManager->deleteTelemetryTask();
             }
-            echo json_encode(["success" => true, "email" => $email, "telemetry_enabled" => ($telemetry_disabled == 0)]);
+            if ($allowEmail) {
+                echo json_encode(["success" => true, "email" => $email, "telemetry_enabled" => ($telemetry_disabled == 0)]);
+            } else {
+                echo json_encode(["success" => true, "telemetry_enabled" => ($telemetry_disabled == 0)]);
+            }
         } else {
             http_response_code(500);
             echo json_encode(["message" => xlt("Failed to update registration")]);

--- a/library/ajax/track_events.php
+++ b/library/ajax/track_events.php
@@ -13,6 +13,7 @@
 require_once("../../interface/globals.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Services\VersionService;
 use OpenEMR\Telemetry\TelemetryRepository;
 use OpenEMR\Telemetry\TelemetryService;
@@ -36,7 +37,8 @@ function handleRequest(): void
 
     $telemetryRepo = new TelemetryRepository();
     $versionService = new VersionService();
-    $telemetryService = new TelemetryService($telemetryRepo, $versionService);
+    $logger = new SystemLogger();
+    $telemetryService = new TelemetryService($telemetryRepo, $versionService, $logger);
 
     $action = $data['action'] ?? '';
     switch ($action) {

--- a/library/ajax/track_events.php
+++ b/library/ajax/track_events.php
@@ -43,10 +43,6 @@ function handleRequest(): void
         case 'reportMenuClickData':
             $telemetryService->reportClickEvent($data);
             break;
-        case 'reportUsageData':
-            $result = $telemetryService->reportUsageData();
-            echo json_encode($result);
-            break;
         default:
             http_response_code(400);
             echo json_encode(["error" => "Invalid action"]);

--- a/library/telemetry_reporting_service.php
+++ b/library/telemetry_reporting_service.php
@@ -10,6 +10,7 @@
  * @license        https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Services\VersionService;
 use OpenEMR\Telemetry\TelemetryRepository;
 use OpenEMR\Telemetry\TelemetryService;
@@ -22,7 +23,8 @@ function reportTelemetryTask(): void
 
     $telemetryRepo = new TelemetryRepository();
     $versionService = new VersionService();
-    $telemetryService = new TelemetryService($telemetryRepo, $versionService);
+    $logger = new SystemLogger();
+    $telemetryService = new TelemetryService($telemetryRepo, $versionService, $logger);
 
     $telemetryService->reportUsageData();
 }

--- a/portal/lib/track_portal_events.php
+++ b/portal/lib/track_portal_events.php
@@ -59,7 +59,7 @@ function handleRequest(): void
     $action = $data['action'] ?? '';
     switch ($action) {
         case 'portalCardClickData':
-            $telemetryService->reportClickEvent($data);
+            $telemetryService->reportClickEvent($data, true);
             break;
         default:
             http_response_code(400);

--- a/portal/lib/track_portal_events.php
+++ b/portal/lib/track_portal_events.php
@@ -61,10 +61,6 @@ function handleRequest(): void
         case 'portalCardClickData':
             $telemetryService->reportClickEvent($data);
             break;
-        case 'allUsageData':
-            $result = $telemetryService->reportUsageData();
-            echo json_encode($result);
-            break;
         default:
             http_response_code(400);
             echo json_encode(["error" => "Invalid action"]);

--- a/portal/lib/track_portal_events.php
+++ b/portal/lib/track_portal_events.php
@@ -31,6 +31,7 @@ if (isset($_SESSION['pid']) && isset($_SESSION['patient_portal_onsite_two'])) {
 
 
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Services\VersionService;
 use OpenEMR\Telemetry\TelemetryRepository;
 use OpenEMR\Telemetry\TelemetryService;
@@ -54,7 +55,8 @@ function handleRequest(): void
 
     $telemetryRepo = new TelemetryRepository();
     $versionService = new VersionService();
-    $telemetryService = new TelemetryService($telemetryRepo, $versionService);
+    $logger = new SystemLogger();
+    $telemetryService = new TelemetryService($telemetryRepo, $versionService, $logger);
 
     $action = $data['action'] ?? '';
     switch ($action) {

--- a/src/Services/ProductRegistrationService.php
+++ b/src/Services/ProductRegistrationService.php
@@ -39,12 +39,13 @@ class ProductRegistrationService
         $optOut = $row['opt_out'] ?? null;
         $telemetry_disabled = $row['telemetry_disabled'] ?? null;
 
-        $row['allowEmail'] = 0;
-        $row['allowTelemetry'] = 0;
-        $row['allowRegisterDialog'] = 0;
+        $row['allowEmail'] = 0; // if show email dialog
+        $row['allowTelemetry'] = 0; // if show telemetry dialog
+        $row['allowRegisterDialog'] = 0; // if show registration dialog
         $currentVersion = (new VersionService())->asString();
         if ($currentVersion != $lastAskVersion) {
             // Change in version (or empty entry), so ignore opt outs and show the dialog if empty email or telemetry not enabled
+            //  (if do show the dialog, then return if show email and/or telemetry dialog)
             if (empty($email) || $telemetry_disabled == 1 || $telemetry_disabled == null) {
                 $row['allowRegisterDialog'] = 1;
                 if (empty($email)) {
@@ -55,15 +56,16 @@ class ProductRegistrationService
                 }
             }
         } else {
-            // No change in version, so do not show the dialog if has opted out
-            if ($telemetry_disabled === null || $optOut == null) {
+            // No change in version, so do not show the dialog if has opted out of both email and telemetry
+            //  (if do show the dialog, then return if show email and/or telemetry dialog)
+            if ($telemetry_disabled == null || $optOut == null) {
                 $row['allowRegisterDialog'] = 1;
-            }
-            if ($optOut == null) {
-                $row['allowEmail'] = 1;
-            }
-            if (empty($telemetry_disabled)) {
-                $row['allowTelemetry'] = 1;
+                if ($optOut == null) {
+                    $row['allowEmail'] = 1;
+                }
+                if ($telemetry_disabled == null) {
+                    $row['allowTelemetry'] = 1;
+                }
             }
         }
 

--- a/src/Services/ProductRegistrationService.php
+++ b/src/Services/ProductRegistrationService.php
@@ -28,7 +28,7 @@ class ProductRegistrationService
     {
     }
 
-    public function getProductStatus(): array
+    public function getProductDialogStatus(): array
     {
         $row = sqlQuery("SELECT * FROM `product_registration`");
         if (empty($row)) {
@@ -70,6 +70,11 @@ class ProductRegistrationService
         }
 
         return $row;
+    }
+
+    public function getRegistrationEmail(): string
+    {
+        return sqlQuery("SELECT `email` FROM `product_registration`")['email'] ?? '';
     }
 
     public function getRegistrationStatus(): string

--- a/src/Telemetry/TelemetryService.php
+++ b/src/Telemetry/TelemetryService.php
@@ -11,6 +11,7 @@
 
 namespace OpenEMR\Telemetry;
 
+use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Common\Uuid\UniqueInstallationUuid;
 use OpenEMR\Services\VersionService;
 
@@ -21,8 +22,10 @@ class TelemetryService
 {
     protected TelemetryRepository $repository;
     protected VersionService $versionService;
+    protected SystemLogger $logger;
 
-    public function __construct(TelemetryRepository $repository = null, VersionService $versionService = null)
+
+    public function __construct(TelemetryRepository $repository = null, VersionService $versionService = null, SystemLogger $logger = null)
     {
         if (!($versionService instanceof VersionService) || !($repository instanceof TelemetryRepository)) {
             $repository = new TelemetryRepository();
@@ -30,6 +33,11 @@ class TelemetryService
         }
         $this->repository = $repository;
         $this->versionService = $versionService;
+
+        if (!($logger instanceof SystemLogger)) {
+            $logger = new SystemLogger();
+        }
+        $this->logger = $logger;
     }
 
     /**
@@ -90,8 +98,20 @@ class TelemetryService
         );
 
         if ($success) {
+            $this->logger->debug("Telemetry Event has been saved", [
+                'eventType' => $eventType,
+                'eventLabel' => $eventLabel,
+                'eventUrl' => $eventUrl,
+                'eventTarget' => $eventTarget,
+            ]);
             return json_encode(["success" => true]);
         } else {
+            $this->logger->error("Telemetry Event failed to save", [
+                'eventType' => $eventType,
+                'eventLabel' => $eventLabel,
+                'eventUrl' => $eventUrl,
+                'eventTarget' => $eventTarget,
+            ]);
             return json_encode(["error" => "Database insertion/update failed"]);
         }
     }

--- a/src/Telemetry/TelemetryService.php
+++ b/src/Telemetry/TelemetryService.php
@@ -179,7 +179,7 @@ class TelemetryService
      *
      * @param mixed $event_data The event data to set.
      */
-    public function trackApiRequestEvent(mixed $event_data): void
+    public function trackApiRequestEvent(array $event_data): void
     {
         if (!empty($this->isTelemetryEnabled())) {
             $this->reportClickEvent($event_data);

--- a/src/Telemetry/TelemetryService.php
+++ b/src/Telemetry/TelemetryService.php
@@ -42,7 +42,7 @@ class TelemetryService
     {
         // Check if telemetry is disabled in the product registration table.
         $isEnabled = sqlQuery("SELECT `telemetry_disabled` FROM `product_registration` WHERE `telemetry_disabled` = 0")['telemetry_disabled'] ?? null;
-        if ((int)$isEnabled === 0) {
+        if (!is_null($isEnabled)) {
             // If telemetry_disabled is 0, it means telemetry is enabled.
             $isEnabled = 1;
         } else {

--- a/version.php
+++ b/version.php
@@ -47,7 +47,7 @@ if (!empty($_ENV['OPENEMR__ENVIRONMENT']) && ($_ENV['OPENEMR__ENVIRONMENT'] === 
     $v_js_includes = md5(microtime());
 } else {
     // Change this number when bumping
-    $v_js_includes = 77;
+    $v_js_includes = 78;
 }
 
 // Do not modify below


### PR DESCRIPTION
fixes #8334

~~(prob gonna do a little more work to make it clear what getProductStatus() is for by renaming it to getProductStatusDialog() and then offshooting the call from the about page to a small new function for collecting the email adress)~~ DONE
