### PR TITLE
fix: remove only-null annotations

### DIFF
--- a/interface/therapy_groups/therapy_groups_controllers/therapy_groups_controller.php
+++ b/interface/therapy_groups/therapy_groups_controllers/therapy_groups_controller.php
@@ -86,7 +86,7 @@ class TherapyGroupsController extends BaseController
     /**
      * add / edit therapy group
      * making validation and saving in the match tables.
-     * @param null $groupId - must pass when edit group
+     * @param ?int $groupId - must pass when edit group
      */
     public function index($groupId = null)
     {

--- a/library/classes/thumbnail/Thumbnail.class.php
+++ b/library/classes/thumbnail/Thumbnail.class.php
@@ -159,33 +159,21 @@ class Thumbnail
     }
 
     /**
-     *  Create new file from resource file with GD functions.
-     *  @param (string) extension of file
-     *  @param (resource) file resource from create_thumbnail()
-     *  @param (optional)(string) file name for saving (pull path with wanted name)
-     *  @param (optional) (int) quality for 'jpeg' type
-     *  @return false if failed
+     * Create new file from resource file with GD functions.
+     *
+     * @param resource $image_resource file resource from create_thumbnail()
+     * @param string|null $file_name file name for saving (full path with wanted name)
+     * @param int $quality quality for 'jpeg' type
+     * @return bool true on success, false on failure
      */
-    private function create_file($image_resource, $file_name = null, $quality = 80)
+    private function create_file($image_resource, $file_name = null, $quality = 80): bool
     {
-        switch ($this->thumbnail_type) {
-            case 'gif':
-                $file = imagegif($image_resource, $file_name);
-                break;
-            case 'jpg':
-            case 'jpeg':
-                $file =  imagejpeg($image_resource, $file_name, $quality);
-                break;
-            case 'png':
-                $file =  imagepng($image_resource, $file_name);
-                break;
-            case 'bmp':
-                $file =  imagewbmp($image_resource, $file_name);
-                break;
-            default:
-                return false;
-        }
-
-        return $file;
+        return match ($this->thumbnail_type) {
+            'gif' => imagegif($image_resource, $file_name),
+            'jpg', 'jpeg' => imagejpeg($image_resource, $file_name, $quality),
+            'png' => imagepng($image_resource, $file_name),
+            'bmp' => imagewbmp($image_resource, $file_name),
+            default => false
+        };
     }
 }

--- a/phpstan.github.neon
+++ b/phpstan.github.neon
@@ -11468,10 +11468,6 @@ parameters:
     identifier: variable.undefined
     count: 2
     path: interface/modules/custom_modules/oe-module-comlink-telehealth/src/Controller/TeleHealthVideoRegistrationController.php
-  - message: '#^Variable \$uuidBinary in empty\(\) always exists and is always falsy\.$#'
-    identifier: empty.variable
-    count: 1
-    path: interface/modules/custom_modules/oe-module-comlink-telehealth/src/Controller/TeleconferenceRoomController.php
   - message: '#^Variable \$userSaveRecord might not be defined\.$#'
     identifier: variable.undefined
     count: 1
@@ -18012,24 +18008,12 @@ parameters:
     identifier: variable.undefined
     count: 1
     path: src/Services/DocumentTemplates/DocumentTemplateRender.php
-  - message: '#^Variable \$category in empty\(\) always exists and is always falsy\.$#'
-    identifier: empty.variable
-    count: 1
-    path: src/Services/DocumentTemplates/DocumentTemplateService.php
   - message: '#^Variable \$group_list might not be defined\.$#'
     identifier: variable.undefined
     count: 1
     path: src/Services/DocumentTemplates/DocumentTemplateService.php
-  - message: '#^Variable \$pid in empty\(\) always exists and is always falsy\.$#'
-    identifier: empty.variable
-    count: 1
-    path: src/Services/DocumentTemplates/DocumentTemplateService.php
   - message: '#^Variable \$rtn might not be defined\.$#'
     identifier: variable.undefined
