### PR TITLE
refactor(calendar): remove return/store polymorphism from pnHTML

### DIFF
--- a/.phpstan/baseline/assign.propertyType.php
+++ b/.phpstan/baseline/assign.propertyType.php
@@ -97,16 +97,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/vitals/C_FormVitals.class.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Property pnHTML\\:\\:\\$header \\(string\\) does not accept array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/includes/pnHTML.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Property pnHTML\\:\\:\\$output \\(string\\) does not accept mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/includes/pnHTML.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Property Smarty_Legacy\\:\\:\\$caching \\(int\\) does not accept false\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/pnadmin.php',

--- a/.phpstan/baseline/assignOp.invalid.php
+++ b/.phpstan/baseline/assignOp.invalid.php
@@ -457,11 +457,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/main/calendar/find_appt_popup.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Binary operation "\\.\\=" between string and list\\<string\\|null\\>\\|string\\|null results in an error\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/includes/pnHTML.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Binary operation "\\.\\=" between \'\' and mixed results in an error\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/main/calendar/modules/PostCalendar/common.api.php',

--- a/.phpstan/baseline/foreach.nonIterable.php
+++ b/.phpstan/baseline/foreach.nonIterable.php
@@ -512,11 +512,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/main/calendar/find_patient_popup.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Argument of an invalid type string supplied for foreach, only iterables are supported\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/includes/pnHTML.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/main/calendar/index.php',

--- a/.phpstan/baseline/missingType.iterableValue.php
+++ b/.phpstan/baseline/missingType.iterableValue.php
@@ -437,7 +437,12 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/main/calendar/includes/pnAPI.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method pnHTML\\:\\:FormSelectMultiple\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#',
+    'message' => '#^Method pnHTML\\:\\:generateFormSelectMultiple\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#',
+    'count' => 1,
+    'path' => __DIR__ . '/../../interface/main/calendar/includes/pnHTML.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Property pnHTML\\:\\:\\$header type has no value type specified in iterable type array\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/main/calendar/includes/pnHTML.php',
 ];

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -4907,12 +4907,12 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/main/calendar/includes/pnAPI.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method pnHTML\\:\\:FormSelectMultiple\\(\\) has parameter \\$disable with no type specified\\.$#',
+    'message' => '#^Method pnHTML\\:\\:generateFormSelectMultiple\\(\\) has parameter \\$disable with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/main/calendar/includes/pnHTML.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method pnHTML\\:\\:FormSelectMultiple\\(\\) has parameter \\$readonly with no type specified\\.$#',
+    'message' => '#^Method pnHTML\\:\\:generateFormSelectMultiple\\(\\) has parameter \\$readonly with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/main/calendar/includes/pnHTML.php',
 ];

--- a/.phpstan/baseline/missingType.return.php
+++ b/.phpstan/baseline/missingType.return.php
@@ -3352,11 +3352,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/main/calendar/includes/pnAPI.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method pnHTML\\:\\:PrintPage\\(\\) has no return type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/includes/pnHTML.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function pnModAPIFunc\\(\\) has no return type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/main/calendar/includes/pnMod.php',

--- a/.phpstan/baseline/return.empty.php
+++ b/.phpstan/baseline/return.empty.php
@@ -17,16 +17,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method pnHTML\\:\\:FormHidden\\(\\) should return string but empty return statement found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/includes/pnHTML.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method pnHTML\\:\\:FormSelectMultiple\\(\\) should return string but empty return statement found\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/includes/pnHTML.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function pnModAPILoad\\(\\) should return true but empty return statement found\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/main/calendar/includes/pnMod.php',

--- a/.phpstan/baseline/return.missing.php
+++ b/.phpstan/baseline/return.missing.php
@@ -22,51 +22,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/eRxGlobals.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method pnHTML\\:\\:EndPage\\(\\) should return string but return statement is missing\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/includes/pnHTML.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method pnHTML\\:\\:FormEnd\\(\\) should return string but return statement is missing\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/includes/pnHTML.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method pnHTML\\:\\:FormHidden\\(\\) should return string but return statement is missing\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/includes/pnHTML.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method pnHTML\\:\\:FormSelectMultiple\\(\\) should return string but return statement is missing\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/includes/pnHTML.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method pnHTML\\:\\:FormStart\\(\\) should return string but return statement is missing\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/includes/pnHTML.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method pnHTML\\:\\:FormSubmit\\(\\) should return string but return statement is missing\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/includes/pnHTML.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method pnHTML\\:\\:Linebreak\\(\\) should return string but return statement is missing\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/includes/pnHTML.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method pnHTML\\:\\:StartPage\\(\\) should return string but return statement is missing\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/includes/pnHTML.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method pnHTML\\:\\:Text\\(\\) should return string but return statement is missing\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/includes/pnHTML.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function DateFormatRead\\(\\) should return string but return statement is missing\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/formatting.inc.php',

--- a/.phpstan/baseline/return.type.php
+++ b/.phpstan/baseline/return.type.php
@@ -392,17 +392,17 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/main/calendar/includes/pnAPI.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method pnHTML\\:\\:EndPage\\(\\) should return string but returns string\\|false\\.$#',
+    'message' => '#^Method pnHTML\\:\\:generateEndPage\\(\\) should return string but returns string\\|false\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/main/calendar/includes/pnHTML.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method pnHTML\\:\\:StartPage\\(\\) should return string but returns string\\|false\\.$#',
+    'message' => '#^Method pnHTML\\:\\:generateStartPage\\(\\) should return string but returns string\\|false\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/main/calendar/includes/pnHTML.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method pnHTML\\:\\:Text\\(\\) should return string but returns list\\<string\\|null\\>\\|string\\|null\\.$#',
+    'message' => '#^Method pnHTML\\:\\:generateText\\(\\) should return string but returns list\\<string\\|null\\>\\|string\\|null\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/main/calendar/includes/pnHTML.php',
 ];

