### PR TITLE
fix(php): explicit precedence for `??`

### DIFF
--- a/interface/billing/edit_payment.php
+++ b/interface/billing/edit_payment.php
@@ -596,7 +596,7 @@ $ResultSearchSub = sqlStatement(
 <body class="body_top" onload="OnloadAction()">
     <div class="container-fluid">
         <?php
-        if ($_REQUEST['ParentPage'] ?? '' == 'new_payment') {
+        if (($_REQUEST['ParentPage'] ?? '') == 'new_payment') {
             ?>
             <div class="row">
                 <div class="col-12">

--- a/interface/forms/eye_mag/a_issue.php
+++ b/interface/forms/eye_mag/a_issue.php
@@ -760,7 +760,7 @@ foreach (explode(',', $given) as $item) {
                         <td class="right text-nowrap"><strong id="by_whom"><?php echo xlt('Eye Med'); ?>:</strong></td>
                         <td colspan="3"><?php echo $irow['subtype'] ?? ''; ?>
                             <input type='checkbox' name='form_eye_subtype' id='form_eye_subtype' value='1' <?php
-                            if ($irow['subtype'] ?? '' == 'eye') {
+                            if (($irow['subtype'] ?? '') == 'eye') {
                                 echo " checked";
                             }
                             ?> style="margin:3px 3px 3px 5px;" title='<?php echo xla('Indicates if this issue is an ophthalmic-specific medication'); ?>' />

--- a/interface/forms/eye_mag/php/eye_mag_functions.php
+++ b/interface/forms/eye_mag/php/eye_mag_functions.php
@@ -333,8 +333,11 @@ function display_PRIOR_section($zone, $orig_id, $id_to_show, $pid, $report = '0'
                     </table>
                 </div>
 
-            <?php ($EXT_VIEW ?? '' == 1) ? ($display_EXT_view = "wide_textarea") : ($display_EXT_view = "narrow_textarea");?>
-            <?php ($display_EXT_view == "wide_textarea") ? ($marker = "fa-minus-square-o") : ($marker = "fa-plus-square-o");?>
+            <?php
+                [$display_EXT_view, $marker] = (($EXT_VIEW ?? '') == 1)
+                    ? ['wide_textarea', 'fa-minus-square-o']
+                    : ['narrow_textarea', 'fa-plus-square-o'];
+            ?>
             <div id="PRIOR_EXT_text_list" name="PRIOR_EXT_text_list" class="borderShadow PRIORS <?php echo attr($display_EXT_view); ?>" >
                 <span class="top_right fa <?php echo attr($marker); ?>" name="PRIOR_EXT_text_view" id="PRIOR_EXT_text_view"></span>
                 <table cellspacing="0" cellpadding="0" >
@@ -495,8 +498,11 @@ function display_PRIOR_section($zone, $orig_id, $id_to_show, $pid, $report = '0'
                 </tr>
             </table>
         </div>
-        <?php ($ANTSEG_VIEW ?? '' == '1') ? ($display_ANTSEG_view = "wide_textarea") : ($display_ANTSEG_view = "narrow_textarea");?>
-        <?php ($display_ANTSEG_view == "wide_textarea") ? ($marker = "fa-minus-square-o") : ($marker = "fa-plus-square-o");?>
+        <?php
+            [$display_ANTSEG_view, $marker] = (($ANTSEG_VIEW ?? '') == '1')
+                ? ['wide_textarea', 'fa-minus-square-o']
+                : ['narrow_textarea', 'fa-plus-square-o'];
+        ?>
         <div id="PRIOR_ANTSEG_text_list"  name="PRIOR_ANTSEG_text_list" class="borderShadow PRIORS <?php echo attr($display_ANTSEG_view); ?>" >
                 <span class="top_right fa <?php echo attr($marker); ?>" name="PRIOR_ANTSEG_text_view" id="PRIOR_ANTSEG_text_view"></span>
                 <table>
@@ -595,8 +601,11 @@ function display_PRIOR_section($zone, $orig_id, $id_to_show, $pid, $report = '0'
             </table>
         </div>
 
-        <?php ($RETINA_VIEW ?? '' == 1) ? ($display_RETINA_view = "wide_textarea") : ($display_RETINA_view = "narrow_textarea");?>
-        <?php ($display_RETINA_view == "wide_textarea") ? ($marker = "fa-minus-square-o") : ($marker = "fa-plus-square-o");?>
+        <?php
+            [$display_RETINA_view, $marker] = (($RETINA_VIEW ?? '') == 1)
+                ? ['wide_textarea', 'fa-minus-square-o']
+                : ['narrow_textarea', 'fa-plus-square-o'];
+        ?>
         <div>
             <div id="PRIOR_RETINA_text_list" name="PRIOR_RETINA_text_list" class="borderShadow PRIORS <?php echo attr($display_RETINA_view); ?>">
                     <span class="top_right fa <?php echo attr($marker); ?>" name="PRIOR_RETINA_text_view" id="PRIOR_RETINA_text_view"></span>

--- a/interface/forms/procedure_order/common.php
+++ b/interface/forms/procedure_order/common.php
@@ -1314,9 +1314,9 @@ $reasonCodeStatii[ReasonStatusCodes::NONE]['description'] = xl("Select a status 
                             <label for='form_order_abn' class="col-form-label col-md-2"><?php echo xlt('ABN Status'); ?></label>
                             <div class="col-md-2">
                                 <select name='form_order_abn' id='form_order_abn' class='form-control'>
-                                    <option value="not_required" <?php echo $row['order_abn'] ?? '' === 'not_required' ? ' selected' : '' ?>><?php echo xlt('Not Required'); ?></option>
-                                    <option value="required" <?php echo $row['order_abn'] ?? '' === 'required' ? ' selected' : '' ?>><?php echo xlt('Required'); ?></option>
-                                    <option value="signed" <?php echo $row['order_abn'] ?? '' === 'signed' ? ' selected' : '' ?>><?php echo xlt('Signed'); ?></option>
+                                    <option value="not_required" <?php echo ($row['order_abn'] ?? '') === 'not_required' ? ' selected' : '' ?>><?php echo xlt('Not Required'); ?></option>
+                                    <option value="required" <?php echo ($row['order_abn'] ?? '') === 'required' ? ' selected' : '' ?>><?php echo xlt('Required'); ?></option>
+                                    <option value="signed" <?php echo ($row['order_abn'] ?? '') === 'signed' ? ' selected' : '' ?>><?php echo xlt('Signed'); ?></option>
                                 </select>
                             </div>
                             <div class="clearfix"></div>

--- a/interface/main/calendar/find_appt_popup.php
+++ b/interface/main/calendar/find_appt_popup.php
@@ -176,7 +176,7 @@ if ($_REQUEST['providerid']) {
         array_push($sqlBindArray, $providerid, $eid, $sdate, $edate, $sdate, $edate);
 
     // phyaura whimmel facility filtering
-    if ($_REQUEST['facility'] ?? '' > 0) {
+    if (($_REQUEST['facility'] ?? '') > 0) {
             $facility = $_REQUEST['facility'];
             $query .= " AND pc_facility = ?";
             array_push($sqlBindArray, $facility);

--- a/interface/modules/custom_modules/oe-module-weno/scripts/weno_pharmacy_search.php
+++ b/interface/modules/custom_modules/oe-module-weno/scripts/weno_pharmacy_search.php
@@ -56,7 +56,7 @@ if (isset($_GET['searchFor']) && $_GET['searchFor'] == 'weno_pharmacy') {
     $weno_zipcode = $_GET['weno_zipcode'] ?? false ?: '';
     $weno_only = $_GET['weno_only'] == 'true' ? 'True' : '';
     $full_day = $_GET['full_day'] == 'true' ? 'Yes' : '';
-    $weno_test_pharmacies = $_GET['test_pharmacy'] ?? '' == 'true' ? 'True' : '';
+    $weno_test_pharmacies = ($_GET['test_pharmacy'] ?? '') == 'true' ? 'True' : '';
 
 
     // mail order is special case.

--- a/interface/modules/custom_modules/oe-module-weno/src/Services/ModuleService.php
+++ b/interface/modules/custom_modules/oe-module-weno/src/Services/ModuleService.php
@@ -187,7 +187,7 @@ class ModuleService
     {
         $logService = new WenoLogService();
         $log = $logService->getLastPharmacyDownloadStatus();
-        if ($log['status'] ?? '' == 'Failed') {
+        if (($log['status'] ?? '') == 'Failed') {
             if (($log['count'] ?? 0) > 0) {
                 return true;
             }

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php
@@ -943,7 +943,7 @@ class CarecoordinationController extends AbstractActionController
                     $patientCountHash[$patientNameIndex];
                 }
             } elseif ($componentCount == ($patientDocumentsIndex + 1)) {
-                if ($patientCountHash[$patientNameIndex] ?? '' > $maxDocuments) {
+                if (($patientCountHash[$patientNameIndex] ?? '') > $maxDocuments) {
                     $shouldDeleteIndex = true;
                 } else {
                     if (!empty($patientCountHash[$patientNameIndex])) {

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php
@@ -353,13 +353,13 @@ class CarecoordinationTable extends AbstractTableGateway
         } else {
             $tel = $xml['recordTarget']['patientRole']['telecom'] ?? '';
             if (!empty($tel)) {
-                if ($tel['use'] ?? '' == 'MC') {
+                if (($tel['use'] ?? '') == 'MC') {
                     $this->documentData['field_name_value_array']['patient_data'][1]['phone_cell'] = preg_replace('/[^0-9]+/i', '', ($tel['value'] ?? null));
-                } elseif ($tel['use'] ?? '' == 'HP') {
+                } elseif (($tel['use'] ?? '') == 'HP') {
                     $this->documentData['field_name_value_array']['patient_data'][1]['phone_home'] = preg_replace('/[^0-9]+/i', '', ($tel['value'] ?? null));
-                } elseif ($tel['use'] ?? '' == 'WP') {
+                } elseif (($tel['use'] ?? '') == 'WP') {
                     $this->documentData['field_name_value_array']['patient_data'][1]['phone_biz'] = preg_replace('/[^0-9]+/i', '', ($tel['value'] ?? null));
-                } elseif ($tel['use'] ?? '' == 'EC') {
+                } elseif (($tel['use'] ?? '') == 'EC') {
                     $this->documentData['field_name_value_array']['patient_data'][1]['phone_contact'] = preg_replace('/[^0-9]+/i', '', ($tel['value'] ?? null));
                 } elseif (stripos($tel['value'] ?? '', 'mailto:') !== false) {
                     $regex = "/([a-z0-9_\-\.]+)" . "@" . "([a-z0-9-]{1,64})" . "\." . "([a-z]{2,10})/i";

--- a/interface/reports/collections_report.php
+++ b/interface/reports/collections_report.php
@@ -704,7 +704,7 @@ if (!empty($_POST['form_refresh']) || !empty($_POST['form_export']) || !empty($_
              $newkey = $key_newval['pid'];
              $newencounter =  $key_newval['encounter'];
              # added this condition to handle the downloading of individual invoices (TLH)
-            if ($_POST['form_individual'] ?? '' == 1) {
+            if (($_POST['form_individual'] ?? '') == 1) {
                 $where .= " OR f.encounter = ? ";
                 array_push($sqlArray, $newencounter);
             } else {
@@ -1129,7 +1129,7 @@ if (!empty($_POST['form_refresh']) || !empty($_POST['form_export']) || !empty($_
         list($insname, $unused , $ptname, $trash) = explode('|', $key);
         list($pid, $encounter) = explode(".", $row['invnumber']);
         if (!empty($_POST['form_cb'])) {
-            if ($_POST['form_cb'][$row['invnumber']] ?? '' == 'on') {
+            if (($_POST['form_cb'][$row['invnumber']] ?? '') == 'on') {
                 $encounters[] = $encounter;
             }
         }

--- a/interface/super/edit_globals.php
+++ b/interface/super/edit_globals.php
@@ -189,7 +189,7 @@ function checkBackgroundServices(): void
                             $fldvalue = trim($_POST["form_$i"] ?? '');
                         }
                         setUserSetting($label, $fldvalue, $_SESSION['authUserID'], false);
-                        if ($_POST["toggle_$i"] ?? '' == "YES") {
+                        if (($_POST["toggle_$i"] ?? '') == "YES") {
                             removeUserSetting($label);
                         }
 

--- a/library/ajax/set_pt.php
+++ b/library/ajax/set_pt.php
@@ -21,7 +21,7 @@ if (!CsrfUtils::verifyCsrfToken($_GET["csrf_token_form"])) {
     CsrfUtils::csrfNotVerified();
 }
 
-if ($_GET["set_pid"] ?? '' && ($_GET["set_pid"] != $_SESSION["pid"])) {
+if (in_array("set_pid", $_GET, true) && !empty($_GET["set_pid"]) && ($_GET["set_pid"] != $_SESSION["pid"])) {
     setpid($_GET["set_pid"]);
 }
 

--- a/library/custom_template/add_context.php
+++ b/library/custom_template/add_context.php
@@ -38,9 +38,9 @@ if (trim($_POST['contextname'] ?? '') != '' && $_POST['action'] == 'add') {
         $id = sqlInsert("INSERT INTO customlists (cl_list_type,cl_list_item_long) VALUES(?,?)", array(2,$_POST['contextname']));
         sqlStatement("UPDATE customlists SET cl_list_id=? WHERE cl_list_slno=?", array($id,$id));
     }
-} elseif ($_POST['action'] ?? '' == 'delete' && $_POST['item'] != '') {
+} elseif (($_POST['action'] ?? '') == 'delete' && $_POST['item'] != '') {
     sqlStatement("UPDATE customlists SET cl_deleted=1 WHERE cl_list_type=2 AND cl_list_slno=?", array($_POST['item']));
-} elseif ($_POST['action'] ?? '' == 'update' && $_POST['item'] != '') {
+} elseif (($_POST['action'] ?? '') == 'update' && $_POST['item'] != '') {
     sqlStatement("UPDATE customlists SET cl_list_item_long=? WHERE cl_deleted=0 AND cl_list_type=2 AND cl_list_slno=?", array($_POST['updatecontextname'],$_POST['item']));
 }
 ?>
@@ -180,7 +180,7 @@ if (trim($_POST['contextname'] ?? '') != '' && $_POST['action'] == 'add') {
                         $i = 0;
                         while ($row = sqlFetchArray($res)) {
                             $i++;
-                            $class = ($class ?? '' == 'class1') ? 'class2' : 'class1';
+                            $class = (($class ?? '') == 'class1') ? 'class2' : 'class1';
                             ?>
                             <tr class="text <?php echo $class;?>">
                                 <td class="right bottom left"><?php echo htmlspecialchars($i, ENT_QUOTES);?></td>


### PR DESCRIPTION
Fixes #8969

#### Short description of what this resolves:

Explicitly group the null coalescing (`??`) operator with parentheses to ensure coalescing is done before comparison.


#### Changes proposed in this pull request:

- [x] Add parens around null coalescing operations where needed.


#### Does your code include anything generated by an AI Engine? No
