### PR TITLE
ci(test): make error logs available

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -441,6 +441,33 @@ jobs:
         . ci/ciLibrary.source
         build_test e2e
 
+    ##
+    # The logs for the e2e run are directly in the container logs for nginx/php-fpm
+    # but in /var/log/apache2/error.log for apache.
+    - name: E2e container logs
+      if: ${{ (success() || failure()) && matrix.configurations.e2e_enabled == 'true' }}
+      run: |
+        . ci/ciLibrary.source
+        dc logs openemr
+
+    - name: E2e error logs
+      if: ${{ (success() || failure()) && matrix.configurations.e2e_enabled == 'true' && matrix.configurations.webserver == 'apache' }}
+      run: |
+        . ci/ciLibrary.source
+        dump_error_log ${{ matrix.configurations.webserver }}
+
+    - name: E2e selenium logs
+      if: ${{ (success() || failure()) && matrix.configurations.e2e_enabled == 'true' }}
+      run: |
+        . ci/ciLibrary.source
+        dc logs selenium
+
+    - name: E2e video logs
+      if: ${{ (success() || failure()) && matrix.configurations.e2e_enabled == 'true' }}
+      run: |
+        . ci/ciLibrary.source
+        dc logs video
+
     - name: Upload e2e test results to Codecov
       if: ${{ !cancelled() && hashFiles('junit-e2e.xml') != '' }}
       uses: codecov/test-results-action@v1

--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -59,7 +59,7 @@ _exec() {
 }
 
 dockers_env_start() {
-    dc up --detach --wait --wait-timeout 300
+    dc up --detach --quiet-pull --wait --wait-timeout 300
 }
 
 selenium_video_start() {
@@ -70,8 +70,6 @@ selenium_video_start() {
 
 selenium_video_stop() {
     dc stop selenium video
-    dc logs selenium
-    dc logs video
 }
 
 actions_chmod() {
@@ -194,6 +192,23 @@ build_test_e2e() {
     fi
 
     return "${status}"
+}
+
+##
+# Print the webserver error log
+dump_error_log() {
+    case "$1" in
+        apache)
+            _exec sh -c 'test -r /var/log/apache2/error.log && cat /var/log/apache2/error.log'
+            ;;
+        nginx)
+            echo 'php-fpm logs are in the container logs'
+            ;;
+        *)
+            echo "Webserver '$1' not known."
+            exit 255
+            ;;
+    esac
 }
 
 ##


### PR DESCRIPTION
fixes #9214 

- [x] isolate large logs for easier viewing
- [x] make php-fpm logs available by making the `openemr` service logs available
- [x] make apache (mod-php) logs available by dumping `/var/log/apache2/error.log`