### PR TITLE
chore: PHPUnit deprecations

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd" backupGlobals="false" bootstrap="tests/bootstrap.php" colors="false" processIsolation="false" stopOnError="false" stopOnFailure="false" stopOnIncomplete="false" stopOnSkipped="false" stopOnRisky="false" displayDetailsOnTestsThatTriggerDeprecations="true" displayDetailsOnTestsThatTriggerErrors="true" displayDetailsOnTestsThatTriggerWarnings="true" displayDetailsOnTestsThatTriggerNotices="true" testdox="false"> 
-  <coverage cacheDirectory=".phpunit.cache"> </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" backupGlobals="false" bootstrap="tests/bootstrap.php" colors="false" processIsolation="false" stopOnError="false" stopOnFailure="false" stopOnIncomplete="false" stopOnSkipped="false" stopOnRisky="false" displayDetailsOnTestsThatTriggerDeprecations="true" displayDetailsOnTestsThatTriggerErrors="true" displayDetailsOnTestsThatTriggerWarnings="true" displayDetailsOnTestsThatTriggerNotices="true" testdox="false">
+  <coverage> </coverage>
   <php>
     <ini name="error_reporting" value="-1"/>
     <server name="PANTHER_WEB_SERVER_DIR" value="interface"/>

--- a/tests/Tests/Api/FacilityApiTest.php
+++ b/tests/Tests/Api/FacilityApiTest.php
@@ -2,13 +2,15 @@
 
 namespace OpenEMR\Tests\Api;
 
-use PHPUnit\Framework\TestCase;
+use OpenEMR\RestControllers\FacilityRestController;
 use OpenEMR\Tests\Api\ApiTestClient;
 use OpenEMR\Tests\Fixtures\FacilityFixtureManager;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
  * Facility API Endpoint Test Cases.
- * @coversDefaultClass \OpenEMR\RestControllers\FacilityRestController
+ *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Yash Bothra <yashrajbothra786gmail.com>
@@ -16,6 +18,8 @@ use OpenEMR\Tests\Fixtures\FacilityFixtureManager;
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  *
  */
+
+#[CoversClass(FacilityRestController::class)]
 class FacilityApiTest extends TestCase
 {
     const FACILITY_API_ENDPOINT = "/apis/default/api/facility";
@@ -44,9 +48,7 @@ class FacilityApiTest extends TestCase
         $this->testClient->cleanupClient();
     }
 
-    /**
-     * @covers ::post with an invalid facility request
-     */
+    #[Test]
     public function testInvalidPost()
     {
         unset($this->facilityRecord["name"]);
@@ -59,9 +61,7 @@ class FacilityApiTest extends TestCase
         $this->assertEquals(0, count($responseBody["data"]));
     }
 
-    /**
-     * @covers ::post with a valid facility request
-     */
+    #[Test]
     public function testPost()
     {
         $actualResponse = $this->testClient->post(self::FACILITY_API_ENDPOINT, $this->facilityRecord);
@@ -79,9 +79,7 @@ class FacilityApiTest extends TestCase
         $this->assertIsString($newFacilityUuid);
     }
 
-    /**
-     * @covers ::put with an invalid uuid
-     */
+    #[Test]
     public function testInvalidPut()
     {
         $actualResponse = $this->testClient->post(self::FACILITY_API_ENDPOINT, $this->facilityRecord);
@@ -101,9 +99,7 @@ class FacilityApiTest extends TestCase
         $this->assertEquals(0, count($responseBody["data"]));
     }
 
-    /**
-     * @covers ::put with a valid resource uuid and payload
-     */
+    #[Test]
     public function testPut()
     {
         $actualResponse = $this->testClient->post(self::FACILITY_API_ENDPOINT, $this->facilityRecord);
@@ -124,9 +120,7 @@ class FacilityApiTest extends TestCase
         $this->assertEquals($this->facilityRecord["email"], $updatedResource["email"]);
     }
 
-    /**
-     * @covers ::getOne with an invalid uuid
-     */
+    #[Test]
     public function testGetOneInvalidId()
     {
         $actualResponse = $this->testClient->getOne(self::FACILITY_API_ENDPOINT, "not-a-uuid");
@@ -138,9 +132,7 @@ class FacilityApiTest extends TestCase
         $this->assertEquals(0, count($responseBody["data"]));
     }
 
-    /**
-     * @covers ::getOne with a valid uuid
-     */
+    #[Test]
     public function testGetOne()
     {
         $actualResponse = $this->testClient->post(self::FACILITY_API_ENDPOINT, $this->facilityRecord);
@@ -160,10 +152,7 @@ class FacilityApiTest extends TestCase
         $this->assertEquals($facilityId, $responseBody["data"]["id"]);
     }
 
