### PR TITLE
fix(docker): apt-get install with update

### DIFF
--- a/docker/library/dockers/dev-php-fpm-5-6-redis/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-5-6-redis/Dockerfile
@@ -11,36 +11,33 @@
 #
 FROM php:5.6-fpm
 
-# Update
-RUN apt-get update
-
 # Add mysql-client package that is needed in the OpenEMR Backup gui, which does direct command mysql commands
 # Add imagemagick that is needed for some image processing in OpenEMR
 # Note this basically add 160MB of space to the docker, so would be nice for OpenEMR to not require this stuff
 #  and instead rely on php scripts, if possible.
-RUN apt-get install -y mysql-client \
-                       imagemagick
+RUN apt-get update \
+ && apt-get install -y imagemagick \
+                       mysql-client
 
 # Add the php extensions (note using a very cool script by mlocati to do this)
 ADD https://raw.githubusercontent.com/mlocati/docker-php-extension-installer/master/install-php-extensions /usr/local/bin/
-RUN chmod uga+x /usr/local/bin/install-php-extensions && sync && \
-    install-php-extensions pdo_mysql \
-                           ldap \
-                           xsl \
-                           gd \
-                           zip \
-                           soap \
+RUN chmod uga+x /usr/local/bin/install-php-extensions \
+ && sync \
+ && install-php-extensions gd \
                            gettext \
+                           ldap \
                            mysqli \
+                           pdo_mysql \
+                           redis \
+                           soap \
                            sockets \
                            tokenizer \
                            xmlreader \
-                           redis
-
-
-
-# Copy over the php.ini conf
-COPY php.ini /usr/local/etc/php/php.ini
+                           xsl \
+                           zip
 
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
 RUN usermod -u 1000 www-data
+
+# Copy over the php.ini conf
+COPY php.ini /usr/local/etc/php/php.ini

--- a/docker/library/dockers/dev-php-fpm-5-6/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-5-6/Dockerfile
@@ -11,33 +11,32 @@
 #
 FROM php:5.6-fpm
 
-# Update
-RUN apt-get update
-
 # Add mysql-client package that is needed in the OpenEMR Backup gui, which does direct command mysql commands
 # Add imagemagick that is needed for some image processing in OpenEMR
 # Note this basically add 160MB of space to the docker, so would be nice for OpenEMR to not require this stuff
 #  and instead rely on php scripts, if possible.
-RUN apt-get install -y mysql-client \
-                       imagemagick
+RUN apt-get update \
+ && apt-get install -y imagemagick \
+                       mysql-client
 
 # Add the php extensions (note using a very cool script by mlocati to do this)
 ADD https://raw.githubusercontent.com/mlocati/docker-php-extension-installer/master/install-php-extensions /usr/local/bin/
-RUN chmod uga+x /usr/local/bin/install-php-extensions && sync && \
-    install-php-extensions pdo_mysql \
-                           ldap \
-                           xsl \
-                           gd \
-                           zip \
-                           soap \
+RUN chmod uga+x /usr/local/bin/install-php-extensions \
+ && sync \
+ && install-php-extensions gd \
                            gettext \
+                           ldap \
                            mysqli \
+                           pdo_mysql \
+                           soap \
                            sockets \
                            tokenizer \
-                           xmlreader
-
-# Copy over the php.ini conf
-COPY php.ini /usr/local/etc/php/php.ini
+                           xmlreader \
+                           xsl \
+                           zip
 
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
 RUN usermod -u 1000 www-data
+
+# Copy over the php.ini conf
+COPY php.ini /usr/local/etc/php/php.ini

--- a/docker/library/dockers/dev-php-fpm-7-0-redis/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-7-0-redis/Dockerfile
@@ -11,36 +11,35 @@
 #
 FROM php:7.0-fpm
 
-# Update
-RUN apt-get update
-
 # Add mysql-client package that is needed in the OpenEMR Backup gui, which does direct command mysql commands
 # Add imagemagick that is needed for some image processing in OpenEMR
 # Note this basically add 160MB of space to the docker, so would be nice for OpenEMR to not require this stuff
 #  and instead rely on php scripts, if possible.
-RUN apt-get install -y mysql-client \
-                       imagemagick
+RUN apt-get update \
+ && apt-get install -y imagemagick \
+                       mysql-client
 
 # Add the php extensions (note using a very cool script by mlocati to do this)
 ADD https://raw.githubusercontent.com/mlocati/docker-php-extension-installer/master/install-php-extensions /usr/local/bin/
-RUN chmod uga+x /usr/local/bin/install-php-extensions && sync && \
-    install-php-extensions pdo_mysql \
-                           ldap \
-                           xsl \
-                           gd \
-                           zip \
-                           soap \
+RUN chmod uga+x /usr/local/bin/install-php-extensions \
+ && sync \
+ && install-php-extensions gd \
                            gettext \
+                           ldap \
                            mysqli \
+                           pdo_mysql \
+                           redis \
+                           soap \
                            sockets \
                            tokenizer \
                            xmlreader \
-                           redis
+                           xsl \
+                           zip
 
 
-
-# Copy over the php.ini conf
-COPY php.ini /usr/local/etc/php/php.ini
 
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
 RUN usermod -u 1000 www-data
+
+# Copy over the php.ini conf
+COPY php.ini /usr/local/etc/php/php.ini

--- a/docker/library/dockers/dev-php-fpm-7-0/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-7-0/Dockerfile
@@ -11,33 +11,32 @@
 #
 FROM php:7.0-fpm
 
-# Update
-RUN apt-get update
-
 # Add mysql-client package that is needed in the OpenEMR Backup gui, which does direct command mysql commands
 # Add imagemagick that is needed for some image processing in OpenEMR
 # Note this basically add 160MB of space to the docker, so would be nice for OpenEMR to not require this stuff
 #  and instead rely on php scripts, if possible.
