### PR TITLE
refactor(php): wrappers to first class callables

### DIFF
--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Repository/TeleHealthPersonSettingsRepository.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Repository/TeleHealthPersonSettingsRepository.php
@@ -95,9 +95,7 @@ class TeleHealthPersonSettingsRepository
         $records = QueryUtils::fetchRecords("Select id,user_id, patient_id,date_created,date_updated,enabled "
             . " from comlink_telehealth_person_settings WHERE enabled = 1 ORDER BY user_id ");
         if (!empty($records)) {
-            return array_map(function ($record) {
-                return $this->createResultRecordFromDatabaseResult($record);
-            }, $records);
+            return array_map($this->createResultRecordFromDatabaseResult(...), $records);
         }
         return [];
     }

--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Repository/TeleHealthProviderRepository.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/src/Repository/TeleHealthProviderRepository.php
@@ -55,9 +55,7 @@ class TeleHealthProviderRepository
                 $service->getUsersForCalendar($_SESSION['authUserID']);
             }
             if (!empty($dataArray)) {
-                $providers = array_map(function ($provider) {
-                    return $this->mapProviderToPersonSetting($provider);
-                }, $dataArray);
+                $providers = array_map($this->mapProviderToPersonSetting(...), $dataArray);
             }
         } else {
             // just grab all of our enabled users

--- a/src/Common/Twig/TwigExtension.php
+++ b/src/Common/Twig/TwigExtension.php
@@ -89,9 +89,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
         return [
             new TwigFunction(
                 'setupHeader',
-                function ($assets = array()) {
-                    return Header::setupHeader($assets);
-                }
+                Header::setupHeader(...)
             ),
 
             new TwigFunction(
@@ -180,9 +178,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
             ),
             new TwigFunction(
                 'csrfTokenRaw',
-                function ($subject = 'default') {
-                    return CsrfUtils::collectCsrfToken($subject);
-                }
+                CsrfUtils::collectCsrfToken(...)
             ),
             new TwigFunction(
                 'jqueryDateTimePicker',
@@ -236,9 +232,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
             ),
             new TwigFunction(
                 'aclCore',
-                function ($section, $value, $user = '', $return_value = '') {
-                    return AclMain::aclCheckCore($section, $value, $user, $return_value);
-                }
+                AclMain::aclCheckCore(...)
             ),
             new TwigFunction(
                 'getLogo',
@@ -249,15 +243,11 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
             ),
             new TwigFunction(
                 'getListItemTitle',
-                function (string $list, $option) {
-                    return LayoutsUtils::getListItemTitle($list, $option);
-                }
+                LayoutsUtils::getListItemTitle(...)
             )
             ,new TwigFunction(
                 'getAssetCacheParamRaw',
-                function () {
-                    return CacheUtils::getAssetCacheParamRaw();
-                }
+                CacheUtils::getAssetCacheParamRaw(...)
             )
         ];
     }
@@ -390,9 +380,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
             ),
             new TwigFilter(
                 'addCacheParam',
-                function ($path) {
-                    return CacheUtils::addAssetCacheParamToPath($path);
-                }
+                CacheUtils::addAssetCacheParamToPath(...)
             )
         ];
     }

--- a/src/Controllers/Interface/Forms/Observation/ObservationController.php
+++ b/src/Controllers/Interface/Forms/Observation/ObservationController.php
@@ -595,7 +595,7 @@ class ObservationController
 
         $result = $this->observationService->search(['form_id' => $id, 'pid' => $pid, 'encounter' => $encounter]);
         $observations = $result->getData();
-        $formattedObs = array_map(fn($observation): array => $this->formatObservationForDisplay($observation), $observations);
+        $formattedObs = array_map($this->formatObservationForDisplay(...), $observations);
         return $this->twig->render($this->getTemplatePath("observation_report.html.twig"), ['observations' => $formattedObs]);
     }
 
@@ -628,7 +628,7 @@ class ObservationController
             'ob_reason_code' => $observation['ob_reason_code'] ?? '',
             'ob_reason_status' => $observation['ob_reason_status'] ?? '',
             'ob_reason_text' => $observation['ob_reason_text'] ?? '',
-            'subObservations' => array_map(fn($observation): array => $this->formatObservationForDisplay($observation), $observation['sub_observations'] ?? [])
+            'subObservations' => array_map($this->formatObservationForDisplay(...), $observation['sub_observations'] ?? [])
         ];
     }
 

