### PR TITLE
ci: coverage reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+    ENABLE_COVERAGE: "false"
+
 jobs:
 
   build_apache_82_114:
@@ -55,53 +58,92 @@ jobs:
           source ci/ciLibrary.source
           install_configure
 
+      - name: Prepare for coverage reporting
+        if: ${{ env.ENABLE_COVERAGE == 'true' }}
+        run: |
+          source ci/ciLibrary.source
+          configure_coverage
+
       - name: Unit testing
         run: |
           source ci/ciLibrary.source
-          build_test_unit
+          build_test unit
         if: ${{ success() || failure() }}
 
       - name: E2e testing
         run: |
           source ci/ciLibrary.source
-          build_test_e2e
+          build_test e2e
         if: ${{ success() || failure() }}
 
       - name: Api testing
         run: |
           source ci/ciLibrary.source
-          build_test_api
+          build_test api
         if: ${{ success() || failure() }}
 
       - name: Fixtures testing
         run: |
           source ci/ciLibrary.source
-          build_test_fixtures
+          build_test fixtures
         if: ${{ success() || failure() }}
 
       - name: Services testing
         run: |
           source ci/ciLibrary.source
-          build_test_services
+          build_test services
         if: ${{ success() || failure() }}
 
       - name: Validators testing
         run: |
           source ci/ciLibrary.source
-          build_test_validators
+          build_test validators
         if: ${{ success() || failure() }}
 
       - name: Controllers testing
         run: |
           source ci/ciLibrary.source
-          build_test_controllers
+          build_test controllers
         if: ${{ success() || failure() }}
 
       - name: Common testing
         run: |
           source ci/ciLibrary.source
-          build_test_common
+          build_test common
         if: ${{ success() || failure() }}
+
+      - name: Combine coverage
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        run: |
+          . ci/ciLibrary.source
+          merge_coverage
+
+      - name: Check if coverage files exist
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        id: check-files
+        run: |
+          echo "clover_exists=$(test -f coverage.clover.xml && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "htmlcov_exists=$(test -d ./htmlcov && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+        with:
+          name: coverage.clover.xml
+          path: coverage.clover.xml
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.htmlcov_exists == 'true' && (success() || failure()) }}
+        with:
+          name: htmlcov
+          path: ./htmlcov/
+
+      # - name: Upload coverage reports to Codecov
+      #   if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+      #   uses: codecov/codecov-action@v5
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     files: coverage.clover.xml
+
 
   build_apache_83_116:
     name: PHP 8.3 - Apache - MariaDB 11.6 (Rolling version)
@@ -110,6 +152,7 @@ jobs:
       DOCKER_DIR: apache_83_116
       OPENEMR_DIR: /var/www/localhost/htdocs/openemr
       CHROMIUM_INSTALL: "apk update; apk add --no-cache chromium chromium-chromedriver; export PANTHER_CHROME_DRIVER_BINARY=/usr/lib/chromium/chromedriver"
+      ENABLE_COVERAGE: "true"
     steps:
       - uses: actions/checkout@v4
 
@@ -147,53 +190,91 @@ jobs:
           source ci/ciLibrary.source
           install_configure
 
+      - name: Prepare for coverage reporting
+        if: ${{ env.ENABLE_COVERAGE == 'true' }}
+        run: |
+          source ci/ciLibrary.source
+          configure_coverage
+
       - name: Unit testing
         run: |
           source ci/ciLibrary.source
-          build_test_unit
+          build_test unit
         if: ${{ success() || failure() }}
 
       - name: E2e testing
         run: |
           source ci/ciLibrary.source
-          build_test_e2e
+          build_test e2e
         if: ${{ success() || failure() }}
 
       - name: Api testing
         run: |
           source ci/ciLibrary.source
-          build_test_api
+          build_test api
         if: ${{ success() || failure() }}
 
       - name: Fixtures testing
         run: |
           source ci/ciLibrary.source
-          build_test_fixtures
+          build_test fixtures
         if: ${{ success() || failure() }}
 
       - name: Services testing
         run: |
           source ci/ciLibrary.source
-          build_test_services
+          build_test services
         if: ${{ success() || failure() }}
 
       - name: Validators testing
         run: |
           source ci/ciLibrary.source
-          build_test_validators
+          build_test validators
         if: ${{ success() || failure() }}
 
       - name: Controllers testing
         run: |
           source ci/ciLibrary.source
-          build_test_controllers
+          build_test controllers
         if: ${{ success() || failure() }}
 
       - name: Common testing
         run: |
           source ci/ciLibrary.source
-          build_test_common
+          build_test common
         if: ${{ success() || failure() }}
+
+      - name: Combine coverage
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        run: |
+          . ci/ciLibrary.source
+          merge_coverage
+
+      - name: Check if coverage files exist
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        id: check-files
+        run: |
+          echo "clover_exists=$(test -f coverage.clover.xml && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "htmlcov_exists=$(test -d ./htmlcov && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+        with:
+          name: coverage.clover.xml
+          path: coverage.clover.xml
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.htmlcov_exists == 'true' && (success() || failure()) }}
+        with:
+          name: htmlcov
+          path: ./htmlcov/
+
+      # - name: Upload coverage reports to Codecov
+      #   if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+      #   uses: codecov/codecov-action@v5
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     files: coverage.clover.xml
 
   build_apache_83_114:
     name: PHP 8.3 - Apache - MariaDB 11.4
@@ -239,53 +320,91 @@ jobs:
           source ci/ciLibrary.source
           install_configure
 
+      - name: Prepare for coverage reporting
+        if: ${{ env.ENABLE_COVERAGE == 'true' }}
+        run: |
+          source ci/ciLibrary.source
+          configure_coverage
+
       - name: Unit testing
         run: |
           source ci/ciLibrary.source
-          build_test_unit
+          build_test unit
         if: ${{ success() || failure() }}
 
       - name: E2e testing
         run: |
           source ci/ciLibrary.source
-          build_test_e2e
+          build_test e2e
         if: ${{ success() || failure() }}
 
       - name: Api testing
         run: |
           source ci/ciLibrary.source
-          build_test_api
+          build_test api
         if: ${{ success() || failure() }}
 
       - name: Fixtures testing
         run: |
           source ci/ciLibrary.source
-          build_test_fixtures
+          build_test fixtures
         if: ${{ success() || failure() }}
 
       - name: Services testing
         run: |
           source ci/ciLibrary.source
-          build_test_services
+          build_test services
         if: ${{ success() || failure() }}
 
       - name: Validators testing
         run: |
           source ci/ciLibrary.source
