### PR TITLE
ci(dependabot): enable for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: /
+  open-pull-requests-limit: 5
+  schedule:
+    interval: weekly
+  labels:
+  - dependencies
+  - github-actions


### PR DESCRIPTION
Fixes #8438

#### Short description of what this resolves:

Configure/activate Dependabot for Github Actions

#### Changes proposed in this pull request:

Add a .github/dependabot.yml so that dependabot aids OpenEMR in keeping Github Actions up-to-date.


#### Does your code include anything generated by an AI Engine? No