--- a/.phpstan/baseline/return.void.php
+++ b/.phpstan/baseline/return.void.php
@@ -2,11 +2,6 @@
 
 $ignoreErrors = [];
 $ignoreErrors[] = [
-    'message' => '#^Method pnHTML\\:\\:__construct\\(\\) with return type void returns true but should not return anything\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/calendar/includes/pnHTML.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method edih_x12_file\\:\\:__construct\\(\\) with return type void returns mixed but should not return anything\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/edihistory/edih_x12file_class.php',

--- a/.phpstan/fatal-baseline-caps.php
+++ b/.phpstan/fatal-baseline-caps.php
@@ -45,7 +45,7 @@ return [
         'method.notFound.php' => 189,
         'require.fileNotFound.php' => 0,
         'requireOnce.fileNotFound.php' => 0,
-        'return.missing.php' => 29,
+        'return.missing.php' => 20,
         'staticMethod.notFound.php' => 0,
         'trait.notFound.php' => 0,
         'variable.undefined.php' => 3444,

--- a/interface/main/calendar/includes/pnHTML.php
+++ b/interface/main/calendar/includes/pnHTML.php
@@ -29,33 +29,11 @@
 // ----------------------------------------------------------------------
 
 /**
- * Set object to keep generated HTML.
- *
- * After calling SetOutputMode() with this value, all future calls to
- * pnHTML methods will store their HTML in the objecr rather than
- * returning it to the calling process.
- *
- * $const _PNH_KEEPOUTPUT Keep the output from method calls
- */
-
-define('_PNH_KEEPOUTPUT', 0);
-
-/**
- * Set object to return generated HTML to caller.
- *
- * After calling SetOutputMode() with this value, all future calls to
- * pnHTML methods will return their HTML directly to the calling process
- * rather than storing it within the object.
- *
- * $const _PNH_RETURNOUTPUT Return the output from method calls
- */
-define('_PNH_RETURNOUTPUT', 1);
-
-/**
  * Set incoming text to be copied verbatim to the output buffer
  *
  * $const _PNH_VERBATIMINPUT Do not parse incoming text
  */
+
 define('_PNH_VERBATIMINPUT', 0);
 
 /**
@@ -68,40 +46,21 @@ define('_PNH_PARSEINPUT', 1);
 /**
  * HTML creation and display functions
  *
- * This class is designed to make generating HTML output in PostNuke
- * very simple, and also allows for much greater control of output by
- * the site administrator.
- *
+ * Every generator method returns an HTML string. Callers assemble the final
+ * page by concatenating the returned strings. Use GetOutput() or PrintPage()
+ * to attach the accumulated headers and emit or return the complete page.
  *
  * <B>Example</B>
  * <pre>
- * // Information array
- * $colors = array(array('id' => 1,
- *                       'name' => 'Red',
- *                       'encoding' => 'ff0000'),
- *                 array('id' => 2,
- *                       'name' => 'Blue',
- *                       'encoding' => '00ff00'),
- *                 array('id' => 3,
- *                       'name' => 'Green',
- *                       'encoding' => '0000ff'));
- *
- * // Create the HTML object and start it
  * $myhtml = new pnHTML();
- * $myhtml->Start();
- *
- * // Add form to select a color
- * $myhtml->Text('&lt;P&gt;&lt;P&gt;');
- * $myhtml->FormStart('colorchosen.php');
- * $myhtml->Text('Select a color: ');
- * $myhtml->FormList('chosen', $colorinfo);
- * $myhtml->FormSubmit('That\'s the color I want');
- * $myhtml->FormEnd();
- *
- *
- * // End the HTML object and print it
- * $myhtml->End();
- * $myhtml->PrintPage();
+ * $body  = $myhtml->generateStartPage();
+ * $body .= $myhtml->generateFormStart('colorchosen.php');
+ * $body .= $myhtml->generateText('Select a color: ');
+ * $body .= $myhtml->generateFormSelectMultiple('chosen', $colorinfo);
+ * $body .= $myhtml->generateFormSubmit('That\'s the color I want');
+ * $body .= $myhtml->generateFormEnd();
+ * $body .= $myhtml->generateEndPage();
+ * $myhtml->PrintPage($body);
  * </pre>
  *
  * @package PostNuke
@@ -122,25 +81,9 @@ class pnHTML
      * Specific headers which must be printed prior to the main body of HTML
      *
      * @access private
-     * @var string $header
+     * @var array $header
      */
     public $header;
-
-    /**
-     * The pending HTML output
-     *
-     * @access private
-     * @var string $output
-     */
-    public $output;
-
-    /**
-     * Return output?
-     *
-     * @access private
-     * @var integer $return
-     */
-    public $return;
 
     /**
      * Parse text for output?
@@ -178,53 +121,9 @@ class pnHTML
     function __construct()
     {
         $this->header =  [];
-        $this->output = '';
-        $this->return = _PNH_KEEPOUTPUT;
         $this->parse = _PNH_PARSEINPUT;
         $this->tabindex = 0;
         $this->fileupload = 0;
-        return true;
-    }
-
-    /**
-     * Return the current state of the output stream
-     *
-     * @access public
-     * @since 1.13 - 2002/01/23
-     * @return integer Current output state
-     * @see SetOutputMode()
-     */
-    function GetOutputMode()
-    {
-        // The ONLY time this should be accessed directly
-        return $this->return;
-    }
-
-    /**
-     * Set state of the output stream
-     *
-     * @access public
-     * @since 1.14 - 2002/01/29
-     * @param int $st Output state to set to
-     * @return integer Previous state
-     * @see GetOutputMode()
-     */
-    function SetOutputMode($st)
-    {
-        $pre = $this->GetOutputMode();
-        switch ($st) {
-            default:
-            case _PNH_KEEPOUTPUT:
-                // The ONLY time this should be accessed directly
-                $this->return = _PNH_KEEPOUTPUT;
-                break;
-            case _PNH_RETURNOUTPUT:
-                // The ONLY time this should be accessed directly
-                $this->return = _PNH_RETURNOUTPUT;
-                break;
-        }
-
-        return $pre;
     }
 
     /**
@@ -274,38 +173,33 @@ class pnHTML
      *==============================================================================*/
 
     /**
-     * Return the HTML output from the buffer.
-     *
-     * Note that this function does not clear out the object's buffer.
+     * Return the full HTML output — accumulated headers plus the supplied body.
      *
      * @access public
      * @since 1.15 - 2002/01/30
+     * @param string $body The assembled HTML body (from generate*() calls)
      * @return string An HTML string
      */
-    function GetOutput()
+    function GetOutput(string $body): string
     {
-        return implode("\n", $this->header) . "\n" . $this->output;
+        return implode("\n", $this->header) . "\n" . $body;
     }
 
     /**
-     * Print the HTML currently held in the object.
-     *
-     * Note that this function does not clear out the object's buffer.
+     * Send the accumulated HTTP headers and print the supplied HTML body.
      *
      * @access public
+     * @param string $body The assembled HTML body (from generate*() calls)
+     * @return void
      */
-    function PrintPage()
+    function PrintPage(string $body): void
     {
         // Headers set by the system
         foreach ($this->header as $headerline) {
             header($headerline);
         }
 
-        // Other headers
-        // Removed as per patch #264 bvdbos
-        // header('Content-length: ' . strlen($this->output));
-
-        print $this->output;
+        print $body;
     }
 
     /*==============================================================================*
@@ -313,14 +207,13 @@ class pnHTML
      *==============================================================================*/
 
     /**
-     * Put the appropriate HTML tags in place to create a valid start to HTML output.
+     * Generate the appropriate HTML tags for a valid start to HTML output.
      *
      * @access public
-     * @return string An HTML string if <code>ReturnHTML()</code> has been called,
-     * otherwise null
-     * @see EndPage()
+     * @return string The HTML string
+     * @see generateEndPage()
      */
-    function StartPage()
+    function generateStartPage(): string
     {
         ob_start();
         print '<table class="w-100 border-0" cellpadding="0" cellspacing="0"><tr><td class="text-left align-top">';
@@ -328,22 +221,17 @@ class pnHTML
         $output = ob_get_contents();
         @ob_end_clean();
 
-        if ($this->GetOutputMode() == _PNH_RETURNOUTPUT) {
-            return $output;
-        } else {
-            $this->output .= $output;
-        }
+        return $output;
     }
 
     /**
-     * Put the appropriate HTML tags in place to create a valid end to HTML output.
+     * Generate the appropriate HTML tags for a valid end to HTML output.
      *
      * @access public
-     * @return string An HTML string if <code>ReturnHTML()</code> has been called,
-     * otherwise null
-     * @see StartPage()
+     * @return string The HTML string
+     * @see generateStartPage()
      */
-    function EndPage()
+    function generateEndPage(): string
     {
         global $index;
         $index = pnVarCleanFromInput('module') ? 0 : 1;
@@ -353,11 +241,7 @@ class pnHTML
         $output = ob_get_contents();
         @ob_end_clean();
 
-        if ($this->GetOutputMode() == _PNH_RETURNOUTPUT) {
-            return $output;
-        } else {
-            $this->output .= $output;
-        }
+        return $output;
     }
 
 
@@ -366,47 +250,37 @@ class pnHTML
      *==============================================================================*/
 
     /**
-     * Add free-form text to the object's buffer
+     * Generate free-form text, parsed according to the current input mode.
      *
      * @access public
      * @param string $text The text string to add
-     * @return string An HTML string if <code>ReturnHTML()</code> has been called,
-     * otherwise null
+     * @return string The processed text
      */
-    function Text($text)
+    function generateText($text): string
     {
         if ($this->GetInputMode() == _PNH_PARSEINPUT) {
             $text = pnVarPrepForDisplay($text);
         }
 
-        if ($this->GetOutputMode() == _PNH_RETURNOUTPUT) {
-            return $text;
-        } else {
-            $this->output .= $text;
-        }
+        return $text;
     }
 
 
     /**
-     * Add line break
+     * Generate a run of HTML line breaks.
      *
      * @access public
      * @param integer $numbreaks number of linebreaks to add
-     * @return string An HTML string if <code>ReturnHTML()</code> has been called,
-     * otherwise null
+     * @return string The HTML string
      */
-    function Linebreak($numbreaks = 1)
+    function generateLinebreak($numbreaks = 1): string
     {
         $out = '';
         for ($i = 0; $i < $numbreaks; $i++) {
             $out .= '<br />';
         }
 
-        if ($this->GetOutputMode() == _PNH_RETURNOUTPUT) {
-            return $out;
-        } else {
-            $this->output .= $out;
-        }
+        return $out;
     }
 
 
@@ -415,60 +289,46 @@ class pnHTML
      *==============================================================================*/
 
     /**
-     * Add HTML tags to start a form.
+     * Generate HTML tags to start a form.
      *
      * @access public
      * @param string $action the URL that this form should go to on submission
-     * @return string An HTML string if <code>ReturnHTML()</code> has been called,
-     * otherwise null
+     * @return string The HTML string
      */
-    function FormStart($action)
+    function generateFormStart($action): string
     {
-        $output = '<form'
+        return '<form'
             . ' action="' . pnVarPrepForDisplay($action) . '"'
             . ' method="post"'
             . ' enctype="' . ((empty($this->fileupload)) ? 'application/x-www-form-urlencoded' : 'multipart/form-data') . '"'
             . '>'
         ;
-        if ($this->GetOutputMode() == _PNH_RETURNOUTPUT) {
-            return $output;
-        } else {
-            $this->output .= $output;
-        }
     }
 
     /**
-     * Add HTML tags to end a form.
+     * Generate HTML tags to end a form.
      *
      * @access public
-     * @return string An HTML string if <code>ReturnHTML()</code> has been called,
-     * otherwise null
+     * @return string The HTML string
      */
-    function FormEnd()
+    function generateFormEnd(): string
     {
-        $output = '</form>';
-
-        if ($this->GetOutputMode() == _PNH_RETURNOUTPUT) {
-            return $output;
-        } else {
-            $this->output .= $output;
-        }
+        return '</form>';
     }
 
     /**
-     * Add HTML tags for a submission button as part of a form.
+     * Generate HTML tags for a submission button as part of a form.
      *
      * @access public
      * @param string $label (optional) the name of the submission button.  This
      * defaults to <code>'Submit'</code>
      * @param string $accesskey (optional) accesskey to active this button
-     * @return string An HTML string if <code>ReturnHTML()</code> has been called,
-     * otherwise null
+     * @return string The HTML string
      */
-    function FormSubmit($label = 'Submit', $accesskey = '')
+    function generateFormSubmit($label = 'Submit', $accesskey = ''): string
     {
         $this->tabindex++;
-        $output = '<input class="btn btn-primary"'
+        return '<input class="btn btn-primary"'
             . ' type="submit"'
             . ' value="' . pnVarPrepForDisplay($label) . '"'
             . ' align="middle"'
@@ -476,27 +336,21 @@ class pnHTML
             . ' tabindex="' . $this->tabindex . '"'
             . ' />'
         ;
-        if ($this->GetOutputMode() == _PNH_RETURNOUTPUT) {
-            return $output;
-        } else {
-            $this->output .= $output;
-        }
     }
 
 
     /**
-     * Add HTML tags for a hidden field as part of a form.
+     * Generate HTML tags for a hidden field as part of a form.
      *
      * @access public
      * @param mixed $fieldname the name of the hidden field.  can also be an array.
      * @param string $value the value of the hidden field
-     * @return string An HTML string if <code>ReturnHTML()</code> has been called,
-     * otherwise null
+     * @return string The HTML string (empty when $fieldname is empty)
      */
-    function FormHidden($fieldname, $value = '')
+    function generateFormHidden($fieldname, $value = ''): string
     {
         if (empty($fieldname)) {
-            return;
+            return '';
         }
 
         if (is_array($fieldname)) {
@@ -520,15 +374,11 @@ class pnHTML
             ;
         }
 
-        if ($this->GetOutputMode() == _PNH_RETURNOUTPUT) {
-            return $output;
-        } else {
-            $this->output .= $output;
-        }
+        return $output;
     }
 
     /**
-     * Add HTML tags for a select field as part of a form.
+     * Generate HTML tags for a select field as part of a form.
      *
      * @access public
      * @since 1.13 - 2002/01/23
@@ -546,13 +396,12 @@ class pnHTML
      * shrink automatically to the correct size
      * @param string $selected (optional) selected value of <code>id</code>
      * @param string $accesskey (optional) accesskey to active this item
-     * @return string An HTML string if <code>ReturnHTML()</code> has been called,
-     * otherwise null
+     * @return string The HTML string (empty when $fieldname is empty)
      */
-    function FormSelectMultiple($fieldname, $data, $multiple = 0, $size = 1, $selected = '', $accesskey = '', $disable = false, $readonly = false)
+    function generateFormSelectMultiple($fieldname, $data, $multiple = 0, $size = 1, $selected = '', $accesskey = '', $disable = false, $readonly = false): string
     {
         if (empty($fieldname)) {
-            return;
+            return '';
         }
 
         $disable_text = "";
@@ -601,10 +450,6 @@ class pnHTML
         }
 
         $output .= '</select>';
-        if ($this->GetOutputMode() == _PNH_RETURNOUTPUT) {
-            return $output;
-        } else {
-            $this->output .= $output;
-        }
+        return $output;
     }
 }

