### PR TITLE
chore: remove summernote-plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
     "jquery-panelslider": "https://github.com/eduardomb/jquery-panelslider/archive/1.0.0.tar.gz",
     "jquery-ui": "https://jqueryui.com/resources/download/jquery-ui-1.12.1.zip",
     "jquery-ui-themes": "https://jqueryui.com/resources/download/jquery-ui-themes-1.12.1.zip",
-    "summernote-nugget": "https://github.com/pHAlkaline/summernote-plugins",
     "literallycanvas": "https://github.com/literallycanvas/literallycanvas/archive/v0.4.14.tar.gz",
     "react": "https://github.com/facebook/react/releases/download/v15.1.0/react-15.1.0.zip",
     "lforms": "https://clinicaltables.nlm.nih.gov/lforms-versions/lforms-33.0.0.zip"


### PR DESCRIPTION
Fixes #8383

#### Short description of what this resolves:

Makes it a bit easier and faster to npm install, and prevents unintended consequences from upstream updating their repo.

#### Changes proposed in this pull request:

- removes the reference to summernotes-plugins, which is obsolete.

#### Does your code include anything generated by an AI Engine? No

