### PR TITLE
Switch REPLACE INTO with INSERT … ON DUPLICATE KEY UPDATE

### DIFF
--- a/src/Common/ORDataObject/ORDataObject.php
+++ b/src/Common/ORDataObject/ORDataObject.php
@@ -56,12 +56,12 @@ class ORDataObject
             return true;
         }
 
-		$sql = "INSERT INTO " . $this->_prefix . $this->_table . " SET ";
+        $sql = "INSERT INTO " . $this->_prefix . $this->_table . " SET ";
         //echo "<br /><br />";
         $fields = QueryUtils::listTableFields($this->_table);
         $db = get_db();
         $pkeys = $db->MetaPrimaryKeys($this->_table);
-		$setClause = "";
+        $setClause = "";
 
         foreach ($fields as $field) {
             $func = "get_" . $field;
@@ -98,8 +98,8 @@ class ORDataObject
 
         $setClause = rtrim($setClause, ',');
 
-		$sql .= $setClause;
-		$sql .= " ON DUPLICATE KEY UPDATE " . $setClause;
+        $sql .= $setClause;
+        $sql .= " ON DUPLICATE KEY UPDATE " . $setClause;
 
         if ($this->_throwExceptionOnError) {
             QueryUtils::sqlStatementThrowException($sql, []);


### PR DESCRIPTION
- Swap out `REPLACE INTO` (which issues DELETE+INSERT) for `INSERT … ON DUPLICATE KEY UPDATE` (in-place UPSERT)
- Introduce `$setClause` accumulator to build the column-value list once and replace manual `substr` trimming with `rtrim()`

Fixes [8333](https://github.com/openemr/openemr/issues/8333)

#### Short description of what this resolves:

This patch fixes the unintended deletion/re-insertion cycle in all `ORDataObject` subclasses (e.g. InsuranceCompany) by replacing the `REPLACE INTO` logic with an in-place upsert (`INSERT … ON DUPLICATE KEY UPDATE`), thereby preserving the original `uuid` on every save.

#### Changes proposed in this pull request:

- Swap out the existing `REPLACE INTO` statement for an `INSERT … ON DUPLICATE KEY UPDATE` in the `ORDataObject::save()` method.
- Introduce a `$setClause` string accumulator to build the `column = value` list once, rather than concatenating and then trimming with `substr`.

#### Does your code include anything generated by an AI Engine? Yes

`src/Common/ORDataObject/ORDataObject.php` used *ChatGPT o4-mini-high*