### PR TITLE
refactor(php): use __DIR__ instead of dirname

### DIFF
--- a/interface/billing/edi_271.php
+++ b/interface/billing/edi_271.php
@@ -14,7 +14,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__file__) . "/../globals.php");
+require_once(__DIR__ . "/../globals.php");
 require_once("$srcdir/forms.inc.php");
 require_once("$srcdir/patient.inc.php");
 require_once("$srcdir/report.inc.php");

--- a/interface/billing/ub04_dispose.php
+++ b/interface/billing/ub04_dispose.php
@@ -84,7 +84,7 @@ function saveTemplate($encounter, $pid, $ub04id, $action = 'form'): void
         $ub04id = json_encode($ub04id);
         $isAuthorized = true;
         ob_start();
-        require(dirname(__file__) . "/ub04_form.php");
+        require(__DIR__ . "/ub04_form.php");
         $htmlin = ob_get_clean();
         $isAuthorized = false;
         ub04Dispose('download', $htmlin, "ub04_download.pdf", $action);

--- a/interface/forms/newGroupEncounter/report.php
+++ b/interface/forms/newGroupEncounter/report.php
@@ -14,7 +14,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__file__) . "/../../globals.php");
+require_once(__DIR__ . "/../../globals.php");
 require_once("$srcdir/group.inc.php");
 
 use OpenEMR\Common\Acl\AclMain;

--- a/interface/forms/newpatient/report.php
+++ b/interface/forms/newpatient/report.php
@@ -13,7 +13,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__file__) . "/../../globals.php");
+require_once(__DIR__ . "/../../globals.php");
 
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Services\AppointmentService;

--- a/interface/patient_file/report/custom_report.php
+++ b/interface/patient_file/report/custom_report.php
@@ -21,7 +21,7 @@ require_once("$srcdir/patient.inc.php");
 require_once("$srcdir/options.inc.php");
 require_once("$srcdir/lists.inc.php");
 require_once("$srcdir/report.inc.php");
-require_once(dirname(__file__) . "/../../../custom/code_types.inc.php");
+require_once(__DIR__ . "/../../../custom/code_types.inc.php");
 require_once $GLOBALS['srcdir'] . '/ESign/Api.php';
 require_once($GLOBALS["include_root"] . "/orders/single_order_results.inc.php");
 require_once("$srcdir/appointments.inc.php");

--- a/interface/reports/custom_report_range.php
+++ b/interface/reports/custom_report_range.php
@@ -10,7 +10,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-require_once(dirname(__file__) . "/../globals.php");
+require_once(__DIR__ . "/../globals.php");
 require_once("$srcdir/forms.inc.php");
 require_once("$srcdir/patient.inc.php");
 require_once("$srcdir/report.inc.php");

--- a/portal/lib/download_template.php
+++ b/portal/lib/download_template.php
@@ -11,9 +11,9 @@
 
 $is_module = $_POST['isModule'] ?? 0;
 if ($is_module) {
-    require_once(dirname(__file__) . '/../../interface/globals.php');
+    require_once(__DIR__ . '/../../interface/globals.php');
 } else {
-    require_once(dirname(__file__) . "/../verify_session.php");
+    require_once(__DIR__ . "/../verify_session.php");
     // ensure patient is bootstrapped (if sent)
     if (!empty($_POST['pid'])) {
         if ($_POST['pid'] != $_SESSION['pid']) {

--- a/portal/report/portal_custom_report.php
+++ b/portal/report/portal_custom_report.php
@@ -48,7 +48,7 @@ require_once("$srcdir/lists.inc.php");
 require_once("$srcdir/report.inc.php");
 require_once("$srcdir/classes/Document.class.php");
 require_once("$srcdir/classes/Note.class.php");
-require_once(dirname(__file__) . "/../../custom/code_types.inc.php");
+require_once(__DIR__ . "/../../custom/code_types.inc.php");
 require_once $GLOBALS['srcdir'] . '/ESign/Api.php';
 require_once($GLOBALS["include_root"] . "/orders/single_order_results.inc.php");
 require_once($GLOBALS['fileroot'] . "/controllers/C_Document.class.php");

--- a/rector.php
+++ b/rector.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 use Rector\Caching\ValueObject\Storage\FileCacheStorage;
 use Rector\CodingStyle\Rector\FuncCall\ConsistentImplodeRector;
 use Rector\Config\RectorConfig;
+use Rector\Php53\Rector\FuncCall\DirNameFileConstantToDirConstantRector;
 use Rector\Php55\Rector\Class_\ClassConstantToSelfClassRector;
 use Rector\Php71\Rector\Assign\AssignArrayToStringRector;
 use Rector\Php71\Rector\BinaryOp\BinaryOpBetweenNumberAndStringRector;
@@ -57,6 +58,7 @@ return RectorConfig::configure()
         ClassConstantToSelfClassRector::class, // one of the withPhpSets rules
         ConsistentImplodeRector::class, // one of the withPhpSets rules
         CreateFunctionToAnonymousFunctionRector::class, // one of the withPhpSets rules
+        DirNameFileConstantToDirConstantRector::class, // one of the withPhpSets rules
     ])
     ->withSkip([
         __DIR__ . '/sites/default/documents/smarty'


### PR DESCRIPTION
Fixes #8988

#### Short description of what this resolves:

Use `__DIR__` instead of dirname

#### Changes proposed in this pull request:

- [x] chore(rector): set DirNameFileConstantToDirConstantRector**
- [x] refactor(php): use `__DIR__` instead of dirname**
- [x] run checks

#### Does your code include anything generated by an AI Engine? No
