### PR TITLE
doc(CONTRIBUTING): use docker compose syntax directly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,21 +62,16 @@ You will need a "local" version of OpenEMR to make changes to the source code. T
 
     - An exception to this is if making changes to styling scripts in interface/themes/. In that case will need to clear web browser cache and run the following command to rebuild the theme files:
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools build-themes'
+      docker compose exec openemr /root/devtools build-themes
       ```
 7. When you're done, it's best to clean up after yourself with `docker compose down -v`
     - If you don't want to build from scratch every time, just use `docker compose down` so your next `docker compose up` will use the cached volumes.
 8. To ensure you are using the most recent dockers, recommend running below set of commands intermittently:
+
     ```console
-    docker pull openemr/openemr:flex
-    docker pull openemr/openemr:flex-3.18
-    docker pull openemr/openemr:flex-3.20
-    docker pull openemr/openemr:flex-3.21
-    docker pull mariadb:11.4
-    docker pull phpmyadmin/phpmyadmin
-    docker pull couchdb
-    docker pull openemr/dev-ldap:easy
+    docker compose pull
     ```
+
 9. [Submit a PR](https://github.com/openemr/openemr/compare) from your fork into `openemr/openemr#master`!
 
 We look forward to your contribution...
@@ -133,110 +128,110 @@ The OpenEMR development docker environment has a very rich advanced feature set.
     - Make sure port 9003 is open on your host operating system
     - Profiling output can be found in /tmp directory in the docker. Following will list the profiling output files:
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools list-xdebug-profiles'
+      docker compose exec openemr /root/devtools list-xdebug-profiles
       ```
     - To check Xdebug log:
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools xdebug-log'
+      docker compose exec openemr /root/devtools xdebug-log
       ```
 2. <a name="api"></a>API development and testing.
     - Swagger is including in OpenEMR to ease API documentation, development, and testing.
     - The following command will update the API documentation (derive documentation from [_rest_routes.inc.php](_rest_routes.inc.php) to [swagger/openemr-api.yaml](swagger/openemr-api.yaml)):
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools build-api-docs'
+      docker compose exec openemr /root/devtools build-api-docs
       ```
     - Can go to Swagger at [https://localhost:9300/swagger](https://localhost:9300/swagger) where it is super easy to test the API:
         - First, click on 'Authorize' button.
         - Then click 'Select All' scopes.
         - Can then do the following from command line to get a client id and secret, which then can copy/paste into the fields:
           ```sh
-          docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools register-oauth2-client'
+          docker compose exec openemr /root/devtools register-oauth2-client
           ```
         - Then click 'Authorize' button and follow the flow and before you know it, you will be authorized to test the api endpoints!
     - There is also a mechanism to allow use of the above Swagger tool with multisite.
         - Before going to the Swagger gui linked above, run the following command (after running below command, the Swagger gui will then be configured to work with the selected multisite):
           ```sh
-          docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools set-swagger-to-multisite <multisite-name>'
+          docker compose exec openemr /root/devtools set-swagger-to-multisite <multisite-name>
           ```
         - To collect a client id and secret for the selected multisite, can then do:
           ```sh
-          docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools register-oauth2-client <multisite-name>'
+          docker compose exec openemr /root/devtools register-oauth2-client <multisite-name>
           ```
         - When done testing with Swagger on the selected multisite, recommend setting swagger back to the default multisite to avoid changes to the swagger configuration script showing up in your local git repository:
           ```sh
-          docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools set-swagger-to-multisite'
+          docker compose exec openemr /root/devtools set-swagger-to-multisite
           ```
     - There is also a dev tool to make it easy to test the API on the online OpenEMR demo farm. For example, what if you wanted to test the API at [https://eleven.openemr.io/a/openemr](https://eleven.openemr.io/a/openemr):
         - Go to [https://eleven.openemr.io/a/openemr/swagger](https://eleven.openemr.io/a/openemr/swagger/index.html) and follow the Swagger gui flow above. The following command can be used to get a client id and secret from that online demo:
           ```sh
