### PR TITLE
fix: change selenium testing from chrome to chromium to support arm64 docker builds in dev environments

### DIFF
--- a/ci/compose-shared-selenium.yml
+++ b/ci/compose-shared-selenium.yml
@@ -1,6 +1,6 @@
 services:
   selenium:
-    image: selenium/standalone-chrome:134.0-chromedriver-134.0-grid-4.31.0-20250414    # Pinned to Chrome 134 and grid 4.31
+    image: selenium/standalone-chromium:135.0-chromedriver-135.0-grid-4.31.0-20250404 # Pinned to Chromium 135 and grid 4.31
     # Services with profiles don't start by default.
     profiles:
     - selenium

--- a/docker/development-insane/docker-compose.yml
+++ b/docker/development-insane/docker-compose.yml
@@ -678,7 +678,7 @@ services:
     - 9443:9443
   selenium:
     restart: always
-    image: selenium/standalone-chrome:134.0-chromedriver-134.0-grid-4.31.0-20250414    # Pinned to Chrome 134 and grid 4.31
+    image: selenium/standalone-chromium:135.0-chromedriver-135.0-grid-4.31.0-20250404 # Pinned to Chromium 135 and grid 4.31
     ports:
     - 4444:4444    # Selenium WebDriver interface
     - 7900:7900    # VNC port for viewing browser during tests (to work, will require SELENIUM_FORCE_HEADLESS to be "false" in openemr service)


### PR DESCRIPTION
fix: change selenium testing from chrome to chromium to support arm64 docker builds in dev environments
