### PR TITLE
fix(import_ccda): don't use result of void function

### DIFF
--- a/contrib/util/ccda_import/import_ccda.php
+++ b/contrib/util/ccda_import/import_ccda.php
@@ -161,7 +161,7 @@ foreach (glob($dir) as $file) {
         if ($dedup) {
             $patientData = CdaComponentParseHelpers::parseCcdaPatientRole($file);
             if (empty($patientData)) {
-                echo outputMessage("File load issue. Skipping: " . text($file) . "\n");
+                outputMessage("File load issue. Skipping: " . text($file) . "\n");
                 continue;
             }
             $duplicates = CdaComponentParseHelpers::checkDuplicatePatient($patientData);
@@ -170,7 +170,7 @@ foreach (glob($dir) as $file) {
                     CdaComponentParseHelpers::moveToDuplicateDir($file, $duplicateDir);
                 }
                 $dups = count(($duplicates ?? []));
-                echo outputMessage("Patient is duplicated " . text($dups) . " times. Patient skipped: " . json_encode($duplicates[0]) . "\n");
+                outputMessage("Patient is duplicated " . text($dups) . " times. Patient skipped: " . json_encode($duplicates[0]) . "\n");
                 continue;
             }
         }
@@ -218,12 +218,12 @@ foreach (glob($dir) as $file) {
 }
 $timeSec = round(((round(microtime(true) * 1000)) - $millisecondsStart) / 1000);
 if ($counter > 0) {
-    echo outputMessage("Completed patients import (" . $counter . " patients) (" . $timeSec . " total seconds) (" . (($timeSec) / $counter) . " average seconds per patient)");
-//  4. run function to populate all the uuids via the universal service function that already exists
-    echo outputMessage("Started uuid creation");
+    outputMessage("Completed patients import (" . $counter . " patients) (" . $timeSec . " total seconds) (" . (($timeSec) / $counter) . " average seconds per patient)");
+    //  4. run function to populate all the uuids via the universal service function that already exists
+    outputMessage("Started uuid creation");
     UuidRegistry::populateAllMissingUuids(false);
     $timeSec = round(((round(microtime(true) * 1000)) - $millisecondsStart) / 1000);
-    echo outputMessage("Completed uuid creation (" . $timeSec . " total seconds; " . $timeSec / 3600 . " total hours)\n");
+    outputMessage("Completed uuid creation (" . $timeSec . " total seconds; " . $timeSec / 3600 . " total hours)\n");
 }
 
 outputMessage("Finished patients import" . " $counter\n");

--- a/phpstan.github.neon
+++ b/phpstan.github.neon
@@ -184,10 +184,6 @@ parameters:
     identifier: variable.undefined
     count: 2
     path: ccr/transmitCCD.php
-  - message: '#^Result of function outputMessage \(void\) is used\.$#'
-    identifier: function.void
-    count: 5
-    path: contrib/util/ccda_import/import_ccda.php
   - message: '#^Variable \$duplicates on left side of \?\? always exists and is not nullable\.$#'
     identifier: nullCoalesce.variable
     count: 1
@@ -11624,10 +11620,6 @@ parameters:
     identifier: nullCoalesce.variable
     count: 1
     path: interface/modules/custom_modules/oe-module-faxsms/index.php
-  - message: '#^Function cron_updateentry invoked with 4 parameters, 3 required\.$#'
-    identifier: arguments.count
-    count: 2
-    path: interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php
   - message: '#^Variable \$args on left side of \?\? always exists and is not nullable\.$#'
     identifier: nullCoalesce.variable
     count: 1
@@ -12843,18 +12835,6 @@ parameters:
   - message: '#^Function oeFormatMoney invoked with 3 parameters, 1\-2 required\.$#'
     identifier: arguments.count
     count: 5
-    path: interface/patient_file/pos_checkout_ippf.php
-  - message: '#^Function receiptPaymentLine invoked with 4 parameters, 2\-3 required\.$#'
-    identifier: arguments.count
-    count: 1
-    path: interface/patient_file/pos_checkout_ippf.php
-  - message: '#^Function receiptPaymentLine invoked with 6 parameters, 2\-3 required\.$#'
-    identifier: arguments.count
-    count: 1
-    path: interface/patient_file/pos_checkout_ippf.php
-  - message: '#^Function write_form_line invoked with 10 parameters, 8 required\.$#'
-    identifier: arguments.count
-    count: 2
     path: interface/patient_file/pos_checkout_ippf.php
   - message: '#^Variable \$arates in empty\(\) always exists and is not falsy\.$#'
     identifier: empty.variable


### PR DESCRIPTION
Fixes #8805

#### Short description of what this resolves:

Removes `echo` before function call on a void function.


#### Changes proposed in this pull request:

- [x] remove use of void function output.
- [x] remove some phpstan baseline misses.

#### Does your code include anything generated by an AI Engine? No
