### PR TITLE
refactor(php): prefer preg_match to ereg

### DIFF
--- a/library/classes/smtp/smtp.php
+++ b/library/classes/smtp/smtp.php
@@ -718,7 +718,7 @@ class smtp_class
 		&& function_exists("preg_replace"))
 			$output=preg_replace(array("/\n\n|\r\r/","/(^|[^\r])\n/","/\r([^\n]|\$)/D","/(^|\n)\\./"),array("\r\n\r\n","\\1\r\n","\r\n\\1","\\1.."),$data);
 		else
-			$output=ereg_replace("(^|\n)\\.","\\1..",ereg_replace("\r([^\n]|\$)","\r\n\\1",ereg_replace("(^|[^\r])\n","\\1\r\n",ereg_replace("\n\n|\r\r","\r\n\r\n",$data))));
+			$output=preg_replace("#(^|\n)\\.#m","\\1..",preg_replace("#\r([^\n]|\$)#m","\r\n\\1",preg_replace("#(^|[^\r])\n#m","\\1\r\n",preg_replace("#\n\n|\r\r#m","\r\n\r\n",$data))));
 	}
 
 	Function SendData($data)

--- a/phpstan.github.neon
+++ b/phpstan.github.neon
@@ -14852,10 +14852,6 @@ parameters:
     identifier: constant.notFound
     count: 1
     path: library/classes/smtp/smtp.php
-  - message: '#^Function ereg_replace not found\.$#'
-    identifier: function.notFound
-    count: 4
-    path: library/classes/smtp/smtp.php
   - message: '#^Method smtp_class\:\:GetLine\(\) invoked with 1 parameter, 0 required\.$#'
     identifier: arguments.count
     count: 1
@@ -16452,10 +16448,6 @@ parameters:
     identifier: variable.undefined
     count: 4
     path: portal/patient/fwk/libs/verysimple/HTTP/FileUpload.php
-  - message: '#^Function eregi not found\.$#'
-    identifier: function.notFound
-    count: 1
-    path: portal/patient/fwk/libs/verysimple/HTTP/FormValidator.php
   - message: '#^Method HttpRequest\:\:FilePost\(\) should return string but return statement is missing\.$#'
     identifier: return.missing
     count: 1

--- a/portal/patient/fwk/libs/verysimple/HTTP/FormValidator.php
+++ b/portal/patient/fwk/libs/verysimple/HTTP/FormValidator.php
@@ -29,7 +29,7 @@ class FormValidator
      */
     static function IsValidEmail($email)
     {
-        return (eregi("^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,3})$", $email));
+        return (preg_match("#^[_a-z0-9\\-]+(\\.[_a-z0-9\\-]+)*@[a-z0-9\\-]+(\\.[a-z0-9\\-]+)*(\\.[a-z]{2,3})\$#mi", $email));
     }
 
     /**

--- a/rector.php
+++ b/rector.php
@@ -9,6 +9,7 @@ use Rector\CodingStyle\Rector\FuncCall\ConsistentImplodeRector;
 use Rector\Config\RectorConfig;
 use Rector\Php53\Rector\FuncCall\DirNameFileConstantToDirConstantRector;
 use Rector\Php55\Rector\Class_\ClassConstantToSelfClassRector;
+use Rector\Php70\Rector\FuncCall\EregToPregMatchRector;
 use Rector\Php71\Rector\Assign\AssignArrayToStringRector;
 use Rector\Php71\Rector\BinaryOp\BinaryOpBetweenNumberAndStringRector;
 use Rector\Php72\Rector\FuncCall\CreateFunctionToAnonymousFunctionRector;
@@ -61,6 +62,7 @@ return RectorConfig::configure()
         ConsistentImplodeRector::class, // one of the withPhpSets rules
         CreateFunctionToAnonymousFunctionRector::class, // one of the withPhpSets rules
         DirNameFileConstantToDirConstantRector::class, // one of the withPhpSets rules
+        EregToPregMatchRector::class, // one of the withPhpSets rules
     ])
     ->withSkip([
         __DIR__ . '/sites/default/documents/smarty'


### PR DESCRIPTION
Fixes #8992

#### Short description of what this resolves:

Replace deprecated `ereg` functions.


#### Changes proposed in this pull request:

- [x] chore(rector): set EregToPregMatchRector
- [x] refactor(php): prefer preg_match to ereg
- [x] run checks

#### Does your code include anything generated by an AI Engine? No
