### PR TITLE
fix(shellcheck): autofix

### DIFF
--- a/bin/generate-ehi-documentation.sh
+++ b/bin/generate-ehi-documentation.sh
@@ -43,4 +43,4 @@ FILTER_CLAUSE="-i ${TABLES_INCLUDE}"
 # -noDbObjectPaging
 # schema file is named openemr.meta.xml
 
-java -jar ${JAR_FILES}/schemaspy.jar -t ${TYPE} -host ${DB_HOST} -port ${DB_PORT} -db ${DB_NAME} -u ${DB_USER} -p ${DB_PASSWORD} -o ${DOC_OUTPUT} -s ${DB_SCHEMA} -dp ${JAVA_CONNECTOR} -vizjs -norows -noimplied -nopages ${FILTER_CLAUSE} -meta ${SCHEMA_LOCATION} -template ${TEMPLATE_LOCATION}
+java -jar "${JAR_FILES}"/schemaspy.jar -t "${TYPE}" -host "${DB_HOST}" -port "${DB_PORT}" -db "${DB_NAME}" -u "${DB_USER}" -p "${DB_PASSWORD}" -o "${DOC_OUTPUT}" -s "${DB_SCHEMA}" -dp "${JAVA_CONNECTOR}" -vizjs -norows -noimplied -nopages "${FILTER_CLAUSE}" -meta "${SCHEMA_LOCATION}" -template "${TEMPLATE_LOCATION}"

--- a/contrib/util/backup_oemr.sh
+++ b/contrib/util/backup_oemr.sh
@@ -18,29 +18,29 @@ newerthan='2005-01-01'
 file=$(date +%F)
 
 #get the content from the mysql database
-mysqldump -u ${dbuser} -p${dbpass} --databases ${db} > ${workdir}${file}.sql.bak
+mysqldump -u "${dbuser}" -p"${dbpass}" --databases "${db}" > "${workdir}""${file}".sql.bak
 
 # compress the file
-bzip2 ${workdir}${file}.sql.bak
+bzip2 "${workdir}""${file}".sql.bak
 
 #get the content from the postgres database
-pg_dumpall -U ${pguser} > ${workdir}${file}postgres.bak
+pg_dumpall -U "${pguser}" > "${workdir}""${file}"postgres.bak
 
 # compress the file
-bzip2 ${workdir}${file}postgres.bak
+bzip2 "${workdir}""${file}"postgres.bak
 
 # get all the files on the site
 # we are using bzip2 here
-tar -N ${newerthan} -jcf ${workdir}${file}openemr.tar.bzip2 ${installdir}
+tar -N "${newerthan}" -jcf "${workdir}""${file}"openemr.tar.bzip2 "${installdir}"
 
 # create a disk image
 label=$(date +%y%m%d)
-mkisofs -J -R -V ${label} -o ${tempdir}image.iso ${workdir}
+mkisofs -J -R -V "${label}" -o "${tempdir}"image.iso "${workdir}"
 
 #burn it
-cdrecord -dao -v -data -eject ${tempdir}image.iso
+cdrecord -dao -v -data -eject "${tempdir}"image.iso
 
 #delete the original files
-rm -rf ${workdir}*
+rm -rf "${workdir}"*
 
 exit 0

--- a/docker/library/dockers/dev-php-fpm/data/docker-php-ext-configure
+++ b/docker/library/dockers/dev-php-fpm/data/docker-php-ext-configure
@@ -55,7 +55,7 @@ if [ "${pm}" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual .phpize-deps-configure ${PHPIZE_DEPS}
+		apk add --no-cache --virtual .phpize-deps-configure "${PHPIZE_DEPS}"
 	fi
 fi
 

--- a/docker/library/dockers/dev-php-fpm/data/docker-php-ext-enable
+++ b/docker/library/dockers/dev-php-fpm/data/docker-php-ext-enable
@@ -110,5 +110,5 @@ for module in ${modules}; do
 done
 
 if [ "${pm}" = 'apk' ] && [ -n "${apkDel}" ]; then
-	apk del ${apkDel}
+	apk del "${apkDel}"
 fi

--- a/docker/library/dockers/dev-php-fpm/data/docker-php-ext-install
+++ b/docker/library/dockers/dev-php-fpm/data/docker-php-ext-install
@@ -92,7 +92,7 @@ if [ "${pm}" = 'apk' ]; then
 		if apk info --installed .phpize-deps-configure > /dev/null; then
 			apkDel='.phpize-deps-configure'
 		elif ! apk info --installed .phpize-deps > /dev/null; then
-			apk add --no-cache --virtual .phpize-deps ${PHPIZE_DEPS}
+			apk add --no-cache --virtual .phpize-deps "${PHPIZE_DEPS}"
 			apkDel='.phpize-deps'
 		fi
 	fi
@@ -114,7 +114,7 @@ for ext in ${exts}; do
 done
 
 if [ "${pm}" = 'apk' ] && [ -n "${apkDel}" ]; then
-	apk del ${apkDel}
+	apk del "${apkDel}"
 fi
 
 if [ -e /usr/src/php/.docker-delete-me ]; then

--- a/interface/de_identification_forms/de_identification_procedure.sh
+++ b/interface/de_identification_forms/de_identification_procedure.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ########### calls de-identification procedure ###########
-mysql -u $2 -p$3 -h $1 -D $4 -e "call de_identification()"
+mysql -u "$2" -p"$3" -h "$1" -D "$4" -e "call de_identification()"
 
 
 

--- a/interface/de_identification_forms/re_identification_procedure.sh
+++ b/interface/de_identification_forms/re_identification_procedure.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ###########  calls re-identification procedure  ###########
-mysql -u $2 -p$3 -h $1 -D $4 -e "call re_identification()"
+mysql -u "$2" -p"$3" -h "$1" -D "$4" -e "call re_identification()"
 
 
 


### PR DESCRIPTION
#### Short description of what this resolves:

Use `shellcheck -f diff | git apply` to automatically fix those remaining shellcheck issues that can be automatically fixed.

#### Changes proposed in this pull request:

Mostly putting quotes around expansions.

This can cause issues in cases where whitespace was built up in a variable directly. I'm not sure how to test for that expressly, but we can address those if they should appear.

#### Does your code include anything generated by an AI Engine? No

By automation, yes. By AI? No.