-          docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools register-oauth2-client-demo https://eleven.openemr.io/a/openemr'
+          docker compose exec openemr /root/devtools register-oauth2-client-demo https://eleven.openemr.io/a/openemr
           ```
 3. <a name="other_php_versions"></a>Testing other PHP versions.
     - The standard `flex` docker used in the easy development environments is PHP 8.4. This can be modified by changing the image (`image: openemr/openemr:flex`) used in the docker-compose.yml script. To use PHP 8.2, then just need to change it to `image: openemr/openemr:flex-3.18`. To use PHP 8.3 then change it to `image: openemr/openemr:flex-3.20`.
 4. <a name="dev_tools_tests"></a>Php syntax checking, psr12 checking, and automated testing.
     - To check PHP error logs:
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools php-log'
+      docker compose exec openemr /root/devtools php-log
       ```
     - To create a report of PSR12 code styling issues (this takes several minutes):
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools psr12-report'
+      docker compose exec openemr /root/devtools psr12-report
       ```
     - To fix PSR12 code styling issues (this takes several minutes):
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools psr12-fix'
+      docker compose exec openemr /root/devtools psr12-fix
       ```
     - To create a report of theme styling issues:
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools lint-themes-report'
+      docker compose exec openemr /root/devtools lint-themes-report
       ```
     - To fix theme styling issues:
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools lint-themes-fix'
+      docker compose exec openemr /root/devtools lint-themes-fix
       ```
     - To check PHP parsing errors (this takes several minutes):
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools php-parserror'
+      docker compose exec openemr /root/devtools php-parserror
       ```
     - To run unit testing:
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools unit-test'
+      docker compose exec openemr /root/devtools unit-test
       ```
     - To run api testing:
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools api-test'
+      docker compose exec openemr /root/devtools api-test
       ```
     - To run e2e testing:
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools e2e-test'
+      docker compose exec openemr /root/devtools e2e-test
       ```
     - To run services testing:
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools services-test'
+      docker compose exec openemr /root/devtools services-test
       ```
     - To run fixtures testing:
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools fixtures-test'
+      docker compose exec openemr /root/devtools fixtures-test
       ```
     - To run validators testing:
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools validators-test'
+      docker compose exec openemr /root/devtools validators-test
       ```
     - To run controllers testing:
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools controllers-test'
+      docker compose exec openemr /root/devtools controllers-test
       ```
     - To run common testing:
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools common-test'
+      docker compose exec openemr /root/devtools common-test
       ```
 5. <a name="dev_tools_suite"></a>Run the entire dev tool suite (PSR12 fix, lint themes fix, PHP parse error, unit/API/e2e/services/fixtures/validators/controllers/common tests) in one command, run
     ```sh
-    docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools clean-sweep'
+    docker compose exec openemr /root/devtools clean-sweep
     ```
 6. <a name="dev_tools_auto"></a>Run only all the automated tests (unit/API/e2e/services/fixtures/validators/controllers/common tests) in one command, run
     ```sh
-    docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools clean-sweep-tests'
+    docker compose exec openemr /root/devtools clean-sweep-tests
     ```
 7. <a name="dev_tools_reset"></a>Resetting OpenEMR and loading demo data.
     - For the Video Tutorial, click below:
@@ -247,16 +242,16 @@ The OpenEMR development docker environment has a very rich advanced feature set.
 
     - To reset OpenEMR only (then can reinstall manually via setup.php in web browser):
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools dev-reset'
+      docker compose exec openemr /root/devtools dev-reset
       ```
         - When running setup.php, need to use `mysql` for 'Server Host', `root` for 'Root Password', and `%` for 'User Hostname'.
     - To reset and reinstall OpenEMR:
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools dev-reset-install'
+      docker compose exec openemr /root/devtools dev-reset-install
       ```
     - To reset and reinstall OpenEMR with demo data (this includes several users with access controls setup in addition to patient portal logins. [See HERE for those credentials](https://www.open-emr.org/wiki/index.php/Development_Demo#Demo_Credentials).):
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools dev-reset-install-demodata'
+      docker compose exec openemr /root/devtools dev-reset-install-demodata
       ```
         - hint: this is also a great way to test any changes a developer has made to the sql upgrade stuff (ie. such as sql/5_0_2-to-6_0_0_upgrade.sql)
 8. <a name="dev_tools_backup"></a>Backup and restore OpenEMR data (database and data on drive) via snapshots.
