### PR TITLE
chore(ccdaservice): bump libxmljs2 to 0.37.0

### DIFF
--- a/ccdaservice/README.md
+++ b/ccdaservice/README.md
@@ -19,19 +19,19 @@ To ensure the lastest libraries are installed, node version changes or the packa
 
 
 ## Ubuntu Setup
-* Latest version tested is node v20.10.0
+* Latest version tested is node v24.1.0
 
 If node is not already installed then do the following(Research the required installation for your environment):
 - `cd ~`
 - `apt-get remove --purge nodejs npm` // Ensures clean install and will allow chance to clean up.
-- `curl -sL https://deb.nodesource.com/setup_20.x | sudo -E bash -`
+- `curl -sL https://deb.nodesource.com/setup_24.x | sudo -E bash -`
 - `sudo apt-get install -y nodejs`
 
 Navigate to: openemr/ccdaservice and run the following to install requires dependencies.
 - `sudo npm install --omit=dev`
 ## Windows Setup
 * Download and install nodejs for your Windows version.
-  - Latest version tested is node v20.10.0
+  - Latest version tested is node v24.1.0
 * Ensure system variable NODE_PATH is set i.e. `%USERPROFILE%\AppData\Roaming\npm\node_modules`.
 
 Navigate to: openemr/ccdaservice and run the following from an elevated PowerShell or CMD.exe (run as Administrator):

--- a/ccdaservice/package-lock.json
+++ b/ccdaservice/package-lock.json
@@ -10,7 +10,7 @@
             "license": "GPL-3.0",
             "dependencies": {
                 "file": "./oe-blue-button-generate",
-                "libxmljs2": "0.35.0",
+                "libxmljs2": "0.37.0",
                 "lodash": "4.17.21",
                 "moment": "2.30.1",
                 "net": "1.0.2",
@@ -46,6 +46,18 @@
                 "node": ">=12"
             }
         },
+        "node_modules/@isaacs/fs-minipass": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+            "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.4"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
         "node_modules/@lhncbc/ucum-lhc": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/@lhncbc/ucum-lhc/-/ucum-lhc-4.2.0.tgz",
@@ -65,9 +77,9 @@
             }
         },
         "node_modules/@npmcli/agent": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-2.2.2.tgz",
-            "integrity": "sha512-OrcNPXdpSl9UX7qPVRWbmWMCSXrcDa2M9DvrbOTj7ao1S4PlqVFYv9/yLKMkrJKZ/V5A/kDBC690or307i26Og==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-3.0.0.tgz",
+            "integrity": "sha512-S79NdEgDQd/NGCay6TCoVzXSj74skRZIKJcpJjC5lOq34SZzyI6MqtiiWoiVWoVrTcGjNeC4ipbh1VIHlpfF5Q==",
             "license": "ISC",
             "dependencies": {
                 "agent-base": "^7.1.0",
@@ -77,19 +89,19 @@
                 "socks-proxy-agent": "^8.0.3"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/@npmcli/fs": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.1.tgz",
-            "integrity": "sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-4.0.0.tgz",
+            "integrity": "sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q==",
             "license": "ISC",
             "dependencies": {
                 "semver": "^7.3.5"
             },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/@pkgjs/parseargs": {
@@ -137,12 +149,12 @@
             "license": "MIT"
         },
         "node_modules/abbrev": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
-            "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
+            "integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
             "license": "ISC",
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/accepts": {
@@ -174,19 +186,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 14"
-            }
-        },
-        "node_modules/aggregate-error": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-            "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-            "license": "MIT",
-            "dependencies": {
-                "clean-stack": "^2.0.0",
-                "indent-string": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/ansi-regex": {
@@ -388,12 +387,12 @@
             }
         },
         "node_modules/cacache": {
-            "version": "18.0.4",
-            "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.4.tgz",
-            "integrity": "sha512-B+L5iIa9mgcjLbliir2th36yEwPftrzteHYujzsx3dFP/31GCHcIeS8f5MGd80odLOjaOvSpU3EEAmRQptkxLQ==",
+            "version": "19.0.1",
+            "resolved": "https://registry.npmjs.org/cacache/-/cacache-19.0.1.tgz",
+            "integrity": "sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ==",
             "license": "ISC",
             "dependencies": {
-                "@npmcli/fs": "^3.1.0",
+                "@npmcli/fs": "^4.0.0",
                 "fs-minipass": "^3.0.0",
                 "glob": "^10.2.2",
                 "lru-cache": "^10.0.1",
@@ -401,13 +400,13 @@
                 "minipass-collect": "^2.0.1",
                 "minipass-flush": "^1.0.5",
                 "minipass-pipeline": "^1.2.4",
-                "p-map": "^4.0.0",
-                "ssri": "^10.0.0",
-                "tar": "^6.1.11",
-                "unique-filename": "^3.0.0"
+                "p-map": "^7.0.2",
+                "ssri": "^12.0.0",
+                "tar": "^7.4.3",
+                "unique-filename": "^4.0.0"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/call-bind-apply-helpers": {
@@ -440,21 +439,12 @@
             }
         },
         "node_modules/chownr": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-            "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-            "license": "ISC",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+            "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+            "license": "BlueOak-1.0.0",
             "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/clean-stack": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-            "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
