### PR TITLE
ci: create phpinfo dynamically

### DIFF
--- a/ci/compose-shared-apache.yml
+++ b/ci/compose-shared-apache.yml
@@ -6,8 +6,9 @@ services:
     volumes:
     - ../:/var/www/localhost/htdocs/openemr
     environment:
-      FORCE_NO_BUILD_MODE: "yes"
       EMPTY: "yes"
+      FORCE_NO_BUILD_MODE: "yes"
+      OPENEMR_E2E_ENABLE_CI_PHP: "1"
       SELENIUM_BASE_URL: "http://openemr"
     healthcheck:
       test:

--- a/ci/compose-shared-nginx.yml
+++ b/ci/compose-shared-nginx.yml
@@ -2,6 +2,7 @@ services:
   openemr:
     environment:
       OPENEMR_BASE_URL_API: "https://nginx"
+      OPENEMR_E2E_ENABLE_CI_PHP: "1"
       SELENIUM_BASE_URL: "http://nginx"
     volumes:
     - ../:/usr/share/nginx/html/openemr

--- a/ci/phpinfo.php
+++ b/ci/phpinfo.php
@@ -1,3 +1,11 @@
 <?php
 
+/**
+ * This page should only be available during CI.
+ */
+
+if (!getenv('OPENEMR_E2E_ENABLE_CI_PHP')) {
+    die('Set OPENEMR_E2E_ENABLE_CI_PHP=1 environment variable to enable this script');
+}
+
 phpinfo();


### PR DESCRIPTION
Fixes #9218

#### Short description of what this resolves:

Guard ci/phpinfo.php and other ci php with an environment variable, preventing it from being accessed accidentally.


#### Changes proposed in this pull request:

Add an environment variable guard to ci/phpinfo.php.
Add the environment variable to the docker compose files.

#### Does your code include anything generated by an AI Engine? No
