### PR TITLE
ci(test): remove max-parallel setting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,8 +135,6 @@ jobs:
       fail-fast: false
       matrix:
         configurations: ${{ fromJson(needs.collect.outputs.configurations) }}
-      # hypothesis: If we limit the parallelism of these jobs, we won't get the sporadic timeout in the e2e tests.
-      max-parallel: 7  # half of the current 14 test configs
     env:
       DOCKER_DIR: ${{ matrix.configurations.docker_dir }}
       ENABLE_COVERAGE: ${{ matrix.configurations.docker_dir == 'apache_84_114' && 'true' || 'false' }}


### PR DESCRIPTION
Fixes #8810 


#### Short description of what this resolves:

The max-parallel setting is not doing any good, so let's remove it.