### PR TITLE
CQM dependency cqm-execution

### DIFF
--- a/ccdaservice/package-lock.json
+++ b/ccdaservice/package-lock.json
@@ -646,7 +646,6 @@
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
             "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -2187,7 +2186,6 @@
             "version": "7.1.7",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
             "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -2457,7 +2455,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -3546,9 +3543,9 @@
             }
         },
         "node_modules/node-gyp": {
-            "version": "11.2.0",
-            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-11.2.0.tgz",
-            "integrity": "sha512-T0S1zqskVUSxcsSTkAsLc7xCycrRYmtDHadDinzocrThjyQCn5kMlEBSj6H4qDbgsIOSLmmlRIeb0lZXj+UArA==",
+            "version": "11.3.0",
+            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-11.3.0.tgz",
+            "integrity": "sha512-9J0+C+2nt3WFuui/mC46z2XCZ21/cKlFDuywULmseD/LlmnOrSeEAE4c/1jw6aybXLmpZnQY3/LmOJfgyHIcng==",
             "license": "MIT",
             "dependencies": {
                 "env-paths": "^2.2.0",
@@ -3729,7 +3726,6 @@
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
             "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-            "deprecated": "This package is no longer supported.",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -5439,7 +5435,7 @@
             "dependencies": {
                 "bluebird": "3.5.1",
                 "compression": "1.8.1",
-                "cqm-execution": "4.4.0",
+                "cqm-execution": "4.3.4",
                 "cqm-models": "4.3.0",
                 "express": "4.21.2",
                 "logform": "1.10.0",
@@ -5458,6 +5454,37 @@
             "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.14"
+            }
+        },
+        "packages/oe-cqm-service/node_modules/cql-execution": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-2.4.1.tgz",
+            "integrity": "sha512-1FRAPEy3zdQcN4dy9NyBcXoCoR3ubhrKyD+Og/4sxsahJx7U+ZAQbnJ5eFbfPxjvVnO/feWpMyXW8odvK1GCbQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@lhncbc/ucum-lhc": "^4.1.3",
+                "luxon": "^1.25.0"
+            }
+        },
+        "packages/oe-cqm-service/node_modules/cqm-execution": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/cqm-execution/-/cqm-execution-4.3.4.tgz",
+            "integrity": "sha512-Cm1NaoH8s+Eiu04STRMR2NbUZ3txzKaCqRIfdU72DApgzhVX2YICeyy0aZJ44nApAAWKHw0UfNIU08NNbQzh2w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "cqm-models": "4.2.4",
+                "lodash": "^4.17.19",
+                "moment": "^2.29.4"
+            }
+        },
+        "packages/oe-cqm-service/node_modules/cqm-execution/node_modules/cqm-models": {
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/cqm-models/-/cqm-models-4.2.4.tgz",
+            "integrity": "sha512-ZCC+3w/+D+9GU9mkxunnzCsDpebO3uDpOuZB2DO/uO2Mm6w7y3XAlZbqcMt0C/2DTY3wrO6yTTB/p0XKxU6qog==",
+            "license": "ISC",
+            "dependencies": {
+                "cql-execution": "2.4.1",
+                "mongoose": "^7.8.4"
             }
         },
         "packages/oe-cqm-service/node_modules/winston": {

--- a/ccdaservice/packages/oe-cqm-service/package.json
+++ b/ccdaservice/packages/oe-cqm-service/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "bluebird": "3.5.1",
     "compression": "1.8.1",
-    "cqm-execution": "4.4.0",
+    "cqm-execution": "4.3.4",
     "cqm-models": "4.3.0",
     "express": "4.21.2",
     "logform": "1.10.0",

--- a/ccdaservice/packages/oe-cqm-service/server.js
+++ b/ccdaservice/packages/oe-cqm-service/server.js
@@ -116,7 +116,7 @@ app.post('/calculate', function (request, response) {
   } catch(error) {
     logger.log({ level: 'error', message: `GET /calculate. error in the calculation engine: ${error} headers: ${JSON.stringify(request.headers)}` });
     response.status(500).send({'error in the calculation engine': error});
-    return;
+
   }
 
 });

--- a/src/Services/Qdm/QdmBuilder.php
+++ b/src/Services/Qdm/QdmBuilder.php
@@ -96,12 +96,18 @@ class QdmBuilder
                     // Use the service to make a QDM model with the data from the query result
                     try {
                         $qdmModel = $service->makeQdmModel($qdmRecord);
-                        // If for some reason the the model doesn't need to return a value, or the date is invalid, makeQdmModel can return null
-                        if ($qdmModel !== null) {
+                        // If for some reason the model doesn't need to return a value, or the date is invalid, makeQdmModel can return null
+                        if (!empty($qdmModel)) {
                             // Using the PID map, find the patient this model belongs to and add this data element
                             // to the correct patient's QDM model
                             $qdmPatient = $qdm_patients_map[$qdmRecord->getPid()];
-                            $qdmPatient->add_data_element($qdmModel);
+                            if (($qdmPatient ?? null) !== null) {
+                                $qdmPatient->add_data_element($qdmModel ?? '');
+                            } else {
+                                // If we don't have a QDM Patient model for this PID it's usually from a patient delete data model leftovers
+                                // care plans, medications etc. that were not deleted.
+                                error_log("QDM Builder Warning: No QDM Patient model found  on `$serviceClass` for PID = `{$qdmRecord->getPid()}`... Continuing execution.");
+                            }
                         } else {
                             error_log("QDM Builder Warning: NULL returned by makeQdmModel() on `$serviceClass` for PID = `{$qdmRecord->getPid()}`... Continuing execution.");
                         }


### PR DESCRIPTION
fix QdmBuilder to ignore pid's from deleted patients leaving artifacts. care plan, medications etc.
use highest cqm-execution v4.3.4 that supports 2022 reporting period. v4.4.0 dropped!

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #8712
