### PR TITLE
fix(gen_hl7_order): consistent signature

### DIFF
--- a/interface/orders/gen_hl7_order.inc.php
+++ b/interface/orders/gen_hl7_order.inc.php
@@ -1,25 +1,17 @@
 <?php
 
 /**
-* Functions to support HL7 order generation.
-*
-* Copyright (C) 2012-2013 Rod Roark <rod@sunsetsystems.com>
-*
-* LICENSE: This program is free software; you can redistribute it and/or
-* modify it under the terms of the GNU General Public License
-* as published by the Free Software Foundation; either version 2
-* of the License, or (at your option) any later version.
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
-* You should have received a copy of the GNU General Public License
-* along with this program.  If not, see <http://opensource.org/licenses/gpl-license.php>.
-*
-* @package   OpenEMR
-* @author    Rod Roark <rod@sunsetsystems.com>
-* @author    Jerry Padgett <sjpadgett@gmail.com>
-*/
+ * Functions to support HL7 order generation
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Rod Roark <rod@sunsetsystems.com>
+ * @author    Jerry Padgett <sjpadgett@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2012-2013 Rod Roark <rod@sunsetsystems.com>
+ * @copyright Copyright (c) 2025 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
 
 /*
 * A bit of documentation that will need to go into the manual:
@@ -39,6 +31,8 @@
 require_once("$webserver_root/custom/code_types.inc.php");
 
 use OpenEMR\Common\Logging\EventAuditLogger;
+use OpenEMR\Common\Orders\Hl7OrderGenerationException;
+use OpenEMR\Common\Orders\Hl7OrderResult;
 
 function hl7Text($s)
 {
@@ -166,11 +160,11 @@ function loadPayerInfo($pid, $date = '')
 /**
  * Generate HL7 for the specified procedure order.
  *
- * @param  integer $orderid  Procedure order ID.
- * @param  string  &$out     Container for target HL7 text.
- * @return string            Error text, or empty if no errors.
+ * @param  int   $orderid  Procedure order ID.
+ * @return Hl7OrderResult  Result object containing HL7 text and optional lab-specific requisition data.
+ * @throws Hl7OrderGenerationException On errors with descriptive message.
  */
-function gen_hl7_order($orderid, &$out)
+function gen_hl7_order(int $orderid): Hl7OrderResult
 {
 
   // Delimiters
@@ -200,7 +194,7 @@ function gen_hl7_order($orderid, &$out)
         [$orderid]
     );
     if (empty($porow)) {
-        return "Procedure order, ordering provider or lab is missing for order ID '$orderid'";
+        throw new Hl7OrderGenerationException("Procedure order, ordering provider or lab is missing for order ID '$orderid'");
     }
 
     $pcres = sqlStatement(
@@ -464,7 +458,7 @@ function gen_hl7_order($orderid, &$out)
         }
     }
 
-    return '';
+    return new Hl7OrderResult($out);
 }
 
 /**

--- a/interface/procedure_tools/quest/gen_hl7_order.inc.php
+++ b/interface/procedure_tools/quest/gen_hl7_order.inc.php
@@ -1,24 +1,16 @@
 <?php
 
 /**
-* Functions to support HL7 order generation.
-*
-* Copyright (C) 2012-2013 Rod Roark <rod@sunsetsystems.com>
-*
-* LICENSE: This program is free software; you can redistribute it and/or
-* modify it under the terms of the GNU General Public License
-* as published by the Free Software Foundation; either version 2
-* of the License, or (at your option) any later version.
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
-* You should have received a copy of the GNU General Public License
-* along with this program.  If not, see <http://opensource.org/licenses/gpl-license.php>.
-*
-* @package   OpenEMR
-* @author    Rod Roark <rod@sunsetsystems.com>
-*/
+ * Functions to support HL7 order generation
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @author    Rod Roark <rod@sunsetsystems.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2012-2013 Rod Roark <rod@sunsetsystems.com>
+ * @copyright Copyright (c) 2025 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
 
 /*
 * A bit of documentation that will need to go into the manual:
@@ -38,6 +30,8 @@
 require_once("$webserver_root/custom/code_types.inc.php");
 
 use OpenEMR\Common\Logging\EventAuditLogger;
+use OpenEMR\Common\Orders\Hl7OrderGenerationException;
+use OpenEMR\Common\Orders\Hl7OrderResult;
 
 function hl7Text($s)
 {
@@ -165,11 +159,11 @@ function loadPayerInfo($pid, $date = '')
 /**
  * Generate HL7 for the specified procedure order.
  *
- * @param  integer $orderid  Procedure order ID.
- * @param  string  &$out     Container for target HL7 text.
- * @return string            Error text, or empty if no errors.
+ * @param  int   $orderid  Procedure order ID.
+ * @return Hl7OrderResult  Result object containing HL7 text and optional lab-specific requisition data.
+ * @throws Hl7OrderGenerationException On errors with descriptive message.
  */
