### PR TITLE
refactor: decouple SQLUpgradeService and SQLUpgradeEvent

### DIFF
--- a/src/Events/Core/SQLUpgradeEvent.php
+++ b/src/Events/Core/SQLUpgradeEvent.php
@@ -15,7 +15,7 @@
 
 namespace OpenEMR\Events\Core;
 
-use OpenEMR\Services\Utils\SQLUpgradeService;
+use OpenEMR\Services\Utils\Interfaces\ISQLUpgradeService;
 use Symfony\Contracts\EventDispatcher\Event;
 
 class SQLUpgradeEvent extends Event
@@ -41,11 +41,11 @@ class SQLUpgradeEvent extends Event
     private $path;
 
     /**
-     * @var SQLUpgradeService The sql upgrade service object
+     * @var ISQLUpgradeService The sql upgrade service object
      */
     private $sqlUpgradeService;
 
-    public function __construct($filename, $path, SQLUpgradeService $upgradeService)
+    public function __construct($filename, $path, ISQLUpgradeService $upgradeService)
     {
         $this->filename = $filename;
         $this->path = $path;
@@ -89,18 +89,18 @@ class SQLUpgradeEvent extends Event
     }
 
     /**
-     * @return SQLUpgradeService
+     * @return ISQLUpgradeService
      */
-    public function getSqlUpgradeService(): SQLUpgradeService
+    public function getSqlUpgradeService(): ISQLUpgradeService
     {
         return $this->sqlUpgradeService;
     }
 
     /**
-     * @param SQLUpgradeService $sqlUpgradeService
+     * @param ISQLUpgradeService $sqlUpgradeService
      * @return SQLUpgradeEvent
      */
-    public function setSqlUpgradeService(SQLUpgradeService $sqlUpgradeService): SQLUpgradeEvent
+    public function setSqlUpgradeService(ISQLUpgradeService $sqlUpgradeService): SQLUpgradeEvent
     {
         $this->sqlUpgradeService = $sqlUpgradeService;
         return $this;

--- a/src/Services/Utils/Interfaces/ISQLUpgradeService.php
+++ b/src/Services/Utils/Interfaces/ISQLUpgradeService.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Interface for SQL Upgrade Service
+ *
+ * This interface defines the contract for services that handle SQL upgrades
+ * within the OpenEMR system. Implementations should provide methods for
+ * analyzing, executing, and tracking database schema upgrades.
+ *
+ * @package    OpenEMR
+ * @link       http://www.open-emr.org
+ * @subpackage Services
+ * @author     Michael A. Smith <michael@opencoreemr.com>
+ * @copyright  Copyright (c) 2025
+ * @license    https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ *
+ * This interface was generated with the assistance of GitHub Copilot and Claude 3.7 Sonnet
+ */
+
+namespace OpenEMR\Services\Utils\Interfaces;
+
+interface ISQLUpgradeService
+{
+    /**
+     * @return bool
+     */
+    public function isRenderOutputToScreen(): bool;
+
+    /**
+     * @param bool $renderOutputToScreen
+     * @return $this
+     */
+    public function setRenderOutputToScreen(bool $renderOutputToScreen);
+
+    /**
+     * Get the buffer of output messages when rendering to screen is disabled
+     *
+     * @return array
+     */
+    public function getRenderOutputBuffer(): array;
+
+    /**
+     * @return bool
+     */
+    public function isThrowExceptionOnError(): bool;
+
+    /**
+     * @param bool $throwExceptionOnError
+     * @return $this
+     */
+    public function setThrowExceptionOnError(bool $throwExceptionOnError);
+
+    /**
+     * Upgrade or patch the database with a selected upgrade/patch file
+     *
+     * @param string $filename Sql upgrade/patch filename
+     * @param string $path Path to the SQL file directory
+     */
+    public function upgradeFromSqlFile($filename, $path = '');
+
+    /**
+     * Output string to the screen with flushing to ensure immediate display
+     *
+     * @param string $string The string to output
+     */
+    public function flush_echo($string = '');
+}

--- a/src/Services/Utils/SQLUpgradeService.php
+++ b/src/Services/Utils/SQLUpgradeService.php
@@ -21,8 +21,9 @@ namespace OpenEMR\Services\Utils;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Database\SqlQueryException;
 use OpenEMR\Events\Core\SQLUpgradeEvent;
+use OpenEMR\Services\Utils\Interfaces\ISQLUpgradeService;
 
-class SQLUpgradeService
+class SQLUpgradeService implements ISQLUpgradeService
 {
     private $renderOutputToScreen = true;
     private $throwExceptionOnError = false;


### PR DESCRIPTION
Fixes #8380

#### Short description of what this resolves:

Resolves a circular dependency between SQLUpgradeService and SQLUpgradeEvent.
Opens the door to dependency injection.


#### Changes proposed in this pull request:

- Create `ISQLUpgradeService`, an interface 
- Reference the interface instead of the implementation in `SQLUpgradeEvent`

#### Does your code include anything generated by an AI Engine? Yes
