### PR TITLE
test(php): remove erroneous @cover annotations

### DIFF
--- a/src/RestControllers/FHIR/FhirCoverageRestController.php
+++ b/src/RestControllers/FHIR/FhirCoverageRestController.php
@@ -13,13 +13,11 @@ require_once(__DIR__ . '/../../../_rest_config.php');
 /**
  * FHIR Organization Service
  *
- * @coversDefaultClass OpenEMR\Services\FHIR\FhirOrganizationService
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Yash Bothra <yashrajbothra786@gmail.com>
  * @copyright Copyright (c) 2020 Yash Bothra <yashrajbothra786@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
- *
  */
 class FhirCoverageRestController
 {

--- a/src/RestControllers/FHIR/FhirOrganizationRestController.php
+++ b/src/RestControllers/FHIR/FhirOrganizationRestController.php
@@ -19,7 +19,6 @@ require_once(__DIR__ . '/../../../_rest_config.php');
 /**
  * FHIR Organization Service
  *
- * @coversDefaultClass OpenEMR\Services\FHIR\FhirOrganizationService
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Yash Bothra <yashrajbothra786@gmail.com>

--- a/src/RestControllers/FHIR/FhirPractitionerRoleRestController.php
+++ b/src/RestControllers/FHIR/FhirPractitionerRoleRestController.php
@@ -11,7 +11,6 @@ require_once(__DIR__ . '/../../../_rest_config.php');
 /**
  * FHIR PractitionerRole Service
  *
- * @coversDefaultClass OpenEMR\Services\FHIR\FhirPractitionerRoleService
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Yash Bothra <yashrajbothra786@gmail.com>

--- a/src/Services/FHIR/FhirAllergyIntoleranceService.php
+++ b/src/Services/FHIR/FhirAllergyIntoleranceService.php
@@ -41,13 +41,11 @@ use OpenEMR\Common\Uuid\UuidRegistry;
 /**
  * FHIR AllergyIntolerance Service
  *
- * @coversDefaultClass OpenEMR\Services\FHIR\FhirAllergyIntoleranceService
  * @package   OpenEMR
  * @author    Yash Bothra <yashrajbothra786gmail.com>
  * @copyright Copyright (c) 2020 Yash Bothra <yashrajbothra786gmail.com>
  * @link      http://www.open-emr.org
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
- *
  */
 class FhirAllergyIntoleranceService extends FhirServiceBase implements IResourceUSCIGProfileService, IPatientCompartmentResourceService, IFhirExportableResourceService
 {

--- a/src/Services/FHIR/FhirConditionService.php
+++ b/src/Services/FHIR/FhirConditionService.php
@@ -22,7 +22,6 @@ use OpenEMR\Validators\ProcessingResult;
 /**
  * FHIR Condition Service
  *
- * @coversDefaultClass OpenEMR\Services\FHIR\FhirConditionService
  * @package            OpenEMR
  * @link               http://www.open-emr.org
  * @author             Yash Bothra <yashrajbothra786gmail.com>

--- a/src/Services/FHIR/FhirCoverageService.php
+++ b/src/Services/FHIR/FhirCoverageService.php
@@ -22,7 +22,6 @@ use OpenEMR\Validators\ProcessingResult;
 /**
  * FHIR Coverage Service
  *
- * @coversDefaultClass OpenEMR\Services\FHIR\FhirCoverageService
  * @package            OpenEMR
  * @link               http://www.open-emr.org
  * @author             Vishnu Yarmaneni <vardhanvishnu@gmail.com>

--- a/src/Services/FHIR/FhirImmunizationService.php
+++ b/src/Services/FHIR/FhirImmunizationService.php
@@ -27,7 +27,6 @@ use OpenEMR\Validators\ProcessingResult;
 /**
  * FHIR Immunization Service
  *
- * @coversDefaultClass OpenEMR\Services\FHIR\FhirImmunizationService
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Yash Bothra <yashrajbothra786gmail.com>

--- a/src/Services/FHIR/FhirMedicationService.php
+++ b/src/Services/FHIR/FhirMedicationService.php
@@ -20,7 +20,6 @@ use OpenEMR\Validators\ProcessingResult;
 /**
  * FHIR Medication Service
  *
- * @coversDefaultClass OpenEMR\Services\FHIR\FhirMedicationService
  * @package            OpenEMR
  * @link               http://www.open-emr.org
  * @author             Yash Bothra <yashrajbothra786gmail.com>

--- a/src/Services/FHIR/FhirObservationService.php
+++ b/src/Services/FHIR/FhirObservationService.php
@@ -25,7 +25,6 @@ use OpenEMR\Validators\ProcessingResult;
 /**
  * FHIR Observation Service
  *
- * @coversDefaultClass OpenEMR\Services\FHIR\FhirObservationService
  * @package            OpenEMR
  * @link               http://www.open-emr.org
  * @author             Yash Bothra <yashrajbothra786gmail.com>

--- a/src/Services/FHIR/FhirOrganizationService.php
+++ b/src/Services/FHIR/FhirOrganizationService.php
@@ -24,7 +24,6 @@ use OpenEMR\Validators\ProcessingResult;
 /**
  * FHIR Organization Service
  *
- * @coversDefaultClass OpenEMR\Services\FHIR\FhirOrganizationService
  * @package            OpenEMR
  * @link               http://www.open-emr.org
  * @author             Yash Bothra <yashrajbothra786@gmail.com>

--- a/src/Services/FHIR/FhirPractitionerRoleService.php
+++ b/src/Services/FHIR/FhirPractitionerRoleService.php
@@ -17,13 +17,11 @@ use OpenEMR\Validators\ProcessingResult;
 /**
  * FHIR PractitionerRole Service
  *
- * @coversDefaultClass OpenEMR\Services\FHIR\FhirPractitionerRoleService
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Yash Bothra <yashrajbothra786@gmail.com>
  * @copyright Copyright (c) 2020 Yash Bothra <yashrajbothra786@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
- *
  */
 class FhirPractitionerRoleService extends FhirServiceBase implements IResourceUSCIGProfileService
 {

--- a/src/Services/FHIR/FhirPractitionerService.php
+++ b/src/Services/FHIR/FhirPractitionerService.php
@@ -22,14 +22,12 @@ use OpenEMR\Validators\ProcessingResult;
 /**
  * FHIR Practitioner Service
  *
- * @coversDefaultClass OpenEMR\Services\FHIR\FhirPractitionerService
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Jerry Padgett <sjpadgett@gmail.com>
  * @author    Yash Bothra <yashrajbothra786@gmail.com>
  * @copyright Copyright (c) 2020 Jerry Padgett <sjpadgett@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
- *
  */
 class FhirPractitionerService extends FhirServiceBase implements IFhirExportableResourceService, IResourceUSCIGProfileService
 {

--- a/src/Services/FHIR/FhirProcedureService.php
+++ b/src/Services/FHIR/FhirProcedureService.php
@@ -3,7 +3,6 @@
 /**
  * FHIR Procedure Service
  *
- * @coversDefaultClass OpenEMR\Services\FHIR\FhirProcedureService
  * @package            OpenEMR
  * @link               http://www.open-emr.org
  * @author             Yash Bothra <yashrajbothra786gmail.com>

--- a/tests/Tests/Api/ApiTestClientTest.php
+++ b/tests/Tests/Api/ApiTestClientTest.php
@@ -7,14 +7,12 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Test cases for the OpenEMR Api Test Client
- * NOTE: currently disabled (by naming convention) until work is completed to support running as part of Travis CI
- * @coversDefaultClass OpenEMR\Tests\Api\ApiTestClient
+ *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Dixon Whitmire <dixonwh@gmail.com>
  * @copyright Copyright (c) 2020 Dixon Whitmire <dixonwh@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
- *
  */
 class ApiTestClientTest extends TestCase
 {
@@ -37,9 +35,6 @@ class ApiTestClientTest extends TestCase
         $this->client = new ApiTestClient($baseUrl, false);
     }
 
-    /**
-     * @cover ::getConfig with a null value
-     */
     public function testGetConfigWithNull(): void
     {
         $this->client->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT);
@@ -50,9 +45,6 @@ class ApiTestClientTest extends TestCase
         $this->client->cleanupClient();
     }
 
-    /**
-     * @cover ::getConfig for HTTP client settings
-     */
     public function testGetConfig(): void
     {
         $this->client->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT);
@@ -70,7 +62,6 @@ class ApiTestClientTest extends TestCase
 
     /**
      * Tests the automated testing when invalid credentials arguments are provided
-     * @covers ::setAuthToken with invalid credential argument
      */
     public function testApiAuthInvalidArgs(): void
     {
@@ -94,7 +85,6 @@ class ApiTestClientTest extends TestCase
     }
     /**
      * Tests OpenEMR OAuth when invalid client id is provided
-     * @covers ::setAuthToken with invalid credentials
      */
     public function testApiAuthInvalidClientId(): void
     {
@@ -110,7 +100,6 @@ class ApiTestClientTest extends TestCase
 
     /**
      * Tests OpenEMR OAuth when invalid user credentials are provided
-     * @covers ::setAuthToken with invalid credentials
      */
     public function testApiAuthInvalidUserCredentials(): void
     {
@@ -126,8 +115,6 @@ class ApiTestClientTest extends TestCase
 
     /**
      * Tests OpenEMR API Auth for the REST and FHIR APIs
-     * @cover ::setAuthToken
-     * @cover ::removeAuthToken
      */
     public function testApiAuth(): void
     {
@@ -153,8 +140,6 @@ class ApiTestClientTest extends TestCase
 
     /**
      * Tests OpenEMR API Auth for the REST and FHIR APIs (test refresh request after the auth)
-     * @cover ::setAuthToken
-     * @cover ::removeAuthToken
      */
     public function testApiAuthThenRefresh(): void
     {
@@ -205,8 +190,6 @@ class ApiTestClientTest extends TestCase
 
     /**
      * Tests OpenEMR API Auth for the REST and FHIR APIs (test refresh request after the auth with bad refresh token)
-     * @cover ::setAuthToken
-     * @cover ::removeAuthToken
      */
     public function testApiAuthThenBadRefresh(): void
     {
@@ -547,9 +530,6 @@ class ApiTestClientTest extends TestCase
         $this->client->cleanupClient();
     }
 
-    /**
-     * @cover ::removeAuthToken when an auth token is not present
-     */
     public function testRemoveAuthTokenNoToken(): void
     {
         $this->client->removeAuthToken();

--- a/tests/Tests/Api/CapabilityFhirTest.php
+++ b/tests/Tests/Api/CapabilityFhirTest.php
@@ -10,13 +10,12 @@ use OpenEMR\Tests\Api\ApiTestClient;
 
 /**
  * Capability FHIR Endpoint Test Cases.
- * @coversDefaultClass OpenEMR\Tests\Api\ApiTestClient
+ *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2018-2019 Brady Miller <brady.g.miller@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
- *
  */
 class CapabilityFhirTest extends TestCase
 {
@@ -54,27 +53,18 @@ class CapabilityFhirTest extends TestCase
         $this->testClient->cleanupClient();
     }
 
-    /**
-     * @covers ::get with an invalid path
-     */
     public function testInvalidPathGet(): void
     {
         $actualResponse = $this->testClient->get(self::CAPABILITY_FHIR_ENDPOINT . "ss");
         $this->assertEquals(401, $actualResponse->getStatusCode());
     }
 
-    /**
-     * @covers ::get with an invalid site
-     */
     public function testInvalidSiteGet(): void
     {
         $actualResponse = $this->testClient->get(self::CAPABILITY_FHIR_ENDPOINT_INVALID_SITE);
         $this->assertEquals(400, $actualResponse->getStatusCode());
     }
 
-    /**
-     * @covers ::get
-     */
     public function testGet(): void
     {
         $actualResponse = $this->testClient->get(self::CAPABILITY_FHIR_ENDPOINT);

--- a/tests/Tests/Api/IntrospectionTest.php
+++ b/tests/Tests/Api/IntrospectionTest.php
@@ -7,13 +7,12 @@ use OpenEMR\Tests\Api\ApiTestClient;
 
 /**
  * Capability FHIR Endpoint Test Cases.
- * @coversDefaultClass OpenEMR\Tests\Api\ApiTestClient
+ *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Brady Miller <brady.g.miller@gmail.com>
  * @copyright Copyright (c) 2018-2019 Brady Miller <brady.g.miller@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
- *
  */
 class IntrospectionTest extends TestCase
 {

--- a/tests/Tests/Api/PatientApiTest.php
+++ b/tests/Tests/Api/PatientApiTest.php
@@ -8,13 +8,12 @@ use OpenEMR\Tests\Fixtures\FixtureManager;
 
 /**
  * Patient API Endpoint Test Cases.
- * @coversDefaultClass \OpenEMR\RestControllers\PatientRestController
+ *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Dixon Whitmire <dixonwh@gmail.com>
  * @copyright Copyright (c) 2020 Dixon Whitmire <dixonwh@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
- *
  */
 class PatientApiTest extends TestCase
 {
@@ -40,9 +39,6 @@ class PatientApiTest extends TestCase
         $this->testClient->cleanupClient();
     }
 
-    /**
-     * @covers ::post with an invalid patient request
-     */
     public function testInvalidPost(): void
     {
         unset($this->patientRecord["fname"]);
@@ -55,9 +51,6 @@ class PatientApiTest extends TestCase
         $this->assertEquals(0, count($responseBody["data"]));
     }
 
-    /**
-     * @covers ::post with a valid patient request
-     */
     public function testPost(): void
     {
         $actualResponse = $this->testClient->post(self::PATIENT_API_ENDPOINT, $this->patientRecord);
@@ -75,9 +68,6 @@ class PatientApiTest extends TestCase
         $this->assertIsString($newPatientUuid);
     }
 
-    /**
-     * @covers ::put with an invalid pid and uuid
-     */
     public function testInvalidPut(): void
     {
         $actualResponse = $this->testClient->post(self::PATIENT_API_ENDPOINT, $this->patientRecord);
@@ -93,9 +83,6 @@ class PatientApiTest extends TestCase
         $this->assertEquals(0, count($responseBody["data"]));
     }
 
-    /**
-     * @covers ::put with a valid resource id and payload
-     */
     public function testPut(): void
     {
         $actualResponse = $this->testClient->post(self::PATIENT_API_ENDPOINT, $this->patientRecord);
@@ -116,9 +103,6 @@ class PatientApiTest extends TestCase
         $this->assertEquals($this->patientRecord["phone_home"], $updatedResource["phone_home"]);
     }
 
-    /**
-     * @covers ::getOne with an invalid pid
-     */
     public function testGetOneInvalidPid(): void
     {
         $actualResponse = $this->testClient->getOne(self::PATIENT_API_ENDPOINT, "not-a-uuid");
@@ -130,9 +114,6 @@ class PatientApiTest extends TestCase
         $this->assertEquals(0, count($responseBody["data"]));
     }
 
-    /**
-     * @covers ::getOne with a valid pid
-     */
     public function testGetOne(): void
     {
         $actualResponse = $this->testClient->post(self::PATIENT_API_ENDPOINT, $this->patientRecord);
@@ -152,9 +133,6 @@ class PatientApiTest extends TestCase
         $this->assertEquals($patientPid, $responseBody["data"]["pid"]);
     }
 
-    /**
-     * @covers ::getAll
-     */
     public function testGetAll(): void
     {
         $this->fixtureManager->installPatientFixtures();

--- a/tests/Tests/Api/PractitionerApiTest.php
+++ b/tests/Tests/Api/PractitionerApiTest.php
@@ -8,14 +8,12 @@ use OpenEMR\Tests\Fixtures\PractitionerFixtureManager;
 
 /**
  * Practitioner API Endpoint Test Cases.
- * @coversDefaultClass \OpenEMR\RestControllers\PractitionerRestController
  *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Yash Bothra <yashrajbothra786gmail.com>
  * @copyright Copyright (c) 2020 Yash Bothra <yashrajbothra786gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
- *
  */
 class PractitionerApiTest extends TestCase
 {
@@ -45,9 +43,6 @@ class PractitionerApiTest extends TestCase
         $this->testClient->cleanupClient();
     }
 
-    /**
-     * @covers ::post with an invalid practitioner request
-     */
     public function testInvalidPost(): void
     {
         unset($this->practitionerRecord["fname"]);
@@ -60,9 +55,6 @@ class PractitionerApiTest extends TestCase
         $this->assertEquals(0, count($responseBody["data"]));
     }
 
-    /**
-     * @covers ::post with a valid practitioner request
-     */
     public function testPost(): void
     {
         $actualResponse = $this->testClient->post(self::PRACTITIONER_API_ENDPOINT, $this->practitionerRecord);
@@ -80,9 +72,6 @@ class PractitionerApiTest extends TestCase
         $this->assertIsString($newPractitionerUuid);
     }
 
-    /**
-     * @covers ::put with an invalid pid and uuid
-     */
     public function testInvalidPut(): void
     {
         $actualResponse = $this->testClient->post(self::PRACTITIONER_API_ENDPOINT, $this->practitionerRecord);
@@ -102,9 +91,6 @@ class PractitionerApiTest extends TestCase
         $this->assertEquals(0, count($responseBody["data"]));
     }
 
-    /**
-     * @covers ::put with a valid resource id and payload
-     */
     public function testPut(): void
     {
         $actualResponse = $this->testClient->post(self::PRACTITIONER_API_ENDPOINT, $this->practitionerRecord);
@@ -126,9 +112,6 @@ class PractitionerApiTest extends TestCase
         $this->assertEquals($this->practitionerRecord["email"], $updatedResource["email"]);
     }
 
-    /**
-     * @covers ::getOne with an invalid pid
-     */
     public function testGetOneInvalidId(): void
     {
         $actualResponse = $this->testClient->getOne(self::PRACTITIONER_API_ENDPOINT, "not-a-uuid");
@@ -140,9 +123,6 @@ class PractitionerApiTest extends TestCase
         $this->assertEquals(0, count($responseBody["data"]));
     }
 
-    /**
-     * @covers ::getOne with a valid pid
-     */
     public function testGetOne(): void
     {
         $actualResponse = $this->testClient->post(self::PRACTITIONER_API_ENDPOINT, $this->practitionerRecord);
@@ -163,9 +143,6 @@ class PractitionerApiTest extends TestCase
     }
 
 
-    /**
-     * @covers ::getAll
-     */
     public function testGetAll(): void
     {
         $this->fixtureManager->installPractitionerFixtures();

--- a/tests/Tests/Api/SmartConfigurationTest.php
+++ b/tests/Tests/Api/SmartConfigurationTest.php
@@ -9,12 +9,11 @@ use OpenEMR\Tests\Api\ApiTestClient;
 
 /**
  * Capability FHIR Endpoint Test Cases.
- * @coversDefaultClass OpenEMR\Tests\Api\ApiTestClient
+ *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Stephen Nielson <stephen@nielson.org>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
- *
  */
 class SmartConfigurationTest extends TestCase
 {
@@ -48,18 +47,12 @@ class SmartConfigurationTest extends TestCase
         $this->testClient->cleanupClient();
     }
 
-    /**
-     * @covers ::get with an invalid path
-     */
     public function testInvalidPathGet(): void
     {
         $actualResponse = $this->testClient->get(self::SMART_CONFIG_ENDPOINT . "ss");
         $this->assertEquals(401, $actualResponse->getStatusCode());
     }
 
-    /**
-     * @covers ::get
-     */
     public function testGet(): void
     {
         $actualResponse = $this->testClient->get(self::SMART_CONFIG_ENDPOINT);

--- a/tests/Tests/Common/Uuid/UuidRegistryTest.php
+++ b/tests/Tests/Common/Uuid/UuidRegistryTest.php
@@ -8,13 +8,12 @@ use Ramsey\Uuid\UuidFactory;
 
 /**
  * Uuid Registry Tests
- * @coversDefaultClass OpenEMR\Common\UuidRegistry
+ *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Dixon Whitmire <dixonwh@gmail.com>
  * @copyright Copyright (c) 2020 Dixon Whitmire <dixonwh@gmail.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
- *
  */
 class UuidRegistryTest extends TestCase
 {
@@ -27,8 +26,6 @@ class UuidRegistryTest extends TestCase
 
     /**
      * Tests bi-directional uuid conversions
-     * @covers \OpenEMR\Common\Uuid\UuidRegistry::uuidToBytes
-     * @covers \OpenEMR\Common\Uuid\UuidRegistry::uuidToString
      */
     public function testUuidConversions(): void
     {

--- a/tests/Tests/Fixtures/FixtureManagerTest.php
+++ b/tests/Tests/Fixtures/FixtureManagerTest.php
@@ -6,8 +6,6 @@ use PHPUnit\Framework\TestCase;
 use OpenEMR\Tests\Fixtures\FixtureManager;
 
 /**
- * @coversDefaultClass \OpenEMR\Tests\Fixtures\FixtureManager
- *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Dixon Whitmire <dixonwh@gmail.com>
@@ -102,9 +100,6 @@ class FixtureManagerTest extends TestCase
         }
     }
 
-    /**
-     * @covers ::getPatientFixtures
-     */
     public function testGetPatientFixtures(): void
     {
         $patientFixtures = $this->fixtureManager->getPatientFixtures();
@@ -116,19 +111,12 @@ class FixtureManagerTest extends TestCase
         }
     }
 
-    /**
-     * @covers ::getSinglePatientFixture
-     */
     public function testGetPatientFixture(): void
     {
         $patientFixture = $this->fixtureManager->getSinglePatientFixture();
         $this->assertPatientFields($patientFixture);
     }
 
-    /**
-     * @covers ::installPatientFixtures
-     * @covers ::removePatientFixtures
-     */
     public function testInstallAndRemovePatientFixtures(): void
     {
         $actualCount = $this->fixtureManager->installPatientFixtures();
@@ -143,9 +131,6 @@ class FixtureManagerTest extends TestCase
         $this->assertEquals(0, $recordCount);
     }
 
-    /**
-     * @covers ::getFhirPatientFixtures
-     */
     public function testGetFhirPatientFixtures(): void
     {
         $fhirPatientFixtures = $this->fixtureManager->getFhirPatientFixtures();

--- a/tests/Tests/RestControllers/FHIR/FhirOrganizationRestControllerTest.php
+++ b/tests/Tests/RestControllers/FHIR/FhirOrganizationRestControllerTest.php
@@ -7,8 +7,6 @@ use OpenEMR\RestControllers\FHIR\FhirOrganizationRestController;
 use OpenEMR\Tests\Fixtures\FacilityFixtureManager;
 
 /**
- * @coversDefaultClass \OpenEMR\RestControllers\FHIR\FhirOrganizationRestController
- *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Yash Bothra <yashrajbothra786gmail.com>
@@ -44,9 +42,6 @@ class FhirOrganizationRestControllerTest extends TestCase
         $this->fixtureManager->removeFixtures();
     }
 
-    /**
-     * @cover ::post with valid data
-     */
     public function testPost(): void
     {
         $actualResult = $this->fhirOrganizationController->post($this->fhirFixture);
@@ -54,9 +49,6 @@ class FhirOrganizationRestControllerTest extends TestCase
         $this->assertNotEmpty($actualResult['uuid']);
     }
 
-    /**
-     * @cover ::post with invalid data
-     */
     public function testInvalidPost(): void
     {
         unset($this->fhirFixture['name']);
@@ -66,9 +58,6 @@ class FhirOrganizationRestControllerTest extends TestCase
         $this->assertGreaterThan(0, count($actualResult['validationErrors']));
     }
 
-    /**
-     * @cover ::patch with valid data
-     */
     public function testPatch(): void
     {
         $actualResult = $this->fhirOrganizationController->post($this->fhirFixture);
@@ -81,9 +70,6 @@ class FhirOrganizationRestControllerTest extends TestCase
         $this->assertEquals($fhirId, $actualResult->getId());
     }
 
-    /**
-     * @cover ::patch with valid data
-     */
     public function testInvalidPatch(): void
     {
         $this->fhirOrganizationController->post($this->fhirFixture);

--- a/tests/Tests/RestControllers/FHIR/FhirPatientRestControllerTest.php
+++ b/tests/Tests/RestControllers/FHIR/FhirPatientRestControllerTest.php
@@ -6,10 +6,6 @@ use PHPUnit\Framework\TestCase;
 use OpenEMR\RestControllers\FHIR\FhirPatientRestController;
 use OpenEMR\Tests\Fixtures\FixtureManager;
 
-/**
- * @coversDefaultClass \OpenEMR\RestControllers\FHIR\FhirPatientRestController
- */
-
 class FhirPatientRestControllerTest extends TestCase
 {
     private $fhirPatientController;
@@ -32,9 +28,6 @@ class FhirPatientRestControllerTest extends TestCase
         $this->fixtureManager->removePatientFixtures();
     }
 
-    /**
-     * @cover ::post with valid data
-     */
     public function testPost(): void
     {
         $actualResult = $this->fhirPatientController->post($this->fhirFixture);
@@ -42,9 +35,6 @@ class FhirPatientRestControllerTest extends TestCase
         $this->assertNotEmpty($actualResult['uuid']);
     }
 
-    /**
-     * @cover ::post with invalid data
-     */
     public function testInvalidPost(): void
     {
         unset($this->fhirFixture['name']);
@@ -54,9 +44,6 @@ class FhirPatientRestControllerTest extends TestCase
         $this->assertGreaterThan(0, count($actualResult['validationErrors']));
     }
 
-    /**
-     * @cover ::put with valid data
-     */
     public function testPut(): void
     {
         $actualResult = $this->fhirPatientController->post($this->fhirFixture);
@@ -69,9 +56,6 @@ class FhirPatientRestControllerTest extends TestCase
         $this->assertEquals($fhirId, $actualResult->getId());
     }
 
-    /**
-     * @cover ::put with valid data
-     */
     public function testInvalidPut(): void
     {
         $this->fhirPatientController->post($this->fhirFixture);

--- a/tests/Tests/RestControllers/FHIR/FhirPractitionerRestControllerTest.php
+++ b/tests/Tests/RestControllers/FHIR/FhirPractitionerRestControllerTest.php
@@ -7,8 +7,6 @@ use OpenEMR\RestControllers\FHIR\FhirPractitionerRestController;
 use OpenEMR\Tests\Fixtures\PractitionerFixtureManager;
 
 /**
- * @coversDefaultClass OpenEMR\RestControllers\FHIR\FhirPractitionerRestController
- *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Yash Bothra <yashrajbothra786gmail.com>
@@ -40,9 +38,6 @@ class FhirPractitionerRestControllerTest extends TestCase
         $this->fixtureManager->removePractitionerFixtures();
     }
 
-    /**
-     * @cover ::post with valid data
-     */
     public function testPost(): void
     {
         $actualResult = $this->fhirPractitionerController->post($this->fhirFixture);
@@ -50,9 +45,6 @@ class FhirPractitionerRestControllerTest extends TestCase
         $this->assertNotEmpty($actualResult['uuid']);
     }
 
-    /**
-     * @cover ::post with invalid data
-     */
     public function testInvalidPost(): void
     {
         unset($this->fhirFixture['name']);
@@ -62,9 +54,6 @@ class FhirPractitionerRestControllerTest extends TestCase
         $this->assertGreaterThan(0, count($actualResult['validationErrors']));
     }
 
-    /**
-     * @cover ::patch with valid data
-     */
     public function testPatch(): void
     {
         $actualResult = $this->fhirPractitionerController->post($this->fhirFixture);
@@ -77,9 +66,6 @@ class FhirPractitionerRestControllerTest extends TestCase
         $this->assertEquals($fhirId, $actualResult->getId());
     }
 
-    /**
-     * @cover ::patch with valid data
-     */
     public function testInvalidPatch(): void
     {
         $this->fhirPractitionerController->post($this->fhirFixture);

--- a/tests/Tests/RestControllers/FacilityRestControllerTest.php
+++ b/tests/Tests/RestControllers/FacilityRestControllerTest.php
@@ -7,8 +7,6 @@ use OpenEMR\RestControllers\FacilityRestController;
 use OpenEMR\Tests\Fixtures\FacilityFixtureManager;
 
 /**
- * @coversDefaultClass OpenEMR\RestControllers\FacilityRestControllerTest
- *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Yash Bothra <yashrajbothra786gmail.com>
@@ -78,9 +76,6 @@ class FacilityRestControllerTest extends TestCase
         $this->fixtureManager->removeFixtures();
     }
 
-    /**
-     * @cover ::post with invalid data
-     */
     public function testPostInvalidData(): void
     {
         unset($this->facilityData["name"]);
@@ -91,9 +86,6 @@ class FacilityRestControllerTest extends TestCase
         $this->assertEquals(0, count($actualResult["data"]));
     }
 
-    /**
-     * @cover ::post with valid data
-     */
     public function testPost(): void
     {
         $actualResult = $this->facilityController->post($this->facilityData);
@@ -107,9 +99,6 @@ class FacilityRestControllerTest extends TestCase
         $this->assertGreaterThan(0, $facilityPid);
     }
 
-    /**
-     * @cover ::patch with invalid data
-     */
     public function testPatchInvalidData(): void
     {
         $actualResult = $this->facilityController->post($this->facilityData);
@@ -126,9 +115,6 @@ class FacilityRestControllerTest extends TestCase
         $this->assertEquals(0, count($actualResult["data"]));
     }
 
-    /**
-     * @cover ::patch with valid data
-     */
     public function testPatch(): void
     {
         $actualResult = $this->facilityController->post($this->facilityData);
@@ -149,9 +135,6 @@ class FacilityRestControllerTest extends TestCase
         $this->assertEquals($this->facilityData["email"], $updatedFacility["email"]);
     }
 
-    /**
-     * @cover ::getOne with an invalid uuid
-     */
     public function testGetOneInvalidUuid(): void
     {
         $actualResult = $this->facilityController->getOne("not-a-uuid");
@@ -161,9 +144,6 @@ class FacilityRestControllerTest extends TestCase
         $this->assertEquals([], $actualResult["data"]);
     }
 
-    /**
-     * @cover ::getOne with a valid uuid
-     */
     public function testGetOne(): void
     {
         // create a record
@@ -175,9 +155,6 @@ class FacilityRestControllerTest extends TestCase
         $this->assertEquals($postedUuid, $actualResult["data"]["uuid"]);
     }
 
-    /**
-     * @cover ::getAll
-     */
     public function testGetAll(): void
     {
         $this->fixtureManager->installFacilityFixtures();

--- a/tests/Tests/RestControllers/HandleProcessingResultTest.php
+++ b/tests/Tests/RestControllers/HandleProcessingResultTest.php
@@ -6,9 +6,6 @@ use PHPUnit\Framework\TestCase;
 use OpenEMR\RestControllers\RestControllerHelper;
 use OpenEMR\Validators\ProcessingResult;
 
-/**
- * @coverDefault RestControllerHelper::handleProcessingResult
- */
 class HandleProcessingResultTest extends TestCase
 {
     private $processingResult;

--- a/tests/Tests/RestControllers/PatientRestControllerTest.php
+++ b/tests/Tests/RestControllers/PatientRestControllerTest.php
@@ -7,9 +7,6 @@ use PHPUnit\Framework\TestCase;
 use OpenEMR\RestControllers\PatientRestController;
 use OpenEMR\Tests\Fixtures\FixtureManager;
 
-/**
- * @coversDefaultClass OpenEMR\RestControllers\PatientRestController
- */
 class PatientRestControllerTest extends TestCase
 {
     const PATIENT_API_URL = "/apis/api/patient";
@@ -50,9 +47,6 @@ class PatientRestControllerTest extends TestCase
         $this->fixtureManager->removePatientFixtures();
     }
 
-    /**
-     * @cover ::post with invalid data
-     */
     public function testPostInvalidData(): void
     {
         unset($this->patientData["fname"]);
@@ -63,9 +57,6 @@ class PatientRestControllerTest extends TestCase
         $this->assertEquals(0, count($actualResult["data"]));
     }
 
-    /**
-     * @cover ::post with valid data
-     */
     public function testPost(): void
     {
         $actualResult = $this->patientController->post($this->patientData);
@@ -79,9 +70,6 @@ class PatientRestControllerTest extends TestCase
         $this->assertGreaterThan(0, $patientPid);
     }
 
-    /**
-     * @cover ::put with invalid data
-     */
     public function testPutInvalidData(): void
     {
         $actualResult = $this->patientController->post($this->patientData);
@@ -98,9 +86,6 @@ class PatientRestControllerTest extends TestCase
         $this->assertEquals(0, count($actualResult["data"]));
     }
 
-    /**
-     * @cover ::put with valid data
-     */
     public function testPut(): void
     {
         $actualResult = $this->patientController->post($this->patientData);
@@ -121,9 +106,6 @@ class PatientRestControllerTest extends TestCase
         $this->assertEquals($this->patientData["phone_home"], $updatedPatient["phone_home"]);
     }
 
-    /**
-     * @cover ::getOne with an invalid uuid
-     */
     public function testGetOneInvalidUuid(): void
     {
         $actualResult = $this->patientController->getOne("not-a-uuid");
@@ -133,9 +115,6 @@ class PatientRestControllerTest extends TestCase
         $this->assertEquals([], $actualResult["data"]);
     }
 
-    /**
-     * @cover ::getOne with a valid uuid
-     */
     public function testGetOne(): void
     {
         // create a record
@@ -147,9 +126,6 @@ class PatientRestControllerTest extends TestCase
         $this->assertEquals($postedUuid, $actualResult["data"]["uuid"]);
     }
 
-    /**
-     * @cover ::getAll
-     */
     public function testGetAll(): void
     {
         $this->fixtureManager->installPatientFixtures();

--- a/tests/Tests/RestControllers/PractitionerRestControllerTest.php
+++ b/tests/Tests/RestControllers/PractitionerRestControllerTest.php
@@ -7,8 +7,6 @@ use OpenEMR\RestControllers\PractitionerRestController;
 use OpenEMR\Tests\Fixtures\PractitionerFixtureManager;
 
 /**
- * @coversDefaultClass OpenEMR\RestControllers\PractitionerRestController
- *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Yash Bothra <yashrajbothra786gmail.com>
@@ -74,9 +72,6 @@ class PractitionerRestControllerTest extends TestCase
         $this->fixtureManager->removePractitionerFixtures();
     }
 
-    /**
-     * @cover ::post with invalid data
-     */
     public function testPostInvalidData(): void
     {
         unset($this->practitionerData["fname"]);
@@ -87,9 +82,6 @@ class PractitionerRestControllerTest extends TestCase
         $this->assertEquals(0, count($actualResult["data"]));
     }
 
-    /**
-     * @cover ::post with valid data
-     */
     public function testPost(): void
     {
         $actualResult = $this->practitionerController->post($this->practitionerData);
@@ -103,9 +95,6 @@ class PractitionerRestControllerTest extends TestCase
         $this->assertGreaterThan(0, $practitionerPid);
     }
 
-    /**
-     * @cover ::put with invalid data
-     */
     public function testPutInvalidData(): void
     {
         $actualResult = $this->practitionerController->post($this->practitionerData);
@@ -122,9 +111,6 @@ class PractitionerRestControllerTest extends TestCase
         $this->assertEquals(0, count($actualResult["data"]));
     }
 
-    /**
-     * @cover ::put with valid data
-     */
     public function testPut(): void
     {
         $actualResult = $this->practitionerController->post($this->practitionerData);
@@ -145,9 +131,6 @@ class PractitionerRestControllerTest extends TestCase
         $this->assertEquals($this->practitionerData["email"], $updatedPractitioner["email"]);
     }
 
-    /**
-     * @cover ::getOne with an invalid uuid
-     */
     public function testGetOneInvalidUuid(): void
     {
         $actualResult = $this->practitionerController->getOne("not-a-uuid");
@@ -157,9 +140,6 @@ class PractitionerRestControllerTest extends TestCase
         $this->assertEquals([], $actualResult["data"]);
     }
 
-    /**
-     * @cover ::getOne with a valid uuid
-     */
     public function testGetOne(): void
     {
         // create a record
@@ -171,9 +151,6 @@ class PractitionerRestControllerTest extends TestCase
         $this->assertEquals($postedUuid, $actualResult["data"]["uuid"]);
     }
 
-    /**
-     * @cover ::getAll
-     */
     public function testGetAll(): void
     {
         $this->fixtureManager->installPractitionerFixtures();

--- a/tests/Tests/Validators/PatientValidatorTest.php
+++ b/tests/Tests/Validators/PatientValidatorTest.php
@@ -7,9 +7,6 @@ use OpenEMR\Tests\Fixtures\FixtureManager;
 use OpenEMR\Validators\PatientValidator;
 use OpenEMR\Common\Uuid\UuidRegistry;
 
-/**
- * @coversDefaultClass OpenEMR\Validators\PatientValidator
- */
 class PatientValidatorTest extends TestCase
 {
     private $patientValidator;
@@ -30,18 +27,12 @@ class PatientValidatorTest extends TestCase
         $this->fixtureManager->removePatientFixtures();
     }
 
-    /**
-     * @covers ::validate when an invalid context is used
-     */
     public function testValidationInvalidContext(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->patientValidator->validate($this->patientFixture, 'invalid-context');
     }
 
-    /**
-     * @covers ::validate for an insert context with an invalid record
-     */
     public function testValidationInsertFailure(): void
     {
         $this->patientFixture["fname"] = "";
@@ -52,9 +43,6 @@ class PatientValidatorTest extends TestCase
         $this->assertEquals(1, count($actualResult->getValidationMessages()));
     }
 
-    /**
-     * @covers ::validate for an insert context with a valid record
-     */
     public function testValidationInsertSuccess(): void
     {
         $actualResult = $this->patientValidator->validate($this->patientFixture, PatientValidator::DATABASE_INSERT_CONTEXT);
@@ -63,9 +51,6 @@ class PatientValidatorTest extends TestCase
         $this->assertEquals(0, count($actualResult->getValidationMessages()));
     }
 
-    /**
-     * @covers ::validate for an update context with an invalid record
-     */
     public function testValidationUpdateFailure(): void
     {
         $this->patientFixture["uuid"] = $this->fixtureManager->getUnregisteredUuid();
@@ -82,9 +67,6 @@ class PatientValidatorTest extends TestCase
         $this->assertEquals(3, count($actualResult->getValidationMessages()));
     }
 
-    /**
-     * @covers ::validate for an update context with a valid record
-     */
     public function testValidationUpdateSuccess(): void
     {
         $patientFixture = $this->fixtureManager->getSinglePatientFixture();
@@ -115,9 +97,6 @@ class PatientValidatorTest extends TestCase
         $this->assertEquals(0, count($actualResult->getValidationMessages()));
     }
 
-    /**
-     * @covers ::isExistingUuid for success and failure use-cases
-     */
     public function testIsExistingUuid(): void
     {
         // ensure we have an installed record/patient

--- a/tests/Tests/Validators/ProcessingResultTest.php
+++ b/tests/Tests/Validators/ProcessingResultTest.php
@@ -8,7 +8,6 @@ use OpenEMR\Validators\ProcessingResult;
 /**
  * Processing Result Tests
  *
- * @coversDefaultClass OpenEMR\Services\ServiceResult
  * @package   OpenEMR
  * @link      http://www.open-emr.org
  * @author    Dixon Whitmire <dixonwh@gmail.com>
@@ -25,9 +24,6 @@ class ProcessingResultTest extends TestCase
         $this->processingResult = new ProcessingResult();
     }
 
-    /**
-     * @cover ::__construct
-     */
     public function testConstruct(): void
     {
         $this->assertEquals(0, count($this->processingResult->getValidationMessages()));
@@ -39,14 +35,6 @@ class ProcessingResultTest extends TestCase
         $this->assertFalse($this->processingResult->hasErrors());
     }
 
-    /**
-     * @cover ::addValidationMessages
-     * @cover ::getValidationMessages
-     * @cover ::getInternalErrors
-     * @cover ::addInternalError
-     * @cover ::getData
-     * @cover ::addData
-     */
     public function testGetSetOperations(): void
     {
         $this->assertEquals(0, count($this->processingResult->getValidationMessages()));
@@ -62,9 +50,6 @@ class ProcessingResultTest extends TestCase
         $this->assertEquals(1, count($this->processingResult->getData()));
     }
 
-    /**
-     * @cover ::isValid
-     */
     public function testIsValid(): void
     {
         $this->assertTrue($this->processingResult->isValid());
@@ -73,9 +58,6 @@ class ProcessingResultTest extends TestCase
         $this->assertFalse($this->processingResult->isValid());
     }
 
-    /**
-     * @cover ::hasErrors
-     */
     public function testHasErrors(): void
     {
         // no validation or processing errors
@@ -95,9 +77,6 @@ class ProcessingResultTest extends TestCase
         $this->assertTrue($this->processingResult->hasErrors());
     }
 
-    /**
-     * @cover ::hasInternalErrors
-     */
     public function testHasInternalErrors(): void
     {
         $this->assertFalse($this->processingResult->hasInternalErrors());

--- a/tests/Tests/Validators/Rules/ListOptionRuleTest.php
+++ b/tests/Tests/Validators/Rules/ListOptionRuleTest.php
@@ -16,14 +16,8 @@ use OpenEMR\Validators\Rules\ListOptionRule;
 use Particle\Validator\MessageStack;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @coversDefaultClass OpenEMR\Validators\Rules\ListOptionRule
- */
 class ListOptionRuleTest extends TestCase
 {
-    /**
-     * @covers ::validate
-     */
     public function testValidateWithValidOptionId(): void
     {
         // test with a valid list id


### PR DESCRIPTION
Fixes #8683

#### Short description of what this resolves:

Removes the problematic `@covers` annotations. Ironically, this should cause the coverage ratio to increase, slightly.


#### Changes proposed in this pull request:

- [x] remove `@covers` annotations

#### Does your code include anything generated by an AI Engine? No
