### PR TITLE
fix: Initialize numeric variables to 0 instead of null

### DIFF
--- a/interface/billing/billing_report.php
+++ b/interface/billing/billing_report.php
@@ -950,6 +950,7 @@ $partners = $x->_utility_array($x->x12_partner_factory());
 
                         $mmo_empty_mod = false;
                         $mmo_num_charges = 0;
+                        $encount = 0;
 
                         foreach ($ret as $iter) {
                         // We include encounters here that have never been billed. However
@@ -989,7 +990,6 @@ $partners = $x->_utility_array($x->x12_partner_factory());
                                         }
                                         echo "<tr style='background-color: " . attr($bgcolor) . ";'>\n<td class='align-top' rowspan='" . attr($rcount) . "'>\n$lhtml</td>$rhtml\n";
                                         echo "<tr style='background-color: " . attr($bgcolor) . ";'><td colspan='9' height='5'></td></tr>\n\n";
-                                        $encount = $encount ?? null;
                                         ++$encount;
                                     }
                                 }
@@ -1041,7 +1041,7 @@ $partners = $x->_utility_array($x->x12_partner_factory());
                                 );
                                 $namecolor = ($res['count'] > 0) ? "black" : "#ff7777";
 
-                                $bgcolor = ((($encount ?? null) & 1) ? "var(--light)" : "var(--gray300)");
+                                $bgcolor = (($encount & 1) ? "var(--light)" : "var(--gray300)");
                                 echo "<tr style='background-color: " . attr($bgcolor) . ";'><td colspan='9' height='5'></td></tr>\n";
                                 $lcount = 1;
                                 $rcount = 0;

