### PR TITLE
fix(C_controllers): clean up dead code and wrong-case comparisons

### DIFF
--- a/controllers/C_InsuranceCompany.class.php
+++ b/controllers/C_InsuranceCompany.class.php
@@ -28,11 +28,9 @@ class C_InsuranceCompany extends Controller
         return $this->list_action();
     }
 
-    public function edit_action($id = "", $patient_id = "", $p_obj = null)
+    public function edit_action($id = "", $patient_id = "")
     {
-        if ($p_obj != null && get_class($p_obj) == "insurancecompany") {
-            $this->icompanies[0] = $p_obj;
-        } elseif (empty($this->icompanies[0]) || $this->icompanies[0] == null || get_class($this->icompanies[0]) != "insurancecompany") {
+        if (!(($this->icompanies[0] ?? null) instanceof InsuranceCompany)) {
             $this->icompanies[0] = new InsuranceCompany($id);
         }
 

--- a/controllers/C_InsuranceNumbers.class.php
+++ b/controllers/C_InsuranceNumbers.class.php
@@ -33,16 +33,16 @@ class C_InsuranceNumbers extends Controller
         return $this->list_action();
     }
 
-    function edit_action($id = "", $provider_id = "", $p_obj = null)
+    function edit_action($id = "", $provider_id = "")
     {
 
         //case where a direct id is provided, doesn't matter if a provider id is available get it from the insurance_numbers record
-        if ((empty($this->insurance_numbers[0]) || !is_object($this->insurance_numbers[0]) || get_class($this->insurance_numbers[0]) != "insurancenumbers") && is_numeric($id)) {
+        if (!(($this->insurance_numbers[0] ?? null) instanceof InsuranceNumbers) && is_numeric($id)) {
             $this->insurance_numbers[0] = new InsuranceNumbers($id);
             $this->providers[0] = new Provider($this->insurance_numbers[0]->get_provider_id());
         } elseif (is_numeric($provider_id)) {
             $this->providers[0] = new Provider($provider_id);
-            if (empty($this->insurance_numbers[0]) || !is_object($this->insurance_numbers[0]) || get_class($this->insurance_numbers[0]) != "insurancenumbers") {
+            if (!(($this->insurance_numbers[0] ?? null) instanceof InsuranceNumbers)) {
                 if ($id == "default") {
                     $this->insurance_numbers[0] = $this->providers[0]->get_insurance_numbers_default();
                     if (!is_object($this->insurance_numbers[0])) {
@@ -54,7 +54,7 @@ class C_InsuranceNumbers extends Controller
                     $this->insurance_numbers[0]->set_provider_id($provider_id);
                 }
             }
-        } elseif (get_class($this->insurance_numbers[0]) == "insurancenumbers") {
+        } elseif (($this->insurance_numbers[0] ?? null) instanceof InsuranceNumbers) {
             //this is the case that occurs after an update
             $this->providers[0] = new Provider($this->insurance_numbers[0]->get_provider_id());
         } else {

--- a/controllers/C_Pharmacy.class.php
+++ b/controllers/C_Pharmacy.class.php
@@ -37,11 +37,9 @@ class C_Pharmacy extends Controller
         return $this->list_action();
     }
 
-    function edit_action($id = "", $patient_id = "", $p_obj = null)
+    function edit_action($id = "", $patient_id = "")
     {
-        if ($p_obj != null && get_class($p_obj) == "pharmacy") {
-            $this->pharmacies[0] = $p_obj;
-        } elseif (empty($this->pharmacies[0]) || !is_object($this->pharmacies[0]) || get_class($this->pharmacies[0]) != "pharmacy") {
+        if (!(($this->pharmacies[0] ?? null) instanceof Pharmacy)) {
             $this->pharmacies[0] = new Pharmacy($id);
         }
 

--- a/controllers/C_Prescription.class.php
+++ b/controllers/C_Prescription.class.php
@@ -119,12 +119,9 @@ class C_Prescription extends Controller
         echo $twig->render("prescription/" . $this->template_mod . "_edit.html.twig", $vars);
     }
 
-    function edit_action($id = "", $patient_id = "", $p_obj = null)
+    function edit_action($id = "", $patient_id = "")
     {
-
-        if ($p_obj != null && get_class($p_obj) == "prescription") {
-            $this->prescriptions[0] = $p_obj;
-        } elseif (empty($this->prescriptions[0]) || !is_object($this->prescriptions[0]) || (get_class($this->prescriptions[0]) != "prescription")) {
+        if (!(($this->prescriptions[0] ?? null) instanceof Prescription)) {
             $this->prescriptions[0] = new Prescription($id);
         }
 


### PR DESCRIPTION
Fixes #8998

#### Short description of what this resolves:

Remove dead code and unused parameters.
Replace wrong-case class name comparisons with instanceof.

#### Changes proposed in this pull request:

- [x] Remove dead code and unused parameters.
- [x] Replace wrong-case class name comparisons with instanceof.

#### Does your code include anything generated by an AI Engine? No
