### PR TITLE
fix(sql.inc.php): exit(1) on query error

### DIFF
--- a/custom/code_types.inc.php
+++ b/custom/code_types.inc.php
@@ -729,15 +729,13 @@ function code_set_search($form_code_type, $search_term = "", $count = false, $ac
         }
     } // End specific code type search
 
-    if (isset($res)) {
-        if ($count) {
-            // just return the count
-            $ret = sqlFetchArray($res);
-            return $ret['count'];
-        }
-        // return the data
-        return $res;
+    if ($count) {
+        // just return the count
+        $ret = sqlFetchArray($res);
+        return $ret['count'];
     }
+    // return the data
+    return $res;
 }
 
 /**

--- a/library/sql.inc.php
+++ b/library/sql.inc.php
@@ -98,7 +98,6 @@ if (!$GLOBALS['dbh']) {
         echo "Check that you can ping the server " . text($host) . ".<p>";
     }//if local
     HelpfulDie("Could not connect to server!", getSqlLastError());
-    exit;
 }//if no connection
 
 /**
@@ -547,7 +546,7 @@ function sqlNumRows($r)
 * @param string $statement
 * @param string $sqlerr
 */
-function HelpfulDie($statement, $sqlerr = ''): void
+function HelpfulDie($statement, $sqlerr = ''): never
 {
 
     echo "<h2><font color='red'>" . xlt('Query Error') . "</font></h2>";
@@ -582,7 +581,7 @@ function HelpfulDie($statement, $sqlerr = ''): void
 
     error_log(errorLogEscape($logMsg));
 
-    exit;
+    exit(1);
 }
 
 /**
@@ -817,7 +816,7 @@ function privStatement($sql, $params = null)
 
         error_log("Executing as user:" . errorLogEscape(getPrivDB()->user) . " Statement failed:" . errorLogEscape($sql) . ":" . errorLogEscape($GLOBALS['last_mysql_error'])
             . "==>" . errorLogEscape($backtrace[1]["file"]) . " at " . errorLogEscape($backtrace[1]["line"]) . ":" . errorLogEscape($backtrace[1]["function"]));
-        exit;
+        exit(1);
     }
 
     return $recordset;


### PR DESCRIPTION
Fixes #8753

#### Short description of what this resolves:

`exit(1)` instead of `exit` in sql.inc.php so the OS can correctly interpret them as failure conditions.


#### Changes proposed in this pull request:

- [x] change error exits to `exit(1)`
- [x] clarify that `HelpfulDie` never returns
- [x] don't run dead code after `HelpfulDie`

#### Does your code include anything generated by an AI Engine? No