@@ -268,15 +263,15 @@ The OpenEMR development docker environment has a very rich advanced feature set.
 
      - Create a backup snapshot (using `example` below, but can use any alphanumeric identifier):
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools backup example'
+      docker compose exec openemr /root/devtools backup example
       ```
     - Restore from a snapshot (using `example` below, but can use any alphanumeric identifier)
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools restore example'
+      docker compose exec openemr /root/devtools restore example
       ```
     - To list the snapshots
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools list-snapshots'
+      docker compose exec openemr /root/devtools list-snapshots
       ```
 9. <a name="dev_tools_send"></a>Send/receive snapshots (via capsules) that are created above in item 8.
     - For the Video Tutorial, click below:
@@ -288,24 +283,24 @@ The OpenEMR development docker environment has a very rich advanced feature set.
     - Here is how to grab a capsule from the docker, which can then store or share with friends.
         - List the capsules:
           ```sh
-          docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools list-capsules'
+          docker compose exec openemr /root/devtools list-capsules
           ```
         - Copy the capsule from the docker to your current directory (using `example.tgz` below):
           ```sh
-          docker cp $(docker ps | grep _openemr | cut -f 1 -d " "):/snapshots/example.tgz .
+          docker compose cp openemr:/snapshots/example.tgz .
           ```
     - Here is how to send a capsule into the docker.
         - Copy the capsule from current directory into the docker (using `example.tgz` below):
           ```sh
-          docker cp example.tgz $(docker ps | grep _openemr | cut -f 1 -d " "):/snapshots/
+          docker compose cp example.tgz openemr:/snapshots/
           ```
         - Restore from the new shiny snapshot (using `example` below):
           ```sh
-          docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools restore example'
+          docker compose exec openemr /root/devtools restore example
           ```
         - Ensure run upgrade to ensure will work with current version OpenEMR:
           ```sh
-          docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools upgrade 5.0.2'
+          docker compose exec openemr /root/devtools upgrade 5.0.2
           ```
 10. <a name="dev_tools_randompatients"></a>Create and add random patient data. This will use synthea to create random patients that are then imported into OpenEMR. You can choose the number of patients. Note that each patient will take several seconds.
     - For the Video Tutorial, click below:
@@ -316,144 +311,144 @@ The OpenEMR development docker environment has a very rich advanced feature set.
 
     - Create and add 100 random patients (defaults to development mode set to true, which is set be default to true; development mode will markedly improve performance by bypassing the import of the ccda document and bypassing the use of the audit_master and audit_details tables and will directly import the new patient data from the ccda. Note this should never be done on sites that already contain real data/use, and it will also turn off the audit log during the import.):
        ```sh
-       docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools import-random-patients 100'
+       docker compose exec openemr /root/devtools import-random-patients 100
        ```
        or
        ```sh
-       docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools import-random-patients 100 true'
+       docker compose exec openemr /root/devtools import-random-patients 100 true
        ```
     - Create and add 100 random patients (with development mode set to false)
        ```sh
