### PR TITLE
fix(ci docker-compose): healthchecks in lieu of sleep 60

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,6 @@ jobs:
         run: |
           source ci/ciLibrary.source
           dockers_env_start
-          sleep 60
 
       - name: Install and configure
         run: |
@@ -142,7 +141,6 @@ jobs:
         run: |
           source ci/ciLibrary.source
           dockers_env_start
-          sleep 60
 
       - name: Install and configure
         run: |
@@ -235,7 +233,6 @@ jobs:
         run: |
           source ci/ciLibrary.source
           dockers_env_start
-          sleep 60
 
       - name: Install and configure
         run: |
@@ -328,7 +325,6 @@ jobs:
         run: |
           source ci/ciLibrary.source
           dockers_env_start
-          sleep 60
 
       - name: Install and configure
         run: |
@@ -421,7 +417,6 @@ jobs:
         run: |
           source ci/ciLibrary.source
           dockers_env_start
-          sleep 60
 
       - name: Install and configure
         run: |
@@ -514,7 +509,6 @@ jobs:
         run: |
           source ci/ciLibrary.source
           dockers_env_start
-          sleep 60
 
       - name: Install and configure
         run: |
@@ -886,7 +880,6 @@ jobs:
         run: |
           source ci/ciLibrary.source
           dockers_env_start
-          sleep 60
 
       - name: Install and configure
         run: |
@@ -979,7 +972,6 @@ jobs:
         run: |
           source ci/ciLibrary.source
           dockers_env_start
-          sleep 60
 
       - name: Install and configure
         run: |
@@ -1073,7 +1065,6 @@ jobs:
         run: |
           source ci/ciLibrary.source
           dockers_env_start
-          sleep 60
 
       - name: Install and configure
         run: |
@@ -1166,7 +1157,6 @@ jobs:
         run: |
           source ci/ciLibrary.source
           dockers_env_start
-          sleep 60
 
       - name: Install and configure
         run: |

--- a/ci/apache_82_114/docker-compose.yml
+++ b/ci/apache_82_114/docker-compose.yml
@@ -1,4 +1,3 @@
-# docker-compose.yml for travis ci testing
 services:
   mysql:
     restart: always
@@ -6,6 +5,18 @@ services:
     command: ['mariadbd','--character-set-server=utf8mb4']
     environment:
       MYSQL_ROOT_PASSWORD: root
+    healthcheck:
+      test:
+      - CMD
+      - /usr/local/bin/healthcheck.sh
+      - --su-mysql
+      - --connect
+      - --innodb_initialized
+      start_period: 1m
+      start_interval: 10s
+      interval: 1m
+      timeout: 5s
+      retries: 3
   openemr:
     restart: always
     image: openemr/openemr:flex-3.18
@@ -18,4 +29,5 @@ services:
       FORCE_NO_BUILD_MODE: "yes"
       EMPTY: "yes"
     depends_on:
-    - mysql
+      mysql:
+        condition: service_healthy

--- a/ci/apache_83_1011/docker-compose.yml
+++ b/ci/apache_83_1011/docker-compose.yml
@@ -1,4 +1,3 @@
-# docker-compose.yml for travis ci testing
 services:
   mysql:
     restart: always
@@ -6,6 +5,18 @@ services:
     command: ['mysqld','--character-set-server=utf8mb4']
     environment:
       MYSQL_ROOT_PASSWORD: root
+    healthcheck:
+      test:
+      - CMD
+      - /usr/local/bin/healthcheck.sh
+      - --su-mysql
+      - --connect
+      - --innodb_initialized
+      start_period: 1m
+      start_interval: 10s
+      interval: 1m
+      timeout: 5s
+      retries: 3
   openemr:
     restart: always
     image: openemr/openemr:flex-3.20
@@ -18,4 +29,5 @@ services:
       FORCE_NO_BUILD_MODE: "yes"
       EMPTY: "yes"
     depends_on:
-    - mysql
+      mysql:
+        condition: service_healthy

--- a/ci/apache_83_105/docker-compose.yml
+++ b/ci/apache_83_105/docker-compose.yml
@@ -1,4 +1,3 @@
-# docker-compose.yml for travis ci testing
 services:
   mysql:
     restart: always
@@ -6,6 +5,18 @@ services:
     command: ['mysqld','--character-set-server=utf8mb4']
     environment:
       MYSQL_ROOT_PASSWORD: root
