### PR TITLE
ci: run against release branches

### DIFF
--- a/.github/workflows/inferno-test.yml
+++ b/.github/workflows/inferno-test.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
     - master
+    - rel-*
   pull_request:
     branches:
     - master
+    - rel-*
 
 permissions:
   contents: read

--- a/.github/workflows/isolated-tests.yml
+++ b/.github/workflows/isolated-tests.yml
@@ -11,9 +11,11 @@ on:
   push:
     branches:
     - master
+    - rel-*
   pull_request:
     branches:
     - master
+    - rel-*
 
 jobs:
   isolated-tests:

--- a/.github/workflows/js-test.yml
+++ b/.github/workflows/js-test.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
     - master
+    - rel-*
   pull_request:
     branches:
     - master
+    - rel-*
 
 permissions:
   contents: read

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
     - master
+    - rel-*
   pull_request:
     branches:
     - master
+    - rel-*
 
 permissions:
   contents: read

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
     - master
+    - rel-*
   pull_request:
     branches:
     - master
+    - rel-*
 
 jobs:
   rector:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
     - master
+    - rel-*
     # GitHub Actions do not support YAML anchors
     # There are five places in here we must keep
     # the paths in sync and the exclusion logic.
@@ -25,6 +26,7 @@ on:
   pull_request:
     branches:
     - master
+    - rel-*
     paths:
     - '**.sh'
     - '**.source'

--- a/.github/workflows/styling.yml
+++ b/.github/workflows/styling.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
     - master
+    - rel-*
   pull_request:
     branches:
     - master
+    - rel-*
 
 permissions:
   contents: read

--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -2,9 +2,13 @@ name: Syntax
 
 on:
   push:
-    branches: [ master ]
+    branches:
+    - master
+    - rel-*
   pull_request:
-    branches: [ master ]
+    branches:
+    - master
+    - rel-*
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,11 @@ on:
   push:
     branches:
     - master
+    - rel-*
   pull_request:
     branches:
     - master
+    - rel-*
 
 permissions:
   contents: read


### PR DESCRIPTION
Fixes #8867

#### Short description of what this resolves:

Ensure CI runs against release branches as well as master.


#### Changes proposed in this pull request:

- [x] Update the targets for all the targeted actions so they run against `rel-*`.

#### Does your code include anything generated by an AI Engine? No
