### PR TITLE
ci(styling): actions annotations

### DIFF
--- a/.github/workflows/styling.yml
+++ b/.github/workflows/styling.yml
@@ -19,7 +19,8 @@ jobs:
     strategy:
       matrix:
         # Single-element matrix provides named variable and job title
-        php-version: ['8.4']
+        php-version:
+        - '8.4'
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -45,8 +46,19 @@ jobs:
           ${{ runner.os }}-composer-
     - name: Composer Install
       run: composer install --prefer-dist --no-progress
+    # There's no "problem matcher" for phpcs, so we use checkstyle and cs2pr
+    # per https://github.com/shivammathur/setup-php?tab=readme-ov-file#tools-with-checkstyle-support
     - name: Check PHP Styling
-      run: ./vendor/bin/phpcs -p -n --extensions=php,inc --report-width=120 --standard=ci/phpcs.xml --report=full .
+      run: |
+        vendor/bin/phpcs -p -n --extensions=inc,php \
+                               --report-full \
+                               --report-checkstyle=phpcs.checkstyle.xml \
+                               --report-width=120 \
+                               --report=checkstyle \
+                               --standard=ci/phpcs.xml \
+                               .
+    - name: Annotate Checkstyle Results
+      run: vendor/bin/cs2pr --notices-as-warnings phpcs.checkstyle.xml
 
   css_styling:
     runs-on: ubuntu-24.04
@@ -54,7 +66,8 @@ jobs:
     strategy:
       matrix:
         # Single-element matrix provides named variable and job title
-        node-version: ['22']
+        node-version:
+        - '22'
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -77,6 +90,8 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-${{ matrix.node-version }}-
           ${{ runner.os }}-node-
+    - name: Stylelint problem matcher
+      uses: xt0rted/stylelint-problem-matcher@v1
     - name: NPM CI
       run: npm ci
     - name: Check CSS Styling
@@ -88,7 +103,8 @@ jobs:
     strategy:
       matrix:
         # Single-element matrix provides named variable and job title
-        node-version: ['22']
+        node-version:
+        - '22'
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -113,5 +129,8 @@ jobs:
           ${{ runner.os }}-node-
     - name: NPM CI
       run: npm ci
+    # setup-node sets up problem matchers for the default eslint output
+    # so we should not need to do anything special to get the results
+    # as GitHub Actions annotations.
     - name: Check JS Linting
       run: npm run lint:js

--- a/composer.json
+++ b/composer.json
@@ -100,6 +100,7 @@
         "phpunit/phpunit": "11.*",
         "rector/rector": "^2.1",
         "squizlabs/php_codesniffer": "^3.13",
+        "staabm/annotate-pull-request-from-checkstyle": "^1.8",
         "symfony/panther": "2.*",
         "zircote/swagger-php": "3.*"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "270039180d7b3e8e0dfa58c60aaacb6c",
+    "content-hash": "e16fe6018bf842e59034e97c2f30c225",
     "packages": [
         {
             "name": "academe/authorizenet-objects",
@@ -13157,6 +13157,58 @@
                 }
             ],
             "time": "2025-06-17T22:17:01+00:00"
+        },
+        {
+            "name": "staabm/annotate-pull-request-from-checkstyle",
+            "version": "1.8.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/staabm/annotate-pull-request-from-checkstyle.git",
+                "reference": "082e7f859860f6e79094b6ec86606bd6d0fe9014"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/staabm/annotate-pull-request-from-checkstyle/zipball/082e7f859860f6e79094b6ec86606bd6d0fe9014",
+                "reference": "082e7f859860f6e79094b6ec86606bd6d0fe9014",
+                "shasum": ""
+            },
+            "require": {
+                "ext-libxml": "*",
+                "ext-simplexml": "*",
+                "php": "^5.3 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.16.1"
+            },
+            "bin": [
+                "cs2pr"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Markus Staab"
+                }
+            ],
+            "keywords": [
+                "Github Actions",
+                "continous integration",
+                "dev"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/annotate-pull-request-from-checkstyle/issues",
+                "source": "https://github.com/staabm/annotate-pull-request-from-checkstyle/tree/1.8.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-05-08T15:56:45+00:00"
         },
         {
             "name": "staabm/side-effects-detector",

--- a/test-eslint-errors.js
+++ b/test-eslint-errors.js
@@ -1,0 +1,39 @@
+// This file contains intentional eslint violations for testing
+
+var global_var = "bad variable";
+var unused_variable = 123;
+
+function badFunction(){
+    var x=1;
+    var y=2;
+    if(x==y){
+        console.log("Equal")
+    }
+    return x+y
+}
+
+function anotherBadFunction(param1,param2){
+    if(param1==param2)
+        return true
+    else
+        return false
+}
+
+class BadClass{
+    constructor(){
+        this.property=123;
+    }
+    
+    badMethod(){
+        var result=this.property*2;
+        if(result>100){
+            alert("Large number");
+        }
+        return result;
+    }
+}
+
+var obj=new BadClass();
+console.log(obj.badMethod())
+
+// Missing semicolons, bad spacing, unused variables, etc.

--- a/test-phpcs-errors.php
+++ b/test-phpcs-errors.php
@@ -1,0 +1,30 @@
+<?php
+// This file contains intentional phpcs violations for testing
+
+class badClassName {
+    public $bad_variable_name;
+    
+    function badFunctionName(){
+        $x=1+2;
+        if($x==3){
+            echo"Hello World";
+        }
+        return $x;
+    }
+    
+    public function anotherBadFunction( $param1,$param2 )
+    {
+        $result=$param1+$param2;
+        if($result>10)
+        {
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+}
+
+$global_var = new badClassName();
+$global_var->bad_variable_name = "test";

--- a/test-stylelint-errors.css
+++ b/test-stylelint-errors.css
@@ -1,0 +1,39 @@
+/* This file contains intentional stylelint violations for testing */
+
+.bad-class-name {
+    COLOR: red;
+    BACKGROUND-COLOR: blue;
+    margin:0px;
+    padding:0px;
+    border:1px solid black;
+    font-size:12px;
+}
+
+.another_bad_class {
+    color: #FF0000;
+    background: url('bad-image.jpg');
+    display:block;
+    position:absolute;
+    top:0px;
+    left:0px;
+    width:100px;
+    height:100px;
+}
+
+#bad_id {
+    color: #ffffff;
+    background-color: #000000;
+    font-family: Arial;
+    line-height: 1.2;
+    text-align: center;
+}
+
+.redundant {
+    color: red;
+    color: blue;
+}
+
+.missing-semicolon {
+    color: red
+    background: blue;
+}


### PR DESCRIPTION
Fixes #8624 

#### Short description of what this resolves:

Present styling action findings as github annotations

#### Changes proposed in this pull request:

- [x] ci(styling): actions annotations
- [ ] test(styling): deliberate style breakages (to be removed before merge)

#### Does your code include anything generated by an AI Engine? No 
