### PR TITLE
fix(QdmBuilder): phpstan complaint

### DIFF
--- a/src/Services/Qdm/QdmBuilder.php
+++ b/src/Services/Qdm/QdmBuilder.php
@@ -102,7 +102,7 @@ class QdmBuilder
                             // to the correct patient's QDM model
                             $qdmPatient = $qdm_patients_map[$qdmRecord->getPid()];
                             if (($qdmPatient ?? null) !== null) {
-                                $qdmPatient->add_data_element($qdmModel ?? '');
+                                $qdmPatient->add_data_element($qdmModel);
                             } else {
                                 // If we don't have a QDM Patient model for this PID it's usually from a patient delete data model leftovers
                                 // care plans, medications etc. that were not deleted.


### PR DESCRIPTION
Fixes #8728

#### Short description of what this resolves:

Address `Variable $qdmModel on left side of ?? always exists and is not nullable.`

#### Changes proposed in this pull request:

Remove the null coalescing operator.

#### Does your code include anything generated by an AI Engine? No
