### PR TITLE
fix(code_types): convert_type_id_to_key explicit return

### DIFF
--- a/custom/code_types.inc.php
+++ b/custom/code_types.inc.php
@@ -312,7 +312,7 @@ function related_codes_are_used()
  * Convert a code type id (ct_id) to the key string (ct_key)
  *
  * @param  integer $id
- * @return string
+ * @return string|null
  */
 function convert_type_id_to_key($id)
 {
@@ -322,6 +322,7 @@ function convert_type_id_to_key($id)
             return $key;
         }
     }
+    return null;
 }
 
 /**
@@ -333,12 +334,7 @@ function convert_type_id_to_key($id)
 function check_is_code_type_justify($key)
 {
     global $code_types;
-
-    if (!empty($code_types[$key]['just'])) {
-          return true;
-    } else {
-        return false;
-    }
+    return !empty($code_types[$key]['just']);
 }
 
 /**


### PR DESCRIPTION
Fixes #8489

#### Short description of what this resolves:

Fix the type of the function by clarifying that it can return null.

#### Changes proposed in this pull request:

Clarify the type signature of the function and explicitly return `null` when no match is found. This does not change the actual runtime behavior of the function – just aids typecheckers and other static analyzers in understanding the behavior.

Also fix a small style error in the following function.

#### Does your code include anything generated by an AI Engine? No