### PR TITLE
ci(inferno): pin ubuntu runner to 24.04

### DIFF
--- a/.github/workflows/inferno-test.yml
+++ b/.github/workflows/inferno-test.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
     check_secret:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         name: Check Required Secret
         outputs:
             has_inferno_pat: ${{ steps.check.outputs.has_inferno_pat }}
@@ -30,7 +30,7 @@ jobs:
 
     inferno_certification_test:
         needs: check_secret
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         name: Inferno Certification Test
         timeout-minutes: 180  # 3 hours timeout due to potential terminology downloads
         if: needs.check_secret.outputs.has_inferno_pat == 'true'


### PR DESCRIPTION
Still part of #8632

#### Short description of what this resolves:

Pin the runner for inferno tests the same as the other runners.

#### Changes proposed in this pull request:

Change the alias for the runner in inferno tests from "latest" to 24.04

#### Does your code include anything generated by an AI Engine? No
