### PR TITLE
fix(EventAuditLogger): instantiate cryptogen only when needed

### DIFF
--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -22,15 +22,8 @@ class EventAuditLogger
 {
     use Singleton;
 
-    /**
-     * @var CryptoGen
-     */
-    private $cryptoGen;
-
-    /**
-     * @var boolean
-     */
-    private $breakglassUser;
+    private CryptoGen $cryptoGen;
+    private ?bool $breakglassUser = null;
 
     /**
      * Event action codes indicate whether the event is read/write.
@@ -42,6 +35,19 @@ class EventAuditLogger
     private const EVENT_ACTION_CODE_SELECT = 'R';
     private const EVENT_ACTION_CODE_UPDATE = 'U';
     private const EVENT_ACTION_CODE_DELETE = 'D';
+
+    /**
+     * Get the CryptoGen instance, initializing it if necessary
+     *
+     * @return CryptoGen
+     */
+    protected function getCryptoGen(): CryptoGen
+    {
+        if (!isset($this->cryptoGen)) {
+            $this->cryptoGen = new CryptoGen();
+        }
+        return $this->cryptoGen;
+    }
 
     /**
      * Keep track of the table mapping in a class constant to prevent reloading the data each time the method is called.
@@ -149,11 +155,11 @@ MSG;
      * @param $user
      * @param $groupname
      * @param $success
-     * @param string    $comments
-     * @param null      $patient_id
-     * @param string    $log_from
-     * @param string    $menu_item
-     * @param int       $ccda_doc_id
+     * @param string $comments
+     * @param null   $patient_id
+     * @param string $log_from
+     * @param string $menu_item
+     * @param int    $ccda_doc_id
      */
     public function newEvent(
         $event,
@@ -176,7 +182,7 @@ MSG;
             $sqlMenuItems = "SELECT * FROM patient_portal_menu";
 
             $resMenuItems = sqlStatement($sqlMenuItems);
-            $menuItems = array();
+            $menuItems = [];
             for ($iter = 0; $rowMenuItem = sqlFetchArray($resMenuItems); $iter++) {
                 $menuItems[$rowMenuItem['patient_portal_menu_id']] = $rowMenuItem['menu_name'];
             }
@@ -272,7 +278,7 @@ MSG;
                 $sortby = "";  //VicarePlus :: since there is no category field in extended_log
             }
 
-            $sqlBindArray = array();
+            $sqlBindArray = [];
             $columns = "DISTINCT date, event, user, recipient,patient_id,description";
             $sql = "SELECT $columns FROM extended_log WHERE date >= ? AND date <= ?";
             array_push($sqlBindArray, $date1, $date2);
@@ -293,13 +299,13 @@ MSG;
             }
 
             if ($sortby != "") {
-                $sql .= " ORDER BY " . escape_sql_column_name($sortby, array('extended_log')) . " DESC"; // descending order
+                $sql .= " ORDER BY " . escape_sql_column_name($sortby, ['extended_log']) . " DESC"; // descending order
             }
 
             $sql .= " LIMIT 5000";
         } else {
             // do the query
-            $sqlBindArray = array();
+            $sqlBindArray = [];
             $sql = "SELECT $cols FROM `log_comment_encrypt` as el " .
                 "LEFT OUTER JOIN `log` as l ON el.`log_id` = l.`id` " .
                 "LEFT OUTER JOIN `api_log` as al ON el.`log_id` = al.`log_id` " .
@@ -327,7 +333,7 @@ MSG;
             }
 
             if ($sortby != "") {
-                $sql .= " ORDER BY `" . escape_sql_column_name($sortby, array('log')) . "`  " . escape_sort_order($direction); // descending order
+                $sql .= " ORDER BY `" . escape_sql_column_name($sortby, ['log']) . "`  " . escape_sort_order($direction); // descending order
             } else {
                 $sql .= " ORDER BY el.`log_id` DESC";
             }
