### PR TITLE
ci(phpstan): remove missed ignore pattern

### DIFF
--- a/phpstan.github.neon
+++ b/phpstan.github.neon
@@ -11960,10 +11960,6 @@ parameters:
     identifier: variable.undefined
     count: 1
     path: interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncounterccdadispatchController.php
-  - message: '#^Variable \$downloadccda in empty\(\) always exists and is not falsy\.$#'
-    identifier: empty.variable
-    count: 1
-    path: interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncounterccdadispatchController.php
   - message: '#^Variable \$result might not be defined\.$#'
     identifier: variable.undefined
     count: 1

--- a/phpstan.local.neon
+++ b/phpstan.local.neon
@@ -11888,10 +11888,6 @@ parameters:
     identifier: variable.undefined
     count: 1
     path: interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncounterccdadispatchController.php
-  - message: '#^Variable \$downloadccda in empty\(\) always exists and is not falsy\.$#'
-    identifier: empty.variable
-    count: 1
-    path: interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncounterccdadispatchController.php
   - message: '#^Variable \$result might not be defined\.$#'
     identifier: variable.undefined
     count: 1


### PR DESCRIPTION
#### Short description of what this resolves:

PHPStan is failing due to an extra ignore pattern that is no longer matching anything.

#### Changes proposed in this pull request:

- ci(phpstan): remove unused ignore pattern

#### Does your code include anything generated by an AI Engine? No
