### PR TITLE
fix: dev-php-fpm-8-5 docker build which is used by the ci for PHP 8.5 (php dev version) testing

### DIFF
--- a/docker/library/dockers/dev-php-fpm-8-5-redis/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-5-redis/Dockerfile
@@ -26,11 +26,26 @@ RUN apt-get install -y mariadb-client \
 RUN curl -sL https://deb.nodesource.com/setup_20.x  | bash -
 RUN apt-get install nodejs -y
 
+# Temporary fix to get ldap install working by bypassing below install-php-extensions run (these issues are usually temporary
+#  in dev versions of PHP, so this is not a permanent solution)
+# TODO:
+# TODO: intermittently try to remove this block of code and uncomment ldap in below ../install-php-extensions run
+# TODO:
+RUN apt-get install -y \
+    libldap2-dev \
+    libsasl2-dev \
+    libldap-common \
+    pkg-config
+RUN LDAP_CFLAGS="-I/usr/include" \
+    LDAP_LIBS="-lldap -llber" \
+    docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
+    && docker-php-ext-install ldap
+
 # Add the php extensions (note using a very cool script by mlocati to do this)
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod uga+x /usr/local/bin/install-php-extensions && sync && \
     install-php-extensions pdo_mysql \
-                           ldap \
+                           # ldap \
                            xsl \
                            gd \
                            zip \

--- a/docker/library/dockers/dev-php-fpm-8-5/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-5/Dockerfile
@@ -26,11 +26,26 @@ RUN apt-get install -y mariadb-client \
 RUN curl -sL https://deb.nodesource.com/setup_20.x  | bash -
 RUN apt-get install nodejs -y
 
+# Temporary fix to get ldap install working by bypassing below install-php-extensions run (these issues are usually temporary
+#  in dev versions of PHP, so this is not a permanent solution)
+# TODO:
+# TODO: intermittently try to remove this block of code and uncomment ldap in below ../install-php-extensions run
+# TODO:
+RUN apt-get install -y \
+    libldap2-dev \
+    libsasl2-dev \
+    libldap-common \
+    pkg-config
+RUN LDAP_CFLAGS="-I/usr/include" \
+    LDAP_LIBS="-lldap -llber" \
+    docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
+    && docker-php-ext-install ldap
+
 # Add the php extensions (note using a very cool script by mlocati to do this)
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod uga+x /usr/local/bin/install-php-extensions && sync && \
     install-php-extensions pdo_mysql \
-                           ldap \
+                           # ldap \
                            xsl \
                            gd \
                            zip \


### PR DESCRIPTION
fixes #8487