### PR TITLE
Fix: Add missing RuleLibrary properties and correct method calls (Iss…

### DIFF
--- a/src/ClinicalDecisionRules/Interface/RuleLibrary/Rule.php
+++ b/src/ClinicalDecisionRules/Interface/RuleLibrary/Rule.php
@@ -143,6 +143,16 @@ class Rule
     var $groups;
 
     /**
+     * @var RuleTargets
+     */
+    var $targets;
+
+    /**
+     * @var RuleActions
+     */
+    var $actions;
+
+    /**
      * User provided feedback on an applied rule instance
      * @return void
      */

--- a/src/ClinicalDecisionRules/Interface/RuleLibrary/RuleManager.php
+++ b/src/ClinicalDecisionRules/Interface/RuleLibrary/RuleManager.php
@@ -232,9 +232,6 @@ class RuleManager
 
     private function fillRuleTargetActionGroups($rule)
     {
-        $stmt = sqlStatement(self::SQL_RULE_TARGET, array($rule->id));
-        $criterion = $this->gatherCriteria($rule, $stmt, $this->targetCriteriaFactory);
-
         $ruleTargetGroups = $this->fetchRuleTargetCriteria($rule);
         $ruleActionGroups = $this->fetchRuleActions($rule);
         $groups = array();
@@ -332,17 +329,28 @@ class RuleManager
     }
 
     /**
+     * @param Rule $rule
      * @param string $guid
-     * @return array of OpenEMR\ClinicalDecisionRules\Interface\RuleLibrary\RuleTargetActionGroup
+     * @return array RuleTargetActionGroup|null
      */
-    function getRuleTargetActionGroups($rule)
+    function getRuleTargetActionGroups($rule, $guid)
     {
-        $criterion = $this->getRuleTargetCriteria($rule);
-        $actions = $this->getRuleAction($rule);
-        if (sizeof($criterion) > 0) {
-            $criteria = $criterion[0];
-            $criteria->guid = $guid;
-            return $criterion[0];
+        $criterion = $this->getRuleTargetCriteria($rule, $guid);
+        $actions = $this->getRuleAction($rule, $guid);
+
+        if ($criterion || $actions) {
+            $group = new RuleTargetActionGroup();
+            if ($criterion) {
+                $targets = new RuleTargets();
+                $targets->add($criterion);
+                $group->setRuleTargets($targets);
+            }
+            if ($actions) {
+                $actionGroup = new RuleActions();
+                $actionGroup->add($actions);
+                $group->setRuleActions($actionGroup);
+            }
+            return $group;
         }
 
         return null;


### PR DESCRIPTION
Fixes #8481 

#### Short description of what this resolves:

Static analysis tool PHPStan was reporting multiple errors in the `ClinicalDecisionRules\RuleLibrary` due to missing properties and incorrect method invocations. This pull request resolves those issues.

#### Changes proposed in this pull request:

- Added missing `$targets` and `$actions` properties to `Rule` class with correct type annotations.
- Updated calls to `getRuleTargetCriteria()` and `getRuleAction()` in `RuleManager` to pass the required number of arguments.

#### Does your code include anything generated by an AI Engine? No