### PR TITLE
Add alert message to confirm success on patient form submission.

### DIFF
--- a/interface/forms/newpatient/templates/newpatient/common.html.twig
+++ b/interface/forms/newpatient/templates/newpatient/common.html.twig
@@ -15,6 +15,13 @@
 #}
 <!DOCTYPE html>
 <html>
+<script>
+    function showSuccess(){
+        alert("Form submitted successfully!");
+        return true;
+    }
+</script>
+
 {% include "newpatient/partials/common/_head.html.twig" %}
 <body class="{{ bodyClass|attr }}">
 <div id="container_div" class="{{ oemrUiContainerClass(oemrUiSettings) }} mt-3">
@@ -26,7 +33,7 @@
     </div>
 
     {# Note formAction HAS to be escaped in the twig caller class #}
-    <form id="new-encounter-form" method="post" action="{{ webroot }}{{ formAction }}" name="new_encounter" class="mt-3">
+    <form id="new-encounter-form" method="post" action="{{ webroot }}{{ formAction }}" name="new_encounter" class="mt-3" onsubmit="return showSuccess();">
         {% include "newpatient/partials/common/_form-start.html.twig" %}
         {% include "newpatient/partials/common/fields/_hidden-fields.html.twig" %}
         {% include "newpatient/partials/common/_form-heading.html.twig" %}


### PR DESCRIPTION
#### Short description of what this resolves:
This pull request adds a simple alert message when submitting the new patient encounter form to provide basic user feedback.

#### Changes proposed in this pull request:
- Created a `showSuccess()` JavaScript function in `common.html.twig`.
- Added `onsubmit="return showSuccess();"` to the `<form>` element.

