### PR TITLE
fix: use 24 hour format for billing tracker created at datetime

### DIFF
--- a/src/Billing/BillingProcessor/X12RemoteTracker.php
+++ b/src/Billing/BillingProcessor/X12RemoteTracker.php
@@ -139,8 +139,8 @@ class X12RemoteTracker extends BaseService
 
     public static function create($fields)
     {
-        $fields['created_at'] = date('Y-m-d h:i:s');
-        $fields['updated_at'] = date('Y-m-d h:i:s');
+        $fields['created_at'] = date('Y-m-d H:i:s');
+        $fields['updated_at'] = date('Y-m-d H:i:s');
         $remoteTracker = new X12RemoteTracker();
         return $remoteTracker->insert($fields);
     }


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #8807

#### Short description of what this resolves:


#### Changes proposed in this pull request:

#### Does your code include anything generated by an AI Engine? Yes / No

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.
