### PR TITLE
chore(oe-module-prior-authorizations): remove extra autoload

### DIFF
--- a/interface/modules/custom_modules/oe-module-prior-authorizations/public/index.php
+++ b/interface/modules/custom_modules/oe-module-prior-authorizations/public/index.php
@@ -9,7 +9,6 @@
  */
 
 require_once dirname(__FILE__, 5) . "/globals.php";
-require_once dirname(__FILE__, 2) . '/vendor/autoload.php';
 
 use Juggernaut\OpenEMR\Modules\PriorAuthModule\Controller\AuthorizationService;
 use Juggernaut\OpenEMR\Modules\PriorAuthModule\Controller\ListAuthorizations;

--- a/interface/modules/custom_modules/oe-module-prior-authorizations/public/reports/list_report.php
+++ b/interface/modules/custom_modules/oe-module-prior-authorizations/public/reports/list_report.php
@@ -9,7 +9,6 @@
  */
 
 require_once dirname(__FILE__, 6) . "/globals.php";
-require_once dirname(__FILE__, 3) . '/vendor/autoload.php';
 
 use Juggernaut\OpenEMR\Modules\PriorAuthModule\Controller\AuthorizationService;
 use OpenEMR\Core\Header;

--- a/interface/modules/custom_modules/oe-module-prior-authorizations/welcome.php
+++ b/interface/modules/custom_modules/oe-module-prior-authorizations/welcome.php
@@ -13,7 +13,6 @@ use Juggernaut\OpenEMR\Modules\PriorAuthModule\Controller\ListAuthorizations;
 use OpenEMR\Core\Header;
 
 require_once dirname(__FILE__, 4) . "/globals.php";
-require_once __DIR__ . '/vendor/autoload.php';
 
 $clinic = AuthorizationService::registerFacility();
 AuthorizationService::registration($clinic);


### PR DESCRIPTION
Fixes #8920

#### Short description of what this resolves:

It isn't necessary to require vendor/autoload.php after requiring globals.php. This removes the extra require.


#### Changes proposed in this pull request:

- [x] remove `require` of vendor/autoload.php after requiring globals.php.

#### Does your code include anything generated by an AI Engine? No
