### PR TITLE
experiment: max-parallel in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,7 +121,7 @@ jobs:
       matrix:
         configurations: ${{ fromJson(needs.collect.outputs.configurations) }}
       # hypothesis: If we limit the parallelism of these jobs, we won't get the sporadic timeout in the e2e tests.
-      max-parallel: 8
+      max-parallel: 16
     env:
       DOCKER_DIR: ${{ matrix.configurations.docker_dir }}
       ENABLE_COVERAGE: ${{ matrix.configurations.docker_dir == 'apache_84_114' && 'true' || 'false' }}


### PR DESCRIPTION
My hypothesis is that by limiting the parallelism we might avoid the sporadic timeout that impacts the e2e tests