-RUN apt-get install -y mysql-client \
-                       imagemagick
+RUN apt-get update \
+ && apt-get install -y imagemagick \
+                       mysql-client
 
 # Add the php extensions (note using a very cool script by mlocati to do this)
 ADD https://raw.githubusercontent.com/mlocati/docker-php-extension-installer/master/install-php-extensions /usr/local/bin/
-RUN chmod uga+x /usr/local/bin/install-php-extensions && sync && \
-    install-php-extensions pdo_mysql \
-                           ldap \
-                           xsl \
-                           gd \
-                           zip \
-                           soap \
+RUN chmod uga+x /usr/local/bin/install-php-extensions \
+ && sync \
+ && install-php-extensions gd \
                            gettext \
+                           ldap \
                            mysqli \
+                           pdo_mysql \
+                           soap \
                            sockets \
                            tokenizer \
-                           xmlreader
-
-# Copy over the php.ini conf
-COPY php.ini /usr/local/etc/php/php.ini
+                           xmlreader \
+                           xsl \
+                           zip
 
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
 RUN usermod -u 1000 www-data
+
+# Copy over the php.ini conf
+COPY php.ini /usr/local/etc/php/php.ini

--- a/docker/library/dockers/dev-php-fpm-7-1-redis/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-7-1-redis/Dockerfile
@@ -11,37 +11,36 @@
 #
 FROM php:7.1-fpm
 
-# Update
-RUN apt-get update
-
 # Add mysql-client package that is needed in the OpenEMR Backup gui, which does direct command mysql commands
 # Add imagemagick that is needed for some image processing in OpenEMR
 # Note this basically add 160MB of space to the docker, so would be nice for OpenEMR to not require this stuff
 #  and instead rely on php scripts, if possible.
-RUN apt-get install -y mysql-client \
-                       imagemagick
+RUN apt-get update \
+ && apt-get install -y imagemagick \
+                       mysql-client
 
 # Add the php extensions (note using a very cool script by mlocati to do this)
 ADD https://raw.githubusercontent.com/mlocati/docker-php-extension-installer/master/install-php-extensions /usr/local/bin/
-RUN chmod uga+x /usr/local/bin/install-php-extensions && sync && \
-    install-php-extensions pdo_mysql \
-                           ldap \
-                           xsl \
+RUN chmod uga+x /usr/local/bin/install-php-extensions \
+ && sync \
+ && install-php-extensions calendar \
                            gd \
-                           zip \
-                           soap \
                            gettext \
+                           ldap \
                            mysqli \
+                           pdo_mysql \
+                           redis \
+                           soap \
                            sockets \
                            tokenizer \
                            xmlreader \
-                           calendar \
-                           redis
+                           xsl \
+                           zip
 
 
-
-# Copy over the php.ini conf
-COPY php.ini /usr/local/etc/php/php.ini
 
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
 RUN usermod -u 1000 www-data
+
+# Copy over the php.ini conf
+COPY php.ini /usr/local/etc/php/php.ini

--- a/docker/library/dockers/dev-php-fpm-7-1/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-7-1/Dockerfile
@@ -11,34 +11,33 @@
 #
 FROM php:7.1-fpm
 
-# Update
-RUN apt-get update
-
 # Add mysql-client package that is needed in the OpenEMR Backup gui, which does direct command mysql commands
 # Add imagemagick that is needed for some image processing in OpenEMR
 # Note this basically add 160MB of space to the docker, so would be nice for OpenEMR to not require this stuff
 #  and instead rely on php scripts, if possible.
-RUN apt-get install -y mysql-client \
-                       imagemagick
+RUN apt-get update \
+ && apt-get install -y imagemagick \
+                       mysql-client
 
 # Add the php extensions (note using a very cool script by mlocati to do this)
 ADD https://raw.githubusercontent.com/mlocati/docker-php-extension-installer/master/install-php-extensions /usr/local/bin/
-RUN chmod uga+x /usr/local/bin/install-php-extensions && sync && \
-    install-php-extensions pdo_mysql \
-                           ldap \
-                           xsl \
+RUN chmod uga+x /usr/local/bin/install-php-extensions \
+ && sync \
+ && install-php-extensions calendar \
                            gd \
-                           zip \
-                           soap \
                            gettext \
+                           ldap \
                            mysqli \
+                           pdo_mysql \
+                           soap \
                            sockets \
                            tokenizer \
                            xmlreader \
-                           calendar
-
-# Copy over the php.ini conf
-COPY php.ini /usr/local/etc/php/php.ini
+                           xsl \
+                           zip
 
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
 RUN usermod -u 1000 www-data
+
+# Copy over the php.ini conf
+COPY php.ini /usr/local/etc/php/php.ini

--- a/docker/library/dockers/dev-php-fpm-7-2-redis/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-7-2-redis/Dockerfile
@@ -11,35 +11,34 @@
 #
 FROM php:7.2-fpm
 
-# Update
-RUN apt-get update
-
 # Add mariadb-client package that is needed in the OpenEMR Backup gui, which does direct command mysql commands
 # Add imagemagick that is needed for some image processing in OpenEMR
 # Note this basically add 160MB of space to the docker, so would be nice for OpenEMR to not require this stuff
 #  and instead rely on php scripts, if possible.
-RUN apt-get install -y mariadb-client \
-                       imagemagick
+RUN apt-get update \
+ && apt-get install -y imagemagick \
+                       mariadb-client
 
 # Add the php extensions (note using a very cool script by mlocati to do this)
 ADD https://raw.githubusercontent.com/mlocati/docker-php-extension-installer/master/install-php-extensions /usr/local/bin/
