### PR TITLE
Fixes #8958 oauth2 session

### DIFF
--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -606,6 +606,8 @@ class AuthorizationController
 
             // If needed, serialize into a users session
             if ($this->providerForm) {
+                // used to keep track of the auth flow and avoid the session from being destroyed on login / patient selection
+                $session->set("oauth2_in_progress", true);
                 $this->serializeUserSession($authRequest, $session);
                 $logger->debug("AuthorizationController->oauthAuthorizationFlow() redirecting to provider form");
                 $psrFactory = new Psr17Factory();

--- a/src/RestControllers/SMART/SMARTAuthorizationController.php
+++ b/src/RestControllers/SMART/SMARTAuthorizationController.php
@@ -296,7 +296,6 @@ class SMARTAuthorizationController
         try {
             // we've got a user by their UUID... we need to grab the db user id
             $searchParams = $request->get('search', []);
-            $session = $request->getSession();
 
             // grab our list of patients to select from.
             $searchController = $this->getPatientContextSearchController();
@@ -316,7 +315,7 @@ class SMARTAuthorizationController
                     , 'lname' => $searchParams['lname'] ?? ''
                     , 'mname' => $searchParams['mname'] ?? ''
                     , 'redirect' => $redirect
-                    , 'csrfToken' => CsrfUtils::collectCsrfToken('oauth2', $session)
+                    , 'csrfToken' => CsrfUtils::collectCsrfToken('oauth2', $this->session)
                 ]
             );
         } catch (AccessDeniedException $error) {
@@ -330,10 +329,12 @@ class SMARTAuthorizationController
         } catch (Exception $error) {
             // error occurred, no patients found just display the screen with an error message
             $error_message = "There was a server error in loading patients.  Contact your system administrator for assistance";
-            $this->logger->error("AuthorizationController->patientSelect() Exception thrown", ['exception' => $error->getMessage()]);
+            $this->logger->error("AuthorizationController->patientSelect() Exception thrown", [
+                'exception' => $error->getMessage()
+                ,'trace' => $error->getTraceAsString()]);
             return $this->renderTwigPage(
                 'oauth2/authorize/patient-select',
-                "smart/patient-select.html.twig",
+                "oauth2/patient-select.html.twig",
                 [
                     'patients' => $patients
                     , 'hasMore' => $hasMore

--- a/src/RestControllers/SMART/SMARTAuthorizationController.php
+++ b/src/RestControllers/SMART/SMARTAuthorizationController.php
@@ -296,6 +296,7 @@ class SMARTAuthorizationController
         try {
             // we've got a user by their UUID... we need to grab the db user id
             $searchParams = $request->get('search', []);
+            $session = $request->getSession();
 
             // grab our list of patients to select from.
             $searchController = $this->getPatientContextSearchController();
@@ -315,6 +316,7 @@ class SMARTAuthorizationController
                     , 'lname' => $searchParams['lname'] ?? ''
                     , 'mname' => $searchParams['mname'] ?? ''
                     , 'redirect' => $redirect
+                    , 'csrfToken' => CsrfUtils::collectCsrfToken('oauth2', $session)
                 ]
             );
         } catch (AccessDeniedException $error) {

--- a/src/RestControllers/Subscriber/SiteSetupListener.php
+++ b/src/RestControllers/Subscriber/SiteSetupListener.php
@@ -196,6 +196,6 @@ class SiteSetupListener implements EventSubscriberInterface
     private function checkForOauth2Request(HttpRestRequest $request): bool
     {
         $path = $request->getBasePath();
-        return str_ends_with($path, "/oauth2/");
+        return str_ends_with($path, "/oauth2");
     }
 }

--- a/templates/oauth2/patient-select.html.twig
+++ b/templates/oauth2/patient-select.html.twig
@@ -77,7 +77,7 @@
         </div>
         {% endif %}
         <form method="post" name="patientForm" id="patientForm" action="{{ redirect|attr }}">
-            <input type="hidden" name="csrf_token" value="{{ csrfTokenRaw('oauth2')|attr }}" />
+            <input type="hidden" name="csrf_token" value="{{ csrfToken|attr }}" />
             <input id="patient_id" type="hidden" name="patient_id" value="" />
         </form>
     </div>


### PR DESCRIPTION
The OAuth2 Authorization Code grant flow was not working properly due to changes with the session handling / management.  Needed to fix the issue with the session being cleaned up on every request if it wasn't a local api request (launched within the GUI application in OpenEMR).

Also discovered that the launch/patient scope was not working with the patient selector due to the CSRF token not properly populating due to the session changes so fixed that issue also.

Fixes #8958