### PR TITLE
Appt api missing fields

### DIFF
--- a/src/Services/AppointmentService.php
+++ b/src/Services/AppointmentService.php
@@ -114,6 +114,7 @@ class AppointmentService extends BaseService
             }
             return true;
         });
+        $validator->optional('pc_website')->string();
 
         return $validator->validate($appointment);
     }
@@ -309,6 +310,7 @@ class AppointmentService extends BaseService
         $sql .= "     pc_pid=?,";
         $sql .= "     pc_catid=?,";
         $sql .= "     pc_title=?,";
+        $sql .= "     pc_time=NOW(),";
         $sql .= "     pc_duration=?,";
         $sql .= "     pc_hometext=?,";
         $sql .= "     pc_eventDate=?,";
@@ -317,10 +319,11 @@ class AppointmentService extends BaseService
         $sql .= "     pc_endTime=?,";
         $sql .= "     pc_facility=?,";
         $sql .= "     pc_billing_location=?,";
-        $sql .= "     pc_informant=1,";
+        $sql .= "     pc_informant=?,";
         $sql .= "     pc_eventstatus=1,";
         $sql .= "     pc_sharing=1,";
-        $sql .= "     pc_aid=?";
+        $sql .= "     pc_aid=?,";
+        $sql .= "     pc_website=?";
 
         $results = sqlInsert(
             $sql,
@@ -337,7 +340,9 @@ class AppointmentService extends BaseService
                 $endTime->format('H:i:s'),
                 $data["pc_facility"],
                 $data["pc_billing_location"],
-                $data["pc_aid"] ?? null
+                $_SESSION['authUserID'] ?? 1, // Grab authenticated user ID or default to 1
+                $data["pc_aid"] ?? null,
+                $data["pc_website"] ?? null,
             )
         );
 

--- a/src/Services/AppointmentService.php
+++ b/src/Services/AppointmentService.php
@@ -142,6 +142,8 @@ class AppointmentService extends BaseService
                        pce.pc_pid,
                        pce.pc_duration,
                        pce.pc_title,
+                       pce.pc_website,
+                       pce.pc_informant,
                        f1.name as facility_name,
                        f1_map.uuid as facility_uuid,
                        f2.name as billing_location_name,
@@ -161,7 +163,9 @@ class AppointmentService extends BaseService
                                pc_billing_location,
                                pc_catid,
                                pc_pid,
-                               pc_title
+                               pc_title,
+                               pc_website,
+                               pc_informant
                             FROM
                                  openemr_postcalendar_events
                        ) pce
@@ -218,6 +222,8 @@ class AppointmentService extends BaseService
                        pce.pc_catid,
                        pce.pc_pid,
                        pce.pc_title,
+                       pce.pc_website,
+                       pce.pc_informant,
                        f1.name as facility_name,
                        f1_map.uuid as facility_uuid,
                        f2.name as billing_location_name,
@@ -270,6 +276,8 @@ class AppointmentService extends BaseService
                        pce.pc_pid,
                        pce.pc_hometext,
                        pce.pc_title,
+                       pce.pc_website,
+                       pce.pc_informant,
                        f1.name as facility_name,
                        f1_map.uuid as facility_uuid,
                        f2.name as billing_location_name,


### PR DESCRIPTION
Fixes #8926 

#### Short description of what this resolves:
Grants access to a few missing fields on the Standard API Appointment endpoints.

#### Changes proposed in this pull request:
Grants read access to the following fields:
- `pc_website` URL associated with the Appointment
- `pc_informant` ID of user who created this appointment record

Grants write access to the following field:
- `pc_website`

Auto-sets the following fields on appointment creation:
- `pc_time` Create/update timestamp
- `pc_informant`

#### Does your code include anything generated by an AI Engine?  No

