### PR TITLE
fix(php scripts): avoid unequivocal early exit

### DIFF
--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -124,11 +124,9 @@ install_configure() {
     	actions_chmod -R 0777 sites/default/documents
     )
     # we need this to occur on the docker image of OpenEMR, on local systems this may be the same but in the ci engine its inside the docker container
-    _exec sh -c "sed -e 's@^exit;@ @' < ./contrib/util/installScripts/InstallerAuto.php > ./contrib/util/installScripts/InstallerAutoTemp.php"
     # until we get the devops repo setup we'll just grab the auto_configure.php script and use that
     _exec sh -c 'curl -v https://raw.githubusercontent.com/openemr/openemr-devops/refs/heads/master/docker/openemr/flex/auto_configure.php > /root/auto_configure.php'
-    _exec php -f ./contrib/util/installScripts/InstallerAutoTemp.php rootpass=root server=mysql loginhost=%
-    _exec rm -f ./contrib/util/installScripts/InstallerAutoTemp.php
+    _exec sh -c 'OPENEMR_ENABLE_INSTALLER_AUTO=1 php -f ./contrib/util/installScripts/InstallerAuto.php rootpass=root server=mysql loginhost=%'
     _exec mysql -u openemr --password=openemr --ssl=false -h mysql -e 'INSERT INTO product_registration (opt_out) VALUES (1)' openemr
     _exec mysql -u openemr --password=openemr --ssl=false -h mysql -e 'UPDATE globals SET gl_value = 1 WHERE gl_name = "rest_api"' openemr
     _exec mysql -u openemr --password=openemr --ssl=false -h mysql -e 'UPDATE globals SET gl_value = 1 WHERE gl_name = "rest_fhir_api"' openemr

--- a/contrib/util/billing/load_fee_schedule.php
+++ b/contrib/util/billing/load_fee_schedule.php
@@ -10,8 +10,10 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
 */
 
