### PR TITLE
fix: crypto encrypt fix to maintain behavior of encryption of empty string when empty string or null

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,6 @@
 codecov:
   notify:
-    after_n_builds: 2
+    after_n_builds: 5
 
 coverage:
   status:

--- a/src/Common/Crypto/CryptoGen.php
+++ b/src/Common/Crypto/CryptoGen.php
@@ -186,8 +186,8 @@ class CryptoGen implements CryptoInterface
             throw new CryptoGenException("OpenEMR Error: Random Bytes error - exiting");
         }
 
-        $processedValue = empty($sValue) ? '' : $this->openSSLEncrypt(
-            $sValue,
+        $processedValue = $this->openSSLEncrypt(
+            $sValue ?? '',
             'aes-256-cbc',
             $sSecretKey,
             $iv


### PR DESCRIPTION
Fixes #8902
