### PR TITLE
Fix FhirServiceBase::searchForOpenEMRRecords

### DIFF
--- a/src/Services/FHIR/Condition/FhirConditionEncounterDiagnosisService.php
+++ b/src/Services/FHIR/Condition/FhirConditionEncounterDiagnosisService.php
@@ -32,6 +32,7 @@ use OpenEMR\Services\FHIR\Traits\MappedServiceCategoryTrait;
 use OpenEMR\Services\FHIR\Traits\MappedServiceTrait;
 use OpenEMR\Services\Search\FhirSearchParameterDefinition;
 use OpenEMR\Services\Search\FhirSearchWhereClauseBuilder;
+use OpenEMR\Services\Search\ISearchField;
 use OpenEMR\Services\Search\SearchFieldType;
 use OpenEMR\Services\Search\ServiceField;
 use OpenEMR\Services\Search\TokenSearchField;
@@ -97,7 +98,7 @@ class FhirConditionEncounterDiagnosisService extends FhirServiceBase implements 
      * AI Generated
      * Searches for OpenEMR records using OpenEMR search parameters
      *
-     * @param  array openEMRSearchParameters OpenEMR search fields
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
      * @return ProcessingResult
      */
     protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult

--- a/src/Services/FHIR/Condition/FhirConditionProblemsHealthConcernService.php
+++ b/src/Services/FHIR/Condition/FhirConditionProblemsHealthConcernService.php
@@ -28,6 +28,7 @@ use OpenEMR\Services\FHIR\Traits\MappedServiceCategoryTrait;
 use OpenEMR\Services\FHIR\Traits\MappedServiceTrait;
 use OpenEMR\Services\Search\FhirSearchParameterDefinition;
 use OpenEMR\Services\Search\FhirSearchWhereClauseBuilder;
+use OpenEMR\Services\Search\ISearchField;
 use OpenEMR\Services\Search\SearchFieldType;
 use OpenEMR\Services\Search\ServiceField;
 use OpenEMR\Validators\ProcessingResult;
@@ -119,11 +120,10 @@ class FhirConditionProblemsHealthConcernService extends FhirServiceBase implemen
      * Searches for OpenEMR records using OpenEMR search parameters
      * This handles problem list items and health concerns (NOT linked to specific encounters)
      *
-     * @param  array openEMRSearchParameters OpenEMR search fields
-     * @param $puuidBind - Optional variable to only allow visibility of the patient with this puuid.
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
      * @return ProcessingResult
      */
