### PR TITLE
fix(C_FormEvaluation): typo

### DIFF
--- a/contrib/forms/evaluation/C_FormEvaluation.class.php
+++ b/contrib/forms/evaluation/C_FormEvaluation.class.php
@@ -78,7 +78,7 @@ class C_FormEvaluation extends Controller
 
             $row = sqlFetchArray($results);
             if (!empty($row)) {
-                BillingUtilites::addBilling(date("Ymd"), 'CPT4', $row['code'], $row['code_text'], $_SESSION['pid'], $_SESSION['userauthorized'], $_SESSION['authUserID'], $row['modifier'], $row['units'], $row['fee']);
+                BillingUtilities::addBilling(date("Ymd"), 'CPT4', $row['code'], $row['code_text'], $_SESSION['pid'], $_SESSION['userauthorized'], $_SESSION['authUserID'], $row['modifier'], $row['units'], $row['fee']);
             }
         }
 


### PR DESCRIPTION
Fixes #8454

#### Short description of what this resolves:

Fix a typo that references an object that doesn't exist because the object it means to reference is spelled differently.

#### Changes proposed in this pull request:

s/BillingUtilites/BillingUtilities/ in contrib/forms/evaluation/C_FormEvaluation.class.php.

#### Does your code include anything generated by an AI Engine? No