-function gen_hl7_order($orderid, &$out)
+function gen_hl7_order(int $orderid): Hl7OrderResult
 {
     $labSample = '';
     $labNote = '';
@@ -200,7 +194,7 @@ function gen_hl7_order($orderid, &$out)
         [$orderid]
     );
     if (empty($porow)) {
-        return "Procedure order, ordering provider or lab is missing for order ID '$orderid'";
+        throw new Hl7OrderGenerationException("Procedure order, ordering provider or lab is missing for order ID '$orderid'");
     }
 
     $pcres = sqlStatement(
@@ -337,7 +331,7 @@ function gen_hl7_order($orderid, &$out)
             }
         }
         if ($setid === 0) {
-            return "\nInsurance is being billed but patient does not have any payers on record!";
+            throw new Hl7OrderGenerationException("Insurance is being billed but patient does not have any payers on record!");
         }
     } else { // no insurance record
         ++$setid;
@@ -493,7 +487,7 @@ function gen_hl7_order($orderid, &$out)
             $d1 . $porow['clinical_hx'] .
             $d0;
 
-    return '';
+    return new Hl7OrderResult($out);
 }
 
 /**

--- a/phpstan.github.neon
+++ b/phpstan.github.neon
@@ -9192,10 +9192,6 @@ parameters:
     identifier: variable.undefined
     count: 1
     path: interface/forms/prior_auth/view.php
-  - message: '#^Function gen_hl7_order invoked with 3 parameters, 2 required\.$#'
-    identifier: arguments.count
-    count: 2
-    path: interface/forms/procedure_order/common.php
   - message: '#^Variable \$encounter might not be defined\.$#'
     identifier: variable.undefined
     count: 1

--- a/src/Common/Orders/Hl7OrderGenerationException.php
+++ b/src/Common/Orders/Hl7OrderGenerationException.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Hl7OrderGenerationException is thrown when HL7 order generation fails.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2025 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Common\Orders;
+
+class Hl7OrderGenerationException extends \RuntimeException
+{
+}

--- a/src/Common/Orders/Hl7OrderResult.php
+++ b/src/Common/Orders/Hl7OrderResult.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Result object returned by gen_hl7_order functions.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2025 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Common\Orders;
+
+/**
+ * Immutable result object containing HL7 order data and optional lab-specific requisition data.
+ */
+class Hl7OrderResult
+{
+    /**
+     * @param string $hl7 The generated HL7 message
+     * @param string $requisitionData Lab-specific requisition data (e.g., LabCorp 2D barcode data), empty string for most labs
+     */
+    public function __construct(
+        public readonly string $hl7,
+        public readonly string $requisitionData = ''
+    ) {
+    }
+}


### PR DESCRIPTION
Fixes #9206

#### Short description of what this resolves:

Use a consistent function signature for all the `gen_hl7_order` implementations so that static analysis can work.

#### Changes proposed in this pull request:

- [x] create a new `Hl7OrderResult` class. (Currently basically a struct, but these function implementations could be moved into it some day.) 
- [x] rewrite all the `gen_hl7_order` implementations to always take an int, return an `Hl7OrderResult`, and throw exceptions instead of taking an int and various references, and returning a string that indicates an error.
- [x] clean up the header docblocks to use consistent layout for author, copyright and license.

#### Does your code include anything generated by an AI Engine? No
