### PR TITLE
fix(history_sdoh_widget): goals must be array

### DIFF
--- a/interface/patient_file/history/history_sdoh_widget.php
+++ b/interface/patient_file/history/history_sdoh_widget.php
@@ -23,9 +23,12 @@ require_once(dirname(__FILE__, 3) . "/globals.php");
 require_once($srcdir . "/options.inc.php");
 
 use OpenEMR\Common\Acl\AclMain;
+use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Core\Header;
 use OpenEMR\Menu\PatientMenuRole;
 use OpenEMR\Services\Sdoh\HistorySdohService;
+
+$logger = new SystemLogger();
 
 /** Lookup a list option title by (list_id, option_id). */
 function hs_lo_title(string $listId, ?string $value): string
@@ -71,7 +74,11 @@ if ($authorized && !empty($pid)) {
     ) ?: [];
 }
 
-$goals_arr = json_decode($info['goals'] ?? '[]', true);
+$goals_arr = json_decode($info['goals'] ?? '', true) ?? [];
+if (!is_array($goals_arr)) {
+    $logger->warning("Dropping goals json because it is not an array.");
+    $goals_arr = [];
+}
 $goals_text = HistorySdohService::goalsToText($goals_arr, [
     'include_category' => true,
     'include_measure'  => true,


### PR DESCRIPTION
Fixes #8894

#### Short description of what this resolves:

Handle when SDOH Assessment Goals are not a valid array serialized as json.


#### Changes proposed in this pull request:

- [x] If the goals are not an array, replace the result with an empty array and log a warning.


#### Does your code include anything generated by an AI Engine? No
