### PR TITLE
Improve error message for missing access to any system resources

### DIFF
--- a/src/RestControllers/FHIR/Operations/FhirOperationExportRestController.php
+++ b/src/RestControllers/FHIR/Operations/FhirOperationExportRestController.php
@@ -533,7 +533,7 @@ class FhirOperationExportRestController
             }
         }
         if (empty($approvedResources)) {
-            throw new AccessDeniedException('system', $resource . '.read', 'AccessToken does grant access to any supported system resources');
+            throw new AccessDeniedException('system', $resource . '.read', 'AccessToken does not grant access to any supported system resources');
         }
         return $approvedResources;
     }


### PR DESCRIPTION
#### Short description of what this resolves:

Improve error message when access token does not have access to any system resources.

#### Changes proposed in this pull request:

The existing error message is slightly confusing and I believe a "not" is missing. This is in line with the other error message (for when a specific resource was requested for which the token has no access).
This makes it clear that the access token does **not** have access to any system resources.

#### Does your code include anything generated by an AI Engine? Yes / No

No