### PR TITLE
chore: rector ignore smarty dir for openemr-cmd

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -39,4 +39,7 @@ return RectorConfig::configure()
         cacheClass: FileCacheStorage::class,
         // specify a path that works locally as well as on CI job runners
         cacheDirectory: '/tmp/rector'
-    );
+    )
+    ->withSkip([
+        __DIR__ . '/sites/default/documents/smarty'
+    ]);


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #8834 

#### Short description of what this resolves:


#### Changes proposed in this pull request:

#### Does your code include anything generated by an AI Engine? Yes / No

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.
