### PR TITLE
ci(test): make phpinfo available from testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -247,6 +247,17 @@ jobs:
         . ci/ciLibrary.source
         install_configure
 
+    - name: PHP info
+      run: |
+        curl -fsSL phpinfo.html http://localhost/ci/phpinfo.php | tee phpinfo.html
+
+    - name: Upload PHP info to GitHub
+      uses: actions/upload-artifact@v4
+      if: ${{ hashFiles('phpinfo.html') != '' }}
+      with:
+        name: phpinfo-${{ matrix.configurations.docker_dir }}.html
+        path: phpinfo.html
+
     - name: Prepare for coverage reporting
       if: ${{ env.ENABLE_COVERAGE == 'true' }}
       run: |

--- a/ci/phpinfo.php
+++ b/ci/phpinfo.php
@@ -1,0 +1,3 @@
+<?php
+
+phpinfo();


### PR DESCRIPTION
#### Short description of what this resolves:

Create a phpinfo.php file for the web api, and make it an artifact for easier observability during testing.


#### Changes proposed in this pull request:

Create ci/phpinfo.php, use curl to fetch it, and upload it to Github during testing.

#### Does your code include anything generated by an AI Engine? No