-RUN chmod uga+x /usr/local/bin/install-php-extensions && sync && \
-    install-php-extensions pdo_mysql \
-                           ldap \
-                           xsl \
+RUN chmod uga+x /usr/local/bin/install-php-extensions \
+ && sync \
+ && install-php-extensions calendar \
                            gd \
-                           zip \
-                           soap \
                            gettext \
+                           ldap \
                            mysqli \
+                           pdo_mysql \
+                           redis \
+                           soap \
                            sockets \
                            tokenizer \
                            xmlreader \
-                           calendar \
-                           redis
-
-# Copy over the php.ini conf
-COPY php.ini /usr/local/etc/php/php.ini
+                           xsl \
+                           zip
 
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
 RUN usermod -u 1000 www-data
+
+# Copy over the php.ini conf
+COPY php.ini /usr/local/etc/php/php.ini

--- a/docker/library/dockers/dev-php-fpm-7-2/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-7-2/Dockerfile
@@ -11,34 +11,33 @@
 #
 FROM php:7.2-fpm
 
-# Update
-RUN apt-get update
-
 # Add mariadb-client package that is needed in the OpenEMR Backup gui, which does direct command mysql commands
 # Add imagemagick that is needed for some image processing in OpenEMR
 # Note this basically add 160MB of space to the docker, so would be nice for OpenEMR to not require this stuff
 #  and instead rely on php scripts, if possible.
-RUN apt-get install -y mariadb-client \
-                       imagemagick
+RUN apt-get update \
+ && apt-get install -y imagemagick \
+                       mariadb-client
 
 # Add the php extensions (note using a very cool script by mlocati to do this)
 ADD https://raw.githubusercontent.com/mlocati/docker-php-extension-installer/master/install-php-extensions /usr/local/bin/
-RUN chmod uga+x /usr/local/bin/install-php-extensions && sync && \
-    install-php-extensions pdo_mysql \
-                           ldap \
-                           xsl \
+RUN chmod uga+x /usr/local/bin/install-php-extensions \
+ && sync \
+ && install-php-extensions calendar \
                            gd \
-                           zip \
-                           soap \
                            gettext \
+                           ldap \
                            mysqli \
+                           pdo_mysql \
+                           soap \
                            sockets \
                            tokenizer \
                            xmlreader \
-                           calendar
-
-# Copy over the php.ini conf
-COPY php.ini /usr/local/etc/php/php.ini
+                           xsl \
+                           zip
 
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
 RUN usermod -u 1000 www-data
+
+# Copy over the php.ini conf
+COPY php.ini /usr/local/etc/php/php.ini

--- a/docker/library/dockers/dev-php-fpm-7-3-redis/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-7-3-redis/Dockerfile
@@ -11,36 +11,35 @@
 #
 FROM php:7.3-fpm
 
-# Update
-RUN apt-get update
-
 # Add mariadb-client package that is needed in the OpenEMR Backup gui, which does direct command mysql commands
 # Add imagemagick that is needed for some image processing in OpenEMR
 # Note this basically add 160MB of space to the docker, so would be nice for OpenEMR to not require this stuff
 #  and instead rely on php scripts, if possible.
-RUN apt-get install -y mariadb-client \
-                       imagemagick
+RUN apt-get update \
+ && apt-get install -y imagemagick \
+                       mariadb-client
 
 # Add the php extensions (note using a very cool script by mlocati to do this)
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod uga+x /usr/local/bin/install-php-extensions && sync && \
-    install-php-extensions pdo_mysql \
-                           ldap \
-                           xsl \
+RUN chmod uga+x /usr/local/bin/install-php-extensions \
+ && sync \
+ && install-php-extensions calendar \
                            gd \
-                           zip \
-                           soap \
                            gettext \
+                           intl \
+                           ldap \
                            mysqli \
+                           pdo_mysql \
+                           redis \
+                           soap \
                            sockets \
                            tokenizer \
                            xmlreader \
-                           calendar \
-                           intl \
-                           redis
-
-# Copy over the php.ini conf
-COPY php.ini /usr/local/etc/php/php.ini
+                           xsl \
+                           zip
 
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
 RUN usermod -u 1000 www-data
+
+# Copy over the php.ini conf
+COPY php.ini /usr/local/etc/php/php.ini

--- a/docker/library/dockers/dev-php-fpm-7-3/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-7-3/Dockerfile
@@ -11,35 +11,34 @@
 #
 FROM php:7.3-fpm
 
-# Update
-RUN apt-get update
-
 # Add mariadb-client package that is needed in the OpenEMR Backup gui, which does direct command mysql commands
 # Add imagemagick that is needed for some image processing in OpenEMR
 # Note this basically add 160MB of space to the docker, so would be nice for OpenEMR to not require this stuff
 #  and instead rely on php scripts, if possible.
-RUN apt-get install -y mariadb-client \
-                       imagemagick
+RUN apt-get update \
+ && apt-get install -y imagemagick \
+                       mariadb-client
 
 # Add the php extensions (note using a very cool script by mlocati to do this)
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod uga+x /usr/local/bin/install-php-extensions && sync && \
-    install-php-extensions pdo_mysql \
-                           ldap \
-                           xsl \
+RUN chmod uga+x /usr/local/bin/install-php-extensions \
+ && sync \
+ && install-php-extensions calendar \
                            gd \
-                           zip \
-                           soap \
                            gettext \
+                           intl \
+                           ldap \
                            mysqli \
+                           pdo_mysql \
+                           soap \
                            sockets \
                            tokenizer \
                            xmlreader \