@@ -347,26 +353,14 @@ MSG;
      */
     protected function determineRFC3881EventActionCode($event)
     {
-        switch (substr($event, -7)) {
-            case '-create':
-                return self::EVENT_ACTION_CODE_CREATE;
-                break;
-            case '-insert':
-                return self::EVENT_ACTION_CODE_INSERT;
-                break;
-            case '-select':
-                return self::EVENT_ACTION_CODE_SELECT;
-                break;
-            case '-update':
-                return self::EVENT_ACTION_CODE_UPDATE;
-                break;
-            case '-delete':
-                return self::EVENT_ACTION_CODE_DELETE;
-                break;
-            default:
-                return self::EVENT_ACTION_CODE_EXECUTE;
-                break;
-        }
+        return match (substr((string) $event, -7)) {
+            '-create' => self::EVENT_ACTION_CODE_CREATE,
+            '-insert' => self::EVENT_ACTION_CODE_INSERT,
+            '-select' => self::EVENT_ACTION_CODE_SELECT,
+            '-update' => self::EVENT_ACTION_CODE_UPDATE,
+            '-delete' => self::EVENT_ACTION_CODE_DELETE,
+            default => self::EVENT_ACTION_CODE_EXECUTE,
+        };
     }
 
     /**
@@ -381,17 +375,17 @@ MSG;
 
         $eventIdDisplayName = $event;
 
-        if (strpos($event, 'patient-record') !== false) {
+        if (str_contains((string) $event, 'patient-record')) {
             $eventIdDisplayName = 'Patient Record';
-        } elseif (strpos($event, 'view') !== false) {
+        } elseif (str_contains((string) $event, 'view')) {
             $eventIdDisplayName = 'Patient Record';
-        } elseif (strpos($event, 'login') !== false) {
+        } elseif (str_contains((string) $event, 'login')) {
             $eventIdDisplayName = 'Login';
-        } elseif (strpos($event, 'logout') !== false) {
+        } elseif (str_contains((string) $event, 'logout')) {
             $eventIdDisplayName = 'Logout';
-        } elseif (strpos($event, 'scheduling') !== false) {
+        } elseif (str_contains((string) $event, 'scheduling')) {
             $eventIdDisplayName = 'Patient Care Assignment';
-        } elseif (strpos($event, 'security-administration') !== false) {
+        } elseif (str_contains((string) $event, 'security-administration')) {
             $eventIdDisplayName = 'Security Administration';
         }
 
@@ -454,7 +448,7 @@ MSG;
      */
     protected function createTlsConn($host, $port, $localcert, $cafile)
     {
-        $sslopts = array();
+        $sslopts = [];
         if ($cafile !== null && $cafile != "") {
             $sslopts['cafile'] = $cafile;
             $sslopts['verify_peer'] = true;
@@ -465,7 +459,7 @@ MSG;
             $sslopts['local_cert'] = $localcert;
         }
 
-        $opts = array('tls' => $sslopts, 'ssl' => $sslopts);
+        $opts = ['tls' => $sslopts, 'ssl' => $sslopts];
         $ctx = stream_context_create($opts);
         $timeout = 60;
         $flags = STREAM_CLIENT_CONNECT;
@@ -526,15 +520,10 @@ MSG;
      *
      * @param $statement
      * @param $outcome
-     * @param null      $binds
+     * @param null $binds
      */
     public function auditSQLEvent($statement, $outcome, $binds = null)
     {
-        // Set up crypto object that will be used by this singleton class for encryption/decryption (if not set up already)
-        if (!isset($this->cryptoGen)) {
-            $this->cryptoGen = new CryptoGen();
-        }
-
         $user =  $_SESSION['authUser'] ?? "";
 
         /* Don't log anything if the audit logging is not enabled. Exception for "emergency" users */
@@ -544,14 +533,14 @@ MSG;
             }
         }
 
