### PR TITLE
Update dependabot.yml - changed rebase-strategy for composer to manual since the auto was overtaking the ci testing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "08:00"
+    rebase-strategy: "disabled"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"


### PR DESCRIPTION
Update dependabot.yml - changed rebase-strategy for composer to manual since the auto was overtaking the ci testing
