### PR TITLE
fix: phpunit dataprovider defaults

### DIFF
--- a/tests/Tests/E2e/HhMainMenuLinksTest.php
+++ b/tests/Tests/E2e/HhMainMenuLinksTest.php
@@ -29,10 +29,10 @@ class HhMainMenuLinksTest extends PantherTestCase
     private $crawler;
 
     /**
-     * @dataProvider menuLinkProvider
      * @depends testLoginAuthorized
      */
-    public function testMainMenuLink(string $menuLink, string $expectedTabTitle, ?string $loading): void
+    #[DataProvider('menuLink')]
+    public function testMainMenuLink(string $menuLink, string $expectedTabTitle, ?string $loading = null): void
     {
         if ($expectedTabTitle == "Care Coordination" && !empty(getenv('UNABLE_SUPPORT_OPENEMR_NODEJS', true) ?? '')) {
             // Care Coordination page check will be skipped since this flag is set (which means the environment does not have
@@ -74,7 +74,7 @@ class HhMainMenuLinksTest extends PantherTestCase
         }
     }
 
-    public static function menuLinkProvider()
+    public static function menuLink()
     {
         return [
             'Calendar menu link' => ['Calendar', 'Calendar'],

--- a/tests/Tests/E2e/HhMainMenuLinksTest.php
+++ b/tests/Tests/E2e/HhMainMenuLinksTest.php
@@ -29,10 +29,10 @@ class HhMainMenuLinksTest extends PantherTestCase
     private $crawler;
 
     /**
+     * @dataProvider menuLinkProvider
      * @depends testLoginAuthorized
      */
-    #[DataProvider('menuLink')]
-    public function testMainMenuLink(string $menuLink, string $expectedTabTitle, ?string $loading = null): void
+    public function testMainMenuLink(string $menuLink, string $expectedTabTitle, ?string $loading = ''): void
     {
         if ($expectedTabTitle == "Care Coordination" && !empty(getenv('UNABLE_SUPPORT_OPENEMR_NODEJS', true) ?? '')) {
             // Care Coordination page check will be skipped since this flag is set (which means the environment does not have
@@ -74,7 +74,7 @@ class HhMainMenuLinksTest extends PantherTestCase
         }
     }
 
-    public static function menuLink()
+    public static function menuLinkProvider()
     {
         return [
             'Calendar menu link' => ['Calendar', 'Calendar'],

--- a/tests/Tests/E2e/IiPatientContextMainMenuLinksTest.php
+++ b/tests/Tests/E2e/IiPatientContextMainMenuLinksTest.php
@@ -32,11 +32,11 @@ class IiPatientContextMainMenuLinksTest extends PantherTestCase
     private $crawler;
 
     /**
+     * @dataProvider menuLinkProvider
      * @depends testLoginAuthorized
      * @depends testPatientOpen
      */
-    #[DataProvider('menuLink')]
-    public function testPatientContextMainMenuLink(string $menuLink, string $expectedTabPopupTitle, bool $popup, ?string $loading = null, ?bool $clearAlert = false): void
+    public function testPatientContextMainMenuLink(string $menuLink, string $expectedTabPopupTitle, bool $popup, ?string $loading = '', ?bool $clearAlert = false): void
     {
         if ($expectedTabPopupTitle == "Care Coordination" && !empty(getenv('UNABLE_SUPPORT_OPENEMR_NODEJS', true) ?? '')) {
             // Care Coordination page check will be skipped since this flag is set (which means the environment does not have
@@ -87,7 +87,7 @@ class IiPatientContextMainMenuLinksTest extends PantherTestCase
         }
     }
 
-    public static function menuLink()
+    public static function menuLinkProvider()
     {
         return [
             'Patient -> Dashboard menu link' => ['Patient||Dashboard', 'Dashboard', false],

--- a/tests/Tests/E2e/IiPatientContextMainMenuLinksTest.php
+++ b/tests/Tests/E2e/IiPatientContextMainMenuLinksTest.php
@@ -32,11 +32,11 @@ class IiPatientContextMainMenuLinksTest extends PantherTestCase
     private $crawler;
 
     /**
-     * @dataProvider menuLinkProvider
      * @depends testLoginAuthorized
      * @depends testPatientOpen
      */
-    public function testPatientContextMainMenuLink(string $menuLink, string $expectedTabPopupTitle, bool $popup, ?string $loading, ?bool $clearAlert = false): void
+    #[DataProvider('menuLink')]
+    public function testPatientContextMainMenuLink(string $menuLink, string $expectedTabPopupTitle, bool $popup, ?string $loading = null, ?bool $clearAlert = false): void
     {
         if ($expectedTabPopupTitle == "Care Coordination" && !empty(getenv('UNABLE_SUPPORT_OPENEMR_NODEJS', true) ?? '')) {
             // Care Coordination page check will be skipped since this flag is set (which means the environment does not have
@@ -87,7 +87,7 @@ class IiPatientContextMainMenuLinksTest extends PantherTestCase
         }
     }
 
-    public static function menuLinkProvider()
+    public static function menuLink()
     {
         return [
             'Patient -> Dashboard menu link' => ['Patient||Dashboard', 'Dashboard', false],


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #8567 

#### Short description of what this resolves:


#### Changes proposed in this pull request:

#### Does your code include anything generated by an AI Engine? Yes / No

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.
