### PR TITLE
fix(toString): consistently initialize $string

### DIFF
--- a/contrib/forms/dap/FormDAP.class.php
+++ b/contrib/forms/dap/FormDAP.class.php
@@ -68,15 +68,10 @@ class FormDAP extends ORDataObject
 
     function toString($html = false)
     {
-        $string .= "\n"
-            . "ID: " . $this->id . "\n";
-
-        if ($html) {
-            return nl2br($string);
-        } else {
-            return $string;
-        }
+        $string = "\n" . "ID: " . $this->id . "\n";
+        return $html ? nl2br($string) : $string;
     }
+
     function set_id($id)
     {
         if (!empty($id) && is_numeric($id)) {

--- a/contrib/forms/evaluation/FormEvaluation.class.php
+++ b/contrib/forms/evaluation/FormEvaluation.class.php
@@ -86,13 +86,9 @@ class FormEvaluation extends ORDataObject
     function toString($html = false)
     {
         $string = "\n" . "ID: " . $this->id . "\n";
-
-        if ($html) {
-            return nl2br($string);
-        } else {
-            return $string;
-        }
+        return $html ? nl2br($string) : $string;
     }
+
     function set_id($id)
     {
         if (!empty($id) && is_numeric($id)) {

--- a/contrib/forms/hand/FormHand.class.php
+++ b/contrib/forms/hand/FormHand.class.php
@@ -75,13 +75,9 @@ class FormHand extends ORDataObject
     function toString($html = false)
     {
         $string = "\n" . "ID: " . $this->id . "\n";
-
-        if ($html) {
-            return nl2br($string);
-        } else {
-            return $string;
-        }
+        return $html ? nl2br($string) : $string;
     }
+
     function set_id($id)
     {
         if (!empty($id) && is_numeric($id)) {

--- a/contrib/forms/hp_tje_primary/FormHpTjePrimary.class.php
+++ b/contrib/forms/hp_tje_primary/FormHpTjePrimary.class.php
@@ -106,12 +106,7 @@ class FormHpTjePrimary extends ORDataObject
     function toString($html = false)
     {
         $string = "\n" . "ID: " . $this->id . "\n";
-
-        if ($html) {
-            return nl2br($string);
-        } else {
-            return $string;
-        }
+        return $html ? nl2br($string) : $string;
     }
     function set_id($id)
     {

--- a/contrib/forms/soap2/FormSOAP.class.php
+++ b/contrib/forms/soap2/FormSOAP.class.php
@@ -77,14 +77,8 @@ class FormSOAP extends ORDataObject
 
     function toString($html = false)
     {
-        $string .= "\n"
-            . "ID: " . $this->id . "\n";
-
-        if ($html) {
-            return nl2br($string);
-        } else {
-            return $string;
-        }
+        $string = "\n" . "ID: " . $this->id . "\n";
+        return $html ? nl2br($string) : $string;
     }
     function set_id($id)
     {

--- a/interface/forms/ros/FormROS.class.php
+++ b/interface/forms/ros/FormROS.class.php
@@ -1648,15 +1648,10 @@ class FormROS extends ORDataObject
     }
     function toString($html = false)
     {
-        $string .= "\n"
-            . "ID: " . $this->id . "\n";
-
-        if ($html) {
-            return nl2br($string);
-        } else {
-            return $string;
-        }
+        $string = "\n" . "ID: " . $this->id . "\n";
+        return $html ? nl2br($string) : $string;
     }
+
     function persist()
     {
         parent::persist();

--- a/interface/forms/soap/FormSOAP.class.php
+++ b/interface/forms/soap/FormSOAP.class.php
@@ -75,15 +75,10 @@ class FormSOAP extends ORDataObject
 
     function toString($html = false)
     {
-        $string .= "\n"
-            . "ID: " . $this->id . "\n";
-
-        if ($html) {
-            return nl2br($string);
-        } else {
-            return $string;
-        }
+        $string = "\n" . "ID: " . $this->id . "\n";
+        return $html ? nl2br($string) : $string;
     }
+
     function set_id($id)
     {
         if (!empty($id) && is_numeric($id)) {

--- a/library/classes/Company.class.php
+++ b/library/classes/Company.class.php
@@ -75,19 +75,14 @@ class Company extends ORDataObject
 
     function toString($html = false)
     {
-        $string .= "\n"
+        $string = "\n"
         . "ID: " . $this->id . "\n"
         . "FID: " . $this->foreign_id . "\n"
         . $this->line1 . "\n"
         . $this->line2 . "\n"
         . $this->city . ", " . strtoupper($this->state) . " " . $this->zip . "-" . $this->plus_four . "\n"
         . $this->country . "\n";
-
-        if ($html) {
-            return nl2br($string);
-        } else {
-            return $string;
-        }
+        return $html ? nl2br($string) : $string;
     }
 
     function set_id($id)

--- a/library/classes/Document.class.php
+++ b/library/classes/Document.class.php
@@ -475,7 +475,7 @@ class Document extends ORDataObject
      */
     function toString($html = false)
     {
-        $string .= "\n"
+        $string = "\n"
         . "ID: " . $this->id . "\n"
         . "FID: " . $this->foreign_id . "\n"
         . "type: " . $this->type . "\n"
@@ -492,12 +492,7 @@ class Document extends ORDataObject
         . "list_id: " . $this->list_id . "\n"
         . "encounter_id: " . $this->encounter_id . "\n"
         . "encounter_check: " . $this->encounter_check . "\n";
-
-        if ($html) {
-            return nl2br($string);
-        } else {
-            return $string;
-        }
+        return $html ? nl2br($string) : $string;
     }
 
     /**#@+

--- a/library/classes/InsuranceCompany.class.php
+++ b/library/classes/InsuranceCompany.class.php
@@ -363,7 +363,7 @@ class InsuranceCompany extends ORDataObject
 
     public function toString($html = false)
     {
-        $string .= "\n"
+        $string = "\n"
         . "ID: " . $this->id . "\n"
         . "Name: " . $this->name . "\n"
         . "Attn:" . $this->attn . "\n"
@@ -371,11 +371,6 @@ class InsuranceCompany extends ORDataObject
         . "ALT Payer ID:" . $this->alt_cms_id . "\n"
         //. "Phone: " . $this->phone_numbers[0]->toString($html) . "\n"
         . "Address: " . $this->address->toString($html) . "\n";
-
-        if ($html) {
-            return nl2br($string);
-        } else {
-            return $string;
-        }
+        return $html ? nl2br($string) : $string;
     }
 }

--- a/library/classes/Note.class.php
+++ b/library/classes/Note.class.php
@@ -114,19 +114,14 @@ class Note extends ORDataObject
      */
     function toString($html = false)
     {
-        $string .= "\n"
+        $string = "\n"
         . "ID: " . $this->id . "\n"
         . "FID: " . $this->foreign_id . "\n"
         . "note: " . $this->note . "\n"
         . "date: " . $this->date . "\n"
         . "owner: " . $this->owner . "\n"
         . "revision: " . $this->revision . "\n";
-
-        if ($html) {
-            return nl2br($string);
-        } else {
-            return $string;
-        }
+        return $html ? nl2br($string) : $string;
     }
 
     /**#@+

--- a/library/classes/Pharmacy.class.php
+++ b/library/classes/Pharmacy.class.php
@@ -265,19 +265,14 @@ class Pharmacy extends ORDataObject
 
     function toString($html = false)
     {
-        $string .= "\n"
+        $string = "\n"
         . "ID: " . $this->id . "\n"
         . "Name: " . $this->name . "\n"
         . "Phone: " . $this->phone_numbers[0]->toString($html) . "\n"
         . "Email:" . $this->email . "\n"
         . "Address: " . $this->address->toString($html) . "\n"
         . "Method: " . $this->transmit_method_array[$this->transmit_method];
-
-        if ($html) {
-            return nl2br($string);
-        } else {
-            return $string;
-        }
+        return $html ? nl2br($string) : $string;
     }
 
     function totalPages()

--- a/library/classes/PhoneNumber.class.php
+++ b/library/classes/PhoneNumber.class.php
@@ -196,15 +196,11 @@ class PhoneNumber extends ORDataObject
 
     function toString($html = false)
     {
-        $string .= "\n"
+        $string = "\n"
         . "ID: " . $this->id . "\n"
         . "FID: " . $this->foreign_id . "\n"
         . $this->country_code . " (" . $this->area_code . ") " . $this->prefix . "-" . $this->number . " " . $this->type_array[$this->type];
-        if ($html) {
-            return nl2br($string);
-        } else {
-            return $string;
-        }
+        return $html ? nl2br($string) : $string;
     }
 
     function persist($fid = "")

--- a/library/classes/Prescription.class.php
+++ b/library/classes/Prescription.class.php
@@ -232,7 +232,7 @@ class Prescription extends ORDataObject
 
     function toString($html = false)
     {
-        $string .= "\n"
+        $string = "\n"
             . "ID: " . $this->id . "\n"
             . "Patient:" . $this->patient . "\n"
             . "Patient ID:" . $this->patient->id . "\n"
@@ -262,12 +262,7 @@ class Prescription extends ORDataObject
             . "Drug ID: " . $this->drug_id . "\n"
             . "Active: " . $this->active . "\n"
             . "Transmitted: " . $this->ntx;
-
-        if ($html) {
-            return nl2br($string);
-        } else {
-            return $string;
-        }
+        return $html ? nl2br($string) : $string;
     }
 
     private function load_drug_attributes($id)

--- a/src/Common/Forms/FormVitals.php
+++ b/src/Common/Forms/FormVitals.php
@@ -112,15 +112,10 @@ class FormVitals extends ORDataObject
 
     public function toString($html = false)
     {
-        $string = "\n"
-            . "ID: " . $this->id . "\n";
-
-        if ($html) {
-            return nl2br($string);
-        }
-
-        return $string;
+        $string = "\n" . "ID: " . $this->id . "\n";
+        return $html ? nl2br($string) : $string;
     }
+
     public function set_id($id)
     {
         if (!empty($id) && is_numeric($id)) {

--- a/src/Common/ORDataObject/Address.php
+++ b/src/Common/ORDataObject/Address.php
@@ -90,12 +90,7 @@ class Address extends ORDataObject implements \JsonSerializable
         . $this->line2 . "\n"
         . $this->city . ", " . strtoupper($this->state) . " " . $this->zip . "-" . $this->plus_four . "\n"
         . $this->country . "\n";
-
-        if ($html) {
-            return nl2br($string);
-        } else {
-            return $string;
-        }
+        return $html ? nl2br($string) : $string;
     }
 
     function set_id($id)


### PR DESCRIPTION
Fixes #8449

#### Short description of what this resolves:

phpstan found that $string wasn't always being initialized because we were appending to it on the first use. This change ensures that all implementations of toString are consistent.


#### Changes proposed in this pull request:

Mainly, replace `$string .=` with `$string =` in toString implementations in cases where `$string` was not previously initialized.

#### Does your code include anything generated by an AI Engine? No