-       docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools import-random-patients 100 false'
+       docker compose exec openemr /root/devtools import-random-patients 100 false
        ```
 11. <a name="dev_tools_bankmultisite"></a>Create a bank of multisites with selected number of multisites that are all labelled from run1..runx. It will clone from the default instance. This can be helpful for testing of multisites and other larger scale testing.
     - Create 5 multisites (will be run1, run2, run3, run4, run5):
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools generate-multisite-bank 5'
+      docker compose exec openemr /root/devtools generate-multisite-bank 5
       ```
 12. <a name="dev_tools_multisite"></a>Turn on and turn off support for multisite feature (to allow setting up multisites in setup.php script).
     - Turn on support for multisite:
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools enable-multisite'
+      docker compose exec openemr /root/devtools enable-multisite
       ```
     - Turn off support for multisite:
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools disable-multisite'
+      docker compose exec openemr /root/devtools disable-multisite
       ```
 13. <a name="dev_tools_listmultisite"></a>The available multsites can be listed via following command:
     ```sh
-    docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools list-multisites'
+    docker compose exec openemr /root/devtools list-multisites
     ```
 14. <a name="dev_tools_charset"></a>Change the database character set and collation (character set is the encoding that is used to store data in the database; collation are a set of rules that the database uses to sort the stored data).
     - Best to demonstrate this devtool with examples.
         - Set character set to utf8mb4 and collation to utf8mb4_general_ci (this is default for OpenEMR 6 and higher):
           ```sh
-          docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools change-encoding-collation utf8mb4 utf8mb4_general_ci'
+          docker compose exec openemr /root/devtools change-encoding-collation utf8mb4 utf8mb4_general_ci
           ```
         - Set character set to utf8mb4 and collation to utf8mb4_unicode_ci:
           ```sh
-          docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools change-encoding-collation utf8mb4 utf8mb4_unicode_ci'
+          docker compose exec openemr /root/devtools change-encoding-collation utf8mb4 utf8mb4_unicode_ci
           ```
         - Set character set to utf8mb4 and collation to utf8mb4_vietnamese_ci:
           ```sh
-          docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools change-encoding-collation utf8mb4 utf8mb4_vietnamese_ci'
+          docker compose exec openemr /root/devtools change-encoding-collation utf8mb4 utf8mb4_vietnamese_ci
           ```
         - Set character set to utf8 and collation to utf8_general_ci (this is default for OpenEMR 5 and lower):
           ```sh
-          docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools change-encoding-collation utf8 utf8_general_ci'
+          docker compose exec openemr /root/devtools change-encoding-collation utf8 utf8_general_ci
           ```
 15. <a name="dev_tools_https"></a>Test ssl certificate (to test client based certificates and revert back to default self signed certificate) and force/unforce https.
     - To test client based certificates, create a zip package of the certificate in OpenEMR at Administration->System->Certificates. Then can import this zip package (example `ssl.zip`) into the docker via:
       ```sh
-      docker cp ssl.zip $(docker ps | grep _openemr | cut -f 1 -d " "):/certs/
+      docker compose cp ssl.zip openemr:/certs/
       ```
     - To list the available certificate packages on docker:
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools list-client-certs'
+      docker compose exec openemr /root/devtools list-client-certs
       ```
     - To install and configure a certificate package (example `ssl`):
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools setup-client-cert ssl'
+      docker compose exec openemr /root/devtools setup-client-cert ssl
       ```
     - To revert back to selfsigned certicates (ie. revert the changes required for client based certificates):
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools on-self-signed-cert'
+      docker compose exec openemr /root/devtools on-self-signed-cert
       ```
     - To force https in apache script via redirect:
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools force-https'
+      docker compose exec openemr /root/devtools force-https
       ```
     - To revert the changes that forced https in apache script:
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools un-force-https'
+      docker compose exec openemr /root/devtools un-force-https
       ```
 16. <a name="dev_tools_ssl"></a>Place/remove testing sql ssl certificate and testing sql ssl client key/cert.
     - Place the testing sql ssl CA cert:
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools sql-ssl'
+      docker compose exec openemr /root/devtools sql-ssl
       ```
     - Remove the testing sql ssl CA cert:
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools sql-ssl-off'
+      docker compose exec openemr /root/devtools sql-ssl-off
       ```
     - Place the testing sql ssl CA cert and testing sql ssl client key/cert:
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools sql-ssl-client'
+      docker compose exec openemr /root/devtools sql-ssl-client
       ```
     - Remove the testing sql ssl CA cert and testing sql ssl client key/cert:
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools sql-ssl-client-off'
+      docker compose exec openemr /root/devtools sql-ssl-client-off
       ```
 17. <a name="dev_tools_couchdb"></a>CouchDB integration.
     - In OpenEMR, CouchDB is an option for the patients document storage. For this reason, a CouchDB docker is included in this OpenEMR docker development environment. You can visit the CouchDB GUI directly via http://localhost:5984/_utils/ or https://localhost:6984/_utils/ with username `admin` and password `password`. You can configure OpenEMR to use this CouchDB docker for patient document storage in OpenEMR at Administration->Globals->Documents:
         - Document Storage Method->CouchDB
     - After running the following devtools, 'dev-reset', 'dev-install', 'dev-reset-install', 'dev-reset-install-demodata', 'restore-snapshot', then need to restart the couchdb docker via the following command:
         ```sh
