### PR TITLE
fix: php unit deprecations

### DIFF
--- a/src/FHIR/SMART/ExternalClinicalDecisionSupport/DecisionSupportInterventionEntity.php
+++ b/src/FHIR/SMART/ExternalClinicalDecisionSupport/DecisionSupportInterventionEntity.php
@@ -85,7 +85,7 @@ abstract class DecisionSupportInterventionEntity
         $this->type = $type;
     }
 
-    protected function populateServiceWithFhirQuestionnaireForType(string $serviceType, string $questionnaire, string $response = null)
+    protected function populateServiceWithFhirQuestionnaireForType(string $serviceType, string $questionnaire, ?string $response = null)
     {
 
         $questionnaire = json_decode($questionnaire, true);

--- a/src/FHIR/SMART/ExternalClinicalDecisionSupport/PredictiveDSIServiceEntity.php
+++ b/src/FHIR/SMART/ExternalClinicalDecisionSupport/PredictiveDSIServiceEntity.php
@@ -12,7 +12,7 @@ class PredictiveDSIServiceEntity extends DecisionSupportInterventionEntity
         parent::__construct(self::TYPE, $clientEntity);
     }
 
-    public function populateServiceWithFhirQuestionnaire(string $questionnaire, string $response = null)
+    public function populateServiceWithFhirQuestionnaire(string $questionnaire, ?string $response = null)
     {
 
         return $this->populateServiceWithFhirQuestionnaireForType(self::TYPE, $questionnaire, $response);

--- a/tests/Tests/Api/FacilityApiTest.php
+++ b/tests/Tests/Api/FacilityApiTest.php
@@ -20,6 +20,7 @@ class FacilityApiTest extends TestCase
 {
     const FACILITY_API_ENDPOINT = "/apis/default/api/facility";
     private $testClient;
+    private $facilityRecord;
 
     /**
      * @var FacilityFixtureManager

--- a/tests/Tests/Api/PatientApiTest.php
+++ b/tests/Tests/Api/PatientApiTest.php
@@ -21,6 +21,7 @@ class PatientApiTest extends TestCase
     const PATIENT_API_ENDPOINT = "/apis/default/api/patient";
     private $testClient;
     private $fixtureManager;
+    private $patientRecord;
 
     protected function setUp(): void
     {

--- a/tests/Tests/Api/PractitionerApiTest.php
+++ b/tests/Tests/Api/PractitionerApiTest.php
@@ -26,6 +26,7 @@ class PractitionerApiTest extends TestCase
      */
     private $testClient;
     private $fixtureManager;
+    private $practitionerRecord;
 
     protected function setUp(): void
     {

--- a/tests/Tests/Fixtures/BaseFixtureManager.php
+++ b/tests/Tests/Fixtures/BaseFixtureManager.php
@@ -184,7 +184,7 @@ abstract class BaseFixtureManager
 
     private function isFunctionCall($value)
     {
-        return preg_match("/[a-zA-Z]+\(['a-zA-Z_0-9\-]*\)/", $value) === 1;
+        return preg_match("/[a-zA-Z]+\(['a-zA-Z_0-9\-]*\)/", $value ?? '') === 1;
     }
 
     private function isForeignReference(array $reference)


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #8421 

#### Short description of what this resolves:


#### Changes proposed in this pull request:

#### Does your code include anything generated by an AI Engine? Yes / No

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.