--- a/interface/main/calendar/index.php
+++ b/interface/main/calendar/index.php
@@ -164,22 +164,19 @@ if (pnModAvailable($module)) {
 if ((empty($return)) || ($return == false)) {
     // Failed to load the module
     $output = new pnHTML();
-    $output->StartPage();
-    $output->Text('Failed to load module ' . text($module) . ' ( At function: "' . text($func) . '" )');
-    $output->EndPage();
-    $output->PrintPage();
+    $body  = $output->generateStartPage();
+    $body .= $output->generateText('Failed to load module ' . text($module) . ' ( At function: "' . text($func) . '" )');
+    $body .= $output->generateEndPage();
+    $output->PrintPage($body);
     exit;
 } elseif (strlen((string) $return) > 1) {
     // Text
     $output = new pnHTML();
-    //$output->StartPage();
     $output->SetInputMode(_PNH_VERBATIMINPUT);
-    $output->Text($return);
+    $body = $output->generateText($return);
     $output->SetInputMode(_PNH_PARSEINPUT);
-    //$output->EndPage();
-    $output->PrintPage();
-} else {
-    // duh?
+    $output->PrintPage($body);
 }
 
+// $return === true means "finished"; fall through to exit.
 exit;

--- a/interface/main/calendar/modules/PostCalendar/plugins/function.pc_date_select.php
+++ b/interface/main/calendar/modules/PostCalendar/plugins/function.pc_date_select.php
@@ -78,20 +78,19 @@ function smarty_function_pc_date_select($args): void
 
     $dayselect = $monthselect = $yearselect = $viewselect = '';
     $output = new pnHTML();
-    $output->SetOutputMode(_PNH_RETURNOUTPUT);
     if ($args['day'] === true) {
         $sel_data = pnModAPIFunc(__POSTCALENDAR__, 'user', 'buildDaySelect', ['pc_day' => $d]);
-        $dayselect = $output->FormSelectMultiple('jumpday', $sel_data);
+        $dayselect = $output->generateFormSelectMultiple('jumpday', $sel_data);
     }
 
     if ($args['month'] === true) {
         $sel_data = pnModAPIFunc(__POSTCALENDAR__, 'user', 'buildMonthSelect', ['pc_month' => $m]);
-        $monthselect = $output->FormSelectMultiple('jumpmonth', $sel_data);
+        $monthselect = $output->generateFormSelectMultiple('jumpmonth', $sel_data);
     }
 
     if ($args['year'] === true) {
         $sel_data = pnModAPIFunc(__POSTCALENDAR__, 'user', 'buildYearSelect', ['pc_year' => $y]);
-        $yearselect = $output->FormSelectMultiple('jumpyear', $sel_data);
+        $yearselect = $output->generateFormSelectMultiple('jumpyear', $sel_data);
     }
 
     if ($args['view'] === true) {
@@ -108,7 +107,7 @@ function smarty_function_pc_date_select($args): void
         $sel_data[3]['id']         = 'year';
         $sel_data[3]['selected']   = $viewtype == 'year';
         $sel_data[3]['name']       = _CAL_YEARVIEW;
-        $viewselect = $output->FormSelectMultiple('viewtype', $sel_data);
+        $viewselect = $output->generateFormSelectMultiple('viewtype', $sel_data);
     }
 
     if (!isset($args['label'])) {
@@ -116,7 +115,6 @@ function smarty_function_pc_date_select($args): void
     }
 
         $jumpsubmit = '<input type="submit" class="btn btn-primary align-middle" name="submit" value="' . $args['label'] . '" />';
-    $output->SetOutputMode(_PNH_KEEPOUTPUT);
 
     $orderArray = ['day' => $dayselect,
                         'month' => $monthselect,

--- a/interface/main/calendar/modules/PostCalendar/plugins/function.pc_filter.php
+++ b/interface/main/calendar/modules/PostCalendar/plugins/function.pc_filter.php
@@ -58,7 +58,6 @@ function smarty_function_pc_filter($args, &$smarty): void
 
     $types = explode(',', (string) $type);
     $output = new pnHTML();
-    $output->SetOutputMode(_PNH_RETURNOUTPUT);
     $modinfo = pnModGetInfo(pnModGetIDFromName(__POSTCALENDAR__));
     $mdir = pnVarPrepForOS($modinfo['directory']);
     unset($modinfo);
@@ -164,6 +163,6 @@ function smarty_function_pc_filter($args, &$smarty): void
     }
 
     if (!in_array('user', $types)) {
-        echo $output->FormHidden('pc_username', $pc_username);
+        echo $output->generateFormHidden('pc_username', $pc_username);
     }
 }