-        docker restart $(docker ps | grep _couchdb_1 | cut -f 1 -d " ")
+        docker compose restart couchdb
         ```
     - Developer tools to place/remove testing couchdb ssl certificate and testing couchdb ssl client key/cert.
         - Place the testing couchdb ssl CA cert:
           ```sh
-          docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools couchdb-ssl'
+          docker compose exec openemr /root/devtools couchdb-ssl
           ```
         - Remove the testing couchdb ssl CA cert:
           ```sh
-          docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools couchdb-ssl-off'
+          docker compose exec openemr /root/devtools couchdb-ssl-off
           ```
         - Place the testing couchdb ssl CA cert and testing couchdb ssl client key/cert:
           ```sh
-          docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools couchdb-ssl-client'
+          docker compose exec openemr /root/devtools couchdb-ssl-client
           ```
         - Remove the testing couchdb ssl CA cert and testing couchdb ssl client key/cert:
           ```sh
-          docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools couchdb-ssl-client-off'
+          docker compose exec openemr /root/devtools couchdb-ssl-client-off
           ```
 18. <a name="dev_tools_ldap"></a>LDAP integration.
     - In OpenEMR, LDAP is an option for authentication. If this is turned on, then this will be supported for the `admin` user, which will use the following password: `admin`
     - Turn on LDAP:
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools enable-ldap'
+      docker compose exec openemr /root/devtools enable-ldap
       ```
     - Turn off LDAP:
       ```sh
-      docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools disable-ldap'
+      docker compose exec openemr /root/devtools disable-ldap
       ```
     - Developer tools to place/remove testing ldap tls/ssl certificate and testing ldap tls/ssl client key/cert.
         - Place the testing ldap tls/ssl CA cert:
           ```sh
-          docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools ldap-ssl'
+          docker compose exec openemr /root/devtools ldap-ssl
           ```
         - Remove the testing ldap tls/ssl CA cert:
           ```sh
-          docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools ldap-ssl-off'
+          docker compose exec openemr /root/devtools ldap-ssl-off
           ```
         - Place the testing ldap tls/ssl CA cert and testing ldap tls/ssl client key/cert:
           ```sh
-          docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools ldap-ssl-client'
+          docker compose exec openemr /root/devtools ldap-ssl-client
           ```
         - Remove the testing ldap tls/ssl CA cert and testing ldap tls/ssl client key/cert:
           ```sh
-          docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools ldap-ssl-client-off'
+          docker compose exec openemr /root/devtools ldap-ssl-client-off
           ```
 19. <a name="dev_tools_webroot"></a>Test webroot value.
     - The default setup of the docker development environments are with a blank webroot, however, it is a good idea to also test with a webroot setting. There is an option to set the webroot to openemr.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ You will need a "local" version of OpenEMR to make changes to the source code. T
       - (Recommend using Ubuntu Desktop 22.04 for above video and other videos in the [OpenEMR Easy Docker Development Environment Video Series](https://www.youtube.com/playlist?list=PLFiWG_dDadgQT7zjqvEqbXm1OiuubOVO8). Easiest way to do this is setting up a [Ubuntu Desktop 22.04 Virtual Machine on VirtualBox](https://ubuntu.com/tutorials/how-to-run-ubuntu-desktop-on-a-virtual-machine-using-virtualbox), which recommend configuring with 40GB hard drive, assigning 25% of computer memory, and assigning 25% of cpu cores to the virtual machine.)
 
     - If you haven't already, [install git](https://git-scm.com/downloads) for your system
-	- (optional) If you want to set up the base services(e.g. git, docker, docker-compose, openemr-cmd, minkube and kubectl) easily, please try [openemr-env-installer](https://github.com/openemr/openemr-devops/tree/master/utilities/openemr-env-installer)
+	- (optional) If you want to set up the base services(e.g. git, docker, docker compose, openemr-cmd, minkube and kubectl) easily, please try [openemr-env-installer](https://github.com/openemr/openemr-devops/tree/master/utilities/openemr-env-installer)
     - (optional) It's best to also add an `upstream` origin to keep your local fork up to date. [Check out this guide](https://oneemptymind.wordpress.com/2018/07/11/keeping-a-fork-up-to-date/) for more info.
 2. `cd openemr/docker/development-easy` (if you are running this on Raspberry Pi, then instead do `cd openemr/docker/development-easy-arm32` or `cd openemr/docker/development-easy-arm64`)
     - If you haven't already, [install Docker](https://docs.docker.com/install/) and [install compose](https://docs.docker.com/compose/install/) for your system
@@ -36,7 +36,7 @@ You will need a "local" version of OpenEMR to make changes to the source code. T
     - (optional) If you want to monitor and easily manage the docker environment, please also [install openemr-monitor](https://github.com/openemr/openemr-devops/tree/master/utilities/openemr-monitor) and [install portainer](https://github.com/openemr/openemr-devops/tree/master/utilities/portainer) for your system
     - (optional) If you want to migrate the running docker environment, please try [openemr-env-migrator](https://github.com/openemr/openemr-devops/tree/master/utilities/openemr-env-migrator)
     - (optional) If you want to set up with orchestration tool, please try [OpenEMR Kubernetes Orchestrations](https://github.com/openemr/openemr-devops/tree/master/kubernetes/minikube)
-3. Run `docker-compose up` from your command line
+3. Run `docker compose up` from your command line
     - When the build is done, you'll see the following message:
     ```sh
     openemr_1  | Love OpenEMR? You can now support the project via the open collective:
@@ -64,8 +64,8 @@ You will need a "local" version of OpenEMR to make changes to the source code. T
       ```sh
       docker exec -i $(docker ps | grep _openemr | cut -f 1 -d " ") sh -c '/root/devtools build-themes'
       ```
-7. When you're done, it's best to clean up after yourself with `docker-compose down -v`
-    - If you don't want to build from scratch every time, just use `docker-compose down` so your next `docker-compose up` will use the cached volumes.
+7. When you're done, it's best to clean up after yourself with `docker compose down -v`
+    - If you don't want to build from scratch every time, just use `docker compose down` so your next `docker compose up` will use the cached volumes.
 8. To ensure you are using the most recent dockers, recommend running below set of commands intermittently:
     ```console
     docker pull openemr/openemr:flex

--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -18,13 +18,13 @@ Several example docker-compose.yml scripts are discussed below.
 ### Production example
 An example docker-compose.yml script can be found at
 [docker/production/docker-compose.yml](docker/production/docker-compose.yml). After modifying the
-script for your purposes, it can then be started with `docker-compose up`, which will then take about 5-10
+script for your purposes, it can then be started with `docker compose up`, which will then take about 5-10
 minutes to complete.
 
 ### Production example for Raspberry Pi
 An example docker-compose.yml script for Raspberry Pi can be found at
 [docker/production-arm/docker-compose.yml](docker/production-arm/docker-compose.yml). After modifying the
-script for your purposes, it can then be started with `docker-compose up`, which will then take about 5-10
+script for your purposes, it can then be started with `docker compose up`, which will then take about 5-10
 minutes to complete.
 
 ## Development Dockers

--- a/docker/development-insane/README.md
+++ b/docker/development-insane/README.md
@@ -9,7 +9,7 @@ Docker Environment. See below for instructions of use of the Insane Development 
 [docker](https://www.docker.com/get-docker) and
 [compose](https://docs.docker.com/compose/install/) for your system. Also, make
 sure you have a [fork](https://help.github.com/articles/fork-a-repo/) of OpenEMR.
-- If you want to set up the base services(e.g. git, docker, docker-compose, openemr-cmd) easily, please try [openemr-env-installer](https://github.com/openemr/openemr-devops/tree/master/utilities/openemr-env-installer)
+- If you want to set up the base services(e.g. git, docker, docker compose, openemr-cmd) easily, please try [openemr-env-installer](https://github.com/openemr/openemr-devops/tree/master/utilities/openemr-env-installer)
 - If you want to troubleshoot with the below steps easier, please also [install openemr-cmd](https://github.com/openemr/openemr-devops/tree/master/utilities/openemr-cmd) for your system
 - If you want to monitor and easily manage the docker environment, please also [install openemr-monitor](https://github.com/openemr/openemr-devops/tree/master/utilities/openemr-monitor) and [install portainer](https://github.com/openemr/openemr-devops/tree/master/utilities/portainer) for your system
 - If you want to migrator the running docker environment, please try [openemr-env-migrator](https://github.com/openemr/openemr-devops/tree/master/utilities/openemr-env-migrator)
@@ -23,13 +23,13 @@ There are 2 different schools of thought on where to run the docker from.
 scripts in your editor)
 ```bash
 $ cd openemr/docker/development-insane
-$ docker-compose up -d
+$ docker compose up -d
 ```
 - Option 2. Run the docker from a separate directory that is synchronized with your git
 repository. For example, if used /var/www/openemr.
 ```bash
  $ cd /var/www/openemr/docker/development-insane
- $ docker-compose up -d
+ $ docker compose up -d
 ```
 - At this time, I highly recommend option 2 since running OpenEMR will change
 scripts, add files, add cache files, thus making it very tough to track your
@@ -111,8 +111,8 @@ different github branch. This is done by first running a command or script
 to delete and replace the synchronized directory (ie. remove the /var/www/openemr
 directory) and then restart the development docker:
 ```bash
-docker-compose down -v
-docker-compose up -d
+docker compose down -v
+docker compose up -d
 ```
 
 #### Updating Dockers

--- a/docker/development-insane/docker-compose.yml
+++ b/docker/development-insane/docker-compose.yml
@@ -7,7 +7,7 @@
 # Brief instructions on how to use (for fuller instructions and examples,
 #  see the document at contrib/util/docker/README.md):
 #   1. go to contrib/util/docker directory
-#   2. docker-compose up -d
+#   2. docker compose up -d
 #   3. Choose one of any of the following links:
 #        http://localhost:8082 (with Alpine 3.15 (Apache and PHP 8.0))
 #        http://localhost:8083 (with Alpine 3.17 (Apache and PHP 8.1))
@@ -64,8 +64,8 @@
 #     2. for Root Pass, use 'root'
 #     3. for User Hostname, use '%'
 #    And when need to tear it down and restart it
-#     1. docker-compose down -v
-#     2. docker-compose up -d
+#     1. docker compose down -v
+#     2. docker compose up -d
 #    Can see databases via http://localhost:8200
 #
 services:


### PR DESCRIPTION
Fixes #8515

#### Short description of what this resolves:

Use `docker compose` directly instead of `docker ... $(docker compose ps)` to run commands in compose services.

#### Changes proposed in this pull request:

- doc: s/docker-compose/docker compose/ for command guidance
- doc(CONTRIBUTING): use docker compose syntax directly

#### Does your code include anything generated by an AI Engine? No