+                "node": ">=18"
             }
         },
         "node_modules/coffeescript": {
@@ -704,9 +694,9 @@
             }
         },
         "node_modules/debug": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-            "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+            "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
@@ -1022,6 +1012,20 @@
             "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
             "license": "MIT"
         },
+        "node_modules/fdir": {
+            "version": "6.4.5",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.5.tgz",
+            "integrity": "sha512-4BG7puHpVsIYxZUbiUE3RqGloLaSSwzYie5jvasC4LWuBWzZawynvYouhjbQKw2JuIGYdm0DzIxl8iVidKlUEw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/fecha": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
@@ -1238,9 +1242,9 @@
             }
         },
         "node_modules/http-cache-semantics": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-            "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+            "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
             "license": "BSD-2-Clause"
         },
         "node_modules/http-errors": {
@@ -1326,15 +1330,6 @@
                 "node": ">=0.8.19"
             }
         },
-        "node_modules/indent-string": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/inherits": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -1404,12 +1399,6 @@
             "dependencies": {
                 "is-finite": "^1.0.0"
             }
-        },
-        "node_modules/is-lambda": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-            "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
-            "license": "MIT"
         },
         "node_modules/is-stream": {
             "version": "1.1.0",
@@ -1487,19 +1476,19 @@
             }
         },
         "node_modules/libxmljs2": {
-            "version": "0.35.0",
-            "resolved": "https://registry.npmjs.org/libxmljs2/-/libxmljs2-0.35.0.tgz",
-            "integrity": "sha512-SpVopqn4YNydnLjkGfL6yQwzjlipmEnCCsVrD/0hQmdgsQWb5rVmSJxxjQltHIUTto29vgX+PhLjXoc+gMeABQ==",
+            "version": "0.37.0",
+            "resolved": "https://registry.npmjs.org/libxmljs2/-/libxmljs2-0.37.0.tgz",
+            "integrity": "sha512-Xb78V8GZouoZFrq8cCwx7+G3WYOcJG0xb3YUbweSyE4z2EIrQCZMr3Ye/dHn4mESs6YxUMeQeUZm5IXg+iLHog==",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
                 "bindings": "~1.5.0",
-                "nan": "~2.20.0",
-                "node-gyp": "^10.2.0",
-                "prebuild-install": "^7.1.2"
+                "nan": "~2.22.2",
+                "node-gyp": "^11.2.0",
+                "prebuild-install": "^7.1.3"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=22"
             }
         },
         "node_modules/lodash": {
@@ -1544,26 +1533,25 @@
             }
         },
         "node_modules/make-fetch-happen": {
-            "version": "13.0.1",
-            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-13.0.1.tgz",
-            "integrity": "sha512-cKTUFc/rbKUd/9meOvgrpJ2WrNzymt6jfRDdwg5UCnVzv9dTpEj9JS5m3wtziXVCjluIXyL8pcaukYqezIzZQA==",
+            "version": "14.0.3",
+            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-14.0.3.tgz",
+            "integrity": "sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==",
             "license": "ISC",
             "dependencies": {
-                "@npmcli/agent": "^2.0.0",
-                "cacache": "^18.0.0",
+                "@npmcli/agent": "^3.0.0",
+                "cacache": "^19.0.1",
                 "http-cache-semantics": "^4.1.1",
-                "is-lambda": "^1.0.1",
                 "minipass": "^7.0.2",
-                "minipass-fetch": "^3.0.0",
+                "minipass-fetch": "^4.0.0",
                 "minipass-flush": "^1.0.5",
                 "minipass-pipeline": "^1.2.4",
-                "negotiator": "^0.6.3",
-                "proc-log": "^4.2.0",
+                "negotiator": "^1.0.0",
+                "proc-log": "^5.0.0",
                 "promise-retry": "^2.0.1",
-                "ssri": "^10.0.0"
+                "ssri": "^12.0.0"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/math-intrinsics": {
@@ -1703,17 +1691,17 @@
             }
         },
         "node_modules/minipass-fetch": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-3.0.5.tgz",
