### PR TITLE
ci(e2e): bookends to manage coverage during e2e

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -443,6 +443,14 @@ jobs:
         flags: email,php${{ matrix.configurations.php }},${{ matrix.configurations.webserver }},${{ matrix.configurations.database }}${{ matrix.configurations.db }}
 
     ##
+    # Activate prepend and shutdown code for webserver for e2e tests
+    - name: E2e setup
+      if: ${{ (success() || failure()) && matrix.configurations.e2e_enabled == 'true' }}
+      run: |
+        . ci/ciLibrary.source
+        setup_e2e_bookends ${{ matrix.configurations.webserver }}
+
+    ##
     # To skip E2E tests for specific docker directories,
     # rename the docker directory to end with "_no-e2e".
     - name: E2e testing

--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -132,6 +132,73 @@ install_configure() {
     _exec mysql -u openemr --password=openemr --ssl=false -h mysql -e 'UPDATE globals SET gl_value = 1 WHERE gl_name = "rest_system_scopes_api"' openemr
 }
 
+##
+# Add a php auto prepend file we can use for telemetry
+# and measuring code coverage.
+# Arguments:
+#   $1 - webserver type (apache or nginx)
+setup_e2e_bookends() {
+    local webserver="${1:-apache}"
+    local php_scan_dir
+    local prepend_file='ci/e2e_prepend.php'
+    local prepend_marker='openemr-e2e-PREPEND_EXECUTED'
+    local shutdown_marker='openemr-e2e-SHUTDOWN_EXECUTED'
+    local webserver_host
+
+    # Map webserver types to their hostnames
+    declare -A webserver_hosts=(
+        [apache]='localhost'
+        [nginx]='nginx'
+    )
+
+    webserver_host="${webserver_hosts[${webserver}]}"
+    if [[ -z "${webserver_host}" ]]; then
+        echo "Error: Unknown webserver type '${webserver}'"
+        return 1
+    fi
+
+    php_scan_dir=$(_exec php -r "echo ini_get('scan.directory') ?: (dirname(php_ini_loaded_file()) . '/conf.d');" 2>/dev/null)
+    if [[ -z "${php_scan_dir}" ]]; then
+        echo "Error: Could not detect PHP configuration scan directory"
+        return 1
+    fi
+    echo "Detected PHP config scan directory: ${php_scan_dir}"
+
+    echo 'Confirming prepend file is present'
+    _exec sh -xc "
+        if [[ ! -f ${OPENEMR_DIR}/${prepend_file} ]]; then
+            echo '${OPENEMR_DIR}/${prepend_file} is missing'
+            exit 1
+        fi
+    "
+
+    echo 'Configuring PHP to use auto_prepend'
+    {
+        echo "auto_prepend_file=${OPENEMR_DIR}/${prepend_file}"
+    } > php_prepend.ini
+    dc cp php_prepend.ini "openemr:${php_scan_dir}/php_prepend.ini"
+
+    echo 'Restarting services to pick up the new PHP configuration'
+    dc restart openemr
+    dockers_env_start
+
+    echo 'Testing prepend/shutdown behavior…'
+    _exec rm -f "${prepend_marker}" "${shutdown_marker}"
+
+    echo "Verifying E2E prepend configuration via web server (${webserver} at ${webserver_host})…"
+    _exec sh -c "curl -fsSL http://${webserver_host}/ci/phpinfo.php | grep -E auto_prepend_file"
+
+    sleep 1  # Give filesystem time to flush
+
+    _exec sh -c 'ls /tmp/openemr-e2e-*_EXECUTED'
+
+    echo 'Checking prepend marker file after web request:'
+    _exec sh -c "cat '/tmp/${prepend_marker}'"
+
+    echo 'Checking shutdown marker file after web request:'
+    _exec sh -c "cat '/tmp/${shutdown_marker}'"
+}
+
 enable_e2e_coverage() {
     echo 'not implemented' >&2
     false

--- a/ci/e2e_prepend.php
+++ b/ci/e2e_prepend.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Auto-prepend file for E2E testing
+ *
+ * This file is automatically included before every PHP script execution.
+ * (If enabled in the environment.)
+ * Eventually this will be used to manage code coverage.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2025 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+if (!getenv('OPENEMR_E2E_ENABLE_CI_PHP')) {
+    error_log('Tried to run ci/e2e_prepend without setting OPENEMR_E2E_ENABLE_CI_PHP in the environment.');
+    return;
+}
+
+// Write marker to prove this file executes (only once)
+$prepend_marker = '/tmp/openemr-e2e-PREPEND_EXECUTED';
+if (!file_exists($prepend_marker)) {
+    $data = date('Y-m-d H:i:s') . " - prepend executed\n";
+    if (file_put_contents($prepend_marker, $data, LOCK_EX) === false) {
+        error_log("E2E DEBUG: Failed to write prepend marker to $prepend_marker");
+    }
+}
+
+function e2e_shutdown_handler(): void
+{
+    if (!getenv('OPENEMR_E2E_ENABLE_CI_PHP')) {
+        error_log('Tried to run e2e shutdown without setting OPENEMR_E2E_ENABLE_CI_PHP in the environment.');
+        return;
+    }
+    $shutdown_marker = '/tmp/openemr-e2e-SHUTDOWN_EXECUTED';
+    if (!file_exists($shutdown_marker)) {
+        $data = date('Y-m-d H:i:s') . " - shutdown executed\n";
+        if (file_put_contents($shutdown_marker, $data, LOCK_EX) === false) {
+            error_log("E2E DEBUG: Failed to write shutdown marker to $shutdown_marker");
+        }
+    }
+}
+
+register_shutdown_function('e2e_shutdown_handler');


### PR DESCRIPTION
Fixes #9221 

#### Short description of what this resolves:

Provide hooks to prepend and append to php code for instrumentation during e2e testing in CI.

#### Changes proposed in this pull request:

Create an `auto_prepend_file` target in ci, and use it to register a shutdown function. Currently it just writes a file once to prove that it's working, but in future PRs it can be used to instrument for coverage or profiling.

#### Does your code include anything generated by an AI Engine? No
