### PR TITLE
fix(phpstan): space after closing

### DIFF
--- a/interface/modules/custom_modules/oe-module-claimrev-connect/templates/benefit.php
+++ b/interface/modules/custom_modules/oe-module-claimrev-connect/templates/benefit.php
@@ -1,10 +1,8 @@
 <?php
 
 /**
- *
- * @package OpenEMR
- * @link    http://www.open-emr.org
- *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
  * @author    Brad Sharp <brad.sharp@claimrev.com>
  * @copyright Copyright (c) 2022 Brad Sharp <brad.sharp@claimrev.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
@@ -63,13 +61,7 @@ foreach ($benefits as $benefit) {
             include 'related_entity.php';
             include 'messages.php';
     ?>
-
-
-
     </div>
 </div>
     <?php
 }
-?>
-
-

--- a/interface/modules/custom_modules/oe-module-claimrev-connect/templates/source.php
+++ b/interface/modules/custom_modules/oe-module-claimrev-connect/templates/source.php
@@ -1,10 +1,8 @@
 <?php
 
 /**
- *
- * @package OpenEMR
- * @link    http://www.open-emr.org
- *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
  * @author    Brad Sharp <brad.sharp@claimrev.com>
  * @copyright Copyright (c) 2022 Brad Sharp <brad.sharp@claimrev.com>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
@@ -30,11 +28,6 @@ if ($source != null) {
                     </div>
                 </div>
             </div>
-
         </div>
-
     <?php
 }
-?>
-
-

--- a/interface/reports/message_list.php
+++ b/interface/reports/message_list.php
@@ -305,6 +305,4 @@ if (empty($_POST['form_csvexport'])) {
 
 </html>
     <?php
-} // end not export
-?>
-
+}

--- a/phpstan.github.neon
+++ b/phpstan.github.neon
@@ -11384,10 +11384,6 @@ parameters:
     identifier: variable.undefined
     count: 3
     path: interface/modules/custom_modules/oe-module-claimrev-connect/templates/additional_info.php
-  - message: '#^File ends with a trailing whitespace\. This may cause problems when running the code in the web browser\. Remove the closing \?\> mark or remove the whitespace\.$#'
-    identifier: whitespace.fileEnd
-    count: 1
-    path: interface/modules/custom_modules/oe-module-claimrev-connect/templates/benefit.php
   - message: '#^Variable \$benefits might not be defined\.$#'
     identifier: variable.undefined
     count: 1
@@ -11440,10 +11436,6 @@ parameters:
     identifier: variable.undefined
     count: 3
     path: interface/modules/custom_modules/oe-module-claimrev-connect/templates/service_delivery.php
-  - message: '#^File ends with a trailing whitespace\. This may cause problems when running the code in the web browser\. Remove the closing \?\> mark or remove the whitespace\.$#'
-    identifier: whitespace.fileEnd
-    count: 1
-    path: interface/modules/custom_modules/oe-module-claimrev-connect/templates/source.php
   - message: '#^Variable \$source might not be defined\.$#'
     identifier: variable.undefined
     count: 1
@@ -14060,10 +14052,6 @@ parameters:
     identifier: variable.undefined
     count: 1
     path: interface/reports/ippf_statistics.php
-  - message: '#^File ends with a trailing whitespace\. This may cause problems when running the code in the web browser\. Remove the closing \?\> mark or remove the whitespace\.$#'
-    identifier: whitespace.fileEnd
-    count: 1
-    path: interface/reports/message_list.php
   - message: '#^Variable \$srcdir might not be defined\.$#'
     identifier: variable.undefined
     count: 2

--- a/phpstan.local.neon
+++ b/phpstan.local.neon
@@ -11384,10 +11384,6 @@ parameters:
     identifier: variable.undefined
     count: 3
     path: interface/modules/custom_modules/oe-module-claimrev-connect/templates/additional_info.php
-  - message: '#^File ends with a trailing whitespace\. This may cause problems when running the code in the web browser\. Remove the closing \?\> mark or remove the whitespace\.$#'
-    identifier: whitespace.fileEnd
-    count: 1
-    path: interface/modules/custom_modules/oe-module-claimrev-connect/templates/benefit.php
   - message: '#^Variable \$benefits might not be defined\.$#'
     identifier: variable.undefined
     count: 1
@@ -11440,10 +11436,6 @@ parameters:
     identifier: variable.undefined
     count: 3
     path: interface/modules/custom_modules/oe-module-claimrev-connect/templates/service_delivery.php
-  - message: '#^File ends with a trailing whitespace\. This may cause problems when running the code in the web browser\. Remove the closing \?\> mark or remove the whitespace\.$#'
-    identifier: whitespace.fileEnd
-    count: 1
-    path: interface/modules/custom_modules/oe-module-claimrev-connect/templates/source.php
   - message: '#^Variable \$source might not be defined\.$#'
     identifier: variable.undefined
     count: 1
@@ -14036,10 +14028,6 @@ parameters:
     identifier: variable.undefined
     count: 1
     path: interface/reports/ippf_statistics.php
-  - message: '#^File ends with a trailing whitespace\. This may cause problems when running the code in the web browser\. Remove the closing \?\> mark or remove the whitespace\.$#'
-    identifier: whitespace.fileEnd
-    count: 1
-    path: interface/reports/message_list.php
   - message: '#^Variable \$srcdir might not be defined\.$#'
     identifier: variable.undefined
     count: 2


### PR DESCRIPTION
Fixes #8800 

#### Short description of what this resolves:

Fixes the three cases where a file ends with `?>`.


#### Changes proposed in this pull request:

Remove the `?>` at the end of files.

#### Does your code include anything generated by an AI Engine? No