-    protected function searchForOpenEMRRecords($openEMRSearchParameters, $puuidBind = null): ProcessingResult
+    protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {
         // This query finds conditions that are NOT linked to specific encounters via issue_encounter
         // These represent ongoing problems/health concerns rather than encounter-specific diagnoses

--- a/src/Services/FHIR/DiagnosticReport/FhirDiagnosticReportClinicalNotesService.php
+++ b/src/Services/FHIR/DiagnosticReport/FhirDiagnosticReportClinicalNotesService.php
@@ -177,9 +177,8 @@ class FhirDiagnosticReportClinicalNotesService extends FhirServiceBase
 
     /**
      * Searches for OpenEMR records using OpenEMR search parameters
-     * @param openEMRSearchParameters OpenEMR search fields
-     * @param $puuidBind - Optional variable to only allow visibility of the patient with this puuid.
-     * @return OpenEMR records
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
+     * @return ProcessingResult OpenEMR records
      */
     protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {

--- a/src/Services/FHIR/DiagnosticReport/FhirDiagnosticReportLaboratoryService.php
+++ b/src/Services/FHIR/DiagnosticReport/FhirDiagnosticReportLaboratoryService.php
@@ -191,9 +191,8 @@ class FhirDiagnosticReportLaboratoryService extends FhirServiceBase
 
     /**
      * Searches for OpenEMR records using OpenEMR search parameters
-     * @param openEMRSearchParameters OpenEMR search fields
-     * @param $puuidBind - Optional variable to only allow visibility of the patient with this puuid.
-     * @return OpenEMR records
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
+     * @return ProcessingResult OpenEMR records
      */
     protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {

--- a/src/Services/FHIR/DocumentReference/FhirClinicalNotesService.php
+++ b/src/Services/FHIR/DocumentReference/FhirClinicalNotesService.php
@@ -200,9 +200,8 @@ class FhirClinicalNotesService extends FhirServiceBase
 
     /**
      * Searches for OpenEMR records using OpenEMR search parameters
-     * @param openEMRSearchParameters OpenEMR search fields
-     * @param $puuidBind - Optional variable to only allow visibility of the patient with this puuid.
-     * @return OpenEMR records
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
+     * @return ProcessingResult OpenEMR records
      */
     protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {

--- a/src/Services/FHIR/DocumentReference/FhirPatientDocumentReferenceService.php
+++ b/src/Services/FHIR/DocumentReference/FhirPatientDocumentReferenceService.php
@@ -84,6 +84,10 @@ class FhirPatientDocumentReferenceService extends FhirServiceBase
         return new FhirSearchParameterDefinition('_lastUpdated', SearchFieldType::DATETIME, ['date']);
     }
 
+    /**
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
+     * @return ProcessingResult OpenEMR records
+     */
     protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {
         if (isset($openEMRSearchParameters['category'])) {

--- a/src/Services/FHIR/FhirAllergyIntoleranceService.php
+++ b/src/Services/FHIR/FhirAllergyIntoleranceService.php
@@ -262,13 +262,12 @@ class FhirAllergyIntoleranceService extends FhirServiceBase implements IResource
     /**
      * Searches for OpenEMR records using OpenEMR search parameters
      *
-     * @param array openEMRSearchParameters OpenEMR search fields
-     * @param $puuidBind - Optional variable to only allow visibility of the patient with this puuid.
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
      * @return ProcessingResult
      */
-    protected function searchForOpenEMRRecords($openEMRSearchParameters, $puuidBind = null): ProcessingResult
+    protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {
-        return $this->allergyIntoleranceService->search($openEMRSearchParameters, true, $puuidBind);
+        return $this->allergyIntoleranceService->search($openEMRSearchParameters, true);
     }
 
     public function getProfileURIs(): array

--- a/src/Services/FHIR/FhirAppointmentService.php
+++ b/src/Services/FHIR/FhirAppointmentService.php
@@ -26,6 +26,7 @@ use OpenEMR\Services\FHIR\Traits\FhirBulkExportDomainResourceTrait;
 use OpenEMR\Services\FHIR\Traits\FhirServiceBaseEmptyTrait;
 use OpenEMR\Services\FHIR\Traits\PatientSearchTrait;
 use OpenEMR\Services\Search\FhirSearchParameterDefinition;
+use OpenEMR\Services\Search\ISearchField;
 use OpenEMR\Services\Search\SearchFieldType;
 use OpenEMR\Services\Search\ServiceField;
 use OpenEMR\Validators\ProcessingResult;
@@ -260,13 +261,12 @@ class FhirAppointmentService extends FhirServiceBase implements IPatientCompartm
 
     /**
      * Searches for OpenEMR records using OpenEMR search parameters
-     * @param openEMRSearchParameters OpenEMR search fields
-     * @param $puuidBind - Optional variable to only allow visibility of the patient with this puuid.
-     * @return OpenEMR records
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
+    * @return ProcessingResult OpenEMR records
      */
-    protected function searchForOpenEMRRecords($openEMRSearchParameters, $puuidBind = null): ProcessingResult
+    protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {
-        return $this->appointmentService->search($openEMRSearchParameters, true, $puuidBind);
+        return $this->appointmentService->search($openEMRSearchParameters, true);
     }
 
     /**

--- a/src/Services/FHIR/FhirCarePlanService.php
+++ b/src/Services/FHIR/FhirCarePlanService.php
@@ -143,13 +143,12 @@ class FhirCarePlanService extends FhirServiceBase implements IResourceUSCIGProfi
     /**
      * Searches for OpenEMR records using OpenEMR search parameters
      *
-     * @param  array openEMRSearchParameters OpenEMR search fields
-     * @param $puuidBind - Optional variable to only allow visibility of the patient with this puuid.
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
      * @return ProcessingResult
      */
-    protected function searchForOpenEMRRecords($openEMRSearchParameters, $puuidBind = null): ProcessingResult
+    protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {
-        return $this->service->search($openEMRSearchParameters, true, $puuidBind);
+        return $this->service->search($openEMRSearchParameters, true);
     }
 
     public function createProvenanceResource($dataRecord, $encode = false)

--- a/src/Services/FHIR/FhirCareTeamService.php
+++ b/src/Services/FHIR/FhirCareTeamService.php
@@ -184,13 +184,13 @@ class FhirCareTeamService extends FhirServiceBase implements IResourceUSCIGProfi
     /**
      * Searches for OpenEMR records using OpenEMR search parameters
      *
-     * @param  array openEMRSearchParameters OpenEMR search fields
-     * @param $puuidBind - Optional variable to only allow visibility of the patient with this puuid.
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
      * @return ProcessingResult
      */
-    protected function searchForOpenEMRRecords($openEMRSearchParameters, $puuidBind = null): ProcessingResult
+    protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {
-        return $this->careTeamService->getAll($openEMRSearchParameters, true, $puuidBind);
+        // note the calling function will pass in the patient in the $openEMRSearchParameters
+        return $this->careTeamService->getAll($openEMRSearchParameters, true);
     }
 
     public function createProvenanceResource($dataRecord = [], $encode = false)

--- a/src/Services/FHIR/FhirCoverageService.php
+++ b/src/Services/FHIR/FhirCoverageService.php
@@ -127,7 +127,7 @@ class FhirCoverageService extends FhirServiceBase implements IPatientCompartment
     /**
      * Searches for OpenEMR records using OpenEMR search parameters
      *
-     * @param  array openEMRSearchParameters OpenEMR search fields
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
      * @return ProcessingResult
      */
     protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult

--- a/src/Services/FHIR/FhirDeviceService.php
+++ b/src/Services/FHIR/FhirDeviceService.php
@@ -140,9 +140,8 @@ class FhirDeviceService extends FhirServiceBase implements IResourceUSCIGProfile
 
     /**
      * Searches for OpenEMR records using OpenEMR search parameters
-     * @param openEMRSearchParameters OpenEMR search fields
-     * @param $puuidBind - Optional variable to only allow visibility of the patient with this puuid.
-     * @return OpenEMR records
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
+     * @return ProcessingResult OpenEMR records
      */
     protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {

--- a/src/Services/FHIR/FhirEncounterService.php
+++ b/src/Services/FHIR/FhirEncounterService.php
@@ -309,13 +309,12 @@ class FhirEncounterService extends FhirServiceBase implements
     /**
      * Searches for OpenEMR records using OpenEMR search parameters
      *
-     * @param array openEMRSearchParameters OpenEMR search fields
-     * @param $puuidBind - Optional variable to only allow visibility of the patient with this puuid.
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
      * @return ProcessingResult
      */
-    protected function searchForOpenEMRRecords($searchParam, $puuidBind = null): ProcessingResult
+    protected function searchForOpenEMRRecords($searchParam): ProcessingResult
     {
-        return $this->encounterService->search($searchParam, true, $puuidBind);
+        return $this->encounterService->search($searchParam, true);
     }
 
     /**

--- a/src/Services/FHIR/FhirGoalService.php
+++ b/src/Services/FHIR/FhirGoalService.php
@@ -352,13 +352,12 @@ class FhirGoalService extends FhirServiceBase implements IResourceUSCIGProfileSe
     /**
      * Searches for OpenEMR records using OpenEMR search parameters
      *
-     * @param  array openEMRSearchParameters OpenEMR search fields
-     * @param $puuidBind - Optional variable to only allow visibility of the patient with this puuid.
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
      * @return ProcessingResult
      */
-    protected function searchForOpenEMRRecords($openEMRSearchParameters, $puuidBind = null): ProcessingResult
+    protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {
-        return $this->service->search($openEMRSearchParameters, true, $puuidBind);
+        return $this->service->search($openEMRSearchParameters, true);
     }
 
     public function createProvenanceResource($dataRecord, $encode = false)

--- a/src/Services/FHIR/FhirImmunizationService.php
+++ b/src/Services/FHIR/FhirImmunizationService.php
@@ -21,6 +21,7 @@ use OpenEMR\FHIR\R4\FHIRElement\FHIRQuantity;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRReference;
 use OpenEMR\FHIR\R4\FHIRResource\FHIRImmunization\FHIRImmunizationEducation;
 use OpenEMR\Services\Search\FhirSearchParameterDefinition;
+use OpenEMR\Services\Search\ISearchField;
 use OpenEMR\Services\Search\SearchFieldType;
 use OpenEMR\Services\Search\ServiceField;
 use OpenEMR\Validators\ProcessingResult;
@@ -224,13 +225,13 @@ class FhirImmunizationService extends FhirServiceBase implements IResourceUSCIGP
     /**
      * Searches for OpenEMR records using OpenEMR search parameters
      *
-     * @param array openEMRSearchParameters OpenEMR search fields
-     * @param $puuidBind - Optional variable to only allow visibility of the patient with this puuid.
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
      * @return ProcessingResult
      */
-    protected function searchForOpenEMRRecords($openEMRSearchParameters, $puuidBind = null): ProcessingResult
+    protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {
-        return $this->immunizationService->getAll($openEMRSearchParameters, true, $puuidBind);
+        // puuid binding happens in the $openEMRSearchParameters
+        return $this->immunizationService->getAll($openEMRSearchParameters, true);
     }
     public function createProvenanceResource($dataRecord = [], $encode = false)
     {

--- a/src/Services/FHIR/FhirLocationService.php
+++ b/src/Services/FHIR/FhirLocationService.php
@@ -177,7 +177,7 @@ class FhirLocationService extends FhirServiceBase implements IFhirExportableReso
     /**
      * Searches for OpenEMR records using OpenEMR search parameters
      *
-     * @param  array openEMRSearchParameters OpenEMR search fields
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
      * @return ProcessingResult
      */
     protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult

--- a/src/Services/FHIR/FhirMedicationRequestService.php
+++ b/src/Services/FHIR/FhirMedicationRequestService.php
@@ -25,6 +25,7 @@ use OpenEMR\Services\FHIR\Traits\VersionedProfileTrait;
 use OpenEMR\Services\ListService;
 use OpenEMR\Services\PrescriptionService;
 use OpenEMR\Services\Search\FhirSearchParameterDefinition;
+use OpenEMR\Services\Search\ISearchField;
 use OpenEMR\Services\Search\SearchFieldType;
 use OpenEMR\Services\Search\ServiceField;
 use OpenEMR\Validators\ProcessingResult;
@@ -294,13 +295,12 @@ class FhirMedicationRequestService extends FhirServiceBase implements IResourceU
     /**
      * Searches for OpenEMR records using OpenEMR search parameters
      *
-     * @param  array openEMRSearchParameters OpenEMR search fields
-     * @param $puuidBind - Optional variable to only allow visibility of the patient with this puuid.
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
      * @return ProcessingResult
      */
-    protected function searchForOpenEMRRecords($openEMRSearchParameters, $puuidBind = null): ProcessingResult
+    protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {
-        return $this->prescriptionService->getAll($openEMRSearchParameters, true, $puuidBind);
+        return $this->prescriptionService->getAll($openEMRSearchParameters, true);
     }
 
     public function createProvenanceResource($dataRecord = [], $encode = false)

--- a/src/Services/FHIR/FhirMedicationService.php
+++ b/src/Services/FHIR/FhirMedicationService.php
@@ -14,6 +14,7 @@ use OpenEMR\Services\FHIR\FhirServiceBase;
 use OpenEMR\Services\FHIR\Traits\FhirServiceBaseEmptyTrait;
 use OpenEMR\Services\FHIR\Traits\VersionedProfileTrait;
 use OpenEMR\Services\Search\FhirSearchParameterDefinition;
+use OpenEMR\Services\Search\ISearchField;
 use OpenEMR\Services\Search\SearchFieldType;
 use OpenEMR\Services\Search\ServiceField;
 use OpenEMR\Validators\ProcessingResult;
@@ -153,13 +154,12 @@ class FhirMedicationService extends FhirServiceBase implements IResourceUSCIGPro
     /**
      * Searches for OpenEMR records using OpenEMR search parameters
      *
-     * @param  array openEMRSearchParameters OpenEMR search fields
-     * @param $puuidBind - Patient uuid to return drug resources that are only visible to the current patient
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
      * @return ProcessingResult
      */
-    protected function searchForOpenEMRRecords($openEMRSearchParameters, $puuidBind = null): ProcessingResult
+    protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {
-        return $this->medicationService->getAll($openEMRSearchParameters, true, $puuidBind);
+        return $this->medicationService->getAll($openEMRSearchParameters, true);
     }
 
     /**

--- a/src/Services/FHIR/FhirPatientService.php
+++ b/src/Services/FHIR/FhirPatientService.php
@@ -671,8 +671,7 @@ class FhirPatientService extends FhirServiceBase implements IFhirExportableResou
     /**
      * Searches for OpenEMR records using OpenEMR search parameters
      *
-     * @param ISearchField[] openEMRSearchParameters OpenEMR search fields
-     * @param $puuidBind - Optional variable to only allow visibility of the patient with this puuid.
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
      * @return ProcessingResult
      */
     protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult

--- a/src/Services/FHIR/FhirPersonService.php
+++ b/src/Services/FHIR/FhirPersonService.php
@@ -22,6 +22,7 @@ use OpenEMR\FHIR\R4\FHIRElement\FHIRMeta;
 use OpenEMR\Services\FHIR\Traits\BulkExportSupportAllOperationsTrait;
 use OpenEMR\Services\FHIR\Traits\FhirBulkExportDomainResourceTrait;
 use OpenEMR\Services\Search\FhirSearchParameterDefinition;
+use OpenEMR\Services\Search\ISearchField;
 use OpenEMR\Services\Search\SearchFieldType;
 use OpenEMR\Services\Search\ServiceField;
 use OpenEMR\Services\UserService;
@@ -269,11 +270,10 @@ class FhirPersonService extends FhirServiceBase implements IFhirExportableResour
     /**
      * Searches for OpenEMR records using OpenEMR search parameters
      *
-     * @param array openEMRSearchParameters OpenEMR search fields
-     * @param $puuidBind - NOT USED
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
      * @return ProcessingResult
      */
-    protected function searchForOpenEMRRecords($openEMRSearchParameters, $puuidBind = null): ProcessingResult
+    protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {
         return $this->userService->search($openEMRSearchParameters);
     }

--- a/src/Services/FHIR/FhirPractitionerRoleService.php
+++ b/src/Services/FHIR/FhirPractitionerRoleService.php
@@ -11,6 +11,7 @@ use OpenEMR\Services\FHIR\Traits\FhirServiceBaseEmptyTrait;
 use OpenEMR\Services\FHIR\Traits\VersionedProfileTrait;
 use OpenEMR\Services\PractitionerRoleService;
 use OpenEMR\Services\Search\FhirSearchParameterDefinition;
+use OpenEMR\Services\Search\ISearchField;
 use OpenEMR\Services\Search\SearchFieldType;
 use OpenEMR\Services\Search\ServiceField;
 use OpenEMR\Validators\ProcessingResult;
@@ -133,11 +134,10 @@ class FhirPractitionerRoleService extends FhirServiceBase implements IResourceUS
     /**
      * Searches for OpenEMR records using OpenEMR search parameters
      *
-     * @param array openEMRSearchParameters OpenEMR search fields
-     * @param $puuidBind - NOT USED
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
      * @return ProcessingResult
      */
-    protected function searchForOpenEMRRecords($openEMRSearchParameters, $puuidBind = null): ProcessingResult
+    protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {
         return $this->practitionerRoleService->search($openEMRSearchParameters);
     }

--- a/src/Services/FHIR/FhirPractitionerService.php
+++ b/src/Services/FHIR/FhirPractitionerService.php
@@ -16,6 +16,7 @@ use OpenEMR\FHIR\R4\FHIRElement\FHIRId;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRHumanName;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRAddress;
 use OpenEMR\Services\Search\FhirSearchParameterDefinition;
+use OpenEMR\Services\Search\ISearchField;
 use OpenEMR\Services\Search\SearchFieldType;
 use OpenEMR\Services\Search\ServiceField;
 use OpenEMR\Validators\ProcessingResult;
@@ -299,11 +300,10 @@ class FhirPractitionerService extends FhirServiceBase implements IFhirExportable
     /**
      * Searches for OpenEMR records using OpenEMR search parameters
      *
-     * @param array openEMRSearchParameters OpenEMR search fields
-     * @param $puuidBind - NOT USED
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
      * @return ProcessingResult
      */
-    protected function searchForOpenEMRRecords($openEMRSearchParameters, $puuidBind = null): ProcessingResult
+    protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {
         return $this->practitionerService->getAll($openEMRSearchParameters, true);
     }

--- a/src/Services/FHIR/FhirServiceRequestService.php
+++ b/src/Services/FHIR/FhirServiceRequestService.php
@@ -29,6 +29,7 @@ use OpenEMR\Services\FHIR\Traits\FhirServiceBaseEmptyTrait;
 use OpenEMR\Services\FHIR\Traits\PatientSearchTrait;
 use OpenEMR\Services\ProcedureService;
 use OpenEMR\Services\Search\FhirSearchParameterDefinition;
+use OpenEMR\Services\Search\ISearchField;
 use OpenEMR\Services\Search\SearchFieldType;
 use OpenEMR\Services\Search\ServiceField;
 use OpenEMR\Services\Search\TokenSearchField;
@@ -142,6 +143,7 @@ class FhirServiceRequestService extends FhirServiceBase implements
 
     /**
      * Searches for OpenEMR records using OpenEMR search parameters
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
      */
     protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {

--- a/src/Services/FHIR/FhirSpecimenService.php
+++ b/src/Services/FHIR/FhirSpecimenService.php
@@ -27,6 +27,7 @@ use OpenEMR\Services\FHIR\Traits\FhirServiceBaseEmptyTrait;
 use OpenEMR\Services\ProcedureService;
 use OpenEMR\Services\Search\FhirSearchParameterDefinition;
 use OpenEMR\Services\Search\FhirSearchWhereClauseBuilder;
+use OpenEMR\Services\Search\ISearchField;
 use OpenEMR\Services\Search\SearchFieldException;
 use OpenEMR\Services\Search\SearchFieldType;
 use OpenEMR\Services\Search\ServiceField;
@@ -70,7 +71,7 @@ class FhirSpecimenService extends FhirServiceBase implements IPatientCompartment
     /**
      * Searches for OpenEMR records using OpenEMR search parameters
      *
-     * @param array $openEMRSearchParameters OpenEMR search fields
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
      * @return ProcessingResult
      */
     protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
@@ -148,7 +149,7 @@ class FhirSpecimenService extends FhirServiceBase implements IPatientCompartment
      */
     private function searchSpecimens(array $searchParams): array
     {
-        $sql = "SELECT 
+        $sql = "SELECT
             ps.procedure_specimen_id,
             ps.uuid,
             ps.procedure_order_id,

--- a/src/Services/FHIR/Group/FhirPatientProviderGroupService.php
+++ b/src/Services/FHIR/Group/FhirPatientProviderGroupService.php
@@ -55,6 +55,10 @@ class FhirPatientProviderGroupService extends FhirServiceBase
         return new FhirSearchParameterDefinition('_lastUpdated', SearchFieldType::DATETIME, ['patient_last_updated']);
     }
 
+    /**
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
+     * @return ProcessingResult
+     */
     protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {
         return $this->service->searchPatientProviderGroups($openEMRSearchParameters);

--- a/src/Services/FHIR/Observation/FhirObservationEmployerService.php
+++ b/src/Services/FHIR/Observation/FhirObservationEmployerService.php
@@ -20,6 +20,7 @@ use OpenEMR\Services\FHIR\Observation\Trait\FhirObservationTrait;
 use OpenEMR\Services\ListService;
 use OpenEMR\Services\Search\CompositeSearchField;
 use OpenEMR\Services\Search\FhirSearchParameterDefinition;
+use OpenEMR\Services\Search\ISearchField;
 use OpenEMR\Services\Search\SearchFieldException;
 use OpenEMR\Services\Search\SearchFieldType;
 use OpenEMR\Services\Search\SearchModifier;
@@ -190,6 +191,10 @@ class FhirObservationEmployerService extends FhirServiceBase implements IPatient
     // occupation, industry
     // sexual_orientation
 
+    /**
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
+     * @return ProcessingResult
+     */
     protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {
         $processingResult = new ProcessingResult();

--- a/src/Services/FHIR/Observation/FhirObservationHistorySdohService.php
+++ b/src/Services/FHIR/Observation/FhirObservationHistorySdohService.php
@@ -126,11 +126,10 @@ class FhirObservationHistorySdohService extends FhirServiceBase implements IPati
 
     /**
      * Searches for OpenEMR records using OpenEMR search parameters
-     * @param ISearchField $openEMRSearchParameters OpenEMR search fields
-     * @param string|null $puuidBind - Optional variable to only allow visibility of the patient with this puuid.
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
      * @return ProcessingResult OpenEMR records
      */
-    protected function searchForOpenEMRRecords($openEMRSearchParameters, ?string $puuidBind = null): ProcessingResult
+    protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {
         $processingResult = new ProcessingResult();
 

--- a/src/Services/FHIR/Observation/FhirObservationLaboratoryService.php
+++ b/src/Services/FHIR/Observation/FhirObservationLaboratoryService.php
@@ -33,6 +33,7 @@ use OpenEMR\Services\FHIR\Traits\VersionedProfileTrait;
 use OpenEMR\Services\FHIR\UtilsService;
 use OpenEMR\Services\ProcedureService;
 use OpenEMR\Services\Search\FhirSearchParameterDefinition;
+use OpenEMR\Services\Search\ISearchField;
 use OpenEMR\Services\Search\SearchFieldException;
 use OpenEMR\Services\Search\SearchFieldType;
 use OpenEMR\Services\Search\ServiceField;
@@ -127,7 +128,7 @@ class FhirObservationLaboratoryService extends FhirServiceBase implements IPatie
     /**
      * Searches for OpenEMR records using OpenEMR search parameters
      *
-     * @param openEMRSearchParameters OpenEMR search fields
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
      * @return ProcessingResult records
      */
     protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult

--- a/src/Services/FHIR/Observation/FhirObservationObservationFormService.php
+++ b/src/Services/FHIR/Observation/FhirObservationObservationFormService.php
@@ -121,16 +121,11 @@ class FhirObservationObservationFormService extends FhirServiceBase implements I
 
     /**
      * Searches for OpenEMR records using OpenEMR search parameters
-     * @param ISearchField $openEMRSearchParameters OpenEMR search fields
-     * @param string|null $puuidBind - Optional variable to only allow visibility of the patient with this puuid.
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
      * @return ProcessingResult OpenEMR records
      */
-    protected function searchForOpenEMRRecords($openEMRSearchParameters, ?string $puuidBind = null): ProcessingResult
+    protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {
-        if (!empty($puuidBind)) {
-            $puuidSearch = $this->getPatientContextSearchField();
-            $openEMRSearchParameters[$puuidSearch->getName()] = $puuidSearch;
-        }
         // we grab the records and grab any children records and populate them if we have them.
         return $this->observationService->searchAndPopulateChildObservations($openEMRSearchParameters);
     }

--- a/src/Services/FHIR/Observation/FhirObservationPatientService.php
+++ b/src/Services/FHIR/Observation/FhirObservationPatientService.php
@@ -22,6 +22,7 @@ use OpenEMR\Services\ListService;
 use OpenEMR\Services\PatientService;
 use OpenEMR\Services\Search\CompositeSearchField;
 use OpenEMR\Services\Search\FhirSearchParameterDefinition;
+use OpenEMR\Services\Search\ISearchField;
 use OpenEMR\Services\Search\SearchFieldException;
 use OpenEMR\Services\Search\SearchFieldType;
 use OpenEMR\Services\Search\SearchModifier;
@@ -147,6 +148,10 @@ class FhirObservationPatientService extends FhirServiceBase implements IPatientC
     // patient_data observations currently are the following:
     // occupation, industry
     // sexual_orientation
+    /**
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
+     * @return ProcessingResult
+     */
 
     protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {

--- a/src/Services/FHIR/Observation/FhirObservationSocialHistoryService.php
+++ b/src/Services/FHIR/Observation/FhirObservationSocialHistoryService.php
@@ -127,9 +127,8 @@ class FhirObservationSocialHistoryService extends FhirServiceBase implements IPa
 
     /**
      * Searches for OpenEMR records using OpenEMR search parameters
-     * @param openEMRSearchParameters OpenEMR search fields
-     * @param $puuidBind - Optional variable to only allow visibility of the patient with this puuid.
-     * @return OpenEMR records
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
+     * @return ProcessingResult OpenEMR records
      */
     protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {

--- a/src/Services/FHIR/Observation/FhirObservationVitalsService.php
+++ b/src/Services/FHIR/Observation/FhirObservationVitalsService.php
@@ -30,6 +30,7 @@ use OpenEMR\Services\FHIR\Traits\FhirServiceBaseEmptyTrait;
 use OpenEMR\Services\FHIR\Traits\VersionedProfileTrait;
 use OpenEMR\Services\FHIR\UtilsService;
 use OpenEMR\Services\Search\FhirSearchParameterDefinition;
+use OpenEMR\Services\Search\ISearchField;
 use OpenEMR\Services\Search\SearchFieldException;
 use OpenEMR\Services\Search\SearchFieldType;
 use OpenEMR\Services\Search\ServiceField;
@@ -356,9 +357,8 @@ class FhirObservationVitalsService extends FhirServiceBase implements IPatientCo
 
     /**
      * Searches for OpenEMR records using OpenEMR search parameters
-     * @param openEMRSearchParameters OpenEMR search fields
-     * @param $puuidBind - Optional variable to only allow visibility of the patient with this puuid.
-     * @return OpenEMR records
+     * @param <string, ISearchField> $openEMRSearchParameters OpenEMR search fields
+     * @return ProcessingResult OpenEMR records
      */
     protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {

--- a/src/Services/FHIR/Organization/FhirOrganizationFacilityService.php
+++ b/src/Services/FHIR/Organization/FhirOrganizationFacilityService.php
@@ -25,6 +25,7 @@ use OpenEMR\Services\FHIR\Traits\FhirServiceBaseEmptyTrait;
 use OpenEMR\Services\FHIR\UtilsService;
 use OpenEMR\Services\Search\CompositeSearchField;
 use OpenEMR\Services\Search\FhirSearchParameterDefinition;
+use OpenEMR\Services\Search\ISearchField;
 use OpenEMR\Services\Search\SearchFieldType;
 use OpenEMR\Services\Search\SearchModifier;
 use OpenEMR\Services\Search\ServiceField;
@@ -113,9 +114,8 @@ class FhirOrganizationFacilityService extends FhirServiceBase
 
     /**
      * Searches for OpenEMR records using OpenEMR search parameters
-     * @param openEMRSearchParameters OpenEMR search fields
-     * @param $puuidBind - Optional variable to only allow visibility of the patient with this puuid.
-     * @return OpenEMR records
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
+     * @return ProcessingResult OpenEMR records
      */
     protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {

--- a/src/Services/FHIR/Organization/FhirOrganizationInsuranceService.php
+++ b/src/Services/FHIR/Organization/FhirOrganizationInsuranceService.php
@@ -23,6 +23,7 @@ use OpenEMR\Services\FHIR\UtilsService;
 use OpenEMR\Services\InsuranceCompanyService;
 use OpenEMR\Services\Search\CompositeSearchField;
 use OpenEMR\Services\Search\FhirSearchParameterDefinition;
+use OpenEMR\Services\Search\ISearchField;
 use OpenEMR\Services\Search\SearchFieldType;
 use OpenEMR\Services\Search\SearchModifier;
 use OpenEMR\Services\Search\ServiceField;
@@ -69,6 +70,10 @@ class FhirOrganizationInsuranceService extends FhirServiceBase
         return new FhirSearchParameterDefinition('_lastUpdated', SearchFieldType::DATETIME, ['last_updated']);
     }
 
+    /**
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
+     * @return ProcessingResult
+     */
     protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {
         if (!isset($openEMRSearchParameters['name'])) {

--- a/src/Services/FHIR/Organization/FhirOrganizationProcedureProviderService.php
+++ b/src/Services/FHIR/Organization/FhirOrganizationProcedureProviderService.php
@@ -23,6 +23,7 @@ use OpenEMR\Services\InsuranceCompanyService;
 use OpenEMR\Services\ProcedureProviderService;
 use OpenEMR\Services\Search\CompositeSearchField;
 use OpenEMR\Services\Search\FhirSearchParameterDefinition;
+use OpenEMR\Services\Search\ISearchField;
 use OpenEMR\Services\Search\SearchFieldType;
 use OpenEMR\Services\Search\SearchModifier;
 use OpenEMR\Services\Search\ServiceField;
@@ -65,6 +66,10 @@ class FhirOrganizationProcedureProviderService extends FhirServiceBase
         return new FhirSearchParameterDefinition('_lastUpdated', SearchFieldType::DATETIME, ['last_updated']);
     }
 
+    /**
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
+     * @return ProcessingResult
+     */
     protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {
         if (!isset($openEMRSearchParameters['name'])) {

--- a/src/Services/FHIR/Procedure/FhirProcedureOEProcedureService.php
+++ b/src/Services/FHIR/Procedure/FhirProcedureOEProcedureService.php
@@ -34,6 +34,7 @@ use OpenEMR\Services\FHIR\Traits\PatientSearchTrait;
 use OpenEMR\Services\FHIR\UtilsService;
 use OpenEMR\Services\ProcedureService;
 use OpenEMR\Services\Search\FhirSearchParameterDefinition;
+use OpenEMR\Services\Search\ISearchField;
 use OpenEMR\Services\Search\SearchFieldType;
 use OpenEMR\Services\Search\SearchModifier;
 use OpenEMR\Services\Search\ServiceField;
@@ -94,9 +95,8 @@ class FhirProcedureOEProcedureService extends FhirServiceBase
     /**
      * Searches for OpenEMR records using OpenEMR search parameters
      *
-     * @param openEMRSearchParameters OpenEMR search fields
-     * @param $puuidBind - Optional variable to only allow visibility of the patient with this puuid.
-     * @return OpenEMR records
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
+     * @return ProcessingResult OpenEMR records
      */
     protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {

--- a/src/Services/FHIR/Procedure/FhirProcedureSurgeryService.php
+++ b/src/Services/FHIR/Procedure/FhirProcedureSurgeryService.php
@@ -25,6 +25,7 @@ use OpenEMR\Services\FHIR\Traits\FhirServiceBaseEmptyTrait;
 use OpenEMR\Services\FHIR\Traits\PatientSearchTrait;
 use OpenEMR\Services\FHIR\UtilsService;
 use OpenEMR\Services\Search\FhirSearchParameterDefinition;
+use OpenEMR\Services\Search\ISearchField;
 use OpenEMR\Services\Search\SearchFieldType;
 use OpenEMR\Services\Search\ServiceField;
 use OpenEMR\Services\SurgeryService;
@@ -68,9 +69,8 @@ class FhirProcedureSurgeryService extends FhirServiceBase
 
     /**
      * Searches for OpenEMR records using OpenEMR search parameters
-     * @param openEMRSearchParameters OpenEMR search fields
-     * @param $puuidBind - Optional variable to only allow visibility of the patient with this puuid.
-     * @return OpenEMR records
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
+     * @return ProcessingResult OpenEMR records
      */
     protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {

--- a/src/Services/FHIR/Questionnaire/FhirQuestionnaireFormService.php
+++ b/src/Services/FHIR/Questionnaire/FhirQuestionnaireFormService.php
@@ -27,6 +27,7 @@ use OpenEMR\Services\FHIR\Traits\FhirServiceBaseEmptyTrait;
 use OpenEMR\Services\FHIR\UtilsService;
 use OpenEMR\Services\QuestionnaireService;
 use OpenEMR\Services\Search\FhirSearchParameterDefinition;
+use OpenEMR\Services\Search\ISearchField;
 use OpenEMR\Services\Search\SearchFieldType;
 use OpenEMR\Services\Search\ServiceField;
 use OpenEMR\Validators\ProcessingResult;
@@ -151,6 +152,10 @@ class FhirQuestionnaireFormService extends FhirServiceBase implements IResourceR
         ];
     }
 
+    /**
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
+     * @return ProcessingResult
+     */
     protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {
         return $this->service->search($openEMRSearchParameters);

--- a/src/Services/FHIR/QuestionnaireResponse/FhirQuestionnaireResponseFormService.php
+++ b/src/Services/FHIR/QuestionnaireResponse/FhirQuestionnaireResponseFormService.php
@@ -36,6 +36,7 @@ use OpenEMR\Services\PatientService;
 use OpenEMR\Services\QuestionnaireResponseService;
 use OpenEMR\Services\QuestionnaireService;
 use OpenEMR\Services\Search\FhirSearchParameterDefinition;
+use OpenEMR\Services\Search\ISearchField;
 use OpenEMR\Services\Search\SearchFieldType;
 use OpenEMR\Services\Search\ServiceField;
 use OpenEMR\Services\Search\TokenSearchField;
@@ -290,6 +291,10 @@ class FhirQuestionnaireResponseFormService extends FhirServiceBase implements IR
         ];
     }
 
+    /**
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
+     * @return ProcessingResult
+     */
     protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {
         return $this->service->search($openEMRSearchParameters);

--- a/src/Services/FHIR/Traits/FhirServiceBaseEmptyTrait.php
+++ b/src/Services/FHIR/Traits/FhirServiceBaseEmptyTrait.php
@@ -13,6 +13,7 @@
 
 namespace OpenEMR\Services\FHIR\Traits;
 
+use OpenEMR\Services\Search\ISearchField;
 use OpenEMR\Validators\ProcessingResult;
 
 trait FhirServiceBaseEmptyTrait
@@ -23,9 +24,8 @@ trait FhirServiceBaseEmptyTrait
     }
     /**
      * Searches for OpenEMR records using OpenEMR search parameters
-     * @param openEMRSearchParameters OpenEMR search fields
-     * @param $puuidBind - Optional variable to only allow visibility of the patient with this puuid.
-     * @return OpenEMR records
+     * @param array<string, ISearchField> $openEMRSearchParameters OpenEMR search fields
+     * @return ProcessingResult OpenEMR records
      */
     protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {


### PR DESCRIPTION
This will cleanup all the $puuid references in the searchForOpenEMRRecords which the fhir base service doesn't have.  It also cleans up the doc references.

Fixes #9160.