--- a/interface/main/calendar/modules/PostCalendar/pnadmin.php
+++ b/interface/main/calendar/modules/PostCalendar/pnadmin.php
@@ -49,22 +49,22 @@ function postcalendar_admin_modifyconfig($msg = '', $showMenu = true)
     $header = "<html><head><title>" . xlt("Calendar") . "</title>";
     $header .= Header::setupHeader('', false)  . '</head><body>';
 
-    $output->Text($header);
+    $body  = $output->generateText($header);
 
     if (!empty($msg)) {
-        $output->Text(postcalendar_adminmenu("clearCache"));
-        $output -> Text('<div class="alert alert-success mx-1 text-center" role="alert">');
-        $output->Text("<b>$msg</b>");
-        $output -> Text('</div>');
+        $body .= $output->generateText(postcalendar_adminmenu("clearCache"));
+        $body .= $output->generateText('<div class="alert alert-success mx-1 text-center" role="alert">');
+        $body .= $output->generateText("<b>$msg</b>");
+        $body .= $output->generateText('</div>');
     } else {
         if ($showMenu) {
-            $output->Text(postcalendar_adminmenu(""));
+            $body .= $output->generateText(postcalendar_adminmenu(""));
         }
     }
 
-    $output->Text("</body></html>");
+    $body .= $output->generateText("</body></html>");
 
