### PR TITLE
fix(RuleLibrary): declare properties, remove nonfunctional function

### DIFF
--- a/src/ClinicalDecisionRules/Interface/RuleLibrary/Rule.php
+++ b/src/ClinicalDecisionRules/Interface/RuleLibrary/Rule.php
@@ -29,14 +29,15 @@ use OpenEMR\ClinicalDecisionRules\Interface\RuleLibrary\RuleTargets;
  */
 class Rule
 {
-    public $ruleTypes;
+    private RuleActions $actions;
+    private RuleTargets $targets;
     public $id;
+    public $ruleTypes;
     public string $title;
 
     /**
      * US Regulation 170.315(b)(11)(iv)(A)(1)
-     * @var string Bibliographic citation of the intervention (clinical research or
-    guideline) that the rule is based on
+     * @var string Bibliographic citation of the intervention (clinical research or guideline) that the rule is based on
      */
     public string $bibliographic_citation;
 
@@ -325,18 +326,19 @@ class Rule
     }
 
     /**
-     *
      * @param RuleTargets $ruleTargets
+     * @return void
      */
-    function setRuleTargets($ruleTargets)
+    function setRuleTargets(RuleTargets $ruleTargets): void
     {
         $this->targets = $ruleTargets;
     }
 
     /**
      * @param RuleActions $actions
+     * @return void
      */
-    function setRuleActions($actions)
+    function setRuleActions(RuleActions $actions): void
     {
         $this->actions = $actions;
     }

--- a/src/ClinicalDecisionRules/Interface/RuleLibrary/RuleManager.php
+++ b/src/ClinicalDecisionRules/Interface/RuleLibrary/RuleManager.php
@@ -333,23 +333,6 @@ class RuleManager
 
     /**
      * @param string $guid
-     * @return array of OpenEMR\ClinicalDecisionRules\Interface\RuleLibrary\RuleTargetActionGroup
-     */
-    function getRuleTargetActionGroups($rule)
-    {
-        $criterion = $this->getRuleTargetCriteria($rule);
-        $actions = $this->getRuleAction($rule);
-        if (sizeof($criterion) > 0) {
-            $criteria = $criterion[0];
-            $criteria->guid = $guid;
-            return $criterion[0];
-        }
-
-        return null;
-    }
-
-    /**
-     * @param string $guid
      * @return RuleCriteria
      */
     function getRuleTargetCriteria($rule, $guid)


### PR DESCRIPTION
Fixes #8481

#### Short description of what this resolves:

Fix RuleLibrary, by declaring missing properties and removing a broken function.


#### Changes proposed in this pull request:

1. declare `private RuleActions Rule->$actions`
1. declare `private RuleTargets Rule->$targets`
1. remove `RuleManager::getRuleTargetCriteria`, which could not have worked

#### Does your code include anything generated by an AI Engine? No
