### PR TITLE
ci(codecov): report after two builds

### DIFF
--- a/.github/workflows/validate-codecov.yml
+++ b/.github/workflows/validate-codecov.yml
@@ -1,0 +1,19 @@
+name: Validate codecov.yml
+
+on:
+  pull_request:
+    paths:
+    - codecov.yml
+  push:
+    paths:
+    - codecov.yml
+
+jobs:
+  validate-codecov:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate codecov.yml
+        run: curl -f -X POST --data-binary @codecov.yml https://codecov.io/validate

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,3 +2,13 @@ codecov:
   notify:
     after_n_builds: 2
 
+coverage:
+  status:
+    project:
+      default:
+        target: 4%        # Require at least 4% overall project coverage
+        threshold: 0      # No tolerance below the 4% target
+    patch:
+      default:
+        target: 0%        # New code doesn't need any coverage
+        threshold: 0

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+codecov:
+  notify:
+    after_n_builds: 2
+


### PR DESCRIPTION
Fixes #8900

#### Short description of what this resolves:

Make codecov wait to report until the slower tests have reported, so it doesn't fail a PR just because of one set of tests.


#### Changes proposed in this pull request:

- [x] add codecov.yml
- [x] configure codecov to wait for the second submission.

#### Does your code include anything generated by an AI Engine? No
