### PR TITLE
fix(VoiceClient): make $authUser protected, not private

### DIFF
--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/AppDispatch.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/AppDispatch.php
@@ -34,7 +34,7 @@ abstract class AppDispatch
     protected $_currentAction;
     protected $credentials;
     private $_request, $_response, $_query, $_post, $_server, $_cookies, $_session;
-    private $authUser;
+    protected $authUser;
 
     /**
      * @throws \Exception

--- a/phpstan.github.neon
+++ b/phpstan.github.neon
@@ -11724,10 +11724,6 @@ parameters:
     identifier: staticProperty.notFound
     count: 1
     path: interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php
-  - message: '#^Access to private property \$authUser of parent class OpenEMR\\Modules\\FaxSMS\\Controller\\AppDispatch\.$#'
-    identifier: property.private
-    count: 1
-    path: interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php
   - message: '#^Variable \$tz in empty\(\) is never defined\.$#'
     identifier: empty.variable
     count: 1


### PR DESCRIPTION
Fixes #8818

#### Short description of what this resolves:

This is the simplest possible fix for #8818. It just makes the accessed property legal. That said, I think it's not ideal that this property is accessed multiple times at all. But either way, it's likely this property needs to be not-private. 


#### Changes proposed in this pull request:

- [x] make `$authUser` accessible by subclasses.

#### Does your code include anything generated by an AI Engine? No
