### PR TITLE
fix(NotificationEventListener): isSmsEnabled is always defined

### DIFF
--- a/interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php
@@ -27,11 +27,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class NotificationEventListener implements EventSubscriberInterface
 {
-    /**
-     * @var int|mixed
-     */
     private bool $isSmsEnabled;
-    private mixed $isEmailEnabled;
+    private bool $isEmailEnabled;
     private bool $isFaxEnabled;
     private bool $isVoiceEnabled;
     private EventDispatcherInterface $eventDispatcher;
@@ -442,7 +439,7 @@ class NotificationEventListener implements EventSubscriberInterface
         $baseUrl = "/interface/modules/custom_modules/oe-module-faxsms/contact.php?";
         $type = $_REQUEST['type'] ?? 'sms';
         $queryParams = [];
-        $queryParams['xmitMode'] = (($this->isSmsEnabled ?? false) && ($this->isEmailEnabled ?? false)) ? 'both' : 'sms';
+        $queryParams['xmitMode'] = (($this->isSmsEnabled) && ($this->isEmailEnabled)) ? 'both' : 'sms';
         $queryParams['isSMS'] = $this->isSmsEnabled;
         $queryParams['isEmail'] = $this->isEmailEnabled;
         $queryParams['isFax'] = $this->isFaxEnabled;

--- a/phpstan.github.neon
+++ b/phpstan.github.neon
@@ -11732,10 +11732,6 @@ parameters:
     identifier: empty.variable
     count: 1
     path: interface/modules/custom_modules/oe-module-faxsms/src/EtherFax/EtherFaxClient.php
-  - message: '#^Property OpenEMR\\Modules\\FaxSMS\\Events\\NotificationEventListener\:\:\$isSmsEnabled on left side of \?\? is not nullable nor uninitialized\.$#'
-    identifier: nullCoalesce.initializedProperty
-    count: 1
-    path: interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php
   - message: '#^Variable \$data on left side of \?\? is never defined\.$#'
     identifier: nullCoalesce.variable
     count: 1


### PR DESCRIPTION
Fixes #8816

#### Short description of what this resolves:

Clarify that isSmsEnabled and isEmailEnabled are private booleans defined in the constructor of NotificationEventListener. They cannot be undefined and cannot be null.

#### Does your code include anything generated by an AI Engine? No
