### PR TITLE
chore(deps-dev): bump phpstan/phpstan from 2.1.18 to 2.1.20 in the development group

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -11523,16 +11523,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.18",
+            "version": "2.1.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "ee1f390b7a70cdf74a2b737e554f68afea885db7"
+                "reference": "a9ccfef95210f92ba6feea6e8d1eef42b5605499"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ee1f390b7a70cdf74a2b737e554f68afea885db7",
-                "reference": "ee1f390b7a70cdf74a2b737e554f68afea885db7",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/a9ccfef95210f92ba6feea6e8d1eef42b5605499",
+                "reference": "a9ccfef95210f92ba6feea6e8d1eef42b5605499",
                 "shasum": ""
             },
             "require": {
@@ -11577,7 +11577,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-07-17T17:22:31+00:00"
+            "time": "2025-07-26T20:45:26+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",

--- a/phpstan.github.neon
+++ b/phpstan.github.neon
@@ -11728,10 +11728,6 @@ parameters:
     identifier: variable.undefined
     count: 2
     path: interface/modules/custom_modules/oe-module-faxsms/library/utility.php
-  - message: '#^Variable \$pid might not be defined\.$#'
-    identifier: variable.undefined
-    count: 1
-    path: interface/modules/custom_modules/oe-module-faxsms/messageUI.php
   - message: '#^Variable \$tabTitle on left side of \?\? always exists and is not nullable\.$#'
     identifier: nullCoalesce.variable
     count: 1

--- a/phpstan.local.neon
+++ b/phpstan.local.neon
@@ -11656,10 +11656,6 @@ parameters:
     identifier: variable.undefined
     count: 2
     path: interface/modules/custom_modules/oe-module-faxsms/library/utility.php
-  - message: '#^Variable \$pid might not be defined\.$#'
-    identifier: variable.undefined
-    count: 1
-    path: interface/modules/custom_modules/oe-module-faxsms/messageUI.php
   - message: '#^Variable \$tabTitle on left side of \?\? always exists and is not nullable\.$#'
     identifier: nullCoalesce.variable
     count: 1


### PR DESCRIPTION
Fixes #8695

#### Short description of what this resolves:

Removes the error phpstan raises when updating to phpstan 2.1.20 due to an ignored error no longer being found.


#### Changes proposed in this pull request:

- chore(deps-dev): bump phpstan/phpstan in the development group
- ci(phpstan): remove resolved ignored errors

#### Does your code include anything generated by an AI Engine? No
