### PR TITLE
ci: max-parallel in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,6 +126,8 @@ jobs:
       fail-fast: false
       matrix:
         configurations: ${{ fromJson(needs.collect.outputs.configurations) }}
+      # hypothesis: If we limit the parallelism of these jobs, we won't get the sporadic timeout in the e2e tests.
+      max-parallel: 7  # half of the current 14 test configs
     env:
       DOCKER_DIR: ${{ matrix.configurations.docker_dir }}
       ENABLE_COVERAGE: ${{ matrix.configurations.docker_dir == 'apache_84_114' && 'true' || 'false' }}


### PR DESCRIPTION
#### Short description of what this resolves:

By limiting the parallelism we might avoid the sporadic timeout that impacts the e2e tests. It won't hurt much to try it.


#### Changes proposed in this pull request:

Set max-parallel for the test matrix.

#### Does your code include anything generated by an AI Engine? No
