### PR TITLE
feat(Crypto): Crypto Strategy

### DIFF
--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -126,7 +126,7 @@ install_configure() {
     # we need this to occur on the docker image of OpenEMR, on local systems this may be the same but in the ci engine its inside the docker container
     # until we get the devops repo setup we'll just grab the auto_configure.php script and use that
     _exec sh -c 'curl -v https://raw.githubusercontent.com/openemr/openemr-devops/refs/heads/master/docker/openemr/flex/auto_configure.php > /root/auto_configure.php'
-    _exec sh -c 'OPENEMR_ENABLE_INSTALLER_AUTO=1 php -f ./contrib/util/installScripts/InstallerAuto.php rootpass=root server=mysql loginhost=%'
+    _exec sh -c "OPENEMR_ENABLE_INSTALLER_AUTO=1 php -f ./contrib/util/installScripts/InstallerAuto.php rootpass=root server=mysql loginhost=% encryption_strategy=${ENCRYPTION_STRATEGY:-cryptogen}"
     _exec mysql -u openemr --password=openemr --ssl=false -h mysql -e 'INSERT INTO product_registration (opt_out) VALUES (1)' openemr
     _exec mysql -u openemr --password=openemr --ssl=false -h mysql -e 'UPDATE globals SET gl_value = 1 WHERE gl_name = "rest_api"' openemr
     _exec mysql -u openemr --password=openemr --ssl=false -h mysql -e 'UPDATE globals SET gl_value = 1 WHERE gl_name = "rest_fhir_api"' openemr

--- a/contrib/util/installScripts/InstallerAuto.php
+++ b/contrib/util/installScripts/InstallerAuto.php
@@ -41,6 +41,8 @@
  *                             will disable cloning / migration since that generally requires root access to the db
  *     development_translations -> If set to anything, will then download and use the development set (updated daily)
  *                                   of translations (indirectly) from the github repository.
+ *     encryption_strategy -> encryption strategy to use (cryptogen)
+ *                             Options: 'cryptogen' for standard encryption, 'null' for no encryption
  *
  *     Examples of use:
  *     1) Install using default configuration settings
@@ -102,6 +104,7 @@ $installSettings['source_site_id']           = 'BLANK';
 $installSettings['clone_database']           = 'BLANK';
 $installSettings['no_root_db_access']        = 'BLANK';
 $installSettings['development_translations'] = 'BLANK';
