### PR TITLE
 Updated Patient Portal logout URL point to portal/logout - for bug 8922

### DIFF
--- a/templates/portal/home.html.twig
+++ b/templates/portal/home.html.twig
@@ -662,7 +662,7 @@
                                 <!-- Infeg: Updated logout URL to point to portal/logout.php -->
                                 {% include "portal/partial/_nav_icon.html.twig"
                                     with {
-                                    url:  webroot ~ "/portal/logout.php"
+                                    url:  "./logout.php"
                                     ,localLink: false
                                     , icon: "right-from-bracket"
                                     , navText: "Logout"|xl

--- a/templates/portal/home.html.twig
+++ b/templates/portal/home.html.twig
@@ -659,9 +659,10 @@
                                     , id: "help-go"
                                 } %}
                                 {{ fireEvent(eventNames.dashboardInjectCard) }}
+                                <!-- Infeg: Updated logout URL to point to portal/logout.php -->
                                 {% include "portal/partial/_nav_icon.html.twig"
                                     with {
-                                    url:  webroot ~ "./logout.php"
+                                    url:  webroot ~ "/portal/logout.php"
                                     ,localLink: false
                                     , icon: "right-from-bracket"
                                     , navText: "Logout"|xl


### PR DESCRIPTION
Fix for - https://github.com/openemr/openemr/issues/8922

Describe the bug
The Patient Portal logout functionality is currently not working as expected. When a user attempts to log out, instead of being redirected to the login page, the system displays a "Requested URL not found" error.

Its reproduced in the live demo server also.

Steps to reproduce the behavior:

Login to Patient portal
Click on ' Logout' option
It will show 'Not Found
The requested URL was not found on this server.'