### PR TITLE
ci: drop path coverage

### DIFF
--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -24,7 +24,6 @@ coverage_args=(
     --coverage-filter src
     --coverage-filter tests
     --coverage-text
-    --path-coverage
 )
 
 composer_github_auth() {


### PR DESCRIPTION
Fixes #9184

Path coverage covers every possible path through the code, which is exponential, if more detailed. It's more than OpenEMR needs right now.
