### PR TITLE
ci(tests): wait for healthcheck

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
             jq -cs .
         } >> "$GITHUB_OUTPUT"
     outputs:
-        configurations: ${{ steps.docker-dirs.outputs.configurations }}
+      configurations: ${{ steps.docker-dirs.outputs.configurations }}
   build:
     name: PHP ${{ matrix.configurations.php }} - ${{ matrix.configurations.webserver }} - ${{ matrix.configurations.database }} ${{ matrix.configurations.db }}
     runs-on: ubuntu-22.04

--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -60,7 +60,7 @@ _exec() {
 }
 
 dockers_env_start() {
-    dc up --detach
+    dc up --detach --wait --wait-timeout 10m
 }
 
 actions_chmod() {

--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -60,7 +60,7 @@ _exec() {
 }
 
 dockers_env_start() {
-    dc up --detach --wait --wait-timeout 10m
+    dc up --detach --wait --wait-timeout 300
 }
 
 actions_chmod() {

--- a/ci/compose-shared-apache.yml
+++ b/ci/compose-shared-apache.yml
@@ -8,3 +8,18 @@ services:
     environment:
       FORCE_NO_BUILD_MODE: "yes"
       EMPTY: "yes"
+    healthcheck:
+      test:
+      - CMD
+      - /usr/bin/curl
+      - --fail
+      - --insecure
+      - --location
+      - --show-error
+      - --silent
+      - https://localhost/
+      start_period: 10m
+      start_interval: 10s
+      interval: 1m
+      timeout: 5s
+      retries: 3


### PR DESCRIPTION
Fixes #8432

#### Short description of what this resolves:

Use healthchecks against the openemr service to defer startup until openemr is ready to go


#### Changes proposed in this pull request:

add a healthcheck to ci/ compose, and then --wait for it.

#### Does your code include anything generated by an AI Engine? No
