### PR TITLE
chore(php): use __DIR__

### DIFF
--- a/acl_upgrade.php
+++ b/acl_upgrade.php
@@ -50,7 +50,7 @@
  */
 
 // Checks if the server's PHP version is compatible with OpenEMR:
-require_once(dirname(__FILE__) . "/src/Common/Compatibility/Checker.php");
+require_once(__DIR__ . "/src/Common/Compatibility/Checker.php");
 $response = OpenEMR\Common\Compatibility\Checker::checkPhpVersion();
 if ($response !== true) {
     die(htmlspecialchars($response));

--- a/admin.php
+++ b/admin.php
@@ -14,7 +14,7 @@
  */
 
 // Checks if the server's PHP version is compatible with OpenEMR:
-require_once(dirname(__FILE__) . "/src/Common/Compatibility/Checker.php");
+require_once(__DIR__ . "/src/Common/Compatibility/Checker.php");
 $response = OpenEMR\Common\Compatibility\Checker::checkPhpVersion();
 if ($response !== true) {
     die(htmlspecialchars($response));
@@ -22,7 +22,7 @@ if ($response !== true) {
 
 require_once "version.php";
 
-$webserver_root = dirname(__FILE__);
+$webserver_root = __DIR__;
 if (stripos(PHP_OS, 'WIN') === 0) {
     $webserver_root = str_replace("\\", "/", $webserver_root);
 }

--- a/ccr/createCCR.php
+++ b/ccr/createCCR.php
@@ -40,11 +40,11 @@ if (isset($_GET['portal_auth'])) {
     $notPatientPortal = true;
 }
 
-require_once(dirname(__FILE__) . "/../interface/globals.php");
-require_once(dirname(__FILE__) . "/../library/sql-ccr.inc.php");
-require_once(dirname(__FILE__) . "/uuid.php");
-require_once(dirname(__FILE__) . "/transmitCCD.php");
-require_once(dirname(__FILE__) . "/../custom/code_types.inc.php");
+require_once(__DIR__ . "/../interface/globals.php");
+require_once(__DIR__ . "/../library/sql-ccr.inc.php");
+require_once(__DIR__ . "/uuid.php");
+require_once(__DIR__ . "/transmitCCD.php");
+require_once(__DIR__ . "/../custom/code_types.inc.php");
 
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Twig\TwigContainer;
@@ -221,15 +221,15 @@ function viewCCD($ccr, $raw = "no", $requested_by = ""): void
     $ccr->preserveWhiteSpace = false;
     $ccr->formatOutput = true;
 
-    if (file_exists(dirname(__FILE__) . '/generatedXml')) {
-        $ccr->save(dirname(__FILE__) . '/generatedXml/ccrForCCD.xml');
+    if (file_exists(__DIR__ . '/generatedXml')) {
+        $ccr->save(__DIR__ . '/generatedXml/ccrForCCD.xml');
     }
 
     $xmlDom = new DOMDocument();
     $xmlDom->loadXML($ccr->saveXML());
 
     $ccr_ccd = new DOMDocument();
-    $ccr_ccd->load(dirname(__FILE__) . '/ccd/ccr_ccd.xsl');
+    $ccr_ccd->load(__DIR__ . '/ccd/ccr_ccd.xsl');
 
     $xslt = new XSLTProcessor();
     $xslt->importStylesheet($ccr_ccd);
@@ -240,8 +240,8 @@ function viewCCD($ccr, $raw = "no", $requested_by = ""): void
 
     $ccd->loadXML($xslt->transformToXML($xmlDom));
 
-    if (file_exists(dirname(__FILE__) . '/generatedXml')) {
-        $ccd->save(dirname(__FILE__) . '/generatedXml/ccdDebug.xml');
+    if (file_exists(__DIR__ . '/generatedXml')) {
+        $ccd->save(__DIR__ . '/generatedXml/ccdDebug.xml');
     }
 
     if ($raw == "yes") {
@@ -312,7 +312,7 @@ function viewCCD($ccr, $raw = "no", $requested_by = ""): void
     }
 
         $ss = new DOMDocument();
-        $ss->load(dirname(__FILE__) . "/stylesheet/cda.xsl");
+        $ss->load(__DIR__ . "/stylesheet/cda.xsl");
 
         $xslt->importStyleSheet($ss);
 

--- a/ccr/display.php
+++ b/ccr/display.php
@@ -15,7 +15,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . "/../interface/globals.php");
+require_once(__DIR__ . "/../interface/globals.php");
 
 use OpenEMR\Events\PatientDocuments\PatientDocumentViewCCDAEvent;
 use OpenEMR\Common\Twig\TwigContainer;

--- a/ccr/transmitCCD.php
+++ b/ccr/transmitCCD.php
@@ -25,8 +25,8 @@
  * @link    http://www.open-emr.org
  */
 
-require_once(dirname(__FILE__) . "/../library/patient.inc.php");
-require_once(dirname(__FILE__) . "/../library/direct_message_check.inc.php");
+require_once(__DIR__ . "/../library/patient.inc.php");
+require_once(__DIR__ . "/../library/direct_message_check.inc.php");
 
 use OpenEMR\Common\Crypto\CryptoGen;
 use OpenEMR\Common\Logging\EventAuditLogger;

--- a/contrib/util/dupscore.cli.php
+++ b/contrib/util/dupscore.cli.php
@@ -46,7 +46,7 @@ $args = getopt('cq', array('webdir:', 'site:', 'maxmins:'));
 
 // print_r($args); // debugging
 
-$args['webdir'] = $args['webdir'] ?? dirname(dirname(dirname(__FILE__)));
+$args['webdir'] = $args['webdir'] ?? dirname(dirname(__DIR__));
 $args['site'] = $args['site'] ?? 'default';
 $args['maxmins'] = floatval($args['maxmins'] ?? 60);
 

--- a/contrib/util/installScripts/InstallerAuto.php
+++ b/contrib/util/installScripts/InstallerAuto.php
@@ -80,7 +80,7 @@ if (!getenv('OPENEMR_ENABLE_INSTALLER_AUTO')) {
 }
 
 // Include standard libraries/classes
-require_once dirname(__FILE__) . '/../../../vendor/autoload.php';
+require_once __DIR__ . '/../../../vendor/autoload.php';
 
 // Set up default configuration settings
 $installSettings = array();

--- a/controllers/C_Document.class.php
+++ b/controllers/C_Document.class.php
@@ -444,7 +444,7 @@ class C_Document extends Controller
     {
         global $ISSUE_TYPES;
 
-        require_once(dirname(__FILE__) . "/../library/lists.inc.php");
+        require_once(__DIR__ . "/../library/lists.inc.php");
 
         $d = new Document($doc_id);
         $notes = $d->get_notes();

--- a/custom/readme_rx_printtofax.txt
+++ b/custom/readme_rx_printtofax.txt
@@ -16,7 +16,7 @@ Manual steps:
 
 $GLOBALS['oer_config']['prescriptions']['sig_pic'] = "dr_signature.png";
 $GLOBALS['oer_config']['prescriptions']['use_signature'] = true;
-$GLOBALS['oer_config']['prescriptions']['addendum_file'] = dirname(__FILE__) .
+$GLOBALS['oer_config']['prescriptions']['addendum_file'] = __DIR__ .
   "/../custom/rx_addendum.txt";
 
 "dr_signature.png" must exist in ./interface/pic/ to have the contents of rx_addendum.txt appear. Note that the pre-existing ability to

--- a/gacl/CHANGELOG
+++ b/gacl/CHANGELOG
@@ -434,7 +434,7 @@ Mon Nov 11 2002
         - Fixed bug that prevented ACO/ARO's with the same 'value' in different sections from being assigned to an ACL. - Thanks to Martino
         - Fixed bug that made it seem like assigning a single ARO to a group really added all AROs with the same value to that group. - Thanks to Martino
         - Fixed bug causing virtual subtree'ing to only traverse 2 levels of the tree. - Thanks to Martino
-        - Used dirname(__FILE__) to remove the need for users to manually set the root path in config.inc.php.
+        - Used __DIR__ to remove the need for users to manually set the root path in config.inc.php.
 
 Wed Oct 23 2002
         - Switched away from ID's in favor of VALUES for most functions, including acl_check(). Broke all backwards compatibility.

--- a/gacl/Cache_Lite/Hashed_Cache_Lite.php
+++ b/gacl/Cache_Lite/Hashed_Cache_Lite.php
@@ -29,7 +29,7 @@
  */
 
 if ( !class_exists('Cache_Lite') ) {
-	require_once(dirname(__FILE__) .'/Lite.php');
+	require_once(__DIR__ .'/Lite.php');
 }
 
 define('DIR_SEP',DIRECTORY_SEPARATOR);

--- a/gacl/admin/gacl_admin.inc.php
+++ b/gacl/admin/gacl_admin.inc.php
@@ -30,14 +30,14 @@
 
 
 // Include standard libraries/classes
-require_once(dirname(__FILE__).'/../../vendor/autoload.php');
+require_once(__DIR__.'/../../vendor/autoload.php');
 
 use OpenEMR\Gacl\GaclAdminApi;
 
 // phpGACL Configuration file.
 if ( !isset($config_file) ) {
 #	$config_file = '../gacl.ini.php';
-	$config_file = dirname(__FILE__).'/../gacl.ini.php';
+	$config_file = __DIR__.'/../gacl.ini.php';
 }
 
 //Values supplied in $gacl_options array overwrite those in the config file.

--- a/gacl/docs/phpdoc/phpGACL/_gacl_class_php.html
+++ b/gacl/docs/phpdoc/phpGACL/_gacl_class_php.html
@@ -83,7 +83,7 @@
                     <div>
                         <img src="../media/images/Constant.png" />
                         <span class="const-title">
-                            <span class="const-name">ADODB_DIR</span> = dirname(__FILE__).'/adodb'
+                            <span class="const-name">ADODB_DIR</span> = __DIR__.'/adodb'
                             (line <span class="line-number">38</span>)
                         </span>
                     </div>

--- a/interface/batchcom/batch_reminders.php
+++ b/interface/batchcom/batch_reminders.php
@@ -14,7 +14,7 @@
  * @license https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . "/../../interface/globals.php");
+require_once(__DIR__ . "/../../interface/globals.php");
 require_once($GLOBALS['srcdir'] . "/maviq_phone_api.php");
 require_once($GLOBALS['srcdir'] . "/reminders.php");
 require_once($GLOBALS['srcdir'] . "/report_database.inc.php");

--- a/interface/billing/edih_main.php
+++ b/interface/billing/edih_main.php
@@ -12,7 +12,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . "/../globals.php");
+require_once(__DIR__ . "/../globals.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 
@@ -56,21 +56,21 @@ if (!defined("DS")) {
 
 //
 // path will be "$srcdir/edihistory/filename.php"
-require_once("$srcdir/edihistory/edih_csv_inc.php");    //dirname(__FILE__) . "/edihist/csv_record_include.php");
-require_once("$srcdir/edihistory/edih_io.php");         //dirname(__FILE__) . "/edihist/ibr_io.php");
+require_once("$srcdir/edihistory/edih_csv_inc.php");    //__DIR__ . "/edihist/csv_record_include.php");
+require_once("$srcdir/edihistory/edih_io.php");         //__DIR__ . "/edihist/ibr_io.php");
 require_once("$srcdir/edihistory/edih_x12file_class.php");
-require_once("$srcdir/edihistory/edih_uploads.php");         //dirname(__FILE__) . "/edihist/ibr_uploads.php");
-require_once("$srcdir/edihistory/edih_csv_parse.php");          //dirname(__FILE__) . "/edihist/ibr_997_read.php");
-require_once("$srcdir/edihistory/edih_csv_data.php");          //dirname(__FILE__) . "/edihist/ibr_277_read.php");
+require_once("$srcdir/edihistory/edih_uploads.php");         //__DIR__ . "/edihist/ibr_uploads.php");
+require_once("$srcdir/edihistory/edih_csv_parse.php");          //__DIR__ . "/edihist/ibr_997_read.php");
+require_once("$srcdir/edihistory/edih_csv_data.php");          //__DIR__ . "/edihist/ibr_277_read.php");
 require_once("$srcdir/edihistory/edih_997_error.php");
 require_once("$srcdir/edihistory/edih_segments.php");
-require_once("$srcdir/edihistory/edih_archive.php");        //dirname(__FILE__) . "/edihist/ibr_batch_read.php");
-require_once("$srcdir/edihistory/edih_271_html.php");          //dirname(__FILE__) . "/edihist/ibr_ack_read.php");
+require_once("$srcdir/edihistory/edih_archive.php");        //__DIR__ . "/edihist/ibr_batch_read.php");
+require_once("$srcdir/edihistory/edih_271_html.php");          //__DIR__ . "/edihist/ibr_ack_read.php");
 require_once("$srcdir/edihistory/edih_277_html.php");
 require_once("$srcdir/edihistory/edih_278_html.php");
-require_once("$srcdir/edihistory/edih_835_html.php");           //dirname(__FILE__) . "/edihist/ibr_era_read.php");
-require_once("$srcdir/edihistory/codes/edih_271_code_class.php");      //dirname(__FILE__) . "/edihist/ibr_code_arrays.php");
-require_once("$srcdir/edihistory/codes/edih_835_code_class.php"); //dirname(__FILE__) . "/edihist/ibr_status_code_arrays.php");
+require_once("$srcdir/edihistory/edih_835_html.php");           //__DIR__ . "/edihist/ibr_era_read.php");
+require_once("$srcdir/edihistory/codes/edih_271_code_class.php");      //__DIR__ . "/edihist/ibr_code_arrays.php");
+require_once("$srcdir/edihistory/codes/edih_835_code_class.php"); //__DIR__ . "/edihist/ibr_status_code_arrays.php");
 require_once("$srcdir/edihistory/codes/edih_997_codes.php");
 //
 // php may output line endings with included files
@@ -84,7 +84,7 @@ if (isset($GLOBALS['OE_SITE_DIR'])) {
 }
 
 // if we are not set up, create directories and csv files
-//if (!is_dir(dirname(__FILE__) . '/edihist' . IBR_HISTORY_DIR) ) {
+//if (!is_dir(__DIR__ . '/edihist' . IBR_HISTORY_DIR) ) {
 if (!is_dir($edih_tmp_dir)) {
     //
     //echo "setup with base directory: $edih_base_dir <br />" .PHP_EOL;

--- a/interface/billing/edih_view.php
+++ b/interface/billing/edih_view.php
@@ -12,7 +12,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . '/../globals.php');
+require_once(__DIR__ . '/../globals.php');
 
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;

--- a/interface/billing/get_claim_file.php
+++ b/interface/billing/get_claim_file.php
@@ -12,7 +12,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . "/../globals.php");
+require_once(__DIR__ . "/../globals.php");
 require_once $GLOBALS['OE_SITE_DIR'] . "/config.php";
 
 use OpenEMR\Common\Csrf\CsrfUtils;

--- a/interface/clickmap/AbstractClickmapModel.php
+++ b/interface/clickmap/AbstractClickmapModel.php
@@ -17,7 +17,7 @@ use OpenEMR\Common\ORDataObject\ORDataObject;
 
 /* for $GLOBALS['srcdir','pid'] */
 /* remember that include paths are calculated relative to the including script, not this file. */
-require_once(dirname(__FILE__) . '/../globals.php');
+require_once(__DIR__ . '/../globals.php');
 
 /**
  * @class AbstractClickmapModel

--- a/interface/clickmap/C_AbstractClickmap.php
+++ b/interface/clickmap/C_AbstractClickmap.php
@@ -16,7 +16,7 @@
  * remember that include paths are calculated relative to the including script, not this file.
  * to lock the path to this script (so if called from different scripts) use the dirname(FILE) variable
 */
-require_once(dirname(__FILE__) . '/../globals.php');
+require_once(__DIR__ . '/../globals.php');
 
 /* For the addform() function */
 require_once($GLOBALS['srcdir'] . '/forms.inc.php');

--- a/interface/easipro/pro.php
+++ b/interface/easipro/pro.php
@@ -12,7 +12,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . "/../globals.php");
+require_once(__DIR__ . "/../globals.php");
 require_once("$srcdir/patient.inc.php");
 require_once("$srcdir/options.inc.php");
 

--- a/interface/forms/CAMOS/content_parser.php
+++ b/interface/forms/CAMOS/content_parser.php
@@ -12,8 +12,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . "/../../../library/api.inc.php");
-require_once(dirname(__FILE__) . "/../../forms/vitals/C_FormVitals.class.php");
+require_once(__DIR__ . "/../../../library/api.inc.php");
+require_once(__DIR__ . "/../../forms/vitals/C_FormVitals.class.php");
 
 function addAppt($days, $time)
 {

--- a/interface/forms/CAMOS/report.php
+++ b/interface/forms/CAMOS/report.php
@@ -12,7 +12,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . '/../../globals.php');
+require_once(__DIR__ . '/../../globals.php');
 require_once("../../../library/api.inc.php");
 require_once("content_parser.php");
 

--- a/interface/forms/LBF/report.php
+++ b/interface/forms/LBF/report.php
@@ -12,7 +12,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . '/../../globals.php');
+require_once(__DIR__ . '/../../globals.php');
 require_once($GLOBALS["srcdir"] . "/api.inc.php");
 
 use OpenEMR\Common\Acl\AclMain;

--- a/interface/forms/aftercare_plan/report.php
+++ b/interface/forms/aftercare_plan/report.php
@@ -12,7 +12,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . '/../../globals.php');
+require_once(__DIR__ . '/../../globals.php');
 require_once($GLOBALS["srcdir"] . "/api.inc.php");
 
 function aftercare_plan_report($pid, $encounter, $cols, $id): void