-    return $output->GetOutput();
+    return $output->GetOutput($body);
 }
 
 function postcalendar_admin_categoriesConfirm()
@@ -76,8 +76,8 @@ function postcalendar_admin_categoriesConfirm()
 	<head>
 EOF;
     $header .= Header::setupHeader('', false)  . '</head><body><div class="container">';
-    $output->Text($header);
-    $output->Text(postcalendar_adminmenu("category"));
+    $body  = $output->generateText($header);
+    $body .= $output->generateText(postcalendar_adminmenu("category"));
     [$id, $del, $name, $constantid, $value_cat_type, $desc, $color, $event_repeat, $event_repeat_freq, $event_repeat_freq_type, $event_repeat_on_num, $event_repeat_on_day, $event_repeat_on_freq, $durationh, $durationm, $end_date_flag, $end_date_type, $end_date_freq, $end_all_day, $active, $sequence, $aco, $newname, $newconstantid, $newdesc, $newcolor, $new_event_repeat, $new_event_repeat_freq, $new_event_repeat_freq_type, $new_event_repeat_on_num, $new_event_repeat_on_day, $new_event_repeat_on_freq, $new_durationh, $new_durationm, $new_limitid, $new_end_date_flag, $new_end_date_type, $new_end_date_freq, $new_end_all_day, $new_value_cat_type, $newactive, $newsequence, $newaco] = pnVarCleanFromInput(
         'id',
         'del',
@@ -126,23 +126,23 @@ EOF;
     //data validation
     foreach ($name as $i => $item) {
         if (empty($item)) {
-            $output->Text(postcalendar_admin_categories($msg, "Category Names must contain a value!"));
-            return $output->GetOutput();
+            $body .= $output->generateText(postcalendar_admin_categories($msg, "Category Names must contain a value!"));
+            return $output->GetOutput($body);
         }
         if (empty($constantid[$i])) {
-            $output->Text(postcalendar_admin_categories($msg, "Category Identifiers must contain a value!"));
-            return $output->GetOutput();
+            $body .= $output->generateText(postcalendar_admin_categories($msg, "Category Identifiers must contain a value!"));
+            return $output->GetOutput($body);
         }
         $tmp = $constantid[$i];
         if (strpos(trim((string) $tmp), ' ')) {
-            $output->Text(postcalendar_admin_categories($msg, "Category Identifiers must be one word!"));
-            return $output->GetOutput();
+            $body .= $output->generateText(postcalendar_admin_categories($msg, "Category Identifiers must be one word!"));
+            return $output->GetOutput($body);
         }
         $tmp = $color[$i];
         if (strlen((string) $tmp) != 7 || $tmp[0] != "#") {
             $e = $tmp . " size " . strlen((string) $tmp) . " at 0 " . $tmp[0];
-            $output->Text(postcalendar_admin_categories($msg, "You entered an invalid color(USE Pick) $e!"));
-            return $output->GetOutput();
+            $body .= $output->generateText(postcalendar_admin_categories($msg, "You entered an invalid color(USE Pick) $e!"));
+            return $output->GetOutput($body);
         }
     }
     foreach ($durationh as $i => $val) {
@@ -151,11 +151,11 @@ EOF;
             !is_numeric($event_repeat_freq[$i]) ||
             !is_numeric($event_repeat_on_freq[$i]) || !is_numeric($end_date_freq[$i])
         ) {
-            $output->Text(postcalendar_admin_categories(
+            $body .= $output->generateText(postcalendar_admin_categories(
                 $msg,
                 " Hours, Minutes and recurrence values must be numeric!"
             ));
-            return $output->GetOutput();
+            return $output->GetOutput($body);
         }
     }
     if (!empty($newnam)) {
@@ -166,8 +166,8 @@ EOF;
             !is_numeric($new_event_repeat_on_freq) ||
             !is_numeric($new_end_date_freq)
         ) {
-            $output->Text(postcalendar_admin_categories($msg, "Hours, Minutes and recurrence values must be numeric!"));
-            return $output->GetOutput();
+            $body .= $output->generateText(postcalendar_admin_categories($msg, "Hours, Minutes and recurrence values must be numeric!"));
+            return $output->GetOutput($body);
         }
     }
     $new_duration = ($new_durationh * (60 * 60)) + ($new_durationm * 60);
@@ -189,67 +189,67 @@ EOF;
         $dels = implode(',', $del);
         $delText = _PC_DELETE_CATS . $dels . '.';
     }