-    count: 1
-    path: src/Services/DocumentTemplates/DocumentTemplateService.php
-  - message: '#^Variable \$template in empty\(\) always exists and is always falsy\.$#'
-    identifier: empty.variable
     count: 1
     path: src/Services/DocumentTemplates/DocumentTemplateService.php
   - message: '#^Variable \$tid on left side of \?\? always exists and is not nullable\.$#'
@@ -18044,16 +18028,8 @@ parameters:
     identifier: isset.variable
     count: 1
     path: src/Services/DrugService.php
-  - message: '#^Variable \$pid in empty\(\) always exists and is always falsy\.$#'
-    identifier: empty.variable
-    count: 1
-    path: src/Services/EncounterService.php
   - message: '#^Method OpenEMR\\Services\\FHIR\\FhirDocRefService\:\:getMostCurrentCCDReference\(\) invoked with 2 parameters, 1 required\.$#'
     identifier: arguments.count
-    count: 1
-    path: src/Services/FHIR/FhirDocRefService.php
-  - message: '#^Variable \$uuid in empty\(\) always exists and is always falsy\.$#'
-    identifier: empty.variable
     count: 1
     path: src/Services/FHIR/FhirDocRefService.php
   - message: '#^Variable \$code might not be defined\.$#'
@@ -18164,19 +18140,11 @@ parameters:
     identifier: nullCoalesce.variable
     count: 1
     path: src/Services/QuestionnaireResponseService.php
-  - message: '#^Variable \$uuid in empty\(\) always exists and is always falsy\.$#'
-    identifier: empty.variable
-    count: 1
-    path: src/Services/QuestionnaireResponseService.php
   - message: '#^Variable \$v on left side of \?\? always exists and is not nullable\.$#'
     identifier: nullCoalesce.variable
     count: 1
     path: src/Services/QuestionnaireResponseService.php
   - message: '#^Variable \$form in empty\(\) always exists and is not falsy\.$#'
-    identifier: empty.variable
-    count: 1
-    path: src/Services/QuestionnaireService.php
-  - message: '#^Variable \$q_record_id in empty\(\) always exists and is always falsy\.$#'
     identifier: empty.variable
     count: 1
     path: src/Services/QuestionnaireService.php
@@ -18186,10 +18154,6 @@ parameters:
     path: src/Services/QuestionnaireService.php
   - message: '#^Variable \$q_uuid might not be defined\.$#'
     identifier: variable.undefined
-    count: 1
-    path: src/Services/QuestionnaireService.php
-  - message: '#^Variable \$uuid in empty\(\) always exists and is always falsy\.$#'
-    identifier: empty.variable
     count: 1
     path: src/Services/QuestionnaireService.php
   - message: '#^Method OpenEMR\\Services\\Search\\FHIRSearchFieldFactory\:\:buildSearchField\(\) invoked with 3 parameters, 2 required\.$#'

--- a/src/Common/Logging/EventAuditLogger.php
+++ b/src/Common/Logging/EventAuditLogger.php
@@ -156,7 +156,7 @@ MSG;
      * @param $groupname
      * @param $success
      * @param string $comments
-     * @param null   $patient_id
+     * @param ?int $patient_id
      * @param string $log_from
      * @param string $menu_item
      * @param int    $ccda_doc_id
@@ -520,7 +520,7 @@ MSG;
      *
      * @param $statement
      * @param $outcome
