### PR TITLE
chore(shellcheck): ignore SC1091

### DIFF
--- a/contrib/util/ubuntu_package_scripts/production/config
+++ b/contrib/util/ubuntu_package_scripts/production/config
@@ -20,6 +20,7 @@
 # DUMMY CONFIG FILE
 
 # Source debconf library.
+# shellcheck disable=SC1091
 . /usr/share/debconf/confmodule
 
 # Dummy script to allow prompting within other maintainer scripts

--- a/contrib/util/ubuntu_package_scripts/production/postinst
+++ b/contrib/util/ubuntu_package_scripts/production/postinst
@@ -42,6 +42,7 @@
 # the debian-policy package
 
 # Source debconf library.
+# shellcheck disable=SC1091
 . /usr/share/debconf/confmodule
 
 case "$1" in

--- a/contrib/util/ubuntu_package_scripts/production/postrm
+++ b/contrib/util/ubuntu_package_scripts/production/postrm
@@ -27,6 +27,7 @@
 #
 
 # Source debconf library.
+# shellcheck disable=SC1091
 . /usr/share/debconf/confmodule
 
 #constants

--- a/contrib/util/ubuntu_package_scripts/production/preinst
+++ b/contrib/util/ubuntu_package_scripts/production/preinst
@@ -37,6 +37,7 @@
 # the debian-policy package
 
 # Source debconf library.
+# shellcheck disable=SC1091
 . /usr/share/debconf/confmodule
 
 #constants and paths

--- a/contrib/util/ubuntu_package_scripts/production/prerm
+++ b/contrib/util/ubuntu_package_scripts/production/prerm
@@ -32,6 +32,7 @@
 # the debian-policy package
 
 # Source debconf library.
+# shellcheck disable=SC1091
 . /usr/share/debconf/confmodule
 
 case "$1" in
@@ -84,7 +85,7 @@ case "$1" in
       }
 
       #function to collect variables from config files
-      # 1st param is variable name, 2nd param is filename 
+      # 1st param is variable name, 2nd param is filename
       collect_var () {
          echo $(grep -i "^[[:space:]]*$1[[:space:]=]" $2 | cut -d \= -f 2 | cut -d \; -f 1 | sed "s/[ 	'\"]//gi")
       }


### PR DESCRIPTION
We don't vendor /usr/share/debconf/confmodule for shellcheck to follow it.