-                           calendar \
-                           intl
-
-# Copy over the php.ini conf
-COPY php.ini /usr/local/etc/php/php.ini
+                           xsl \
+                           zip
 
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
 RUN usermod -u 1000 www-data
+
+# Copy over the php.ini conf
+COPY php.ini /usr/local/etc/php/php.ini

--- a/docker/library/dockers/dev-php-fpm-7-4-redis/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-7-4-redis/Dockerfile
@@ -11,36 +11,35 @@
 #
 FROM php:7.4-fpm-buster
 
-# Update
-RUN apt-get update
-
 # Add mariadb-client package that is needed in the OpenEMR Backup gui, which does direct command mysql commands
 # Add imagemagick that is needed for some image processing in OpenEMR
 # Note this basically add 160MB of space to the docker, so would be nice for OpenEMR to not require this stuff
 #  and instead rely on php scripts, if possible.
-RUN apt-get install -y mariadb-client \
-                       imagemagick
+RUN apt-get update \
+ && apt-get install -y imagemagick \
+                       mariadb-client
 
 # Add the php extensions (note using a very cool script by mlocati to do this)
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod uga+x /usr/local/bin/install-php-extensions && sync && \
-    install-php-extensions pdo_mysql \
-                           ldap \
-                           xsl \
+RUN chmod uga+x /usr/local/bin/install-php-extensions \
+ && sync \
+ && install-php-extensions calendar \
                            gd \
-                           zip \
-                           soap \
                            gettext \
+                           intl \
+                           ldap \
                            mysqli \
+                           pdo_mysql \
+                           redis \
+                           soap \
                            sockets \
                            tokenizer \
                            xmlreader \
-                           calendar \
-                           intl \
-                           redis
-
-# Copy over the php.ini conf
-COPY php.ini /usr/local/etc/php/php.ini
+                           xsl \
+                           zip
 
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
 RUN usermod -u 1000 www-data
+
+# Copy over the php.ini conf
+COPY php.ini /usr/local/etc/php/php.ini

--- a/docker/library/dockers/dev-php-fpm-7-4/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-7-4/Dockerfile
@@ -11,35 +11,34 @@
 #
 FROM php:7.4-fpm-buster
 
-# Update
-RUN apt-get update
-
 # Add mariadb-client package that is needed in the OpenEMR Backup gui, which does direct command mysql commands
 # Add imagemagick that is needed for some image processing in OpenEMR
 # Note this basically add 160MB of space to the docker, so would be nice for OpenEMR to not require this stuff
 #  and instead rely on php scripts, if possible.
-RUN apt-get install -y mariadb-client \
-                       imagemagick
+RUN apt-get update \
+ && apt-get install -y imagemagick \
+                       mariadb-client
 
 # Add the php extensions (note using a very cool script by mlocati to do this)
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod uga+x /usr/local/bin/install-php-extensions && sync && \
-    install-php-extensions pdo_mysql \
-                           ldap \
-                           xsl \
+RUN chmod uga+x /usr/local/bin/install-php-extensions \
+ && sync \
+ && install-php-extensions calendar \
                            gd \
-                           zip \
-                           soap \
                            gettext \
+                           intl \
+                           ldap \
                            mysqli \
+                           pdo_mysql \
+                           soap \
                            sockets \
                            tokenizer \
                            xmlreader \
-                           calendar \
-                           intl
-
-# Copy over the php.ini conf
-COPY php.ini /usr/local/etc/php/php.ini
+                           xsl \
+                           zip
 
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
 RUN usermod -u 1000 www-data
+
+# Copy over the php.ini conf
+COPY php.ini /usr/local/etc/php/php.ini

--- a/docker/library/dockers/dev-php-fpm-8-0-redis/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-0-redis/Dockerfile
@@ -11,36 +11,35 @@
 #
 FROM php:8.0-fpm-buster
 
-# Update
-RUN apt-get update
-
 # Add mariadb-client package that is needed in the OpenEMR Backup gui, which does direct command mysql commands
 # Add imagemagick that is needed for some image processing in OpenEMR
 # Note this basically add 160MB of space to the docker, so would be nice for OpenEMR to not require this stuff
 #  and instead rely on php scripts, if possible.
-RUN apt-get install -y mariadb-client \
-                       imagemagick
+RUN apt-get update \
+ && apt-get install -y imagemagick \
+                       mariadb-client
 
 # Add the php extensions (note using a very cool script by mlocati to do this)
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod uga+x /usr/local/bin/install-php-extensions && sync && \
-    install-php-extensions pdo_mysql \
-                           ldap \
-                           xsl \
+RUN chmod uga+x /usr/local/bin/install-php-extensions \
+ && sync \
+ && install-php-extensions calendar \
                            gd \
-                           zip \
-                           soap \
                            gettext \
+                           intl \
+                           ldap \
                            mysqli \
+                           pdo_mysql \
+                           redis \
+                           soap \
                            sockets \
                            tokenizer \
                            xmlreader \
-                           calendar \
-                           intl \
-                           redis
-
-# Copy over the php.ini conf
-COPY php.ini /usr/local/etc/php/php.ini
+                           xsl \
+                           zip
 
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
 RUN usermod -u 1000 www-data
+
+# Copy over the php.ini conf
+COPY php.ini /usr/local/etc/php/php.ini

--- a/docker/library/dockers/dev-php-fpm-8-0/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-0/Dockerfile
@@ -11,35 +11,35 @@
 #
 FROM php:8.0-fpm-buster
 
-# Update
-RUN apt-get update
-
 # Add mariadb-client package that is needed in the OpenEMR Backup gui, which does direct command mysql commands
 # Add imagemagick that is needed for some image processing in OpenEMR
 # Note this basically add 160MB of space to the docker, so would be nice for OpenEMR to not require this stuff
 #  and instead rely on php scripts, if possible.
