### PR TITLE
fix(stats.php): erx enabled and medication comparison operator

### DIFF
--- a/interface/patient_file/summary/demographics.php
+++ b/interface/patient_file/summary/demographics.php
@@ -1155,7 +1155,7 @@ $oemr_ui = new OemrUI($arrOeUiSettings);
 
                 // Render the Prescriptions card if turned on
                 if ($rx === 1) :
-                    if ($GLOBALS['erx_enable'] && $display_current_medications_below == 1) {
+                    if ($GLOBALS['erx_enable'] && ($display_current_medications_below ?? '') == 1) {
                         $sql = "SELECT * FROM prescriptions WHERE patient_id = ? AND active = '1'";
                         $res = sqlStatement($sql, [$pid]);
 

--- a/interface/patient_file/summary/stats.php
+++ b/interface/patient_file/summary/stats.php
@@ -182,7 +182,7 @@ foreach ($ISSUE_TYPES as $key => $arr) {
     //
     if (count($issues) > 0 || $arr[4] == 1) {
         $old_key = $key;
-        if ($GLOBALS['erx_enable'] && $key = "medication") {
+        if ($GLOBALS['erx_enable'] && $key == "medication") {
             $sqlUploadedArr = [
                 "SELECT * FROM lists WHERE pid = ? AND type = 'medication' AND",
                 dateEmptySql('enddate'),


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #8802

#### Short description of what this resolves:


#### Changes proposed in this pull request:

#### Does your code include anything generated by an AI Engine? Yes / No

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.