-     * @param null $binds
+     * @param ?array $binds
      */
     public function auditSQLEvent($statement, $outcome, $binds = null)
     {

--- a/src/Cqm/Qdm/Traits/PatientExtension.php
+++ b/src/Cqm/Qdm/Traits/PatientExtension.php
@@ -46,8 +46,8 @@ trait PatientExtension
     }
 
     /**
-     * @param null $category
-     * @param null $status
+     * @param ?string $category
+     * @param ?string $status
      * @return mixed
      *
      * Return the first actual code for this data element code. This is used for building a hash count of codes

--- a/src/Services/BaseService.php
+++ b/src/Services/BaseService.php
@@ -378,7 +378,7 @@ class BaseService
      * @param string $uuid              - UUID of Resource
      * @param string $table             - Table reffering to the ID field
      * @param string $field             - Identifier field
-     * @return false if nothing found otherwise return ID
+     * @return string|false if nothing found return false, otherwise return ID
      */
     public static function getIdByUuid($uuid, $table, $field)
     {
@@ -393,7 +393,7 @@ class BaseService
      * @param string $id                - ID of Resource
      * @param string $table             - Table reffering to the UUID field
      * @param string $field             - Identifier field
-     * @return false if nothing found otherwise return UUID
+     * @return string|false if nothing found return false, otherwise return UUID string
      */
     public static function getUuidById($id, $table, $field)
     {

--- a/src/Services/DocumentTemplates/DocumentTemplateService.php
+++ b/src/Services/DocumentTemplates/DocumentTemplateService.php
@@ -171,7 +171,7 @@ class DocumentTemplateService extends QuestionnaireService
 
     /**
      * @param      $pids
-     * @param null $category
+     * @param ?string $category
      * @return array
      */
     public function getTemplateCategoriesByPids($pids, $category = null): array
@@ -475,8 +475,8 @@ class DocumentTemplateService extends QuestionnaireService
     }
 
     /**
-     * @param null $pid
-     * @param null $category
+     * @param ?int $pid
+     * @param ?string $category
      * @param bool $include_content
      * @return array
      */
@@ -566,8 +566,8 @@ class DocumentTemplateService extends QuestionnaireService
      * @param      $category
      * @param      $template
      * @param      $content
-     * @param null $mimetype
-     * @param null $profile
+     * @param ?string $mimetype
+     * @param ?string $profile
      * @return int
      */
     public function insertTemplate($pid, $category, $template, $content, $mimetype = null, $profile = null): int
@@ -661,7 +661,7 @@ class DocumentTemplateService extends QuestionnaireService
     /**
      * @param      $pids
      * @param      $templates
-     * @param null $category
+     * @param ?string $category
      * @return int
      */
     public function sendTemplate($pids, $templates, $category = null): int
@@ -717,7 +717,7 @@ class DocumentTemplateService extends QuestionnaireService
 
     /**
      * @param      $id
-     * @param null $template
+     * @param ?string $template
      * @return bool
      */
     public function deleteTemplate($id, $template = null): bool

--- a/src/Services/PatientService.php
+++ b/src/Services/PatientService.php
@@ -644,10 +644,10 @@ class PatientService extends BaseService
     /**
      * Fetch UUID for the patient id
      *
-     * @param string $id                - ID of Patient
-     * @return false if nothing found otherwise return UUID (in binary form)
+     * @param string $pid ID of Patient
+     * @return false|string false if nothing found otherwise return UUID (in binary form)
      */
-    public function getUuid($pid)
+    public function getUuid(string $pid): false|string
     {
         return self::getUuidById($pid, self::TABLE_NAME, 'pid');
     }

--- a/src/Services/QuestionnaireService.php
+++ b/src/Services/QuestionnaireService.php
@@ -42,8 +42,8 @@ class QuestionnaireService extends BaseService
 
     /**
      * @param      $name
-     * @param null $q_id
-     * @param null $uuid
+     * @param ?string $q_id
+     * @param ?string $uuid
      * @return array
      */
     public function getQuestionnaireIdAndVersion($name, $q_id = null, $uuid = null): array
@@ -85,7 +85,7 @@ class QuestionnaireService extends BaseService
     /**
      * @param $q
      * @param $name
-     * @param null $q_record_id
+     * @param ?int $q_record_id
      * @param $q_id
      * @param $lform
      * @param $type

--- a/src/Services/Search/BasicSearchField.php
+++ b/src/Services/Search/BasicSearchField.php
@@ -30,7 +30,7 @@ class BasicSearchField implements ISearchField
      * @param $type The type of
      * @param $field
      * @param $values
-     * @param null $modifier
+     * @param ?string $modifier
      * @param bool $isAnd
      */
     public function __construct($name, $type, $field, $values, $modifier = null)


### PR DESCRIPTION
Fixes #8829

#### Short description of what this resolves:

Fix cases where phpstan is misled by annotations saying a parameter is `null` or a function returns `false` when the type can be other things.


#### Changes proposed in this pull request:

- [x] describe `null` and `false` union types more thoroughly
- [x] remove fixed phpstan complaints from baseline
- [x] fix new phpstan findings

#### Does your code include anything generated by an AI Engine? No
