### PR TITLE
fix(FaxSMS AppDispatch): use ValidationUtils instead of custom email validation

### DIFF
--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/AppDispatch.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/AppDispatch.php
@@ -16,6 +16,7 @@ use MyMailer;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Crypto\CryptoGen;
 use OpenEMR\Common\Session\SessionUtil;
+use OpenEMR\Common\Utils\ValidationUtils;
 use OpenEMR\Modules\FaxSMS\BootstrapService;
 
 /**
@@ -596,11 +597,7 @@ abstract class AppDispatch
      */
     public function validEmail($email): bool
     {
-        if (preg_match("/^[_a-z0-9-]+(\.[_a-z0-9-\+]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,3})$/i", $email)) {
-            return true;
-        }
-
-        return false;
+        return ValidationUtils::isValidEmail($email);
     }
 
     /**


### PR DESCRIPTION
Fixes #9001

#### Short description of what this resolves:

The regex in AppDispatch doesn't allow all valid email addresses.

#### Changes proposed in this pull request:

- [x] remove custom email validation; use ValidationUtils instead.

#### Does your code include anything generated by an AI Engine? No