-// comment this out when using this script (and then uncomment it again when done using script)
-exit;
+// Enable this script via environment variable
+if (!getenv('OPENEMR_ENABLE_LOAD_FEE_SCHEDULE')) {
+    die('Set OPENEMR_ENABLE_LOAD_FEE_SCHEDULE=1 environment variable to enable this script');
+}
 
 if (php_sapi_name() !== 'cli') {
     echo "Only php cli can execute command\n";

--- a/contrib/util/ccda_import/import_ccda.php
+++ b/contrib/util/ccda_import/import_ccda.php
@@ -36,8 +36,10 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-// comment this out when using this script (and then uncomment it again when done using script)
-exit;
+// Enable this script via environment variable
+if (!getenv('OPENEMR_ENABLE_CCDA_IMPORT')) {
+    die('Set OPENEMR_ENABLE_CCDA_IMPORT=1 environment variable to enable this script');
+}
 
 // only allow use from command line
 if (php_sapi_name() !== 'cli') {

--- a/contrib/util/chart_review_pids.php
+++ b/contrib/util/chart_review_pids.php
@@ -10,8 +10,10 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
 */
 
-// comment this out when using this script (and then uncomment it again when done using script)
-exit;
+// Enable this script via environment variable
+if (!getenv('OPENEMR_ENABLE_CHART_REVIEW_PIDS')) {
+    die('Set OPENEMR_ENABLE_CHART_REVIEW_PIDS=1 environment variable to enable this script');
+}
 
 if (php_sapi_name() !== 'cli') {
     echo "Only php cli can execute command\n";

--- a/contrib/util/installScripts/InstallerAuto.php
+++ b/contrib/util/installScripts/InstallerAuto.php
@@ -74,8 +74,10 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-// This exit is to avoid malicious use of this script.
-exit;
+// This safety check prevents accidental execution of this script.
+if (!getenv('OPENEMR_ENABLE_INSTALLER_AUTO')) {
+    die('Set OPENEMR_ENABLE_INSTALLER_AUTO=1 environment variable to enable this script');
+}
 
 // Include standard libraries/classes
 require_once dirname(__FILE__) . '/../../../vendor/autoload.php';

--- a/library/edihistory/test_edih_835_accounting.php
+++ b/library/edihistory/test_edih_835_accounting.php
@@ -24,8 +24,10 @@
  */
 
 
-// comment out below exit when need to use this script
-exit;
+// Enable this script via environment variable
+if (!getenv('OPENEMR_ENABLE_TEST_EDIH_835_ACCOUNTING')) {
+    die('Set OPENEMR_ENABLE_TEST_EDIH_835_ACCOUNTING=1 environment variable to enable this script');
+}
 use OpenEMR\Billing\ParseERA;
 
 function edih_835_accounting($segments, $delimiters)

--- a/library/edihistory/test_edih_sftp_files.php
+++ b/library/edihistory/test_edih_sftp_files.php
@@ -24,8 +24,10 @@
  *
  */
 
-// comment out below exit when need to use this script
-exit;
+// Enable this script via environment variable
+if (!getenv('OPENEMR_ENABLE_TEST_EDIH_SFTP_FILES')) {
+    die('Set OPENEMR_ENABLE_TEST_EDIH_SFTP_FILES=1 environment variable to enable this script');
+}
 
 /* ** add this function to edih_uploads.php
  * -- or work it into edih_upload_files(), since it is almost a direct copy

--- a/modules/sms_email_reminder/batch_phone_notification.php
+++ b/modules/sms_email_reminder/batch_phone_notification.php
@@ -12,8 +12,10 @@
  * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-// comment below exit if plan to use this script
-exit;
+// Enable this script via environment variable
+if (!getenv('OPENEMR_ENABLE_BATCH_PHONE_NOTIFICATION')) {
+    die('Set OPENEMR_ENABLE_BATCH_PHONE_NOTIFICATION=1 environment variable to enable this script');
+}
 
 $backpic = "";
 //phone notification

--- a/modules/sms_email_reminder/batch_reminders.php
+++ b/modules/sms_email_reminder/batch_reminders.php
@@ -6,8 +6,10 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 
-// comment below exit if plan to use this script
-exit;
+// Enable this script via environment variable
+if (!getenv('OPENEMR_ENABLE_BATCH_REMINDERS')) {
+    die('Set OPENEMR_ENABLE_BATCH_REMINDERS=1 environment variable to enable this script');
+}
 
 $backpic = "";
 $ignoreAuth = 1;

--- a/modules/sms_email_reminder/cron_email_notification.php
+++ b/modules/sms_email_reminder/cron_email_notification.php
@@ -11,8 +11,10 @@
  * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-// comment below exit if plan to use this script
-exit;
+// Enable this script via environment variable
+if (!getenv('OPENEMR_ENABLE_CRON_EMAIL_NOTIFICATION')) {
+    die('Set OPENEMR_ENABLE_CRON_EMAIL_NOTIFICATION=1 environment variable to enable this script');
+}
 
 // larry :: hack add for command line version
 $_SERVER['REQUEST_URI'] = $_SERVER['PHP_SELF'];

--- a/modules/sms_email_reminder/cron_sms_notification.php
+++ b/modules/sms_email_reminder/cron_sms_notification.php
@@ -9,8 +9,10 @@
 // Updated by:  Larry Lart on 11/03/2008
 ////////////////////////////////////////////////////////////////////
 
-// comment below exit if plan to use this script
-exit;
+// Enable this script via environment variable
+if (!getenv('OPENEMR_ENABLE_CRON_SMS_NOTIFICATION')) {
+    die('Set OPENEMR_ENABLE_CRON_SMS_NOTIFICATION=1 environment variable to enable this script');
+}
 
 // larry :: hack add for command line version
 $_SERVER['REQUEST_URI'] = $_SERVER['PHP_SELF'];

--- a/tests/api/InternalApiTest.php
+++ b/tests/api/InternalApiTest.php
@@ -10,9 +10,10 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-// comment below exit command to run this test script
-//  (when done, remember to uncomment it again)
-exit;
+// Enable this script via environment variable
+if (!getenv('OPENEMR_ENABLE_INTERNAL_API_TEST')) {
+    die('Set OPENEMR_ENABLE_INTERNAL_API_TEST=1 environment variable to enable this script');
+}
 
 require_once(__DIR__ . "/../../interface/globals.php");
 

--- a/tests/api/InternalFhirTest.php
+++ b/tests/api/InternalFhirTest.php
@@ -12,9 +12,10 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-// comment below exit command to run this test script
-//  (when done, remember to uncomment it again)
-exit;
+// Enable this script via environment variable
+if (!getenv('OPENEMR_ENABLE_INTERNAL_FHIR_TEST')) {
+    die('Set OPENEMR_ENABLE_INTERNAL_FHIR_TEST=1 environment variable to enable this script');
+}
 
 require_once(__DIR__ . "/../../interface/globals.php");
 


### PR DESCRIPTION
Fixes #8618

This can be merged after the two changes below:

- [x] update openemr-devops scripts except obsolete (openemr/openemr-devops#468)
- [x] update https://github.com/openemr/demo_farm_openemr/blob/master/demo_build.sh (openemr/demo_farm_openemr#75)


#### Short description of what this resolves:

Avoid triggering dead code elimination and requiring `sed` to activate scripts.


#### Changes proposed in this pull request:

- Replace `exit` with environment condition on scripts that need a check to start.
- Use that method in the ciLibrary

#### Does your code include anything generated by an AI Engine? No