--- a/interface/forms/ankleinjury/report.php
+++ b/interface/forms/ankleinjury/report.php
@@ -12,7 +12,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . '/../../globals.php');
+require_once(__DIR__ . '/../../globals.php');
 require_once($GLOBALS["srcdir"] . "/api.inc.php");
 
 function ankleinjury_report($pid, $encounter, $cols, $id): void

--- a/interface/forms/bronchitis/report.php
+++ b/interface/forms/bronchitis/report.php
@@ -12,7 +12,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . '/../../globals.php');
+require_once(__DIR__ . '/../../globals.php');
 require_once($GLOBALS["srcdir"] . "/api.inc.php");
 function bronchitis_report($pid, $encounter, $cols, $id): void
 {

--- a/interface/forms/clinical_instructions/report.php
+++ b/interface/forms/clinical_instructions/report.php
@@ -12,7 +12,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . '/../../globals.php');
+require_once(__DIR__ . '/../../globals.php');
 require_once($GLOBALS["srcdir"] . "/api.inc.php");
 
 function clinical_instructions_report($pid, $encounter, $cols, $id): void

--- a/interface/forms/dictation/report.php
+++ b/interface/forms/dictation/report.php
@@ -10,7 +10,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . '/../../globals.php');
+require_once(__DIR__ . '/../../globals.php');
 require_once($GLOBALS["srcdir"] . "/api.inc.php");
 
 function dictation_report($pid, $encounter, $cols, $id): void

--- a/interface/forms/eye_mag/php/eye_mag_functions.php
+++ b/interface/forms/eye_mag/php/eye_mag_functions.php
@@ -13,8 +13,8 @@
  */
 
 $form_folder = "eye_mag";
-require_once(dirname(__FILE__) . "/../../../../custom/code_types.inc.php");
-require_once(dirname(__FILE__) . "/../../../../library/options.inc.php");
+require_once(__DIR__ . "/../../../../custom/code_types.inc.php");
+require_once(__DIR__ . "/../../../../library/options.inc.php");
 global $PMSFH;
 
     use OpenEMR\Common\Acl\AclMain;

--- a/interface/forms/eye_mag/report.php
+++ b/interface/forms/eye_mag/report.php
@@ -30,11 +30,11 @@
  */
 
 require_once(__DIR__ . "/../../globals.php");
-require_once(dirname(__FILE__) . "/../../../library/api.inc.php");
-require_once(dirname(__FILE__) . "/../../../library/lists.inc.php");
-require_once(dirname(__FILE__) . "/../../../library/forms.inc.php");
-require_once(dirname(__FILE__) . "/../../../library/patient.inc.php");
-require_once(dirname(__FILE__) . "/../../../controllers/C_Document.class.php");
+require_once(__DIR__ . "/../../../library/api.inc.php");
+require_once(__DIR__ . "/../../../library/lists.inc.php");
+require_once(__DIR__ . "/../../../library/forms.inc.php");
+require_once(__DIR__ . "/../../../library/patient.inc.php");
+require_once(__DIR__ . "/../../../controllers/C_Document.class.php");
 
 use OpenEMR\Services\FacilityService;
 use OpenEMR\Core\Header;

--- a/interface/forms/fee_sheet/report.php
+++ b/interface/forms/fee_sheet/report.php
@@ -11,7 +11,7 @@
  */
 
 
-require_once(dirname(__FILE__) . '/../../globals.php');
+require_once(__DIR__ . '/../../globals.php');
 require_once($GLOBALS["srcdir"] . "/api.inc.php");
 
 function fee_sheet_report($pid, $encounter, $cols, $id): void

--- a/interface/forms/group_attendance/functions.php
+++ b/interface/forms/group_attendance/functions.php
@@ -12,9 +12,9 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . "/../../../library/api.inc.php");
-require_once(dirname(__FILE__) . "/../../../library/forms.inc.php");
-require_once(dirname(__FILE__) . "/../../../library/patient_tracker.inc.php");
+require_once(__DIR__ . "/../../../library/api.inc.php");
+require_once(__DIR__ . "/../../../library/forms.inc.php");
+require_once(__DIR__ . "/../../../library/patient_tracker.inc.php");
 
 /**
  * Returns form_id of an existing attendance form for group encounter (if one already exists);

--- a/interface/forms/group_attendance/new.php
+++ b/interface/forms/group_attendance/new.php
@@ -16,7 +16,7 @@
 
 require_once(__DIR__ . "/../../globals.php");
 require_once("functions.php");
-require_once(dirname(__FILE__) . "/../../../library/group.inc.php");
+require_once(__DIR__ . "/../../../library/group.inc.php");
 
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Core\Header;

--- a/interface/forms/misc_billing_options/report.php
+++ b/interface/forms/misc_billing_options/report.php
@@ -15,7 +15,7 @@
 
 use OpenEMR\Billing\MiscBillingOptions;
 
-require_once(dirname(__FILE__) . '/../../globals.php');
+require_once(__DIR__ . '/../../globals.php');
 require_once($GLOBALS["srcdir"] . "/api.inc.php");
 
 function misc_billing_options_report($pid, $encounter, $cols, $id): void

--- a/interface/forms/note/report.php
+++ b/interface/forms/note/report.php
@@ -14,7 +14,7 @@
 
 
 
-require_once(dirname(__FILE__) . '/../../globals.php');
+require_once(__DIR__ . '/../../globals.php');
 require_once($GLOBALS["srcdir"] . "/api.inc.php");
 
 function note_report($pid, $encounter, $cols, $id): void

--- a/interface/forms/painmap/new.php
+++ b/interface/forms/painmap/new.php
@@ -10,7 +10,7 @@
  */
 
 /* include globals.php, required. */
-require_once(dirname(__FILE__) . '/../../globals.php');
+require_once(__DIR__ . '/../../globals.php');
 
 /* include api.inc.php. also required. */
 require_once($GLOBALS['srcdir'] . '/api.inc.php');

--- a/interface/forms/painmap/report.php
+++ b/interface/forms/painmap/report.php
@@ -10,7 +10,7 @@
  */
 
 /* include globals.php, required. */
-require_once(dirname(__FILE__) . '/../../globals.php');
+require_once(__DIR__ . '/../../globals.php');
 
 /* include api.inc.php, required. */
 require_once($GLOBALS['srcdir'] . '/api.inc.php');