-RUN apt-get install -y mariadb-client \
-                       imagemagick
+RUN apt-get update \
+ && apt-get install -y curl \
+                       imagemagick \
+                       mariadb-client
 
 # Add the php extensions (note using a very cool script by mlocati to do this)
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod uga+x /usr/local/bin/install-php-extensions && sync && \
-    install-php-extensions pdo_mysql \
-                           ldap \
-                           xsl \
+RUN chmod uga+x /usr/local/bin/install-php-extensions \
+ && sync \
+ && install-php-extensions calendar \
                            gd \
-                           zip \
-                           soap \
                            gettext \
+                           intl \
+                           ldap \
                            mysqli \
+                           pdo_mysql \
+                           soap \
                            sockets \
                            tokenizer \
                            xmlreader \
-                           calendar \
-                           intl
-
-# Copy over the php.ini conf
-COPY php.ini /usr/local/etc/php/php.ini
+                           xsl \
+                           zip
 
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
 RUN usermod -u 1000 www-data
+
+# Copy over the php.ini conf
+COPY php.ini /usr/local/etc/php/php.ini

--- a/docker/library/dockers/dev-php-fpm-8-1-redis/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-1-redis/Dockerfile
@@ -11,41 +11,42 @@
 #
 FROM php:8.1-fpm
 
-# Update
-RUN apt-get update
-
 # Add mariadb-client package that is needed in the OpenEMR Backup gui, which does direct command mysql commands
 # Add imagemagick that is needed for some image processing in OpenEMR
 # Note this basically add 160MB of space to the docker, so would be nice for OpenEMR to not require this stuff
 #  and instead rely on php scripts, if possible.
-RUN apt-get install -y mariadb-client \
+RUN apt-get update \
+ && apt-get install -y curl \
                        imagemagick \
-                       curl
+                       mariadb-client
 
 # Install correct version nodejs
-RUN curl -sL https://deb.nodesource.com/setup_20.x  | bash -
-RUN apt-get install nodejs -y
+RUN curl -sL https://deb.nodesource.com/setup_20.x \
+  | bash - \
+ && apt-get update \
+ && apt-get install -y nodejs
 
 # Add the php extensions (note using a very cool script by mlocati to do this)
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod uga+x /usr/local/bin/install-php-extensions && sync && \
-    install-php-extensions pdo_mysql \
-                           ldap \
-                           xsl \
+RUN chmod uga+x /usr/local/bin/install-php-extensions \
+ && sync \
+ && install-php-extensions calendar \
                            gd \
-                           zip \
-                           soap \
                            gettext \
+                           intl \
+                           ldap \
                            mysqli \
+                           pdo_mysql \
+                           redis \
+                           soap \
                            sockets \
                            tokenizer \
                            xmlreader \
-                           calendar \
-                           intl \
-                           redis
-
-# Copy over the php.ini conf
-COPY php.ini /usr/local/etc/php/php.ini
+                           xsl \
+                           zip
 
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
 RUN usermod -u 1000 www-data
+
+# Copy over the php.ini conf
+COPY php.ini /usr/local/etc/php/php.ini

--- a/docker/library/dockers/dev-php-fpm-8-1/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-1/Dockerfile
@@ -11,40 +11,41 @@
 #
 FROM php:8.1-fpm
 
-# Update
-RUN apt-get update
-
 # Add mariadb-client package that is needed in the OpenEMR Backup gui, which does direct command mysql commands
 # Add imagemagick that is needed for some image processing in OpenEMR
 # Note this basically add 160MB of space to the docker, so would be nice for OpenEMR to not require this stuff
 #  and instead rely on php scripts, if possible.
-RUN apt-get install -y mariadb-client \
+RUN apt-get update \
+ && apt-get install -y curl \
                        imagemagick \
-                       curl
+                       mariadb-client
 
 # Install correct version nodejs
-RUN curl -sL https://deb.nodesource.com/setup_20.x  | bash -
-RUN apt-get install nodejs -y
+RUN curl -sL https://deb.nodesource.com/setup_20.x \
+  | bash - \
+ && apt-get update \
+ && apt-get install -y nodejs
 
 # Add the php extensions (note using a very cool script by mlocati to do this)
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod uga+x /usr/local/bin/install-php-extensions && sync && \
-    install-php-extensions pdo_mysql \
-                           ldap \
-                           xsl \
+RUN chmod uga+x /usr/local/bin/install-php-extensions \
+ && sync \
+ && install-php-extensions calendar \
                            gd \
-                           zip \
-                           soap \
                            gettext \
+                           intl \
+                           ldap \
                            mysqli \
+                           pdo_mysql \
+                           soap \
                            sockets \
                            tokenizer \
                            xmlreader \
-                           calendar \
-                           intl
-
-# Copy over the php.ini conf
-COPY php.ini /usr/local/etc/php/php.ini
+                           xsl \
+                           zip
 
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
 RUN usermod -u 1000 www-data
+
+# Copy over the php.ini conf
+COPY php.ini /usr/local/etc/php/php.ini

--- a/docker/library/dockers/dev-php-fpm-8-2-redis/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-2-redis/Dockerfile
@@ -11,41 +11,42 @@
 #
 FROM php:8.2-fpm
 
-# Update
-RUN apt-get update
-
 # Add mariadb-client package that is needed in the OpenEMR Backup gui, which does direct command mysql commands
 # Add imagemagick that is needed for some image processing in OpenEMR
 # Note this basically add 160MB of space to the docker, so would be nice for OpenEMR to not require this stuff
 #  and instead rely on php scripts, if possible.
-RUN apt-get install -y mariadb-client \
+RUN apt-get update \
+ && apt-get install -y curl \
                        imagemagick \