-          build_test_validators
+          build_test validators
         if: ${{ success() || failure() }}
 
       - name: Controllers testing
         run: |
           source ci/ciLibrary.source
-          build_test_controllers
+          build_test controllers
         if: ${{ success() || failure() }}
 
       - name: Common testing
         run: |
           source ci/ciLibrary.source
-          build_test_common
+          build_test common
         if: ${{ success() || failure() }}
+
+      - name: Combine coverage
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        run: |
+          . ci/ciLibrary.source
+          merge_coverage
+
+      - name: Check if coverage files exist
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        id: check-files
+        run: |
+          echo "clover_exists=$(test -f coverage.clover.xml && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "htmlcov_exists=$(test -d ./htmlcov && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+        with:
+          name: coverage.clover.xml
+          path: coverage.clover.xml
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.htmlcov_exists == 'true' && (success() || failure()) }}
+        with:
+          name: htmlcov
+          path: ./htmlcov/
+
+      # - name: Upload coverage reports to Codecov
+      #   if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+      #   uses: codecov/codecov-action@v5
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     files: coverage.clover.xml
 
   build_apache_83_1011:
     name: PHP 8.3 - Apache - MariaDB 10.11
@@ -331,53 +450,91 @@ jobs:
           source ci/ciLibrary.source
           install_configure
 
+      - name: Prepare for coverage reporting
+        if: ${{ env.ENABLE_COVERAGE == 'true' }}
+        run: |
+          source ci/ciLibrary.source
+          configure_coverage
+
       - name: Unit testing
         run: |
           source ci/ciLibrary.source
-          build_test_unit
+          build_test unit
         if: ${{ success() || failure() }}
 
       - name: E2e testing
         run: |
           source ci/ciLibrary.source
-          build_test_e2e
+          build_test e2e
         if: ${{ success() || failure() }}
 
       - name: Api testing
         run: |
           source ci/ciLibrary.source
-          build_test_api
+          build_test api
         if: ${{ success() || failure() }}
 
       - name: Fixtures testing
         run: |
           source ci/ciLibrary.source
-          build_test_fixtures
+          build_test fixtures
         if: ${{ success() || failure() }}
 
       - name: Services testing
         run: |
           source ci/ciLibrary.source
-          build_test_services
+          build_test services
         if: ${{ success() || failure() }}
 
       - name: Validators testing
         run: |
           source ci/ciLibrary.source
-          build_test_validators
+          build_test validators
         if: ${{ success() || failure() }}
 
       - name: Controllers testing
         run: |
           source ci/ciLibrary.source
-          build_test_controllers
+          build_test controllers
         if: ${{ success() || failure() }}
 
       - name: Common testing
         run: |
           source ci/ciLibrary.source
-          build_test_common
+          build_test common
         if: ${{ success() || failure() }}
+
+      - name: Combine coverage
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        run: |
+          . ci/ciLibrary.source
+          merge_coverage
+
+      - name: Check if coverage files exist
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        id: check-files
+        run: |
+          echo "clover_exists=$(test -f coverage.clover.xml && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "htmlcov_exists=$(test -d ./htmlcov && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+        with:
+          name: coverage.clover.xml
+          path: coverage.clover.xml
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.htmlcov_exists == 'true' && (success() || failure()) }}
+        with:
+          name: htmlcov
+          path: ./htmlcov/
+
+      # - name: Upload coverage reports to Codecov
+      #   if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+      #   uses: codecov/codecov-action@v5
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     files: coverage.clover.xml
 
   build_apache_83_106:
     name: PHP 8.3 - Apache - MariaDB 10.6
@@ -423,53 +580,91 @@ jobs:
           source ci/ciLibrary.source
           install_configure
 
+      - name: Prepare for coverage reporting
+        if: ${{ env.ENABLE_COVERAGE == 'true' }}
+        run: |
+          source ci/ciLibrary.source
+          configure_coverage
+
       - name: Unit testing
         run: |
           source ci/ciLibrary.source
-          build_test_unit
+          build_test unit
         if: ${{ success() || failure() }}
 
       - name: E2e testing
         run: |
           source ci/ciLibrary.source
-          build_test_e2e
+          build_test e2e
         if: ${{ success() || failure() }}
 
       - name: Api testing
         run: |
           source ci/ciLibrary.source
-          build_test_api
+          build_test api
         if: ${{ success() || failure() }}
 
       - name: Fixtures testing
         run: |
           source ci/ciLibrary.source
-          build_test_fixtures
+          build_test fixtures
         if: ${{ success() || failure() }}
 
       - name: Services testing
         run: |
           source ci/ciLibrary.source
-          build_test_services
+          build_test services
         if: ${{ success() || failure() }}
 
       - name: Validators testing
         run: |
           source ci/ciLibrary.source
-          build_test_validators
+          build_test validators
         if: ${{ success() || failure() }}
 
       - name: Controllers testing
         run: |
           source ci/ciLibrary.source
-          build_test_controllers
+          build_test controllers
         if: ${{ success() || failure() }}
 
       - name: Common testing
         run: |
           source ci/ciLibrary.source
-          build_test_common
+          build_test common
         if: ${{ success() || failure() }}
+
+      - name: Combine coverage
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        run: |
+          . ci/ciLibrary.source
+          merge_coverage
+
+      - name: Check if coverage files exist
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        id: check-files
+        run: |
+          echo "clover_exists=$(test -f coverage.clover.xml && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "htmlcov_exists=$(test -d ./htmlcov && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+        with:
+          name: coverage.clover.xml
+          path: coverage.clover.xml
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.htmlcov_exists == 'true' && (success() || failure()) }}
+        with:
+          name: htmlcov
+          path: ./htmlcov/
+
+      # - name: Upload coverage reports to Codecov
+      #   if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+      #   uses: codecov/codecov-action@v5
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     files: coverage.clover.xml
 
   build_apache_83_105:
     name: PHP 8.3 - Apache - MariaDB 10.5
@@ -515,53 +710,91 @@ jobs:
           source ci/ciLibrary.source
           install_configure
 
+      - name: Prepare for coverage reporting
+        if: ${{ env.ENABLE_COVERAGE == 'true' }}
+        run: |
+          source ci/ciLibrary.source
+          configure_coverage
+
       - name: Unit testing
         run: |
           source ci/ciLibrary.source
-          build_test_unit
+          build_test unit
         if: ${{ success() || failure() }}
 
       - name: E2e testing
         run: |
           source ci/ciLibrary.source
