### PR TITLE
Re-add couchdb volume to openemr service in development-easy-light setup

### DIFF
--- a/docker/development-easy-light/docker-compose.yml
+++ b/docker/development-easy-light/docker-compose.yml
@@ -40,6 +40,7 @@ services:
     - vendordir:/var/www/localhost/htdocs/openemr/vendor:rw
     - ccdanodemodules:/var/www/localhost/htdocs/openemr/ccdaservice/node_modules:rw
     - logvolume:/var/log
+    - couchdbvolume:/couchdb/data
     environment:
       DEBUG_COLORS: "true"
       TERM: xterm-256color
@@ -105,3 +106,4 @@ volumes:
   vendordir: {}
   ccdanodemodules: {}
   logvolume: {}
+  couchdbvolume: {}


### PR DESCRIPTION
The couchdb service is missing from this setup but openemr still depends on the volume being present for an rsync command.

Fixes #8593

#### Short description of what this resolves:

Starting the development-easy-light setup using docker-compose currently causes an rsync error in the openemr container, preventing a successful startup.

#### Changes proposed in this pull request:

This solution provides an (easy to understand) quick fix by just re-adding the volume to the container (as in the development-easy setup), although there is no couchdb service present in the easy-light setup.
Another solution, of course, would be to remove the rsync command that represents the broken dependency. But my guess is this would cause container images to diverge, so just adding the volume might be an easier and cleaner solution for the dev setup.

#### Does your code include anything generated by an AI Engine? Yes / No

No
