### PR TITLE
fix(Events): ensure events extend Symfony Event contract

### DIFF
--- a/src/Events/Appointments/AppointmentJavascriptEventNames.php
+++ b/src/Events/Appointments/AppointmentJavascriptEventNames.php
@@ -12,8 +12,9 @@
  */
 
 namespace OpenEMR\Events\Appointments;
+use Symfony\Contracts\EventDispatcher\Event;
 
-class AppointmentJavascriptEventNames
+class AppointmentJavascriptEventNames extends Event
 {
     /**
      * This event is triggered in javascript when a patient is selected for an appointment in the add_edit_event.php class

--- a/src/Events/Appointments/CalendarUserGetEventsFilter.php
+++ b/src/Events/Appointments/CalendarUserGetEventsFilter.php
@@ -15,7 +15,9 @@
 
 namespace OpenEMR\Events\Appointments;
 
-class CalendarUserGetEventsFilter
+use Symfony\Contracts\EventDispatcher\Event;
+
+class CalendarUserGetEventsFilter extends Event
 {
     /**
      * @var array

--- a/src/Events/Codes/CodeTypeInstalledEvent.php
+++ b/src/Events/Codes/CodeTypeInstalledEvent.php
@@ -15,7 +15,9 @@
 
 namespace OpenEMR\Events\Codes;
 
-class CodeTypeInstalledEvent
+use Symfony\Contracts\EventDispatcher\Event;
+
+class CodeTypeInstalledEvent extends Event
 {
     /**
      * This event is triggered before the code system is installed

--- a/src/Events/Command/CommandRunnerFilterEvent.php
+++ b/src/Events/Command/CommandRunnerFilterEvent.php
@@ -17,8 +17,9 @@
 namespace OpenEMR\Events\Command;
 
 use Symfony\Component\Console\Command\Command;
+use Symfony\Contracts\EventDispatcher\Event;
 
-class CommandRunnerFilterEvent
+class CommandRunnerFilterEvent extends Event
 {
     const EVENT_NAME = "openemr.command-runner.filter";
     private $commands = [];

--- a/src/Events/Core/SQLUpgradeEvent.php
+++ b/src/Events/Core/SQLUpgradeEvent.php
@@ -16,8 +16,9 @@
 namespace OpenEMR\Events\Core;
 
 use OpenEMR\Services\Utils\SQLUpgradeService;
+use Symfony\Contracts\EventDispatcher\Event;
 
-class SQLUpgradeEvent
+class SQLUpgradeEvent extends Event
 {
     /**
      * This event is triggered just before the upgrade starts processing the upgrade file

--- a/src/Events/Core/SqlConfigEvent.php
+++ b/src/Events/Core/SqlConfigEvent.php
@@ -14,8 +14,9 @@
 namespace OpenEMR\Events\Core;
 
 use OpenEMR\Events\Core\Interfaces\SqlConfigInterface;
+use Symfony\Contracts\EventDispatcher\Event;
 
-class SqlConfigEvent
+class SqlConfigEvent extends Event
 {
     public const EVENT_NAME = "sql.config";
 

--- a/src/Events/Core/TemplatePageEvent.php
+++ b/src/Events/Core/TemplatePageEvent.php
@@ -17,7 +17,9 @@
 
 namespace OpenEMR\Events\Core;
 
-class TemplatePageEvent
+use Symfony\Contracts\EventDispatcher\Event;
+
+class TemplatePageEvent extends Event
 {
     const CONTEXT_ARGUMENT_SCRIPT_NAME = "script_name";
 

--- a/src/Events/Core/TwigEnvironmentEvent.php
+++ b/src/Events/Core/TwigEnvironmentEvent.php
@@ -27,9 +27,10 @@
 
 namespace OpenEMR\Events\Core;
 
+use Symfony\Contracts\EventDispatcher\Event;
 use Twig\Environment;
 
-class TwigEnvironmentEvent
+class TwigEnvironmentEvent extends Event
 {
     /**
      * This event is triggered after the twig environment has been created in the TwigContainer

--- a/src/Events/Encounter/EncounterFormsListRenderEvent.php
+++ b/src/Events/Encounter/EncounterFormsListRenderEvent.php
@@ -13,7 +13,9 @@
 
 namespace OpenEMR\Events\Encounter;
 
-class EncounterFormsListRenderEvent
+use Symfony\Contracts\EventDispatcher\Event;
+
+class EncounterFormsListRenderEvent extends Event
 {
     /**
      * Allows screen output after all of the encounter forms have been rendered for the encounter/forms.php screen

--- a/src/Events/Encounter/LoadEncounterFormFilterEvent.php
+++ b/src/Events/Encounter/LoadEncounterFormFilterEvent.php
@@ -14,7 +14,9 @@
 
 namespace OpenEMR\Events\Encounter;
 
-class LoadEncounterFormFilterEvent
+use Symfony\Contracts\EventDispatcher\Event;
+
+class LoadEncounterFormFilterEvent extends Event
 {
     const EVENT_NAME = 'encounter.load_form_filter';
     private $formName;

--- a/src/Events/Patient/Summary/PortalCredentialsUpdatedEvent.php
+++ b/src/Events/Patient/Summary/PortalCredentialsUpdatedEvent.php
@@ -16,7 +16,9 @@
 
 namespace OpenEMR\Events\Patient\Summary;
 
-class PortalCredentialsUpdatedEvent
+use Symfony\Contracts\EventDispatcher\Event;
+
+class PortalCredentialsUpdatedEvent extends Event
 {
     const EVENT_UPDATE_PRE = 'patient.portal-credentials.update.pre';
     const EVENT_UPDATE_POST  = 'patient.portal-credentials.update.post';

--- a/src/Events/PatientDocuments/PatientDocumentCreateCCDAEvent.php
+++ b/src/Events/PatientDocuments/PatientDocumentCreateCCDAEvent.php
@@ -14,8 +14,9 @@ namespace OpenEMR\Events\PatientDocuments;
 
 use OpenEMR\Services\Search\DateSearchField;
 use DateTime;
+use Symfony\Contracts\EventDispatcher\Event;
 
-class PatientDocumentCreateCCDAEvent
+class PatientDocumentCreateCCDAEvent extends Event
 {
     const EVENT_NAME_CCDA_CREATE = "patient.ccda.create";
 

--- a/src/Events/PatientDocuments/PatientDocumentTreeViewFilterEvent.php
+++ b/src/Events/PatientDocuments/PatientDocumentTreeViewFilterEvent.php
@@ -16,8 +16,9 @@ namespace OpenEMR\Events\PatientDocuments;
 
 use HTML_TreeNode;
 use CategoryTree;
+use Symfony\Contracts\EventDispatcher\Event;
 
-class PatientDocumentTreeViewFilterEvent
+class PatientDocumentTreeViewFilterEvent extends Event
 {
     const EVENT_NAME = "patient.document.tree.view.filter";
 

--- a/src/Events/PatientDocuments/PatientDocumentViewCCDAEvent.php
+++ b/src/Events/PatientDocuments/PatientDocumentViewCCDAEvent.php
@@ -16,7 +16,9 @@
 
 namespace OpenEMR\Events\PatientDocuments;
 
-class PatientDocumentViewCCDAEvent
+use Symfony\Contracts\EventDispatcher\Event;
+
+class PatientDocumentViewCCDAEvent extends Event
 {
     /**
      * Name of the event

--- a/src/Events/RestApiExtend/RestApiResourceServiceEvent.php
+++ b/src/Events/RestApiExtend/RestApiResourceServiceEvent.php
@@ -2,7 +2,9 @@
 
 namespace OpenEMR\Events\RestApiExtend;
 
-class RestApiResourceServiceEvent
+use Symfony\Contracts\EventDispatcher\Event;
+
+class RestApiResourceServiceEvent extends Event
 {
     /**
      * Used whenever the service for a rest api resource needs to be returned for metadata or other kind of resource purposes

--- a/src/Events/UserInterface/PageHeadingRenderEvent.php
+++ b/src/Events/UserInterface/PageHeadingRenderEvent.php
@@ -15,11 +15,12 @@
 
 namespace OpenEMR\Events\UserInterface;
 
+use Symfony\Contracts\EventDispatcher\Event;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Menu\MenuItems;
 use OpenEMR\Menu\MenuItemInterface;
 
-class PageHeadingRenderEvent
+class PageHeadingRenderEvent extends Event
 {
     const EVENT_PAGE_HEADING_RENDER = 'oemrui.page.header.render';
 


### PR DESCRIPTION
Fixes #8339

#### Short description of what this resolves:

The events defined in src/Events look like they're intended to be subclasses of the Symfony Event contract. Many of them are. This is an attempt to ensure the rest of them get the same treatment.

#### Changes proposed in this pull request:

Update classes defined in src/Event to extend `Symfony\Contracts\EventDispatcher\Event`.

#### Does your code include anything generated by an AI Engine? No