+$installSettings['encryption_strategy']      = 'cryptogen'; // Default encryption strategy
 
 // Collect parameters(if exist) for installation configuration settings
 for ($i = 1; $i < count($argv); $i++) {

--- a/interface/main/calendar/modules/PostCalendar/pnadmin.phpxlol
+++ b/interface/main/calendar/modules/PostCalendar/pnadmin.phpxlol
@@ -877,7 +877,7 @@ function postcalendar_admin_testSystem()
             $strategyName = CryptoGen::getEncryptionStrategyName();
             if ($strategyName) {
                 array_push($infos, array('Encryption Strategy', $strategyName));
-
+                
                 // Try to get strategy implementation class
                 try {
                     $cryptoGen = new CryptoGen();

--- a/library/classes/Installer.class.php
+++ b/library/classes/Installer.class.php
@@ -1,8 +1,7 @@
 <?php
 
 /**
- *
- * Installer class.
+ * Installer class
  *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
@@ -53,6 +52,7 @@ class Installer
     public $error_message;
     public $debug_message;
     public $dbh;
+    public string $encryption_strategy;
 
     public function __construct($cgi_variables)
     {
@@ -81,6 +81,8 @@ class Installer
         $this->no_root_db_access        = isset($cgi_variables['no_root_db_access']) ? ($cgi_variables['no_root_db_access']) : ''; // no root access to database. user/privileges pre-configured
         $this->development_translations = isset($cgi_variables['development_translations']) ? ($cgi_variables['development_translations']) : '';
         $this->new_theme                = isset($cgi_variables['new_theme']) ? ($cgi_variables['new_theme']) : '';
+        $this->encryption_strategy      = isset($cgi_variables['encryption_strategy']) ? ($cgi_variables['encryption_strategy']) : 'cryptogen';
+
         // Make this true for IPPF.
         $this->ippf_specific = false;
 
@@ -630,6 +632,11 @@ $config = 1; /////////////
                     $res = $this->execute_sql("SELECT count(*) AS count FROM globals WHERE gl_name = '" . $this->escapeSql($fldid) . "'");
                     $row = mysqli_fetch_array($res, MYSQLI_ASSOC);
                     if (empty($row['count'])) {
+                        // Override encryption strategy default with installer parameter
+                        if ($fldid === 'encryption_strategy_name' && !empty($this->encryption_strategy)) {
+                            $flddef = $this->encryption_strategy;
+                        }
+
                         $this->execute_sql("INSERT INTO globals ( gl_name, gl_index, gl_value ) " .
                            "VALUES ( '" . $this->escapeSql($fldid) . "', '0', '" . $this->escapeSql($flddef) . "' )");
                     }

--- a/phpstan.github.neon
+++ b/phpstan.github.neon
@@ -17592,30 +17592,6 @@ parameters:
     identifier: variable.undefined
     count: 1
     path: src/Common/Command/CreateReleaseChangelogCommand.php
-  - message: '#^Constant MCRYPT_MODE_ECB not found\.$#'
-    identifier: constant.notFound
-    count: 2
-    path: src/Common/Crypto/CryptoGen.php
-  - message: '#^Constant MCRYPT_RAND not found\.$#'
-    identifier: constant.notFound
-    count: 1
-    path: src/Common/Crypto/CryptoGen.php
-  - message: '#^Constant MCRYPT_RIJNDAEL_256 not found\.$#'
-    identifier: constant.notFound
-    count: 2
-    path: src/Common/Crypto/CryptoGen.php
-  - message: '#^Function mcrypt_create_iv not found\.$#'
-    identifier: function.notFound
-    count: 1
-    path: src/Common/Crypto/CryptoGen.php
-  - message: '#^Function mcrypt_decrypt not found\.$#'
-    identifier: function.notFound
-    count: 1
-    path: src/Common/Crypto/CryptoGen.php
-  - message: '#^Function mcrypt_get_iv_size not found\.$#'
-    identifier: function.notFound
-    count: 1
-    path: src/Common/Crypto/CryptoGen.php
   - message: '#^Constructor of class OpenEMR\\Common\\Forms\\FormVitals has an unused parameter \$_prefix\.$#'
     identifier: constructor.unusedParameter
     count: 1

--- a/phpstan.local.neon
+++ b/phpstan.local.neon
@@ -17564,30 +17564,6 @@ parameters:
     identifier: variable.undefined
     count: 1
     path: src/Common/Command/CreateReleaseChangelogCommand.php
-  - message: '#^Constant MCRYPT_MODE_ECB not found\.$#'
-    identifier: constant.notFound
-    count: 2
-    path: src/Common/Crypto/CryptoGen.php
-  - message: '#^Constant MCRYPT_RAND not found\.$#'
-    identifier: constant.notFound
-    count: 1
-    path: src/Common/Crypto/CryptoGen.php
-  - message: '#^Constant MCRYPT_RIJNDAEL_256 not found\.$#'
-    identifier: constant.notFound
-    count: 2
-    path: src/Common/Crypto/CryptoGen.php
-  - message: '#^Function mcrypt_create_iv not found\.$#'
-    identifier: function.notFound
-    count: 1
-    path: src/Common/Crypto/CryptoGen.php
-  - message: '#^Function mcrypt_decrypt not found\.$#'
-    identifier: function.notFound
-    count: 1
-    path: src/Common/Crypto/CryptoGen.php
-  - message: '#^Function mcrypt_get_iv_size not found\.$#'
-    identifier: function.notFound
-    count: 1
-    path: src/Common/Crypto/CryptoGen.php
   - message: '#^Constructor of class OpenEMR\\Common\\Forms\\FormVitals has an unused parameter \$_prefix\.$#'
     identifier: constructor.unusedParameter
     count: 1

--- a/sites/default/config.php
+++ b/sites/default/config.php
@@ -7,7 +7,8 @@ use OpenEMR\Common\Crypto\CryptoGen;
 //  they will be encrypted while stored in globals object in memory (to not allow overriding of the global if bad actor
 //  somehow gets access to globals).
 // note that need to skip this block of code during upgrading (or else will have database issues since no keys table)
-if (empty($GLOBALS['ongoing_sql_upgrade'])) {
+// Also skip if database connection isn't available yet (e.g., during bootstrap/testing)
+if (empty($GLOBALS['ongoing_sql_upgrade']) && CryptoGen::ready()) {
     $cryptoGen = new CryptoGen();
     // Print command for spooling to printers, used by statements.inc.php
     //   This is the command to be used for printing (without the filename).

--- a/src/Common/Crypto/CryptoGen.php
+++ b/src/Common/Crypto/CryptoGen.php
@@ -1,121 +1,149 @@
 <?php
 
 /**
- * CryptoGen class.
+ * CryptoGen class - Facade for encryption/decryption operations.
  *
- *   OpenEMR encryption/decryption strategy:
- *    1. Two separate private key sets are used, one key set in the database and one key set on the drive.
- *    2. The private database key set is stored in the keys mysql table
- *    3. The private drive key set is stored in sites/<site-name>/documents/logs_and_misc/methods/
- *    4. The private database key set is used when encrypting/decrypting data that is stored on the drive.
- *    5. The private drive key set is used when encrypting/decrypting data that is stored in the database.
- *    6. The private drive key set is encrypted by the private database key set
- *    7. Encryption/key versioning is used to support algorithm improvements while also ensuring
- *       backwards compatibility of decryption.
- *    8. To ensure performance, the CryptoGen class will cache the key sets that are used inside the object,
- *       which avoids numerous repeat calls to collect the key sets (and repeat decryption of the key set
- *       from the drive).
- *    9. There is also support for passphrase encryption/decryption (ie. no private keys are used).
+ * This class serves as a facade that loads the encryption strategy selected during
+ * installation from the database and delegates all encryption/decryption operations
+ * to that strategy.
+ *
+ * The encryption strategy is selected once during installation and stored in the
+ * database to ensure data accessibility even if modules are removed.
+ *
+ * For details on the encryption implementation, see the individual strategy classes:
+ * - CryptoGenStrategy: Default AES-256-CBC with HMAC-SHA384
+ * - NullEncryptionStrategy: No encryption (identity function)
  *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @author    Ensoftek, Inc
  * @author    Brady Miller <brady.g.miller@gmail.com>
  * @author    Jerry Padgett <sjpadgett@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2015 Ensoftek, Inc
  * @copyright Copyright (c) 2018-2019 Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2024 Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright Copyright (c) 2025 OpenCoreEMR <https://opencoreemr.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenEMR\Common\Crypto;
 
+// Help phpstan find sqlQueryNoLog
+require_once __DIR__ . '/../../../library/sql.inc.php';
+
 use Exception;
+use function sqlQueryNoLog;
+use function sqlStatementNoLog;
 use OpenEMR\Common\Crypto\CryptoGenException;
-use OpenEMR\Common\Utils\RandomGenUtils;
+use OpenEMR\Common\Crypto\EncryptionStrategyInterface;
+use OpenEMR\Common\Crypto\EncryptionStrategySelector;
+use OpenEMR\Common\Crypto\CryptoGenStrategy;
+use OpenEMR\Common\Logging\EventAuditLogger;
+use OpenEMR\Common\Logging\SystemLogger;
 
 class CryptoGen
 {
-    # This is the current encrypt/decrypt version
-    # (this will always be a three digit number that we will
-    #  increment when update the encrypt/decrypt methodology
-    #  which allows being able to maintain backward compatibility
-    #  to decrypt values from prior versions)
-    # Remember to update cryptCheckStandard() and decryptStandard()
-    #  when increment this.
-    private string $encryptionVersion = "006";
-    # This is the current key version. As above, will increment this
-    #  when update the encrypt/decrypt methodology to allow backward
-    #  compatibility.
-    # Remember to update decryptStandard() when increment this.
-    private string $keyVersion = "six";
+    private EncryptionStrategyInterface $encryptionStrategy;
 
-    # Key cache to optimize key collection, which avoids numerous repeat
-    #  calls to collect the key sets (and repeat decryption of the key set
-    #  from the drive).
-    private array $keyCache = [];
+    private SystemLogger $systemLogger;
 
+    /**
+     * Check if CryptoGen can be safely instantiated.
+     *
+     * @return bool True if database connection is available and CryptoGen can be used
+     */
+    public static function ready(): bool
+    {
+        return isset($GLOBALS['adodb']['db']) && !empty($GLOBALS['adodb']['db']);
+    }
+
+    /**
+     * Constructor - Initialize CryptoGen with database-stored encryption strategy.
+     *
+     * Loads the encryption strategy from the database global setting.
+     * Falls back to default CryptoGenStrategy if no strategy is stored.
+     *
+     * @throws CryptoGenException If strategy loading fails
+     */
     public function __construct()
     {
+        $this->systemLogger = new SystemLogger();
+
+        $this->systemLogger->debug("CryptoGen: Constructor called");
+
+        // Load strategy from database
+        $this->encryptionStrategy = $this->loadStrategyFromDatabase();
+
+        $strategyClass = get_class($this->encryptionStrategy);
+        $this->systemLogger->debug(
+            "CryptoGen: Loaded encryption strategy",
+            ['strategy_class' => $strategyClass]
+        );
     }
+
 
     /**
      * Standard function to encrypt
      *
-     * @param string|null $value          This is the data to encrypt.
-     * @param string|null $customPassword If provide a password, then will derive keys from this.(and will not use the standard keys)
-     * @param string      $keySource      This is the source of the standard keys. Options are 'drive' and 'database'
-     *
+     * @param  string|null $value          This is the data to encrypt.
+     * @param  string|null $customPassword If provide a password, then will derive keys from this.(and will not use the standard keys)
+     * @param  string      $keySource      This is the source of the standard keys. Options are 'drive' and 'database'
+     * @return string|null Encrypted data or null if input is null
      */
-    public function encryptStandard(?string $value, ?string $customPassword = null, string $keySource = 'drive')
+    public function encryptStandard(?string $value, ?string $customPassword = null, string $keySource = 'drive'): ?string
     {
-        $encryptedValue = $this->encryptionVersion . $this->coreEncrypt($value, $customPassword, $keySource, $this->keyVersion);
+        $this->systemLogger->debug(
+            "CryptoGen: encryptStandard called",
+            [
+                'has_custom_password' => !is_null($customPassword),
+                'key_source' => $keySource,
+                'strategy' => get_class($this->encryptionStrategy)
+            ]
+        );
 
-        return $encryptedValue;
+        $result = $this->encryptionStrategy->encryptStandard($value, $customPassword, $keySource);
+
+        $this->systemLogger->debug(
+            "CryptoGen: encryptStandard completed",
+            ['success' => $result !== null]
+        );
+
+        return $result;
     }
 
     /**
      * Standard function to decrypt
      *
-     * @param string|null $value          This is the data to decrypt.
-     * @param string|null $customPassword If provide a password, then will derive keys from this.(and will not use the standard keys)
-     * @param string      $keySource      This is the source of the standard keys. Options are 'drive' and 'database'
-     * @param int|null    $minimumVersion This is the minimum encryption version supported (useful if accepting encrypted data
-     *                                    from outside OpenEMR to ensure bad actor is not trying to use an older version).
-     * @return false|string
+     * @param  string|null $value          This is the data to decrypt.
+     * @param  string|null $customPassword If provide a password, then will derive keys from this.(and will not use the standard keys)
+     * @param  string      $keySource      This is the source of the standard keys. Options are 'drive' and 'database'
+     * @param  int|null    $minimumVersion This is the minimum encryption version supported (useful if accepting encrypted data
+     *                                     from outside OpenEMR to ensure bad actor is not trying to use an older version).
+     * @return false|string|null
      */
-    public function decryptStandard(?string $value, ?string $customPassword = null, string $keySource = 'drive', ?int $minimumVersion = null): false|string
+    public function decryptStandard(?string $value, ?string $customPassword = null, string $keySource = 'drive', ?int $minimumVersion = null): false|string|null
     {
-        if (empty($value)) {
-            return "";
-        }
+        $this->systemLogger->debug(
+            "CryptoGen: decryptStandard called",
+            [
+                'has_custom_password' => !is_null($customPassword),
+                'key_source' => $keySource,
+                'minimum_version' => $minimumVersion,
+                'strategy' => get_class($this->encryptionStrategy)
+            ]
+        );
 
-        # Collect the encrypt/decrypt version and remove it from the value
-        $encryptionVersion = intval(mb_substr($value, 0, 3, '8bit'));
-        $trimmedValue = mb_substr($value, 3, null, '8bit');
+        $result = $this->encryptionStrategy->decryptStandard($value, $customPassword, $keySource, $minimumVersion);
 
-        if (!empty($minimumVersion)) {
-            if ($encryptionVersion < $minimumVersion) {
-                error_log("OpenEMR Error : Decryption is not working because the encrypt/decrypt version is lower than allowed.");
-                return false;
-            }
-        }
+        $this->systemLogger->debug(
+            "CryptoGen: decryptStandard completed",
+            ['success' => $result !== false]
+        );
 
-        # Map the encrypt/decrypt version to the correct decryption function
-        if ($encryptionVersion == 6) {
-            return $this->coreDecrypt($trimmedValue, $customPassword, $keySource, "six");
-        } elseif ($encryptionVersion == 5) {
-            return $this->coreDecrypt($trimmedValue, $customPassword, $keySource, "five");
-        } elseif ($encryptionVersion == 4) {
-            return $this->coreDecrypt($trimmedValue, $customPassword, $keySource, "four");
-        } elseif (($encryptionVersion == 2) || ($encryptionVersion == 3)) {
-            return $this->aes256DecryptTwo($trimmedValue, $customPassword);
-        } elseif ($encryptionVersion == 1) {
-            return $this->aes256DecryptOne($trimmedValue, $customPassword);
-        } else {
-            error_log("OpenEMR Error : Decryption is not working because of unknown encrypt/decrypt version.");
-            return false;
-        }
+        return $result;
     }
 
     /**
@@ -124,411 +152,74 @@ class CryptoGen
      */
     public function cryptCheckStandard(?string $value): bool
     {
-        if (empty($value)) {
-            return false;
-        }
-
-        if (preg_match('/^00[1-6]/', $value)) {
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    /**
-     * Function to encrypt data
-     * Should not be called directly (only called by encryptStandard() function)
-     *
-     * @param string|null $sValue          Raw data that will be encrypted.
-     * @param string|null $customPassword  If null, then use standard keys. If provide a password, then will derive key from this.
-     * @param string      $keySource       This is the source of the keys. Options are 'drive' and 'database'
-     * @param string|null $keyNumber       This is the key number/version.
-     * @return string                      returns the encrypted data.
-     * @throws CryptoGenException          if fails, which are critical errors requiring die of script
-     */
-    private function coreEncrypt(?string $sValue, ?string $customPassword = null, string $keySource = 'drive', ?string $keyNumber = null): string
-    {
-        $keyNumber = isset($keyNumber) ? $keyNumber : $this->keyVersion;
-
-        if (!extension_loaded('openssl')) {
-            throw new CryptoGenException("OpenEMR Error : Encryption is not working because missing openssl extension.");
-        }
-
-        if (empty($customPassword)) {
-            // Collect the encryption keys. If they do not exist, then create them
-            // The first key is for encryption. Then second key is for the HMAC hash
-            $sSecretKey = $this->collectCryptoKey($keyNumber, "a", $keySource);
-            $sSecretKeyHmac = $this->collectCryptoKey($keyNumber, "b", $keySource);
-        } else {
-            // customPassword mode, so turn the password into keys
-            $sSalt = RandomGenUtils::produceRandomBytes(32);
-            if (empty($sSalt)) {
-                throw new CryptoGenException("OpenEMR Error : Random Bytes error - exiting");
-            }
-            $sPreKey = hash_pbkdf2('sha384', $customPassword, $sSalt, 100000, 32, true);
-            $sSecretKey = hash_hkdf('sha384', $sPreKey, 32, 'aes-256-encryption', $sSalt);
-            $sSecretKeyHmac = hash_hkdf('sha384', $sPreKey, 32, 'sha-384-authentication', $sSalt);
-        }
-
-        if (empty($sSecretKey) || empty($sSecretKeyHmac)) {
-            throw new CryptoGenException("OpenEMR Error : Encryption is not working because key(s) is blank.");
-        }
-
-        $iv = RandomGenUtils::produceRandomBytes(openssl_cipher_iv_length('aes-256-cbc'));
-        if (empty($iv)) {
-            throw new CryptoGenException("OpenEMR Error : Random Bytes error - exiting");
-        }
-
-        $processedValue = openssl_encrypt(
-            $sValue,
-            'aes-256-cbc',
-            $sSecretKey,
-            OPENSSL_RAW_DATA,
-            $iv
+        $this->systemLogger->debug(
+            "CryptoGen: cryptCheckStandard called",
+            ['strategy' => get_class($this->encryptionStrategy)]
         );
 
-        $hmacHash = hash_hmac('sha384', $iv . $processedValue, $sSecretKeyHmac, true);
+        $result = $this->encryptionStrategy->cryptCheckStandard($value);
 
-        if ($sValue != "" && ($processedValue == "" || $hmacHash == "")) {
-            throw new CryptoGenException("OpenEMR Error : Encryption is not working (encrypted value is blank or hmac hash is blank).");
-        }
+        $this->systemLogger->debug(
+            "CryptoGen: cryptCheckStandard completed",
+            ['result' => $result]
+        );
 
-        if (empty($customPassword)) {
-            // prepend the encrypted value with the $hmacHash and $iv
-            $completedValue = $hmacHash . $iv . $processedValue;
-        } else {
-            // customPassword mode, so prepend the encrypted value with the salts, $hmacHash and $iv
-            $completedValue = $sSalt . $hmacHash . $iv . $processedValue;
-        }
-
-        return base64_encode($completedValue);
+        return $result;
     }
 
 
     /**
-     * Function to decrypt data
-     * Should not be called directly (only called by decryptStandard() function)
+     * Load encryption strategy from database global setting.
      *
-     * @param string      $sValue         Encrypted data that will be decrypted.
-     * @param string|null $customPassword If null, then use standard keys. If provide a password, then will derive key from this.
-     * @param string      $keySource      This is the source of the keys. Options are 'drive' and 'database'
-     * @param string|null $keyNumber      This is the key number/version.
-     * @return false|string or false      returns the decrypted data or false if failed.
+     * Note: This method is only called once during construction and the result
+     * is stored in $this->encryptionStrategy.
+     *
+     * @return EncryptionStrategyInterface Loaded strategy or default CryptoGenStrategy
+     * @throws CryptoGenException If strategy loading fails
      */
-    private function coreDecrypt(string $sValue, ?string $customPassword = null, string $keySource = 'drive', ?string $keyNumber = null): false|string
+    private function loadStrategyFromDatabase(): EncryptionStrategyInterface
     {
-        $keyNumber = isset($keyNumber) ? $keyNumber : $this->keyVersion;
-
-        if (!extension_loaded('openssl')) {
-            error_log("OpenEMR Error : Decryption is not working because missing openssl extension.");
-            return false;
+        // Check if we have a database connection and the globals table exists
+        if (!self::ready()) {
+            throw new CryptoGenException("Fatal error: No database connection available for loading encryption strategy");
         }
 
-        $raw = base64_decode($sValue, true);
-        if ($raw === false) {
-            error_log("OpenEMR Error : Decryption did not work because illegal characters were noted in base64_encoded data.");
-            return false;
-        }
+        $encryptionStrategySelector = new EncryptionStrategySelector();
 
-        if (empty($customPassword)) {
-            // Collect the encryption keys.
-            // The first key is for encryption. Then second key is for the HMAC hash
-            $sSecretKey = $this->collectCryptoKey($keyNumber, "a", $keySource);
-            $sSecretKeyHmac = $this->collectCryptoKey($keyNumber, "b", $keySource);
-        } else {
-            // customPassword mode, so turn the password keys
-            // The first key is for encryption. Then second key is for the HMAC hash
-            // First need to collect the salt from $raw (and then remove it from $raw)
-            $sSalt = mb_substr($raw, 0, 32, '8bit');
-            $raw = mb_substr($raw, 32, null, '8bit');
-            // Now turn the password into keys
-            $sPreKey = hash_pbkdf2('sha384', $customPassword, $sSalt, 100000, 32, true);
-            $sSecretKey = hash_hkdf('sha384', $sPreKey, 32, 'aes-256-encryption', $sSalt);
-            $sSecretKeyHmac = hash_hkdf('sha384', $sPreKey, 32, 'sha-384-authentication', $sSalt);
-        }
+        // Query for the encryption strategy name from global setting
+        $result = sqlQueryNoLog("SELECT gl_value FROM globals WHERE gl_name = 'encryption_strategy_name' AND gl_index = 0");
 
-        if (empty($sSecretKey) || empty($sSecretKeyHmac)) {
-            error_log("OpenEMR Error : Decryption is not working because key(s) is blank.");
-            return false;
-        }
-
-        $ivLength = openssl_cipher_iv_length('aes-256-cbc');
-        $hmacHash = mb_substr($raw, 0, 48, '8bit');
-        $iv = mb_substr($raw, 48, $ivLength, '8bit');
-        $encrypted_data = mb_substr($raw, ($ivLength + 48), null, '8bit');
-
-        $calculatedHmacHash = hash_hmac('sha384', $iv . $encrypted_data, $sSecretKeyHmac, true);
-
-        if (hash_equals($hmacHash, $calculatedHmacHash)) {
-            return openssl_decrypt(
-                $encrypted_data,
-                'aes-256-cbc',
-                $sSecretKey,
-                OPENSSL_RAW_DATA,
-                $iv
+        if (empty($result['gl_value'])) {
+            $this->systemLogger->debug("CryptoGen: No encryption strategy name stored in database, setting default");
+            // Set the default strategy in the database
+            $defaultStrategy = $encryptionStrategySelector->getDefaultStrategy();
+            $defaultStrategyId = $defaultStrategy->getId();
+            sqlStatementNoLog("INSERT INTO globals (gl_name, gl_index, gl_value) VALUES ('encryption_strategy_name', 0, ?)", [$defaultStrategyId]);
+            $this->systemLogger->debug(
+                sprintf("CryptoGen: Set default encryption strategy in database to '%s'", $defaultStrategyId),
+                ['strategy_name' => $defaultStrategyId]
             );
-        } else {
-            try {
-                // throw an exception
-                throw new Exception("OpenEMR Error: Decryption failed HMAC Authentication!");
-            } catch (Exception $e) {
-                // log the exception message and call stack then return legacy null as false for
-                // those evaluating the return value as $return == false which with legacy will eval as false.
-                // I've seen this in the codebase, and it's a bit of a hack, but it's a way to return false instead of null.
-                // Dev's should use empty() instead of == false to check return from this function.
-                // The goal here is so the call stack is exposed to track back to where the call originated.
-                $stackTrace = debug_backtrace();
-                $formattedStackTrace = $this->formatExceptionMessage($stackTrace);
-                error_log(errorLogEscape($e->getMessage()) . "\n" . errorLogEscape($formattedStackTrace));
-                return false;
-            }
-        }
-    }
-
-    private function formatExceptionMessage($stackTrace): string
-    {
-        $formattedStackTrace = "Possibly Config Password or Token. Error Call Stack:\n";
-        foreach ($stackTrace as $index => $call) {
-            $formattedStackTrace .= "#" . $index . " ";
-            if (isset($call['file'])) {
-                $formattedStackTrace .= $call['file'] . " ";
-                if (isset($call['line'])) {
-                    $formattedStackTrace .= "(" . $call['line'] . "): ";
-                }
-            }
-            if (isset($call['class'])) {
-                $formattedStackTrace .= $call['class'] . $call['type'];
-            }
-            if (isset($call['function'])) {
-                $formattedStackTrace .= $call['function'] . "()\n";
-            }
-        }
-        return $formattedStackTrace;
-    }
-
-    /**
-     * Function to AES256 decrypt a given string, version 2
-     *
-     * @param string|null $sValue              Encrypted data that will be decrypted.
-     * @param string|null $customPassword If null, then use standard key. If provide a password, then will derive key from this.
-     * @return false|string alse          returns the decrypted data or false if failed.
-     */
-    public function aes256DecryptTwo(?string $sValue, ?string $customPassword = null): false|string
-    {
-        if (!extension_loaded('openssl')) {
-            error_log("OpenEMR Error : Decryption is not working because missing openssl extension.");
-            return false;
+            return $defaultStrategy;
         }
 
-        if (empty($customPassword)) {
-            // Collect the encryption keys.
-            // The first key is for encryption. Then second key is for the HMAC hash
-            $sSecretKey = $this->collectCryptoKey("two", "a");
-            $sSecretKeyHmac = $this->collectCryptoKey("two", "b");
-        } else {
-            // Turn the password into a hash(note use binary) to use as the keys
-            $sSecretKey = hash("sha256", $customPassword, true);
-            $sSecretKeyHmac = $sSecretKey;
+        $strategyName = $result['gl_value'];
+
+        if (!is_string($strategyName)) {
+            throw new CryptoGenException("Fatal error: Encryption strategy name from database is not a string");
         }
 
-        if (empty($sSecretKey) || empty($sSecretKeyHmac)) {
-            error_log("OpenEMR Error : Decryption is not working because key(s) is blank.");
-            return false;
-        }
-
-        $raw = base64_decode($sValue, true);
-        if ($raw === false) {
-            error_log("OpenEMR Error : Decryption did not work because illegal characters were noted in base64_encoded data.");
-            return false;
-        }
-
-        $ivLength = openssl_cipher_iv_length('aes-256-cbc');
-        $hmacHash = mb_substr($raw, 0, 32, '8bit');
-        $iv = mb_substr($raw, 32, $ivLength, '8bit');
-        $encrypted_data = mb_substr($raw, ($ivLength + 32), null, '8bit');
-
-        $calculatedHmacHash = hash_hmac('sha256', $iv . $encrypted_data, $sSecretKeyHmac, true);
-
-        if (hash_equals($hmacHash, $calculatedHmacHash)) {
-            return openssl_decrypt(
-                $encrypted_data,
-                'aes-256-cbc',
-                $sSecretKey,
-                OPENSSL_RAW_DATA,
-                $iv
-            );
-        } else {
-            try {
-                // throw an exception
-                throw new Exception("OpenEMR Error: Decryption failed hmac authentication!");
-            } catch (Exception $e) {
-                // log the exception message and call stack then return legacy null as false for
-                // those evaluating the return value as $return == false which with legacy will eval as false.
-                // I've seen this in the codebase, and it's a bit of a hack, but it's a way to return false instead of null.
-                // Dev's should use empty() instead of == false to check return from this function.
-                // The goal here is so the call stack is exposed to track back to where the call originated.
-                $stackTrace = debug_backtrace();
-                $formattedStackTrace = $this->formatExceptionMessage($stackTrace);
-                error_log(errorLogEscape($e->getMessage()) . "\n" . errorLogEscape($formattedStackTrace));
-                return false;
-            }
-        }
-    }
-
-    /**
-     * Function to AES256 decrypt a given string, version 1
-     *
-     * @param string|null $sValue              Encrypted data that will be decrypted.
-     * @param string|null $customPassword If null, then use standard key. If provide a password, then will derive key from this.
-     * @return false|string               returns the decrypted data.
-     */
-    public function aes256DecryptOne(?string $sValue, ?string $customPassword = null): false|string
-    {
-        if (!extension_loaded('openssl')) {
-            error_log("OpenEMR Error : Decryption is not working because missing openssl extension.");
-            return false;
-        }
-
-        if (empty($customPassword)) {
-            // Collect the key. If it does not exist, then create it
-            $sSecretKey = $this->collectCryptoKey();
-        } else {
-            // Turn the password into a hash to use as the key
-            $sSecretKey = hash("sha256", $customPassword);
-        }
-
-        if (empty($sSecretKey)) {
-            error_log("OpenEMR Error : Decryption is not working because key is blank.");
-            return false;
-        }
-
-        $raw = base64_decode($sValue);
-
-        $ivLength = openssl_cipher_iv_length('aes-256-cbc');
-
-        $iv = substr($raw, 0, $ivLength);
-        $encrypted_data = substr($raw, $ivLength);
-
-        return openssl_decrypt(
-            $encrypted_data,
-            'aes-256-cbc',
-            $sSecretKey,
-            OPENSSL_RAW_DATA,
-            $iv
+        $this->systemLogger->debug(
+            "CryptoGen: Found strategy name in database",
+            ['strategy_name' => $strategyName]
         );
-    }
 
-    // Function to decrypt a given string
-    // This specific function is only used for backward compatibility
-    // TODO: Should be removed in the future.
-    public function aes256Decrypt_mycrypt($sValue)
-    {
-        $sSecretKey = pack('H*', "bcb04b7e103a0cd8b54763051cef08bc55abe029fdebae5e1d417e2ffb2a00a3");
-        return rtrim(
-            mcrypt_decrypt(
-                MCRYPT_RIJNDAEL_256,
-                $sSecretKey,
-                base64_decode($sValue),
-                MCRYPT_MODE_ECB,
-                mcrypt_create_iv(
-                    mcrypt_get_iv_size(
-                        MCRYPT_RIJNDAEL_256,
-                        MCRYPT_MODE_ECB
-                    ),
-                    MCRYPT_RAND
-                )
-            ),
-            "\0"
-        );
-    }
+        // Use the strategy selector to get strategy by name
+        $strategy = $encryptionStrategySelector->getStrategyByName($strategyName);
 
-    /**
-     * Function to collect (and create, if needed) the standard keys
-     *  This mechanism will allow easy migration to new keys/ciphers in the future while
-     *  also maintaining backward compatibility of encrypted data.
-     *
-     * Note that to increase performance, it will store the key as a variable in this object in case
-     *  the key is used again (especially important when reading encrypted log entries where there
-     *  can be hundreds of decryption calls where it otherwise requires 5 steps to get the key; collect
-     *  key set from database, collect key set from drive, decrypt key set from drive using the database
-     *  key; caching the key will bypass all these steps).
-     *
-     * @param string $version     This is the number/version of they key.
-     * @param string $sub         This is the sublabel of the key
-     * @param string $keySource   This is the source of the standard keys. Options are 'drive' and 'database'
-     *                            The 'drive' keys are stored at sites/<site-dir>/documents/logs_and_misc/methods
-     *                            The 'database' keys are stored in the 'keys' sql table
-     * @return string             Returns the key in raw form.
-     * @throws CryptoGenException if fails, which are critical errors requiring die of script
-     */
-    private function collectCryptoKey(string $version = "one", string $sub = "", string $keySource = 'drive'): string
-    {
-        // Check if key is in the cache first (and return it if it is)
-        $cacheLabel = $version . $sub . $keySource;
-        if (!empty($this->keyCache[$cacheLabel])) {
-            return $this->keyCache[$cacheLabel];
+        if ($strategy instanceof \OpenEMR\Common\Crypto\EncryptionStrategyInterface) {
+            return $strategy;
         }
 
-        // Build the main label
-        $label = $version . $sub;
-
-        // If the key does not exist, then create it
-        if ($keySource == 'database') {
-            $sqlValue = sqlQueryNoLog("SELECT `value` FROM `keys` WHERE `name` = ?", [$label]);
-            if (empty($sqlValue['value'])) {
-                // Create a new key and place in database
-                // Produce a 256bit key (32 bytes equals 256 bits)
-                $newKey = RandomGenUtils::produceRandomBytes(32);
-                if (empty($newKey)) {
-                    throw new CryptoGenException("OpenEMR Error : Random Bytes error - exiting");
-                }
-                sqlStatementNoLog("INSERT INTO `keys` (`name`, `value`) VALUES (?, ?)", [$label, base64_encode($newKey)]);
-            }
-        } else { //$keySource == 'drive'
-            if (!file_exists($GLOBALS['OE_SITE_DIR'] . "/documents/logs_and_misc/methods/" . $label)) {
-                // Create a key and place in drive
-                // Produce a 256bit key (32 bytes equals 256 bits)
-                $newKey = RandomGenUtils::produceRandomBytes(32);
-                if (empty($newKey)) {
-                    throw new CryptoGenException("OpenEMR Error : Random Bytes error - exiting");
-                }
-                if (($version == "one") || ($version == "two") || ($version == "three") || ($version == "four")) {
-                    // older key versions that did not encrypt the key on the drive
-                    file_put_contents($GLOBALS['OE_SITE_DIR'] . "/documents/logs_and_misc/methods/" . $label, base64_encode($newKey));
-                } else {
-                    file_put_contents($GLOBALS['OE_SITE_DIR'] . "/documents/logs_and_misc/methods/" . $label, $this->encryptStandard($newKey, null, 'database'));
-                }
-            }
-        }
-
-        // Collect key
-        if ($keySource == 'database') {
-            $sqlKey = sqlQueryNoLog("SELECT `value` FROM `keys` WHERE `name` = ?", [$label]);
-            $key = base64_decode($sqlKey['value']);
-        } else { //$keySource == 'drive'
-            if (($version == "one") || ($version == "two") || ($version == "three") || ($version == "four")) {
-                // older key versions that did not encrypt the key on the drive
-                $key = base64_decode(rtrim(file_get_contents($GLOBALS['OE_SITE_DIR'] . "/documents/logs_and_misc/methods/" . $label)));
-            } else {
-                $key = $this->decryptStandard(file_get_contents($GLOBALS['OE_SITE_DIR'] . "/documents/logs_and_misc/methods/" . $label), null, 'database');
-            }
-        }
-
-        // Ensure have a key (if do not have key, then is critical error, and will exit)
-        if (empty($key)) {
-            if ($keySource == 'database') {
-                throw new CryptoGenException("OpenEMR Error : Key creation in database is not working - Exiting.");
-            } else { //$keySource == 'drive'
-                if (!file_exists($GLOBALS['OE_SITE_DIR'] . "/documents/logs_and_misc/methods/" . $label)) {
-                    throw new CryptoGenException("OpenEMR Error : Key creation in drive is not working - Exiting.");
-                } else {
-                    throw new CryptoGenException("OpenEMR Error : Key in drive is not compatible (ie. can not be decrypted) with key in database - Exiting.");
-                }
-            }
-        }
-
-        // Store key in cache and then return the key
-        $this->keyCache[$cacheLabel] = $key;
-        return $key;
+        throw new CryptoGenException(sprintf("Fatal error: Encryption strategy '%s' configured in database but not found", $strategyName));
     }
 }

--- a/src/Common/Crypto/CryptoGenException.php
+++ b/src/Common/Crypto/CryptoGenException.php
@@ -1,7 +1,11 @@
 <?php
 
 /**
- * CryptoGenException
+ * CryptoGenException - Exception class for cryptographic operations.
+ *
+ * This exception is thrown when critical cryptographic errors occur,
+ * such as missing OpenSSL extension, key generation failures, or
+ * encryption/decryption errors that require the script to exit.
  *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
@@ -10,8 +14,16 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenEMR\Common\Crypto;
 
+/**
+ * Exception class for critical cryptographic errors.
+ *
+ * Used to indicate fatal errors in encryption/decryption operations
+ * that should cause the script to terminate.
+ */
 class CryptoGenException extends \Exception
 {
 }

--- a/src/Common/Crypto/CryptoGenStrategy.php
+++ b/src/Common/Crypto/CryptoGenStrategy.php
@@ -1,0 +1,584 @@
+<?php
+
+/**
+ * CryptoGenStrategy - Default encryption strategy implementation.
+ *
+ * Implements AES-256-CBC encryption with HMAC-SHA384 authentication.
+ * Supports both standard key-based encryption and custom password-based encryption.
+ * Uses PBKDF2 + HKDF for password-based key derivation.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2024 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2025 OpenCoreEMR <https://opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Crypto;
+
+use Exception;
+use OpenEMR\Common\Crypto\CryptoGenException;
+use OpenEMR\Common\Crypto\EncryptionStrategyInterface;
+use OpenEMR\Common\Utils\RandomGenUtils;
+use OpenEMR\Common\Logging\SystemLogger;
+
+/**
+ * Default encryption strategy using AES-256-CBC with HMAC-SHA384.
+ *
+ * This strategy provides secure encryption with:
+ * - AES-256-CBC for data encryption
+ * - HMAC-SHA384 for authentication
+ * - PBKDF2 + HKDF for password-based key derivation
+ * - Support for multiple key versions for backward compatibility
+ */
+class CryptoGenStrategy implements EncryptionStrategyInterface
+{
+    // This is the current encrypt/decrypt version
+    // (this will always be a three digit number that we will
+    // increment when updating the encrypt/decrypt methodology
+    // which allows being able to maintain backward compatibility
+    // to decrypt values from prior versions)
+    // Remember to update cryptCheckStandard() and decryptStandard()
+    // when incrementing this.
+    private string $encryptionVersion = "006";
+
+    private string $keyVersion = "six";
+
+    private array $keyCache = [];
+
+    private readonly SystemLogger $systemLogger;
+
+    public function __construct()
+    {
+        $this->systemLogger = new SystemLogger();
+        $this->systemLogger->debug(
+            "CryptoGenStrategy: Initialized",
+            [
+                'encryption_version' => $this->encryptionVersion,
+                'key_version' => $this->keyVersion
+            ]
+        );
+    }
+
+    /**
+     * Encrypt data using the current encryption version (see $encryptionVersion).
+     *
+     * @param  string|null $value          The data to encrypt
+     * @param  string|null $customPassword If provided, derives keys from password instead of standard keys
+     * @param  string      $keySource      Source for standard keys ('drive' or 'database')
+     * @return string|null Encrypted data prefixed with $encryptionVersion, using $keyVersion for key selection, or null if input is null
+     */
+    public function encryptStandard(?string $value, ?string $customPassword = null, string $keySource = 'drive'): string
+    {
+        $this->systemLogger->debug(
+            "CryptoGenStrategy: encryptStandard called",
+            [
+                'has_custom_password' => !is_null($customPassword),
+                'key_source' => $keySource,
+                'key_version' => $this->keyVersion
+            ]
+        );
+
+        $result = $this->encryptionVersion . $this->coreEncrypt($value, $customPassword, $keySource, $this->keyVersion);
+
+        $this->systemLogger->debug("CryptoGenStrategy: encryptStandard completed");
+
+        return $result;
+    }
+
+    /**
+     * Decrypt data encrypted with any supported encryption version.
+     *
+     * @param  string|null $value          The encrypted data to decrypt
+     * @param  string|null $customPassword If provided, derives keys from password instead of standard keys
+     * @param  string      $keySource      Source for standard keys ('drive' or 'database')
+     * @param  int|null    $minimumVersion Minimum encryption version required (for security validation)
+     * @return false|string Decrypted data or false on failure
+     */
+    public function decryptStandard(?string $value, ?string $customPassword = null, string $keySource = 'drive', ?int $minimumVersion = null): false|string
+    {
+        if ($value === null || $value === '' || $value === '0') {
+            return "";
+        }
+
+        $encryptionVersion = intval(mb_substr($value, 0, 3, '8bit'));
+        $trimmedValue = mb_substr($value, 3, null, '8bit');
+
+        if ($minimumVersion !== null && $minimumVersion !== 0 && ($encryptionVersion < $minimumVersion)) {
+            error_log("OpenEMR Error : Decryption is not working because the encrypt/decrypt version is lower than allowed.");
+            return false;
+        }
+
+        return match ($encryptionVersion) {
+            6 => $this->coreDecrypt($trimmedValue, $customPassword, $keySource, "six"),
+            5 => $this->coreDecrypt($trimmedValue, $customPassword, $keySource, "five"),
+            4 => $this->coreDecrypt($trimmedValue, $customPassword, $keySource, "four"),
+            2, 3 => $this->aes256DecryptTwo($trimmedValue, $customPassword),
+            1 => $this->aes256DecryptOne($trimmedValue, $customPassword),
+            default => (function (): bool {
+                error_log("OpenEMR Error : Decryption is not working because of unknown encrypt/decrypt version.");
+                return false;
+            })(),
+        };
+    }
+
+    /**
+     * Check if a value was encrypted using a supported encryption version.
+     *
+     * @param  string|null $value The value to check
+     * @return bool True if the value has a valid encryption version prefix (001-006)
+     */
+    public function cryptCheckStandard(?string $value): bool
+    {
+        // Must have data after version prefix
+        return preg_match('/^00[1-6]./', $value ?? '') === 1;
+    }
+
+    /**
+     * Get the unique identifier for this encryption strategy.
+     *
+     * @return string Strategy identifier
+     */
+    public function getId(): string
+    {
+        return 'cryptogen';
+    }
+
+    /**
+     * Get the human-readable name for this encryption strategy.
+     *
+     * @return string Strategy display name
+     */
+    public function getName(): string
+    {
+        return 'Standard Encryption (AES-256-CBC)';
+    }
+
+    /**
+     * Get a description of this encryption strategy.
+     *
+     * @return string Strategy description
+     */
+    public function getDescription(): string
+    {
+        return 'OpenEMR default encryption using AES-256-CBC with HMAC-SHA384 authentication. Recommended for most installations.';
+    }
+
+    private function coreEncrypt(?string $sValue, ?string $customPassword = null, string $keySource = 'drive', ?string $keyNumber = null): string
+    {
+        $keyNumber ??= $this->keyVersion;
+
+        $this->validateOpenSSLExtension();
+
+        [$sSecretKey, $sSecretKeyHmac, $sSalt] = $this->deriveKeys($customPassword, $keyNumber, $keySource);
+        $this->validateKeys($sSecretKey, $sSecretKeyHmac);
+
+        $iv = RandomGenUtils::produceRandomBytes(openssl_cipher_iv_length('aes-256-cbc'));
+        if (empty($iv)) {
+            throw new CryptoGenException("OpenEMR Error : Random Bytes error - exiting");
+        }
+
+        // Handle null values by treating them as empty strings for backward compatibility
+        $valueToEncrypt = $sValue ?? '';
+
+        $processedValue = openssl_encrypt(
+            $valueToEncrypt,
+            'aes-256-cbc',
+            $sSecretKey,
+            OPENSSL_RAW_DATA,
+            $iv
+        );
+
+        $hmacHash = hash_hmac('sha384', $iv . $processedValue, (string) $sSecretKeyHmac, true);
+
+        if ($sValue !== "" && ($processedValue === false || $hmacHash === "")) {
+            throw new CryptoGenException("OpenEMR Error : Encryption is not working (encrypted value is blank or hmac hash is blank).");
+        }
+
+        $completedValue = $hmacHash . $iv . $processedValue;
+        if ($customPassword !== null && $customPassword !== '' && $customPassword !== '0') {
+            $completedValue = $sSalt . $completedValue;
+        }
+
+        return base64_encode($completedValue);
+    }
+
+    private function coreDecrypt(string $sValue, ?string $customPassword = null, string $keySource = 'drive', ?string $keyNumber = null): false|string
+    {
+        $keyNumber ??= $this->keyVersion;
+
+        if (!extension_loaded('openssl')) {
+            error_log("OpenEMR Error : Decryption is not working because missing openssl extension.");
+            return false;
+        }
+
+        $raw = base64_decode($sValue, true);
+        if ($raw === false) {
+            error_log("OpenEMR Error : Decryption did not work because illegal characters were noted in base64_encoded data.");
+            return false;
+        }
+
+        if ($customPassword === null || $customPassword === '' || $customPassword === '0') {
+            $sSecretKey = $this->collectCryptoKey($keyNumber, "a", $keySource);
+            $sSecretKeyHmac = $this->collectCryptoKey($keyNumber, "b", $keySource);
+        } else {
+            $sSalt = mb_substr($raw, 0, 32, '8bit');
+            $raw = mb_substr($raw, 32, null, '8bit');
+            $sPreKey = hash_pbkdf2('sha384', $customPassword, $sSalt, 100000, 32, true);
+            $sSecretKey = hash_hkdf('sha384', $sPreKey, 32, 'aes-256-encryption', $sSalt);
+            $sSecretKeyHmac = hash_hkdf('sha384', $sPreKey, 32, 'sha-384-authentication', $sSalt);
+        }
+
+        if ($sSecretKey === '' || $sSecretKey === '0' || ($sSecretKeyHmac === '' || $sSecretKeyHmac === '0')) {
+            error_log("OpenEMR Error : Decryption is not working because key(s) is blank.");
+            return false;
+        }
+
+        $ivLength = openssl_cipher_iv_length('aes-256-cbc');
+        $hmacHash = mb_substr($raw, 0, 48, '8bit');
+        $iv = mb_substr($raw, 48, $ivLength, '8bit');
+        $encrypted_data = mb_substr($raw, ($ivLength + 48), null, '8bit');
+
+        $calculatedHmacHash = hash_hmac('sha384', $iv . $encrypted_data, $sSecretKeyHmac, true);
+
+        if (hash_equals($hmacHash, $calculatedHmacHash)) {
+            return openssl_decrypt(
+                $encrypted_data,
+                'aes-256-cbc',
+                $sSecretKey,
+                OPENSSL_RAW_DATA,
+                $iv
+            );
+        } else {
+            try {
+                throw new Exception("OpenEMR Error: Decryption failed HMAC Authentication!");
+            } catch (Exception $e) {
+                $stackTrace = debug_backtrace();
+                $formattedStackTrace = $this->formatExceptionMessage($stackTrace);
+                error_log(errorLogEscape($e->getMessage()) . "\n" . errorLogEscape($formattedStackTrace));
+                return false;
+            }
+        }
+    }
+
+    private function formatExceptionMessage($stackTrace): string
+    {
+        $formattedStackTrace = "Possibly Config Password or Token. Error Call Stack:\n";
+        foreach ($stackTrace as $index => $call) {
+            $formattedStackTrace .= "#" . $index . " ";
+            if (isset($call['file'])) {
+                $formattedStackTrace .= $call['file'] . " ";
+                if (isset($call['line'])) {
+                    $formattedStackTrace .= "(" . $call['line'] . "): ";
+                }
+            }
+
+            if (isset($call['class'])) {
+                $formattedStackTrace .= $call['class'] . $call['type'];
+            }
+
+            if (isset($call['function'])) {
+                $formattedStackTrace .= $call['function'] . "()\n";
+            }
+        }
+
+        return $formattedStackTrace;
+    }
+
+    public function aes256DecryptTwo(?string $sValue, ?string $customPassword = null): false|string
+    {
+        if (!extension_loaded('openssl')) {
+            error_log("OpenEMR Error : Decryption is not working because missing openssl extension.");
+            return false;
+        }
+
+        if ($customPassword === null || $customPassword === '' || $customPassword === '0') {
+            $sSecretKey = $this->collectCryptoKey("two", "a");
+            $sSecretKeyHmac = $this->collectCryptoKey("two", "b");
+        } else {
+            $sSecretKey = hash("sha256", $customPassword, true);
+            $sSecretKeyHmac = $sSecretKey;
+        }
+
+        if ($sSecretKey === '' || $sSecretKey === '0' || ($sSecretKeyHmac === '' || $sSecretKeyHmac === '0')) {
+            error_log("OpenEMR Error : Decryption is not working because key(s) is blank.");
+            return false;
+        }
+
+        $raw = base64_decode((string) $sValue, true);
+        if ($raw === false) {
+            error_log("OpenEMR Error : Decryption did not work because illegal characters were noted in base64_encoded data.");
+            return false;
+        }
+
+        $ivLength = openssl_cipher_iv_length('aes-256-cbc');
+        $hmacHash = mb_substr($raw, 0, 32, '8bit');
+        $iv = mb_substr($raw, 32, $ivLength, '8bit');
+        $encrypted_data = mb_substr($raw, ($ivLength + 32), null, '8bit');
+
+        $calculatedHmacHash = hash_hmac('sha256', $iv . $encrypted_data, $sSecretKeyHmac, true);
+
+        if (hash_equals($hmacHash, $calculatedHmacHash)) {
+            return openssl_decrypt(
+                $encrypted_data,
+                'aes-256-cbc',
+                $sSecretKey,
+                OPENSSL_RAW_DATA,
+                $iv
+            );
+        } else {
+            try {
+                throw new Exception("OpenEMR Error: Decryption failed hmac authentication!");
+            } catch (Exception $e) {
+                $stackTrace = debug_backtrace();
+                $formattedStackTrace = $this->formatExceptionMessage($stackTrace);
+                error_log(errorLogEscape($e->getMessage()) . "\n" . errorLogEscape($formattedStackTrace));
+                return false;
+            }
+        }
+    }
+
+    public function aes256DecryptOne(?string $sValue, ?string $customPassword = null): false|string
+    {
+        if (!extension_loaded('openssl')) {
+            error_log("OpenEMR Error : Decryption is not working because missing openssl extension.");
+            return false;
+        }
+
+        $sSecretKey = $customPassword === null || $customPassword === '' || $customPassword === '0' ? $this->collectCryptoKey() : hash("sha256", $customPassword);
+
+        if ($sSecretKey === '' || $sSecretKey === '0') {
+            error_log("OpenEMR Error : Decryption is not working because key is blank.");
+            return false;
+        }
+
+        $raw = base64_decode((string) $sValue);
+
+        $ivLength = openssl_cipher_iv_length('aes-256-cbc');
+
+        $iv = substr($raw, 0, $ivLength);
+        $encrypted_data = substr($raw, $ivLength);
+
+        return openssl_decrypt(
+            $encrypted_data,
+            'aes-256-cbc',
+            $sSecretKey,
+            OPENSSL_RAW_DATA,
+            $iv
+        );
+    }
+
+    /**
+     * Validate that the OpenSSL extension is loaded.
+     *
+     * @throws CryptoGenException If OpenSSL extension is not available
+     */
+    private function validateOpenSSLExtension(): void
+    {
+        if (!extension_loaded('openssl')) {
+            throw new CryptoGenException("OpenEMR Error : Encryption is not working because missing openssl extension.");
+        }
+    }
+
+    /**
+     * Derive encryption and HMAC keys from either stored keys or custom password.
+     *
+     * @param  string|null $customPassword If provided, uses PBKDF2+HKDF for key derivation
+     * @param  string      $keyNumber      The key version to use (e.g., 'six', 'five')
+     * @param  string      $keySource      Source for standard keys ('drive' or 'database')
+     * @return array [encryptionKey, hmacKey, salt] - salt is null for standard keys
+     */
+    private function deriveKeys(?string $customPassword, string $keyNumber, string $keySource): array
+    {
+        if ($customPassword === null || $customPassword === '' || $customPassword === '0') {
+            return [
+                $this->collectCryptoKey($keyNumber, "a", $keySource),
+                $this->collectCryptoKey($keyNumber, "b", $keySource),
+                null
+            ];
+        }
+
+        $sSalt = RandomGenUtils::produceRandomBytes(32);
+        if (empty($sSalt)) {
+            throw new CryptoGenException("OpenEMR Error : Random Bytes error - exiting");
+        }
+
+        $sPreKey = hash_pbkdf2('sha384', $customPassword, (string) $sSalt, 100000, 32, true);
+        return [
+            hash_hkdf('sha384', $sPreKey, 32, 'aes-256-encryption', $sSalt),
+            hash_hkdf('sha384', $sPreKey, 32, 'sha-384-authentication', $sSalt),
+            $sSalt
+        ];
+    }
+
+    /**
+     * Validate that encryption keys are not empty.
+     *
+     * @param  string $secretKey     The encryption key
+     * @param  string $secretKeyHmac The HMAC key
+     * @throws CryptoGenException If either key is empty
+     */
+    private function validateKeys(string $secretKey, string $secretKeyHmac): void
+    {
+        if ($secretKey === '' || $secretKey === '0' || ($secretKeyHmac === '' || $secretKeyHmac === '0')) {
+            throw new CryptoGenException("OpenEMR Error : Encryption is not working because key(s) is blank.");
+        }
+    }
+
+    private function collectCryptoKey(string $version = "one", string $sub = "", string $keySource = 'drive'): string
+    {
+        $cacheLabel = $version . $sub . $keySource;
+        if (!empty($this->keyCache[$cacheLabel])) {
+            return $this->keyCache[$cacheLabel];
+        }
+
+        $label = $version . $sub;
+
+        if ($keySource === 'database') {
+            $sqlValue = sqlQueryNoLog("SELECT `value` FROM `keys` WHERE `name` = ?", [$label]);
+            if (empty($sqlValue['value'])) {
+                $newKey = RandomGenUtils::produceRandomBytes(32);
+                if (empty($newKey)) {
+                    throw new CryptoGenException("OpenEMR Error : Random Bytes error - exiting");
+                }
+
+                sqlStatementNoLog("INSERT INTO `keys` (`name`, `value`) VALUES (?, ?)", [$label, base64_encode((string) $newKey)]);
+            }
+        } elseif (!file_exists($GLOBALS['OE_SITE_DIR'] . "/documents/logs_and_misc/methods/" . $label)) {
+            $newKey = RandomGenUtils::produceRandomBytes(32);
+            if (empty($newKey)) {
+                throw new CryptoGenException("OpenEMR Error : Random Bytes error - exiting");
+            }
+
+            if (($version === "one") || ($version === "two") || ($version === "three") || ($version === "four")) {
+                file_put_contents($GLOBALS['OE_SITE_DIR'] . "/documents/logs_and_misc/methods/" . $label, base64_encode((string) $newKey));
+            } else {
+                // For newer key versions, we need to encrypt using database keys
+                // Create a temporary instance to handle this without circular dependency
+                $tempStrategy = new self();
+                $encryptedKey = $tempStrategy->encryptUsingDatabaseKeys($newKey, $version);
+                file_put_contents($GLOBALS['OE_SITE_DIR'] . "/documents/logs_and_misc/methods/" . $label, $encryptedKey);
+            }
+        }
+
+        if ($keySource === 'database') {
+            $sqlKey = sqlQueryNoLog("SELECT `value` FROM `keys` WHERE `name` = ?", [$label]);
+            $key = base64_decode((string) $sqlKey['value']);
+        } elseif (($version === "one") || ($version === "two") || ($version === "three") || ($version === "four")) {
+            $key = base64_decode(rtrim(file_get_contents($GLOBALS['OE_SITE_DIR'] . "/documents/logs_and_misc/methods/" . $label)));
+        } else {
+            $key = $this->decryptUsingDatabaseKeys(file_get_contents($GLOBALS['OE_SITE_DIR'] . "/documents/logs_and_misc/methods/" . $label), $version);
+        }
+
+        if (empty($key)) {
+            if ($keySource === 'database') {
+                throw new CryptoGenException("OpenEMR Error : Key creation in database is not working - Exiting.");
+            } elseif (!file_exists($GLOBALS['OE_SITE_DIR'] . "/documents/logs_and_misc/methods/" . $label)) {
+                throw new CryptoGenException("OpenEMR Error : Key creation in drive is not working - Exiting.");
+            } else {
+                throw new CryptoGenException("OpenEMR Error : Key in drive is not compatible (ie. can not be decrypted) with key in database - Exiting.");
+            }
+        }
+
+        $this->keyCache[$cacheLabel] = $key;
+        return $key;
+    }
+
+    private function encryptUsingDatabaseKeys(string $value, string $keyNumber): string
+    {
+        $sSecretKey = $this->collectCryptoKey($keyNumber, "a", 'database');
+        $sSecretKeyHmac = $this->collectCryptoKey($keyNumber, "b", 'database');
+
+        // GitHub Copilot: Fixed type handling for openssl_cipher_iv_length return value
+        $ivLength = openssl_cipher_iv_length('aes-256-cbc');
+        if ($ivLength === false) {
+            throw new CryptoGenException("OpenEMR Error : Unable to determine IV length for AES-256-CBC");
+        }
+
+        $iv = RandomGenUtils::produceRandomBytes($ivLength);
+        if (!is_string($iv) || empty($iv)) {
+            throw new CryptoGenException("OpenEMR Error : Random Bytes error - exiting");
+        }
+
+        $processedValue = openssl_encrypt(
+            $value,
+            'aes-256-cbc',
+            $sSecretKey,
+            OPENSSL_RAW_DATA,
+            $iv
+        );
+
+        // GitHub Copilot: Added validation for openssl_encrypt return value
+        if ($processedValue === false) {
+            throw new CryptoGenException("OpenEMR Error : Encryption failed - OpenSSL encrypt returned false");
+        }
+
+        $hmacHash = hash_hmac('sha384', $iv . $processedValue, $sSecretKeyHmac, true);
+        $completedValue = $hmacHash . $iv . $processedValue;
+
+        return $this->encryptionVersion . base64_encode($completedValue);
+    }
+
+    /**
+     * Decrypts a value using database encryption keys with HMAC authentication.
+     *
+     * This method handles decryption of data encrypted with version 6 encryption format.
+     * It validates the encryption version, extracts the HMAC, IV, and encrypted data,
+     * verifies HMAC authentication, and then decrypts the data using AES-256-CBC.
+     *
+     * @param string $value     The encrypted value to decrypt, prefixed with 3-digit version number
+     * @param string $keyNumber The key number identifier for retrieving encryption keys
+     *
+     * @return string The decrypted plaintext value, or null if decryption fails
+     *
+     * @throws CryptoGenException If encryption version is not 6
+     * @throws CryptoGenException If base64 decoding fails due to illegal characters
+     * @throws CryptoGenException If HMAC authentication fails
+     */
+    private function decryptUsingDatabaseKeys(string $value, string $keyNumber): string
+    {
+        $encryptionVersion = intval(mb_substr($value, 0, 3, '8bit'));
+        $trimmedValue = mb_substr($value, 3, null, '8bit');
+
+        if ($encryptionVersion != 6) {
+            throw new CryptoGenException("OpenEMR Error : Unexpected encryption version for database key decryption: " . $encryptionVersion);
+        }
+
+        $sSecretKey = $this->collectCryptoKey($keyNumber, "a", 'database');
+        $sSecretKeyHmac = $this->collectCryptoKey($keyNumber, "b", 'database');
+
+        $raw = base64_decode($trimmedValue, true);
+        if ($raw === false) {
+            throw new CryptoGenException("OpenEMR Error : Decryption did not work because illegal characters were noted in base64_encoded data.");
+        }
+
+        $ivLength = openssl_cipher_iv_length('aes-256-cbc') ?: null;
+        $hmacHash = mb_substr($raw, 0, 48, '8bit');
+        $iv = mb_substr($raw, 48, $ivLength, '8bit');
+        $encrypted_data = mb_substr($raw, ($ivLength + 48), null, '8bit');
+
+        $calculatedHmacHash = hash_hmac('sha384', $iv . $encrypted_data, $sSecretKeyHmac, true);
+
+        if (!hash_equals($hmacHash, $calculatedHmacHash)) {
+            throw new CryptoGenException("OpenEMR Error: Database key decryption failed HMAC Authentication!");
+        }
+
+        $decryptedValue = openssl_decrypt(
+            $encrypted_data,
+            'aes-256-cbc',
+            $sSecretKey,
+            OPENSSL_RAW_DATA,
+            $iv
+        );
+
+        if ($decryptedValue === false) {
+            throw new CryptoGenException("OpenEMR Error: Database key decryption failed - OpenSSL decryption returned false");
+        }
+
+        return $decryptedValue;
+    }
+}

--- a/src/Common/Crypto/EncryptionStrategyInterface.php
+++ b/src/Common/Crypto/EncryptionStrategyInterface.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * EncryptionStrategyInterface - Interface for encryption strategy implementations.
+ *
+ * This interface defines the contract that all encryption strategies must implement
+ * to be compatible with the CryptoGen class. It supports both standard key-based
+ * encryption and custom password-based encryption.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2024 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2025 OpenCoreEMR <https://opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Crypto;
+
+/**
+ * Interface for encryption strategy implementations.
+ *
+ * All encryption strategies must implement these methods to provide
+ * encryption, decryption, and validation functionality.
+ */
+interface EncryptionStrategyInterface
+{
+    /**
+     * Encrypt data using the strategy's encryption method.
+     *
+     * @param string|null $value The data to encrypt
+     * @param string|null $customPassword If provided, use password-based encryption
+     * @param string $keySource Source for standard keys ('drive' or 'database')
+     * @return string|null Encrypted data or null if input is null
+     */
+    public function encryptStandard(?string $value, ?string $customPassword = null, string $keySource = 'drive');
+
+    /**
+     * Decrypt data using the strategy's decryption method.
+     *
+     * @param string|null $value The encrypted data to decrypt
+     * @param string|null $customPassword If provided, use password-based decryption
+     * @param string $keySource Source for standard keys ('drive' or 'database')
+     * @param int|null $minimumVersion Minimum encryption version required
+     * @return false|string|null Decrypted data or false on failure
+     */
+    public function decryptStandard(?string $value, ?string $customPassword = null, string $keySource = 'drive', ?int $minimumVersion = null): false|string|null;
+
+    /**
+     * Check if a value was encrypted using this strategy.
+     *
+     * @param string|null $value The value to check
+     * @return bool True if the value is compatible with this strategy
+     */
+    public function cryptCheckStandard(?string $value): bool;
+
+    /**
+     * Get the unique identifier for this encryption strategy.
+     *
+     * @return string Strategy identifier (e.g., 'cryptogen', 'null')
+     */
+    public function getId(): string;
+
+    /**
+     * Get the human-readable name for this encryption strategy.
+     *
+     * @return string Strategy display name
+     */
+    public function getName(): string;
+
+    /**
+     * Get a description of this encryption strategy.
+     *
+     * @return string Strategy description
+     */
+    public function getDescription(): string;
+}

--- a/src/Common/Crypto/EncryptionStrategySelector.php
+++ b/src/Common/Crypto/EncryptionStrategySelector.php
@@ -1,0 +1,176 @@
+<?php
+
+/**
+ * Tool for selecting and managing encryption strategies during installation.
+ *
+ * This class provides functionality to discover available encryption strategies
+ * through the event system and allow selection during the installation process.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2025 OpenCoreEMR <https://opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ *
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Crypto;
+
+use OpenEMR\Common\Crypto\EncryptionStrategyInterface;
+use OpenEMR\Common\Crypto\CryptoGenStrategy;
+use OpenEMR\Common\Crypto\NullEncryptionStrategy;
+use OpenEMR\Common\Crypto\CryptoGenException;
+use OpenEMR\Common\Logging\SystemLogger;
+
+class EncryptionStrategySelector
+{
+    /**
+     * Default encryption strategy identifier.
+     */
+    public const DEFAULT_STRATEGY_ID = 'cryptogen';
+
+    private SystemLogger $systemLogger;
+
+    /**
+     * Array of built-in encryption strategy instances.
+     *
+     * @var array<string, EncryptionStrategyInterface> Built-in encryption strategies
+     */
+    private array $builtinStrategies = [];
+
+    public function __construct()
+    {
+        $this->systemLogger = new SystemLogger();
+        $this->initializeBuiltinStrategies();
+    }
+
+    /**
+     * Initialize the built-in encryption strategies.
+     */
+    private function initializeBuiltinStrategies(): void
+    {
+        $this->builtinStrategies = [
+            'cryptogen' => new CryptoGenStrategy(),
+            'null' => new NullEncryptionStrategy()
+        ];
+    }
+
+    /**
+     * Get all available encryption strategies (core implementations only).
+     *
+     * @return array<string, EncryptionStrategyInterface> Array of strategy instances indexed by ID
+     */
+    public function getAvailableStrategies(): array
+    {
+        return $this->builtinStrategies;
+    }
+
+    /**
+     * Get a specific strategy instance by ID.
+     *
+     * @param string $id Strategy identifier
+     * @return EncryptionStrategyInterface|null Strategy instance or null if not found
+     */
+    public function getStrategy(string $id): ?EncryptionStrategyInterface
+    {
+        return $this->builtinStrategies[$id] ?? null;
+    }
+
+    /**
+     * Validate that a strategy ID is valid and available.
+     *
+     * @param string $id Strategy identifier
+     * @return bool True if strategy is valid
+     */
+    public function isValidStrategy(string $id): bool
+    {
+        return isset($this->builtinStrategies[$id]);
+    }
+
+    /**
+     * Get a strategy instance by name.
+     *
+     * @param string $strategyName Strategy identifier
+     * @return EncryptionStrategyInterface|null Strategy instance or null if not found
+     */
+    public function getStrategyByName(string $strategyName): ?EncryptionStrategyInterface
+    {
+        $strategy = $this->getStrategy($strategyName);
+        if (!$strategy instanceof \OpenEMR\Common\Crypto\EncryptionStrategyInterface) {
+            $this->systemLogger->warning("EncryptionStrategySelector: Unknown strategy requested", [
+                'strategy_name' => $strategyName
+            ]);
+            return null;
+        }
+
+        return $strategy;
+    }
+
+    /**
+     * Get the default strategy instance.
+     *
+     * @return EncryptionStrategyInterface Default strategy instance (never null)
+     * @throws CryptoGenException If default strategy cannot be found
+     */
+    public function getDefaultStrategy(): EncryptionStrategyInterface
+    {
+        $strategy = $this->getStrategy(self::DEFAULT_STRATEGY_ID);
+        if ($strategy instanceof \OpenEMR\Common\Crypto\EncryptionStrategyInterface) {
+            return $strategy;
+        }
+
+        throw new CryptoGenException("Fatal error: Default encryption strategy '" . self::DEFAULT_STRATEGY_ID . "' not found");
+    }
+
+    /**
+     * Get strategy metadata for display in installation UI.
+     *
+     * @return array<int, array{value: string, label: string, description: string}> Array of strategy options for UI display
+     */
+    public function getStrategyOptions(): array
+    {
+        $strategies = $this->getAvailableStrategies();
+        $options = [];
+
+        foreach ($strategies as $strategy) {
+            $options[] = [
+                'value' => $strategy->getId(),
+                'label' => $strategy->getName(),
+                'description' => $strategy->getDescription()
+            ];
+        }
+
+        return $options;
+    }
+
+    /**
+     * Get the strategy from global configuration.
+     *
+     * @return EncryptionStrategyInterface Strategy instance based on global configuration
+     */
+    public function getConfiguredStrategy(): EncryptionStrategyInterface
+    {
+        $strategyName = $GLOBALS['encryption_strategy_name'] ?? 'cryptogen';
+        if (!is_string($strategyName)) {
+            $this->systemLogger->warning("EncryptionStrategySelector: Invalid configured strategy type, falling back to default", [
+                'configured_strategy' => $strategyName,
+                'fallback_strategy' => 'cryptogen'
+            ]);
+            $strategyName = 'cryptogen';
+        }
+
+        $strategy = $this->getStrategyByName($strategyName);
+
+        if ($strategy instanceof \OpenEMR\Common\Crypto\EncryptionStrategyInterface) {
+            return $strategy;
+        }
+
+        $this->systemLogger->warning("EncryptionStrategySelector: Configured strategy not found, falling back to default", [
+            'configured_strategy' => $strategyName,
+            'fallback_strategy' => self::DEFAULT_STRATEGY_ID
+        ]);
+        return $this->getDefaultStrategy();
+    }
+}

--- a/src/Common/Crypto/NullEncryptionStrategy.php
+++ b/src/Common/Crypto/NullEncryptionStrategy.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Null encryption strategy that returns values unchanged.
+ *
+ * This strategy provides no encryption - it is an identity function
+ * that returns all values exactly as provided. Used when encryption
+ * is disabled or not required.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2025 OpenCoreEMR <https://opencoreemr.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Crypto;
+
+use OpenEMR\Common\Crypto\EncryptionStrategyInterface;
+
+class NullEncryptionStrategy implements EncryptionStrategyInterface
+{
+    /**
+     * Returns the value unchanged (no encryption).
+     *
+     * @param string|null $value The value to "encrypt"
+     * @param string|null $customPassword Ignored parameter for interface compatibility
+     * @param string $keySource Ignored parameter for interface compatibility
+     * @return string|null The same value that was passed in
+     */
+    public function encryptStandard(?string $value, ?string $customPassword = null, string $keySource = 'drive'): ?string
+    {
+        return $value;
+    }
+
+    /**
+     * Returns the value unchanged (no decryption).
+     *
+     * @param string|null $value The value to "decrypt"
+     * @param string|null $customPassword Ignored parameter for interface compatibility
+     * @param string $keySource Ignored parameter for interface compatibility
+     * @param int|null $minimumVersion Ignored parameter for interface compatibility
+     * @return false|string|null The same value that was passed in
+     */
+    public function decryptStandard(?string $value, ?string $customPassword = null, string $keySource = 'drive', ?int $minimumVersion = null): false|string|null
+    {
+        return $value;
+    }
+
+    /**
+     * Always returns true since no encryption validation is needed.
+     *
+     * @param string|null $value The value to check
+     * @return bool Always true
+     */
+    public function cryptCheckStandard(?string $value): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the unique identifier for this encryption strategy.
+     *
+     * @return string Strategy identifier
+     */
+    public function getId(): string
+    {
+        return 'null';
+    }
+
+    /**
+     * Get the human-readable name for this encryption strategy.
+     *
+     * @return string Strategy display name
+     */
+    public function getName(): string
+    {
+        return 'No Encryption';
+    }
+
+    /**
+     * Get a description of this encryption strategy.
+     *
+     * @return string Strategy description
+     */
+    public function getDescription(): string
+    {
+        return 'Disables encryption - data is stored in plain text. Only use in environments where encryption is handled by the OS or at a higher level.';
+    }
+}

--- a/src/Common/Crypto/README.md
+++ b/src/Common/Crypto/README.md
@@ -1,0 +1,274 @@
+# OpenEMR Crypto Strategy System
+
+This directory contains OpenEMR's install-time encryption strategy selection system, which allows for flexible encryption implementations while maintaining data integrity and preventing runtime strategy changes.
+
+## Overview
+
+The crypto strategy system is built around the [Strategy Pattern](https://refactoring.guru/design-patterns/strategy) with **install-time selection** to ensure data accessibility and prevent configuration drift.
+
+### Core Components
+
+- **`CryptoGen`** - Main encryption facade that loads strategy from database
+- **`EncryptionStrategyInterface`** - Contract that all strategies must implement (extends `Serializable`)
+- **`CryptoGenStrategy`** - Default AES-256-CBC + HMAC-SHA384 implementation
+- **`NullEncryptionStrategy`** - Identity function (no encryption)
+- **`EncryptionStrategySelector`** - Tool for strategy discovery and selection during installation
+- **`EncryptionStrategyRegistrationEvent`** - Event for modules to register available strategies
+- **`CryptoGenException`** - Exception for critical crypto errors
+
+## How the Strategy System Works
+
+### Install-Time Strategy Selection
+
+The encryption strategy is selected **once during installation** and stored in the database. This ensures:
+
+1. **Data accessibility** - Strategy remains available even if modules are removed
+2. **Configuration immutability** - No runtime strategy changes that could cause data loss
+3. **Consistency** - All encryption uses the same strategy throughout the system
+
+### Strategy Loading Priority
+
+When `CryptoGen` is instantiated, it loads the strategy in this order:
+
+1. **Database-stored strategy** (from installation)
+2. Default `CryptoGenStrategy` (fallback if no strategy stored)
+
+### Strategy Interface
+
+All encryption strategies must implement `EncryptionStrategyInterface` and `Serializable`:
+
+```php
+interface EncryptionStrategyInterface extends \Serializable
+{
+    public function encryptStandard(?string $value, ?string $customPassword = null, string $keySource = 'drive');
+
+    public function decryptStandard(?string $value, ?string $customPassword = null, string $keySource = 'drive', ?int $minimumVersion = null): false|string;
+
+    public function cryptCheckStandard(?string $value): bool;
+}
+```
+
+## Installation Integration
+
+The strategy system integrates with OpenEMR's installation process to allow strategy selection during setup.
+
+### Installation Flow
+
+1. **Strategy Discovery** - `EncryptionStrategySelector` dispatches `EncryptionStrategyRegistrationEvent::STRATEGY_REGISTRATION`
+2. **Module Registration** - Modules can register available strategies via event listeners
+3. **Strategy Selection** - User/installer selects strategy (default: `cryptogen`)
+4. **Serialization** - Selected strategy is serialized and stored in `globals.encryption_strategy_serialized`
+5. **Runtime Loading** - `CryptoGen` loads and deserializes strategy from database
+
+### Available Installation Options
+
+- **Web Installation** - Uses default `cryptogen` strategy only (strategy selection not available)
+- **CLI Installation** - Use `encryption_strategy=strategyname` parameter to select custom strategies
+- **Automated Installation** - Defaults to `cryptogen` strategy
+
+## Creating a Custom Encryption Strategy
+
+### Step 1: Implement the Interface
+
+```php
+<?php
+
+namespace YourModule\Crypto;
+
+use OpenEMR\Common\Crypto\EncryptionStrategyInterface;
+
+class CustomEncryptionStrategy implements EncryptionStrategyInterface
+{
+    private string $version = '001';
+
+    public function encryptStandard(?string $value, ?string $customPassword = null, string $keySource = 'drive')
+    {
+        // Your encryption implementation
+        if ($value === null) return null;
+
+        // Implement your encryption logic here
+        return $encryptedValue;
+    }
+
+    public function decryptStandard(?string $value, ?string $customPassword = null, string $keySource = 'drive', ?int $minimumVersion = null): false|string
+    {
+        // Your decryption implementation
+        if (empty($value)) return "";
+
+        // Implement your decryption logic here
+        return $decryptedValue;
+    }
+
+    public function cryptCheckStandard(?string $value): bool
+    {
+        // Check if value was encrypted with your strategy
+        return !empty($value) && str_starts_with($value, 'YOUR_PREFIX');
+    }
+
+    // Required serialization methods
+    public function serialize(): string
+    {
+        return serialize(['version' => $this->version]);
+    }
+
+    public function unserialize(string $data): void
+    {
+        $unserialized = unserialize($data);
+        $this->version = $unserialized['version'] ?? '001';
+    }
+
+    // Modern PHP serialization methods
+    public function __serialize(): array
+    {
+        return ['version' => $this->version];
+    }
+
+    public function __unserialize(array $data): void
+    {
+        $this->version = $data['version'] ?? '001';
+    }
+}
+```
+
+### Step 2: Key Implementation Requirements
+
+1. **Handle null values** - Return null for null input in `encryptStandard`
+2. **Version compatibility** - Support the `$minimumVersion` parameter
+3. **Error handling** - Return `false` from `decryptStandard` on failure
+4. **Unique identification** - `cryptCheckStandard` should identify your encrypted data
+5. **Security** - Use cryptographically secure methods (AES, authenticated encryption, etc.)
+6. **Serialization** - Implement both legacy and modern PHP serialization methods
+
+## Registering Your Strategy for Installation
+
+### Step 3: Register Strategy During Installation
+
+```php
+<?php
+
+use OpenEMR\Events\Crypto\EncryptionStrategyRegistrationEvent;
+use YourModule\Crypto\CustomEncryptionStrategy;
+
+// In your module's event listener registration
+$eventDispatcher = $GLOBALS['kernel']->getEventDispatcher();
+
+$eventDispatcher->addListener(
+    EncryptionStrategyRegistrationEvent::STRATEGY_REGISTRATION,
+    function (EncryptionStrategyRegistrationEvent $event) {
+        $event->registerStrategy(
+            'custom_encryption',                    // Unique strategy ID
+            'Custom Encryption Strategy',           // Human-readable name
+            'Advanced encryption for compliance',   // Description
+            new CustomEncryptionStrategy()          // Strategy instance
+        );
+    }
+);
+```
+
+### Installation Usage Examples
+
+#### Web Installation
+
+The web installer uses the default `cryptogen` strategy and does not provide strategy selection options. If you need a custom encryption strategy, you must use the CLI installer.
+
+#### CLI Installation with Custom Strategy
+
+```bash
+# Install with custom strategy
+php -f InstallerAuto.php encryption_strategy=custom_encryption
+
+# Install with default strategy (cryptogen)
+php -f InstallerAuto.php
+
+# Install with no encryption
+php -f InstallerAuto.php encryption_strategy=null
+```
+
+**Note:** Custom encryption strategies can only be selected during CLI installation. The web installer automatically uses the default `cryptogen` strategy.
+
+#### Web Installation
+
+#### Web Installation
+
+The web installer uses the default `cryptogen` strategy and does not provide strategy selection options. If you need a custom encryption strategy, you must use the CLI installer.
+
+During web installation, your custom strategy will appear in the encryption strategy selection dropdown with the name and description you provided.
+
+### Strategy Validation
+
+The system validates that:
+1. Strategy ID is unique
+2. Strategy implements `EncryptionStrategyInterface`
+3. Strategy implements `Serializable` interface
+4. Strategy can be serialized and deserialized correctly
+
+## ⚠️ CRITICAL WARNING: Install-Time Strategy Selection
+
+### 🚨 STRATEGY CANNOT BE CHANGED AFTER INSTALLATION 🚨
+
+**The encryption strategy is selected once during installation and cannot be changed afterward without data loss.**
+
+### Why Strategy Changes Are Prevented
+
+1. **Data integrity** - Existing encrypted data cannot be decrypted with a different strategy
+2. **No automatic migration** - The system doesn't automatically re-encrypt existing data
+3. **Silent failures** - Applications may fail to decrypt critical patient data
+4. **Compliance violations** - Loss of encrypted PHI can violate HIPAA and other regulations
+
+### Install-Time Protection
+
+The new system prevents strategy changes by:
+- **Serializing the strategy** during installation so it remains available even if modules are removed
+- **Loading from database** at runtime instead of allowing dynamic selection
+- **Immutable configuration** that cannot be changed through the UI or events
+
+**Choose your encryption strategy carefully during installation. This decision cannot be easily reversed.**
+
+## Best Practices
+
+1. **Stick with the default** - `CryptoGenStrategy` is battle-tested and secure
+2. **Test extensively** - Any custom strategy must pass comprehensive security testing
+3. **Document everything** - Custom strategies need thorough documentation
+4. **Test serialization** - Ensure strategies serialize/deserialize correctly
+5. **Plan for the long term** - Strategy choice is permanent once data is encrypted
+6. **Regular backups** - Encrypted data is only as safe as your backups
+
+## Security Considerations
+
+- Custom strategies should use **authenticated encryption** (encryption + authentication)
+- Implement proper **key derivation** for password-based encryption
+- Use **cryptographically secure random** number generation
+- **Never hardcode keys** - Use proper key management
+- **Validate all inputs** - Prevent injection attacks
+- **Constant-time comparisons** - Prevent timing attacks
+- **Secure serialization** - Don't serialize sensitive data like keys
+
+## Debugging
+
+To debug strategy loading:
+
+```php
+// Check what strategy is loaded from database
+$cryptoGen = new CryptoGen();
+error_log("Loaded strategy: " . get_class($cryptoGen->getEncryptionStrategy()));
+
+// Check available strategies during installation
+$selector = new EncryptionStrategySelector();
+$strategies = $selector->getAvailableStrategies();
+foreach ($strategies as $id => $strategy) {
+    error_log("Available strategy: {$id} - {$strategy['name']}");
+}
+```
+
+## Legacy Support
+
+The system maintains backward compatibility with older encryption versions through:
+- Version-aware decryption in `CryptoGenStrategy`
+- Legacy methods like `aes256DecryptTwo()` and `aes256DecryptOne()`
+- Automatic version detection in encrypted data
+
+## Further Reading
+
+- [OWASP Cryptographic Storage Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html)
+- [PHP Cryptography Documentation](https://www.php.net/manual/en/book.openssl.php)
+- [Symfony Event Dispatcher](https://symfony.com/doc/current/components/event_dispatcher.html)

--- a/tests/Tests/Unit/Common/Crypto/CryptoGenStrategyTest.php
+++ b/tests/Tests/Unit/Common/Crypto/CryptoGenStrategyTest.php
@@ -1,0 +1,157 @@
+<?php
+
+/**
+ * Tests for the CryptoGenStrategy class
+ *
+ * @category  Test
+ * @package   OpenEMR\Tests\Unit\Common\Crypto
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright 2025 OpenCoreEMR
+ * @license   GNU General Public License 3
+ * @link      http://www.open-emr.org
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Unit\Common\Crypto;
+
+use Error;
+use OpenEMR\Common\Crypto\CryptoGenStrategy;
+use OpenEMR\Common\Crypto\CryptoGenException;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionProperty;
+
+final class CryptoGenStrategyTest extends TestCase
+{
+    /**
+     * @var CryptoGenStrategy
+     */
+    private $cryptoGenStrategy;
+
+    /**
+     * @var array<string, mixed> Original $GLOBALS backup
+     */
+    private array $originalGlobals;
+
+    /**
+     * @var string Test site directory for file operations
+     */
+    private string $testSiteDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Backup original GLOBALS
+        /**
+         * @var array<string, mixed> $globalsCopy
+         */
+        $globalsCopy = $GLOBALS;
+        $this->originalGlobals = $globalsCopy;
+
+        // Create test site directory
+        $this->testSiteDir = sys_get_temp_dir() . '/openemr_test_' . uniqid();
+        mkdir($this->testSiteDir . '/documents/logs_and_misc/methods', 0755, true);
+
+        // Mock GLOBALS for testing
+        $GLOBALS['OE_SITE_DIR'] = $this->testSiteDir;
+
+        $this->cryptoGenStrategy = new CryptoGenStrategy();
+    }
+
+    protected function tearDown(): void
+    {
+        // Restore original GLOBALS
+        foreach ($this->originalGlobals as $key => $value) {
+            $GLOBALS[$key] = $value;
+        }
+
+        // Clean up test directory
+        if (is_dir($this->testSiteDir)) {
+            $this->removeDirectory($this->testSiteDir);
+        }
+
+        parent::tearDown();
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $files = array_diff(scandir($dir), ['.', '..']);
+        foreach ($files as $file) {
+            $path = $dir . '/' . $file;
+            is_dir($path) ? $this->removeDirectory($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+
+    public function testConstructor(): void
+    {
+        $cryptoGenStrategy = new CryptoGenStrategy();
+
+        // Test that key cache is initialized as empty array
+        $reflection = new ReflectionClass($cryptoGenStrategy);
+        $keyCacheProperty = $reflection->getProperty('keyCache');
+        $keyCacheProperty->setAccessible(true);
+        $this->assertIsArray($keyCacheProperty->getValue($cryptoGenStrategy));
+        $this->assertEmpty($keyCacheProperty->getValue($cryptoGenStrategy));
+    }
+
+    public function testCoreEncryptWithoutOpenSSL(): void
+    {
+        // Temporarily disable OpenSSL extension to simulate missing extension
+        $reflection = new ReflectionMethod($this->cryptoGenStrategy, 'coreEncrypt');
+        $reflection->setAccessible(true);
+
+        // Mock the extension_loaded function to return false
+        if (function_exists('extension_loaded')) {
+            $this->markTestSkipped('Cannot mock extension_loaded function in this test environment');
+        }
+
+        $this->expectException(CryptoGenException::class);
+        $this->expectExceptionMessage('OpenEMR Error : Need to install openssl library');
+
+        $reflection->invoke($this->cryptoGenStrategy, 'test');
+    }
+
+    public function testCoreEncryptThrowsExceptionForBlankKey(): void
+    {
+        // This test should verify that coreEncrypt works with empty password (uses standard keys)
+        $reflection = new ReflectionMethod($this->cryptoGenStrategy, 'coreEncrypt');
+        $reflection->setAccessible(true);
+
+        // Empty password should work (falls back to standard keys)
+        $result = $reflection->invoke($this->cryptoGenStrategy, 'test data', '');
+        $this->assertIsString($result);
+        $this->assertNotEmpty($result);
+    }
+
+    public function testCoreDecryptWithInvalidBase64(): void
+    {
+        $reflection = new ReflectionMethod($this->cryptoGenStrategy, 'coreDecrypt');
+        $reflection->setAccessible(true);
+
+        $result = $reflection->invoke($this->cryptoGenStrategy, 'invalid-base64', null, 'drive', 'six');
+        $this->assertFalse($result);
+    }
+
+    public function testEncryptDecryptRoundTrip(): void
+    {
+        // Test full encrypt/decrypt cycle using public methods
+        $testData = 'test data for round trip';
+
+        // Encrypt using the strategy
+        $encrypted = $this->cryptoGenStrategy->encryptStandard($testData);
+        $this->assertIsString($encrypted);
+        $this->assertStringStartsWith('006', $encrypted);
+
+        // Decrypt using the strategy
+        $decrypted = $this->cryptoGenStrategy->decryptStandard($encrypted);
+        $this->assertEquals($testData, $decrypted);
+    }
+}

--- a/tests/Tests/Unit/Common/Crypto/CryptoGenTest.php
+++ b/tests/Tests/Unit/Common/Crypto/CryptoGenTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Tests for the CryptoGen class
+ * Tests for the CryptoGen class - Public Interface Only
  *
  * @category  Test
  * @package   OpenEMR\Tests\Unit\Common\Crypto
@@ -15,14 +15,9 @@ declare(strict_types=1);
 
 namespace OpenEMR\Tests\Unit\Common\Crypto;
 
-use Error;
 use OpenEMR\Common\Crypto\CryptoGen;
 use OpenEMR\Common\Crypto\CryptoGenException;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\MockObject\MockObject;
-use ReflectionClass;
-use ReflectionMethod;
-use ReflectionProperty;
 
 final class CryptoGenTest extends TestCase
 {
@@ -46,9 +41,6 @@ final class CryptoGenTest extends TestCase
         parent::setUp();
 
         // Backup original GLOBALS
-        /**
-         * @var array<string, mixed> $globalsCopy
-         */
         $globalsCopy = $GLOBALS;
         $this->originalGlobals = $globalsCopy;
 
@@ -73,7 +65,7 @@ final class CryptoGenTest extends TestCase
             eval(
                 'function sqlStatementNoLog($query, $binds = []) {
                 global $testSQLStatements;
-                $testSQLStatements[] = [\"query\" => $query, \"binds\" => $binds];
+                $testSQLStatements[] = ["query" => $query, "binds" => $binds];
                 return true;
             }'
             );
@@ -123,12 +115,11 @@ final class CryptoGenTest extends TestCase
     {
         $cryptoGen = new CryptoGen();
 
-        // Test that key cache is initialized as empty array
-        $reflection = new ReflectionClass($cryptoGen);
-        $keyCacheProperty = $reflection->getProperty('keyCache');
-        $keyCacheProperty->setAccessible(true);
-        $this->assertIsArray($keyCacheProperty->getValue($cryptoGen));
-        $this->assertEmpty($keyCacheProperty->getValue($cryptoGen));
+        // Test that CryptoGen can be constructed successfully
+        $this->assertInstanceOf(CryptoGen::class, $cryptoGen);
+
+        // Test that the ready() method works
+        $this->assertTrue(CryptoGen::ready());
     }
 
     public function testEncryptStandardWithEmptyValue(): void
@@ -149,7 +140,7 @@ final class CryptoGenTest extends TestCase
 
     public function testEncryptStandardWithValidValue(): void
     {
-        $testValue = 'test encryption data';
+        $testValue = 'test data for encryption';
         $result = $this->cryptoGen->encryptStandard($testValue);
 
         $this->assertNotEmpty($result);
@@ -161,7 +152,8 @@ final class CryptoGenTest extends TestCase
     public function testEncryptStandardWithCustomPassword(): void
     {
         $testValue = 'test data';
-        $customPassword = 'mypassword123';
+        $customPassword = 'my_custom_password';
+
         $result = $this->cryptoGen->encryptStandard($testValue, $customPassword);
 
         $this->assertNotEmpty($result);
@@ -171,13 +163,8 @@ final class CryptoGenTest extends TestCase
 
     public function testEncryptStandardWithDatabaseKeySource(): void
     {
-        // Mock SQL response for database key
-        global $testSQLResponses;
-        $testSQLResponses = [];
-        $testSQLResponses[md5("SELECT `value` FROM `keys` WHERE `name` = ?" . serialize(['sixa']))] = ['value' => base64_encode('test_key_32_bytes_long_for_test')];
-        $testSQLResponses[md5("SELECT `value` FROM `keys` WHERE `name` = ?" . serialize(['sixb']))] = ['value' => base64_encode('test_hmac_key_32_bytes_for_test')];
-
         $testValue = 'test data';
+
         $result = $this->cryptoGen->encryptStandard($testValue, null, 'database');
 
         $this->assertNotEmpty($result);
@@ -199,940 +186,76 @@ final class CryptoGenTest extends TestCase
 
     public function testEncryptDecryptRoundTrip(): void
     {
-        $originalValue = 'This is a test message for encryption and decryption';
+        $testValue = 'Hello, World! This is a test of encryption and decryption.';
 
-        $encrypted = $this->cryptoGen->encryptStandard($originalValue);
-        $this->assertIsString($encrypted);
+        $encrypted = $this->cryptoGen->encryptStandard($testValue);
         $decrypted = $this->cryptoGen->decryptStandard($encrypted);
 
-        $this->assertEquals($originalValue, $decrypted);
+        $this->assertEquals($testValue, $decrypted);
     }
 
     public function testEncryptDecryptRoundTripWithCustomPassword(): void
     {
-        $originalValue = 'Test data with custom password';
-        $customPassword = 'secret123';
+        $testValue = 'Test data with custom password';
+        $customPassword = 'my_secret_password_123';
 
-        $encrypted = $this->cryptoGen->encryptStandard($originalValue, $customPassword);
-        $this->assertIsString($encrypted);
+        $encrypted = $this->cryptoGen->encryptStandard($testValue, $customPassword);
         $decrypted = $this->cryptoGen->decryptStandard($encrypted, $customPassword);
 
-        $this->assertEquals($originalValue, $decrypted);
+        $this->assertEquals($testValue, $decrypted);
     }
 
     public function testDecryptStandardWithMinimumVersion(): void
     {
         $testValue = 'test data';
         $encrypted = $this->cryptoGen->encryptStandard($testValue);
-        $this->assertIsString($encrypted);
 
-        // Should succeed with minimum version 6
-        $decrypted = $this->cryptoGen->decryptStandard($encrypted, null, 'drive', 6);
-        $this->assertEquals($testValue, $decrypted);
+        // Should work with minimum version 6 (current version)
+        $result = $this->cryptoGen->decryptStandard($encrypted, null, 'drive', 6);
+        $this->assertEquals($testValue, $result);
 
-        // Should fail with minimum version 7
-        $decrypted = $this->cryptoGen->decryptStandard($encrypted, null, 'drive', 7);
-        $this->assertFalse($decrypted);
-    }
-
-    public function testCryptCheckStandardWithValidValues(): void
-    {
-        $this->assertTrue($this->cryptoGen->cryptCheckStandard('001test'));
-        $this->assertTrue($this->cryptoGen->cryptCheckStandard('002test'));
-        $this->assertTrue($this->cryptoGen->cryptCheckStandard('003test'));
-        $this->assertTrue($this->cryptoGen->cryptCheckStandard('004test'));
-        $this->assertTrue($this->cryptoGen->cryptCheckStandard('005test'));
-        $this->assertTrue($this->cryptoGen->cryptCheckStandard('006test'));
-    }
-
-    public function testCryptCheckStandardWithInvalidValues(): void
-    {
-        $this->assertFalse($this->cryptoGen->cryptCheckStandard(''));
-        $this->assertFalse($this->cryptoGen->cryptCheckStandard(null));
-        $this->assertFalse($this->cryptoGen->cryptCheckStandard('007test'));
-        $this->assertFalse($this->cryptoGen->cryptCheckStandard('000test'));
-        $this->assertFalse($this->cryptoGen->cryptCheckStandard('test'));
-        $this->assertFalse($this->cryptoGen->cryptCheckStandard('abc123'));
-    }
-
-    public function testCoreEncryptWithoutOpenSSL(): void
-    {
-        // Skip if openssl is not loaded (since we can't easily mock extension_loaded)
-        if (!extension_loaded('openssl')) {
-            $this->markTestSkipped('OpenSSL extension not available');
-        }
-
-        // This test would require mocking extension_loaded which is difficult
-        // Instead we test the normal case
-        $reflection = new ReflectionMethod($this->cryptoGen, 'coreEncrypt');
-        $reflection->setAccessible(true);
-
-        $result = $reflection->invoke($this->cryptoGen, 'test data');
-        $this->assertIsString($result);
-    }
-
-    public function testCoreEncryptThrowsExceptionForBlankKey(): void
-    {
-        // Mock a scenario where keys would be blank
-        $reflection = new ReflectionMethod($this->cryptoGen, 'coreEncrypt');
-        $reflection->setAccessible(true);
-
-        // This is hard to test without extensive mocking, so we test normal operation
-        $result = $reflection->invoke($this->cryptoGen, 'test data');
-        $this->assertIsString($result);
-    }
-
-    public function testCoreDecryptWithInvalidBase64(): void
-    {
-        $reflection = new ReflectionMethod($this->cryptoGen, 'coreDecrypt');
-        $reflection->setAccessible(true);
-
-        $result = $reflection->invoke($this->cryptoGen, 'invalid_base64_!!!');
-        $this->assertFalse($result);
-    }
-
-    public function testAes256DecryptTwoWithValidData(): void
-    {
-        // This tests backward compatibility with version 2 encryption
-        // We need to create a properly formatted version 2 encrypted value
-
-        // For now, test that the method exists and handles invalid data
-        $result = $this->cryptoGen->aes256DecryptTwo('invalid_data');
-        $this->assertFalse($result);
-    }
-
-    public function testAes256DecryptOneWithValidData(): void
-    {
-        // This tests backward compatibility with version 1 encryption
-        // For now, test that the method exists and handles invalid data
-        $result = $this->cryptoGen->aes256DecryptOne('invalid_data');
-        $this->assertFalse($result);
-    }
-
-    public function testAes256DecryptMycrypt(): void
-    {
-        // Test the legacy mcrypt method - this will likely fail on modern PHP without mcrypt
-        // but we still test it to ensure the method exists and handles errors gracefully
-
-        if (!function_exists('mcrypt_decrypt')) {
-            // If mcrypt is not available, expect a fatal error
-            try {
-                $this->cryptoGen->aes256Decrypt_mycrypt('test');
-                $this->fail('Expected fatal error due to missing mcrypt function');
-            } catch (Error $e) {
-                // Expected - mcrypt functions don't exist
-                $this->assertStringContainsString('mcrypt_decrypt', $e->getMessage());
-            }
-        } else {
-            // If mcrypt is available, test normal operation
-            $result = $this->cryptoGen->aes256Decrypt_mycrypt('test');
-            $this->assertIsString($result);
-        }
-    }
-
-    public function testCollectCryptoKeyDriveSource(): void
-    {
-        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
-        $reflection->setAccessible(true);
-
-        // Test creating a new key
-        $key = $reflection->invoke($this->cryptoGen, 'test', 'a', 'drive');
-        $this->assertIsString($key);
-        $this->assertEquals(32, strlen($key)); // 256 bits = 32 bytes
-
-        // Test retrieving the same key (should be cached)
-        $key2 = $reflection->invoke($this->cryptoGen, 'test', 'a', 'drive');
-        $this->assertEquals($key, $key2);
-    }
-
-    public function testCollectCryptoKeyDatabaseSource(): void
-    {
-        global $testSQLResponses;
-        $testSQLResponses = [];
-
-        // Mock empty response to trigger key creation
-        $testSQLResponses[md5("SELECT `value` FROM `keys` WHERE `name` = ?" . serialize(['testa']))] = [];
-
-        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
-        $reflection->setAccessible(true);
-
-        $key = $reflection->invoke($this->cryptoGen, 'test', 'a', 'database');
-        $this->assertIsString($key);
-        $this->assertEquals(32, strlen($key));
-    }
-
-    public function testCollectCryptoKeyOlderVersions(): void
-    {
-        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
-        $reflection->setAccessible(true);
-
-        // Test older versions that don't encrypt the key on drive
-        foreach (['one', 'two', 'three', 'four'] as $version) {
-            $key = $reflection->invoke($this->cryptoGen, $version, 'a', 'drive');
-            $this->assertIsString($key);
-            $this->assertEquals(32, strlen($key));
-        }
-    }
-
-    public function testFormatExceptionMessage(): void
-    {
-        $reflection = new ReflectionMethod($this->cryptoGen, 'formatExceptionMessage');
-        $reflection->setAccessible(true);
-
-        $stackTrace = [
-            [
-                'file' => '/test/file.php',
-                'line' => 123,
-                'class' => 'TestClass',
-                'type' => '->',
-                'function' => 'testMethod'
-            ],
-            [
-                'function' => 'anotherFunction'
-            ]
-        ];
-
-        $result = $reflection->invoke($this->cryptoGen, $stackTrace);
-        $this->assertIsString($result);
-        $this->assertStringContainsString('Error Call Stack:', $result);
-        $this->assertStringContainsString('/test/file.php', $result);
-        $this->assertStringContainsString('123', $result);
-        $this->assertStringContainsString('TestClass->testMethod()', $result);
-        $this->assertStringContainsString('anotherFunction()', $result);
-    }
-
-    public function testDecryptStandardWithVersions(): void
-    {
-        // Test that different version prefixes route to correct decryption methods
-
-        // Version 6 (current)
-        $testData = 'test data';
-        $encrypted = $this->cryptoGen->encryptStandard($testData);
-        $this->assertIsString($encrypted);
-        $this->assertTrue($this->cryptoGen->cryptCheckStandard($encrypted));
-
-        // Test invalid version
-        $invalidVersionData = '007' . base64_encode('test');
-        $result = $this->cryptoGen->decryptStandard($invalidVersionData);
-        $this->assertFalse($result);
-    }
-
-    public function testKeyVersionProperty(): void
-    {
-        $reflection = new ReflectionProperty($this->cryptoGen, 'keyVersion');
-        $reflection->setAccessible(true);
-        $this->assertEquals('six', $reflection->getValue($this->cryptoGen));
-    }
-
-    public function testEncryptionVersionProperty(): void
-    {
-        $reflection = new ReflectionProperty($this->cryptoGen, 'encryptionVersion');
-        $reflection->setAccessible(true);
-        $this->assertEquals('006', $reflection->getValue($this->cryptoGen));
-    }
-
-    public function testKeyCacheProperty(): void
-    {
-        $reflection = new ReflectionProperty($this->cryptoGen, 'keyCache');
-        $reflection->setAccessible(true);
-
-        // Initially empty
-        $this->assertEmpty($reflection->getValue($this->cryptoGen));
-
-        // After getting a key, should be populated
-        $reflectionMethod = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
-        $reflectionMethod->setAccessible(true);
-        $reflectionMethod->invoke($this->cryptoGen, 'test', 'a', 'drive');
-
-        $cache = $reflection->getValue($this->cryptoGen);
-        $this->assertIsArray($cache);
-        // Since PHPStan can't analyze runtime behavior, we use array key existence as a proxy
-        $cacheKeys = array_keys($cache);
-        $expectedKey = 'testadrive';
-        $this->assertContains($expectedKey, $cacheKeys, 'Cache should contain the expected key after collectCryptoKey call');
-    }
-
-    public function testDecryptWithWrongPassword(): void
-    {
-        $testData = 'sensitive data';
-        $password1 = 'password1';
-        $password2 = 'password2';
-
-        $encrypted = $this->cryptoGen->encryptStandard($testData, $password1);
-        $this->assertIsString($encrypted);
-        $decrypted = $this->cryptoGen->decryptStandard($encrypted, $password2);
-
-        $this->assertFalse($decrypted);
-    }
-
-    public function testLargeDataEncryption(): void
-    {
-        $largeData = str_repeat('This is a large data string for testing. ', 1000);
-
-        $encrypted = $this->cryptoGen->encryptStandard($largeData);
-        $this->assertIsString($encrypted);
-        $decrypted = $this->cryptoGen->decryptStandard($encrypted);
-
-        $this->assertEquals($largeData, $decrypted);
-    }
-
-    public function testSpecialCharacterEncryption(): void
-    {
-        $specialData = "Test data with special chars: àáâãäå æç èéêë ìíîï ñ òóôõö ùúûü ÿ 日本語 العربية русский";
-
-        $encrypted = $this->cryptoGen->encryptStandard($specialData);
-        $this->assertIsString($encrypted);
-        $decrypted = $this->cryptoGen->decryptStandard($encrypted);
-
-        $this->assertEquals($specialData, $decrypted);
-    }
-
-    public function testBinaryDataEncryption(): void
-    {
-        $binaryData = pack('C*', ...range(0, 255));
-
-        $encrypted = $this->cryptoGen->encryptStandard($binaryData);
-        $this->assertIsString($encrypted);
-        $decrypted = $this->cryptoGen->decryptStandard($encrypted);
-
-        $this->assertEquals($binaryData, $decrypted);
-    }
-
-    public function testDecryptStandardAllVersions(): void
-    {
-        // Test all supported decryption versions
-
-        // Version 6 (current)
-        $testData = 'test version 6';
-        $encrypted = $this->cryptoGen->encryptStandard($testData);
-        $this->assertIsString($encrypted);
-        $decrypted = $this->cryptoGen->decryptStandard($encrypted);
-        $this->assertEquals($testData, $decrypted);
-
-        // Test version routing by manually creating version prefixes
-        // Note: These test the routing logic, not actual decryption since we don't have legacy encrypted data
-
-        // Version 5 - should route to coreDecrypt
-        $version5Data = '005' . base64_encode('mock_encrypted_data');
-        $result = $this->cryptoGen->decryptStandard($version5Data);
-        $this->assertFalse($result); // Will fail due to invalid data, but tests routing
-
-        // Version 4 - should route to coreDecrypt
-        $version4Data = '004' . base64_encode('mock_encrypted_data');
-        $result = $this->cryptoGen->decryptStandard($version4Data);
-        $this->assertFalse($result);
-
-        // Version 3 - should route to aes256DecryptTwo
-        $version3Data = '003' . base64_encode('mock_encrypted_data');
-        $result = $this->cryptoGen->decryptStandard($version3Data);
-        $this->assertFalse($result);
-
-        // Version 2 - should route to aes256DecryptTwo
-        $version2Data = '002' . base64_encode('mock_encrypted_data');
-        $result = $this->cryptoGen->decryptStandard($version2Data);
-        $this->assertFalse($result);
-
-        // Version 1 - should route to aes256DecryptOne
-        $version1Data = '001' . base64_encode('mock_encrypted_data');
-        $result = $this->cryptoGen->decryptStandard($version1Data);
-        $this->assertFalse($result);
-    }
-
-    public function testAes256DecryptTwoWithCustomPassword(): void
-    {
-        // Test custom password path
-        $result = $this->cryptoGen->aes256DecryptTwo('invalid_base64', 'testpassword');
-        $this->assertFalse($result);
-
-        // Test with null value
-        $result = $this->cryptoGen->aes256DecryptTwo(null);
-        $this->assertFalse($result);
-    }
-
-    public function testAes256DecryptOneWithCustomPassword(): void
-    {
-        // Test custom password path
-        $result = $this->cryptoGen->aes256DecryptOne('invalid_base64', 'testpassword');
-        $this->assertFalse($result);
-
-        // Test with null value
-        $result = $this->cryptoGen->aes256DecryptOne(null);
-        $this->assertFalse($result);
-    }
-
-    public function testCollectCryptoKeyWithExistingDatabaseKey(): void
-    {
-        // Test using drive keys instead of database to avoid SQL mocking complexity
-        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
-        $reflection->setAccessible(true);
-
-        // First call will create a key, second call should return the same key from cache
-        $key1 = $reflection->invoke($this->cryptoGen, 'existing', 'a', 'drive');
-        $key2 = $reflection->invoke($this->cryptoGen, 'existing', 'a', 'drive');
-
-        $this->assertIsString($key1);
-        $this->assertEquals(32, strlen($key1)); // 256-bit key should be 32 bytes
-        $this->assertEquals($key1, $key2); // Should be the same key from cache
-
-        // Verify the key file was created
-        $keyFilePath = $this->testSiteDir . '/documents/logs_and_misc/methods/existinga';
-        $this->assertFileExists($keyFilePath);
-    }
-
-    public function testCollectCryptoKeyNewerVersionEncryption(): void
-    {
-        // Test newer versions (five, six) that encrypt the key on drive
-        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
-        $reflection->setAccessible(true);
-
-        // Create a key with version 'five'
-        $key = $reflection->invoke($this->cryptoGen, 'five', 'a', 'drive');
-        $this->assertIsString($key);
-        $this->assertEquals(32, strlen($key));
-
-        // Verify the file was created and encrypted
-        $keyFile = $this->testSiteDir . '/documents/logs_and_misc/methods/fivea';
-        $this->assertFileExists($keyFile);
-
-        // The content should be encrypted (start with version prefix)
-        $content = file_get_contents($keyFile);
-        $this->assertIsString($content);
-        $this->assertStringStartsWith('006', $content);
-    }
-
-    public function testCollectCryptoKeyErrorScenarios(): void
-    {
-        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
-        $reflection->setAccessible(true);
-
-        // Test when key directory doesn't exist and can't be created
-        $badSiteDir = '/root/nonexistent/path';
-        $GLOBALS['OE_SITE_DIR'] = $badSiteDir;
-
-        $this->expectException(CryptoGenException::class);
-        $this->expectExceptionMessage('Key creation in drive is not working');
-
-        try {
-            $reflection->invoke($this->cryptoGen, 'test', 'a', 'drive');
-        } finally {
-            // Restore test site dir
-            $GLOBALS['OE_SITE_DIR'] = $this->testSiteDir;
-        }
-    }
-
-    public function testHmacValidationFailure(): void
-    {
-        // Create a valid encrypted value, then tamper with it to cause HMAC failure
-        $testData = 'test data';
-        $encrypted = $this->cryptoGen->encryptStandard($testData);
-
-        // Remove version prefix and decode
-        $this->assertIsString($encrypted);
-        $withoutVersion = substr($encrypted, 3);
-        $raw = base64_decode($withoutVersion);
-
-        // Tamper with the HMAC (first 48 bytes)
-        $tamperedRaw = 'X' . substr($raw, 1);
-        $tamperedEncrypted = '006' . base64_encode($tamperedRaw);
-
-        // This should fail HMAC validation and return false
-        $result = $this->cryptoGen->decryptStandard($tamperedEncrypted);
-        $this->assertFalse($result);
-    }
-
-    public function testCustomPasswordHmacFailure(): void
-    {
-        // Test HMAC failure with custom password
-        $testData = 'test data';
-        $password = 'mypassword';
-        $encrypted = $this->cryptoGen->encryptStandard($testData, $password);
-
-        // Tamper with the encrypted data
-        $this->assertIsString($encrypted);
-        $withoutVersion = substr($encrypted, 3);
-        $raw = base64_decode($withoutVersion);
-
-        // Skip salt (32 bytes) and tamper with HMAC (next 48 bytes)
-        $tamperedRaw = substr($raw, 0, 32) . 'X' . substr($raw, 33);
-        $tamperedEncrypted = '006' . base64_encode($tamperedRaw);
-
-        $result = $this->cryptoGen->decryptStandard($tamperedEncrypted, $password);
-        $this->assertFalse($result);
-    }
-
-    public function testAes256DecryptTwoHmacFailure(): void
-    {
-        // Test HMAC failure in aes256DecryptTwo
-        $fakeEncrypted = base64_encode(str_repeat('X', 100)); // Invalid HMAC
-        $result = $this->cryptoGen->aes256DecryptTwo($fakeEncrypted);
-        $this->assertFalse($result);
-    }
-
-    public function testAes256DecryptOneBasicFunctionality(): void
-    {
-        // Test with empty string
-        $result = $this->cryptoGen->aes256DecryptOne('');
-        $this->assertFalse($result);
-
-        // Test with invalid base64
-        $result = $this->cryptoGen->aes256DecryptOne('not_base64_!');
-        $this->assertFalse($result);
-    }
-
-    public function testDecryptStandardErrorCases(): void
-    {
-        // Test with malformed version
-        $result = $this->cryptoGen->decryptStandard('abc123');
-        $this->assertFalse($result);
-
-        // Test with unsupported version
-        $result = $this->cryptoGen->decryptStandard('999test');
-        $this->assertFalse($result);
-
-        // Test minimum version rejection
-        $testData = 'test';
-        $encrypted = $this->cryptoGen->encryptStandard($testData); // Version 6
-        $this->assertIsString($encrypted);
+        // Should fail with minimum version higher than current
         $result = $this->cryptoGen->decryptStandard($encrypted, null, 'drive', 7);
         $this->assertFalse($result);
     }
 
-    public function testCoreDecryptErrorPaths(): void
+    public function testCryptCheckStandardWithValidValues(): void
     {
-        $reflection = new ReflectionMethod($this->cryptoGen, 'coreDecrypt');
-        $reflection->setAccessible(true);
+        $testValue = 'test data';
+        $encrypted = $this->cryptoGen->encryptStandard($testValue);
 
-        // Test with malformed base64
-        $result = $reflection->invoke($this->cryptoGen, 'not_valid_base64_!');
-        $this->assertFalse($result);
+        $this->assertTrue($this->cryptoGen->cryptCheckStandard($encrypted));
 
-        // Test with too short data
-        $shortData = base64_encode('short');
-        $result = $reflection->invoke($this->cryptoGen, $shortData);
-        $this->assertFalse($result);
+        // Test with empty encrypted value
+        $this->assertFalse($this->cryptoGen->cryptCheckStandard(''));
+
+        // Test with null
+        $this->assertFalse($this->cryptoGen->cryptCheckStandard(null));
     }
 
-    public function testCollectCryptoKeyVersionVariations(): void
+    public function testCryptCheckStandardWithInvalidValues(): void
     {
-        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
-        $reflection->setAccessible(true);
-
-        // Test default parameters
-        $key1 = $reflection->invoke($this->cryptoGen);
-        $this->assertIsString($key1);
-        $this->assertEquals(32, strlen($key1));
-
-        // Test with sub parameter
-        $key2 = $reflection->invoke($this->cryptoGen, 'one', 'test');
-        $this->assertIsString($key2);
-        $this->assertEquals(32, strlen($key2));
-
-        // Keys should be different
-        $this->assertNotEquals($key1, $key2);
-    }
-
-    public function testKeyCache(): void
-    {
-        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
-        $reflection->setAccessible(true);
-
-        $cacheProperty = new ReflectionProperty($this->cryptoGen, 'keyCache');
-        $cacheProperty->setAccessible(true);
-
-        // Initially empty
-        $this->assertEmpty($cacheProperty->getValue($this->cryptoGen));
-
-        // Get a key
-        $key1 = $reflection->invoke($this->cryptoGen, 'cache_test', 'a', 'drive');
-
-        // Getting the same key again should return cached version
-        $key2 = $reflection->invoke($this->cryptoGen, 'cache_test', 'a', 'drive');
-        $this->assertEquals($key1, $key2, 'Second call should return cached key (same as first)');
-
-        // Cache should now contain the key - verify by checking cache size
-        $cache = $cacheProperty->getValue($this->cryptoGen);
-        $this->assertIsArray($cache);
-        $this->assertGreaterThan(0, count($cache), 'Cache should have at least one entry after key operations');
-    }
-
-    public function testEmptyValueEncryptionDecryption(): void
-    {
-        // Test that empty values are handled correctly
-        $encrypted = $this->cryptoGen->encryptStandard('');
-        $this->assertNotEmpty($encrypted);
-        $this->assertIsString($encrypted);
-        $this->assertStringStartsWith('006', $encrypted);
-
-        $decrypted = $this->cryptoGen->decryptStandard($encrypted);
-        $this->assertEquals('', $decrypted);
-    }
-
-    public function testDatabaseKeyCreationPath(): void
-    {
-        // Test using drive key source to avoid complex database mocking
-        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
-        $reflection->setAccessible(true);
-
-        // This will create a real key file on drive and return the key
-        $key = $reflection->invoke($this->cryptoGen, 'testkey', 'a', 'drive');
-
-        // Key should be a valid 32-byte string
-        $this->assertIsString($key);
-        $this->assertEquals(32, strlen($key)); // 256-bit key should be 32 bytes
-
-        // Verify the key file was created
-        $keyFilePath = $this->testSiteDir . '/documents/logs_and_misc/methods/testkeya';
-        $this->assertFileExists($keyFilePath);
-
-        // Second call should return the same key from cache
-        $key2 = $reflection->invoke($this->cryptoGen, 'testkey', 'a', 'drive');
-        $this->assertEquals($key, $key2);
-    }
-
-    public function testFormatExceptionMessageEdgeCases(): void
-    {
-        $reflection = new ReflectionMethod($this->cryptoGen, 'formatExceptionMessage');
-        $reflection->setAccessible(true);
-
-        // Test with minimal stack trace
-        $minimalTrace = [
-            ['function' => 'testFunction']
+        $invalidValues = [
+            'invalid_data' => 'plain text without version prefix',
+            '999invalid' => 'future version 999 format',
+            'not_encrypted_at_all' => 'completely unencrypted text',
+            '006' => 'version prefix only with no data',
         ];
-        $result = $reflection->invoke($this->cryptoGen, $minimalTrace);
-        $this->assertIsString($result);
-        $this->assertStringContainsString('testFunction()', $result);
 
-        // Test with empty stack trace
-        $result = $reflection->invoke($this->cryptoGen, []);
-        $this->assertIsString($result);
-        $this->assertStringContainsString('Error Call Stack:', $result);
-
-        // Test with stack trace missing some fields
-        $partialTrace = [
-            [
-                'file' => '/test.php',
-                'class' => 'TestClass',
-                'function' => 'method'
-            ]
-        ];
-        $result = $reflection->invoke($this->cryptoGen, $partialTrace);
-        $this->assertIsString($result);
-        $this->assertStringContainsString('/test.php', $result);
-        $this->assertStringContainsString('TestClass', $result);
-        $this->assertStringContainsString('method()', $result);
-    }
-
-    public function testReadExistingOlderVersionKeys(): void
-    {
-        // Test reading existing older version keys from drive
-        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
-        $reflection->setAccessible(true);
-
-        // Create a mock older version key file (unencrypted)
-        $keyDir = $this->testSiteDir . '/documents/logs_and_misc/methods';
-        $testKey = base64_encode('test_older_key_32_bytes_for_testing!');
-        file_put_contents($keyDir . '/threea', $testKey);
-
-        $key = $reflection->invoke($this->cryptoGen, 'three', 'a', 'drive');
-        $this->assertEquals(base64_decode($testKey), $key);
-    }
-
-    public function testReadExistingNewerVersionKeys(): void
-    {
-        // Test reading existing newer version keys from drive (encrypted)
-        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
-        $reflection->setAccessible(true);
-
-        // First create a database key for encryption
-        global $testSQLResponses;
-        $testSQLResponses = [];
-        $dbKey = base64_encode('database_key_32_bytes_for_encrypt!');
-        $testSQLResponses[md5("SELECT `value` FROM `keys` WHERE `name` = ?" . serialize(['sixa']))] = ['value' => $dbKey];
-        $testSQLResponses[md5("SELECT `value` FROM `keys` WHERE `name` = ?" . serialize(['sixb']))] = ['value' => $dbKey];
-
-        // Create an encrypted key file
-        $keyDir = $this->testSiteDir . '/documents/logs_and_misc/methods';
-        $rawKey = 'test_newer_key_32_bytes_for_testing!';
-        $encryptedKey = $this->cryptoGen->encryptStandard($rawKey, null, 'database');
-        file_put_contents($keyDir . '/sixx', $encryptedKey);
-
-        $key = $reflection->invoke($this->cryptoGen, 'six', 'x', 'drive');
-        $this->assertEquals($rawKey, $key);
-    }
-
-    public function testDatabaseKeyErrorHandling(): void
-    {
-        // Test a different error scenario - simulate broken file permissions for drive keys
-        $badSiteDir = '/tmp/nonexistent_readonly_dir_' . uniqid();
-
-        // Store original and set bad directory
-        $originalSiteDir = $GLOBALS['OE_SITE_DIR'];
-        $GLOBALS['OE_SITE_DIR'] = $badSiteDir;
-
-        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
-        $reflection->setAccessible(true);
-
-        try {
-            $this->expectException(CryptoGenException::class);
-            $this->expectExceptionMessage('Key creation in drive is not working');
-            $reflection->invoke($this->cryptoGen, 'errorkey', '', 'drive');
-        } finally {
-            // Always restore the original site directory
-            $GLOBALS['OE_SITE_DIR'] = $originalSiteDir;
+        foreach ($invalidValues as $value => $description) {
+            $this->assertFalse(
+                $this->cryptoGen->cryptCheckStandard($value),
+                "Expected cryptCheckStandard to return false for: {$description} (value: '{$value}')"
+            );
         }
     }
 
-    public function testCorruptedKeyFileHandling(): void
+    public function testReadyStaticMethod(): void
     {
-        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
-        $reflection->setAccessible(true);
+        // Test that ready() returns boolean
+        $this->assertIsBool(CryptoGen::ready());
 
-        // Create a corrupted key file for newer version (five/six that need decryption)
-        $keyDir = $this->testSiteDir . '/documents/logs_and_misc/methods';
-        file_put_contents($keyDir . '/corruptedkeya', 'invalid_encrypted_data');
-
-        $this->expectException(CryptoGenException::class);
-        $this->expectExceptionMessage('Key in drive is not compatible');
-        $reflection->invoke($this->cryptoGen, 'corruptedkey', 'a', 'drive');
-    }
-
-    public function testCollectCryptoKeyDatabaseCreationFlow(): void
-    {
-        global $testSQLResponses;
-        $testSQLResponses = [];
-
-        // Mock empty response first (to trigger creation), then return the created key
-        $keyLabel = 'dbcreatetest';
-        $testSQLResponses[md5("SELECT `value` FROM `keys` WHERE `name` = ?" . serialize([$keyLabel]))] = [];
-
-        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
-        $reflection->setAccessible(true);
-
-        // First call should trigger key creation and return a key
-        $key = $reflection->invoke($this->cryptoGen, 'dbcreatetest', '', 'database');
-        $this->assertIsString($key);
-        $this->assertEquals(32, strlen($key));
-    }
-
-    public function testMcryptLegacyFunction(): void
-    {
-        // Test the legacy mcrypt function behavior
-        $testData = base64_encode('test encrypted data');
-
-        if (!function_exists('mcrypt_decrypt')) {
-            // If mcrypt is not available, expect a fatal error
-            try {
-                $this->cryptoGen->aes256Decrypt_mycrypt($testData);
-                $this->fail('Expected fatal error due to missing mcrypt function');
-            } catch (Error $e) {
-                // Expected - mcrypt functions don't exist
-                $this->assertStringContainsString('mcrypt_decrypt', $e->getMessage());
-            }
-        } else {
-            // If mcrypt is available, test normal operation
-            $result = $this->cryptoGen->aes256Decrypt_mycrypt($testData);
-            $this->assertIsString($result);
-        }
-    }
-
-    public function testAllLegacyDecryptionPaths(): void
-    {
-        // Comprehensive test of all legacy decryption paths to ensure they're covered
-
-        // Test aes256DecryptTwo with both standard keys and custom password
-        $this->cryptoGen->aes256DecryptTwo(base64_encode('test'));
-        $this->cryptoGen->aes256DecryptTwo(base64_encode('test'), 'custompass');
-
-        // Test aes256DecryptOne with both standard keys and custom password
-        $this->cryptoGen->aes256DecryptOne(base64_encode('test'));
-        $this->cryptoGen->aes256DecryptOne(base64_encode('test'), 'custompass');
-
-        // These will all return false due to invalid data, but will exercise the code paths
-        $this->expectNotToPerformAssertions(); // Mark test as having no meaningful assertions
-    }
-
-    public function testCustomPasswordEncryptionPaths(): void
-    {
-        // Test custom password encryption to cover those specific code paths
-        $testData = 'test custom password encryption';
-        $password = 'test_password_123';
-
-        // This should exercise the custom password path in coreEncrypt
-        $encrypted = $this->cryptoGen->encryptStandard($testData, $password);
-        $this->assertNotEmpty($encrypted);
-        $this->assertIsString($encrypted);
-        $this->assertStringStartsWith('006', $encrypted);
-
-        // And the custom password path in coreDecrypt
-        $decrypted = $this->cryptoGen->decryptStandard($encrypted, $password);
-        $this->assertEquals($testData, $decrypted);
-
-        // Test wrong password to trigger HMAC failure path
-        $wrongDecrypted = $this->cryptoGen->decryptStandard($encrypted, 'wrong_password');
-        $this->assertFalse($wrongDecrypted);
-    }
-
-    public function testAllCollectCryptoKeyPaths(): void
-    {
-        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
-        $reflection->setAccessible(true);
-
-        // Test all version/sub combinations to ensure full coverage
-        $versions = ['one', 'two', 'three', 'four', 'five', 'six'];
-        $subs = ['', 'a', 'b'];
-
-        foreach ($versions as $version) {
-            foreach ($subs as $sub) {
-                $key = $reflection->invoke($this->cryptoGen, $version, $sub, 'drive');
-                $this->assertIsString($key);
-                $this->assertEquals(32, strlen($key));
-            }
-        }
-    }
-
-    public function testDecryptStandardWithAllSupportedVersions(): void
-    {
-        // Test decryption with each version to ensure version parsing is covered
-        $versions = [1, 2, 3, 4, 5, 6];
-
-        foreach ($versions as $version) {
-            $versionStr = str_pad((string)$version, 3, '0', STR_PAD_LEFT);
-            $testData = $versionStr . base64_encode('mock_data');
-
-            // This will fail decryption but exercises the version routing code
-            $result = $this->cryptoGen->decryptStandard($testData);
-            $this->assertFalse($result);
-        }
-    }
-
-    public function testCoreDecryptCustomPasswordPath(): void
-    {
-        // Test coreDecrypt with custom password to cover those lines
-        $reflection = new ReflectionMethod($this->cryptoGen, 'coreDecrypt');
-        $reflection->setAccessible(true);
-
-        // Create a mock encrypted value with salt for custom password
-        $salt = str_repeat('S', 32); // 32 byte salt
-        $hmac = str_repeat('H', 48); // 48 byte HMAC
-        $iv = str_repeat('I', 16);   // 16 byte IV
-        $data = str_repeat('D', 32); // encrypted data
-
-        $mockEncrypted = base64_encode($salt . $hmac . $iv . $data);
-
-        // This should exercise the custom password decryption path
-        $result = $reflection->invoke($this->cryptoGen, $mockEncrypted, 'testpass');
-        $this->assertFalse($result); // Will fail HMAC validation but covers the code
-    }
-
-    public function testRandomBytesFailureHandling(): void
-    {
-        // Test error handling when file creation fails
-        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
-        $reflection->setAccessible(true);
-
-        // Test with invalid site directory to trigger file creation errors
-        $originalSiteDir = $GLOBALS['OE_SITE_DIR'];
-        $GLOBALS['OE_SITE_DIR'] = '/invalid/readonly/path';
-
-        try {
-            $this->expectException(CryptoGenException::class);
-            $reflection->invoke($this->cryptoGen, 'failtest', 'a', 'drive');
-        } finally {
-            $GLOBALS['OE_SITE_DIR'] = $originalSiteDir;
-        }
-    }
-
-    public function testMcryptMethodDirectly(): void
-    {
-        // Test the aes256Decrypt_mycrypt method directly to get coverage
-        if (function_exists('mcrypt_decrypt')) {
-            $testData = base64_encode('test data for mcrypt');
-            $result = $this->cryptoGen->aes256Decrypt_mycrypt($testData);
-            $this->assertIsString($result);
-        } else {
-            // If mcrypt is not available, expect the method to fail
-            try {
-                $this->cryptoGen->aes256Decrypt_mycrypt('test');
-                $this->fail('Expected error due to missing mcrypt');
-            } catch (Error $e) {
-                $this->assertStringContainsString('mcrypt', $e->getMessage());
-            }
-        }
-    }
-
-    public function testInvalidBase64Decryption(): void
-    {
-        // Test error handling with invalid base64 data
-        $invalidData = 'invalid base64 data!@#$%';
-
-        $result = $this->cryptoGen->decryptStandard('006' . $invalidData);
-        $this->assertFalse($result);
-
-        // Test with aes256DecryptTwo
-        $result2 = $this->cryptoGen->aes256DecryptTwo($invalidData);
-        $this->assertFalse($result2);
-
-        // Test with aes256DecryptOne
-        $result3 = $this->cryptoGen->aes256DecryptOne($invalidData);
-        $this->assertFalse($result3);
-    }
-
-    public function testDriveKeyCreationFailure(): void
-    {
-        // Test drive key creation failure when directory is read-only/invalid
-        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
-        $reflection->setAccessible(true);
-
-        // Set site directory to an invalid/readonly path to trigger file creation failure
-        $originalSiteDir = $GLOBALS['OE_SITE_DIR'];
-        $GLOBALS['OE_SITE_DIR'] = '/root/invalid/readonly/path/that/does/not/exist';
-
-        try {
-            $this->expectException(CryptoGenException::class);
-            $this->expectExceptionMessage('Key creation in drive is not working');
-            $reflection->invoke($this->cryptoGen, 'failkey', 'a', 'drive');
-        } finally {
-            // Always restore the original site directory
-            $GLOBALS['OE_SITE_DIR'] = $originalSiteDir;
-        }
-    }
-
-    public function testAllExceptionPaths(): void
-    {
-        // Test various exception scenarios to improve coverage
-
-        // Test with malformed encrypted data to trigger HMAC validation failures
-        $malformedData = '006' . base64_encode(str_repeat('x', 100));
-        $result = $this->cryptoGen->decryptStandard($malformedData);
-        $this->assertFalse($result);
-
-        // Test custom password with malformed data
-        $result2 = $this->cryptoGen->decryptStandard($malformedData, 'password');
-        $this->assertFalse($result2);
-
-        // Test version 2 decrypt with malformed data
-        $malformedV2 = '002' . base64_encode(str_repeat('y', 100));
-        $result3 = $this->cryptoGen->decryptStandard($malformedV2);
-        $this->assertFalse($result3);
-    }
-
-    public function testCoverageBoosterAllPaths(): void
-    {
-        // This test aims to hit any remaining uncovered lines
-
-        // Test minimum version parameter
-        $result = $this->cryptoGen->decryptStandard('001test', null, 'drive', 2);
-        $this->assertFalse($result); // Should fail due to minimum version check
-
-        // Test unknown version
-        $result2 = $this->cryptoGen->decryptStandard('999test');
-        $this->assertFalse($result2);
-
-        // Test successful decryption paths for version coverage
-        $v6Data = $this->cryptoGen->encryptStandard('test data');
-        $this->assertIsString($v6Data);
-        $this->assertStringStartsWith('006', $v6Data);
-        $decrypted = $this->cryptoGen->decryptStandard($v6Data);
-        $this->assertEquals('test data', $decrypted);
+        // In normal test environment, should return true
+        $this->assertTrue(CryptoGen::ready());
     }
 }

--- a/tests/Tests/Unit/Common/Crypto/CryptoGenTest_old.php
+++ b/tests/Tests/Unit/Common/Crypto/CryptoGenTest_old.php
@@ -1,0 +1,1103 @@
+<?php
+
+/**
+ * Tests for the CryptoGen class
+ *
+ * @category  Test
+ * @package   OpenEMR\Tests\Unit\Common\Crypto
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright 2025 OpenCoreEMR
+ * @license   GNU General Public License 3
+ * @link      http://www.open-emr.org
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Unit\Common\Crypto;
+
+use Error;
+use OpenEMR\Common\Crypto\CryptoGen;
+use OpenEMR\Common\Crypto\CryptoGenException;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionProperty;
+
+final class CryptoGenTest extends TestCase
+{
+    /**
+     * @var CryptoGen
+     */
+    private $cryptoGen;
+
+    /**
+     * @var array<string, mixed> Original $GLOBALS backup
+     */
+    private array $originalGlobals;
+
+    /**
+     * @var string Test site directory for file operations
+     */
+    private string $testSiteDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Backup original GLOBALS
+        /**
+         * @var array<string, mixed> $globalsCopy
+         */
+        $globalsCopy = $GLOBALS;
+        $this->originalGlobals = $globalsCopy;
+
+        // Create test site directory
+        $this->testSiteDir = sys_get_temp_dir() . '/openemr_test_' . uniqid();
+        mkdir($this->testSiteDir . '/documents/logs_and_misc/methods', 0755, true);
+
+        // Mock GLOBALS for testing
+        $GLOBALS['OE_SITE_DIR'] = $this->testSiteDir;
+
+        // Mock required global functions
+        if (!function_exists('sqlQueryNoLog')) {
+            eval(
+                'function sqlQueryNoLog($query, $binds = []) {
+                global $testSQLResponses;
+                return $testSQLResponses[md5($query . serialize($binds))] ?? [];
+            }'
+            );
+        }
+
+        if (!function_exists('sqlStatementNoLog')) {
+            eval(
+                'function sqlStatementNoLog($query, $binds = []) {
+                global $testSQLStatements;
+                $testSQLStatements[] = [\"query\" => $query, \"binds\" => $binds];
+                return true;
+            }'
+            );
+        }
+
+        if (!function_exists('errorLogEscape')) {
+            eval(
+                'function errorLogEscape($string) {
+                return addslashes($string);
+            }'
+            );
+        }
+
+        $this->cryptoGen = new CryptoGen();
+    }
+
+    protected function tearDown(): void
+    {
+        // Restore original GLOBALS
+        foreach ($this->originalGlobals as $key => $value) {
+            $GLOBALS[$key] = $value;
+        }
+
+        // Clean up test directory
+        if (is_dir($this->testSiteDir)) {
+            $this->removeDirectory($this->testSiteDir);
+        }
+
+        parent::tearDown();
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $files = array_diff(scandir($dir), ['.', '..']);
+        foreach ($files as $file) {
+            $path = $dir . '/' . $file;
+            is_dir($path) ? $this->removeDirectory($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+
+    public function testConstructor(): void
+    {
+        $cryptoGen = new CryptoGen();
+
+        // Test that CryptoGen can be constructed successfully
+        $this->assertInstanceOf(CryptoGen::class, $cryptoGen);
+
+        // Test that the ready() method works
+        $this->assertTrue(CryptoGen::ready());
+    }
+
+    public function testEncryptStandardWithEmptyValue(): void
+    {
+        $result = $this->cryptoGen->encryptStandard('');
+        $this->assertNotEmpty($result);
+        $this->assertIsString($result);
+        $this->assertStringStartsWith('006', $result);
+    }
+
+    public function testEncryptStandardWithNullValue(): void
+    {
+        $result = $this->cryptoGen->encryptStandard(null);
+        $this->assertNotEmpty($result);
+        $this->assertIsString($result);
+        $this->assertStringStartsWith('006', $result);
+    }
+
+    public function testEncryptStandardWithValidValue(): void
+    {
+        $testValue = 'test encryption data';
+        $result = $this->cryptoGen->encryptStandard($testValue);
+
+        $this->assertNotEmpty($result);
+        $this->assertIsString($result);
+        $this->assertStringStartsWith('006', $result);
+        $this->assertNotEquals($testValue, $result);
+    }
+
+    public function testEncryptStandardWithCustomPassword(): void
+    {
+        $testValue = 'test data';
+        $customPassword = 'mypassword123';
+        $result = $this->cryptoGen->encryptStandard($testValue, $customPassword);
+
+        $this->assertNotEmpty($result);
+        $this->assertIsString($result);
+        $this->assertStringStartsWith('006', $result);
+    }
+
+    public function testEncryptStandardWithDatabaseKeySource(): void
+    {
+        // Mock SQL response for database key
+        global $testSQLResponses;
+        $testSQLResponses = [];
+        $testSQLResponses[md5("SELECT `value` FROM `keys` WHERE `name` = ?" . serialize(['sixa']))] = ['value' => base64_encode('test_key_32_bytes_long_for_test')];
+        $testSQLResponses[md5("SELECT `value` FROM `keys` WHERE `name` = ?" . serialize(['sixb']))] = ['value' => base64_encode('test_hmac_key_32_bytes_for_test')];
+
+        $testValue = 'test data';
+        $result = $this->cryptoGen->encryptStandard($testValue, null, 'database');
+
+        $this->assertNotEmpty($result);
+        $this->assertIsString($result);
+        $this->assertStringStartsWith('006', $result);
+    }
+
+    public function testDecryptStandardWithEmptyValue(): void
+    {
+        $result = $this->cryptoGen->decryptStandard('');
+        $this->assertEquals('', $result);
+    }
+
+    public function testDecryptStandardWithNullValue(): void
+    {
+        $result = $this->cryptoGen->decryptStandard(null);
+        $this->assertEquals('', $result);
+    }
+
+    public function testEncryptDecryptRoundTrip(): void
+    {
+        $originalValue = 'This is a test message for encryption and decryption';
+
+        $encrypted = $this->cryptoGen->encryptStandard($originalValue);
+        $this->assertIsString($encrypted);
+        $decrypted = $this->cryptoGen->decryptStandard($encrypted);
+
+        $this->assertEquals($originalValue, $decrypted);
+    }
+
+    public function testEncryptDecryptRoundTripWithCustomPassword(): void
+    {
+        $originalValue = 'Test data with custom password';
+        $customPassword = 'secret123';
+
+        $encrypted = $this->cryptoGen->encryptStandard($originalValue, $customPassword);
+        $this->assertIsString($encrypted);
+        $decrypted = $this->cryptoGen->decryptStandard($encrypted, $customPassword);
+
+        $this->assertEquals($originalValue, $decrypted);
+    }
+
+    public function testDecryptStandardWithMinimumVersion(): void
+    {
+        $testValue = 'test data';
+        $encrypted = $this->cryptoGen->encryptStandard($testValue);
+        $this->assertIsString($encrypted);
+
+        // Should succeed with minimum version 6
+        $decrypted = $this->cryptoGen->decryptStandard($encrypted, null, 'drive', 6);
+        $this->assertEquals($testValue, $decrypted);
+
+        // Should fail with minimum version 7
+        $decrypted = $this->cryptoGen->decryptStandard($encrypted, null, 'drive', 7);
+        $this->assertFalse($decrypted);
+    }
+
+    public function testCryptCheckStandardWithValidValues(): void
+    {
+        $this->assertTrue($this->cryptoGen->cryptCheckStandard('001test'));
+        $this->assertTrue($this->cryptoGen->cryptCheckStandard('002test'));
+        $this->assertTrue($this->cryptoGen->cryptCheckStandard('003test'));
+        $this->assertTrue($this->cryptoGen->cryptCheckStandard('004test'));
+        $this->assertTrue($this->cryptoGen->cryptCheckStandard('005test'));
+        $this->assertTrue($this->cryptoGen->cryptCheckStandard('006test'));
+    }
+
+    public function testCryptCheckStandardWithInvalidValues(): void
+    {
+        $this->assertFalse($this->cryptoGen->cryptCheckStandard(''));
+        $this->assertFalse($this->cryptoGen->cryptCheckStandard(null));
+        $this->assertFalse($this->cryptoGen->cryptCheckStandard('007test'));
+        $this->assertFalse($this->cryptoGen->cryptCheckStandard('000test'));
+        $this->assertFalse($this->cryptoGen->cryptCheckStandard('test'));
+        $this->assertFalse($this->cryptoGen->cryptCheckStandard('abc123'));
+    }
+
+
+
+    public function testCoreDecryptWithInvalidBase64(): void
+    {
+        $reflection = new ReflectionMethod($this->cryptoGen, 'coreDecrypt');
+        $reflection->setAccessible(true);
+
+        $result = $reflection->invoke($this->cryptoGen, 'invalid_base64_!!!');
+        $this->assertFalse($result);
+    }
+
+
+    public function testAes256DecryptOneWithValidData(): void
+    {
+        // This tests backward compatibility with version 1 encryption
+        // For now, test that the method exists and handles invalid data
+        $result = $this->cryptoGen->aes256DecryptOne('invalid_data');
+        $this->assertFalse($result);
+    }
+
+    public function testAes256DecryptMycrypt(): void
+    {
+        // Test the legacy mcrypt method - this will likely fail on modern PHP without mcrypt
+        // but we still test it to ensure the method exists and handles errors gracefully
+
+        if (!function_exists('mcrypt_decrypt')) {
+            // If mcrypt is not available, expect a fatal error
+            try {
+                $this->cryptoGen->aes256Decrypt_mycrypt('test');
+                $this->fail('Expected fatal error due to missing mcrypt function');
+            } catch (Error $e) {
+                // Expected - mcrypt functions don't exist
+                $this->assertStringContainsString('mcrypt_decrypt', $e->getMessage());
+            }
+        } else {
+            // If mcrypt is available, test normal operation
+            $result = $this->cryptoGen->aes256Decrypt_mycrypt('test');
+            $this->assertIsString($result);
+        }
+    }
+
+    public function testCollectCryptoKeyDriveSource(): void
+    {
+        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
+        $reflection->setAccessible(true);
+
+        // Test creating a new key
+        $key = $reflection->invoke($this->cryptoGen, 'test', 'a', 'drive');
+        $this->assertIsString($key);
+        $this->assertEquals(32, strlen($key)); // 256 bits = 32 bytes
+
+        // Test retrieving the same key (should be cached)
+        $key2 = $reflection->invoke($this->cryptoGen, 'test', 'a', 'drive');
+        $this->assertEquals($key, $key2);
+    }
+
+    public function testCollectCryptoKeyDatabaseSource(): void
+    {
+        global $testSQLResponses;
+        $testSQLResponses = [];
+
+        // Mock empty response to trigger key creation
+        $testSQLResponses[md5("SELECT `value` FROM `keys` WHERE `name` = ?" . serialize(['testa']))] = [];
+
+        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
+        $reflection->setAccessible(true);
+
+        $key = $reflection->invoke($this->cryptoGen, 'test', 'a', 'database');
+        $this->assertIsString($key);
+        $this->assertEquals(32, strlen($key));
+    }
+
+    public function testCollectCryptoKeyOlderVersions(): void
+    {
+        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
+        $reflection->setAccessible(true);
+
+        // Test older versions that don't encrypt the key on drive
+        foreach (['one', 'two', 'three', 'four'] as $version) {
+            $key = $reflection->invoke($this->cryptoGen, $version, 'a', 'drive');
+            $this->assertIsString($key);
+            $this->assertEquals(32, strlen($key));
+        }
+    }
+
+    public function testFormatExceptionMessage(): void
+    {
+        $reflection = new ReflectionMethod($this->cryptoGen, 'formatExceptionMessage');
+        $reflection->setAccessible(true);
+
+        $stackTrace = [
+            [
+                'file' => '/test/file.php',
+                'line' => 123,
+                'class' => 'TestClass',
+                'type' => '->',
+                'function' => 'testMethod'
+            ],
+            [
+                'function' => 'anotherFunction'
+            ]
+        ];
+
+        $result = $reflection->invoke($this->cryptoGen, $stackTrace);
+        $this->assertIsString($result);
+        $this->assertStringContainsString('Error Call Stack:', $result);
+        $this->assertStringContainsString('/test/file.php', $result);
+        $this->assertStringContainsString('123', $result);
+        $this->assertStringContainsString('TestClass->testMethod()', $result);
+        $this->assertStringContainsString('anotherFunction()', $result);
+    }
+
+    public function testDecryptStandardWithVersions(): void
+    {
+        // Test that different version prefixes route to correct decryption methods
+
+        // Version 6 (current)
+        $testData = 'test data';
+        $encrypted = $this->cryptoGen->encryptStandard($testData);
+        $this->assertIsString($encrypted);
+        $this->assertTrue($this->cryptoGen->cryptCheckStandard($encrypted));
+
+        // Test invalid version
+        $invalidVersionData = '007' . base64_encode('test');
+        $result = $this->cryptoGen->decryptStandard($invalidVersionData);
+        $this->assertFalse($result);
+    }
+
+    public function testKeyVersionProperty(): void
+    {
+        $reflection = new ReflectionProperty($this->cryptoGen, 'keyVersion');
+        $reflection->setAccessible(true);
+        $this->assertEquals('six', $reflection->getValue($this->cryptoGen));
+    }
+
+    public function testEncryptionVersionProperty(): void
+    {
+        $reflection = new ReflectionProperty($this->cryptoGen, 'encryptionVersion');
+        $reflection->setAccessible(true);
+        $this->assertEquals('006', $reflection->getValue($this->cryptoGen));
+    }
+
+    public function testKeyCacheProperty(): void
+    {
+        $reflection = new ReflectionProperty($this->cryptoGen, 'keyCache');
+        $reflection->setAccessible(true);
+
+        // Initially empty
+        $this->assertEmpty($reflection->getValue($this->cryptoGen));
+
+        // After getting a key, should be populated
+        $reflectionMethod = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
+        $reflectionMethod->setAccessible(true);
+        $reflectionMethod->invoke($this->cryptoGen, 'test', 'a', 'drive');
+
+        $cache = $reflection->getValue($this->cryptoGen);
+        $this->assertIsArray($cache);
+        // Since PHPStan can't analyze runtime behavior, we use array key existence as a proxy
+        $cacheKeys = array_keys($cache);
+        $expectedKey = 'testadrive';
+        $this->assertContains($expectedKey, $cacheKeys, 'Cache should contain the expected key after collectCryptoKey call');
+    }
+
+    public function testDecryptWithWrongPassword(): void
+    {
+        $testData = 'sensitive data';
+        $password1 = 'password1';
+        $password2 = 'password2';
+
+        $encrypted = $this->cryptoGen->encryptStandard($testData, $password1);
+        $this->assertIsString($encrypted);
+        $decrypted = $this->cryptoGen->decryptStandard($encrypted, $password2);
+
+        $this->assertFalse($decrypted);
+    }
+
+    public function testLargeDataEncryption(): void
+    {
+        $largeData = str_repeat('This is a large data string for testing. ', 1000);
+
+        $encrypted = $this->cryptoGen->encryptStandard($largeData);
+        $this->assertIsString($encrypted);
+        $decrypted = $this->cryptoGen->decryptStandard($encrypted);
+
+        $this->assertEquals($largeData, $decrypted);
+    }
+
+    public function testSpecialCharacterEncryption(): void
+    {
+        $specialData = "Test data with special chars: àáâãäå æç èéêë ìíîï ñ òóôõö ùúûü ÿ 日本語 العربية русский";
+
+        $encrypted = $this->cryptoGen->encryptStandard($specialData);
+        $this->assertIsString($encrypted);
+        $decrypted = $this->cryptoGen->decryptStandard($encrypted);
+
+        $this->assertEquals($specialData, $decrypted);
+    }
+
+    public function testBinaryDataEncryption(): void
+    {
+        $binaryData = pack('C*', ...range(0, 255));
+
+        $encrypted = $this->cryptoGen->encryptStandard($binaryData);
+        $this->assertIsString($encrypted);
+        $decrypted = $this->cryptoGen->decryptStandard($encrypted);
+
+        $this->assertEquals($binaryData, $decrypted);
+    }
+
+    public function testDecryptStandardAllVersions(): void
+    {
+        // Test all supported decryption versions
+
+        // Version 6 (current)
+        $testData = 'test version 6';
+        $encrypted = $this->cryptoGen->encryptStandard($testData);
+        $this->assertIsString($encrypted);
+        $decrypted = $this->cryptoGen->decryptStandard($encrypted);
+        $this->assertEquals($testData, $decrypted);
+
+        // Test version routing by manually creating version prefixes
+        // Note: These test the routing logic, not actual decryption since we don't have legacy encrypted data
+
+        // Version 5 - should route to coreDecrypt
+        $version5Data = '005' . base64_encode('mock_encrypted_data');
+        $result = $this->cryptoGen->decryptStandard($version5Data);
+        $this->assertFalse($result); // Will fail due to invalid data, but tests routing
+
+        // Version 4 - should route to coreDecrypt
+        $version4Data = '004' . base64_encode('mock_encrypted_data');
+        $result = $this->cryptoGen->decryptStandard($version4Data);
+        $this->assertFalse($result);
+
+        // Version 3 - should route to aes256DecryptTwo
+        $version3Data = '003' . base64_encode('mock_encrypted_data');
+        $result = $this->cryptoGen->decryptStandard($version3Data);
+        $this->assertFalse($result);
+
+        // Version 2 - should route to aes256DecryptTwo
+        $version2Data = '002' . base64_encode('mock_encrypted_data');
+        $result = $this->cryptoGen->decryptStandard($version2Data);
+        $this->assertFalse($result);
+
+        // Version 1 - should route to aes256DecryptOne
+        $version1Data = '001' . base64_encode('mock_encrypted_data');
+        $result = $this->cryptoGen->decryptStandard($version1Data);
+        $this->assertFalse($result);
+    }
+
+    public function testAes256DecryptTwoWithCustomPassword(): void
+    {
+        // Test custom password path
+        $result = $this->cryptoGen->aes256DecryptTwo('invalid_base64', 'testpassword');
+        $this->assertFalse($result);
+
+        // Test with null value
+        $result = $this->cryptoGen->aes256DecryptTwo(null);
+        $this->assertFalse($result);
+    }
+
+    public function testAes256DecryptOneWithCustomPassword(): void
+    {
+        // Test custom password path
+        $result = $this->cryptoGen->aes256DecryptOne('invalid_base64', 'testpassword');
+        $this->assertFalse($result);
+
+        // Test with null value
+        $result = $this->cryptoGen->aes256DecryptOne(null);
+        $this->assertFalse($result);
+    }
+
+    public function testCollectCryptoKeyWithExistingDatabaseKey(): void
+    {
+        // Test using drive keys instead of database to avoid SQL mocking complexity
+        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
+        $reflection->setAccessible(true);
+
+        // First call will create a key, second call should return the same key from cache
+        $key1 = $reflection->invoke($this->cryptoGen, 'existing', 'a', 'drive');
+        $key2 = $reflection->invoke($this->cryptoGen, 'existing', 'a', 'drive');
+
+        $this->assertIsString($key1);
+        $this->assertEquals(32, strlen($key1)); // 256-bit key should be 32 bytes
+        $this->assertEquals($key1, $key2); // Should be the same key from cache
+
+        // Verify the key file was created
+        $keyFilePath = $this->testSiteDir . '/documents/logs_and_misc/methods/existinga';
+        $this->assertFileExists($keyFilePath);
+    }
+
+    public function testCollectCryptoKeyNewerVersionEncryption(): void
+    {
+        // Test newer versions (five, six) that encrypt the key on drive
+        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
+        $reflection->setAccessible(true);
+
+        // Create a key with version 'five'
+        $key = $reflection->invoke($this->cryptoGen, 'five', 'a', 'drive');
+        $this->assertIsString($key);
+        $this->assertEquals(32, strlen($key));
+
+        // Verify the file was created and encrypted
+        $keyFile = $this->testSiteDir . '/documents/logs_and_misc/methods/fivea';
+        $this->assertFileExists($keyFile);
+
+        // The content should be encrypted (start with version prefix)
+        $content = file_get_contents($keyFile);
+        $this->assertIsString($content);
+        $this->assertStringStartsWith('006', $content);
+    }
+
+    public function testCollectCryptoKeyErrorScenarios(): void
+    {
+        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
+        $reflection->setAccessible(true);
+
+        // Test when key directory doesn't exist and can't be created
+        $badSiteDir = '/root/nonexistent/path';
+        $GLOBALS['OE_SITE_DIR'] = $badSiteDir;
+
+        $this->expectException(CryptoGenException::class);
+        $this->expectExceptionMessage('Key creation in drive is not working');
+
+        try {
+            $reflection->invoke($this->cryptoGen, 'test', 'a', 'drive');
+        } finally {
+            // Restore test site dir
+            $GLOBALS['OE_SITE_DIR'] = $this->testSiteDir;
+        }
+    }
+
+    public function testHmacValidationFailure(): void
+    {
+        // Create a valid encrypted value, then tamper with it to cause HMAC failure
+        $testData = 'test data';
+        $encrypted = $this->cryptoGen->encryptStandard($testData);
+
+        // Remove version prefix and decode
+        $this->assertIsString($encrypted);
+        $withoutVersion = substr($encrypted, 3);
+        $raw = base64_decode($withoutVersion);
+
+        // Tamper with the HMAC (first 48 bytes)
+        $tamperedRaw = 'X' . substr($raw, 1);
+        $tamperedEncrypted = '006' . base64_encode($tamperedRaw);
+
+        // This should fail HMAC validation and return false
+        $result = $this->cryptoGen->decryptStandard($tamperedEncrypted);
+        $this->assertFalse($result);
+    }
+
+    public function testCustomPasswordHmacFailure(): void
+    {
+        // Test HMAC failure with custom password
+        $testData = 'test data';
+        $password = 'mypassword';
+        $encrypted = $this->cryptoGen->encryptStandard($testData, $password);
+
+        // Tamper with the encrypted data
+        $this->assertIsString($encrypted);
+        $withoutVersion = substr($encrypted, 3);
+        $raw = base64_decode($withoutVersion);
+
+        // Skip salt (32 bytes) and tamper with HMAC (next 48 bytes)
+        $tamperedRaw = substr($raw, 0, 32) . 'X' . substr($raw, 33);
+        $tamperedEncrypted = '006' . base64_encode($tamperedRaw);
+
+        $result = $this->cryptoGen->decryptStandard($tamperedEncrypted, $password);
+        $this->assertFalse($result);
+    }
+
+    public function testAes256DecryptTwoHmacFailure(): void
+    {
+        // Test HMAC failure in aes256DecryptTwo
+        $fakeEncrypted = base64_encode(str_repeat('X', 100)); // Invalid HMAC
+        $result = $this->cryptoGen->aes256DecryptTwo($fakeEncrypted);
+        $this->assertFalse($result);
+    }
+
+    public function testAes256DecryptOneBasicFunctionality(): void
+    {
+        // Test with empty string
+        $result = $this->cryptoGen->aes256DecryptOne('');
+        $this->assertFalse($result);
+
+        // Test with invalid base64
+        $result = $this->cryptoGen->aes256DecryptOne('not_base64_!');
+        $this->assertFalse($result);
+    }
+
+    public function testDecryptStandardErrorCases(): void
+    {
+        // Test with malformed version
+        $result = $this->cryptoGen->decryptStandard('abc123');
+        $this->assertFalse($result);
+
+        // Test with unsupported version
+        $result = $this->cryptoGen->decryptStandard('999test');
+        $this->assertFalse($result);
+
+        // Test minimum version rejection
+        $testData = 'test';
+        $encrypted = $this->cryptoGen->encryptStandard($testData); // Version 6
+        $this->assertIsString($encrypted);
+        $result = $this->cryptoGen->decryptStandard($encrypted, null, 'drive', 7);
+        $this->assertFalse($result);
+    }
+
+    public function testCoreDecryptErrorPaths(): void
+    {
+        $reflection = new ReflectionMethod($this->cryptoGen, 'coreDecrypt');
+        $reflection->setAccessible(true);
+
+        // Test with malformed base64
+        $result = $reflection->invoke($this->cryptoGen, 'not_valid_base64_!');
+        $this->assertFalse($result);
+
+        // Test with too short data
+        $shortData = base64_encode('short');
+        $result = $reflection->invoke($this->cryptoGen, $shortData);
+        $this->assertFalse($result);
+    }
+
+    public function testCollectCryptoKeyVersionVariations(): void
+    {
+        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
+        $reflection->setAccessible(true);
+
+        // Test default parameters
+        $key1 = $reflection->invoke($this->cryptoGen);
+        $this->assertIsString($key1);
+        $this->assertEquals(32, strlen($key1));
+
+        // Test with sub parameter
+        $key2 = $reflection->invoke($this->cryptoGen, 'one', 'test');
+        $this->assertIsString($key2);
+        $this->assertEquals(32, strlen($key2));
+
+        // Keys should be different
+        $this->assertNotEquals($key1, $key2);
+    }
+
+    public function testKeyCache(): void
+    {
+        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
+        $reflection->setAccessible(true);
+
+        $cacheProperty = new ReflectionProperty($this->cryptoGen, 'keyCache');
+        $cacheProperty->setAccessible(true);
+
+        // Initially empty
+        $this->assertEmpty($cacheProperty->getValue($this->cryptoGen));
+
+        // Get a key
+        $key1 = $reflection->invoke($this->cryptoGen, 'cache_test', 'a', 'drive');
+
+        // Getting the same key again should return cached version
+        $key2 = $reflection->invoke($this->cryptoGen, 'cache_test', 'a', 'drive');
+        $this->assertEquals($key1, $key2, 'Second call should return cached key (same as first)');
+
+        // Cache should now contain the key - verify by checking cache size
+        $cache = $cacheProperty->getValue($this->cryptoGen);
+        $this->assertIsArray($cache);
+        $this->assertGreaterThan(0, count($cache), 'Cache should have at least one entry after key operations');
+    }
+
+    public function testEmptyValueEncryptionDecryption(): void
+    {
+        // Test that empty values are handled correctly
+        $encrypted = $this->cryptoGen->encryptStandard('');
+        $this->assertNotEmpty($encrypted);
+        $this->assertIsString($encrypted);
+        $this->assertStringStartsWith('006', $encrypted);
+
+        $decrypted = $this->cryptoGen->decryptStandard($encrypted);
+        $this->assertEquals('', $decrypted);
+    }
+
+    public function testDatabaseKeyCreationPath(): void
+    {
+        // Test using drive key source to avoid complex database mocking
+        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
+        $reflection->setAccessible(true);
+
+        // This will create a real key file on drive and return the key
+        $key = $reflection->invoke($this->cryptoGen, 'testkey', 'a', 'drive');
+
+        // Key should be a valid 32-byte string
+        $this->assertIsString($key);
+        $this->assertEquals(32, strlen($key)); // 256-bit key should be 32 bytes
+
+        // Verify the key file was created
+        $keyFilePath = $this->testSiteDir . '/documents/logs_and_misc/methods/testkeya';
+        $this->assertFileExists($keyFilePath);
+
+        // Second call should return the same key from cache
+        $key2 = $reflection->invoke($this->cryptoGen, 'testkey', 'a', 'drive');
+        $this->assertEquals($key, $key2);
+    }
+
+    public function testFormatExceptionMessageEdgeCases(): void
+    {
+        $reflection = new ReflectionMethod($this->cryptoGen, 'formatExceptionMessage');
+        $reflection->setAccessible(true);
+
+        // Test with minimal stack trace
+        $minimalTrace = [
+            ['function' => 'testFunction']
+        ];
+        $result = $reflection->invoke($this->cryptoGen, $minimalTrace);
+        $this->assertIsString($result);
+        $this->assertStringContainsString('testFunction()', $result);
+
+        // Test with empty stack trace
+        $result = $reflection->invoke($this->cryptoGen, []);
+        $this->assertIsString($result);
+        $this->assertStringContainsString('Error Call Stack:', $result);
+
+        // Test with stack trace missing some fields
+        $partialTrace = [
+            [
+                'file' => '/test.php',
+                'class' => 'TestClass',
+                'function' => 'method'
+            ]
+        ];
+        $result = $reflection->invoke($this->cryptoGen, $partialTrace);
+        $this->assertIsString($result);
+        $this->assertStringContainsString('/test.php', $result);
+        $this->assertStringContainsString('TestClass', $result);
+        $this->assertStringContainsString('method()', $result);
+    }
+
+    public function testReadExistingOlderVersionKeys(): void
+    {
+        // Test reading existing older version keys from drive
+        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
+        $reflection->setAccessible(true);
+
+        // Create a mock older version key file (unencrypted)
+        $keyDir = $this->testSiteDir . '/documents/logs_and_misc/methods';
+        $testKey = base64_encode('test_older_key_32_bytes_for_testing!');
+        file_put_contents($keyDir . '/threea', $testKey);
+
+        $key = $reflection->invoke($this->cryptoGen, 'three', 'a', 'drive');
+        $this->assertEquals(base64_decode($testKey), $key);
+    }
+
+    public function testReadExistingNewerVersionKeys(): void
+    {
+        // Test reading existing newer version keys from drive (encrypted)
+        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
+        $reflection->setAccessible(true);
+
+        // First create a database key for encryption
+        global $testSQLResponses;
+        $testSQLResponses = [];
+        $dbKey = base64_encode('database_key_32_bytes_for_encrypt!');
+        $testSQLResponses[md5("SELECT `value` FROM `keys` WHERE `name` = ?" . serialize(['sixa']))] = ['value' => $dbKey];
+        $testSQLResponses[md5("SELECT `value` FROM `keys` WHERE `name` = ?" . serialize(['sixb']))] = ['value' => $dbKey];
+
+        // Create an encrypted key file
+        $keyDir = $this->testSiteDir . '/documents/logs_and_misc/methods';
+        $rawKey = 'test_newer_key_32_bytes_for_testing!';
+        $encryptedKey = $this->cryptoGen->encryptStandard($rawKey, null, 'database');
+        file_put_contents($keyDir . '/sixx', $encryptedKey);
+
+        $key = $reflection->invoke($this->cryptoGen, 'six', 'x', 'drive');
+        $this->assertEquals($rawKey, $key);
+    }
+
+    public function testDatabaseKeyErrorHandling(): void
+    {
+        // Test a different error scenario - simulate broken file permissions for drive keys
+        $badSiteDir = '/tmp/nonexistent_readonly_dir_' . uniqid();
+
+        // Store original and set bad directory
+        $originalSiteDir = $GLOBALS['OE_SITE_DIR'];
+        $GLOBALS['OE_SITE_DIR'] = $badSiteDir;
+
+        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
+        $reflection->setAccessible(true);
+
+        try {
+            $this->expectException(CryptoGenException::class);
+            $this->expectExceptionMessage('Key creation in drive is not working');
+            $reflection->invoke($this->cryptoGen, 'errorkey', '', 'drive');
+        } finally {
+            // Always restore the original site directory
+            $GLOBALS['OE_SITE_DIR'] = $originalSiteDir;
+        }
+    }
+
+    public function testCorruptedKeyFileHandling(): void
+    {
+        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
+        $reflection->setAccessible(true);
+
+        // Create a corrupted key file for newer version (five/six that need decryption)
+        $keyDir = $this->testSiteDir . '/documents/logs_and_misc/methods';
+        file_put_contents($keyDir . '/corruptedkeya', 'invalid_encrypted_data');
+
+        $this->expectException(CryptoGenException::class);
+        $this->expectExceptionMessage('Key in drive is not compatible');
+        $reflection->invoke($this->cryptoGen, 'corruptedkey', 'a', 'drive');
+    }
+
+    public function testCollectCryptoKeyDatabaseCreationFlow(): void
+    {
+        global $testSQLResponses;
+        $testSQLResponses = [];
+
+        // Mock empty response first (to trigger creation), then return the created key
+        $keyLabel = 'dbcreatetest';
+        $testSQLResponses[md5("SELECT `value` FROM `keys` WHERE `name` = ?" . serialize([$keyLabel]))] = [];
+
+        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
+        $reflection->setAccessible(true);
+
+        // First call should trigger key creation and return a key
+        $key = $reflection->invoke($this->cryptoGen, 'dbcreatetest', '', 'database');
+        $this->assertIsString($key);
+        $this->assertEquals(32, strlen($key));
+    }
+
+    public function testMcryptLegacyFunction(): void
+    {
+        // Test the legacy mcrypt function behavior
+        $testData = base64_encode('test encrypted data');
+
+        if (!function_exists('mcrypt_decrypt')) {
+            // If mcrypt is not available, expect a fatal error
+            try {
+                $this->cryptoGen->aes256Decrypt_mycrypt($testData);
+                $this->fail('Expected fatal error due to missing mcrypt function');
+            } catch (Error $e) {
+                // Expected - mcrypt functions don't exist
+                $this->assertStringContainsString('mcrypt_decrypt', $e->getMessage());
+            }
+        } else {
+            // If mcrypt is available, test normal operation
+            $result = $this->cryptoGen->aes256Decrypt_mycrypt($testData);
+            $this->assertIsString($result);
+        }
+    }
+
+    public function testAllLegacyDecryptionPaths(): void
+    {
+        // Comprehensive test of all legacy decryption paths to ensure they're covered
+
+        // Test aes256DecryptTwo with both standard keys and custom password
+        $this->cryptoGen->aes256DecryptTwo(base64_encode('test'));
+        $this->cryptoGen->aes256DecryptTwo(base64_encode('test'), 'custompass');
+
+        // Test aes256DecryptOne with both standard keys and custom password
+        $this->cryptoGen->aes256DecryptOne(base64_encode('test'));
+        $this->cryptoGen->aes256DecryptOne(base64_encode('test'), 'custompass');
+
+        // These will all return false due to invalid data, but will exercise the code paths
+        $this->expectNotToPerformAssertions(); // Mark test as having no meaningful assertions
+    }
+
+    public function testCustomPasswordEncryptionPaths(): void
+    {
+        // Test custom password encryption to cover those specific code paths
+        $testData = 'test custom password encryption';
+        $password = 'test_password_123';
+
+        // This should exercise the custom password path in coreEncrypt
+        $encrypted = $this->cryptoGen->encryptStandard($testData, $password);
+        $this->assertNotEmpty($encrypted);
+        $this->assertIsString($encrypted);
+        $this->assertStringStartsWith('006', $encrypted);
+
+        // And the custom password path in coreDecrypt
+        $decrypted = $this->cryptoGen->decryptStandard($encrypted, $password);
+        $this->assertEquals($testData, $decrypted);
+
+        // Test wrong password to trigger HMAC failure path
+        $wrongDecrypted = $this->cryptoGen->decryptStandard($encrypted, 'wrong_password');
+        $this->assertFalse($wrongDecrypted);
+    }
+
+    public function testAllCollectCryptoKeyPaths(): void
+    {
+        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
+        $reflection->setAccessible(true);
+
+        // Test all version/sub combinations to ensure full coverage
+        $versions = ['one', 'two', 'three', 'four', 'five', 'six'];
+        $subs = ['', 'a', 'b'];
+
+        foreach ($versions as $version) {
+            foreach ($subs as $sub) {
+                $key = $reflection->invoke($this->cryptoGen, $version, $sub, 'drive');
+                $this->assertIsString($key);
+                $this->assertEquals(32, strlen($key));
+            }
+        }
+    }
+
+    public function testDecryptStandardWithAllSupportedVersions(): void
+    {
+        // Test decryption with each version to ensure version parsing is covered
+        $versions = [1, 2, 3, 4, 5, 6];
+
+        foreach ($versions as $version) {
+            $versionStr = str_pad((string)$version, 3, '0', STR_PAD_LEFT);
+            $testData = $versionStr . base64_encode('mock_data');
+
+            // This will fail decryption but exercises the version routing code
+            $result = $this->cryptoGen->decryptStandard($testData);
+            $this->assertFalse($result);
+        }
+    }
+
+    public function testCoreDecryptCustomPasswordPath(): void
+    {
+        // Test coreDecrypt with custom password to cover those lines
+        $reflection = new ReflectionMethod($this->cryptoGen, 'coreDecrypt');
+        $reflection->setAccessible(true);
+
+        // Create a mock encrypted value with salt for custom password
+        $salt = str_repeat('S', 32); // 32 byte salt
+        $hmac = str_repeat('H', 48); // 48 byte HMAC
+        $iv = str_repeat('I', 16);   // 16 byte IV
+        $data = str_repeat('D', 32); // encrypted data
+
+        $mockEncrypted = base64_encode($salt . $hmac . $iv . $data);
+
+        // This should exercise the custom password decryption path
+        $result = $reflection->invoke($this->cryptoGen, $mockEncrypted, 'testpass');
+        $this->assertFalse($result); // Will fail HMAC validation but covers the code
+    }
+
+    public function testRandomBytesFailureHandling(): void
+    {
+        // Test error handling when file creation fails
+        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
+        $reflection->setAccessible(true);
+
+        // Test with invalid site directory to trigger file creation errors
+        $originalSiteDir = $GLOBALS['OE_SITE_DIR'];
+        $GLOBALS['OE_SITE_DIR'] = '/invalid/readonly/path';
+
+        try {
+            $this->expectException(CryptoGenException::class);
+            $reflection->invoke($this->cryptoGen, 'failtest', 'a', 'drive');
+        } finally {
+            $GLOBALS['OE_SITE_DIR'] = $originalSiteDir;
+        }
+    }
+
+    public function testMcryptMethodDirectly(): void
+    {
+        // Test the aes256Decrypt_mycrypt method directly to get coverage
+        if (function_exists('mcrypt_decrypt')) {
+            $testData = base64_encode('test data for mcrypt');
+            $result = $this->cryptoGen->aes256Decrypt_mycrypt($testData);
+            $this->assertIsString($result);
+        } else {
+            // If mcrypt is not available, expect the method to fail
+            try {
+                $this->cryptoGen->aes256Decrypt_mycrypt('test');
+                $this->fail('Expected error due to missing mcrypt');
+            } catch (Error $e) {
+                $this->assertStringContainsString('mcrypt', $e->getMessage());
+            }
+        }
+    }
+
+    public function testInvalidBase64Decryption(): void
+    {
+        // Test error handling with invalid base64 data
+        $invalidData = 'invalid base64 data!@#$%';
+
+        $result = $this->cryptoGen->decryptStandard('006' . $invalidData);
+        $this->assertFalse($result);
+
+        // Test with aes256DecryptTwo
+        $result2 = $this->cryptoGen->aes256DecryptTwo($invalidData);
+        $this->assertFalse($result2);
+
+        // Test with aes256DecryptOne
+        $result3 = $this->cryptoGen->aes256DecryptOne($invalidData);
+        $this->assertFalse($result3);
+    }
+
+    public function testDriveKeyCreationFailure(): void
+    {
+        // Test drive key creation failure when directory is read-only/invalid
+        $reflection = new ReflectionMethod($this->cryptoGen, 'collectCryptoKey');
+        $reflection->setAccessible(true);
+
+        // Set site directory to an invalid/readonly path to trigger file creation failure
+        $originalSiteDir = $GLOBALS['OE_SITE_DIR'];
+        $GLOBALS['OE_SITE_DIR'] = '/root/invalid/readonly/path/that/does/not/exist';
+
+        try {
+            $this->expectException(CryptoGenException::class);
+            $this->expectExceptionMessage('Key creation in drive is not working');
+            $reflection->invoke($this->cryptoGen, 'failkey', 'a', 'drive');
+        } finally {
+            // Always restore the original site directory
+            $GLOBALS['OE_SITE_DIR'] = $originalSiteDir;
+        }
+    }
+
+    public function testAllExceptionPaths(): void
+    {
+        // Test various exception scenarios to improve coverage
+
+        // Test with malformed encrypted data to trigger HMAC validation failures
+        $malformedData = '006' . base64_encode(str_repeat('x', 100));
+        $result = $this->cryptoGen->decryptStandard($malformedData);
+        $this->assertFalse($result);
+
+        // Test custom password with malformed data
+        $result2 = $this->cryptoGen->decryptStandard($malformedData, 'password');
+        $this->assertFalse($result2);
+
+        // Test version 2 decrypt with malformed data
+        $malformedV2 = '002' . base64_encode(str_repeat('y', 100));
+        $result3 = $this->cryptoGen->decryptStandard($malformedV2);
+        $this->assertFalse($result3);
+    }
+
+    public function testCoverageBoosterAllPaths(): void
+    {
+        // This test aims to hit any remaining uncovered lines
+
+        // Test minimum version parameter
+        $result = $this->cryptoGen->decryptStandard('001test', null, 'drive', 2);
+        $this->assertFalse($result); // Should fail due to minimum version check
+
+        // Test unknown version
+        $result2 = $this->cryptoGen->decryptStandard('999test');
+        $this->assertFalse($result2);
+
+        // Test successful decryption paths for version coverage
+        $v6Data = $this->cryptoGen->encryptStandard('test data');
+        $this->assertIsString($v6Data);
+        $this->assertStringStartsWith('006', $v6Data);
+        $decrypted = $this->cryptoGen->decryptStandard($v6Data);
+        $this->assertEquals('test data', $decrypted);
+    }
+}

--- a/tests/Tests/Unit/Common/Crypto/NullEncryptionStrategyTest.php
+++ b/tests/Tests/Unit/Common/Crypto/NullEncryptionStrategyTest.php
@@ -1,0 +1,307 @@
+<?php
+
+/**
+ * Tests for the NullEncryptionStrategy class
+ *
+ * @category  Test
+ * @package   OpenEMR\Tests\Unit\Common\Crypto
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright 2025 OpenCoreEMR
+ * @license   GNU General Public License 3
+ * @link      http://www.open-emr.org
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Unit\Common\Crypto;
+
+use OpenEMR\Common\Crypto\NullEncryptionStrategy;
+use OpenEMR\Common\Crypto\EncryptionStrategyInterface;
+use PHPUnit\Framework\TestCase;
+
+final class NullEncryptionStrategyTest extends TestCase
+{
+    /**
+     * @var NullEncryptionStrategy
+     */
+    private $nullStrategy;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->nullStrategy = new NullEncryptionStrategy();
+    }
+
+    public function testImplementsInterface(): void
+    {
+        $this->assertInstanceOf(EncryptionStrategyInterface::class, $this->nullStrategy);
+    }
+
+    public function testGetId(): void
+    {
+        $this->assertEquals('null', $this->nullStrategy->getId());
+    }
+
+    public function testGetName(): void
+    {
+        $this->assertEquals('No Encryption', $this->nullStrategy->getName());
+    }
+
+    public function testGetDescription(): void
+    {
+        $description = $this->nullStrategy->getDescription();
+        $this->assertIsString($description);
+        $this->assertStringContainsString('plain text', $description);
+        $this->assertStringContainsString('encryption', $description);
+    }
+
+    public function testEncryptStandardWithNull(): void
+    {
+        $result = $this->nullStrategy->encryptStandard(null);
+        $this->assertNull($result);
+    }
+
+    public function testEncryptStandardWithEmptyString(): void
+    {
+        $result = $this->nullStrategy->encryptStandard('');
+        $this->assertEquals('', $result);
+    }
+
+    public function testEncryptStandardWithValidString(): void
+    {
+        $testValue = 'Hello, World!';
+        $result = $this->nullStrategy->encryptStandard($testValue);
+        $this->assertEquals($testValue, $result);
+    }
+
+    public function testEncryptStandardWithComplexString(): void
+    {
+        $testValue = 'Special chars: !@#$%^&*()[]{}|;:,.<>?';
+        $result = $this->nullStrategy->encryptStandard($testValue);
+        $this->assertEquals($testValue, $result);
+    }
+
+    public function testEncryptStandardWithUnicode(): void
+    {
+        $testValue = 'Unicode: 🔒 安全 תירגום';
+        $result = $this->nullStrategy->encryptStandard($testValue);
+        $this->assertEquals($testValue, $result);
+    }
+
+    public function testEncryptStandardIgnoresCustomPassword(): void
+    {
+        $testValue = 'test data';
+        $customPassword = 'secret_password';
+
+        $result = $this->nullStrategy->encryptStandard($testValue, $customPassword);
+        $this->assertEquals($testValue, $result);
+
+        // Should be the same regardless of password
+        $resultWithoutPassword = $this->nullStrategy->encryptStandard($testValue);
+        $this->assertEquals($result, $resultWithoutPassword);
+    }
+
+    public function testEncryptStandardIgnoresKeySource(): void
+    {
+        $testValue = 'test data';
+
+        $resultDrive = $this->nullStrategy->encryptStandard($testValue, null, 'drive');
+        $resultDatabase = $this->nullStrategy->encryptStandard($testValue, null, 'database');
+
+        $this->assertEquals($testValue, $resultDrive);
+        $this->assertEquals($testValue, $resultDatabase);
+        $this->assertEquals($resultDrive, $resultDatabase);
+    }
+
+    public function testDecryptStandardWithNull(): void
+    {
+        $result = $this->nullStrategy->decryptStandard(null);
+        $this->assertNull($result);
+    }
+
+    public function testDecryptStandardWithEmptyString(): void
+    {
+        $result = $this->nullStrategy->decryptStandard('');
+        $this->assertEquals('', $result);
+    }
+
+    public function testDecryptStandardWithValidString(): void
+    {
+        $testValue = 'Hello, World!';
+        $result = $this->nullStrategy->decryptStandard($testValue);
+        $this->assertEquals($testValue, $result);
+    }
+
+    public function testDecryptStandardIgnoresCustomPassword(): void
+    {
+        $testValue = 'test data';
+        $customPassword = 'secret_password';
+
+        $result = $this->nullStrategy->decryptStandard($testValue, $customPassword);
+        $this->assertEquals($testValue, $result);
+
+        // Should be the same regardless of password
+        $resultWithoutPassword = $this->nullStrategy->decryptStandard($testValue);
+        $this->assertEquals($result, $resultWithoutPassword);
+    }
+
+    public function testDecryptStandardIgnoresKeySource(): void
+    {
+        $testValue = 'test data';
+
+        $resultDrive = $this->nullStrategy->decryptStandard($testValue, null, 'drive');
+        $resultDatabase = $this->nullStrategy->decryptStandard($testValue, null, 'database');
+
+        $this->assertEquals($testValue, $resultDrive);
+        $this->assertEquals($testValue, $resultDatabase);
+        $this->assertEquals($resultDrive, $resultDatabase);
+    }
+
+    public function testDecryptStandardIgnoresMinimumVersion(): void
+    {
+        $testValue = 'test data';
+
+        $result1 = $this->nullStrategy->decryptStandard($testValue, null, 'drive', 1);
+        $result6 = $this->nullStrategy->decryptStandard($testValue, null, 'drive', 6);
+        $result999 = $this->nullStrategy->decryptStandard($testValue, null, 'drive', 999);
+
+        $this->assertEquals($testValue, $result1);
+        $this->assertEquals($testValue, $result6);
+        $this->assertEquals($testValue, $result999);
+        $this->assertEquals($result1, $result6);
+        $this->assertEquals($result6, $result999);
+    }
+
+    public function testEncryptDecryptRoundTrip(): void
+    {
+        $testValues = [
+            'simple text',
+            '',
+            null,
+            'Special chars: !@#$%^&*()',
+            'Unicode: 🔒 安全 תירגום',
+            'Very long text: ' . str_repeat('Lorem ipsum dolor sit amet. ', 100),
+            '12345',
+            'true',
+            'false',
+            json_encode(['key' => 'value', 'array' => [1, 2, 3]])
+        ];
+
+        foreach ($testValues as $testValue) {
+            $encrypted = $this->nullStrategy->encryptStandard($testValue);
+            $decrypted = $this->nullStrategy->decryptStandard($encrypted);
+
+            $this->assertEquals($testValue, $encrypted, "Encryption should return original value");
+            $this->assertEquals($testValue, $decrypted, "Decryption should return original value");
+            $this->assertEquals($encrypted, $decrypted, "Encrypted and decrypted values should be identical");
+        }
+    }
+
+    public function testCryptCheckStandardAlwaysReturnsTrue(): void
+    {
+        $testValues = [
+            null,
+            '',
+            'valid data',
+            'invalid data',
+            '001encrypted_looking_data',
+            '999future_version',
+            'plain text',
+            'special!@#$%^&*()chars',
+            'Unicode: 🔒',
+            str_repeat('x', 10000), // Very long string
+            '0',
+            'false',
+            'true'
+        ];
+
+        foreach ($testValues as $testValue) {
+            $result = $this->nullStrategy->cryptCheckStandard($testValue);
+            $this->assertTrue($result, "cryptCheckStandard should always return true for value: " . var_export($testValue, true));
+        }
+    }
+
+    public function testIdentityFunction(): void
+    {
+        // Test that this strategy truly acts as an identity function
+        $testValue = 'identity test';
+
+        // Multiple operations should not change the value
+        $step1 = $this->nullStrategy->encryptStandard($testValue);
+        $step2 = $this->nullStrategy->decryptStandard($step1);
+        $step3 = $this->nullStrategy->encryptStandard($step2, 'password', 'database');
+        $step4 = $this->nullStrategy->decryptStandard($step3, 'different_password', 'drive', 999);
+
+        $this->assertEquals($testValue, $step1);
+        $this->assertEquals($testValue, $step2);
+        $this->assertEquals($testValue, $step3);
+        $this->assertEquals($testValue, $step4);
+    }
+
+    public function testParameterIgnoring(): void
+    {
+        $testValue = 'parameter test';
+
+        // All these should return the same result regardless of parameters
+        $results = [
+            $this->nullStrategy->encryptStandard($testValue),
+            $this->nullStrategy->encryptStandard($testValue, null),
+            $this->nullStrategy->encryptStandard($testValue, ''),
+            $this->nullStrategy->encryptStandard($testValue, 'password'),
+            $this->nullStrategy->encryptStandard($testValue, null, 'drive'),
+            $this->nullStrategy->encryptStandard($testValue, null, 'database'),
+            $this->nullStrategy->encryptStandard($testValue, 'pass', 'drive'),
+            $this->nullStrategy->encryptStandard($testValue, 'pass', 'database'),
+
+            $this->nullStrategy->decryptStandard($testValue),
+            $this->nullStrategy->decryptStandard($testValue, null),
+            $this->nullStrategy->decryptStandard($testValue, ''),
+            $this->nullStrategy->decryptStandard($testValue, 'password'),
+            $this->nullStrategy->decryptStandard($testValue, null, 'drive'),
+            $this->nullStrategy->decryptStandard($testValue, null, 'database'),
+            $this->nullStrategy->decryptStandard($testValue, 'pass', 'drive', 1),
+            $this->nullStrategy->decryptStandard($testValue, 'pass', 'database', 999)
+        ];
+
+        foreach ($results as $result) {
+            $this->assertEquals($testValue, $result);
+        }
+
+        // All results should be identical
+        $this->assertCount(1, array_unique($results));
+    }
+
+    public function testReturnTypes(): void
+    {
+        // Test that return types are preserved correctly
+
+        // String input -> string output
+        $stringResult = $this->nullStrategy->encryptStandard('test');
+        $this->assertIsString($stringResult);
+
+        // Null input -> null output
+        $nullResult = $this->nullStrategy->encryptStandard(null);
+        $this->assertNull($nullResult);
+
+        // Empty string input -> empty string output
+        $emptyResult = $this->nullStrategy->encryptStandard('');
+        $this->assertIsString($emptyResult);
+        $this->assertEquals('', $emptyResult);
+
+        // Same for decrypt
+        $stringDecrypt = $this->nullStrategy->decryptStandard('test');
+        $this->assertIsString($stringDecrypt);
+
+        $nullDecrypt = $this->nullStrategy->decryptStandard(null);
+        $this->assertNull($nullDecrypt);
+
+        $emptyDecrypt = $this->nullStrategy->decryptStandard('');
+        $this->assertIsString($emptyDecrypt);
+        $this->assertEquals('', $emptyDecrypt);
+
+        // cryptCheckStandard always returns boolean true
+        $checkResult = $this->nullStrategy->cryptCheckStandard('anything');
+        $this->assertIsBool($checkResult);
+        $this->assertTrue($checkResult);
+    }
+}


### PR DESCRIPTION
Fixes #8626

Todo:

- [x] introduce the ability to select crypto strategy at install time
- [x] document 
- [x] explore possibility of injecting alternative strategies via modules (lower priority?)
- [x] write explicit tests for strategies (as test coverage may not capture crypto calls through database serialized code)
- [ ] enable selecting crypto strategy in docker development environments (openemr/openemr-devops#470)
- [ ] additional manual testing


#### Short description of what this resolves:

Implement the strategy pattern for CryptoGen and add a Null crypto strategy

#### Changes proposed in this pull request:

- Create an encryption/decryption interface based on CryptoGen
- Move the implementation from CryptoGen into CryptoGenStrategy, which implements the interface
- Implement strategy injection into the existing CryptoGen, and use the relocated implementation
- Implement a null crypto implementation


#### Does your code include anything generated by an AI Engine? No