-
-    /**
-     * @covers ::getAll
-     */
+    #[Test]
     public function testGetAll()
     {
         $this->fixtureManager->installFacilityFixtures();

--- a/tests/Tests/Fixtures/BaseFixtureManager.php
+++ b/tests/Tests/Fixtures/BaseFixtureManager.php
@@ -109,7 +109,7 @@ abstract class BaseFixtureManager
                     $fragment = $this->getQueryForForeignReference($fieldValue);
                     $sqlColumnValues .= $field . " = " . $fragment->getFragment() . ", ";
                     $sqlBinds = array_merge($sqlBinds, $fragment->getBoundValues());
-                } else if ($this->isFunctionCall($fieldValue)) {
+                } elseif ($this->isFunctionCall($fieldValue)) {
                     $sqlColumnValues .= $field . " = ?, ";
                     $fieldValue = $this->getValueFromFunction($fieldValue);
                     array_push($sqlBinds, $fieldValue);
@@ -174,7 +174,7 @@ abstract class BaseFixtureManager
             } else {
                 throw new \BadMethodCallException("uuid(table_name) function is missing table name");
             }
-        } else if ($functionName === "generateId") {
+        } elseif ($functionName === "generateId") {
             return QueryUtils::generateId();
         } else {
             throw new \BadMethodCallException("Function could not be interpreted from fixture: " . $value);

--- a/tests/Tests/Fixtures/EncounterFixtureManager.php
+++ b/tests/Tests/Fixtures/EncounterFixtureManager.php
@@ -20,7 +20,7 @@ class EncounterFixtureManager extends BaseFixtureManager
     private $facilityFixture;
     private $patientFixtureManager;
 
-    public function __construct(FacilityFixtureManager $facilityFixtureManager = null, FixtureManager $patientFixtureManager = null)
+    public function __construct(?FacilityFixtureManager $facilityFixtureManager = null, ?FixtureManager $patientFixtureManager = null)
     {
         parent::__construct("encounters.json", "form_encounter");
         if (isset($facilityFixtureManager)) {

--- a/tests/Tests/Services/CarePlanServiceTest.php
+++ b/tests/Tests/Services/CarePlanServiceTest.php
@@ -13,8 +13,8 @@ namespace OpenEMR\Tests\Services;
 
 use OpenEMR\Services\CarePlanService;
 use OpenEMR\Tests\Fixtures\CarePlanFixtureManager;
-use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
 
 /**
  * CarePlan Service Tests

--- a/tests/Tests/Services/CarePlanServiceTest.php
+++ b/tests/Tests/Services/CarePlanServiceTest.php
@@ -12,12 +12,7 @@
 namespace OpenEMR\Tests\Services;
 
 use OpenEMR\Services\CarePlanService;
-use OpenEMR\Services\EncounterService;
 use OpenEMR\Tests\Fixtures\CarePlanFixtureManager;
-use OpenEMR\Tests\Fixtures\FormFixtureManager;
-use OpenEMR\Common\Uuid\UuidRegistry;
-use OpenEMR\Services\PractitionerService;
-use OpenEMR\Tests\Fixtures\PractitionerFixtureManager;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 
@@ -38,6 +33,11 @@ class CarePlanServiceTest extends TestCase
      * @var CarePlanService
      */
     private $service;
+
+    /**
+     * @var CarePlanFixture
+     */
+    private $fixture;
 
     /**
      * @var CarePlanFixtureManager

--- a/tests/Tests/Services/CarePlanServiceTest.php
+++ b/tests/Tests/Services/CarePlanServiceTest.php
@@ -15,14 +15,14 @@ use OpenEMR\Services\CarePlanService;
 use OpenEMR\Services\EncounterService;
 use OpenEMR\Tests\Fixtures\CarePlanFixtureManager;
 use OpenEMR\Tests\Fixtures\FormFixtureManager;
-use PHPUnit\Framework\TestCase;
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Services\PractitionerService;
 use OpenEMR\Tests\Fixtures\PractitionerFixtureManager;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
- * Practitioner Service Tests
- * @coversDefaultClass OpenEMR\Services\PractitionerService
+ * CarePlan Service Tests
  *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
@@ -30,6 +30,8 @@ use OpenEMR\Tests\Fixtures\PractitionerFixtureManager;
  * @copyright Copyright (c) 2020 Yash Bothra <yashrajbothra786gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
+
+#[CoversClass(CarePlanService::class)]
 class CarePlanServiceTest extends TestCase
 {
     /**
@@ -54,17 +56,13 @@ class CarePlanServiceTest extends TestCase
         $this->fixtureManager->removeFixtures();
     }
 
-    /**
-     * @cover ::getOne
-     */
+    #[Test]
     public function testGetOne()
     {
         $this->markTestIncomplete("This test is not implemented");
     }
 
-    /**
-     * @cover ::getSurrogateKeyForRecord
-     */
+    #[Test]
     public function testGetSurrogateKeyForRecord()
     {
         // we are going to use the old care plan

--- a/tests/Tests/Services/EncounterServiceTest.php
+++ b/tests/Tests/Services/EncounterServiceTest.php
@@ -12,12 +12,13 @@
 namespace OpenEMR\Tests\Services;
 
 use OpenEMR\Common\Database\QueryUtils;
-use OpenEMR\Common\Database\SqlQueryException;
+use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Services\EncounterService;
 use OpenEMR\Tests\Fixtures\EncounterFixtureManager;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use OpenEMR\Common\Uuid\UuidRegistry;
 
+#[CoversClass(EncounterService::class)]
 class EncounterServiceTest extends TestCase
 {
     /**
@@ -29,6 +30,11 @@ class EncounterServiceTest extends TestCase
      * @var EncounterFixtureManager
      */
     private $fixtureManager;
+
+    /**
+     * @var EncounterFixture
+     */
+    private $fixture;
 
     protected function setUp(): void
     {
@@ -42,9 +48,7 @@ class EncounterServiceTest extends TestCase
         $this->fixtureManager->removeFixtures();
     }
 
-    /**
-     * @cover ::getOne
-     */
+    #[Test]
     public function testGetOne()
     {
         $this->fixtureManager->installFixtures();
@@ -59,11 +63,7 @@ class EncounterServiceTest extends TestCase
         $this->assertNotNull($resultData);
     }
 
-    /**
-     * Ran into a bug where the bound patient id was not being checked correctly.  This test case verifies that the patient
-     * binding for the uuid on the service is correctly set and returns valid data.
-     * @cover ::search
-     */
+    #[Test]
     public function testSearchWithBoundPatientUUID()
     {
         $this->fixtureManager->installFixtures();

--- a/tests/Tests/Services/FHIR/FhirAllergyIntoleranceServiceQueryTest.php
+++ b/tests/Tests/Services/FHIR/FhirAllergyIntoleranceServiceQueryTest.php
@@ -7,19 +7,22 @@ use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRAllergyIntolerance;
 use OpenEMR\Services\FHIR\FhirAllergyIntoleranceService;
 use OpenEMR\Services\FHIR\FhirUrlResolver;
-use PHPUnit\Framework\TestCase;
 use OpenEMR\Tests\Fixtures\FixtureManager;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * FHIR Allergy Intolerance Service Query Tests
  *
- * @coversDefaultClass \OpenEMR\Services\FHIR\FhirAllergyIntoleranceService
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Stephen Nielson <stephen@nielson.org>
  * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
+
+#[CoversClass(FhirAllergyIntoleranceService::class)]
 class FhirAllergyIntoleranceServiceQueryTest extends TestCase
 {
     /**
@@ -89,7 +92,7 @@ class FhirAllergyIntoleranceServiceQueryTest extends TestCase
     /**
      * PHPUnit Data Provider for FHIR AllergyIntolerance searches
      */
-    public static function searchParameterPatientReferenceDataProvider()
+    public static function searchParameterPatientReferenceDataProvider(): array
     {
         return [
             ['patient', "Patient/:uuid1"],
@@ -109,11 +112,10 @@ class FhirAllergyIntoleranceServiceQueryTest extends TestCase
     }
 
     /**
-     * Tests getAll queries
-     * @covers ::getAll
-     * @covers ::searchForOpenEMRRecords
-     * @dataProvider searchParameterPatientReferenceDataProvider
-     */
+    * Tests getAll queries
+    */
+    #[Test]
+    #[DataProvider('searchParameterPatientReferenceDataProvider')]
     public function testGetAllPatientReference($parameterName, $parameterValue)
     {
         $pubpid = FixtureManager::PATIENT_FIXTURE_PUBPID_PREFIX . "%";
@@ -137,9 +139,8 @@ class FhirAllergyIntoleranceServiceQueryTest extends TestCase
     /**
      * Tests getAll queries for the _id search parameter.  Since we can't combine a dataProvider with our test fixture
      * installation, we run this test separately
-     * @covers ::getAll
-     * @covers ::searchForOpenEMRRecords
      */
+    #[Test]
     public function testGetAllWithUuid()
     {
         $select = "SELECT `uuid` FROM `lists` WHERE `type`='allergy' LIMIT 1";
@@ -151,8 +152,8 @@ class FhirAllergyIntoleranceServiceQueryTest extends TestCase
 
     /**
      * Uses the getAll method so we can't pass unless that is working.
-     * @covers ::getOne
      */
+    #[Test]
     public function testGetOne()
     {
         $actualResult = $this->fhirService->getAll([]);
@@ -168,9 +169,7 @@ class FhirAllergyIntoleranceServiceQueryTest extends TestCase
         $this->assertEquals($expectedId, $actualId);
     }
 
-       /**
-     * @covers ::getOne with an invalid uuid
-     */
+    #[Test]
     public function testGetOneInvalidUuid()
     {
         $actualResult = $this->fhirService->getOne('not-a-uuid');

--- a/tests/Tests/Services/FHIR/FhirAllergyIntoleranceServiceQueryTest.php
+++ b/tests/Tests/Services/FHIR/FhirAllergyIntoleranceServiceQueryTest.php
@@ -8,9 +8,9 @@ use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRAllergyIntolerance;
 use OpenEMR\Services\FHIR\FhirAllergyIntoleranceService;
 use OpenEMR\Services\FHIR\FhirUrlResolver;
 use OpenEMR\Tests\Fixtures\FixtureManager;
-use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
 
 /**
  * FHIR Allergy Intolerance Service Query Tests

--- a/tests/Tests/Services/FHIR/FhirOrganizationServiceCrudTest.php
+++ b/tests/Tests/Services/FHIR/FhirOrganizationServiceCrudTest.php
@@ -3,14 +3,14 @@
 namespace OpenEMR\Tests\Services\FHIR;
 
 use OpenEMR\FHIR\R4\FHIRDomainResource\FHIROrganization;
-use OpenEMR\Services\FHIR\Serialization\FhirOrganizationSerializer;
-use PHPUnit\Framework\TestCase;
-use OpenEMR\Tests\Fixtures\FacilityFixtureManager;
 use OpenEMR\Services\FHIR\FhirOrganizationService;
+use OpenEMR\Services\FHIR\Serialization\FhirOrganizationSerializer;
+use OpenEMR\Tests\Fixtures\FacilityFixtureManager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
 
 /**
  * FHIR Organization Service Crud Tests
- * @coversDefaultClass \OpenEMR\Services\FHIR\FhirOrganizationService
  *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
@@ -18,6 +18,8 @@ use OpenEMR\Services\FHIR\FhirOrganizationService;
  * @copyright Copyright (c) 2020 Yash Bothra <yashrajbothra786gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
+
+#[CoversClass(FhirOrganizationService::class)]
 class FhirOrganizationServiceCrudTest extends TestCase
 {
     /**
@@ -44,10 +46,7 @@ class FhirOrganizationServiceCrudTest extends TestCase
         $this->fixtureManager->removeFixtures();
     }
 
-    /**
-     * Tests a successful insert operation
-     * @covers ::insert
-     */
+    #[Test]
     public function testInsert()
     {
         $this->fhirOrganizationFixture->setId(null);
@@ -60,10 +59,7 @@ class FhirOrganizationServiceCrudTest extends TestCase
         $this->assertIsString($dataResult['uuid']);
     }
 
-    /**
-     * Tests an insert operation where an error occurs
-     * @covers ::insert
-     */
+    #[Test]
     public function testInsertWithErrors()
     {
         $this->fhirOrganizationFixture->setName(null);
@@ -72,10 +68,7 @@ class FhirOrganizationServiceCrudTest extends TestCase
         $this->assertEquals(0, count($processingResult->getData()));
     }
 
-    /**
-     * Tests a successful update operation
-     * @covers ::update
-     */
+    #[Test]
     public function testUpdate()
     {
         $this->fhirOrganizationFixture->setId(null);
@@ -98,10 +91,7 @@ class FhirOrganizationServiceCrudTest extends TestCase
         $this->assertEquals($fhirId, $actualFhirRecord->getId());
     }
 
-    /**
-     * Tests an update operation where an error occurs
-     * @covers ::update
-     */
+    #[Test]
     public function testUpdateWithErrors()
     {
         $actualResult = $this->fhirOrganizationService->update('bad-uuid', $this->fhirOrganizationFixture);

--- a/tests/Tests/Services/FHIR/FhirPatientServiceCrudTest.php
+++ b/tests/Tests/Services/FHIR/FhirPatientServiceCrudTest.php
@@ -2,15 +2,16 @@
 
 namespace OpenEMR\Tests\Services\FHIR;
 
-use OpenEMR\Services\FHIR\Serialization\FhirPatientSerializer;
-use PHPUnit\Framework\TestCase;
-use OpenEMR\Tests\Fixtures\FixtureManager;
-use OpenEMR\Services\FHIR\FhirPatientService;
 use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRPatient;
+use OpenEMR\Services\FHIR\FhirPatientService;
+use OpenEMR\Services\FHIR\Serialization\FhirPatientSerializer;
+use OpenEMR\Tests\Fixtures\FixtureManager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
 
 /**
  * FHIR Patient Service Crud Tests
- * @coversDefaultClass OpenEMR\Services\FHIR\FhirPatientService
+ *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Dixon Whitmire <dixonwh@gmail.com>
@@ -18,6 +19,8 @@ use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRPatient;
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  *
  */
+
+#[CoversClass(FhirPatientService::class)]
 class FhirPatientServiceCrudTest extends TestCase
 {
     private $fixtureManager;
@@ -47,11 +50,7 @@ class FhirPatientServiceCrudTest extends TestCase
         $this->fixtureManager->removePatientFixtures();
     }
 
-    /**
-     * Tests a successful insert operation
-     * @covers ::insert
-     * @covers ::insertOpenEMRRecord
-     */
+    #[Test]
     public function testInsert()
     {
         $this->fhirPatientFixture->setId(null);
@@ -64,11 +63,7 @@ class FhirPatientServiceCrudTest extends TestCase
         $this->assertIsString($dataResult['uuid']);
     }
 
-    /**
-     * Tests an insert operation where an error occurs
-     * @covers ::insert
-     * @covers ::insertOpenEMRRecord
-     */
+    #[Test]
     public function testInsertWithErrors()
     {
         $this->fhirPatientFixture->name = [];
@@ -77,11 +72,7 @@ class FhirPatientServiceCrudTest extends TestCase
         $this->assertEquals(0, count($processingResult->getData()));
     }
 
-    /**
-     * Tests a successful update operation
-     * @covers ::update
-     * @covers ::updateOpenEMRRecord
-     */
+    #[Test]
     public function testUpdate()
     {
         $this->fhirPatientFixture->setId(null);
@@ -104,11 +95,7 @@ class FhirPatientServiceCrudTest extends TestCase
         $this->assertEquals($fhirId, $actualFhirRecord->getId());
     }
 
-    /**
-     * Tests an update operation where an error occurs
-     * @covers ::update
-     * @covers ::updateOpenEMRRecord
-     */
+    #[Test]
     public function testUpdateWithErrors()
     {
         $actualResult = $this->fhirPatientService->update('bad-uuid', $this->fhirPatientFixture);

--- a/tests/Tests/Services/FHIR/FhirPatientServiceMappingTest.php
+++ b/tests/Tests/Services/FHIR/FhirPatientServiceMappingTest.php
@@ -2,18 +2,16 @@
 
 namespace OpenEMR\Tests\Services\FHIR;
 
-use OpenEMR\FHIR\R4\FHIRElement\FHIRContactPoint;
-use OpenEMR\FHIR\R4\FHIRElement\FHIRIdentifier;
-use OpenEMR\Services\FHIR\Serialization\FhirPatientSerializer;
-use OpenEMR\Services\PatientService;
-use PHPUnit\Framework\TestCase;
-use OpenEMR\Tests\Fixtures\FixtureManager;
-use OpenEMR\Services\FHIR\FhirPatientService;
 use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRPatient;
+use OpenEMR\Services\FHIR\FhirPatientService;
+use OpenEMR\Services\FHIR\Serialization\FhirPatientSerializer;
+use OpenEMR\Tests\Fixtures\FixtureManager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
 
 /**
  * FHIR Patient Service Mapping Tests
- * @coversDefaultClass OpenEMR\Services\FHIR\FhirPatientService
+ *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Dixon Whitmire <dixonwh@gmail.com>
@@ -21,6 +19,8 @@ use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRPatient;
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  *
  */
+
+#[CoversClass(FhirPatientService::class)]
 class FhirPatientServiceMappingTest extends TestCase
 {
     private $fixtureManager;
@@ -157,9 +157,7 @@ class FhirPatientServiceMappingTest extends TestCase
         $this->assertTrue($matchFound);
     }
 
-    /**
-     * @covers ::parseOpenEMRRecord
-     */
+    #[Test]
     public function testParseOpenEMRRecord()
     {
         $this->patientFixture['uuid'] = $this->fixtureManager->getUnregisteredUuid();
@@ -214,9 +212,8 @@ class FhirPatientServiceMappingTest extends TestCase
         }
         return (string)$codeValue;
     }
-    /**
-     * @covers ::parseFhirResource
-     */
+
+    #[Test]
     public function testParseFhirResource()
     {
         $actualResult = $this->fhirPatientService->parseFhirResource($this->fhirPatientFixture);

--- a/tests/Tests/Services/FHIR/FhirPatientServiceQueryTest.php
+++ b/tests/Tests/Services/FHIR/FhirPatientServiceQueryTest.php
@@ -3,14 +3,16 @@
 namespace OpenEMR\Tests\Services\FHIR;
 
 use OpenEMR\Common\Uuid\UuidRegistry;
-use PHPUnit\Framework\TestCase;
 use OpenEMR\Tests\Fixtures\FixtureManager;
 use OpenEMR\Services\FHIR\FhirPatientService;
 use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRPatient;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
 
 /**
  * FHIR Patient Service Query Tests
- * @coversDefaultClass OpenEMR\Services\FHIR\FhirPatientService
+ *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Dixon Whitmire <dixonwh@gmail.com>
@@ -18,6 +20,8 @@ use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRPatient;
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  *
  */
+
+#[CoversClass(FhirPatientService::class)]
 class FhirPatientServiceQueryTest extends TestCase
 {
     private $fixtureManager;
@@ -57,10 +61,7 @@ class FhirPatientServiceQueryTest extends TestCase
         }
     }
 
-    /**
-     * PHPUnit Data Provider for FHIR patient searches
-     */
-    public static function searchParameterDataProvider()
+    public static function searchParameter(): array
     {
 
         return [
@@ -133,8 +134,6 @@ class FhirPatientServiceQueryTest extends TestCase
             ['birthdate', 'ge1977-05'], // search by year, month
             ['birthdate', 'ge1977-05-02'], // search by year, month, day
 
-
-
             // range searches for dates.
 
             ['email', 'info@pennfirm.com'],
@@ -155,10 +154,7 @@ class FhirPatientServiceQueryTest extends TestCase
         ];
     }
 
-    /**
-     * PHPUnit Data Provider for FHIR patient searches
-     */
-    public static function searchParameterCompoundDataProvider()
+    public static function searchParameterCompound(): array
     {
         return [
             ['birthdate', 'le1960-01-01', 'name:contains', 'lias'], // check operators and comparators work combined
@@ -171,12 +167,8 @@ class FhirPatientServiceQueryTest extends TestCase
         ];
     }
 
-    /**
-     * Tests getAll queries
-     * @covers ::getAll
-     * @covers ::searchForOpenEMRRecords
-     * @dataProvider searchParameterDataProvider
-     */
+    #[Test]
+    #[DataProvider('searchParameter')]
     public function testGetAll($parameterName, $parameterValue)
     {
         $fhirSearchParameters = [$parameterName => $parameterValue];
@@ -184,12 +176,7 @@ class FhirPatientServiceQueryTest extends TestCase
         $this->assertGetAllSearchResults($processingResult);
     }
 
-    /**
-     * Tests getAll queries for the _id search parameter.  Since we can't combine a dataProvider with our test fixture
-     * installation, we run this test separately
-     * @covers ::getAll
-     * @covers ::searchForOpenEMRRecords
-     */
+    #[Test]
     public function testGetAllWithUuid()
     {
         $select = "SELECT `uuid` FROM `patient_data` WHERE `pubpid`=?";
@@ -200,12 +187,8 @@ class FhirPatientServiceQueryTest extends TestCase
         $this->assertGetAllSearchResults($processingResult);
     }
 
-    /**
-     * Tests getAll compound search queries
-     * @covers ::getAll
-     * @covers ::searchForOpenEMRRecords
-     * @dataProvider searchParameterCompoundDataProvider
-     */
+    #[Test]
+    #[DataProvider('searchParameterCompound')]
     public function testGetAllCompound($parameter1, $parameter1Value, $parameter2, $parameter2Value)
     {
         $fhirSearchParameters = [$parameter1 => $parameter1Value, $parameter2 => $parameter2Value];
@@ -213,10 +196,7 @@ class FhirPatientServiceQueryTest extends TestCase
         $this->assertGetAllSearchResults($processingResult);
     }
 
-    /**
-     * Uses the getAll method so we can't pass unless that is working.
-     * @covers ::getOne
-     */
+    #[Test]
     public function testGetOne()
     {
         $actualResult = $this->fhirPatientService->getAll([]);
@@ -232,9 +212,7 @@ class FhirPatientServiceQueryTest extends TestCase
         $this->assertEquals($expectedId, $actualId);
     }
 
-       /**
-     * @covers ::getOne with an invalid uuid
-     */
+    #[Test]
     public function testGetOneInvalidUuid()
     {
         $actualResult = $this->fhirPatientService->getOne('not-a-uuid');

--- a/tests/Tests/Services/FHIR/FhirPractitionerServiceCrudTest.php
+++ b/tests/Tests/Services/FHIR/FhirPractitionerServiceCrudTest.php
@@ -2,15 +2,15 @@
 
 namespace OpenEMR\Tests\Services\FHIR;
 
-use OpenEMR\Services\FHIR\Serialization\FhirPractitionerSerializer;
-use PHPUnit\Framework\TestCase;
-use OpenEMR\Tests\Fixtures\PractitionerFixtureManager;
-use OpenEMR\Services\FHIR\FhirPractitionerService;
 use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRPractitioner;
+use OpenEMR\Services\FHIR\FhirPractitionerService;
+use OpenEMR\Services\FHIR\Serialization\FhirPractitionerSerializer;
+use OpenEMR\Tests\Fixtures\PractitionerFixtureManager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
 
 /**
  * FHIR Practitioner Service Crud Tests
- * @coversDefaultClass OpenEMR\Services\FHIR\FhirPractitionerService
  *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
@@ -18,6 +18,8 @@ use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRPractitioner;
  * @copyright Copyright (c) 2020 Yash Bothra <yashrajbothra786gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
+
+#[CoversClass(FhirPractitionerService::class)]
 class FhirPractitionerServiceCrudTest extends TestCase
 {
     private $fixtureManager;
@@ -46,11 +48,7 @@ class FhirPractitionerServiceCrudTest extends TestCase
         $this->fixtureManager->removePractitionerFixtures();
     }
 
-    /**
-     * Tests a successful insert operation
-     * @covers ::insert
-     * @covers ::insertOpenEMRRecord
-     */
+    #[Test]
     public function testInsert()
     {
         $this->fhirPractitionerFixture->setId(null);
@@ -63,11 +61,7 @@ class FhirPractitionerServiceCrudTest extends TestCase
         $this->assertIsString($dataResult['uuid']);
     }
 
-    /**
-     * Tests an insert operation where an error occurs
-     * @covers ::insert
-     * @covers ::insertOpenEMRRecord
-     */
+    #[Test]
     public function testInsertWithErrors()
     {
         $this->fhirPractitionerFixture->name = []; // clear the names TODO: I don't like this public accessor, can we fix it?s
@@ -76,11 +70,7 @@ class FhirPractitionerServiceCrudTest extends TestCase
         $this->assertEquals(0, count($processingResult->getData()));
     }
 
-    /**
-     * Tests a successful update operation
-     * @covers ::update
-     * @covers ::updateOpenEMRRecord
-     */
+    #[Test]
     public function testUpdate()
     {
         $this->fhirPractitionerFixture->setId(null);
@@ -103,11 +93,7 @@ class FhirPractitionerServiceCrudTest extends TestCase
         $this->assertEquals($fhirId, $actualFhirRecord->getId());
     }
 
-    /**
-     * Tests an update operation where an error occurs
-     * @covers ::update
-     * @covers ::updateOpenEMRRecord
-     */
+    #[Test]
     public function testUpdateWithErrors()
     {
         $actualResult = $this->fhirPractitionerService->update('bad-uuid', $this->fhirPractitionerFixture);

--- a/tests/Tests/Services/FacilityServiceTest.php
+++ b/tests/Tests/Services/FacilityServiceTest.php
@@ -2,14 +2,14 @@
 
 namespace OpenEMR\Tests\Services;
 
-use PHPUnit\Framework\TestCase;
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Services\FacilityService;
 use OpenEMR\Tests\Fixtures\FacilityFixtureManager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Facility Service Tests
- * @coversDefaultClass OpenEMR\Services\FacilityService
  *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
@@ -17,6 +17,8 @@ use OpenEMR\Tests\Fixtures\FacilityFixtureManager;
  * @copyright Copyright (c) 2020 Yash Bothra <yashrajbothra786gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
+
+#[CoversClass(FacilityService::class)]
 class FacilityServiceTest extends TestCase
 {
     /**
@@ -41,9 +43,7 @@ class FacilityServiceTest extends TestCase
         $this->fixtureManager->removeFixtures();
     }
 
-    /**
-     * @covers ::insert when the data is invalid
-     */
+    #[Test]
     public function testInsertFailure()
     {
         $this->facilityFixture["name"] = "A";
@@ -59,9 +59,7 @@ class FacilityServiceTest extends TestCase
         $this->assertEquals(2, count($actualResult->getValidationMessages()));
     }
 
-    /**
-     * @covers ::insert when the data is valid
-     */
+    #[Test]
     public function testInsertSuccess()
     {
         $actualResult = $this->facilityService->insert($this->facilityFixture);
@@ -80,9 +78,7 @@ class FacilityServiceTest extends TestCase
         $this->assertFalse($actualResult->hasInternalErrors());
     }
 
-    /**
-     * @covers ::update when the data is not valid
-     */
+    #[Test]
     public function testUpdateFailure()
     {
         $this->facilityService->insert($this->facilityFixture);
@@ -98,9 +94,7 @@ class FacilityServiceTest extends TestCase
         $this->assertEquals(2, count($actualResult->getValidationMessages()));
     }
 
-    /**
-     * @covers ::update when the data is valid
-     */
+    #[Test]
     public function testUpdateSuccess()
     {
         $actualResult = $this->facilityService->insert($this->facilityFixture);
@@ -124,10 +118,7 @@ class FacilityServiceTest extends TestCase
         $this->assertEquals("help@pennfirm.com", $result["email"]);
     }
 
-    /**
-     * @cover ::getOne
-     * @cover ::getAll
-     */
+    #[Test]
     public function testFacilityQueries()
     {
         $this->fixtureManager->installFacilityFixtures();

--- a/tests/Tests/Services/PatientServiceTest.php
+++ b/tests/Tests/Services/PatientServiceTest.php
@@ -2,14 +2,15 @@
 
 namespace OpenEMR\Tests\Services;
 
-use PHPUnit\Framework\TestCase;
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Services\PatientService;
 use OpenEMR\Tests\Fixtures\FixtureManager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Patient Service Tests
- * @coversDefaultClass OpenEMR\Services\PatientService
+ *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Dixon Whitmire <dixonwh@gmail.com>
@@ -17,6 +18,8 @@ use OpenEMR\Tests\Fixtures\FixtureManager;
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  *
  */
+
+#[CoversClass(PatientService::class)]
 class PatientServiceTest extends TestCase
 {
     /**
@@ -37,18 +40,14 @@ class PatientServiceTest extends TestCase
         $this->fixtureManager->removePatientFixtures();
     }
 
-    /**
-     * @covers ::getFreshPid
-     */
+    #[Test]
     public function testGetFreshPid()
     {
         $actualValue = $this->patientService->getFreshPid();
         $this->assertGreaterThan(0, $actualValue);
     }
 
-    /**
-     * @covers ::insert when the data is invalid
-     */
+    #[Test]
     public function testInsertFailure()
     {
         $this->patientFixture["fname"] = "";
@@ -65,9 +64,7 @@ class PatientServiceTest extends TestCase
         $this->assertEquals(3, count($actualResult->getValidationMessages()));
     }
 
-    /**
-     * @covers ::insert when the data is valid
-     */
+    #[Test]
     public function testInsertSuccess()
     {
         $actualResult = $this->patientService->insert($this->patientFixture);
@@ -86,9 +83,7 @@ class PatientServiceTest extends TestCase
         $this->assertFalse($actualResult->hasInternalErrors());
     }
 
-    /**
-     * @covers ::update when the data is not valid
-     */
+    #[Test]
     public function testUpdateFailure()
     {
         $this->patientService->insert($this->patientFixture);
@@ -104,9 +99,7 @@ class PatientServiceTest extends TestCase
         $this->assertEquals(2, count($actualResult->getValidationMessages()));
     }
 
-    /**
-     * @covers ::update when the data is valid
-     */
+    #[Test]
     public function testUpdateSuccess()
     {
         $actualResult = $this->patientService->insert($this->patientFixture);
@@ -130,10 +123,7 @@ class PatientServiceTest extends TestCase
         $this->assertEquals("555-111-4444", $result["phone_home"]);
     }
 
-    /**
-     * @cover ::getOne
-     * @cover ::getAll
-     */
+    #[Test]
     public function testPatientQueries()
     {
         $this->fixtureManager->installPatientFixtures();

--- a/tests/Tests/Services/PractitionerServiceTest.php
+++ b/tests/Tests/Services/PractitionerServiceTest.php
@@ -2,14 +2,14 @@
 
 namespace OpenEMR\Tests\Services;
 
-use PHPUnit\Framework\TestCase;
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Services\PractitionerService;
 use OpenEMR\Tests\Fixtures\PractitionerFixtureManager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Practitioner Service Tests
- * @coversDefaultClass OpenEMR\Services\PractitionerService
  *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
@@ -17,6 +17,8 @@ use OpenEMR\Tests\Fixtures\PractitionerFixtureManager;
  * @copyright Copyright (c) 2020 Yash Bothra <yashrajbothra786gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
+
+#[CoversClass(PractitionerService::class)]
 class PractitionerServiceTest extends TestCase
 {
     /**
@@ -38,9 +40,7 @@ class PractitionerServiceTest extends TestCase
         $this->fixtureManager->removePractitionerFixtures();
     }
 
-    /**
-     * @covers ::insert when the data is invalid
-     */
+    #[Test]
     public function testInsertFailure()
     {
         $this->practitionerFixture["fname"] = "A";
@@ -57,9 +57,7 @@ class PractitionerServiceTest extends TestCase
         $this->assertEquals(3, count($actualResult->getValidationMessages()));
     }
 
-    /**
-     * @covers ::insert when the data is valid
-     */
+    #[Test]
     public function testInsertSuccess()
     {
         $actualResult = $this->practitionerService->insert($this->practitionerFixture);
@@ -78,9 +76,7 @@ class PractitionerServiceTest extends TestCase
         $this->assertFalse($actualResult->hasInternalErrors());
     }
 
-    /**
-     * @covers ::update when the data is not valid
-     */
+    #[Test]
     public function testUpdateFailure()
     {
         $this->practitionerService->insert($this->practitionerFixture);
@@ -96,9 +92,7 @@ class PractitionerServiceTest extends TestCase
         $this->assertEquals(2, count($actualResult->getValidationMessages()));
     }
 
-    /**
-     * @covers ::update when the data is valid
-     */
+    #[Test]
     public function testUpdateSuccess()
     {
         $actualResult = $this->practitionerService->insert($this->practitionerFixture);
@@ -122,10 +116,7 @@ class PractitionerServiceTest extends TestCase
         $this->assertEquals("help@pennfirm.com", $result["email"]);
     }
 
-    /**
-     * @cover ::getOne
-     * @cover ::getAll
-     */
+    #[Test]
     public function testPractitionerQueries()
     {
         $this->fixtureManager->installPractitionerFixtures();


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #8485 

#### Short description of what this resolves:
PHPUnit 10 deprecated docblock comments and annotations in favor of attributes (php8 feature), prepares for migration to PHPUnit 12 maybe

#### Changes proposed in this pull request:
use attributes instead of annotations

#### Does your code include anything generated by an AI Engine? No

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.