+    healthcheck:
+      test:
+      - CMD
+      - /usr/local/bin/healthcheck.sh
+      - --su-mysql
+      - --connect
+      - --innodb_initialized
+      start_period: 1m
+      start_interval: 10s
+      interval: 1m
+      timeout: 5s
+      retries: 3
   openemr:
     restart: always
     image: openemr/openemr:flex-3.20
@@ -18,4 +29,5 @@ services:
       FORCE_NO_BUILD_MODE: "yes"
       EMPTY: "yes"
     depends_on:
-    - mysql
+      mysql:
+        condition: service_healthy

--- a/ci/apache_83_106/docker-compose.yml
+++ b/ci/apache_83_106/docker-compose.yml
@@ -1,4 +1,3 @@
-# docker-compose.yml for travis ci testing
 services:
   mysql:
     restart: always
@@ -6,6 +5,18 @@ services:
     command: ['mysqld','--character-set-server=utf8mb4']
     environment:
       MYSQL_ROOT_PASSWORD: root
+    healthcheck:
+      test:
+      - CMD
+      - /usr/local/bin/healthcheck.sh
+      - --su-mysql
+      - --connect
+      - --innodb_initialized
+      start_period: 1m
+      start_interval: 10s
+      interval: 1m
+      timeout: 5s
+      retries: 3
   openemr:
     restart: always
     image: openemr/openemr:flex-3.20
@@ -18,4 +29,5 @@ services:
       FORCE_NO_BUILD_MODE: "yes"
       EMPTY: "yes"
     depends_on:
-    - mysql
+      mysql:
+        condition: service_healthy

--- a/ci/apache_83_114/docker-compose.yml
+++ b/ci/apache_83_114/docker-compose.yml
@@ -1,4 +1,3 @@
-# docker-compose.yml for travis ci testing
 services:
   mysql:
     restart: always
@@ -6,6 +5,18 @@ services:
     command: ['mariadbd','--character-set-server=utf8mb4']
     environment:
       MYSQL_ROOT_PASSWORD: root
+    healthcheck:
+      test:
+      - CMD
+      - /usr/local/bin/healthcheck.sh
+      - --su-mysql
+      - --connect
+      - --innodb_initialized
+      start_period: 1m
+      start_interval: 10s
+      interval: 1m
+      timeout: 5s
+      retries: 3
   openemr:
     restart: always
     image: openemr/openemr:flex-3.20
@@ -18,4 +29,5 @@ services:
       FORCE_NO_BUILD_MODE: "yes"
       EMPTY: "yes"
     depends_on:
-    - mysql
+      mysql:
+        condition: service_healthy

--- a/ci/apache_83_116/docker-compose.yml
+++ b/ci/apache_83_116/docker-compose.yml
@@ -1,4 +1,3 @@
-# docker-compose.yml for travis ci testing
 services:
   mysql:
     restart: always
@@ -6,6 +5,18 @@ services:
     command: ['mariadbd','--character-set-server=utf8mb4']
     environment:
       MYSQL_ROOT_PASSWORD: root
+    healthcheck:
+      test:
+      - CMD
+      - /usr/local/bin/healthcheck.sh
+      - --su-mysql
+      - --connect
+      - --innodb_initialized
+      start_period: 1m
+      start_interval: 10s
+      interval: 1m
+      timeout: 5s
+      retries: 3
   openemr:
     restart: always
     image: openemr/openemr:flex-3.20
@@ -18,4 +29,5 @@ services:
       FORCE_NO_BUILD_MODE: "yes"
       EMPTY: "yes"
     depends_on:
-    - mysql
+      mysql:
+        condition: service_healthy

--- a/ci/apache_83_57/docker-compose.yml
+++ b/ci/apache_83_57/docker-compose.yml
@@ -1,4 +1,3 @@
-# docker-compose.yml for travis ci testing
 services:
   mysql:
     restart: always

--- a/ci/apache_83_80/docker-compose.yml
+++ b/ci/apache_83_80/docker-compose.yml
@@ -1,4 +1,3 @@
-# docker-compose.yml for travis ci testing
 services:
   mysql:
     restart: always

--- a/ci/apache_83_84/docker-compose.yml
+++ b/ci/apache_83_84/docker-compose.yml
@@ -1,4 +1,3 @@
-# docker-compose.yml for travis ci testing
 services:
   mysql:
     restart: always

--- a/ci/nginx_82/docker-compose.yml
+++ b/ci/nginx_82/docker-compose.yml
@@ -1,4 +1,3 @@
-# docker-compose.yml for travis ci testing
 services:
   mysql:
     restart: always
@@ -6,6 +5,18 @@ services:
     command: ['mariadbd','--character-set-server=utf8mb4']
     environment:
       MYSQL_ROOT_PASSWORD: root