-          build_test_e2e
+          build_test e2e
         if: ${{ success() || failure() }}
 
       - name: Api testing
         run: |
           source ci/ciLibrary.source
-          build_test_api
+          build_test api
         if: ${{ success() || failure() }}
 
       - name: Fixtures testing
         run: |
           source ci/ciLibrary.source
-          build_test_fixtures
+          build_test fixtures
         if: ${{ success() || failure() }}
 
       - name: Services testing
         run: |
           source ci/ciLibrary.source
-          build_test_services
+          build_test services
         if: ${{ success() || failure() }}
 
       - name: Validators testing
         run: |
           source ci/ciLibrary.source
-          build_test_validators
+          build_test validators
         if: ${{ success() || failure() }}
 
       - name: Controllers testing
         run: |
           source ci/ciLibrary.source
-          build_test_controllers
+          build_test controllers
         if: ${{ success() || failure() }}
 
       - name: Common testing
         run: |
           source ci/ciLibrary.source
-          build_test_common
+          build_test common
         if: ${{ success() || failure() }}
+
+      - name: Combine coverage
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        run: |
+          . ci/ciLibrary.source
+          merge_coverage
+
+      - name: Check if coverage files exist
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        id: check-files
+        run: |
+          echo "clover_exists=$(test -f coverage.clover.xml && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "htmlcov_exists=$(test -d ./htmlcov && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+        with:
+          name: coverage.clover.xml
+          path: coverage.clover.xml
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.htmlcov_exists == 'true' && (success() || failure()) }}
+        with:
+          name: htmlcov
+          path: ./htmlcov/
+
+      # - name: Upload coverage reports to Codecov
+      #   if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+      #   uses: codecov/codecov-action@v5
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     files: coverage.clover.xml
 
   build_apache_83_84:
     name: PHP 8.3 - Apache - MySQL 8.4
@@ -608,53 +841,91 @@ jobs:
           source ci/ciLibrary.source
           install_configure
 
+      - name: Prepare for coverage reporting
+        if: ${{ env.ENABLE_COVERAGE == 'true' }}
+        run: |
+          source ci/ciLibrary.source
+          configure_coverage
+
       - name: Unit testing
         run: |
           source ci/ciLibrary.source
-          build_test_unit
+          build_test unit
         if: ${{ success() || failure() }}
 
       - name: E2e testing
         run: |
           source ci/ciLibrary.source
-          build_test_e2e
+          build_test e2e
         if: ${{ success() || failure() }}
 
       - name: Api testing
         run: |
           source ci/ciLibrary.source
-          build_test_api
+          build_test api
         if: ${{ success() || failure() }}
 
       - name: Fixtures testing
         run: |
           source ci/ciLibrary.source
-          build_test_fixtures
+          build_test fixtures
         if: ${{ success() || failure() }}
 
       - name: Services testing
         run: |
           source ci/ciLibrary.source
-          build_test_services
+          build_test services
         if: ${{ success() || failure() }}
 
       - name: Validators testing
         run: |
           source ci/ciLibrary.source
-          build_test_validators
+          build_test validators
         if: ${{ success() || failure() }}
 
       - name: Controllers testing
         run: |
           source ci/ciLibrary.source
-          build_test_controllers
+          build_test controllers
         if: ${{ success() || failure() }}
 
       - name: Common testing
         run: |
           source ci/ciLibrary.source
-          build_test_common
+          build_test common
         if: ${{ success() || failure() }}
+
+      - name: Combine coverage
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        run: |
+          . ci/ciLibrary.source
+          merge_coverage
+
+      - name: Check if coverage files exist
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        id: check-files
+        run: |
+          echo "clover_exists=$(test -f coverage.clover.xml && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "htmlcov_exists=$(test -d ./htmlcov && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+        with:
+          name: coverage.clover.xml
+          path: coverage.clover.xml
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.htmlcov_exists == 'true' && (success() || failure()) }}
+        with:
+          name: htmlcov
+          path: ./htmlcov/
+
+      # - name: Upload coverage reports to Codecov
+      #   if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+      #   uses: codecov/codecov-action@v5
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     files: coverage.clover.xml
 
   build_apache_83_80:
     name: PHP 8.3 - Apache - MySQL 8.0
@@ -701,53 +972,91 @@ jobs:
           source ci/ciLibrary.source
           install_configure
 
+      - name: Prepare for coverage reporting
+        if: ${{ env.ENABLE_COVERAGE == 'true' }}
+        run: |
+          source ci/ciLibrary.source
+          configure_coverage
+
       - name: Unit testing
         run: |
           source ci/ciLibrary.source
-          build_test_unit
+          build_test unit
         if: ${{ success() || failure() }}
 
       - name: E2e testing
         run: |
           source ci/ciLibrary.source
-          build_test_e2e
+          build_test e2e
         if: ${{ success() || failure() }}
 
       - name: Api testing
         run: |
           source ci/ciLibrary.source
-          build_test_api
+          build_test api
         if: ${{ success() || failure() }}
 
       - name: Fixtures testing
         run: |
           source ci/ciLibrary.source
-          build_test_fixtures
+          build_test fixtures
         if: ${{ success() || failure() }}
 
       - name: Services testing
         run: |
           source ci/ciLibrary.source
-          build_test_services
+          build_test services
         if: ${{ success() || failure() }}
 
       - name: Validators testing
         run: |
           source ci/ciLibrary.source
-          build_test_validators
+          build_test validators
         if: ${{ success() || failure() }}
 
       - name: Controllers testing
         run: |
           source ci/ciLibrary.source
-          build_test_controllers
+          build_test controllers
         if: ${{ success() || failure() }}
 
       - name: Common testing
         run: |
           source ci/ciLibrary.source
-          build_test_common
+          build_test common
         if: ${{ success() || failure() }}
+
+      - name: Combine coverage
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        run: |
+          . ci/ciLibrary.source
+          merge_coverage
+
+      - name: Check if coverage files exist
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        id: check-files
+        run: |
+          echo "clover_exists=$(test -f coverage.clover.xml && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "htmlcov_exists=$(test -d ./htmlcov && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+        with:
+          name: coverage.clover.xml
+          path: coverage.clover.xml
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.htmlcov_exists == 'true' && (success() || failure()) }}
+        with:
+          name: htmlcov
+          path: ./htmlcov/
+
+      # - name: Upload coverage reports to Codecov
+      #   if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+      #   uses: codecov/codecov-action@v5
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     files: coverage.clover.xml
 
   build_apache_83_57:
     name: PHP 8.3 - Apache - MySQL 5.7
