### PR TITLE
fix(indexes): disable directory indexes

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,2 @@
+# Prevent directory listing and access to sensitive files
+Options -Indexes

--- a/ccdaservice/packages/oe-cqm-service/index.php
+++ b/ccdaservice/packages/oe-cqm-service/index.php
@@ -1,3 +1,0 @@
-<?php
-
-//require_once 'vendor/autoload.php';


### PR DESCRIPTION
Fixes #8907

#### Short description of what this resolves:

Disable directory indexes at root, remove empty index.php file.


#### Changes proposed in this pull request:

#### Does your code include anything generated by an AI Engine? No
