### PR TITLE
refactor(sql_patch.php,sql_upgrade.php): use insert_globals from Installer

### DIFF
--- a/library/classes/Installer.class.php
+++ b/library/classes/Installer.class.php
@@ -594,31 +594,8 @@ $config = 1; /////////////
 
     public function insert_globals()
     {
-        if (!(function_exists('xl'))) {
-            function xl($s)
-            {
-                return $s;
-            }
-        } else {
-            $GLOBALS['temp_skip_translations'] = true;
-        }
-        $skipGlobalEvent = true; //use in globals.inc.php script to skip event stuff
-        require(dirname(__FILE__) . '/../globals.inc.php');
-        foreach ($GLOBALS_METADATA as $grpname => $grparr) {
-            foreach ($grparr as $fldid => $fldarr) {
-                list($fldname, $fldtype, $flddef, $flddesc) = $fldarr;
-                if (is_array($fldtype) || substr($fldtype, 0, 2) !== 'm_') {
-                    $res = $this->execute_sql("SELECT count(*) AS count FROM globals WHERE gl_name = '" . $this->escapeSql($fldid) . "'");
-                    $row = mysqli_fetch_array($res, MYSQLI_ASSOC);
-                    if (empty($row['count'])) {
-                        $this->execute_sql("INSERT INTO globals ( gl_name, gl_index, gl_value ) " .
-                           "VALUES ( '" . $this->escapeSql($fldid) . "', '0', '" . $this->escapeSql($flddef) . "' )");
-                    }
-                }
-            }
-        }
-
-        return true;
+        // Use the static method from SQLUpgradeService
+        return \OpenEMR\Services\Utils\SQLUpgradeService::insertGlobals();
     }
 
     public function install_gacl()

--- a/sql_patch.php
+++ b/sql_patch.php
@@ -25,7 +25,6 @@ $ignoreAuth = true; // no login required
 
 require_once('interface/globals.php');
 require_once('library/sql_upgrade_fx.php');
-require_once('library/classes/Installer.class.php');
 
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Services\Utils\SQLUpgradeService;
@@ -68,8 +67,8 @@ $sqlUpgradeService = new SQLUpgradeService();
     $sqlUpgradeService->flush_echo();
 
     echo '<p style="font-weight:bold; text-align:left; color:green">',xlt('Updating global configuration defaults'),'...</p>';
-    $installer = new Installer([]);
-    $installer->insert_globals();
+    $sqlUpgradeService->flush_echo();
+    SQLUpgradeService::insertGlobals();
 
     $versionService = new VersionService();
     $currentVersion = $versionService->fetch();

--- a/sql_patch.php
+++ b/sql_patch.php
@@ -25,6 +25,7 @@ $ignoreAuth = true; // no login required
 
 require_once('interface/globals.php');
 require_once('library/sql_upgrade_fx.php');
+require_once('library/classes/Installer.class.php');
 
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Services\Utils\SQLUpgradeService;
@@ -67,20 +68,8 @@ $sqlUpgradeService = new SQLUpgradeService();
     $sqlUpgradeService->flush_echo();
 
     echo '<p style="font-weight:bold; text-align:left; color:green">',xlt('Updating global configuration defaults'),'...</p>';
-    $skipGlobalEvent = true; //use in globals.inc.php script to skip event stuff
-    require_once("library/globals.inc.php");
-    foreach ($GLOBALS_METADATA as $grpname => $grparr) {
-        foreach ($grparr as $fldid => $fldarr) {
-            list($fldname, $fldtype, $flddef, $flddesc) = $fldarr;
-            if (is_array($fldtype) || (substr($fldtype, 0, 2) !== 'm_')) {
-                $row = sqlQuery("SELECT count(*) AS count FROM globals WHERE gl_name = '$fldid'");
-                if (empty($row['count'])) {
-                    sqlStatement("INSERT INTO globals ( gl_name, gl_index, gl_value ) " .
-                    "VALUES ( '$fldid', '0', '$flddef' )");
-                }
-            }
-        }
-    }
+    $installer = new Installer([]);
+    $installer->insert_globals();
 
     $versionService = new VersionService();
     $currentVersion = $versionService->fetch();

--- a/sql_upgrade.php
+++ b/sql_upgrade.php
@@ -47,6 +47,7 @@ $GLOBALS['connection_pooling_off'] = true; // force off database connection pool
 
 require_once('interface/globals.php');
 require_once('library/sql_upgrade_fx.php');
+require_once('library/classes/Installer.class.php');
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Uuid\UuidRegistry;
@@ -288,7 +289,7 @@ function pausePoll(othis) {
 <div class="container my-3">
     <div class="row">
         <div class="col-12">
-            <h2><?php echo xlt("OpenEMR Database Upgrade"); ?></h2>            
+            <h2><?php echo xlt("OpenEMR Database Upgrade"); ?></h2>
         </div>
     </div>
     <div class="row">
@@ -391,20 +392,8 @@ function pausePoll(othis) {
         $sqlUpgradeService->flush_echo("<script>processProgress = 100;doPoll = 0;</script>");
 
         echo "<p class='text-success'>" . xlt("Updating global configuration defaults") . "..." . "</p><br />\n";
-        $skipGlobalEvent = true; //use in globals.inc.php script to skip event stuff
-        require_once("library/globals.inc.php");
-        foreach ($GLOBALS_METADATA as $grpname => $grparr) {
-            foreach ($grparr as $fldid => $fldarr) {
-                list($fldname, $fldtype, $flddef, $flddesc) = $fldarr;
-                if (is_array($fldtype) || (substr($fldtype, 0, 2) !== 'm_')) {
-                    $row = sqlQuery("SELECT count(*) AS count FROM globals WHERE gl_name = '$fldid'");
-                    if (empty($row['count'])) {
-                        sqlStatement("INSERT INTO globals ( gl_name, gl_index, gl_value ) " .
-                            "VALUES ( '$fldid', '0', '$flddef' )");
-                    }
-                }
-            }
-        }
+        $installer = new Installer([]);
+        $installer->insert_globals();
 
         echo "<p class='text-success'>" . xlt("Updating Access Controls") . "..." . "</p><br />\n";
         require("acl_upgrade.php");

--- a/sql_upgrade.php
+++ b/sql_upgrade.php
@@ -47,7 +47,6 @@ $GLOBALS['connection_pooling_off'] = true; // force off database connection pool
 
 require_once('interface/globals.php');
 require_once('library/sql_upgrade_fx.php');
-require_once('library/classes/Installer.class.php');
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Uuid\UuidRegistry;
@@ -392,8 +391,7 @@ function pausePoll(othis) {
         $sqlUpgradeService->flush_echo("<script>processProgress = 100;doPoll = 0;</script>");
 
         echo "<p class='text-success'>" . xlt("Updating global configuration defaults") . "..." . "</p><br />\n";
-        $installer = new Installer([]);
-        $installer->insert_globals();
+        SQLUpgradeService::insertGlobals();
 
         echo "<p class='text-success'>" . xlt("Updating Access Controls") . "..." . "</p><br />\n";
         require("acl_upgrade.php");


### PR DESCRIPTION
Fixes #8363

#### Short description of what this resolves:

Eliminates duplicate code between `sql_patch.php`, `sql_upgrade.php` and the Installer class.


#### Changes proposed in this pull request:

#### Does your code include anything generated by an AI Engine? No