@@ -794,53 +1103,91 @@ jobs:
           source ci/ciLibrary.source
           install_configure
 
+      - name: Prepare for coverage reporting
+        if: ${{ env.ENABLE_COVERAGE == 'true' }}
+        run: |
+          source ci/ciLibrary.source
+          configure_coverage
+
       - name: Unit testing
         run: |
           source ci/ciLibrary.source
-          build_test_unit
+          build_test unit
         if: ${{ success() || failure() }}
 
       - name: E2e testing
         run: |
           source ci/ciLibrary.source
-          build_test_e2e
+          build_test e2e
         if: ${{ success() || failure() }}
 
       - name: Api testing
         run: |
           source ci/ciLibrary.source
-          build_test_api
+          build_test api
         if: ${{ success() || failure() }}
 
       - name: Fixtures testing
         run: |
           source ci/ciLibrary.source
-          build_test_fixtures
+          build_test fixtures
         if: ${{ success() || failure() }}
 
       - name: Services testing
         run: |
           source ci/ciLibrary.source
-          build_test_services
+          build_test services
         if: ${{ success() || failure() }}
 
       - name: Validators testing
         run: |
           source ci/ciLibrary.source
-          build_test_validators
+          build_test validators
         if: ${{ success() || failure() }}
 
       - name: Controllers testing
         run: |
           source ci/ciLibrary.source
-          build_test_controllers
+          build_test controllers
         if: ${{ success() || failure() }}
 
       - name: Common testing
         run: |
           source ci/ciLibrary.source
-          build_test_common
+          build_test common
         if: ${{ success() || failure() }}
+
+      - name: Combine coverage
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        run: |
+          . ci/ciLibrary.source
+          merge_coverage
+
+      - name: Check if coverage files exist
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        id: check-files
+        run: |
+          echo "clover_exists=$(test -f coverage.clover.xml && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "htmlcov_exists=$(test -d ./htmlcov && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+        with:
+          name: coverage.clover.xml
+          path: coverage.clover.xml
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.htmlcov_exists == 'true' && (success() || failure()) }}
+        with:
+          name: htmlcov
+          path: ./htmlcov/
+
+      # - name: Upload coverage reports to Codecov
+      #   if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+      #   uses: codecov/codecov-action@v5
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     files: coverage.clover.xml
 
   build_nginx_82:
     name: PHP 8.2 - Nginx - MariaDB 11.4
@@ -886,53 +1233,91 @@ jobs:
           source ci/ciLibrary.source
           install_configure
 
+      - name: Prepare for coverage reporting
+        if: ${{ env.ENABLE_COVERAGE == 'true' }}
+        run: |
+          source ci/ciLibrary.source
+          configure_coverage
+
       - name: Unit testing
         run: |
           source ci/ciLibrary.source
-          build_test_unit
+          build_test unit
         if: ${{ success() || failure() }}
 
       - name: E2e testing
         run: |
           source ci/ciLibrary.source
-          build_test_e2e
+          build_test e2e
         if: ${{ success() || failure() }}
 
       - name: Api testing
         run: |
           source ci/ciLibrary.source
-          build_test_api
+          build_test api
         if: ${{ success() || failure() }}
 
       - name: Fixtures testing
         run: |
           source ci/ciLibrary.source
-          build_test_fixtures
+          build_test fixtures
         if: ${{ success() || failure() }}
 
       - name: Services testing
         run: |
           source ci/ciLibrary.source
-          build_test_services
+          build_test services
         if: ${{ success() || failure() }}
 
       - name: Validators testing
         run: |
           source ci/ciLibrary.source
-          build_test_validators
+          build_test validators
         if: ${{ success() || failure() }}
 
       - name: Controllers testing
         run: |
           source ci/ciLibrary.source
-          build_test_controllers
+          build_test controllers
         if: ${{ success() || failure() }}
 
       - name: Common testing
         run: |
           source ci/ciLibrary.source
-          build_test_common
+          build_test common
         if: ${{ success() || failure() }}
+
+      - name: Combine coverage
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        run: |
+          . ci/ciLibrary.source
+          merge_coverage
+
+      - name: Check if coverage files exist
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        id: check-files
+        run: |
+          echo "clover_exists=$(test -f coverage.clover.xml && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "htmlcov_exists=$(test -d ./htmlcov && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+        with:
+          name: coverage.clover.xml
+          path: coverage.clover.xml
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.htmlcov_exists == 'true' && (success() || failure()) }}
+        with:
+          name: htmlcov
+          path: ./htmlcov/
+
+      # - name: Upload coverage reports to Codecov
+      #   if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+      #   uses: codecov/codecov-action@v5
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     files: coverage.clover.xml
 
   build_nginx_83:
     name: PHP 8.3 - Nginx - MariaDB 11.4
@@ -978,54 +1363,91 @@ jobs:
           source ci/ciLibrary.source
           install_configure
 
+      - name: Prepare for coverage reporting
+        if: ${{ env.ENABLE_COVERAGE == 'true' }}
+        run: |
+          source ci/ciLibrary.source
+          configure_coverage
+
       - name: Unit testing
         run: |
           source ci/ciLibrary.source
-          build_test_unit
+          build_test unit
         if: ${{ success() || failure() }}
 
       - name: E2e testing
         run: |
           source ci/ciLibrary.source
-          build_test_e2e
+          build_test e2e
         if: ${{ success() || failure() }}
 
       - name: Api testing
         run: |
           source ci/ciLibrary.source
-          build_test_api
+          build_test api
         if: ${{ success() || failure() }}
 
       - name: Fixtures testing
         run: |
           source ci/ciLibrary.source
-          build_test_fixtures
+          build_test fixtures
         if: ${{ success() || failure() }}
 
       - name: Services testing
         run: |
           source ci/ciLibrary.source
-          build_test_services
+          build_test services
         if: ${{ success() || failure() }}
 
       - name: Validators testing
         run: |
           source ci/ciLibrary.source
-          build_test_validators
+          build_test validators
         if: ${{ success() || failure() }}
 
       - name: Controllers testing
         run: |
           source ci/ciLibrary.source
-          build_test_controllers
+          build_test controllers
         if: ${{ success() || failure() }}
 
       - name: Common testing
         run: |
           source ci/ciLibrary.source
-          build_test_common
+          build_test common
         if: ${{ success() || failure() }}
 
