### PR TITLE
fix(MedEx\API): use count query instead of counting in php

### DIFF
--- a/library/MedEx/API.php
+++ b/library/MedEx/API.php
@@ -922,11 +922,11 @@ class Events extends Base
                         continue; //not happening - either not allowed or not possible
                     }
                     if ($no_fu) {
-                        $sql_NoFollowUp = "SELECT pc_pid FROM openemr_postcalendar_events WHERE
+                        $sql_NoFollowUp = "SELECT COUNT(*) AS num FROM openemr_postcalendar_events WHERE
                             pc_pid = ? AND
                             pc_eventDate > ( ? + INTERVAL " . escape_limit($no_interval) . " DAY)";
                         $result = sqlQuery($sql_NoFollowUp, array($appt['pc_pid'], $appt['pc_eventDate']));
-                        if (count($result) > '') {
+                        if ($result['num'] > 0) {
                             continue;
                         }
                     }


### PR DESCRIPTION
Fixes #8999

#### Short description of what this resolves:

Fixes a potential type error by using sql to do counting instead of counting in php.


#### Changes proposed in this pull request:

- [x] update query

#### Does your code include anything generated by an AI Engine? No
