### PR TITLE
fix(questionnaires): add missing api.inc.php require

### DIFF
--- a/interface/forms/questionnaire_assessments/questionnaire_assessments.php
+++ b/interface/forms/questionnaire_assessments/questionnaire_assessments.php
@@ -19,6 +19,7 @@ use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Forms\CoreFormToPortalUtility;
 use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Core\Header;
+use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\QuestionnaireResponseService;
 use OpenEMR\Services\QuestionnaireService;
 
@@ -32,6 +33,7 @@ if ($isPortal) {
 $patientPortalOther = CoreFormToPortalUtility::isPatientPortalOther($_GET);
 
 require_once(__DIR__ . "/../../globals.php");
+require_once(OEGlobalsBag::getInstance()->getString('srcdir') . "/api.inc.php");
 require_once("$srcdir/user.inc.php");
 // used for form generation utilities
 require_once("$srcdir/options.inc.php");


### PR DESCRIPTION
Fixes https://github.com/openemr/openemr/issues/8244

#### Short description of what this resolves:

Under certain circumstances (not yet identified at the time of this PR), the edit button for questionnaire responses returns a 500 Internal Server Error and the following PHP error:

```
PHP Fatal error:  Uncaught Error: Call to undefined function formFetch() in /var/www/localhost/htdocs/openemr/interface/forms/questionnaire_assessments/questionnaire_assessments.php:71
Stack trace:
#0 /var/www/localhost/htdocs/openemr/interface/forms/questionnaire_assessments/view.php(14): require()
#1 /var/www/localhost/htdocs/openemr/interface/patient_file/encounter/view_form.php(50): require_once('...')
#2 {main}
  thrown in /var/www/localhost/htdocs/openemr/interface/forms/questionnaire_assessments/questionnaire_assessments.php on line 71
```

#### Changes proposed in this pull request:

Explicitly include api.inc.php in questionnaire_assessments.php to guarantee `formFetch()` is always defined.

#### Does your code include anything generated by an AI Engine? Yes / No

No