### PR TITLE
Revert "chore(deps): bump the selenium-updates group across 3 directories with 1 update (#9201)"

### DIFF
--- a/ci/compose-shared-selenium/docker-compose.yml
+++ b/ci/compose-shared-selenium/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   selenium:
-    image: selenium/standalone-chromium:4.37.0
+    image: selenium/standalone-chromium:4.36.0
     # Services with profiles don't start by default.
     profiles:
     - selenium

--- a/docker/development-easy/docker-compose.yml
+++ b/docker/development-easy/docker-compose.yml
@@ -110,7 +110,7 @@ services:
       retries: 3
   selenium:
     restart: always
-    image: selenium/standalone-chromium:4.37.0
+    image: selenium/standalone-chromium:4.36.0
     ports:
     - 4444:4444    # Selenium WebDriver interface
     - 7900:7900    # VNC port for viewing browser during tests (to work, will require SELENIUM_FORCE_HEADLESS to be "false" in openemr service)

--- a/docker/development-insane/docker-compose.yml
+++ b/docker/development-insane/docker-compose.yml
@@ -704,7 +704,7 @@ services:
     - 9443:9443
   selenium:
     restart: always
-    image: selenium/standalone-chromium:4.37.0
+    image: selenium/standalone-chromium:4.36.0
     ports:
     - 4444:4444    # Selenium WebDriver interface
     - 7900:7900    # VNC port for viewing browser during tests (to work, will require SELENIUM_FORCE_HEADLESS to be "false" in openemr service)


### PR DESCRIPTION
May need to revert selenium update since appears to be causing real problems on e2e testing in master (basically shutting down before even doing the e2e testing and failing)