-            "integrity": "sha512-2N8elDQAtSnFV0Dk7gt15KHsS0Fyz6CbYZ360h0WTYV1Ty46li3rAXVOQj1THMNLdmrD9Vt5pBPtWtVkpwGBqg==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-4.0.1.tgz",
+            "integrity": "sha512-j7U11C5HXigVuutxebFadoYBbd7VSdZWggSe64NVdvWNBqGAiXPL2QVCehjmw7lY1oF9gOllYbORh+hiNgfPgQ==",
             "license": "MIT",
             "dependencies": {
                 "minipass": "^7.0.3",
                 "minipass-sized": "^1.0.3",
-                "minizlib": "^2.1.2"
+                "minizlib": "^3.0.1"
             },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             },
             "optionalDependencies": {
                 "encoding": "^0.1.13"
@@ -1743,6 +1731,12 @@
                 "node": ">=8"
             }
         },
+        "node_modules/minipass-flush/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "license": "ISC"
+        },
         "node_modules/minipass-pipeline": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
@@ -1766,6 +1760,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/minipass-pipeline/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "license": "ISC"
         },
         "node_modules/minipass-sized": {
             "version": "1.0.3",
@@ -1791,41 +1791,37 @@
                 "node": ">=8"
             }
         },
+        "node_modules/minipass-sized/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "license": "ISC"
+        },
         "node_modules/minizlib": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-            "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz",
+            "integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
             "license": "MIT",
             "dependencies": {
-                "minipass": "^3.0.0",
-                "yallist": "^4.0.0"
+                "minipass": "^7.1.2"
             },
             "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/minizlib/node_modules/minipass": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
+                "node": ">= 18"
             }
         },
         "node_modules/mkdirp": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+            "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
             "license": "MIT",
             "bin": {
-                "mkdirp": "bin/cmd.js"
+                "mkdirp": "dist/cjs/src/bin.js"
             },
             "engines": {
                 "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/mkdirp-classic": {
@@ -2045,9 +2041,9 @@
             "license": "MIT"
         },
         "node_modules/nan": {
-            "version": "2.20.0",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.20.0.tgz",
-            "integrity": "sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==",
+            "version": "2.22.2",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.2.tgz",
+            "integrity": "sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==",
             "license": "MIT"
         },
         "node_modules/napi-build-utils": {
@@ -2057,9 +2053,9 @@
             "license": "MIT"
         },
         "node_modules/negotiator": {
-            "version": "0.6.4",
-            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
-            "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+            "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -2084,42 +2080,42 @@
             }
         },
         "node_modules/node-gyp": {
-            "version": "10.3.1",
-            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-10.3.1.tgz",
-            "integrity": "sha512-Pp3nFHBThHzVtNY7U6JfPjvT/DTE8+o/4xKsLQtBoU+j2HLsGlhcfzflAoUreaJbNmYnX+LlLi0qjV8kpyO6xQ==",
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-11.2.0.tgz",
+            "integrity": "sha512-T0S1zqskVUSxcsSTkAsLc7xCycrRYmtDHadDinzocrThjyQCn5kMlEBSj6H4qDbgsIOSLmmlRIeb0lZXj+UArA==",
             "license": "MIT",
             "dependencies": {
                 "env-paths": "^2.2.0",
                 "exponential-backoff": "^3.1.1",
-                "glob": "^10.3.10",
                 "graceful-fs": "^4.2.6",
-                "make-fetch-happen": "^13.0.0",
-                "nopt": "^7.0.0",
-                "proc-log": "^4.1.0",
+                "make-fetch-happen": "^14.0.3",
+                "nopt": "^8.0.0",
+                "proc-log": "^5.0.0",
                 "semver": "^7.3.5",
-                "tar": "^6.2.1",
-                "which": "^4.0.0"
+                "tar": "^7.4.3",
+                "tinyglobby": "^0.2.12",
+                "which": "^5.0.0"
             },
             "bin": {
                 "node-gyp": "bin/node-gyp.js"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/nopt": {
-            "version": "7.2.1",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
-            "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
+            "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
             "license": "ISC",
             "dependencies": {
-                "abbrev": "^2.0.0"
+                "abbrev": "^3.0.0"
             },
             "bin": {
                 "nopt": "bin/nopt.js"
             },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/object-inspect": {
@@ -2570,15 +2566,12 @@
             }
         },
         "node_modules/p-map": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-            "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
+            "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
             "license": "MIT",
-            "dependencies": {
-                "aggregate-error": "^3.0.0"
-            },
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -2630,6 +2623,18 @@
             "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
             "license": "MIT"
         },
