### PR TITLE
fix(C_EncounterVisitForm): remove unused closure variables

### DIFF
--- a/interface/forms/newpatient/C_EncounterVisitForm.class.php
+++ b/interface/forms/newpatient/C_EncounterVisitForm.class.php
@@ -632,7 +632,7 @@ class C_EncounterVisitForm
             return $provider;
         }, $MBO->getReferringProviders());
 
-        $orderingProviders = array_map(function ($provider) use ($viewmode, $encounter, $pid) {
+        $orderingProviders = array_map(function ($provider) use ($encounter) {
             $provider['selected'] = $provider['id'] == ($encounter['ordering_provider_id'] ?? 0);
             return $provider;
         }, $MBO->getOrderingProviders());

--- a/phpstan.github.neon
+++ b/phpstan.github.neon
@@ -9072,14 +9072,6 @@ parameters:
     identifier: variable.undefined
     count: 1
     path: interface/forms/newGroupEncounter/view.php
-  - message: '#^Anonymous function has an unused use \$pid\.$#'
-    identifier: closure.unusedUse
-    count: 1
-    path: interface/forms/newpatient/C_EncounterVisitForm.class.php
-  - message: '#^Anonymous function has an unused use \$viewmode\.$#'
-    identifier: closure.unusedUse
-    count: 1
-    path: interface/forms/newpatient/C_EncounterVisitForm.class.php
   - message: '#^Variable \$body_javascript on left side of \?\? is never defined\.$#'
     identifier: nullCoalesce.variable
     count: 1


### PR DESCRIPTION
Fixes #8825

#### Short description of what this resolves:

Removes unused closure variables from `use`.


#### Changes proposed in this pull request:

Removes unused closure variables from `use`.


#### Does your code include anything generated by an AI Engine? No