-    $output->FormStart(pnModURL(__POSTCALENDAR__, 'admin', 'categoriesUpdate'));
-    $output->Text(_PC_ARE_YOU_SURE);
-    $output->Linebreak(2);
+    $body .= $output->generateFormStart(pnModURL(__POSTCALENDAR__, 'admin', 'categoriesUpdate'));
+    $body .= $output->generateText(_PC_ARE_YOU_SURE);
+    $body .= $output->generateLinebreak(2);
     // deletions
     if (isset($delText)) {
-        $output->FormHidden('dels', $dels);
-        $output->Text($delText);
-        $output->Linebreak();
+        $body .= $output->generateFormHidden('dels', $dels);
+        $body .= $output->generateText($delText);
+        $body .= $output->generateLinebreak();
     }
     if (!empty($newname)) {
         if (empty($newconstantid)) {
-            $output->Text(postcalendar_admin_categories($msg ?? '', "Category Identifiers must contain a value!"));
-            return $output->GetOutput();
+            $body .= $output->generateText(postcalendar_admin_categories($msg ?? '', "Category Identifiers must contain a value!"));
+            return $output->GetOutput($body);
         }
         if (strpos(trim((string) $newconstantid), ' ')) {
-            $output->Text(postcalendar_admin_categories($msg, "Category Identifiers must be one word!"));
-            return $output->GetOutput();
+            $body .= $output->generateText(postcalendar_admin_categories($msg, "Category Identifiers must be one word!"));
+            return $output->GetOutput($body);
         }
-        $output->FormHidden('newname', $newname);
-        $output->FormHidden('newconstantid', $newconstantid);
-        $output->FormHidden('newdesc', $newdesc);
-        $output->FormHidden('newvalue_cat_type', $new_value_cat_type);
-        $output->FormHidden('newcolor', $newcolor);
-        $output->FormHidden('newevent_repeat', $new_event_repeat);
-        $output->FormHidden('newevent_recurrfreq', $new_event_repeat_freq);
-        $output->FormHidden('newevent_recurrspec', $new_event_recurrspec);
-        $output->FormHidden('newduration', $new_duration);
-        $output->FormHidden('newlimitid', $new_limitid);
-        $output->FormHidden('newend_date_flag', $new_end_date_flag);
-        $output->FormHidden('newend_date_type', $new_end_date_type);
-        $output->FormHidden('newend_date_freq', $new_end_date_freq);
-        $output->FormHidden('newend_all_day', $new_end_all_day);
-        $output->FormHidden("newactive", $newactive);
-        $output->FormHidden("newsequence", $newsequence);
-        $output->FormHidden("newaco", $newaco);
-        $output->Text(_PC_ADD_CAT . text($newname) . '.');
-        $output->Linebreak();
+        $body .= $output->generateFormHidden('newname', $newname);
+        $body .= $output->generateFormHidden('newconstantid', $newconstantid);
+        $body .= $output->generateFormHidden('newdesc', $newdesc);
+        $body .= $output->generateFormHidden('newvalue_cat_type', $new_value_cat_type);
+        $body .= $output->generateFormHidden('newcolor', $newcolor);
+        $body .= $output->generateFormHidden('newevent_repeat', $new_event_repeat);
+        $body .= $output->generateFormHidden('newevent_recurrfreq', $new_event_repeat_freq);
+        $body .= $output->generateFormHidden('newevent_recurrspec', $new_event_recurrspec);
+        $body .= $output->generateFormHidden('newduration', $new_duration);
+        $body .= $output->generateFormHidden('newlimitid', $new_limitid);
+        $body .= $output->generateFormHidden('newend_date_flag', $new_end_date_flag);
+        $body .= $output->generateFormHidden('newend_date_type', $new_end_date_type);
+        $body .= $output->generateFormHidden('newend_date_freq', $new_end_date_freq);
+        $body .= $output->generateFormHidden('newend_all_day', $new_end_all_day);
+        $body .= $output->generateFormHidden("newactive", $newactive);
+        $body .= $output->generateFormHidden("newsequence", $newsequence);
+        $body .= $output->generateFormHidden("newaco", $newaco);
+        $body .= $output->generateText(_PC_ADD_CAT . text($newname) . '.');
+        $body .= $output->generateLinebreak();
     }