+        "node_modules/picomatch": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
         "node_modules/prebuild-install": {
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
@@ -2657,12 +2662,12 @@
             }
         },
         "node_modules/proc-log": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
-            "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz",
+            "integrity": "sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==",
             "license": "ISC",
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/process-nextick-args": {
@@ -3171,15 +3176,15 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/ssri": {
-            "version": "10.0.6",
-            "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.6.tgz",
-            "integrity": "sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==",
+            "version": "12.0.0",
+            "resolved": "https://registry.npmjs.org/ssri/-/ssri-12.0.0.tgz",
+            "integrity": "sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==",
             "license": "ISC",
             "dependencies": {
                 "minipass": "^7.0.3"
             },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/stack-trace": {
@@ -3340,20 +3345,20 @@
             }
         },
         "node_modules/tar": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-            "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+            "version": "7.4.3",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
+            "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
             "license": "ISC",
             "dependencies": {
-                "chownr": "^2.0.0",
-                "fs-minipass": "^2.0.0",
-                "minipass": "^5.0.0",
-                "minizlib": "^2.1.1",
-                "mkdirp": "^1.0.3",
-                "yallist": "^4.0.0"
+                "@isaacs/fs-minipass": "^4.0.0",
+                "chownr": "^3.0.0",
+                "minipass": "^7.1.2",
+                "minizlib": "^3.0.1",
+                "mkdirp": "^3.0.1",
+                "yallist": "^5.0.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             }
         },
         "node_modules/tar-fs": {
@@ -3421,44 +3426,27 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/tar/node_modules/fs-minipass": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-            "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-            "license": "ISC",
-            "dependencies": {
-                "minipass": "^3.0.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/tar/node_modules/minipass": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-            "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/text-hex": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
             "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
             "license": "MIT"
+        },
+        "node_modules/tinyglobby": {
+            "version": "0.2.14",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+            "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.4.4",
+                "picomatch": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
         },
         "node_modules/toidentifier": {
             "version": "1.0.1",
@@ -3510,27 +3498,27 @@
             "license": "MIT"
         },
         "node_modules/unique-filename": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
-            "integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-4.0.0.tgz",
+            "integrity": "sha512-XSnEewXmQ+veP7xX2dS5Q4yZAvO40cBN2MWkJ7D/6sW4Dg6wYBNwM1Vrnz1FhH5AdeLIlUXRI9e28z1YZi71NQ==",
             "license": "ISC",
             "dependencies": {
-                "unique-slug": "^4.0.0"
+                "unique-slug": "^5.0.0"
             },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/unique-slug": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
-            "integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-5.0.0.tgz",
+            "integrity": "sha512-9OdaqO5kwqR+1kVgHAhsp5vPNU0hnxRa26rBFNfNgM7M6pNtgzeBn3s/xbyCQL3dcjzOatcef6UUHpB/6MaETg==",
             "license": "ISC",
             "dependencies": {
                 "imurmurhash": "^0.1.4"
             },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/unpipe": {
@@ -3580,9 +3568,9 @@
             }
         },
         "node_modules/which": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
-            "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+            "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
             "license": "ISC",
             "dependencies": {
                 "isexe": "^3.1.1"
@@ -3591,7 +3579,7 @@
                 "node-which": "bin/which.js"
             },
             "engines": {
-                "node": "^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/winston": {
@@ -3842,13 +3830,15 @@
             }
         },
         "node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "license": "ISC"
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+            "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "oe-blue-button-generate": {
-            "name": "oe-blue-button-generate",
             "version": "1.5.10",
             "license": "Apache-2.0",
             "devDependencies": {},

--- a/ccdaservice/package.json
+++ b/ccdaservice/package.json
@@ -8,12 +8,12 @@
     "license": "GPL-3.0",
     "dependencies": {
         "file": "./oe-blue-button-generate",
-        "libxmljs2": "0.35.0",
+        "libxmljs2": "0.37.0",
         "lodash": "4.17.21",
+        "moment": "2.30.1",
         "net": "1.0.2",
         "oe-cqm-service": "6.0.0",
         "oe-schematron-service": "1.1.1",
-        "moment": "2.30.1",
         "uuid": "11.1.0",
         "xmljson": "0.2.0"
     }


### PR DESCRIPTION
support nodejs 24

Fixes #8418

#### Short description of what this resolves:

Fix that `npm install` fails in ccdaservice when the node version is 24.


#### Changes proposed in this pull request:

Update libxmljs2 to 0.37.0, which works with node 24.

#### Does your code include anything generated by an AI Engine? No
