### PR TITLE
Feat(Option to automatically open a pt's issues tab when pt demographics are open.  Issues tab auto closes when new pt is selected)

### DIFF
--- a/interface/main/tabs/js/frame_proxies.js
+++ b/interface/main/tabs/js/frame_proxies.js
@@ -47,6 +47,40 @@ left_nav.setPatient = function(pname, pid, pubpid, frname, str_dob)
         tabCloseByName('rev');
     });
 
+    if (AutoIssuesTab) {
+        loadPatientIssues("leftNav");
+
+
+//**ERX
+        left_nav.setPatientErx = function () {
+            navigateTab(webroot_url + "/interface/eRx.php", "er1");
+
+
+        };
+
+//Close the open tabs to previous pt.
+        left_nav.closeErx = function () {
+            tabCloseByName('er1');
+            tabCloseByName('er2');
+            tabCloseByName('er3');
+            tabCloseByName('enc2');
+            tabCloseByName('imm1');
+            tabCloseByName('imm2');
+            tabCloseByName('imm3');
+
+        };
+
+//This function has been added to refresh open eRx tabs with a newly selected patient.  At this time
+//the tabRefreshByName function is not working with eRx.
+        left_nav.refreshErx = function () {
+
+            tabRefreshByName('er1');
+            tabRefreshByName('er2');
+            tabRefreshByName('er3');
+            tabRefreshByName('enc2');
+
+        }
+    }
     /* close therapy group tabs */
     tabCloseByName('gdg');
     attendant_type = 'patient';

--- a/interface/main/tabs/js/tabs_view_model.js
+++ b/interface/main/tabs/js/tabs_view_model.js
@@ -5,8 +5,10 @@
  * @link      http://www.open-emr.org
  * @author    Kevin Yeh <kevin.y@integralemr.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Daniel Pflieger <daniel@growlingflea.com>
  * @copyright Copyright (c) 2016 Kevin Yeh <kevin.y@integralemr.com>
  * @copyright Copyright (c) 2016 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2025 Daniel Pflieger <daniel@growlingflea.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -402,6 +404,7 @@ function clearPatient(openFinder = true)
     top.restoreSession();
     app_view_model.application_data.patient(null);
     tabCloseByName('enc');
+    tabCloseByName('enc2'); //***closes the issues tab
     tabCloseByName('rev');
     tabCloseByName('pop');
     tabCloseByName('pat');
@@ -426,6 +429,15 @@ function clearPatient(openFinder = true)
         },
         success:function( msg ) { }
 	});
+}
+
+
+function loadPatientIssues(fun = '')
+{
+    console.log("***loadPatientIssues***" + fun);
+    let  url = webroot_url+'/interface/patient_file/summary/stats_full.php';
+    navigateTab(url,"gfn");
+    //activateTabByName("enc2",true);
 }
 
 function clearTherapyGroup()

--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -118,6 +118,7 @@ $twig = (new TwigContainer(null, $GLOBALS['kernel']))->getTwig();
         jsGlobals.time_display_format = <?php echo js_escape($GLOBALS['time_display_format']); ?>;
         jsGlobals.timezone = <?php echo js_escape($GLOBALS['gbl_time_zone'] ?? ''); ?>;
         jsGlobals.assetVersion = <?php echo js_escape($GLOBALS['v_js_includes']); ?>;
+        let AutoIssuesTab = <?php echo js_escape($GLOBALS['issues_auto_tab']); ?>;
         var WindowTitleAddPatient = <?php echo($GLOBALS['window_title_add_patient_name'] ? 'true' : 'false'); ?>;
         var WindowTitleBase = <?php echo js_escape($openemr_name); ?>;
         const isSms = "<?php echo !empty($GLOBALS['oefax_enable_sms'] ?? null); ?>";

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -1098,6 +1098,13 @@ $GLOBALS_METADATA = array(
             xl('Warn if not enough data to graph')
         ),
 
+        'issues_auto_tab' => array(
+            xl('Automatically Open Pt Issues on Demographics Screen'),
+            'bool',                           // data type
+            '0',                              // default false
+            xl('Pt. Issues will auto open when checked.  Opening a new pt will close all tabs related to previous pt.')
+        ),
+
     ),
     // Report Tab
     //


### PR DESCRIPTION
…raphics is opened.  When a new pt is opened, all tabs activate to the new pt

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:
Feature that allows the end user to automatically open a pt's issue tab when demographics is opened.  When a new pt is selected the previous tabs last pt closed and new tabs open for the new pt. 

#### Changes proposed in this pull request:

#### Does your code include anything generated by an AI Engine? Yes / No

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.