-                       curl
+                       mariadb-client
 
 # Install correct version nodejs
-RUN curl -sL https://deb.nodesource.com/setup_20.x  | bash -
-RUN apt-get install nodejs -y
+RUN curl -sL https://deb.nodesource.com/setup_20.x \
+  | bash - \
+ && apt-get update \
+ && apt-get install -y nodejs
 
 # Add the php extensions (note using a very cool script by mlocati to do this)
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod uga+x /usr/local/bin/install-php-extensions && sync && \
-    install-php-extensions pdo_mysql \
-                           ldap \
-                           xsl \
+RUN chmod uga+x /usr/local/bin/install-php-extensions \
+ && sync \
+ && install-php-extensions calendar \
                            gd \
-                           zip \
-                           soap \
                            gettext \
+                           intl \
+                           ldap \
                            mysqli \
+                           pdo_mysql \
+                           redis \
+                           soap \
                            sockets \
                            tokenizer \
                            xmlreader \
-                           calendar \
-                           intl \
-                           redis
-
-# Copy over the php.ini conf
-COPY php.ini /usr/local/etc/php/php.ini
+                           xsl \
+                           zip
 
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
 RUN usermod -u 1000 www-data
+
+# Copy over the php.ini conf
+COPY php.ini /usr/local/etc/php/php.ini

--- a/docker/library/dockers/dev-php-fpm-8-2/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-2/Dockerfile
@@ -11,40 +11,41 @@
 #
 FROM php:8.2-fpm
 
-# Update
-RUN apt-get update
-
 # Add mariadb-client package that is needed in the OpenEMR Backup gui, which does direct command mysql commands
 # Add imagemagick that is needed for some image processing in OpenEMR
 # Note this basically add 160MB of space to the docker, so would be nice for OpenEMR to not require this stuff
 #  and instead rely on php scripts, if possible.
-RUN apt-get install -y mariadb-client \
+RUN apt-get update \
+ && apt-get install -y curl \
                        imagemagick \
-                       curl
+                       mariadb-client
 
 # Install correct version nodejs
-RUN curl -sL https://deb.nodesource.com/setup_20.x  | bash -
-RUN apt-get install nodejs -y
+RUN curl -sL https://deb.nodesource.com/setup_20.x \
+  | bash - \
+ && apt-get update \
+ && apt-get install -y nodejs
 
 # Add the php extensions (note using a very cool script by mlocati to do this)
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod uga+x /usr/local/bin/install-php-extensions && sync && \
-    install-php-extensions pdo_mysql \
-                           ldap \
-                           xsl \
+RUN chmod uga+x /usr/local/bin/install-php-extensions \
+ && sync \
+ && install-php-extensions calendar \
                            gd \
-                           zip \
-                           soap \
                            gettext \
+                           intl \
+                           ldap \
                            mysqli \
+                           pdo_mysql \
+                           soap \
                            sockets \
                            tokenizer \
                            xmlreader \
-                           calendar \
-                           intl
-
-# Copy over the php.ini conf
-COPY php.ini /usr/local/etc/php/php.ini
+                           xsl \
+                           zip
 
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
 RUN usermod -u 1000 www-data
+
+# Copy over the php.ini conf
+COPY php.ini /usr/local/etc/php/php.ini

--- a/docker/library/dockers/dev-php-fpm-8-3-redis/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-3-redis/Dockerfile
@@ -11,41 +11,42 @@
 #
 FROM php:8.3-fpm
 
-# Update
-RUN apt-get update
-
 # Add mariadb-client package that is needed in the OpenEMR Backup gui, which does direct command mysql commands
 # Add imagemagick that is needed for some image processing in OpenEMR
 # Note this basically add 160MB of space to the docker, so would be nice for OpenEMR to not require this stuff
 #  and instead rely on php scripts, if possible.
-RUN apt-get install -y mariadb-client \
+RUN apt-get update \
+ && apt-get install -y curl \
                        imagemagick \
-                       curl
+                       mariadb-client
 
 # Install correct version nodejs
-RUN curl -sL https://deb.nodesource.com/setup_20.x  | bash -
-RUN apt-get install nodejs -y
+RUN curl -sL https://deb.nodesource.com/setup_20.x \
+  | bash - \
+ && apt-get update \
+ && apt-get install -y nodejs
 
 # Add the php extensions (note using a very cool script by mlocati to do this)
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod uga+x /usr/local/bin/install-php-extensions && sync && \
-    install-php-extensions pdo_mysql \
-                           ldap \
-                           xsl \
+RUN chmod uga+x /usr/local/bin/install-php-extensions \
+ && sync \
+ && install-php-extensions calendar \
                            gd \
-                           zip \
-                           soap \
                            gettext \
+                           intl \
+                           ldap \
                            mysqli \
+                           pdo_mysql \
+                           redis \
+                           soap \
                            sockets \
                            tokenizer \
                            xmlreader \
-                           calendar \
-                           intl \
-                           redis
-
-# Copy over the php.ini conf
-COPY php.ini /usr/local/etc/php/php.ini
+                           xsl \
+                           zip
 
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
 RUN usermod -u 1000 www-data
+
+# Copy over the php.ini conf
+COPY php.ini /usr/local/etc/php/php.ini

--- a/docker/library/dockers/dev-php-fpm-8-3/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-3/Dockerfile
@@ -11,40 +11,41 @@
 #
 FROM php:8.3-fpm
 
-# Update
-RUN apt-get update
-
 # Add mariadb-client package that is needed in the OpenEMR Backup gui, which does direct command mysql commands
 # Add imagemagick that is needed for some image processing in OpenEMR
 # Note this basically add 160MB of space to the docker, so would be nice for OpenEMR to not require this stuff
 #  and instead rely on php scripts, if possible.
