### PR TITLE
ci(e2e): control timeouts for slower tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -277,6 +277,8 @@ jobs:
 
     - name: Api testing
       if: ${{ success() || failure() }}
+      env:
+        ENABLE_COVERAGE: 'false'
       run: |
         . ci/ciLibrary.source
         build_test api
@@ -437,6 +439,7 @@ jobs:
       env:
         # Change this to just 'selenium' to disable video recording.
         COMPOSE_PROFILES: video-recording
+        ENABLE_COVERAGE: 'false'
       run: |
         . ci/ciLibrary.source
         build_test e2e

--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -132,11 +132,27 @@ install_configure() {
     _exec mysql -u openemr --password=openemr --ssl=false -h mysql -e 'UPDATE globals SET gl_value = 1 WHERE gl_name = "rest_system_scopes_api"' openemr
 }
 
+enable_e2e_coverage() {
+    echo 'not implemented' >&2
+    false
+}
+
 build_test_e2e() {
     echo 'Creating selenium-videos directory…'
     mkdir -p selenium-videos
     # Fix permissions for video recording
     actions_chmod 777 selenium-videos
+
+    # Enable E2E coverage collection if coverage is enabled
+    if [[ ${ENABLE_COVERAGE:-false} = true ]]; then
+        echo 'Enabling E2E coverage collection…'
+        enable_e2e_coverage
+
+        # Increase Selenium timeouts when coverage is enabled (coverage slows down page loads)
+        export SELENIUM_IMPLICIT_WAIT=90
+        export SELENIUM_PAGE_LOAD_TIMEOUT=180
+        echo "Selenium timeouts increased: implicit_wait=${SELENIUM_IMPLICIT_WAIT}s, page_load_timeout=${SELENIUM_PAGE_LOAD_TIMEOUT}s"
+    fi
 
     selenium_video_start
     echo 'Checking if selenium container is running…'

--- a/tests/Tests/E2e/Base/BaseTrait.php
+++ b/tests/Tests/E2e/Base/BaseTrait.php
@@ -6,7 +6,9 @@
  * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2024 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2025 OpenCoreEMR Inc.
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -31,6 +33,9 @@ trait BaseTrait
             $seleniumHost = getenv("SELENIUM_HOST", true) ?? "selenium";
             $e2eBaseUrl = getenv("SELENIUM_BASE_URL", true) ?: "http://openemr";
             $forceHeadless = getenv("SELENIUM_FORCE_HEADLESS", true) ?? "false";
+            // Configurable timeouts (higher when coverage is enabled due to performance impact)
+            $implicitWait = (int)(getenv("SELENIUM_IMPLICIT_WAIT") ?: 30);
+            $pageLoadTimeout = (int)(getenv("SELENIUM_PAGE_LOAD_TIMEOUT") ?: 60);
 
             $capabilities = DesiredCapabilities::chrome();
 
@@ -56,8 +61,8 @@ trait BaseTrait
             $seleniumUrl = "http://$seleniumHost:4444/wd/hub";
             $this->client = Client::createSeleniumClient($seleniumUrl, $capabilities, $e2eBaseUrl);
 
-            $this->client->manage()->timeouts()->implicitlyWait(30);
-            $this->client->manage()->timeouts()->pageLoadTimeout(60);
+            $this->client->manage()->timeouts()->implicitlyWait($implicitWait);
+            $this->client->manage()->timeouts()->pageLoadTimeout($pageLoadTimeout);
         } else {
             // Use local ChromeDriver (not a consistent testing environment, which is thus not stable, good luck :) )
             $this->client = static::createPantherClient(['external_base_uri' => "http://localhost"]);


### PR DESCRIPTION
#### Short description of what this resolves:

Adding coverage to e2e and API tests is going to take some effort. One thing I know will be needed is to control the timeouts for the tests, as coverage will slow down response time.

#### Changes proposed in this pull request:

Add environment variables that we can use to control the timeouts during E2E testing.

#### Does your code include anything generated by an AI Engine? No