### PR TITLE
fix: `unset` on nonexistent variable

### DIFF
--- a/interface/main/calendar/modules/PostCalendar/plugins/function.pc_view_select.php
+++ b/interface/main/calendar/modules/PostCalendar/plugins/function.pc_view_select.php
@@ -66,7 +66,6 @@ function smarty_function_pc_view_select($args): void
     }
 
     closedir($handle);
-    unset($no_list);
     sort($viewlist);
     $tcount = count($viewlist);
     //$options = "<select id=\"tplview\" name=\"tplview\" class=\"$args[class]\">"; - pennfirm

--- a/phpstan.github.neon
+++ b/phpstan.github.neon
@@ -10364,10 +10364,6 @@ parameters:
     identifier: variable.undefined
     count: 1
     path: interface/main/calendar/modules/PostCalendar/plugins/function.pc_url.php
-  - message: '#^Call to function unset\(\) contains undefined variable \$no_list\.$#'
-    identifier: unset.variable
-    count: 1
-    path: interface/main/calendar/modules/PostCalendar/plugins/function.pc_view_select.php
   - message: '#^Constant _PC_TPL_VIEW_SUBMIT not found\.$#'
     identifier: constant.notFound
     count: 1
@@ -17416,10 +17412,6 @@ parameters:
     identifier: variable.undefined
     count: 1
     path: src/Common/Auth/MfaUtils.php
-  - message: '#^Call to function unset\(\) contains undefined variable \$auth\.$#'
-    identifier: unset.variable
-    count: 1
-    path: src/Common/Auth/OneTimeAuth.php
   - message: '#^Variable \$this_contacts in empty\(\) is never defined\.$#'
     identifier: empty.variable
     count: 1
@@ -17770,18 +17762,6 @@ parameters:
     path: src/RestControllers/SMART/SMARTAuthorizationController.php
   - message: '#^Call to an undefined static method OpenEMR\\Common\\Http\\oeHttp\:\:get\(\)\.$#'
     identifier: staticMethod.notFound
-    count: 1
-    path: src/Rx/RxList.php
-  - message: '#^Call to function unset\(\) contains undefined variable \$all\.$#'
-    identifier: unset.variable
-    count: 1
-    path: src/Rx/RxList.php
-  - message: '#^Call to function unset\(\) contains undefined variable \$hash\.$#'
-    identifier: unset.variable
-    count: 1
-    path: src/Rx/RxList.php
-  - message: '#^Call to function unset\(\) contains undefined variable \$tokens\.$#'
-    identifier: unset.variable
     count: 1
     path: src/Rx/RxList.php
   - message: '#^Variable \$all might not be defined\.$#'

--- a/src/Common/Auth/OneTimeAuth.php
+++ b/src/Common/Auth/OneTimeAuth.php
@@ -330,7 +330,6 @@ class OneTimeAuth
             }
         } catch (OneTimeAuthExpiredException $e) {
             $this->systemLogger->error("Failed " . $e->getMessage());
-            unset($auth);
             throw new OneTimeAuthException(xlt("Decode Authentication Failed! Contact administrator."));
         }
         if (!empty($auth['error'] ?? null)) {

--- a/src/Rx/RxList.php
+++ b/src/Rx/RxList.php
@@ -109,7 +109,6 @@ class RxList
     {
         $pos = 0;
         $token = 0;
-        unset($tokens);
         $in_token = false;
         while ($pos < strlen($page)) {
             switch (substr($page, $pos, 1)) {
@@ -143,9 +142,7 @@ class RxList
     {
         $record = false;
         $current = 0;
-        unset($hash);
         $hash = [];
-        unset($all);
         for ($pos = 0, $posMax = count($tokens); $pos < $posMax; $pos++) {
             if (str_contains($tokens[$pos], "<name>") && $pos !== 3) {
                 // found a brand line 'token'


### PR DESCRIPTION
Fixes #8827

#### Short description of what this resolves:

Fix `unset` on undefined variables.


#### Changes proposed in this pull request:

Remove `unset` calls where they are not doing anything.

#### Does your code include anything generated by an AI Engine? No
