### PR TITLE
refactor(php): Use multi-catch syntax

### DIFF
--- a/interface/modules/zend_modules/module/Installer/src/Installer/Model/InstModuleTable.php
+++ b/interface/modules/zend_modules/module/Installer/src/Installer/Model/InstModuleTable.php
@@ -183,13 +183,7 @@ class InstModuleTable
                 $sqlUpgradeService->setRenderOutputToScreen(false); // we don't really want to display anything here
                 $sqlUpgradeService->upgradeFromSqlFile($fileName, $dir);
                 return true;
-            } catch (SqlQueryException $exception) {
-                (new SystemLogger())->errorLogCaller(
-                    "Error: " . $exception->getMessage(),
-                    ['statement' => $exception->getSqlStatement(), 'trace' => $exception->getTraceAsString()]
-                );
-                return false;
-            } catch (\Exception $exception) {
+            } catch (SqlQueryException | \Exception $exception) {
                 (new SystemLogger())->errorLogCaller(
                     "Error: " . $exception->getMessage(),
                     ['statement' => $exception->getSqlStatement(), 'trace' => $exception->getTraceAsString()]

--- a/rector.php
+++ b/rector.php
@@ -14,6 +14,7 @@ use Rector\Php70\Rector\FuncCall\MultiDirnameRector;
 use Rector\Php70\Rector\If_\IfToSpaceshipRector;
 use Rector\Php71\Rector\Assign\AssignArrayToStringRector;
 use Rector\Php71\Rector\BinaryOp\BinaryOpBetweenNumberAndStringRector;
+use Rector\Php71\Rector\TryCatch\MultiExceptionCatchRector;
 use Rector\Php72\Rector\FuncCall\CreateFunctionToAnonymousFunctionRector;
 use Rector\Php73\Rector\FuncCall\ArrayKeyFirstLastRector;
 use Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector;
@@ -67,6 +68,7 @@ return RectorConfig::configure()
         EregToPregMatchRector::class, // one of the withPhpSets rules
         IfToSpaceshipRector::class, // one of the withPhpSets rules
         MultiDirnameRector::class, // one of the withPhpSets rules
+        MultiExceptionCatchRector::class, // one of the withPhpSets rules
     ])
     ->withSkip([
         __DIR__ . '/sites/default/documents/smarty'

--- a/src/Cqm/CqmClient.php
+++ b/src/Cqm/CqmClient.php
@@ -58,11 +58,7 @@ class CqmClient extends HttpClient
                 Utils::copyToString($this->request('GET', '/health')->getBody()),
                 true
             );
-        } catch (ConnectException $exception) {
-            return [
-                'uptime' => 0
-            ];
-        } catch (ServerException $exception) {
+        } catch (ConnectException | ServerException $exception) {
             return [
                 'uptime' => 0
             ];
@@ -115,9 +111,7 @@ class CqmClient extends HttpClient
                 ),
                 true
             );
-        } catch (ConnectException $exception) {
-            return [$exception->getMessage()];
-        } catch (ServerException $exception) {
+        } catch (ConnectException | ServerException $exception) {
             return [$exception->getMessage()];
         }
     }


### PR DESCRIPTION
Fixes #9011

#### Short description of what this resolves:

Change multiple catch statements of the same exception to a single one <code>|</code> separated

#### Changes proposed in this pull request:

- [x] chore(rector): set MultiExceptionCatchRector
- [x] refactor(php): Change multiple catch statements of the same exception to a single one <code>|</code> separated
- [x] run checks

#### Does your code include anything generated by an AI Engine? No