-    $output->Text(_PC_MODIFY_CATS);
-    $output->FormHidden('id', serialize($id));
-    $output->FormHidden('del', serialize($del));
-    $output->FormHidden('name', serialize($name));
-    $output->FormHidden('constantid', serialize($constantid));
-    $output->FormHidden('desc', serialize($desc));
-    $output->FormHidden('value_cat_type', serialize($value_cat_type));
-    $output->FormHidden('color', serialize($color));
-    $output->FormHidden('event_repeat', serialize($event_repeat));
-    $output->FormHidden('event_recurrspec', $event_recurrspec);
-    $output->FormHidden('durationh', serialize($durationh));
-    $output->FormHidden('durationm', serialize($durationm));
-    $output->FormHidden('end_date_flag', serialize($end_date_flag));
-    $output->FormHidden('end_date_type', serialize($end_date_type));
-    $output->FormHidden('end_date_freq', serialize($end_date_freq));
-    $output->FormHidden('end_all_day', serialize($end_all_day));
-    $output->FormHidden("active", serialize($active));
-    $output->FormHidden("sequence", serialize($sequence));
-    $output->FormHidden("aco", serialize($aco));
-    $output->Linebreak();
-    $output->FormSubmit(_PC_CATS_CONFIRM);
-    $output->FormEnd();
-    return $output->GetOutput();
+    $body .= $output->generateText(_PC_MODIFY_CATS);
+    $body .= $output->generateFormHidden('id', serialize($id));
+    $body .= $output->generateFormHidden('del', serialize($del));
+    $body .= $output->generateFormHidden('name', serialize($name));
+    $body .= $output->generateFormHidden('constantid', serialize($constantid));
+    $body .= $output->generateFormHidden('desc', serialize($desc));
+    $body .= $output->generateFormHidden('value_cat_type', serialize($value_cat_type));
+    $body .= $output->generateFormHidden('color', serialize($color));
+    $body .= $output->generateFormHidden('event_repeat', serialize($event_repeat));
+    $body .= $output->generateFormHidden('event_recurrspec', $event_recurrspec);
+    $body .= $output->generateFormHidden('durationh', serialize($durationh));
+    $body .= $output->generateFormHidden('durationm', serialize($durationm));
+    $body .= $output->generateFormHidden('end_date_flag', serialize($end_date_flag));
+    $body .= $output->generateFormHidden('end_date_type', serialize($end_date_type));
+    $body .= $output->generateFormHidden('end_date_freq', serialize($end_date_freq));
+    $body .= $output->generateFormHidden('end_all_day', serialize($end_all_day));
+    $body .= $output->generateFormHidden("active", serialize($active));
+    $body .= $output->generateFormHidden("sequence", serialize($sequence));
+    $body .= $output->generateFormHidden("aco", serialize($aco));
+    $body .= $output->generateLinebreak();
+    $body .= $output->generateFormSubmit(_PC_CATS_CONFIRM);
+    $body .= $output->generateFormEnd();
+    return $output->GetOutput($body);
 }
 
 function postcalendar_admin_categoriesUpdate()
@@ -415,8 +415,8 @@ function postcalendar_admin_categoriesUpdate()
     if (empty($e)) {
         $msg = 'DONE';
     }
