### PR TITLE
ci(runner): update to ubuntu 24.04

### DIFF
--- a/.github/workflows/build-dev-php-fpm-docker.yml
+++ b/.github/workflows/build-dev-php-fpm-docker.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     # Only run from master branch on the main repository
     if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr' && github.ref == 'refs/heads/master'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/js-test.yml
+++ b/.github/workflows/js-test.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
 
   js_unit_test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: JS Unit Test
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   phpstan:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: Composer Cache

--- a/.github/workflows/styling.yml
+++ b/.github/workflows/styling.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
 
   php_styling:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: PHP
     steps:
       - uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
           fi
 
   css_styling:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: CSS
     steps:
       - uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
           fi
 
   js_linting:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: JS
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   collect:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: Collect Docker Dirs
@@ -78,7 +78,7 @@ jobs:
       configurations: ${{ steps.docker-dirs.outputs.configurations }}
   build:
     name: PHP ${{ matrix.configurations.php }} - ${{ matrix.configurations.webserver }} - ${{ matrix.configurations.database }} ${{ matrix.configurations.db }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: collect
     strategy:
       fail-fast: false

--- a/.github/workflows/weekly-build-php-fpm-dockers.yml
+++ b/.github/workflows/weekly-build-php-fpm-dockers.yml
@@ -13,7 +13,7 @@ jobs:
   build_8_1:
     # Only run from master branch on the main repository
     if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr' && github.ref == 'refs/heads/master'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -38,7 +38,7 @@ jobs:
   build_8_1_redis:
     # Only run from master branch on the main repository
     if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr' && github.ref == 'refs/heads/master'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -63,7 +63,7 @@ jobs:
   build_8_2:
     # Only run from master branch on the main repository
     if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr' && github.ref == 'refs/heads/master'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -88,7 +88,7 @@ jobs:
   build_8_2_redis:
     # Only run from master branch on the main repository
     if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr' && github.ref == 'refs/heads/master'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -113,7 +113,7 @@ jobs:
   build_8_3:
     # Only run from master branch on the main repository
     if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr' && github.ref == 'refs/heads/master'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -138,7 +138,7 @@ jobs:
   build_8_3_redis:
     # Only run from master branch on the main repository
     if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr' && github.ref == 'refs/heads/master'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -163,7 +163,7 @@ jobs:
   build_8_4:
     # Only run from master branch on the main repository
     if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr' && github.ref == 'refs/heads/master'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -188,7 +188,7 @@ jobs:
   build_8_4_redis:
     # Only run from master branch on the main repository
     if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr' && github.ref == 'refs/heads/master'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -213,7 +213,7 @@ jobs:
   build_8_5:
     # Only run from master branch on the main repository
     if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr' && github.ref == 'refs/heads/master'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -238,7 +238,7 @@ jobs:
   build_8_5_redis:
     # Only run from master branch on the main repository
     if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr' && github.ref == 'refs/heads/master'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Fixes #8632

#### Short description of what this resolves:

Bump actions runner from 22.04 to 24.04


#### Changes proposed in this pull request:

- Bump actions runner from 22.04 to 24.04


#### Does your code include anything generated by an AI Engine? No