-RUN apt-get install -y mariadb-client \
+RUN apt-get update \
+ && apt-get install -y curl \
                        imagemagick \
-                       curl
+                       mariadb-client
 
 # Install correct version nodejs
-RUN curl -sL https://deb.nodesource.com/setup_20.x  | bash -
-RUN apt-get install nodejs -y
+RUN curl -sL https://deb.nodesource.com/setup_20.x \
+  | bash - \
+ && apt-get update \
+ && apt-get install -y nodejs
 
 # Add the php extensions (note using a very cool script by mlocati to do this)
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod uga+x /usr/local/bin/install-php-extensions && sync && \
-    install-php-extensions pdo_mysql \
-                           ldap \
-                           xsl \
+RUN chmod uga+x /usr/local/bin/install-php-extensions \
+ && sync \
+ && install-php-extensions calendar \
                            gd \
-                           zip \
-                           soap \
                            gettext \
+                           intl \
+                           ldap \
                            mysqli \
+                           pdo_mysql \
+                           soap \
                            sockets \
                            tokenizer \
                            xmlreader \
-                           calendar \
-                           intl
-
-# Copy over the php.ini conf
-COPY php.ini /usr/local/etc/php/php.ini
+                           xsl \
+                           zip
 
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
 RUN usermod -u 1000 www-data
+
+# Copy over the php.ini conf
+COPY php.ini /usr/local/etc/php/php.ini

--- a/docker/library/dockers/dev-php-fpm-8-4-redis/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-4-redis/Dockerfile
@@ -11,41 +11,42 @@
 #
 FROM php:8.4-fpm
 
-# Update
-RUN apt-get update
-
 # Add mariadb-client package that is needed in the OpenEMR Backup gui, which does direct command mysql commands
 # Add imagemagick that is needed for some image processing in OpenEMR
 # Note this basically add 160MB of space to the docker, so would be nice for OpenEMR to not require this stuff
 #  and instead rely on php scripts, if possible.
-RUN apt-get install -y mariadb-client \
+RUN apt-get update \
+ && apt-get install -y curl \
                        imagemagick \
-                       curl
+                       mariadb-client
 
 # Install correct version nodejs
-RUN curl -sL https://deb.nodesource.com/setup_20.x  | bash -
-RUN apt-get install nodejs -y
+RUN curl -sL https://deb.nodesource.com/setup_20.x \
+  | bash - \
+ && apt-get update \
+ && apt-get install -y nodejs
 
 # Add the php extensions (note using a very cool script by mlocati to do this)
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod uga+x /usr/local/bin/install-php-extensions && sync && \
-    install-php-extensions pdo_mysql \
-                           ldap \
-                           xsl \
+RUN chmod uga+x /usr/local/bin/install-php-extensions \
+ && sync \
+ && install-php-extensions calendar \
                            gd \
-                           zip \
-                           soap \
                            gettext \
+                           intl \
+                           ldap \
                            mysqli \
+                           pdo_mysql \
+                           redis \
+                           soap \
                            sockets \
                            tokenizer \
                            xmlreader \
-                           calendar \
-                           intl \
-                           redis
-
-# Copy over the php.ini conf
-COPY php.ini /usr/local/etc/php/php.ini
+                           xsl \
+                           zip
 
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
 RUN usermod -u 1000 www-data
+
+# Copy over the php.ini conf
+COPY php.ini /usr/local/etc/php/php.ini

--- a/docker/library/dockers/dev-php-fpm-8-4/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-4/Dockerfile
@@ -11,40 +11,41 @@
 #
 FROM php:8.4-fpm
 
-# Update
-RUN apt-get update
-
 # Add mariadb-client package that is needed in the OpenEMR Backup gui, which does direct command mysql commands
 # Add imagemagick that is needed for some image processing in OpenEMR
 # Note this basically add 160MB of space to the docker, so would be nice for OpenEMR to not require this stuff
 #  and instead rely on php scripts, if possible.
-RUN apt-get install -y mariadb-client \
+RUN apt-get update \
+ && apt-get install -y curl \
                        imagemagick \
-                       curl
+                       mariadb-client
 
 # Install correct version nodejs
-RUN curl -sL https://deb.nodesource.com/setup_20.x  | bash -
-RUN apt-get install nodejs -y
+RUN curl -sL https://deb.nodesource.com/setup_20.x \
+  | bash - \
+ && apt-get update \
+ && apt-get install -y nodejs
 
 # Add the php extensions (note using a very cool script by mlocati to do this)
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod uga+x /usr/local/bin/install-php-extensions && sync && \
-    install-php-extensions pdo_mysql \
-                           ldap \
-                           xsl \
+RUN chmod uga+x /usr/local/bin/install-php-extensions \
+ && sync \
+ && install-php-extensions calendar \
                            gd \
-                           zip \
-                           soap \
                            gettext \
+                           intl \
+                           ldap \
                            mysqli \
+                           pdo_mysql \
+                           soap \
                            sockets \
                            tokenizer \
                            xmlreader \
-                           calendar \
-                           intl
-
-# Copy over the php.ini conf
-COPY php.ini /usr/local/etc/php/php.ini
+                           xsl \
+                           zip
 
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
 RUN usermod -u 1000 www-data
+
+# Copy over the php.ini conf
+COPY php.ini /usr/local/etc/php/php.ini

--- a/docker/library/dockers/dev-php-fpm-8-5-redis/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-5-redis/Dockerfile
@@ -11,56 +11,56 @@
 #
 FROM openemr/dev-php-fpm:pre-build-dev-85
 
