### PR TITLE
refactor: change `array_key_exists` to `property_exists` on property

### DIFF
--- a/portal/patient/fwk/libs/verysimple/Phreeze/Phreezable.php
+++ b/portal/patient/fwk/libs/verysimple/Phreeze/Phreezable.php
@@ -115,7 +115,7 @@ abstract class Phreezable implements Serializable
     {
         $className = get_class($this);
 
-        if (! array_key_exists($className, self::$PublicPropCache)) {
+        if (! property_exists(self::$PublicPropCache, $className)) {
             $props = array ();
             $ro = new ReflectionObject($this);
 

--- a/portal/patient/fwk/libs/verysimple/Phreeze/Reporter.php
+++ b/portal/patient/fwk/libs/verysimple/Phreeze/Reporter.php
@@ -181,7 +181,7 @@ abstract class Reporter implements Serializable
     {
         $className = get_class($this);
 
-        if (! array_key_exists($className, self::$PublicPropCache)) {
+        if (! property_exists(self::$PublicPropCache, $className)) {
             $props = array ();
             $ro = new ReflectionObject($this);
 

--- a/portal/patient/fwk/libs/verysimple/Phreeze/SavantRenderEngine.php
+++ b/portal/patient/fwk/libs/verysimple/Phreeze/SavantRenderEngine.php
@@ -96,7 +96,7 @@ class SavantRenderEngine implements IRenderEngine
      */
     function clear($key)
     {
-        if (array_key_exists($key, $this->savant)) {
+        if (property_exists($this->savant, $key)) {
             unset($this->savant [$key]);
         }
     }

--- a/rector.php
+++ b/rector.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
 
 use Rector\Caching\ValueObject\Storage\FileCacheStorage;
 use Rector\Config\RectorConfig;
+use Rector\Php74\Rector\FuncCall\ArrayKeyExistsOnPropertyRector;
 use Rector\ValueObject\PhpVersion;
 
 return RectorConfig::configure()
@@ -28,18 +29,20 @@ return RectorConfig::configure()
         __DIR__ . '/src',
         __DIR__ . '/tests',
     ])
-    // uncomment to reach your current PHP version
-    // ->withPhpSets()
-    ->withPhpVersion(PhpVersion::PHP_82)
-    ->withTypeCoverageLevel(5)
-    ->withDeadCodeLevel(5)
-    ->withCodeQualityLevel(5)
     ->withCache(
         // ensure file system caching is used instead of in-memory
         cacheClass: FileCacheStorage::class,
         // specify a path that works locally as well as on CI job runners
         cacheDirectory: '/tmp/rector'
     )
+    ->withCodeQualityLevel(5)
+    ->withDeadCodeLevel(5)
+    ->withRules([
+        // add rules one at a time until we can replace them with a named ruleset
+        ArrayKeyExistsOnPropertyRector::class, // one of the withPhpSets rules
+    ])
+    ->withPhpVersion(PhpVersion::PHP_82)
     ->withSkip([
         __DIR__ . '/sites/default/documents/smarty'
-    ]);
+    ])
+    ->withTypeCoverageLevel(5);


### PR DESCRIPTION
Fixes #8953

#### Short description of what this resolves:

Update those cases where `array_key_exists` is being used to check if a property exists on an object.


#### Changes proposed in this pull request:

- [x] chore(rector): set ArrayKeyExistsOnPropertyRector
- [x] refactor: change `array_key_exists` to `property_exists` on property

#### Does your code include anything generated by an AI Engine? No
