### PR TITLE
refactor(php): replace pow() with ** operator

### DIFF
--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/AuthenticateTrait.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/AuthenticateTrait.php
@@ -125,7 +125,7 @@ trait AuthenticateTrait
                 }
             } catch (ApiException $e) {
                 if ($e->getCode() === 429) {
-                    $delay = $baseDelay * pow(2, $attempt); // Exponential backoff
+                    $delay = $baseDelay * 2 ** $attempt; // Exponential backoff
                     sleep($delay);
                     continue;
                 }

--- a/library/edihistory/edih_csv_inc.php
+++ b/library/edihistory/edih_csv_inc.php
@@ -1414,7 +1414,7 @@ function csv_convert_bytes($bytes)
     if ($i == 0) {
         return $bytes . ' ' . $sizes[$i];
     } else {
-        return round($bytes / pow(1024, $i), 1) . ' ' . $sizes[$i];
+        return round($bytes / 1024 ** $i, 1) . ' ' . $sizes[$i];
     }
 }
 

--- a/rector.php
+++ b/rector.php
@@ -7,10 +7,11 @@ declare(strict_types=1);
 use Rector\Caching\ValueObject\Storage\FileCacheStorage;
 use Rector\Config\RectorConfig;
 use Rector\Php55\Rector\Class_\ClassConstantToSelfClassRector;
+use Rector\Php56\Rector\FuncCall\PowToExpRector;
 use Rector\Php71\Rector\Assign\AssignArrayToStringRector;
 use Rector\Php73\Rector\FuncCall\ArrayKeyFirstLastRector;
-use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
 use Rector\Php74\Rector\FuncCall\ArrayKeyExistsOnPropertyRector;
+use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
 use Rector\ValueObject\PhpVersion;
 
 return RectorConfig::configure()
@@ -51,6 +52,7 @@ return RectorConfig::configure()
         AssignArrayToStringRector::class, // one of the withPhpSets rules
         ChangeSwitchToMatchRector::class, // one of the withPhpSets rules
         ClassConstantToSelfClassRector::class, // one of the withPhpSets rules
+        PowToExpRector::class, // one of the withPhpSets rules
     ])
     ->withSkip([
         __DIR__ . '/sites/default/documents/smarty'

--- a/src/Common/Utils/FileUtils.php
+++ b/src/Common/Utils/FileUtils.php
@@ -83,7 +83,7 @@ class FileUtils
         if ($i == 0) {
             return $bytes . ' ' . $sizes[$i];
         } else {
-            return round($bytes / pow(1024, $i), 1) . ' ' . $sizes[$i];
+            return round($bytes / 1024 ** $i, 1) . ' ' . $sizes[$i];
         }
     }
 


### PR DESCRIPTION
Fixes #9017

#### Short description of what this resolves:

Changes <code>pow(val, val2)</code> to <code>**</code> (exp) parameter

#### Changes proposed in this pull request:

- [x] chore(rector): set PowToExpRector
- [x] refactor(php): Changes <code>pow(val, val2)</code> to <code>**</code> (exp) parameter
- [ ] run checks 

#### Does your code include anything generated by an AI Engine? No