-# Update
-RUN apt-get update
-
 # Add mariadb-client package that is needed in the OpenEMR Backup gui, which does direct command mysql commands
 # Add imagemagick that is needed for some image processing in OpenEMR
 # Note this basically add 160MB of space to the docker, so would be nice for OpenEMR to not require this stuff
 #  and instead rely on php scripts, if possible.
-RUN apt-get install -y mariadb-client \
+RUN apt-get update \
+ && apt-get install -y curl \
                        imagemagick \
-                       curl
+                       mariadb-client
 
 # Install correct version nodejs
-RUN curl -sL https://deb.nodesource.com/setup_20.x  | bash -
-RUN apt-get install nodejs -y
+RUN curl -sL https://deb.nodesource.com/setup_20.x \
+  | bash - \
+ && apt-get update \
+ && apt-get install -y nodejs
 
 # Temporary fix to get ldap install working by bypassing below install-php-extensions run (these issues are usually temporary
 #  in dev versions of PHP, so this is not a permanent solution)
 # TODO:
 # TODO: intermittently try to remove this block of code and uncomment ldap in below ../install-php-extensions run
 # TODO:
-RUN apt-get install -y \
-    libldap2-dev \
-    libsasl2-dev \
-    libldap-common \
-    pkg-config
+RUN apt-get update \
+ && apt-get install -y libldap-common \
+                       libldap2-dev \
+                       libsasl2-dev \
+                       pkg-config
 RUN LDAP_CFLAGS="-I/usr/include" \
     LDAP_LIBS="-lldap -llber" \
     docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
-    && docker-php-ext-install ldap
+ && docker-php-ext-install ldap
 
 # Add the php extensions (note using a very cool script by mlocati to do this)
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod uga+x /usr/local/bin/install-php-extensions && sync && \
-    install-php-extensions pdo_mysql \
-                           # ldap \
-                           xsl \
+RUN chmod uga+x /usr/local/bin/install-php-extensions \
+ && sync \
+ && install-php-extensions calendar \
                            gd \
-                           zip \
-                           soap \
                            gettext \
+                           intl \
                            mysqli \
+                           pdo_mysql \
+                           redis \
+                           soap \
                            sockets \
                            tokenizer \
                            xmlreader \
-                           calendar \
-                           intl \
-                           redis
-
-# Copy over the php.ini conf
-COPY php.ini /usr/local/etc/php/php.ini
+                           xsl \
+                           zip
 
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
 RUN usermod -u 1000 www-data
+
+# Copy over the php.ini conf
+COPY php.ini /usr/local/etc/php/php.ini

--- a/docker/library/dockers/dev-php-fpm-8-5/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-5/Dockerfile
@@ -11,55 +11,55 @@
 #
 FROM openemr/dev-php-fpm:pre-build-dev-85
 
-# Update
-RUN apt-get update
-
 # Add mariadb-client package that is needed in the OpenEMR Backup gui, which does direct command mysql commands
 # Add imagemagick that is needed for some image processing in OpenEMR
 # Note this basically add 160MB of space to the docker, so would be nice for OpenEMR to not require this stuff
 #  and instead rely on php scripts, if possible.
-RUN apt-get install -y mariadb-client \
+RUN apt-get update \
+ && apt-get install -y curl \
                        imagemagick \
-                       curl
+                       mariadb-client
 
 # Install correct version nodejs
-RUN curl -sL https://deb.nodesource.com/setup_20.x  | bash -
-RUN apt-get install nodejs -y
+RUN curl -sL https://deb.nodesource.com/setup_20.x \
+  | bash - \
+ && apt-get update \
+ && apt-get install -y nodejs
 
 # Temporary fix to get ldap install working by bypassing below install-php-extensions run (these issues are usually temporary
 #  in dev versions of PHP, so this is not a permanent solution)
 # TODO:
 # TODO: intermittently try to remove this block of code and uncomment ldap in below ../install-php-extensions run
 # TODO:
-RUN apt-get install -y \
-    libldap2-dev \
-    libsasl2-dev \
-    libldap-common \
-    pkg-config
+RUN apt-get update \
+ && apt-get install -y libldap-common \
+                       libldap2-dev \
+                       libsasl2-dev \
+                       pkg-config
 RUN LDAP_CFLAGS="-I/usr/include" \
     LDAP_LIBS="-lldap -llber" \
     docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
-    && docker-php-ext-install ldap
+ && docker-php-ext-install ldap
 
 # Add the php extensions (note using a very cool script by mlocati to do this)
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod uga+x /usr/local/bin/install-php-extensions && sync && \
-    install-php-extensions pdo_mysql \
-                           # ldap \
-                           xsl \
+RUN chmod uga+x /usr/local/bin/install-php-extensions \
+ && sync \
+ && install-php-extensions calendar \
                            gd \
-                           zip \
-                           soap \
                            gettext \
+                           intl \
                            mysqli \
+                           pdo_mysql \
+                           soap \
                            sockets \
                            tokenizer \
                            xmlreader \
-                           calendar \
-                           intl
-
-# Copy over the php.ini conf
-COPY php.ini /usr/local/etc/php/php.ini
+                           xsl \
+                           zip
 
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
 RUN usermod -u 1000 www-data
+
+# Copy over the php.ini conf
+COPY php.ini /usr/local/etc/php/php.ini


### PR DESCRIPTION
Fixes #8635

#### Short description of what this resolves:

Prevent cache stale problems and follow Dockerfile best practices by ensuring that apt-get install is always preceded by apt-get update in the same RUN step.


#### Changes proposed in this pull request:

Refactor Dockerfiles…
- apt-get install always follows apt-get update in the same RUN step
- alphabetize things to install
- break compound commands on lines
- COPY commands come as late as possible to avoid spurious cache invalidation

#### Does your code include anything generated by an AI Engine? No
