### PR TITLE
fix: Use selenium/standalone-chromium to enable support for both AMD64 & ARM64

### DIFF
--- a/docker/development-easy/docker-compose.yml
+++ b/docker/development-easy/docker-compose.yml
@@ -101,7 +101,7 @@ services:
       retries: 3
   selenium:
     restart: always
-    image: selenium/standalone-chrome:134.0-chromedriver-134.0-grid-4.31.0-20250414    # Pinned to Chrome 134 and grid 4.31
+    image: selenium/standalone-chromium:4 # Pins to Selenium Grid major version 4 using the latest compatible version of chrome driver, amd64 & arm64 support
     ports:
     - 4444:4444    # Selenium WebDriver interface
     - 7900:7900    # VNC port for viewing browser during tests (to work, will require SELENIUM_FORCE_HEADLESS to be "false" in openemr service)


### PR DESCRIPTION


This change pins to v4 of the upstream Selenium Grid with the latest compatible version of Chromedriver. It is using Chromium as the base versus Chrome. The primary issue with the selenium/standalone-chrome image is that it does not ship an ARM64 image thereby breaking the docker compose on ARM64 like MacOS.

Fixes # https://github.com/openemr/openemr/issues/8732

#### Short description of what this resolves:

Supports AMD64 & ARM64 with the Selenium Chromedriver.

#### Changes proposed in this pull request:

Use the upstream chromium flavor of the image that does support ARM64

#### Does your code include anything generated by an AI Engine?  No