-    $output->Text(postcalendar_admin_categories($msg, $e));
-    return $output->GetOutput();
+    $body = $output->generateText(postcalendar_admin_categories($msg, $e));
+    return $output->GetOutput($body);
 }
 
 /**
@@ -439,18 +439,18 @@ function postcalendar_admin_categories($msg = '', $e = '', $args = [])
         $template_name = 'default';
     }
 
-    $output->Text(postcalendar_adminmenu("category"));
+    $body = $output->generateText(postcalendar_adminmenu("category"));
 
     if (!empty($e)) {
-        $output -> Text('<div class="alert alert-danger mx-1" role="alert">');
-        $output->Text('<span class="text-center font-weight-bold">' . text($e) . '</span>');
-        $output -> Text('</div><br />');
+        $body .= $output->generateText('<div class="alert alert-danger mx-1" role="alert">');
+        $body .= $output->generateText('<span class="text-center font-weight-bold">' . text($e) . '</span>');
+        $body .= $output->generateText('</div><br />');
     }
 
     if (!empty($msg)) {
-        $output -> Text('<div class="alert alert-success mx-1" role="alert">');
-        $output->Text('<span class="text-center font-weight-bold">' . text($msg) . '</span>');
-        $output -> Text('</div><br />');
+        $body .= $output->generateText('<div class="alert alert-success mx-1" role="alert">');
+        $body .= $output->generateText('<span class="text-center font-weight-bold">' . text($msg) . '</span>');
+        $body .= $output->generateText('</div><br />');
     }
 
     //=================================================================
@@ -665,9 +665,6 @@ function postcalendar_admin_categories($msg = '', $e = '', $args = [])
     $acoList = AclExtended::genAcoArray();
     $tpl->assign('ACO_List', $acoList);
 
-    $output->SetOutputMode(_PNH_RETURNOUTPUT);
-    $output->SetOutputMode(_PNH_KEEPOUTPUT);
-
     if (isset($data_loaded)) {
         $form_hidden = "<input type=\"hidden\" name=\"is_update\" value=\"" . attr($is_update ?? '') . "\" />";
         $form_hidden .= "<input type=\"hidden\" name=\"pc_event_id\" value=\"" . attr($pc_event_id ?? '') . "\" />";
@@ -679,9 +676,9 @@ function postcalendar_admin_categories($msg = '', $e = '', $args = [])
 				   ' . text($authkey ?? '') . '<input class="btn btn-primary" type="submit" name="submit" value="' . xla('Save') . '">';
     $tpl->assign('FormSubmit', $form_submit);
 
-    $output->Text($tpl->fetch($template_name . '/admin/submit_category.html'));
-    $output->Text(postcalendar_footer());
-    return $output->GetOutput();
+    $body .= $output->generateText($tpl->fetch($template_name . '/admin/submit_category.html'));
+    $body .= $output->generateText(postcalendar_footer());
+    return $output->GetOutput($body);
 }
 
 /**

--- a/interface/main/calendar/modules/PostCalendar/pnuser.php
+++ b/interface/main/calendar/modules/PostCalendar/pnuser.php
@@ -258,39 +258,35 @@ function postcalendar_user_search()
     $tpl->assign("event_category", pnVarCleanFromInput("event_category"));
     $tpl->assign("event_subject", pnVarCleanFromInput("event_subject"));
     $output = new pnHTML();
-    $output->SetOutputMode(_PNH_RETURNOUTPUT);
     if (_SETTING_USE_INT_DATES) {
         $sel_data = pnModAPIFunc(__POSTCALENDAR__, 'user', 'buildDaySelect', ['pc_day' => $day,'selected' => $event_startday]);
-        $formdata = $output->FormSelectMultiple('event_startday', $sel_data);
+        $formdata = $output->generateFormSelectMultiple('event_startday', $sel_data);
         $sel_data = pnModAPIFunc(__POSTCALENDAR__, 'user', 'buildMonthSelect', ['pc_month' => $month,'selected' => $event_startmonth]);
-        $formdata .= $output->FormSelectMultiple('event_startmonth', $sel_data);
+        $formdata .= $output->generateFormSelectMultiple('event_startmonth', $sel_data);
     } else {
         $sel_data = pnModAPIFunc(__POSTCALENDAR__, 'user', 'buildMonthSelect', ['pc_month' => ($month ?? null),'selected' => $event_startmonth]);
-        $formdata = $output->FormSelectMultiple('event_startmonth', $sel_data);
+        $formdata = $output->generateFormSelectMultiple('event_startmonth', $sel_data);
         $sel_data = pnModAPIFunc(__POSTCALENDAR__, 'user', 'buildDaySelect', ['pc_day' => ($day ?? null),'selected' => $event_startday]);
-        $formdata .= $output->FormSelectMultiple('event_startday', $sel_data);
+        $formdata .= $output->generateFormSelectMultiple('event_startday', $sel_data);
     }
 
     $sel_data = pnModAPIFunc(__POSTCALENDAR__, 'user', 'buildYearSelect', ['pc_year' => ($year ?? null),'selected' => $event_startyear]);
-    $formdata .= $output->FormSelectMultiple('event_startyear', $sel_data);
-    $output->SetOutputMode(_PNH_KEEPOUTPUT);
+    $formdata .= $output->generateFormSelectMultiple('event_startyear', $sel_data);
     $tpl->assign('SelectDateTimeStart', $formdata);
-    $output->SetOutputMode(_PNH_RETURNOUTPUT);
     if (_SETTING_USE_INT_DATES) {
         $sel_data = pnModAPIFunc(__POSTCALENDAR__, 'user', 'buildDaySelect', ['pc_day' => $day,'selected' => $event_endday]);
-        $formdata = $output->FormSelectMultiple('event_endday', $sel_data);
+        $formdata = $output->generateFormSelectMultiple('event_endday', $sel_data);
         $sel_data = pnModAPIFunc(__POSTCALENDAR__, 'user', 'buildMonthSelect', ['pc_month' => $month,'selected' => $event_endmonth]);
-        $formdata .= $output->FormSelectMultiple('event_endmonth', $sel_data);
+        $formdata .= $output->generateFormSelectMultiple('event_endmonth', $sel_data);
     } else {
         $sel_data = pnModAPIFunc(__POSTCALENDAR__, 'user', 'buildMonthSelect', ['pc_month' => ($month ?? null),'selected' => $event_endmonth]);
-        $formdata = $output->FormSelectMultiple('event_endmonth', $sel_data);
+        $formdata = $output->generateFormSelectMultiple('event_endmonth', $sel_data);
         $sel_data = pnModAPIFunc(__POSTCALENDAR__, 'user', 'buildDaySelect', ['pc_day' => ($day ?? null),'selected' => $event_endday ]);
-        $formdata .= $output->FormSelectMultiple('event_endday', $sel_data);
+        $formdata .= $output->generateFormSelectMultiple('event_endday', $sel_data);
     }
 
     $sel_data = pnModAPIFunc(__POSTCALENDAR__, 'user', 'buildYearSelect', ['pc_year' => ($year ?? null),'selected' => $event_endyear]);
-    $formdata .= $output->FormSelectMultiple('event_endyear', $sel_data);
-    $output->SetOutputMode(_PNH_KEEPOUTPUT);
+    $formdata .= $output->generateFormSelectMultiple('event_endyear', $sel_data);
     $tpl->assign('SelectDateTimeEnd', $formdata);
     $output = null;
     if (_SETTING_DISPLAY_TOPICS) {


### PR DESCRIPTION
Fixes #8586

#### Short description of what this resolves:

The legacy `pnHTML` class used a mutable-state polymorphism: every generator method either *returned* its HTML or *stored* it in an internal buffer, depending on a `SetOutputMode()` toggle maintained across calls. The same method call did different things at different points in the request, making the code hard to reason about and easy to break.

#### Changes proposed in this pull request:

- `pnHTML` generators are now pure functions that always return a `string`. Methods were renamed with a `generate*` prefix (`generateFormStart`, `generateFormSelectMultiple`, `generateText`, etc.) and the old names were deleted so PHPStan flags any stragglers.
- `GetOutput(string $body): string` and `PrintPage(string $body): void` now take the assembled body explicitly, replacing the internal output buffer and `SetOutputMode` toggle.
- All callers in `pnadmin.php`, `pnuser.php`, `pc_date_select`, `pc_filter`, and `interface/main/calendar/index.php` were updated to accumulate a `$body` string and pass it through.

Net effect: +191 / −438 lines across the calendar module, plus net −80 lines across the PHPStan baselines (more stale entries drained than new ones accrued — `return.missing.php` went 29 → 20, which required a ratchet cap update in `.phpstan/fatal-baseline-caps.php`).

#### Does your code include anything generated by an AI Engine? Yes (Claude Code, see `Assisted-by` trailers).