+      - name: Combine coverage
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        run: |
+          . ci/ciLibrary.source
+          merge_coverage
+
+      - name: Check if coverage files exist
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        id: check-files
+        run: |
+          echo "clover_exists=$(test -f coverage.clover.xml && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "htmlcov_exists=$(test -d ./htmlcov && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+        with:
+          name: coverage.clover.xml
+          path: coverage.clover.xml
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.htmlcov_exists == 'true' && (success() || failure()) }}
+        with:
+          name: htmlcov
+          path: ./htmlcov/
+
+      # - name: Upload coverage reports to Codecov
+      #   if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+      #   uses: codecov/codecov-action@v5
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     files: coverage.clover.xml
 
   build_nginx_84:
     name: PHP 8.4 - Nginx - MariaDB 11.4
@@ -1071,53 +1493,91 @@ jobs:
           source ci/ciLibrary.source
           install_configure
 
+      - name: Prepare for coverage reporting
+        if: ${{ env.ENABLE_COVERAGE == 'true' }}
+        run: |
+          source ci/ciLibrary.source
+          configure_coverage
+
       - name: Unit testing
         run: |
           source ci/ciLibrary.source
-          build_test_unit
+          build_test unit
         if: ${{ success() || failure() }}
 
       - name: E2e testing
         run: |
           source ci/ciLibrary.source
-          build_test_e2e
+          build_test e2e
         if: ${{ success() || failure() }}
 
       - name: Api testing
         run: |
           source ci/ciLibrary.source
-          build_test_api
+          build_test api
         if: ${{ success() || failure() }}
 
       - name: Fixtures testing
         run: |
           source ci/ciLibrary.source
-          build_test_fixtures
+          build_test fixtures
         if: ${{ success() || failure() }}
 
       - name: Services testing
         run: |
           source ci/ciLibrary.source
-          build_test_services
+          build_test services
         if: ${{ success() || failure() }}
 
       - name: Validators testing
         run: |
           source ci/ciLibrary.source
-          build_test_validators
+          build_test validators
         if: ${{ success() || failure() }}
 
       - name: Controllers testing
         run: |
           source ci/ciLibrary.source
-          build_test_controllers
+          build_test controllers
         if: ${{ success() || failure() }}
 
       - name: Common testing
         run: |
           source ci/ciLibrary.source
-          build_test_common
+          build_test common
         if: ${{ success() || failure() }}
+
+      - name: Combine coverage
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        run: |
+          . ci/ciLibrary.source
+          merge_coverage
+
+      - name: Check if coverage files exist
+        if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+        id: check-files
+        run: |
+          echo "clover_exists=$(test -f coverage.clover.xml && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "htmlcov_exists=$(test -d ./htmlcov && echo true || echo false)" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+        with:
+          name: coverage.clover.xml
+          path: coverage.clover.xml
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.htmlcov_exists == 'true' && (success() || failure()) }}
+        with:
+          name: htmlcov
+          path: ./htmlcov/
+
+      # - name: Upload coverage reports to Codecov
+      #   if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+      #   uses: codecov/codecov-action@v5
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     files: coverage.clover.xml
 
   build_nginx_85:
     name: PHP 8.5 - Nginx - MariaDB 11.4
@@ -1163,50 +1623,56 @@ jobs:
           source ci/ciLibrary.source
           install_configure
 
+      - name: Prepare for coverage reporting
+        if: ${{ env.ENABLE_COVERAGE == 'true' }}
+        run: |
+          source ci/ciLibrary.source
+          configure_coverage
+
       - name: Unit testing
         run: |
           source ci/ciLibrary.source
-          build_test_unit
+          build_test unit
         if: ${{ success() || failure() }}
 
       - name: E2e testing
         run: |
           source ci/ciLibrary.source
-          build_test_e2e
+          build_test e2e
         if: ${{ success() || failure() }}
 
       - name: Api testing
         run: |
           source ci/ciLibrary.source
-          build_test_api
+          build_test api
         if: ${{ success() || failure() }}
 
       - name: Fixtures testing
         run: |
           source ci/ciLibrary.source
-          build_test_fixtures
+          build_test fixtures
         if: ${{ success() || failure() }}
 
       - name: Services testing
         run: |
           source ci/ciLibrary.source
-          build_test_services
+          build_test services
         if: ${{ success() || failure() }}
 
       - name: Validators testing
         run: |
           source ci/ciLibrary.source
-          build_test_validators
+          build_test validators
         if: ${{ success() || failure() }}
 
       - name: Controllers testing
         run: |
           source ci/ciLibrary.source
-          build_test_controllers
+          build_test controllers
         if: ${{ success() || failure() }}
 
       - name: Common testing
         run: |
           source ci/ciLibrary.source
-          build_test_common
+          build_test common
         if: ${{ success() || failure() }}