--- a/interface/billing/payment_pat_sel.inc.php
+++ b/interface/billing/payment_pat_sel.inc.php
@@ -91,7 +91,7 @@ if (isset($_POST["mode"])) {
                         </div>
                     </fieldset>
                 <?php //New distribution section
-                //$CountIndex=0;
+                $CountIndex = 0;
                 $CountIndexBelow = 0;
                 $PreviousEncounter = 0;
                 $PreviousPID = 0;
@@ -121,7 +121,6 @@ if (isset($_POST["mode"])) {
                                 </thead>
                         <?php
                         do {
-                            $CountIndex = $CountIndex ?? null;
                             $CountIndex++;
                             $CountIndexBelow++;
                             $Ins = 0;

--- a/interface/billing/sl_receipts_report.php
+++ b/interface/billing/sl_receipts_report.php
@@ -533,6 +533,8 @@ $form_facility   = $_POST['form_facility'] ?? null;
 
                         /**************************************************************/
                         //
+                        $grandtotal1 = 0;
+                        $grandtotal2 = 0;
                         $res = sqlStatement($query, $sqlBindArray);
                         while ($row = sqlFetchArray($res)) {
                             $trans_id = $row['trans_id'];
@@ -704,10 +706,7 @@ $form_facility   = $_POST['form_facility'] ?? null;
                             $doctotal1   += $amount1;
                             $doctotal2   += $amount2;
 
-                            $grandtotal1 = $grandtotal1 ?? null;
                             $grandtotal1 += $amount1;
-
-                            $grandtotal2 = $grandtotal2 ?? null;
                             $grandtotal2 += $amount2;
                         }
                         ?>
@@ -732,7 +731,7 @@ $form_facility   = $_POST['form_facility'] ?? null;
                         <?php echo xlt('Grand Totals') ?>
                 </td>
                 <td>
-                        <?php echo text(FormatMoney::getBucks($grandtotal1 ?? '')) ?>
+                        <?php echo text(FormatMoney::getBucks($grandtotal1)) ?>
                 </td>
                         <?php if ($form_procedures) { ?>
                 <td>

--- a/interface/reports/collections_report.php
+++ b/interface/reports/collections_report.php
@@ -263,7 +263,7 @@ function endPatient($ptrow): void
     $grand_total_adjustments += $ptrow['adjustments'];
     $grand_total_paid        += $ptrow['paid'];
     for ($c = 0; $c < $form_age_cols; ++$c) {
-        $grand_total_agedbal[$c] += ($ptrow['agedbal'][$c] ?? null);
+        $grand_total_agedbal[$c] += ($ptrow['agedbal'][$c] ?? 0);
     }
 }
 
@@ -1183,7 +1183,7 @@ if (!empty($_POST['form_refresh']) || !empty($_POST['form_export']) || !empty($_
             $days = floor((time() - $agetime) / (60 * 60 * 24));
             $agecolno = min($form_age_cols - 1, max(0, floor($days / $form_age_inc)));
 
-            $ptrow['agedbal'][$agecolno] = $ptrow['agedbal'][$agecolno] ?? null;
+            $ptrow['agedbal'][$agecolno] ??= 0;
             $ptrow['agedbal'][$agecolno] += $balance;
         }
 

--- a/interface/reports/daily_summary_report.php
+++ b/interface/reports/daily_summary_report.php
@@ -304,7 +304,7 @@ $selectedProvider = isset($_POST['form_provider']) ? $_POST['form_provider'] : "
                                                                     GROUP BY `b`.`encounter`,Date,provider_name ORDER BY Date ASC", $sqlBindArrayTotalPayment);
 
         while ($totalPaymentRecord = sqlFetchArray($totalPaymetsSql)) {
-            $totalPayment[$totalPaymentRecord['Date']][$totalPaymentRecord['facilityName']][$totalPaymentRecord['provider_name']]['payments'] = $totalPayment[$totalPaymentRecord['Date']][$totalPaymentRecord['facilityName']][$totalPaymentRecord['provider_name']]['payments'] ?? null;
+            $totalPayment[$totalPaymentRecord['Date']][$totalPaymentRecord['facilityName']][$totalPaymentRecord['provider_name']]['payments'] ??= 0;
             $totalPayment[$totalPaymentRecord['Date']][$totalPaymentRecord['facilityName']][$totalPaymentRecord['provider_name']]['payments'] += $totalPaymentRecord['totalpayment'];
         }
 
@@ -344,6 +344,12 @@ $selectedProvider = isset($_POST['form_provider']) ? $_POST['form_provider'] : "
                 </tr>
                 <?php
                 if (count($dailySummaryReport) > 0) { // check if daily summary array has value
+                    $totalAppointments = 0;
+                    $totalNewRegisterPatient = 0;
+                    $totalVisits = 0;
+                    $totalPayments = 0;
+                    $totalPaidAmount = 0;
+                    $totalDueAmount = 0;
                     foreach ($dailySummaryReport as $date => $dataValue) { //   daily summary array which consists different/dynamic values
                         foreach ($facilities as $facility) { // facility array
                             if (isset($dataValue[$facility])) {
@@ -372,22 +378,11 @@ $selectedProvider = isset($_POST['form_provider']) ? $_POST['form_provider'] : "
                                     </tr>
                                     <?php
                                     if (count($dailySummaryReport) > 0) { // calculate the total count of the appointments, new patient,visits, payments, paid amount and due amount
-                                        $totalAppointments = $totalAppointments ?? null;
-                                        $totalAppointments += ($information['appointments'] ?? null);
-
-                                        $totalNewRegisterPatient = $totalNewRegisterPatient ?? null;
-                                        $totalNewRegisterPatient += ($information['newPatient'] ?? null);
-
-                                        $totalVisits = $totalVisits ?? null;
-                                        $totalVisits += ($information['visits'] ?? null);
-
-                                        $totalPayments = $totalPayments ?? null;
+                                        $totalAppointments += ($information['appointments'] ?? 0);
+                                        $totalNewRegisterPatient += ($information['newPatient'] ?? 0);
+                                        $totalVisits += ($information['visits'] ?? 0);
                                         $totalPayments += floatval(str_replace(",", "", ($information['payments'] ?? '')));
-
-                                        $totalPaidAmount = $totalPaidAmount ?? null;
                                         $totalPaidAmount += floatval(str_replace(",", "", ($information['paidAmount'] ?? '')));
-
-                                        $totalDueAmount = $totalDueAmount ?? null;
                                         $totalDueAmount += $dueAmount;
                                     }
                                 }

--- a/interface/reports/insurance_allocation_report.php
+++ b/interface/reports/insurance_allocation_report.php
@@ -211,13 +211,13 @@ if (!empty($_POST['form_refresh']) || !empty($_POST['form_csvexport'])) {
         "insurance_companies.id = insurance_data.provider " .
         "ORDER BY insurance_data.date DESC LIMIT 1", array($patient_id, $encounter_date));
         $plan = (!empty($irow['name'])) ? $irow['name'] : '-- No Insurance --';
-        $insarr[$plan]['visits'] = $insarr[$plan]['visits'] ?? null;
+        $insarr[$plan]['visits'] ??= 0;
         $insarr[$plan]['visits'] += 1;
-        $insarr[$plan]['charges'] = $insarr[$plan]['charges'] ?? null;
-        $insarr[$plan]['charges'] += sprintf('%0.2f', $row['charges']);
+        $insarr[$plan]['charges'] ??= 0;
+        $insarr[$plan]['charges'] += (float)$row['charges'];
         if ($patient_id != $prev_pid) {
             ++$patcount;
-            $insarr[$plan]['patients'] =  $insarr[$plan]['patients'] ?? null;
+            $insarr[$plan]['patients'] ??= 0;
             $insarr[$plan]['patients'] += 1;
             $prev_pid = $patient_id;
         }

--- a/phpstan.github.neon
+++ b/phpstan.github.neon
@@ -3536,10 +3536,6 @@ parameters:
     identifier: variable.undefined
     count: 3
     path: interface/billing/sl_receipts_report.php
-  - message: '#^Variable \$grandtotal2 might not be defined\.$#'
-    identifier: variable.undefined
-    count: 1
-    path: interface/billing/sl_receipts_report.php
   - message: '#^Variable \$patient_name might not be defined\.$#'
     identifier: variable.undefined
     count: 1
@@ -13783,30 +13779,6 @@ parameters:
   - message: '#^Variable \$srcdir might not be defined\.$#'
     identifier: variable.undefined
     count: 2
-    path: interface/reports/daily_summary_report.php
-  - message: '#^Variable \$totalAppointments might not be defined\.$#'
-    identifier: variable.undefined
-    count: 1
-    path: interface/reports/daily_summary_report.php
-  - message: '#^Variable \$totalDueAmount might not be defined\.$#'
-    identifier: variable.undefined
-    count: 1
-    path: interface/reports/daily_summary_report.php
-  - message: '#^Variable \$totalNewRegisterPatient might not be defined\.$#'
-    identifier: variable.undefined
-    count: 1
-    path: interface/reports/daily_summary_report.php
-  - message: '#^Variable \$totalPaidAmount might not be defined\.$#'
-    identifier: variable.undefined
-    count: 1
-    path: interface/reports/daily_summary_report.php
-  - message: '#^Variable \$totalPayments might not be defined\.$#'
-    identifier: variable.undefined
-    count: 1
-    path: interface/reports/daily_summary_report.php
-  - message: '#^Variable \$totalVisits might not be defined\.$#'
-    identifier: variable.undefined
-    count: 1
     path: interface/reports/daily_summary_report.php
   - message: '#^Variable \$srcdir might not be defined\.$#'
     identifier: variable.undefined


### PR DESCRIPTION
Fixes #9037

#### Short description of what this resolves:

Fix places where variables were initialized to null and then immediately used in a non-nullable context, such as addition. Also, tried to initialize counter variables outside the loop, avoiding the need to check them inside the loop.


#### Changes proposed in this pull request:

- [x] billing_report.php: Initialize $encount outside loop
- [x] payment_pat_sel.inc.php: Use ??= 0 for $CountIndex
- [x] sl_receipts_report.php: Initialize $grandtotal1/$grandtotal2 outside loop
- [x] collections_report.php: Use ??= 0 and ?? 0 for aged balances
- [x] daily_summary_report.php: Initialize total variables outside loop, use ??= 0 for dynamic keys
- [x] insurance_allocation_report.php: Use ??= 0, accumulate float instead of formatted string

#### Does your code include anything generated by an AI Engine? No
