### PR TITLE
fix(OAuth2AuthorizationListener): right parameters for getScopeRepository

### DIFF
--- a/src/RestControllers/Subscriber/OAuth2AuthorizationListener.php
+++ b/src/RestControllers/Subscriber/OAuth2AuthorizationListener.php
@@ -127,7 +127,7 @@ class OAuth2AuthorizationListener implements EventSubscriberInterface
         if (false !== stripos((string) $end_point, '/openid-configuration')) {
             $oauth2DiscoverController = new OAuth2DiscoveryController(
                 new ClaimRepository(),
-                $authServer->getScopeRepository($request, $request->getSession()),
+                $authServer->getScopeRepository($session),
                 $globalsBag,
                 $authServer->authBaseFullUrl
             );


### PR DESCRIPTION
Fixes #9209

#### Short description of what this resolves:

Pass the right parameters to `getScopeRepository`.