--- a/src/Services/ObservationService.php
+++ b/src/Services/ObservationService.php
@@ -251,7 +251,7 @@ class ObservationService extends BaseService
             $record['ob_status_display'] = $this->getStatusDisplayName($record['ob_status']);
         }
         if (!empty($record['sub_observations']) && is_array($record['sub_observations'])) {
-            $record['sub_observations'] = array_map(fn($rec): array => $this->createResultRecordFromDatabaseResult($rec), $record['sub_observations']);
+            $record['sub_observations'] = array_map($this->createResultRecordFromDatabaseResult(...), $record['sub_observations']);
         }
         $record['ob_reason_status_display'] = $this->getReasonStatusDisplay($record['ob_reason_status']);
         return $record;
@@ -689,7 +689,7 @@ class ObservationService extends BaseService
         $sql .= " ORDER BY date DESC, id DESC";
 
         $mainObservations = QueryUtils::fetchRecords($sql, $params);
-        $mainObservations = array_map(fn($rec): array => $this->createResultRecordFromDatabaseResult($rec), $mainObservations ?? []);
+        $mainObservations = array_map($this->createResultRecordFromDatabaseResult(...), $mainObservations ?? []);
 
         // For each main observation, get its sub-observations
         foreach ($mainObservations as &$observation) {

--- a/src/Services/PatientService.php
+++ b/src/Services/PatientService.php
@@ -849,9 +849,7 @@ class PatientService extends BaseService
     {
         // get integer only filtered pids for sql safety
         $bindString = rtrim(str_repeat("?,", count($patientUuids) - 1)) . "?";
-        $patientUuids = array_map(function ($uuid) {
-            return UuidRegistry::uuidToBytes($uuid);
-        }, $patientUuids);
+        $patientUuids = array_map(UuidRegistry::uuidToBytes(...), $patientUuids);
 
         $sql = "SELECT uuid,providerID FROM patient_data WHERE uuid IN (" . $bindString . ") "
             . " AND providerID IS NOT NULL AND providerID != 0 ORDER BY uuid";

--- a/src/Services/Qdm/ResultsCalculator.php
+++ b/src/Services/Qdm/ResultsCalculator.php
@@ -71,9 +71,7 @@ class ResultsCalculator
          */
         $this->measure_result_hash[$measure->hqmf_id] = [];
         $population_set_keys = array_map(
-            function ($ps) use ($measure) {
-                return $measure->key_for_population_set($ps);
-            },
+            $measure->key_for_population_set(...),
             $measure->population_sets_and_stratifications_for_measure()
         );
         foreach ($population_set_keys as $psk) {

--- a/tests/Tests/Services/FHIR/FhirAllergyIntoleranceServiceQueryTest.php
+++ b/tests/Tests/Services/FHIR/FhirAllergyIntoleranceServiceQueryTest.php
@@ -123,9 +123,7 @@ class FhirAllergyIntoleranceServiceQueryTest extends TestCase
         $select = "SELECT `lists`.`pid`,`patient_data`.`uuid` FROM `lists` INNER JOIN `patient_data` ON `patient_data`.`pid` = "
          . "`lists`.`pid` WHERE `type`='allergy' and `patient_data`.`pubpid` LIKE ? LIMIT 2";
         $records = QueryUtils::fetchTableColumn($select, 'uuid', [$pubpid]);
-        $uuids = array_map(function ($v) {
-            return UuidRegistry::uuidToString($v);
-        }, $records);
+        $uuids = array_map(UuidRegistry::uuidToString(...), $records);
         list($uuidPatient1, $uuidPatient2) = $uuids;
 
         // replace any values that we will use for searching

--- a/tests/Tests/Unit/Common/Crypto/CryptoGenTest.php
+++ b/tests/Tests/Unit/Common/Crypto/CryptoGenTest.php
@@ -1477,7 +1477,7 @@ final class CryptoGenTest extends TestCase
         // comprehensively test every pair of encryptionVersion and minimumVersion
         $min = min(array_map(fn($v) => $v->value, KeyVersion::cases()));
         $max = max(array_map(fn($v) => $v->value, KeyVersion::cases()));
-        $versions = array_map(fn($i) => KeyVersion::from($i), range($min, $max));
+        $versions = array_map(KeyVersion::from(...), range($min, $max));
 
         foreach ($versions as $minValue => $minimumVersion) {
             foreach ($versions as $encryptionValue => $encryptionVersion) {


### PR DESCRIPTION
Fixes #9028

#### Short description of what this resolves:

Reduces the overhead from a wrapper that only calls a function with an identical signature.


#### Changes proposed in this pull request:

I used the rector rule
https://getrector.com/rule-detail/function-like-to-first-class-callable-rector
to apply this change, but on the advice of rector folks, am not putting
this in rector.php right now. It's safe enough if you manually review
each change, but we don't want it to apply to everything without careful
consideration.

#### Does your code include anything generated by an AI Engine? No