--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -52,7 +52,11 @@ dc() {
 }
 
 _exec() {
-    dc exec --env XDEBUG_MODE=coverage --workdir "${OPENEMR_DIR}" openemr "$@"
+    if [[ ${ENABLE_COVERAGE:-false} = true ]]; then
+        dc exec --env XDEBUG_MODE=coverage --workdir "${OPENEMR_DIR}" openemr "$@"
+    else
+        dc exec --workdir "${OPENEMR_DIR}" openemr "$@"
+    fi
 }
 
 dockers_env_start() {

--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -10,14 +10,31 @@
 # Bash library for openemr ci
 #
 
+set -xeuo pipefail
+
+coverage_args=(
+    --coverage-filter apis
+    --coverage-filter gacl
+    --coverage-filter interface
+    --coverage-filter library
+    --coverage-filter modules
+    --coverage-filter oauth2
+    --coverage-filter portal
+    --coverage-filter sites
+    --coverage-filter src
+    --coverage-filter tests
+    --coverage-text
+    --path-coverage
+)
+
 composer_github_auth() {
-    githubToken=`echo MjE2OTcwOGE2MmM5ZWRiMzA3NGFmNGVjMmZkOGE0MWY2YzVkMDJhZgo= | base64 --decode`
-    githubTokenRateLimitRequest=`curl -H "Authorization: token $githubToken" https://api.github.com/rate_limit`
-    githubTokenRateLimit=`echo $githubTokenRateLimitRequest | jq '.rate.remaining'`
+    githubToken=$(base64 --decode <<< MjE2OTcwOGE2MmM5ZWRiMzA3NGFmNGVjMmZkOGE0MWY2YzVkMDJhZgo=)
+    githubTokenRateLimitRequest=$(curl -H "Authorization: token $githubToken" https://api.github.com/rate_limit)
+    githubTokenRateLimit=$(jq '.rate.remaining' <<< "$githubTokenRateLimitRequest")
     echo "Number of github api requests remaining is $githubTokenRateLimit"
-    if [ "$githubTokenRateLimit" -gt 500 ]; then
-        echo "Trying to use composer github api token"
-        if `composer config --global --auth github-oauth.github.com "$githubToken"`; then
+    if (( githubTokenRateLimit > 500 )); then
+        echo 'Trying to use composer github api token'
+        if composer config --global --auth github-oauth.github.com "$githubToken"; then
             echo "github composer token worked"
         else
             echo "github composer token did not work"
@@ -27,123 +44,114 @@ composer_github_auth() {
     fi
 }
 
+##
+# Technically dc is a calculator command in linux,
+# but it's rarely used in the same context as docker compose.
+dc() {
+    docker compose --project-directory "ci/${DOCKER_DIR}" "$@"
+}
+
+_exec() {
+    dc exec --env XDEBUG_MODE=coverage --workdir "${OPENEMR_DIR}" openemr "$@"
+}
+
 dockers_env_start() {
-    failTest=false
-    cd ci/${DOCKER_DIR} || failTest=true
-    docker compose up -d || failTest=true
-    cd ../../ || failTest=true
-    if $failTest; then
-      exit 1
+    dc up --detach
+}
+
+actions_chmod() {
+    # TODO, figure out how not to require the below line (maybe chown or something like that)
+    if [[ -z ${GITHUB_RUN_ID:-} ]]; then
+        echo 'skipping chmod because this is not running in github actions'
+        return
     fi
+    sudo chmod "$@"
 }
 
 main_build() {
-      failTest=false
-      # TODO, figure out how not to require the below line (maybe chown or something like that)
-      sudo chmod -R 0777 .
-      composer install || failTest=true
-      npm install || failTest=true
-      npm run build || failTest=true
-      composer global require phing/phing || failTest=true
-      $HOME/.composer/vendor/bin/phing vendor-clean || failTest=true
-      $HOME/.composer/vendor/bin/phing assets-clean || failTest=true
-      composer global remove phing/phing || failTest=true
-      composer dump-autoload -o || failTest=true
-      rm -fr node_modules || failTest=true
-      if $failTest; then
-        exit 1
-      fi
+    actions_chmod -R 0777 .
+    local composer_home
+    composer_home=$(composer --no-interaction config --global --absolute home) 2> /dev/null
+    composer install
+    npm ci
+    npm run build
+    composer global require phing/phing
+    "${composer_home}/vendor/bin/phing" vendor-clean
+    "${composer_home}/vendor/bin/phing" assets-clean
+    composer global remove phing/phing
+    composer dump-autoload -o
+    rm -fr node_modules
 }
 
-ccda_build() {
-    failTest=false
-    cd ccdaservice || failTest=true
-    npm install || failTest=true
-    cd ../ || failTest=true
-    if $failTest; then
-      exit 1
-    fi
+ccda_build() (
+    cd ccdaservice
+    npm ci
+)
+
+configure_coverage() {
+    _exec sh -c '
+      XDEBUG_IDE_KEY=unimportant XDEBUG_ON=yes ../xdebug.sh
+      mkdir -p ./coverage
+      curl -sSLO https://phar.phpunit.de/phpcov-11.0.0.phar
+    '
+}
+
+phpcov() {
+    _exec php -d memory_limit=8G phpcov-11.0.0.phar "$@"
 }
 
 install_configure() {
-    failTest=false
-    sudo chmod 666 sites/default/sqlconf.php || failTest=true
-    sudo chmod -R 777 sites/default/documents || failTest=true
-    sed -e 's@^exit;@ @' < contrib/util/installScripts/InstallerAuto.php > contrib/util/installScripts/InstallerAutoTemp.php || failTest=true
-    docker exec -i $(docker ps | grep openemr[_\-] | cut -f 1 -d " ") sh -c "php -f ${OPENEMR_DIR}/contrib/util/installScripts/InstallerAutoTemp.php rootpass=root server=mysql loginhost=%" || failTest=true
-    docker exec -i $(docker ps | grep openemr[_\-] | cut -f 1 -d " ") sh -c "rm -f ${OPENEMR_DIR}/contrib/util/installScripts/InstallerAutoTemp.php" || failTest=true
-    docker exec -i $(docker ps | grep openemr[_\-] | cut -f 1 -d " ") sh -c 'mysql -u openemr --password="openemr" -h mysql -e "INSERT INTO product_registration (opt_out) VALUES (1)" openemr' || failTest=true
-    docker exec -i $(docker ps | grep openemr[_\-] | cut -f 1 -d " ") sh -c 'mysql -u openemr --password="openemr" -h mysql -e "UPDATE globals SET gl_value = 1 WHERE gl_name = \"rest_api\"" openemr' || failTest=true
-    docker exec -i $(docker ps | grep openemr[_\-] | cut -f 1 -d " ") sh -c 'mysql -u openemr --password="openemr" -h mysql -e "UPDATE globals SET gl_value = 1 WHERE gl_name = \"rest_fhir_api\"" openemr' || failTest=true
-    docker exec -i $(docker ps | grep openemr[_\-] | cut -f 1 -d " ") sh -c 'mysql -u openemr --password="openemr" -h mysql -e "UPDATE globals SET gl_value = 1 WHERE gl_name = \"rest_portal_api\"" openemr' || failTest=true
-    docker exec -i $(docker ps | grep openemr[_\-] | cut -f 1 -d " ") sh -c 'mysql -u openemr --password="openemr" -h mysql -e "UPDATE globals SET gl_value = 3 WHERE gl_name = \"oauth_password_grant\"" openemr' || failTest=true
-    docker exec -i $(docker ps | grep openemr[_\-] | cut -f 1 -d " ") sh -c 'mysql -u openemr --password="openemr" -h mysql -e "UPDATE globals SET gl_value = 1 WHERE gl_name = \"rest_system_scopes_api\"" openemr' || failTest=true
-    if $failTest; then
-      exit 1
-    fi
-}
-
-build_test_unit() {
-    failTest=false
-    docker exec -i $(docker ps | grep openemr[_\-] | cut -f 1 -d " ") sh -c "cd ${OPENEMR_DIR}; php ${OPENEMR_DIR}/vendor/bin/phpunit --testsuite unit --testdox" || failTest=true
-    if $failTest; then
-      exit 1
-    fi
+    actions_chmod 0666 sites/default/sqlconf.php
+    actions_chmod -R 0777 sites/default/documents
+    sed -e 's@^exit;@ @' < contrib/util/installScripts/InstallerAuto.php > contrib/util/installScripts/InstallerAutoTemp.php
+    _exec php -f ./contrib/util/installScripts/InstallerAutoTemp.php rootpass=root server=mysql loginhost=%
+    _exec rm -f ./contrib/util/installScripts/InstallerAutoTemp.php
+    _exec mysql -u openemr --password="openemr" -h mysql -e 'INSERT INTO product_registration (opt_out) VALUES (1)' openemr
+    _exec mysql -u openemr --password="openemr" -h mysql -e 'UPDATE globals SET gl_value = 1 WHERE gl_name = "rest_api"' openemr
+    _exec mysql -u openemr --password="openemr" -h mysql -e 'UPDATE globals SET gl_value = 1 WHERE gl_name = "rest_fhir_api"' openemr
+    _exec mysql -u openemr --password="openemr" -h mysql -e 'UPDATE globals SET gl_value = 1 WHERE gl_name = "rest_portal_api"' openemr
+    _exec mysql -u openemr --password="openemr" -h mysql -e 'UPDATE globals SET gl_value = 3 WHERE gl_name = "oauth_password_grant"' openemr
+    _exec mysql -u openemr --password="openemr" -h mysql -e 'UPDATE globals SET gl_value = 1 WHERE gl_name = "rest_system_scopes_api"' openemr
 }
 
 build_test_e2e() {
-    failTest=false
-    docker exec -i $(docker ps | grep openemr[_\-] | cut -f 1 -d " ") sh -c "${CHROMIUM_INSTALL}; export PANTHER_NO_SANDBOX=1; export PANTHER_CHROME_ARGUMENTS='--disable-dev-shm-usage'; cd ${OPENEMR_DIR}; php ${OPENEMR_DIR}/vendor/bin/phpunit --testsuite e2e --testdox" || failTest=true
-    if $failTest; then
-      exit 1
-    fi
+    _exec sh -c "${CHROMIUM_INSTALL};
+                 export PANTHER_NO_SANDBOX=1;
+                 export PANTHER_CHROME_ARGUMENTS=--disable-dev-shm-usage;
+                 php -d memory_limit=8G ./vendor/bin/phpunit --testsuite e2e \
+                                                             --testdox"
 }
 
-build_test_api() {
-    failTest=false
-    docker exec -i $(docker ps | grep openemr[_\-] | cut -f 1 -d " ") sh -c "cd ${OPENEMR_DIR}; php ${OPENEMR_DIR}/vendor/bin/phpunit --testsuite api --testdox" || failTest=true
-    if $failTest; then
-      exit 1
-    fi
+phpunit() {
+    _exec php -d memory_limit=8G ./vendor/bin/phpunit --testdox "$@"
 }
 
-build_test_fixtures() {
-    failTest=false
-    docker exec -i $(docker ps | grep openemr[_\-] | cut -f 1 -d " ") sh -c "cd ${OPENEMR_DIR}; php ${OPENEMR_DIR}/vendor/bin/phpunit --testsuite fixtures --testdox" || failTest=true
-    if $failTest; then
-      exit 1
+##
+# Run the tests, enabling coverage if set.
+# Coverage is not handled for api or e2e tests.
+build_test() {
+    local testsuite="$1"
+    local -a args=( --testsuite "$testsuite" )
+    shift
+    case "$testsuite" in
+        api) phpunit "${args[@]}" "$@"
+             return
+             ;;
+        e2e) build_test_e2e "$@"
+             return
+             ;;
+    esac
+    if [[ ${ENABLE_COVERAGE:-false} = true ]]; then
+        args+=(
+            --coverage-php "./coverage/coverage.${testsuite}.cov"
+            "${coverage_args[@]}"
+        )
     fi
+    phpunit "${args[@]}" "$@"
 }
 
-build_test_services() {
-    failTest=false
-    docker exec -i $(docker ps | grep openemr[_\-] | cut -f 1 -d " ") sh -c "cd ${OPENEMR_DIR}; php ${OPENEMR_DIR}/vendor/bin/phpunit --testsuite services --testdox" || failTest=true
-    if $failTest; then
-      exit 1
-    fi
+merge_coverage() {
+    phpcov merge coverage --clover coverage.clover.xml \
+                          --html htmlcov coverage \
+                          --text /dev/stdout
 }
-
-build_test_validators() {
-    failTest=false
-    docker exec -i $(docker ps | grep openemr[_\-] | cut -f 1 -d " ") sh -c "cd ${OPENEMR_DIR}; php ${OPENEMR_DIR}/vendor/bin/phpunit --testsuite validators --testdox" || failTest=true
-    if $failTest; then
-      exit 1
-    fi
-}
-
-build_test_controllers() {
-    failTest=false
-    docker exec -i $(docker ps | grep openemr[_\-] | cut -f 1 -d " ") sh -c "cd ${OPENEMR_DIR}; php ${OPENEMR_DIR}/vendor/bin/phpunit --testsuite controllers --testdox" || failTest=true
-    if $failTest; then
-      exit 1
-    fi
-}
-
-build_test_common() {
-    failTest=false
-    docker exec -i $(docker ps | grep openemr[_\-] | cut -f 1 -d " ") sh -c "cd ${OPENEMR_DIR}; php ${OPENEMR_DIR}/vendor/bin/phpunit --testsuite common --testdox" || failTest=true
-    if $failTest; then
-      exit 1
-    fi
-}
-

--- a/composer.json
+++ b/composer.json
@@ -91,6 +91,7 @@
         }
     },
     "require-dev": {
+        "phpunit/php-code-coverage": "^11.0",
         "phpunit/phpunit": "11.*",
         "symfony/panther": "2.*",
         "zircote/swagger-php": "3.*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d0c87ea2b05978e14645961e3106ad73",
+    "content-hash": "9e66638d862caeb2793e11b7b968d767",
     "packages": [
         {
             "name": "academe/authorizenet-objects",
@@ -13442,16 +13442,16 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.2.0"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.2",
         "ext-intl": "8.2"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/tests/Tests/Api/FacilityApiTest.php
+++ b/tests/Tests/Api/FacilityApiTest.php
@@ -8,7 +8,7 @@ use OpenEMR\Tests\Fixtures\FacilityFixtureManager;
 
 /**
  * Facility API Endpoint Test Cases.
- * @coversDefaultClass OpenEMR\Tests\Api\ApiTestClient
+ * @coversDefaultClass \OpenEMR\RestControllers\FacilityRestController
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Yash Bothra <yashrajbothra786gmail.com>

--- a/tests/Tests/Api/PatientApiTest.php
+++ b/tests/Tests/Api/PatientApiTest.php
@@ -8,8 +8,7 @@ use OpenEMR\Tests\Fixtures\FixtureManager;
 
 /**
  * Patient API Endpoint Test Cases.
- * NOTE: currently disabled (by naming convention) until work is completed to support running as part of Travis CI
- * @coversDefaultClass OpenEMR\Tests\Api\ApiTestClient
+ * @coversDefaultClass \OpenEMR\RestControllers\PatientRestController
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Dixon Whitmire <dixonwh@gmail.com>
@@ -151,7 +150,6 @@ class PatientApiTest extends TestCase
         $this->assertEquals($patientUuid, $responseBody["data"]["uuid"]);
         $this->assertEquals($patientPid, $responseBody["data"]["pid"]);
     }
-
 
     /**
      * @covers ::getAll

--- a/tests/Tests/Api/PractitionerApiTest.php
+++ b/tests/Tests/Api/PractitionerApiTest.php
@@ -8,7 +8,8 @@ use OpenEMR\Tests\Fixtures\PractitionerFixtureManager;
 
 /**
  * Practitioner API Endpoint Test Cases.
- * @coversDefaultClass OpenEMR\Tests\Api\ApiTestClient
+ * @coversDefaultClass \OpenEMR\RestControllers\PractitionerRestController
+ *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Yash Bothra <yashrajbothra786gmail.com>

--- a/tests/Tests/Common/Uuid/UuidRegistryTest.php
+++ b/tests/Tests/Common/Uuid/UuidRegistryTest.php
@@ -27,8 +27,8 @@ class UuidRegistryTest extends TestCase
 
     /**
      * Tests bi-directional uuid conversions
-     * @covers ::uuidToBytes
-     * @covers ::uuidToString
+     * @covers \OpenEMR\Common\Uuid\UuidRegistry::uuidToBytes
+     * @covers \OpenEMR\Common\Uuid\UuidRegistry::uuidToString
      */
     public function testUuidConversions()
     {

--- a/tests/Tests/Fixtures/FixtureManagerTest.php
+++ b/tests/Tests/Fixtures/FixtureManagerTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 use OpenEMR\Tests\Fixtures\FixtureManager;
 
 /**
- * @coversDefaultClass OpenEMR\Tests\Fixture\FixtureManager
+ * @coversDefaultClass \OpenEMR\Tests\Fixtures\FixtureManager
  *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
@@ -117,7 +117,7 @@ class FixtureManagerTest extends TestCase
     }
 
     /**
-     * @covers ::getPatientFixture
+     * @covers ::getSinglePatientFixture
      */
     public function testGetPatientFixture()
     {

--- a/tests/Tests/Services/FHIR/FhirAllergyIntoleranceServiceQueryTest.php
+++ b/tests/Tests/Services/FHIR/FhirAllergyIntoleranceServiceQueryTest.php
@@ -1,15 +1,5 @@
 <?php
 
-/**
- * FHIR Allergy Intolerance Service Query Tests
- * @coversDefaultClass OpenEMR\Services\FHIR\FhirPatientService
- * @package   OpenEMR
- * @link      http://www.open-emr.org
- * @author    Stephen Nielson <stephen@nielson.org>
- * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
- * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
- */
-
 namespace OpenEMR\Tests\Services\FHIR;
 
 use OpenEMR\Common\Database\QueryUtils;
@@ -20,6 +10,16 @@ use OpenEMR\Services\FHIR\FhirUrlResolver;
 use PHPUnit\Framework\TestCase;
 use OpenEMR\Tests\Fixtures\FixtureManager;
 
+/**
+ * FHIR Allergy Intolerance Service Query Tests
+ *
+ * @coversDefaultClass \OpenEMR\Services\FHIR\FhirAllergyIntoleranceService
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
 class FhirAllergyIntoleranceServiceQueryTest extends TestCase
 {
     /**

--- a/tests/Tests/Services/FHIR/FhirOrganizationServiceCrudTest.php
+++ b/tests/Tests/Services/FHIR/FhirOrganizationServiceCrudTest.php
@@ -10,7 +10,7 @@ use OpenEMR\Services\FHIR\FhirOrganizationService;
 
 /**
  * FHIR Organization Service Crud Tests
- * @coversDefaultClass OpenEMR\Services\FHIR\FhirOrganizationService
+ * @coversDefaultClass \OpenEMR\Services\FHIR\FhirOrganizationService
  *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
@@ -47,7 +47,6 @@ class FhirOrganizationServiceCrudTest extends TestCase
     /**
      * Tests a successful insert operation
      * @covers ::insert
-     * @covers ::insertOpenEMRRecord
      */
     public function testInsert()
     {
@@ -64,7 +63,6 @@ class FhirOrganizationServiceCrudTest extends TestCase
     /**
      * Tests an insert operation where an error occurs
      * @covers ::insert
-     * @covers ::insertOpenEMRRecord
      */
     public function testInsertWithErrors()
     {
@@ -77,7 +75,6 @@ class FhirOrganizationServiceCrudTest extends TestCase
     /**
      * Tests a successful update operation
      * @covers ::update
-     * @covers ::updateOpenEMRRecord
      */
     public function testUpdate()
     {
@@ -104,7 +101,6 @@ class FhirOrganizationServiceCrudTest extends TestCase
     /**
      * Tests an update operation where an error occurs
      * @covers ::update
-     * @covers ::updateOpenEMRRecord
      */
     public function testUpdateWithErrors()
     {


### PR DESCRIPTION
Fixes #8403

#### Short description of what this resolves:

Coverage reporting for tests (other than e2e and api).

#### Changes proposed in this pull request:

When the environment variable `ENABLE_COVERAGE=true`, each testsuite (besides e2e and api) will produce a coverage report in the form of both terminal output and php-style coverage in `./coverage/coverage.${testsuite}.cov`.

At the end of that test configuration run, all the `./coverage/coverage.${testsuite}.cov` files are merged by phpcov into coverage.clover.xml, an htmlcov directory and again on standard output for a comprehensive view of the coverage.

Then those artifacts are stored for viewing in the test run's summary.

The htmlcov artifact can be downloaded, unpacked and viewed in a browser for a nice visualization of coverage.

The coverage.clover.xml is suitable for providing to a tool such as codecov.io for further analysis including visualization and historical coverage. The admins would need to uncomment the codecov step and provide the appropriate API key.

#### Does your code include anything generated by an AI Engine? No
