### PR TITLE
fix(VerySimpleStringUtil): regex delimiter

### DIFF
--- a/phpstan.github.neon
+++ b/phpstan.github.neon
@@ -16932,10 +16932,6 @@ parameters:
     identifier: return.missing
     count: 1
     path: portal/patient/fwk/libs/verysimple/String/VerySimpleStringUtil.php
-  - message: '#^Regex pattern is invalid\: Unknown modifier ''/'' in pattern\: /\[\[\:alpha\:\]\]\+\://\[\^\<\>\[\:space\:\]\]\+\[\[\:alnum\:\]/\]/i$#'
-    identifier: regexp.pattern
-    count: 1
-    path: portal/patient/fwk/libs/verysimple/String/VerySimpleStringUtil.php
   - message: '#^Path in require_once\(\) "verysimple/Phreeze/CacheMemCache\.php" is not a file or it does not exist\.$#'
     identifier: requireOnce.fileNotFound
     count: 1

--- a/portal/patient/fwk/libs/verysimple/String/VerySimpleStringUtil.php
+++ b/portal/patient/fwk/libs/verysimple/String/VerySimpleStringUtil.php
@@ -1,7 +1,5 @@
 <?php
 
-/** @package    verysimple::String */
-
 /**
  * A set of utility functions for working with strings
  *
@@ -32,14 +30,11 @@ class VerySimpleStringUtil
     static $CONTROL_CODE_CHARS;
 
     /**
-     * replace the first occurrance only within a string
+     * replace the first occurrence only within a string
      *
-     * @param
-     *          string needle
-     * @param
-     *          string replacement
-     * @param
-     *          string haystack
+     * @param string $s needle
+     * @param string $r replacement
+     * @param string $str haystack
      */
     static function ReplaceFirst($s, $r, $str)
     {
@@ -143,8 +138,7 @@ class VerySimpleStringUtil
      * returning HTML content.
      *
      * @param string $text
-     * @param
-     *          bool true to sanitize the text before parsing for display security
+     * @param bool true to sanitize the text before parsing for display security
      * @return string HTML
      */
     static function ConvertEmailToMailTo($text, $sanitize = false)
@@ -162,8 +156,7 @@ class VerySimpleStringUtil
      * returning HTML content.
      *
      * @param string $text
-     * @param
-     *          bool true to sanitize the text before parsing for display security
+     * @param bool true to sanitize the text before parsing for display security
      * @return string HTML
      */
     static function ConvertUrlToLink($text, $sanitize = false)
@@ -172,7 +165,8 @@ class VerySimpleStringUtil
             $text = VerySimpleStringUtil::Sanitize($text);
         }
 
-        $regex = "/[[:alpha:]]+://[^<>[:space:]]+[[:alnum:]/]/i";
+        // use `;` for the delimiter so we can use forward slashes in the expression.
+        $regex = ";[[:alpha:]]+://[^<>[:space:]]+[[:alnum:]/];i";
         return preg_replace($regex, '<a href=\"\\0\">\\0</a>', $text);
     }
 
@@ -189,7 +183,6 @@ class VerySimpleStringUtil
     }
 
     /**
-     *
      * @param string $string
      * @param bool $numericEncodingOnly
      *          set to true to only use numeric html encoding. warning, setting to false may be slower performance (default true)
@@ -214,8 +207,7 @@ class VerySimpleStringUtil
      * @TODO: warning, this function is BETA!
      *
      * @param string $string
-     * @param
-     *          destination character set (default = $DEFAULT_CHARACTER_SET (UTF-8))
+     * @param string $charset destination character set (default = $DEFAULT_CHARACTER_SET (UTF-8))
      */
     static function DecodeFromHTML($string, $charset = null)
     {
@@ -241,14 +233,10 @@ class VerySimpleStringUtil
      * This function extends EncodeToHTML to additionally strip
      * out characters that may be disruptive when used in HTML or XML data
      *
-     * @param
-     *          string value to parse
-     * @param bool $escapeQuotes
-     *          true to additionally escape ENT_QUOTE characters <>&"' (default = true)
-     * @param bool $numericEncodingOnly
-     *          set to true to only use numeric html encoding. warning, setting to false may be slower performance (default true)
-     * @param bool $replaceSmartQuotes
-     *          true to replace "smart quotes" with standard ascii ones, can be useful for stripping out windows-only codes (default = false)
+     * @param string $string value to parse
+     * @param bool $escapeQuotes true to additionally escape ENT_QUOTE characters <>&"' (default = true)
+     * @param bool $numericEncodingOnly set to true to only use numeric html encoding. warning, setting to false may be slower performance (default true)
+     * @param bool $replaceSmartQuotes true to replace "smart quotes" with standard ascii ones, can be useful for stripping out windows-only codes (default = false)
      * @return string
      */
     static function EncodeSpecialCharacters($string, $escapeQuotes = true, $numericEncodingOnly = true, $replaceSmartQuotes = false)
@@ -264,13 +252,13 @@ class VerySimpleStringUtil
             $result = self::ReplaceSmartQuotes($result);
         }
 
-            // this method does not double-encode, but replaces single-quote with a numeric entity
+        // this method does not double-encode, but replaces single-quote with a numeric entity
         if ($escapeQuotes) {
             $result = htmlspecialchars($result, ENT_QUOTES, null, false);
         }
 
-            // this method double-encodes values but uses the special character entity for single quotes
-            // if ($escapeQuotes) $result = self::ReplaceXMLSpecialChars($result);
+        // this method double-encodes values but uses the special character entity for single quotes
+        // if ($escapeQuotes) $result = self::ReplaceXMLSpecialChars($result);
 
         // for special chars we don't need to insist on numeric encoding only
         return self::EncodeToHTML($result, $numericEncodingOnly);
@@ -349,8 +337,7 @@ class VerySimpleStringUtil
      * UTFToHTML instead unless you absolutely have to have named entities
      *
      * @param string $string
-     * @param bool $encodeControlCharacters
-     *          false = wipe control chars. true = encode control characters (default false)
+     * @param bool $encodeControlCharacters false = wipe control chars. true = encode control characters (default false)
      * @return string
      */
     static function UTFToNamedHTML($string, $encodeControlCharacters = false)
@@ -476,8 +463,7 @@ class VerySimpleStringUtil
      * converts a character that is likely non ascii into the correct UTF-8 char value
      *
      * @link http://www.php.net/manual/en/function.html-entity-decode.php#68491
-     * @param
-     *          $code
+     * @param int $code
      */
     function chr_utf8($code)
     {
@@ -567,8 +553,7 @@ class VerySimpleStringUtil
      * used internally by decode
      *
      * @link http://www.php.net/manual/en/function.html-entity-decode.php#68491
-     * @param
-     *          array
+     * @param array $matches
      */
     function html_entity_replace($matches)
     {


### PR DESCRIPTION
Fixes #8823

#### Short description of what this resolves:

- Use `;` for the delimiter so we can use `/` in the expression.

#### Changes proposed in this pull request:

- [x] use `;` for the delimiter so we can use `/` in the expression.
- [x] neaten up some whitespace and comments.


#### Does your code include anything generated by an AI Engine? No