+    healthcheck:
+      test:
+      - CMD
+      - /usr/local/bin/healthcheck.sh
+      - --su-mysql
+      - --connect
+      - --innodb_initialized
+      start_period: 1m
+      start_interval: 10s
+      interval: 1m
+      timeout: 5s
+      retries: 3
   openemr:
     restart: always
     image: openemr/dev-php-fpm:8.2
@@ -16,7 +27,8 @@ services:
     - ../../:/usr/share/nginx/html/openemr
     - ./php.ini:/usr/local/etc/php/php.ini:ro
     depends_on:
-    - mysql
+      mysql:
+        condition: service_healthy
   nginx:
     restart: always
     image: openemr/dev-nginx

--- a/ci/nginx_83/docker-compose.yml
+++ b/ci/nginx_83/docker-compose.yml
@@ -1,4 +1,3 @@
-# docker-compose.yml for travis ci testing
 services:
   mysql:
     restart: always
@@ -6,6 +5,18 @@ services:
     command: ['mariadbd','--character-set-server=utf8mb4']
     environment:
       MYSQL_ROOT_PASSWORD: root
+    healthcheck:
+      test:
+      - CMD
+      - /usr/local/bin/healthcheck.sh
+      - --su-mysql
+      - --connect
+      - --innodb_initialized
+      start_period: 1m
+      start_interval: 10s
+      interval: 1m
+      timeout: 5s
+      retries: 3
   openemr:
     restart: always
     image: openemr/dev-php-fpm:8.3
@@ -16,7 +27,8 @@ services:
     - ../../:/usr/share/nginx/html/openemr
     - ./php.ini:/usr/local/etc/php/php.ini:ro
     depends_on:
-    - mysql
+      mysql:
+        condition: service_healthy
   nginx:
     restart: always
     image: openemr/dev-nginx

--- a/ci/nginx_84/docker-compose.yml
+++ b/ci/nginx_84/docker-compose.yml
@@ -1,4 +1,3 @@
-# docker-compose.yml for travis ci testing
 services:
   mysql:
     restart: always
@@ -6,6 +5,18 @@ services:
     command: ['mariadbd','--character-set-server=utf8mb4']
     environment:
       MYSQL_ROOT_PASSWORD: root
+    healthcheck:
+      test:
+      - CMD
+      - /usr/local/bin/healthcheck.sh
+      - --su-mysql
+      - --connect
+      - --innodb_initialized
+      start_period: 1m
+      start_interval: 10s
+      interval: 1m
+      timeout: 5s
+      retries: 3
   openemr:
     restart: always
     image: openemr/dev-php-fpm:8.4
@@ -16,7 +27,8 @@ services:
     - ../../:/usr/share/nginx/html/openemr
     - ./php.ini:/usr/local/etc/php/php.ini:ro
     depends_on:
-    - mysql
+      mysql:
+        condition: service_healthy
   nginx:
     restart: always
     image: openemr/dev-nginx

--- a/ci/nginx_85/docker-compose.yml
+++ b/ci/nginx_85/docker-compose.yml
@@ -1,4 +1,3 @@
-# docker-compose.yml for travis ci testing
 services:
   mysql:
     restart: always
@@ -6,6 +5,18 @@ services:
     command: ['mariadbd','--character-set-server=utf8mb4']
     environment:
       MYSQL_ROOT_PASSWORD: root
+    healthcheck:
+      test:
+      - CMD
+      - /usr/local/bin/healthcheck.sh
+      - --su-mysql
+      - --connect
+      - --innodb_initialized
+      start_period: 1m
+      start_interval: 10s
+      interval: 1m
+      timeout: 5s
+      retries: 3
   openemr:
     restart: always
     image: openemr/dev-php-fpm:8.5
@@ -16,7 +27,8 @@ services:
     - ../../:/usr/share/nginx/html/openemr
     - ./php.ini:/usr/local/etc/php/php.ini:ro
     depends_on:
-    - mysql
+      mysql:
+        condition: service_healthy
   nginx:
     restart: always
     image: openemr/dev-nginx


### PR DESCRIPTION
Fixes #8399

#### Short description of what this resolves:

Add healthchecks to ci docker-compose so tests can know when mysql is ready to go, and don't have to sleep for 60 seconds.


#### Changes proposed in this pull request:

- add healthchecks to the mysql service in the docker-compose files in ci/, when the image is mariadb.
- remove the sleep 60 in .github/workflows/tests.yml when the healthcheck will do the same thing.

#### Does your code include anything generated by an AI Engine? No
