### PR TITLE
ci(rector): list applied rules

### DIFF
--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -54,5 +54,8 @@ jobs:
     - name: Create Rector cache directory
       run: mkdir -p /tmp/rector
 
+    - name: Rector List Rules
+      run: vendor/bin/rector list-rules
+
     - name: Rector Dry Run
       run: vendor/bin/rector process --dry-run


### PR DESCRIPTION
Makes the list of applied rector rules visible in the CI job. This gives us important debugging information when dealing with rector.
