### PR TITLE
fix(Phreeze\QueryBuilder): actually strip parens

### DIFF
--- a/portal/patient/fwk/libs/verysimple/Phreeze/QueryBuilder.php
+++ b/portal/patient/fwk/libs/verysimple/Phreeze/QueryBuilder.php
@@ -166,16 +166,15 @@ class QueryBuilder
     /**
      * Removes the "where" from the beginning of a statement
      *
-     * @param
-     *          string partial query to parse
+     * @param string $sql partial query to parse
      * @return string query without the preceeding "where"
      */
-    private function RemoveWherePrefix($sql)
+    private function RemoveWherePrefix(string $sql): string
     {
         $sql = trim($sql);
 
-        // remove if the query is surrounded by parenths
-        while (substr($sql, 0, 1) == "(" && substr($sql, 0, - 1) == ")") {
+        // remove if the query is surrounded by parentheses
+        while (str_starts_with($sql, '(') && str_ends_with($sql, ')')) {
             $sql = trim(substr($sql, 1, - 1));
         }
 


### PR DESCRIPTION
Fixes #8980

#### Short description of what this resolves:

Phreeze\QueryBuilder::RemoveWherePrefix wants to strip parentheses around the query, but doesn't correctly look for parentheses at the end of the query string.


#### Changes proposed in this pull request:

- [x] use `str_ends_with` for an easier way to check the end of a string.

#### Does your code include anything generated by an AI Engine? No