--- a/interface/forms/painmap/view.php
+++ b/interface/forms/painmap/view.php
@@ -10,7 +10,7 @@
  */
 
 /* include globals.php, required. */
-require_once(dirname(__FILE__) . '/../../globals.php');
+require_once(__DIR__ . '/../../globals.php');
 
 /* include api.inc.php. also required. */
 require_once($GLOBALS['srcdir'] . '/api.inc.php');

--- a/interface/forms/phq9/report.php
+++ b/interface/forms/phq9/report.php
@@ -12,7 +12,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . '/../../../library/api.inc.php');
+require_once(__DIR__ . '/../../../library/api.inc.php');
 
 
 function phq9_report($pid, $encounter, $cols, $id): void

--- a/interface/forms/physical_exam/report.php
+++ b/interface/forms/physical_exam/report.php
@@ -12,7 +12,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . '/../../globals.php');
+require_once(__DIR__ . '/../../globals.php');
 require_once($GLOBALS["srcdir"] . "/api.inc.php");
 require_once("lines.php");
 

--- a/interface/forms/prior_auth/C_FormPriorAuth.class.php
+++ b/interface/forms/prior_auth/C_FormPriorAuth.class.php
@@ -24,7 +24,7 @@ class C_FormPriorAuth extends Controller
         parent::__construct();
         $returnurl = 'encounter_top.php';
         $this->template_mod = $template_mod;
-        $this->template_dir = dirname(__FILE__) . "/templates/prior_auth/";
+        $this->template_dir = __DIR__ . "/templates/prior_auth/";
         $this->assign("FORM_ACTION", $GLOBALS['web_root']);
         $this->assign("DONT_SAVE_LINK", $GLOBALS['form_exit_url']);
         $this->assign("STYLE", $GLOBALS['style']);

--- a/interface/forms/prior_auth/report.php
+++ b/interface/forms/prior_auth/report.php
@@ -10,7 +10,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . '/../../globals.php');
+require_once(__DIR__ . '/../../globals.php');
 require_once($GLOBALS["srcdir"] . "/api.inc.php");
 
 function prior_auth_report($pid, $encounter, $cols, $id): void

--- a/interface/forms/reviewofs/report.php
+++ b/interface/forms/reviewofs/report.php
@@ -10,7 +10,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . '/../../globals.php');
+require_once(__DIR__ . '/../../globals.php');
 require_once($GLOBALS["srcdir"] . "/api.inc.php");
 
 function reviewofs_report($pid, $encounter, $cols, $id): void

--- a/interface/forms/ros/C_FormROS.class.php
+++ b/interface/forms/ros/C_FormROS.class.php
@@ -24,7 +24,7 @@ class C_FormROS extends Controller
         parent::__construct();
         $returnurl = 'encounter_top.php';
         $this->template_mod = $template_mod;
-        $this->template_dir = dirname(__FILE__) . "/templates/ros/";
+        $this->template_dir = __DIR__ . "/templates/ros/";
         $this->assign("FORM_ACTION", $GLOBALS['web_root']);
         $this->assign("DONT_SAVE_LINK", $GLOBALS['form_exit_url']);
         $this->assign("STYLE", $GLOBALS['style']);

--- a/interface/forms/ros/report.php
+++ b/interface/forms/ros/report.php
@@ -11,7 +11,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . '/../../globals.php');
+require_once(__DIR__ . '/../../globals.php');
 require_once($GLOBALS["srcdir"] . "/api.inc.php");
 
 function ros_report($pid, $encounter, $cols, $id): void

--- a/interface/forms/sdoh/report.php
+++ b/interface/forms/sdoh/report.php
@@ -10,7 +10,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . '/../../../library/api.inc.php');
+require_once(__DIR__ . '/../../../library/api.inc.php');
 
 function sdoh_report($pid, $encounter, $cols, $id): void
 {

--- a/interface/forms/soap/report.php
+++ b/interface/forms/soap/report.php
@@ -11,7 +11,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . '/../../globals.php');
+require_once(__DIR__ . '/../../globals.php');
 require_once($GLOBALS["srcdir"] . "/api.inc.php");
 
 function soap_report($pid, $encounter, $cols, $id): void

--- a/interface/forms/track_anything/report.php
+++ b/interface/forms/track_anything/report.php
@@ -12,7 +12,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . '/../../globals.php');
+require_once(__DIR__ . '/../../globals.php');
 require_once($GLOBALS["srcdir"] . "/api.inc.php");
 
 function track_anything_report($pid, $encounter, $cols, $id): void

--- a/interface/forms/transfer_summary/report.php
+++ b/interface/forms/transfer_summary/report.php
@@ -12,7 +12,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . '/../../globals.php');
+require_once(__DIR__ . '/../../globals.php');
 require_once($GLOBALS["srcdir"] . "/api.inc.php");
 
 function transfer_summary_report($pid, $encounter, $cols, $id): void

--- a/interface/forms/treatment_plan/report.php
+++ b/interface/forms/treatment_plan/report.php
@@ -12,7 +12,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . '/../../globals.php');
+require_once(__DIR__ . '/../../globals.php');
 require_once($GLOBALS["srcdir"] . "/api.inc.php");
 
 function treatment_plan_report($pid, $encounter, $cols, $id): void

--- a/interface/main/calendar/config.php
+++ b/interface/main/calendar/config.php
@@ -16,9 +16,9 @@
 
 // to collect sql database login info and the utf8 flag
 // also collect the adodb libraries to support mysqli_mod that is needed for mysql ssl support
-require_once(dirname(__FILE__) . "/../../../library/sqlconf.php");
-require_once(dirname(__FILE__) . "/../../../vendor/adodb/adodb-php/adodb.inc.php");
-require_once(dirname(__FILE__) . "/../../../vendor/adodb/adodb-php/drivers/adodb-mysqli.inc.php");
+require_once(__DIR__ . "/../../../library/sqlconf.php");
+require_once(__DIR__ . "/../../../vendor/adodb/adodb-php/adodb.inc.php");
+require_once(__DIR__ . "/../../../vendor/adodb/adodb-php/drivers/adodb-mysqli.inc.php");
 
 // Modified 5/2009 by BM for UTF-8 project
 global $host,$port,$login,$pass,$dbase,$db_encoding,$disable_utf8_flag;

--- a/interface/main/calendar/find_appt_popup.php
+++ b/interface/main/calendar/find_appt_popup.php
@@ -19,7 +19,7 @@
 
 require_once("../../globals.php");
 require_once("$srcdir/patient.inc.php");
-require_once(dirname(__FILE__) . "/../../../library/appointments.inc.php");
+require_once(__DIR__ . "/../../../library/appointments.inc.php");
 require_once($GLOBALS['incdir'] . "/main/holidays/Holidays_Controller.php");
 
 use OpenEMR\Common\Acl\AclMain;

--- a/interface/main/calendar/includes/pnAPI.php
+++ b/interface/main/calendar/includes/pnAPI.php
@@ -212,7 +212,7 @@ function pnInit()
 
     // ADODB configuration
     if (!defined('ADODB_DIR')) {
-        define('ADODB_DIR', dirname(__FILE__) . '/../../../../vendor/adodb/adodb-php');
+        define('ADODB_DIR', __DIR__ . '/../../../../vendor/adodb/adodb-php');
     }
 
     require_once ADODB_DIR . '/adodb.inc.php';

--- a/interface/main/calendar/modules/PostCalendar/pcSmarty.class.php
+++ b/interface/main/calendar/modules/PostCalendar/pcSmarty.class.php
@@ -26,7 +26,7 @@
  *
  */
 
-require_once(dirname(__FILE__) . '/../../../../../library/smarty_legacy/smarty/Smarty_Legacy.class.php');
+require_once(__DIR__ . '/../../../../../library/smarty_legacy/smarty/Smarty_Legacy.class.php');
 
 class pcSmarty extends Smarty_Legacy
 {

--- a/interface/main/finder/dynamic_finder.php
+++ b/interface/main/finder/dynamic_finder.php
@@ -16,7 +16,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . "/../../globals.php");
+require_once(__DIR__ . "/../../globals.php");
 require_once "$srcdir/user.inc.php";
 require_once "$srcdir/options.inc.php";
 

--- a/interface/main/finder/dynamic_finder_ajax.php
+++ b/interface/main/finder/dynamic_finder_ajax.php
@@ -16,7 +16,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . "/../../globals.php");
+require_once(__DIR__ . "/../../globals.php");
 require_once($GLOBALS['srcdir'] . "/options.inc.php");
 
 use OpenEMR\Events\BoundFilter;

--- a/interface/modules/custom_modules/oe-module-prior-authorizations/welcome.php
+++ b/interface/modules/custom_modules/oe-module-prior-authorizations/welcome.php
@@ -13,7 +13,7 @@ use Juggernaut\OpenEMR\Modules\PriorAuthModule\Controller\ListAuthorizations;
 use OpenEMR\Core\Header;
 
 require_once dirname(__FILE__, 4) . "/globals.php";
-require_once dirname(__FILE__) . '/vendor/autoload.php';
+require_once __DIR__ . '/vendor/autoload.php';
 
 $clinic = AuthorizationService::registerFacility();
 AuthorizationService::registration($clinic);