-        $statement = trim($statement);
+        $statement = trim((string) $statement);
 
         if (
             (stripos($statement, "insert into log") !== false)      // avoid infinite loop
             || (stripos($statement, "insert into `log`") !== false) // avoid infinite loop
             || (stripos($statement, "FROM log ") !== false)         // avoid infinite loop
             || (stripos($statement, "FROM `log` ") !== false)       // avoid infinite loop
-            || (strpos($statement, "sequences") !== false)          // Don't log sequences - to avoid the affect due to GenID calls
+            || (str_contains($statement, "sequences"))          // Don't log sequences - to avoid the affect due to GenID calls
             || (stripos($statement, "SELECT count(") === 0)         // Skip SELECT count() statements.
         ) {
             return;
@@ -559,7 +548,7 @@ MSG;
 
         /* Determine the query type (select, update, insert, delete) */
         $querytype = "select";
-        $querytypes = array("select", "update", "insert", "delete","replace");
+        $querytypes = ["select", "update", "insert", "delete","replace"];
         foreach ($querytypes as $qtype) {
             if (stripos($statement, $qtype) === 0) {
                 $querytype = $qtype;
@@ -622,11 +611,11 @@ MSG;
         }
 
         foreach (self::LOG_TABLES as $table => $value) {
-            if (strpos($truncated_sql, $table) !== false) {
+            if (str_contains($truncated_sql, $table)) {
                 $event = $value;
                 $category = $this->eventCategoryFinder($comments, $event, $table);
                 break;
-            } elseif (strpos($truncated_sql, "form_") !== false) {
+            } elseif (str_contains($truncated_sql, "form_")) {
                 $event = "patient-record";
                 $category = $this->eventCategoryFinder($comments, $event, $table);
                 break;
@@ -697,10 +686,10 @@ MSG;
     /**
      * Record the patient disclosures.
      *
-     * @param $dates    - The date when the disclosures are sent to the third party.
-     * @param $event    - The type of the disclosure.
-     * @param $pid      - The id of the patient for whom the disclosures are recorded.
-     * @param $comment  - The recipient name and description of the disclosure.
+     * @param $dates   - The date when the disclosures are sent to the third party.
+     * @param $event   - The type of the disclosure.
+     * @param $pid     - The id of the patient for whom the disclosures are recorded.
+     * @param $comment - The recipient name and description of the disclosure.
      * @uname - The username who is recording the disclosure.
      */
     public function recordDisclosure($dates, $event, $pid, $recipient, $description, $user)
@@ -717,10 +706,14 @@ MSG;
     /**
      * Edit the disclosure record that is stored in the audit log.
      *
-     * @param $dates  - The date when the disclosures are sent to the thrid party.
-     * @param $event  - The type of the disclosure.
-     * param $comment - The recipient and the description of the disclosure are appended.
-     * $logeventid    - The id of the record which is to be edited.
+     * @param $dates - The date when the disclosures are sent to the thrid party.
+     * @param $event - The type of the disclosure.
+     *               param $comment - The
+     *               recipient and the description
+     *               of the disclosure are
+     *               appended. $logeventid    -
+     *               The id of the record which is
+     *               to be edited.
      */
     public function updateRecordedDisclosure($dates, $event, $recipient, $description, $disclosure_id)
     {
@@ -752,23 +745,20 @@ MSG;
         }
 
         // Encrypt if applicable
-        if (!isset($this->cryptoGen)) {
-            $this->cryptoGen = new CryptoGen();
-        }
-        $encrypt = 'No';
-        if (!empty($GLOBALS["enable_auditlog_encryption"])) {
+        if (empty($GLOBALS["enable_auditlog_encryption"])) {
+            // Since storing binary elements (uuid), need to base64 to not jarble them and to ensure the auditing hashing works
+            $comments = base64_encode((string) $comments);
+            $encrypt = 'No';
+        } else {
             // encrypt the comments field
-            $comments =  $this->cryptoGen->encryptStandard($comments);
+            $comments =  $this->getCryptoGen()->encryptStandard($comments);
             if (!empty($api)) {
                 // api log
-                $api['request_url'] = (!empty($api['request_url'])) ? $this->cryptoGen->encryptStandard($api['request_url']) : '';
-                $api['request_body'] = (!empty($api['request_body'])) ? $this->cryptoGen->encryptStandard($api['request_body']) : '';
-                $api['response'] =  (!empty($api['response'])) ? $this->cryptoGen->encryptStandard($api['response']) : '';
+                $api['request_url'] = (!empty($api['request_url'])) ? $this->getCryptoGen()->encryptStandard($api['request_url']) : '';
+                $api['request_body'] = (!empty($api['request_body'])) ? $this->getCryptoGen()->encryptStandard($api['request_body']) : '';
+                $api['response'] =  (!empty($api['response'])) ? $this->getCryptoGen()->encryptStandard($api['response']) : '';
             }
             $encrypt = 'Yes';
-        } else {
-            // Since storing binary elements (uuid), need to base64 to not jarble them and to ensure the auditing hashing works
-            $comments = base64_encode($comments);
         }
 
         // Collect timestamp and if pertinent, collect client cert name
@@ -804,7 +794,7 @@ MSG;
         sqlInsertClean_audit("insert into `log` (`date`, `event`, `category`, `user`, `groupname`, `comments`, `user_notes`, `patient_id`, `success`, `crt_user`, `log_from`, `menu_item_id`, `ccda_doc_id`) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", $logEntry);
         // 2. insert associated entry (in addition to calculating and storing applicable checksums) into log_comment_encrypt
         $last_log_id = $GLOBALS['adodb']['db']->Insert_ID();
-        $checksumGenerate = hash('sha3-512', implode($logEntry));
+        $checksumGenerate = hash('sha3-512', implode('', $logEntry));
         if (!empty($api)) {
             // api log
             $ipAddress = collectIpAddresses()['ip_string'];
@@ -820,7 +810,7 @@ MSG;
                 $api['response'],
                 $current_datetime
             ];
-            $checksumGenerateApi = hash('sha3-512', implode($apiLogEntry));
+            $checksumGenerateApi = hash('sha3-512', implode('', $apiLogEntry));
         } else {
             $checksumGenerateApi = '';
         }
@@ -895,8 +885,8 @@ MSG;
     protected function eventCategoryFinder($sql, $event, $table)
     {
         if ($event == 'delete') {
-            if (strpos($sql, "lists:") === 0) {
-                $fieldValues    = explode("'", $sql);
+            if (str_starts_with((string) $sql, "lists:")) {
+                $fieldValues    = explode("'", (string) $sql);
                 if (in_array('medical_problem', $fieldValues) === true) {
                     return 'Problem List';
                 } elseif (in_array('medication', $fieldValues) === true) {
@@ -908,7 +898,7 @@ MSG;
         }
 
         if ($table == 'lists' || $table == 'lists_touch') {
-            $trimSQL        = stristr($sql, $table);
+            $trimSQL        = stristr((string) $sql, (string) $table);
             $fieldValues    = explode("'", $trimSQL);
             if (in_array('medical_problem', $fieldValues) === true) {
                 return 'Problem List';
@@ -923,7 +913,7 @@ MSG;
             return "Vitals";
         } elseif ($table == 'history_data') {
             return "Social and Family History";
-        } elseif ($table == 'forms' || $table == 'form_encounter' || strpos($table, 'form_') === 0) {
+        } elseif ($table == 'forms' || $table == 'form_encounter' || str_starts_with((string) $table, 'form_')) {
             return "Encounter Form";
         } elseif ($table == 'insurance_data') {
             return "Patient Insurance";
@@ -936,7 +926,7 @@ MSG;
         } elseif ($table == 'prescriptions') {
             return "Medication";
         } elseif ($table == 'transactions') {
-            $trimSQL        = stristr($sql, "transactions");
+            $trimSQL        = stristr((string) $sql, "transactions");
             $fieldValues    = explode("'", $trimSQL);
             if (in_array("LBTref", $fieldValues)) {
                 return "Referral";
@@ -984,13 +974,7 @@ MSG;
             AND BINARY `gacl_aro`.`value` = ?",
             [$user]
         );
-        if (empty($queryUser)) {
-            // user is not in breakglass group
-            $this->breakglassUser = false;
-        } else {
-            // user is in breakglass group
-            $this->breakglassUser = true;
-        }
+        $this->breakglassUser = !empty($queryUser);
         return $this->breakglassUser;
     }
 }


### PR DESCRIPTION
Fixes #8652

- [x] waiting for #8719 

#### Short description of what this resolves:

instantiates CryptoGen in EventAuditLogger when EventAuditLogger tries to use it. Otherwise, doesn't.


#### Changes proposed in this pull request:

Creates a lazy getter for CryptoGen in the EventAuditLogger so it instantiates CryptoGen when something tries to access it.

#### Does your code include anything generated by an AI Engine? No
