### PR TITLE
fix(phpstan): missing returns

### DIFF
--- a/gacl/Cache_Lite/Lite.php
+++ b/gacl/Cache_Lite/Lite.php
@@ -472,11 +472,14 @@ class Cache_Lite
     *
     * @param string $msg error message
     * @param int $code error code
+    * @throws PEAR_Error
+    * @return never
     * @access public
     */
     function raiseError($msg, $code)
     {
         include_once('PEAR.php');
+        /** @phpstan-ignore-next-line */
         PEAR::raiseError($msg, $code, $this->_pearErrorMode);
     }
 

--- a/interface/eRxPage.php
+++ b/interface/eRxPage.php
@@ -132,7 +132,7 @@ class eRxPage
      */
     public function getPrescriptionIds()
     {
-        $this->prescriptionIds;
+        return $this->prescriptionIds;
     }
 
     /**

--- a/interface/forms/eye_mag/php/eye_mag_functions.php
+++ b/interface/forms/eye_mag/php/eye_mag_functions.php
@@ -3286,7 +3286,7 @@ function display_draw_section($zone, $encounter, $pid, $side = 'OU', $counter = 
  * @param string $zone options ALL,EXT,ANTSEG,RETINA,NEURO, EXT_DRAW, ANTSEG_DRAW, RETINA_DRAW, NEURO_DRAW
  * @param string $form_id is the form_eye_*.id where the data to carry forward is located
  * @param string $pid value = patient id
- * @return true : when called directly outputs the ZONE specific HTML for a prior record + widget for the desired zone
+ * @return void : outputs the ZONE specific HTML for a prior record + widget for the desired zone
  */
 function copy_forward($zone, $copy_from, $copy_to, $pid)
 {

--- a/interface/forms/eye_mag/php/eye_mag_functions.php
+++ b/interface/forms/eye_mag/php/eye_mag_functions.php
@@ -1592,7 +1592,7 @@ margin: 2px 0 2px 2px;">
  * via display_PMSFH('2') and show_PMSFH_panel($PMSFH) respectively,
  * to javascript to display changes to the user.
  * @param associative array $PMSFH if it exists
- * @return json encoded string
+ * @return void
  */
 function send_json_values($PMSFH = "")
 {

--- a/interface/forms/eye_mag/php/eye_mag_functions.php
+++ b/interface/forms/eye_mag/php/eye_mag_functions.php
@@ -3172,7 +3172,7 @@ function canvas_select($zone, $encounter, $pid)
  *  @param string $visit_date Future functionality to limit result set. UTC DATE Formatted
  *  @param string $pid value = patient id
  *  @param string OU by default.  Future functionality will allow OD and OS values- not implemented yet.
- *  @return true : when called directly outputs the ZONE specific HTML5 CANVAS widget
+ *  @return void : outputs the ZONE specific HTML5 CANVAS widget
  */
 function display_draw_section($zone, $encounter, $pid, $side = 'OU', $counter = '')
 {

--- a/interface/forms/eye_mag/view.php
+++ b/interface/forms/eye_mag/view.php
@@ -173,7 +173,7 @@ if ($refresh and $refresh != 'fullscreen') {
     } elseif ($refresh == "PMSFH_panel") {
         echo show_PMSFH_panel($PMSFH);
     } elseif ($refresh == "page") {
-        echo send_json_values($PMSFH);
+        send_json_values($PMSFH);
     } elseif ($refresh == "GFS") {
         echo display_GlaucomaFlowSheet($pid);
     }

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/TwilioSMSClient.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/TwilioSMSClient.php
@@ -302,7 +302,7 @@ class TwilioSMSClient extends AppDispatch
      */
     function sendFax(): string|bool
     {
-        // TODO: Implement sendFax() method.
+        throw new \Exception("sendFax() method not implemented");
     }
 
     /**
@@ -318,6 +318,6 @@ class TwilioSMSClient extends AppDispatch
      */
     function sendEmail(): mixed
     {
-        // TODO: Implement sendEmail() method.
+        throw new \Exception("sendEmail() method not implemented");
     }
 }

--- a/interface/therapy_groups/therapy_groups_controllers/therapy_groups_controller.php
+++ b/interface/therapy_groups/therapy_groups_controllers/therapy_groups_controller.php
@@ -404,6 +404,8 @@ class TherapyGroupsController extends BaseController
         foreach ($counselors as $counselorId) {
             $this->counselorsModel->save($groupData['group_id'], $counselorId);
         }
+
+        return $groupData['group_id'];
     }
 
     static function setSession($groupId)

--- a/library/calendar.inc.php
+++ b/library/calendar.inc.php
@@ -90,5 +90,5 @@ function is_weekend_day($day)
  */
 function is_holiday($date)
 {
-    Holidays_Controller::is_holiday($date);
+    return Holidays_Controller::is_holiday($date);
 }

--- a/library/clinical_rules.php
+++ b/library/clinical_rules.php
@@ -868,6 +868,9 @@ function test_rules_clinic_collate($provider = '', $type = '', $dateTarget = '',
         // done, so now can return results
         return $results;
     }
+
+    // Default return for cases not covered by the above conditions
+    return $results;
 }
 
 /**

--- a/library/edihistory/edih_835_html.php
+++ b/library/edihistory/edih_835_html.php
@@ -27,6 +27,7 @@
 function edih_round_cb(&$v, $k)
 {
     $v = round((int)$v, 2);
+    return $v;
 }
 /**
  * Create summary html string for an x12 835 claim payment


### PR DESCRIPTION
#### Short description of what this resolves:

Fixes several PHPStan findings related to return annotations not matching the actual return.

#### Changes proposed in this pull request:

- fix(raiseError): inform phpstan it raises error
- fix(getPrescriptionIds): missing return statement
- fix(send_json_values): no return value
- fix(display_draw_section): return value not meaningful
- fix(copy_forward): return value not meaningful

#### Does your code include anything generated by an AI Engine? No