--- a/interface/modules/custom_modules/oe-module-weno/moduleConfig.php
+++ b/interface/modules/custom_modules/oe-module-weno/moduleConfig.php
@@ -22,5 +22,5 @@ $classLoader->registerNamespaceIfNotExists("OpenEMR\\Modules\\WenoModule\\", __D
 
 $module_config = 1;
 /* renders in a Laminas created iframe */
-require_once dirname(__FILE__) . '/templates/weno_setup.php';
+require_once __DIR__ . '/templates/weno_setup.php';
 exit;

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncountermanagerController.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncountermanagerController.php
@@ -264,7 +264,7 @@ class EncountermanagerController extends AbstractActionController
 
             // time to use our stylesheets
             // TODO: @adunsulag we need to put this transformation process into its own class that we can reuse
-            $stylesheet = dirname(__FILE__) . "/../../../../../public/xsl/cda.xsl";
+            $stylesheet = __DIR__ . "/../../../../../public/xsl/cda.xsl";
 
             if (!file_exists($stylesheet)) {
                 throw new \RuntimeException("Could not find stylesheet file at location: " . $stylesheet);

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Listener/CCDAEventsSubscriber.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Listener/CCDAEventsSubscriber.php
@@ -133,7 +133,7 @@ class CCDAEventsSubscriber implements EventSubscriberInterface
             $format = $event->getFormat();
             if ($format == 'html') {
                 // time to use our stylesheets
-                $stylesheet = dirname(__FILE__) . "/../../../../../public/xsl/";
+                $stylesheet = __DIR__ . "/../../../../../public/xsl/";
 
                 // from original ccr/display.php code
                 if ($type == 'CCR') {

--- a/interface/modules/zend_modules/module/Ccr/src/Ccr/Model/CcrTable.php
+++ b/interface/modules/zend_modules/module/Ccr/src/Ccr/Model/CcrTable.php
@@ -21,7 +21,7 @@ use DOMXpath;
 use Document;
 use CouchDB;
 
-require_once(dirname(__FILE__) . "/../../../../../../../../library/patient.inc.php");
+require_once(__DIR__ . "/../../../../../../../../library/patient.inc.php");
 
 class CcrTable extends AbstractTableGateway
 {

--- a/interface/orders/single_order_results.php
+++ b/interface/orders/single_order_results.php
@@ -12,7 +12,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . '/../globals.php');
+require_once(__DIR__ . '/../globals.php');
 require_once($GLOBALS["include_root"] . "/orders/single_order_results.inc.php");
 
 use Mpdf\Mpdf;

--- a/interface/patient_file/encounter/delete_form.php
+++ b/interface/patient_file/encounter/delete_form.php
@@ -13,7 +13,7 @@
  */
 
 require_once("../../globals.php");
-require_once(dirname(__FILE__) . "/../../../library/forms.inc.php");
+require_once(__DIR__ . "/../../../library/forms.inc.php");
 
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;

--- a/interface/patient_file/encounter/encounter_top.php
+++ b/interface/patient_file/encounter/encounter_top.php
@@ -12,7 +12,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . '/../../globals.php');
+require_once(__DIR__ . '/../../globals.php');
 require_once("$srcdir/pid.inc.php");
 require_once("$srcdir/encounter.inc.php");
 require_once("$srcdir/forms.inc.php");

--- a/interface/patient_file/encounter/forms.php
+++ b/interface/patient_file/encounter/forms.php
@@ -84,7 +84,7 @@ $esignApi = new Api();
 ?>
 
 <?php // if the track_anything form exists, then include the styling and js functions (and js variable) for graphing
-if (file_exists(dirname(__FILE__) . "/../../forms/track_anything/style.css")) { ?>
+if (file_exists(__DIR__ . "/../../forms/track_anything/style.css")) { ?>
     <script>
         var csrf_token_js = <?php echo js_escape(CsrfUtils::collectCsrfToken()); ?>;
     </script>

--- a/interface/patient_file/summary/patient_reminders_fragment.php
+++ b/interface/patient_file/summary/patient_reminders_fragment.php
@@ -10,7 +10,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . "/../../globals.php");
+require_once(__DIR__ . "/../../globals.php");
 require_once("$srcdir/reminders.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;

--- a/interface/therapy_groups/index.php
+++ b/interface/therapy_groups/index.php
@@ -25,9 +25,9 @@
  * @link    http://www.open-emr.org
  */
 
-require_once dirname(__FILE__) . '/../globals.php';
-require_once dirname(__FILE__) . '/therapy_groups_controllers/therapy_groups_controller.php';
-require_once dirname(__FILE__) . '/therapy_groups_controllers/participants_controller.php';
+require_once __DIR__ . '/../globals.php';
+require_once __DIR__ . '/therapy_groups_controllers/therapy_groups_controller.php';
+require_once __DIR__ . '/therapy_groups_controllers/participants_controller.php';
 
 $method = $_GET['method'];
 

--- a/interface/therapy_groups/therapy_groups_controllers/base_controller.php
+++ b/interface/therapy_groups/therapy_groups_controllers/base_controller.php
@@ -38,7 +38,7 @@ class BaseController
     protected function loadView($template, $data = array())
     {
 
-        $template = dirname(__FILE__) . '/../' . self::VIEW_FOLDER . '/' . $template . '.php';
+        $template = __DIR__ . '/../' . self::VIEW_FOLDER . '/' . $template . '.php';
 
         extract($data);
 
@@ -52,7 +52,7 @@ class BaseController
     protected function loadModel($name)
     {
         if (!isset($this->$name)) {
-            require(dirname(__FILE__) . '/../' . self::MODEL_FOLDER . '/' . strtolower($name) . '_model.php');
+            require(__DIR__ . '/../' . self::MODEL_FOLDER . '/' . strtolower($name) . '_model.php');
             $this->$name = new $name();
         }
 

--- a/interface/therapy_groups/therapy_groups_controllers/participants_controller.php
+++ b/interface/therapy_groups/therapy_groups_controllers/participants_controller.php
@@ -25,8 +25,8 @@
  * @link    http://www.open-emr.org
  */
 
-require_once dirname(__FILE__) . '/base_controller.php';
-require_once dirname(__FILE__) . '/therapy_groups_controller.php';
+require_once __DIR__ . '/base_controller.php';
+require_once __DIR__ . '/therapy_groups_controller.php';
 require_once("{$GLOBALS['srcdir']}/pid.inc.php");
 
 class ParticipantsController extends BaseController

--- a/interface/therapy_groups/therapy_groups_controllers/therapy_groups_controller.php
+++ b/interface/therapy_groups/therapy_groups_controllers/therapy_groups_controller.php
@@ -25,7 +25,7 @@
  * @link    http://www.open-emr.org
  */
 
-require_once dirname(__FILE__) . '/base_controller.php';
+require_once __DIR__ . '/base_controller.php';
 require_once("{$GLOBALS['srcdir']}/appointments.inc.php");
 require_once("{$GLOBALS['srcdir']}/pid.inc.php");
 

--- a/library/FeeSheet.class.php
+++ b/library/FeeSheet.class.php
@@ -24,12 +24,12 @@
  * @link    http://www.open-emr.org
  */
 
-require_once(dirname(__FILE__) . "/../interface/globals.php");
-require_once(dirname(__FILE__) . "/../custom/code_types.inc.php");
-require_once(dirname(__FILE__) . "/../interface/drugs/drugs.inc.php");
-require_once(dirname(__FILE__) . "/options.inc.php");
-require_once(dirname(__FILE__) . "/appointment_status.inc.php");
-require_once(dirname(__FILE__) . "/forms.inc.php");
+require_once(__DIR__ . "/../interface/globals.php");
+require_once(__DIR__ . "/../custom/code_types.inc.php");
+require_once(__DIR__ . "/../interface/drugs/drugs.inc.php");
+require_once(__DIR__ . "/options.inc.php");
+require_once(__DIR__ . "/appointment_status.inc.php");
+require_once(__DIR__ . "/forms.inc.php");
 
 use OpenEMR\Billing\BillingUtilities;
 use OpenEMR\Common\Acl\AclMain;
@@ -38,8 +38,8 @@ use OpenEMR\Common\Logging\EventAuditLogger;
 // For logging checksums set this to true.
 define('CHECKSUM_LOGGING', true);
 
-// require_once(dirname(__FILE__) . "/api.inc.php");
-// require_once(dirname(__FILE__) . "/forms.inc.php");
+// require_once(__DIR__ . "/api.inc.php");
+// require_once(__DIR__ . "/forms.inc.php");
 
 class FeeSheet
 {

--- a/library/FeeSheetHtml.class.php
+++ b/library/FeeSheetHtml.class.php
@@ -13,8 +13,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . "/FeeSheet.class.php");
-require_once(dirname(__FILE__) . "/api.inc.php");
+require_once(__DIR__ . "/FeeSheet.class.php");
+require_once(__DIR__ . "/api.inc.php");
 
 class FeeSheetHtml extends FeeSheet
 {

--- a/library/MedEx/MedEx.php
+++ b/library/MedEx/MedEx.php
@@ -31,9 +31,9 @@
     $ignoreAuth = true;
     $_SERVER['HTTP_HOST']   = 'default'; //change for multi-site
 
-    require_once(dirname(__FILE__) . "/../../interface/globals.php");
-    require_once(dirname(__FILE__) . "/../patient.inc.php");
-    require_once(dirname(__FILE__) . "/API.php");
+    require_once(__DIR__ . "/../../interface/globals.php");
+    require_once(__DIR__ . "/../patient.inc.php");
+    require_once(__DIR__ . "/API.php");
 
 if (!empty($_POST['callback_key'])) {
     $MedEx = new MedExApi\MedEx('MedExBank.com');

--- a/library/MedEx/MedEx_background.php
+++ b/library/MedEx/MedEx_background.php
@@ -26,9 +26,9 @@
 
 $ignoreAuth = true;
 
-require_once(dirname(__FILE__) . "/../../interface/globals.php");
-require_once(dirname(__FILE__) . "/API.php");
-require_once(dirname(__FILE__) . "/../patient.inc.php");
+require_once(__DIR__ . "/../../interface/globals.php");
+require_once(__DIR__ . "/API.php");
+require_once(__DIR__ . "/../patient.inc.php");
 
 function start_MedEx(): void
 {

--- a/library/ajax/amc_misc_data.php
+++ b/library/ajax/amc_misc_data.php
@@ -10,8 +10,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . "/../../interface/globals.php");
-require_once(dirname(__FILE__) . "/../amc.php");
+require_once(__DIR__ . "/../../interface/globals.php");
+require_once(__DIR__ . "/../amc.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 

--- a/library/ajax/collect_new_report_id.php
+++ b/library/ajax/collect_new_report_id.php
@@ -10,8 +10,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . "/../../interface/globals.php");
-require_once(dirname(__FILE__) . "/../report_database.inc.php");
+require_once(__DIR__ . "/../../interface/globals.php");
+require_once(__DIR__ . "/../report_database.inc.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 

--- a/library/ajax/document_helpers.php
+++ b/library/ajax/document_helpers.php
@@ -12,7 +12,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . "/../../interface/globals.php");
+require_once(__DIR__ . "/../../interface/globals.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 

--- a/library/ajax/easipro_util.php
+++ b/library/ajax/easipro_util.php
@@ -31,7 +31,7 @@ if (isset($_SESSION['pid']) && isset($_SESSION['patient_portal_onsite_two'])) {
     $ignoreAuth = false;
 }
 
-require_once(dirname(__FILE__) . "/../../interface/globals.php");
+require_once(__DIR__ . "/../../interface/globals.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Easipro\Easipro;

--- a/library/ajax/execute_cdr_report.php
+++ b/library/ajax/execute_cdr_report.php
@@ -10,8 +10,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . "/../../interface/globals.php");
-require_once(dirname(__FILE__) . "/../clinical_rules.php");
+require_once(__DIR__ . "/../../interface/globals.php");
+require_once(__DIR__ . "/../clinical_rules.php");
 
 use OpenEMR\ClinicalDecisionRules\AMC\CertificationReportTypes;
 use OpenEMR\Common\Csrf\CsrfUtils;

--- a/library/ajax/execute_pat_reminder.php
+++ b/library/ajax/execute_pat_reminder.php
@@ -10,8 +10,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . "/../../interface/globals.php");
-require_once(dirname(__FILE__) . "/../reminders.php");
+require_once(__DIR__ . "/../../interface/globals.php");
+require_once(__DIR__ . "/../reminders.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 

--- a/library/ajax/graph_track_anything.php
+++ b/library/ajax/graph_track_anything.php
@@ -14,7 +14,7 @@
  * @copyright Copyright (c) 2014 Joe Slam <joe@produnis.de>
  */
 
-require_once(dirname(__FILE__) . "/../../interface/globals.php");
+require_once(__DIR__ . "/../../interface/globals.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 

--- a/library/ajax/graphs.php
+++ b/library/ajax/graphs.php
@@ -12,7 +12,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . "/../../interface/globals.php");
+require_once(__DIR__ . "/../../interface/globals.php");
 
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;

--- a/library/ajax/lists_touch.php
+++ b/library/ajax/lists_touch.php
@@ -11,8 +11,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . "/../../interface/globals.php");
-require_once(dirname(__FILE__) . "/../lists.inc.php");
+require_once(__DIR__ . "/../../interface/globals.php");
+require_once(__DIR__ . "/../lists.inc.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 

--- a/library/ajax/plan_setting.php
+++ b/library/ajax/plan_setting.php
@@ -11,8 +11,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . "/../../interface/globals.php");
-require_once(dirname(__FILE__) . "/../clinical_rules.php");
+require_once(__DIR__ . "/../../interface/globals.php");
+require_once(__DIR__ . "/../clinical_rules.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 

--- a/library/ajax/rule_setting.php
+++ b/library/ajax/rule_setting.php
@@ -11,8 +11,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . "/../../interface/globals.php");
-require_once(dirname(__FILE__) . "/../clinical_rules.php");
+require_once(__DIR__ . "/../../interface/globals.php");
+require_once(__DIR__ . "/../clinical_rules.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 

--- a/library/ajax/status_report.php
+++ b/library/ajax/status_report.php
@@ -10,8 +10,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . "/../../interface/globals.php");
-require_once(dirname(__FILE__) . "/../report_database.inc.php");
+require_once(__DIR__ . "/../../interface/globals.php");
+require_once(__DIR__ . "/../report_database.inc.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 

--- a/library/ajax/template_context_search.php
+++ b/library/ajax/template_context_search.php
@@ -10,7 +10,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . '/../../interface/globals.php');
+require_once(__DIR__ . '/../../interface/globals.php');
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 

--- a/library/ajax/turnoff_birthday_alert.php
+++ b/library/ajax/turnoff_birthday_alert.php
@@ -12,7 +12,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . "/../../interface/globals.php");
+require_once(__DIR__ . "/../../interface/globals.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Reminder\BirthdayReminder;

--- a/library/ajax/user_settings.php
+++ b/library/ajax/user_settings.php
@@ -11,8 +11,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . "/../../interface/globals.php");
-require_once(dirname(__FILE__) . "/../user.inc.php");
+require_once(__DIR__ . "/../../interface/globals.php");
+require_once(__DIR__ . "/../user.inc.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 use Symfony\Component\HttpFoundation\Response;

--- a/library/api.inc
+++ b/library/api.inc
@@ -12,4 +12,4 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . "/api.inc.php");
+require_once(__DIR__ . "/api.inc.php");

--- a/library/appointment_status.inc.php
+++ b/library/appointment_status.inc.php
@@ -14,7 +14,7 @@
 // See sample code in: interface/patient_tracker/patient_tracker_status.php
 // This updates the patient tracker board as well as the appointment.
 
-require_once(dirname(__FILE__) . '/patient_tracker.inc.php');
+require_once(__DIR__ . '/patient_tracker.inc.php');
 
 function updateAppointmentStatus($pid, $encdate, $newstatus): void
 {

--- a/library/appointments.inc.php
+++ b/library/appointments.inc.php
@@ -15,8 +15,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
 */
 
-require_once(dirname(__FILE__) . "/encounter_events.inc.php");
-require_once(dirname(__FILE__) . "/../interface/main/calendar/modules/PostCalendar/pnincludes/Date/Calc.php");
+require_once(__DIR__ . "/encounter_events.inc.php");
+require_once(__DIR__ . "/../interface/main/calendar/modules/PostCalendar/pnincludes/Date/Calc.php");
 
 use OpenEMR\Events\Appointments\AppointmentsFilterEvent;
 use OpenEMR\Events\BoundFilter;

--- a/library/calendar.inc
+++ b/library/calendar.inc
@@ -12,4 +12,4 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
 */
 
-require_once(dirname(__FILE__) . "/calendar.inc.php");
+require_once(__DIR__ . "/calendar.inc.php");

--- a/library/classes/ClinicalTypes/ClinicalType.php
+++ b/library/classes/ClinicalTypes/ClinicalType.php
@@ -7,11 +7,11 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 //
-require_once(dirname(__FILE__) . "/../../clinical_rules.php");
-require_once(dirname(__FILE__) . "/../../forms.inc.php");
-require_once(dirname(__FILE__) . "/../../patient.inc.php");
-require_once(dirname(__FILE__) . "/../../lists.inc.php");
-require_once(dirname(__FILE__) . "/../rulesets/library/RsPatient.php");
+require_once(__DIR__ . "/../../clinical_rules.php");
+require_once(__DIR__ . "/../../forms.inc.php");
+require_once(__DIR__ . "/../../patient.inc.php");
+require_once(__DIR__ . "/../../lists.inc.php");
+require_once(__DIR__ . "/../rulesets/library/RsPatient.php");
 require_once('codes.php');
 
 abstract class ClinicalType

--- a/library/classes/Installer.class.php
+++ b/library/classes/Installer.class.php
@@ -85,17 +85,17 @@ class Installer
         $this->ippf_specific = false;
 
         // Record name of sql access file
-        $GLOBALS['OE_SITES_BASE'] = dirname(__FILE__) . '/../../sites';
+        $GLOBALS['OE_SITES_BASE'] = __DIR__ . '/../../sites';
         $GLOBALS['OE_SITE_DIR'] = $GLOBALS['OE_SITES_BASE'] . '/' . $this->site;
         $this->conffile  =  $GLOBALS['OE_SITE_DIR'] . '/sqlconf.php';
 
         // Record names of sql table files
-        $this->main_sql = dirname(__FILE__) . '/../../sql/database.sql';
-        $this->translation_sql = dirname(__FILE__) . '/../../contrib/util/language_translations/currentLanguage_utf8.sql';
+        $this->main_sql = __DIR__ . '/../../sql/database.sql';
+        $this->translation_sql = __DIR__ . '/../../contrib/util/language_translations/currentLanguage_utf8.sql';
         $this->devel_translation_sql = "http://translations.openemr.io/languageTranslations_utf8.sql";
-        $this->ippf_sql = dirname(__FILE__) . "/../../sql/ippf_layout.sql";
-        $this->cvx = dirname(__FILE__) . "/../../sql/cvx_codes.sql";
-        $this->additional_users = dirname(__FILE__) . "/../../sql/official_additional_users.sql";
+        $this->ippf_sql = __DIR__ . "/../../sql/ippf_layout.sql";
+        $this->cvx = __DIR__ . "/../../sql/cvx_codes.sql";
+        $this->additional_users = __DIR__ . "/../../sql/official_additional_users.sql";
 
         // Prepare the dumpfile list
         $this->initialize_dumpfile_list();
@@ -388,7 +388,7 @@ class Installer
 
     public function add_version_info()
     {
-        include dirname(__FILE__) . "/../../version.php";
+        include __DIR__ . "/../../version.php";
         /**
          * This annotation declares variables from the legacy include
          * so PHPStan recognizes them.
@@ -621,7 +621,7 @@ $config = 1; /////////////
     {
         $GLOBALS['temp_skip_translations'] = true;
         $skipGlobalEvent = true; // use in globals.inc.php script to skip event stuff
-        require(dirname(__FILE__) . '/../globals.inc.php');
+        require(__DIR__ . '/../globals.inc.php');
         /** @phpstan-ignore variable.undefined */
         foreach ($GLOBALS_METADATA as $grparr) {
             foreach ($grparr as $fldid => $fldarr) {

--- a/library/classes/Prescription.class.php
+++ b/library/classes/Prescription.class.php
@@ -80,7 +80,7 @@
 //
 
 
-require_once(dirname(__FILE__) . "/../lists.inc.php");
+require_once(__DIR__ . "/../lists.inc.php");
 
 
 /**

--- a/library/classes/fpdf/fpdf.php
+++ b/library/classes/fpdf/fpdf.php
@@ -112,8 +112,8 @@ function __construct($orientation='P', $unit='mm', $size='A4')
 		if(substr($this->fontpath,-1)!='/' && substr($this->fontpath,-1)!='\\')
 			$this->fontpath .= '/';
 	}
-	elseif(is_dir(dirname(__FILE__).'/font'))
-		$this->fontpath = dirname(__FILE__).'/font/';
+	elseif(is_dir(__DIR__.'/font'))
+		$this->fontpath = __DIR__.'/font/';
 	else
 		$this->fontpath = '';
 	// Core fonts

--- a/library/classes/rulesets/Amc/AmcReportFactory.php
+++ b/library/classes/rulesets/Amc/AmcReportFactory.php
@@ -11,11 +11,11 @@ class AmcReportFactory extends RsReportFactoryAbstract
 {
     public function __construct()
     {
-        foreach (glob(dirname(__FILE__) . "/library/*.php") as $filename) {
+        foreach (glob(__DIR__ . "/library/*.php") as $filename) {
             require_once($filename);
         }
 
-        foreach (glob(dirname(__FILE__) . "/reports/*.php") as $filename) {
+        foreach (glob(__DIR__ . "/reports/*.php") as $filename) {
             require_once($filename);
         }
     }

--- a/library/classes/rulesets/Amc/library/AbstractAmcReport.php
+++ b/library/classes/rulesets/Amc/library/AbstractAmcReport.php
@@ -24,11 +24,11 @@
  * @link    http://www.open-emr.org
  */
 
-require_once(dirname(__FILE__) . "/../../library/RsFilterIF.php");
+require_once(__DIR__ . "/../../library/RsFilterIF.php");
 require_once('AmcFilterIF.php');
 require_once('IAmcItemizedReport.php');
-require_once(dirname(__FILE__) . "/../../../../clinical_rules.php");
-require_once(dirname(__FILE__) . "/../../../../amc.php");
+require_once(__DIR__ . "/../../../../clinical_rules.php");
+require_once(__DIR__ . "/../../../../amc.php");
 
 use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Reports\AMC\Trackers\AMCItemTracker;
@@ -76,17 +76,17 @@ abstract class AbstractAmcReport implements RsReportIF
         // TODO: This really needs to be moved to using our namespace autoloader... no point in doing a file stat check
         // for every single rule we have, over and over again every time the rule is instantiated.
         $className = get_class($this);
-        foreach (glob(dirname(__FILE__) . "/../reports/" . $className . "/*.php") as $filename) {
+        foreach (glob(__DIR__ . "/../reports/" . $className . "/*.php") as $filename) {
             require_once($filename);
         }
 
         // require common .php files
-        foreach (glob(dirname(__FILE__) . "/../reports/common/*.php") as $filename) {
+        foreach (glob(__DIR__ . "/../reports/common/*.php") as $filename) {
             require_once($filename);
         }
 
         // require clinical types
-        foreach (glob(dirname(__FILE__) . "/../../../ClinicalTypes/*.php") as $filename) {
+        foreach (glob(__DIR__ . "/../../../ClinicalTypes/*.php") as $filename) {
             require_once($filename);
         }
 

--- a/library/classes/rulesets/Cqm/CqmReportFactory.php
+++ b/library/classes/rulesets/Cqm/CqmReportFactory.php
@@ -11,11 +11,11 @@ class CqmReportFactory extends RsReportFactoryAbstract
 {
     public function __construct()
     {
-        foreach (glob(dirname(__FILE__) . "/library/*.php") as $filename) {
+        foreach (glob(__DIR__ . "/library/*.php") as $filename) {
             require_once($filename);
         }
 
-        foreach (glob(dirname(__FILE__) . "/reports/*.php") as $filename) {
+        foreach (glob(__DIR__ . "/reports/*.php") as $filename) {
             require_once($filename);
         }
     }

--- a/library/classes/rulesets/Cqm/library/AbstractCqmReport.php
+++ b/library/classes/rulesets/Cqm/library/AbstractCqmReport.php
@@ -7,7 +7,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 //
-require_once(dirname(__FILE__) . "/../../../../clinical_rules.php");
+require_once(__DIR__ . "/../../../../clinical_rules.php");
 
 abstract class AbstractCqmReport implements RsReportIF
 {
@@ -24,17 +24,17 @@ abstract class AbstractCqmReport implements RsReportIF
     {
         // require all .php files in the report's sub-folder
         $className = get_class($this);
-        foreach (glob(dirname(__FILE__) . "/../reports/" . $className . "/*.php") as $filename) {
+        foreach (glob(__DIR__ . "/../reports/" . $className . "/*.php") as $filename) {
             require_once($filename);
         }
 
         // require common .php files
-        foreach (glob(dirname(__FILE__) . "/../reports/common/*.php") as $filename) {
+        foreach (glob(__DIR__ . "/../reports/common/*.php") as $filename) {
             require_once($filename);
         }
 
         // require clinical types
-        foreach (glob(dirname(__FILE__) . "/../../../ClinicalTypes/*.php") as $filename) {
+        foreach (glob(__DIR__ . "/../../../ClinicalTypes/*.php") as $filename) {
             require_once($filename);
         }
 

--- a/library/classes/rulesets/ReportManager.php
+++ b/library/classes/rulesets/ReportManager.php
@@ -13,15 +13,15 @@ class ReportManager
 {
     public function __construct()
     {
-        foreach (glob(dirname(__FILE__) . "/library/*.php") as $filename) {
+        foreach (glob(__DIR__ . "/library/*.php") as $filename) {
             require_once($filename);
         }
 
-        foreach (glob(dirname(__FILE__) . "/Cqm/*.php") as $filename) {
+        foreach (glob(__DIR__ . "/Cqm/*.php") as $filename) {
             require_once($filename);
         }
 
-        foreach (glob(dirname(__FILE__) . "/Amc/*.php") as $filename) {
+        foreach (glob(__DIR__ . "/Amc/*.php") as $filename) {
             require_once($filename);
         }
     }

--- a/library/classes/rulesets/library/RsPatient.php
+++ b/library/classes/rulesets/library/RsPatient.php
@@ -7,7 +7,7 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 //
-require_once(dirname(__FILE__) . "/../../../patient.inc.php");
+require_once(__DIR__ . "/../../../patient.inc.php");
 
 class RsPatient
 {

--- a/library/classes/smtp/sasl.php
+++ b/library/classes/smtp/sasl.php
@@ -310,7 +310,7 @@ class sasl_client_class
 			if(IsSet($this->drivers[$mechanism]))
 			{
 				if(!class_exists($this->drivers[$mechanism][0]))
-					require(dirname(__FILE__)."/".$this->drivers[$mechanism][1]);
+					require(__DIR__."/".$this->drivers[$mechanism][1]);
 				$this->driver=new $this->drivers[$mechanism][0];
 				if($this->driver->Initialize($this))
 				{

--- a/library/clinical_rules.php
+++ b/library/clinical_rules.php
@@ -14,10 +14,10 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . "/patient.inc.php");
-require_once(dirname(__FILE__) . "/forms.inc.php");
-require_once(dirname(__FILE__) . "/options.inc.php");
-require_once(dirname(__FILE__) . "/report_database.inc.php");
+require_once(__DIR__ . "/patient.inc.php");
+require_once(__DIR__ . "/forms.inc.php");
+require_once(__DIR__ . "/options.inc.php");
+require_once(__DIR__ . "/report_database.inc.php");
 
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\ClinicalDecisionRules\AMC\CertificationReportTypes;
@@ -891,7 +891,7 @@ function test_rules_clinic_cqm_amc_rule($rowRule, $patientData, $dateArray, $dat
     if (is_numeric($provider)) {
         $ruleOptions['provider_id'] = $provider;
     }
-    require_once(dirname(__FILE__) . "/classes/rulesets/ReportManager.php");
+    require_once(__DIR__ . "/classes/rulesets/ReportManager.php");
     $manager = new ReportManager();
     if ($rowRule['amc_flag']) {
         // Send array of dates ('dateBegin' and 'dateTarget')

--- a/library/direct_message_check.inc.php
+++ b/library/direct_message_check.inc.php
@@ -24,9 +24,9 @@
  * @link    http://www.open-emr.org
  */
 
-require_once(dirname(__FILE__) . "/pnotes.inc.php");
-require_once(dirname(__FILE__) . "/documents.php");
-require_once(dirname(__FILE__) . "/gprelations.inc.php");
+require_once(__DIR__ . "/pnotes.inc.php");
+require_once(__DIR__ . "/documents.php");
+require_once(__DIR__ . "/gprelations.inc.php");
 
 use OpenEMR\Common\Crypto\CryptoGen;
 use OpenEMR\Common\Logging\EventAuditLogger;

--- a/library/edihistory/edih_csv_inc.php
+++ b/library/edihistory/edih_csv_inc.php
@@ -85,7 +85,7 @@ if (!defined('DS')) {
 function csv_edihist_log($msg_str)
 {
     //
-    //$dir = dirname(__FILE__).DS.'log';
+    //$dir = __DIR__.DS.'log';
     //$dir = $GLOBALS['OE_EDIH_DIR'].DS.'log';
     //$logfile = $GLOBALS['OE_EDIH_DIR'] . "/log/edi_history_log.txt";
     $logfile = 'edih_log_' . date('Y-m-d') . '.txt';
@@ -147,7 +147,7 @@ function csv_log_html($logname = '')
 function csv_log_manage($list = true)
 {
     //
-    //$dir = dirname(__FILE__).DS.'log';
+    //$dir = __DIR__.DS.'log';
     $dir = csv_edih_basedir() . DS . 'log';
     $list_ar = array();
     $old_ar = array();
@@ -1784,7 +1784,7 @@ function csv_file_by_enctr($clm01, $filetype = 'f837')
         return $ret_ar;
     } else {
         $params = csv_parameters($ft);
-        //$fp = isset($params['claims_csv']) ? dirname(__FILE__).$params['claims_csv'] : false;
+        //$fp = isset($params['claims_csv']) ? __DIR__.$params['claims_csv'] : false;
         $fp = isset($params['claims_csv']) ? $params['claims_csv'] : false;
         $h_ar = csv_table_header($ft, 'claim');
         $hct = count($h_ar);

--- a/library/edihistory/test_edih_sftp_files.php
+++ b/library/edihistory/test_edih_sftp_files.php
@@ -238,7 +238,7 @@ if (php_sapi_name() == 'cli') {
 
 $get_count = extract($_GET, EXTR_OVERWRITE);
 // Following breaks link to OpenEMR structure dependency - assumes phpseclib is subdir
-$script_dir = dirname(__FILE__);
+$script_dir = __DIR__;
 ini_set('include_path', ini_get('include_path') . PATH_SEPARATOR . "$script_dir/phpseclib");
 require_once("$script_dir/phpseclib/Net/SFTP.php");
 function get_openemr_globals($libdir): void

--- a/library/encounter.inc
+++ b/library/encounter.inc
@@ -6,4 +6,4 @@
  *  - Timeframe: this script can be remove in mid 2023
  */
 
-require_once(dirname(__FILE__) . "/encounter.inc.php");
+require_once(__DIR__ . "/encounter.inc.php");

--- a/library/forms.inc
+++ b/library/forms.inc
@@ -6,4 +6,4 @@
  *  - Timeframe: this script can never be removed
  */
 
-require_once(dirname(__FILE__) . "/forms.inc.php");
+require_once(__DIR__ . "/forms.inc.php");

--- a/library/group.inc
+++ b/library/group.inc
@@ -25,4 +25,4 @@
  * @link    http://www.open-emr.org
  */
 
-require_once(dirname(__FILE__) . "/group.inc.php");
+require_once(__DIR__ . "/group.inc.php");

--- a/library/group.inc.php
+++ b/library/group.inc.php
@@ -25,12 +25,12 @@
  * @link    http://www.open-emr.org
  */
 
-require_once(dirname(__FILE__) . "/../interface/therapy_groups/therapy_groups_models/therapy_groups_model.php");
-require_once(dirname(__FILE__) . "/../interface/therapy_groups/therapy_groups_models/group_statuses_model.php");
-require_once(dirname(__FILE__) . "/../interface/therapy_groups/therapy_groups_models/therapy_groups_counselors_model.php");
-require_once(dirname(__FILE__) . "/../interface/therapy_groups/therapy_groups_models/users_model.php");
-require_once(dirname(__FILE__) . "/../interface/therapy_groups/therapy_groups_models/therapy_groups_participants_model.php");
-require_once(dirname(__FILE__) . "/../interface/therapy_groups/therapy_groups_controllers/therapy_groups_controller.php");
+require_once(__DIR__ . "/../interface/therapy_groups/therapy_groups_models/therapy_groups_model.php");
+require_once(__DIR__ . "/../interface/therapy_groups/therapy_groups_models/group_statuses_model.php");
+require_once(__DIR__ . "/../interface/therapy_groups/therapy_groups_models/therapy_groups_counselors_model.php");
+require_once(__DIR__ . "/../interface/therapy_groups/therapy_groups_models/users_model.php");
+require_once(__DIR__ . "/../interface/therapy_groups/therapy_groups_models/therapy_groups_participants_model.php");
+require_once(__DIR__ . "/../interface/therapy_groups/therapy_groups_controllers/therapy_groups_controller.php");
 
 use OpenEMR\Common\Session\SessionUtil;
 

--- a/library/lists.inc
+++ b/library/lists.inc
@@ -23,4 +23,4 @@
  * @link    http://www.open-emr.org
  */
 
-require_once(dirname(__FILE__) . "/lists.inc.php");
+require_once(__DIR__ . "/lists.inc.php");

--- a/library/options.inc.php
+++ b/library/options.inc.php
@@ -52,7 +52,7 @@
 require_once("user.inc.php");
 require_once("patient.inc.php");
 require_once("lists.inc.php");
-require_once(dirname(dirname(__FILE__)) . "/custom/code_types.inc.php");
+require_once(dirname(__DIR__) . "/custom/code_types.inc.php");
 
 use OpenEMR\Common\Acl\AclExtended;
 use OpenEMR\Common\Acl\AclMain;

--- a/library/options_listadd.inc
+++ b/library/options_listadd.inc
@@ -12,4 +12,4 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require(dirname(__FILE__) . "/options_listadd.inc.php");
+require(__DIR__ . "/options_listadd.inc.php");

--- a/library/patient.inc
+++ b/library/patient.inc
@@ -18,4 +18,4 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . "/patient.inc.php");
+require_once(__DIR__ . "/patient.inc.php");

--- a/library/patient.inc.php
+++ b/library/patient.inc.php
@@ -23,7 +23,7 @@ use OpenEMR\Services\SocialHistoryService;
 use OpenEMR\Billing\InsurancePolicyTypes;
 use OpenEMR\Services\InsuranceCompanyService;
 
-require_once(dirname(__FILE__) . "/dupscore.inc.php");
+require_once(__DIR__ . "/dupscore.inc.php");
 
 global $facilityService;
 $facilityService = new FacilityService();

--- a/library/patient_tracker.inc.php
+++ b/library/patient_tracker.inc.php
@@ -27,7 +27,7 @@
 *
 */
 
-require_once(dirname(__FILE__) . '/appointments.inc.php');
+require_once(__DIR__ . '/appointments.inc.php');
 
 use OpenEMR\Services\AppointmentService;
 use OpenEMR\Services\PatientTrackerService;

--- a/library/pid.inc
+++ b/library/pid.inc
@@ -12,4 +12,4 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . "/pid.inc.php");
+require_once(__DIR__ . "/pid.inc.php");

--- a/library/pnotes.inc
+++ b/library/pnotes.inc
@@ -6,4 +6,4 @@
  *  - Timeframe: this script can be remove in mid 2023
  */
 
-require_once(dirname(__FILE__) . "/pnotes.inc.php");
+require_once(__DIR__ . "/pnotes.inc.php");

--- a/library/registry.inc
+++ b/library/registry.inc
@@ -6,4 +6,4 @@
  *  - Timeframe: this script can be remove in mid 2023
  */
 
-require_once(dirname(__FILE__) . "/registry.inc.php");
+require_once(__DIR__ . "/registry.inc.php");

--- a/library/reminders.php
+++ b/library/reminders.php
@@ -27,8 +27,8 @@
 /**
  * Include the main CDR engine library, email class and maviq class
  */
-require_once(dirname(__FILE__) . "/clinical_rules.php");
-require_once(dirname(__FILE__) . "/maviq_phone_api.php");
+require_once(__DIR__ . "/clinical_rules.php");
+require_once(__DIR__ . "/maviq_phone_api.php");
 
 //only used in commented out code
 use OpenEMR\Common\Crypto\CryptoGen;

--- a/library/report.inc
+++ b/library/report.inc
@@ -6,4 +6,4 @@
 *  - Timeframe: this script can never be removed
 */
 
-require_once(dirname(__FILE__) . "/report.inc.php");
+require_once(__DIR__ . "/report.inc.php");

--- a/library/report_database.inc
+++ b/library/report_database.inc
@@ -6,4 +6,4 @@
  *  - Timeframe: this script can be remove in mid 2023
  */
 
-require_once(dirname(__FILE__) . "/report_database.inc.php");
+require_once(__DIR__ . "/report_database.inc.php");

--- a/library/smarty/plugins/function.amcCollect.php
+++ b/library/smarty/plugins/function.amcCollect.php
@@ -25,7 +25,7 @@
  * @param Smarty
  */
 
-require_once(dirname(__FILE__) . '/../../amc.php');
+require_once(__DIR__ . '/../../amc.php');
 
 function smarty_function_amcCollect($params, &$smarty): void
 {

--- a/library/smarty_legacy/smarty/Smarty_Legacy.class.php
+++ b/library/smarty_legacy/smarty/Smarty_Legacy.class.php
@@ -31,8 +31,8 @@
 
 /* $Id$ */
 
-require_once(dirname(__FILE__) . "/Config_File_Legacy.class.php");
-require_once(dirname(__FILE__) . "/Smarty_Compiler_Legacy.class.php");
+require_once(__DIR__ . "/Config_File_Legacy.class.php");
+require_once(__DIR__ . "/Smarty_Compiler_Legacy.class.php");
 
 /**
  * DIR_SEP isn't used anymore, but third party apps might
@@ -48,7 +48,7 @@ if(!defined('DIR_SEP')) {
  */
 
 if (!defined('SMARTY_DIR')) {
-    define('SMARTY_DIR', dirname(__FILE__) . DIRECTORY_SEPARATOR);
+    define('SMARTY_DIR', __DIR__ . DIRECTORY_SEPARATOR);
 }
 
 if (!defined('SMARTY_CORE_DIR')) {

--- a/library/spreadsheet.inc.php
+++ b/library/spreadsheet.inc.php
@@ -12,9 +12,9 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . '/api.inc.php');
-require_once(dirname(__FILE__) . '/forms.inc.php');
-require_once(dirname(__FILE__) . '/../interface/forms/fee_sheet/codes.php');
+require_once(__DIR__ . '/api.inc.php');
+require_once(__DIR__ . '/forms.inc.php');
+require_once(__DIR__ . '/../interface/forms/fee_sheet/codes.php');
 
 use OpenEMR\Core\Header;
 

--- a/library/sql.inc.php
+++ b/library/sql.inc.php
@@ -16,7 +16,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . "/sqlconf.php");
+require_once(__DIR__ . "/sqlconf.php");
 
 /**
  * Variables set by sqlconf.php or SqlConfigEvent
@@ -34,9 +34,9 @@ require_once(dirname(__FILE__) . "/sqlconf.php");
  * @var string $secure_dbase
  */
 
-require_once(dirname(__FILE__) . "/../vendor/adodb/adodb-php/adodb.inc.php");
-require_once(dirname(__FILE__) . "/../vendor/adodb/adodb-php/drivers/adodb-mysqli.inc.php");
-require_once(dirname(__FILE__) . "/ADODB_mysqli_log.php");
+require_once(__DIR__ . "/../vendor/adodb/adodb-php/adodb.inc.php");
+require_once(__DIR__ . "/../vendor/adodb/adodb-php/drivers/adodb-mysqli.inc.php");
+require_once(__DIR__ . "/ADODB_mysqli_log.php");
 
 if (!defined('ADODB_FETCH_ASSOC')) {
     define('ADODB_FETCH_ASSOC', 2);

--- a/library/user.inc
+++ b/library/user.inc
@@ -6,4 +6,4 @@
  *  - Timeframe: this script can be remove in mid 2023
  */
 
-require_once(dirname(__FILE__) . "/user.inc.php");
+require_once(__DIR__ . "/user.inc.php");

--- a/modules/sms_email_reminder/batch_reminders.php
+++ b/modules/sms_email_reminder/batch_reminders.php
@@ -14,7 +14,7 @@ if (!getenv('OPENEMR_ENABLE_BATCH_REMINDERS')) {
 $backpic = "";
 $ignoreAuth = 1;
 
-require_once(dirname(__FILE__) . "/../../interface/globals.php");
+require_once(__DIR__ . "/../../interface/globals.php");
 require_once($GLOBALS['srcdir'] . "/maviq_phone_api.php");
 require_once($GLOBALS['srcdir'] . "/reminders.php");
 

--- a/portal/account/index_reset.php
+++ b/portal/account/index_reset.php
@@ -30,8 +30,8 @@ if (isset($_SESSION['pid']) && isset($_SESSION['patient_portal_onsite_two'])) {
     header('Location: ' . $landingpage . '&w');
     exit;
 }
-require_once(dirname(__FILE__) . '/../../interface/globals.php');
-require_once(dirname(__FILE__) . "/../lib/appsql.class.php");
+require_once(__DIR__ . '/../../interface/globals.php');
+require_once(__DIR__ . "/../lib/appsql.class.php");
 
 use OpenEMR\Common\Auth\AuthHash;
 use OpenEMR\Common\Csrf\CsrfUtils;

--- a/portal/find_appt_popup_user.php
+++ b/portal/find_appt_popup_user.php
@@ -54,7 +54,7 @@ $ignoreAuth_onsite_portal = true;
 
 require_once("../interface/globals.php");
 require_once("$srcdir/patient.inc.php");
-require_once(dirname(__FILE__) . "/../library/appointments.inc.php");
+require_once(__DIR__ . "/../library/appointments.inc.php");
 
 use OpenEMR\Core\Header;
 use OpenEMR\Services\Utils\DateFormatterUtils;

--- a/portal/get_patient_info.php
+++ b/portal/get_patient_info.php
@@ -81,7 +81,7 @@ if (
     exit();
 }
 
-require_once(dirname(__FILE__) . "/lib/appsql.class.php");
+require_once(__DIR__ . "/lib/appsql.class.php");
 require_once("$srcdir/user.inc.php");
 
 use OpenEMR\Common\Auth\AuthHash;

--- a/portal/lib/appsql.class.php
+++ b/portal/lib/appsql.class.php
@@ -10,7 +10,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__FILE__) . '/../../interface/globals.php');
+require_once(__DIR__ . '/../../interface/globals.php');
 
 use OpenEMR\Common\Crypto\CryptoGen;
 use OpenEMR\Common\Logging\EventAuditLogger;

--- a/portal/lib/paylib.php
+++ b/portal/lib/paylib.php
@@ -23,11 +23,11 @@ SessionUtil::portalSessionStart();
 if (isset($_SESSION['pid']) && isset($_SESSION['patient_portal_onsite_two'])) {
     $pid = $_SESSION['pid'];
     $ignoreAuth_onsite_portal = true;
-    require_once(dirname(__FILE__) . "/../../interface/globals.php");
+    require_once(__DIR__ . "/../../interface/globals.php");
 } else {
     SessionUtil::portalSessionCookieDestroy();
     $ignoreAuth = false;
-    require_once(dirname(__FILE__) . "/../../interface/globals.php");
+    require_once(__DIR__ . "/../../interface/globals.php");
     if (!isset($_SESSION['authUserID'])) {
         $landingpage = "index.php";
         header('Location: ' . $landingpage);

--- a/portal/logout.php
+++ b/portal/logout.php
@@ -15,7 +15,7 @@
  */
 
 require_once("verify_session.php");
-require_once(dirname(__FILE__) . "/lib/appsql.class.php");
+require_once(__DIR__ . "/lib/appsql.class.php");
 
 use OpenEMR\Common\Session\SessionUtil;
 

--- a/portal/messaging/handle_note.php
+++ b/portal/messaging/handle_note.php
@@ -30,7 +30,7 @@ if (isset($_SESSION['pid']) && isset($_SESSION['patient_portal_onsite_two'])) {
         }
     }
     $ignoreAuth_onsite_portal = true;
-    require_once(dirname(__FILE__) . "/../../interface/globals.php");
+    require_once(__DIR__ . "/../../interface/globals.php");
     if (empty($_SESSION['portal_username'])) {
         echo xlt("illegal Action");
         SessionUtil::portalSessionCookieDestroy();
@@ -64,7 +64,7 @@ if (isset($_SESSION['pid']) && isset($_SESSION['patient_portal_onsite_two'])) {
 } else {
     SessionUtil::portalSessionCookieDestroy();
     $ignoreAuth = false;
-    require_once(dirname(__FILE__) . "/../../interface/globals.php");
+    require_once(__DIR__ . "/../../interface/globals.php");
     if (!isset($_SESSION['authUserID']) || empty($_SESSION['authUser'])) {
         $landingpage = "index.php";
         header('Location: ' . $landingpage);
@@ -74,7 +74,7 @@ if (isset($_SESSION['pid']) && isset($_SESSION['patient_portal_onsite_two'])) {
     $owner = $_SESSION['authUser'];
 }
 
-require_once(dirname(__FILE__) . "/../lib/portal_mail.inc.php");
+require_once(__DIR__ . "/../lib/portal_mail.inc.php");
 require_once("$srcdir/pnotes.inc.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;

--- a/portal/patient/fwk/libs/savant/Savant3.php
+++ b/portal/patient/fwk/libs/savant/Savant3.php
@@ -17,8 +17,8 @@
 /**
  * Always have these classes available.
  */
-include_once dirname(__FILE__) . '/Savant3/Filter.php';
-include_once dirname(__FILE__) . '/Savant3/Plugin.php';
+include_once __DIR__ . '/Savant3/Filter.php';
+include_once __DIR__ . '/Savant3/Plugin.php';
 
 /**
  *
@@ -696,7 +696,7 @@ class Savant3
                 break;
             case 'resource':
                 // the Savant3 distribution resources
-                $this->addPath($type, dirname(__FILE__) . '/Savant3/resources/');
+                $this->addPath($type, __DIR__ . '/Savant3/resources/');
                 break;
         }
 
@@ -1205,7 +1205,7 @@ class Savant3
         // are we throwing exceptions?
         if ($this->__config ['exceptions']) {
             if (! class_exists('Savant3_Exception', $autoload)) {
-                include_once dirname(__FILE__) . '/Savant3/Exception.php';
+                include_once __DIR__ . '/Savant3/Exception.php';
             }
 
             throw new Savant3_Exception($code);
@@ -1221,7 +1221,7 @@ class Savant3
 
         // make sure the Savant3 error class is available
         if (! class_exists('Savant3_Error', $autoload)) {
-            include_once dirname(__FILE__) . '/Savant3/Error.php';
+            include_once __DIR__ . '/Savant3/Error.php';
         }
 
         // return it
@@ -1254,7 +1254,7 @@ class Savant3
             // make sure the Savant3 error class is available for
             // comparison
             if (! class_exists('Savant3_Error', $autoload)) {
-                include_once dirname(__FILE__) . '/Savant3/Error.php';
+                include_once __DIR__ . '/Savant3/Error.php';
             }
 
             // now compare the parentage

--- a/portal/patient/libs/Controller/AppBasePortalController.php
+++ b/portal/patient/libs/Controller/AppBasePortalController.php
@@ -4,7 +4,7 @@
 
 /** import supporting libraries */
 require_once("verysimple/Phreeze/PortalController.php");
-require_once(dirname(__FILE__) . "/../../../lib/appsql.class.php");
+require_once(__DIR__ . "/../../../lib/appsql.class.php");
 /**
  * AppBaseController is a base class Controller class from which
  * the front controllers inherit.  it is not necessary to use this

--- a/portal/report/portal_custom_report.php
+++ b/portal/report/portal_custom_report.php
@@ -210,7 +210,7 @@ input[type="radio"] {
 <script>var $j = '$';</script>
 
     <?php // if the track_anything form exists, then include the styling
-    if (file_exists(dirname(__FILE__) . "/../../forms/track_anything/style.css")) { ?>
+    if (file_exists(__DIR__ . "/../../forms/track_anything/style.css")) { ?>
  <link rel="stylesheet" href="<?php echo $GLOBALS['web_root']?>/interface/forms/track_anything/style.css?v=<?php echo $v_js_includes; ?>">
     <?php  } ?>
 

--- a/setup.php
+++ b/setup.php
@@ -30,7 +30,7 @@
  */
 
 // Checks if the server's PHP version is compatible with OpenEMR:
-require_once(dirname(__FILE__) . "/src/Common/Compatibility/Checker.php");
+require_once(__DIR__ . "/src/Common/Compatibility/Checker.php");
 $response = OpenEMR\Common\Compatibility\Checker::checkPhpVersion();
 if ($response !== true) {
     die(htmlspecialchars($response));
@@ -55,7 +55,7 @@ $allow_multisite_setup = false;
 $allow_cloning_setup = false;
 
 // Include standard libraries/classes
-require_once dirname(__FILE__) . "/vendor/autoload.php";
+require_once __DIR__ . "/vendor/autoload.php";
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionUtil;
@@ -1616,11 +1616,11 @@ STP4TOP;
                     echo "<p>Configuration of Apache web server...</p><br />\n";
                     echo "The <code>\"" . text(preg_replace("/{$site_id}/", "*", realpath($docsDirectory))) . "\"</code> directory contain patient information, and
                     it is important to secure these directories. Additionally, some settings are required for the Zend Framework to work in OpenEMR. This can be done by pasting the below to end of your apache configuration file:<br /><br />
-                    &nbsp;&nbsp;<code>&lt;Directory \"" . text(realpath(dirname(__FILE__))) . "\"&gt;<br />
+                    &nbsp;&nbsp;<code>&lt;Directory \"" . text(realpath(__DIR__)) . "\"&gt;<br />
                     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;AllowOverride FileInfo<br />
                     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Require all granted<br />
                     &nbsp;&nbsp;<code>&lt;/Directory&gt;</code><br />
-                    &nbsp;&nbsp;&lt;Directory \"" . text(realpath(dirname(__FILE__))) . "/sites\"&gt;<br />
+                    &nbsp;&nbsp;&lt;Directory \"" . text(realpath(__DIR__)) . "/sites\"&gt;<br />
                     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;AllowOverride None<br />
                     &nbsp;&nbsp;&lt;/Directory&gt;</code><br />
                     &nbsp;&nbsp;<code>&lt;Directory \"" . text(preg_replace("/{$site_id}/", "*", realpath($docsDirectory))) . "\"&gt;<br />

--- a/sites/default/config.php
+++ b/sites/default/config.php
@@ -77,12 +77,12 @@ $GLOBALS['oer_config']['druglabels']['disclaimer'] =
 
 //don't alter below this line unless you are an advanced user and know what you are doing
 
-$GLOBALS['oer_config']['prescriptions']['logo'] = dirname(__FILE__) .
+$GLOBALS['oer_config']['prescriptions']['logo'] = __DIR__ .
   "/../../interface/pic/" . $GLOBALS['oer_config']['prescriptions']['logo_pic'];
-$GLOBALS['oer_config']['prescriptions']['signature'] = dirname(__FILE__) .
+$GLOBALS['oer_config']['prescriptions']['signature'] = __DIR__ .
   "/../../interface/pic/" . $GLOBALS['oer_config']['prescriptions']['sig_pic'];
 
-$GLOBALS['oer_config']['druglabels']['logo'] = dirname(__FILE__) .
+$GLOBALS['oer_config']['druglabels']['logo'] = __DIR__ .
   "/../../interface/pic/" . $GLOBALS['oer_config']['druglabels']['logo_pic'];
 
 $GLOBALS['oer_config']['documents']['repository'] = $GLOBALS['oer_config']['documents']['repopath'];

--- a/sql_patch.php
+++ b/sql_patch.php
@@ -12,7 +12,7 @@
 // for the new release.
 
 // Checks if the server's PHP version is compatible with OpenEMR:
-require_once(dirname(__FILE__) . "/src/Common/Compatibility/Checker.php");
+require_once(__DIR__ . "/src/Common/Compatibility/Checker.php");
 $response = OpenEMR\Common\Compatibility\Checker::checkPhpVersion();
 if ($response !== true) {
     die(htmlspecialchars($response));

--- a/src/Billing/EDI270.php
+++ b/src/Billing/EDI270.php
@@ -24,7 +24,7 @@
 
 namespace OpenEMR\Billing;
 
-require_once(dirname(__FILE__) . "/../../library/edihistory/codes/edih_271_code_class.php");
+require_once(__DIR__ . "/../../library/edihistory/codes/edih_271_code_class.php");
 
 use edih_271_codes;
 use GuzzleHttp\Client;

--- a/src/Billing/InvoiceSummary.php
+++ b/src/Billing/InvoiceSummary.php
@@ -34,7 +34,7 @@
 //  arseq - ar_activity.sequence_no when it applies.
 namespace OpenEMR\Billing;
 
-require_once(dirname(__FILE__) . "/../../custom/code_types.inc.php");
+require_once(__DIR__ . "/../../custom/code_types.inc.php");
 
 use OpenEMR\Billing\SLEOB;
 

--- a/src/Billing/SLEOB.php
+++ b/src/Billing/SLEOB.php
@@ -14,7 +14,7 @@
 
 namespace OpenEMR\Billing;
 
-require_once(dirname(__FILE__) . "/../../library/patient.inc.php");
+require_once(__DIR__ . "/../../library/patient.inc.php");
 
 use OpenEMR\Billing\BillingUtilities;
 

--- a/src/Common/Acl/AclExtended.php
+++ b/src/Common/Acl/AclExtended.php
@@ -238,7 +238,7 @@ class AclExtended
 
         //see if this user is gacl protected (ie. do not allow
         //removal from the Administrators group)
-        require_once(dirname(__FILE__) . '/../../../library/user.inc.php');
+        require_once(__DIR__ . '/../../../library/user.inc.php');
 
         $userNameToID = (new UserService())->getIdByUsername($user_name);
 

--- a/src/Common/Acl/AclMain.php
+++ b/src/Common/Acl/AclMain.php
@@ -339,7 +339,7 @@ class AclMain
     //
     public static function aclCheckForm($formdir, $user = '', $return_value = '')
     {
-        require_once(dirname(__FILE__) . '/../../../library/registry.inc.php');
+        require_once(__DIR__ . '/../../../library/registry.inc.php');
         $tmp = getRegistryEntryByDirectory($formdir, 'aco_spec');
         return self::aclCheckAcoSpec($tmp['aco_spec'], $user, $return_value);
     }
@@ -349,7 +349,7 @@ class AclMain
     //
     public static function aclCheckIssue($type, $user = '', $return_value = '')
     {
-        require_once(dirname(__FILE__) . '/../../../library/lists.inc.php');
+        require_once(__DIR__ . '/../../../library/lists.inc.php');
         global $ISSUE_TYPES;
         if (empty($ISSUE_TYPES[$type][5])) {
             return true;

--- a/src/Gacl/Gacl.php
+++ b/src/Gacl/Gacl.php
@@ -24,15 +24,15 @@ namespace OpenEMR\Gacl;
  * Path to ADODB.
  */
 if ( !defined('ADODB_DIR') ) {
-	define('ADODB_DIR', dirname(__FILE__).'/../vendor/adodb/adodb-php');
+	define('ADODB_DIR', __DIR__.'/../vendor/adodb/adodb-php');
 }
 
 //openemr configuration file - bm - 05-2009
 // to collect sql database login info and the utf8 flag
 // also collect the adodb libraries to support mysqli_mod that is needed for mysql ssl support
-require_once(dirname(__FILE__) . "/../../library/sqlconf.php");
-require_once(dirname(__FILE__) . "/../../vendor/adodb/adodb-php/adodb.inc.php");
-require_once(dirname(__FILE__) . "/../../vendor/adodb/adodb-php/drivers/adodb-mysqli.inc.php");
+require_once(__DIR__ . "/../../library/sqlconf.php");
+require_once(__DIR__ . "/../../vendor/adodb/adodb-php/adodb.inc.php");
+require_once(__DIR__ . "/../../vendor/adodb/adodb-php/drivers/adodb-mysqli.inc.php");
 
 class Gacl {
 	/*
@@ -213,7 +213,7 @@ class Gacl {
 
 		if ( $this->_caching == TRUE ) {
 			if (!class_exists('Hashed_Cache_Lite')) {
-				require_once(dirname(__FILE__) .'/Cache_Lite/Hashed_Cache_Lite.php');
+				require_once(__DIR__ .'/Cache_Lite/Hashed_Cache_Lite.php');
 			}
 
 			/*

--- a/src/Menu/MenuRole.php
+++ b/src/Menu/MenuRole.php
@@ -17,7 +17,7 @@
 
 namespace OpenEMR\Menu;
 
-require_once(dirname(__FILE__) . "/../../library/registry.inc.php");
+require_once(__DIR__ . "/../../library/registry.inc.php");
 
 use OpenEMR\Common\Acl\AclMain;
 

--- a/src/Services/DocumentService.php
+++ b/src/Services/DocumentService.php
@@ -14,7 +14,7 @@
 
 namespace OpenEMR\Services;
 
-require_once(dirname(__FILE__) . "/../../controllers/C_Document.class.php");
+require_once(__DIR__ . "/../../controllers/C_Document.class.php");
 
 use Document;
 use OpenEMR\Common\Database\QueryUtils;

--- a/src/Services/EncounterService.php
+++ b/src/Services/EncounterService.php
@@ -34,8 +34,8 @@ use OpenEMR\Validators\EncounterValidator;
 use OpenEMR\Validators\ProcessingResult;
 use Particle\Validator\Validator;
 
-require_once dirname(__FILE__) . "/../../library/forms.inc.php";
-require_once dirname(__FILE__) . "/../../library/encounter.inc.php";
+require_once __DIR__ . "/../../library/forms.inc.php";
+require_once __DIR__ . "/../../library/encounter.inc.php";
 
 class EncounterService extends BaseService
 {

--- a/src/Services/Utils/SQLUpgradeService.php
+++ b/src/Services/Utils/SQLUpgradeService.php
@@ -984,8 +984,8 @@ class SQLUpgradeService implements ISQLUpgradeService
     private function clickOptionsMigrate()
     {
         // If the clickoptions.txt file exist, then import it.
-        if (file_exists(dirname(__FILE__) . "/../sites/" . $_SESSION['site_id'] . "/clickoptions.txt")) {
-            $file_handle = fopen(dirname(__FILE__) . "/../sites/" . $_SESSION['site_id'] . "/clickoptions.txt", "rb");
+        if (file_exists(__DIR__ . "/../sites/" . $_SESSION['site_id'] . "/clickoptions.txt")) {
+            $file_handle = fopen(__DIR__ . "/../sites/" . $_SESSION['site_id'] . "/clickoptions.txt", "rb");
             $seq = 10;
             $prev = '';
             $this->echo("Importing clickoption setting<br />");

--- a/tests/Tests/Fixtures/BaseFixtureManager.php
+++ b/tests/Tests/Fixtures/BaseFixtureManager.php
@@ -50,7 +50,7 @@ abstract class BaseFixtureManager
      */
     protected function loadJsonFile($fileName)
     {
-        $filePath = dirname(__FILE__) . "/" . $fileName;
+        $filePath = __DIR__ . "/" . $fileName;
         $jsonData = file_get_contents($filePath);
         $parsedRecords = json_decode($jsonData, true);
         return $parsedRecords;

--- a/tests/Tests/Fixtures/FixtureManager.php
+++ b/tests/Tests/Fixtures/FixtureManager.php
@@ -53,7 +53,7 @@ class FixtureManager
      */
     private function loadJsonFile($fileName)
     {
-        $filePath = dirname(__FILE__) . "/" . $fileName;
+        $filePath = __DIR__ . "/" . $fileName;
         $jsonData = file_get_contents($filePath);
         $parsedRecords = json_decode($jsonData, true);
         return $parsedRecords;

--- a/tests/Tests/Fixtures/PractitionerFixtureManager.php
+++ b/tests/Tests/Fixtures/PractitionerFixtureManager.php
@@ -41,7 +41,7 @@ class PractitionerFixtureManager
      */
     private function loadJsonFile($fileName)
     {
-        $filePath = dirname(__FILE__) . "/" . $fileName;
+        $filePath = __DIR__ . "/" . $fileName;
         $jsonData = file_get_contents($filePath);
         $parsedRecords = json_decode($jsonData, true);
         return $parsedRecords;

--- a/tests/Tests/Unit/Common/Auth/OpenIDConnect/Grant/CustomClientCredentialsGrantTest.php
+++ b/tests/Tests/Unit/Common/Auth/OpenIDConnect/Grant/CustomClientCredentialsGrantTest.php
@@ -267,7 +267,7 @@ class CustomClientCredentialsGrantTest extends TestCase
 
     private function loadJSONFile($fileName)
     {
-        $filePath = dirname(__FILE__) . "/../../../../../data/Unit/Common/Auth/Grant/" . $fileName;
+        $filePath = __DIR__ . "/../../../../../data/Unit/Common/Auth/Grant/" . $fileName;
         $jsonData = file_get_contents($filePath);
         return $jsonData;
     }


### PR DESCRIPTION
Fixes #8874

#### Short description of what this resolves:

Use up-to-date `__DIR__` instead of `dirname(__FILE__)`


#### Changes proposed in this pull request:

- [x] replace `dirname(__FILE__)` with `__DIR__` in all php code.

#### Does your code include anything generated by an AI Engine? No
