### PR TITLE
ci(tests): provide junit.xml as artifacts

### DIFF
--- a/.github/workflows/isolated-tests.yml
+++ b/.github/workflows/isolated-tests.yml
@@ -84,6 +84,13 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
+    - name: Upload JUnit test results
+      if: ${{ success() || failure() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: junit-isolated-tests-php-${{ matrix.php-version }}
+        path: junit.xml
+
     - name: Check if coverage files exist
       if: ${{ (success() || failure()) }}
       id: check-files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -341,6 +341,13 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
+    - name: Upload JUnit test results
+      if: ${{ success() || failure() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: junit-test-results-${{ matrix.configurations.docker_dir }}
+        path: junit.xml
+
     - name: Combine coverage
       if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
       run: |


### PR DESCRIPTION
Fixes #9097

#### Short description of what this resolves:

Upload the junit.xml from actions test runs for easier debugging.


#### Changes proposed in this pull request:

Upload the junit.xml from actions test runs

#### Does your code include anything generated by an AI Engine? No
