### PR TITLE
fix(EventAuditLogger): initialize $menuItems array

### DIFF
--- a/phpstan.github.neon
+++ b/phpstan.github.neon
@@ -17720,10 +17720,6 @@ parameters:
     identifier: isset.variable
     count: 1
     path: src/Common/Layouts/LayoutsUtils.php
-  - message: '#^Variable \$menuItems might not be defined\.$#'
-    identifier: variable.undefined
-    count: 1
-    path: src/Common/Logging/EventAuditLogger.php
   - message: '#^Variable \$logLevel in empty\(\) is never defined\.$#'
     identifier: empty.variable
     count: 1

--- a/phpstan.local.neon
+++ b/phpstan.local.neon
@@ -17624,10 +17624,6 @@ parameters:
     identifier: isset.variable
     count: 1
     path: src/Common/Layouts/LayoutsUtils.php
-  - message: '#^Variable \$menuItems might not be defined\.$#'
-    identifier: variable.undefined
-    count: 1
-    path: src/Common/Logging/EventAuditLogger.php
   - message: '#^Variable \$logLevel in empty\(\) is never defined\.$#'
     identifier: empty.variable
     count: 1

--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -176,6 +176,7 @@ MSG;
             $sqlMenuItems = "SELECT * FROM patient_portal_menu";
 
             $resMenuItems = sqlStatement($sqlMenuItems);
+            $menuItems = array();
             for ($iter = 0; $rowMenuItem = sqlFetchArray($resMenuItems); $iter++) {
                 $menuItems[$rowMenuItem['patient_portal_menu_id']] = $rowMenuItem['menu_name'];
             }


### PR DESCRIPTION
Fixes #8703

#### Short description of what this resolves:

Initialize $menuItems before use.


#### Changes proposed in this pull request:

Create an empty $menuItems array before adding items to it.

#### Does your code include anything generated by an AI Engine? No
