### PR TITLE
ci(e2e): fix bookends damaged in merge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -373,10 +373,10 @@ jobs:
     ##
     # Activate prepend and shutdown code for webserver for e2e tests
     - name: E2e setup
-      if: ${{ (success() || failure()) && matrix.configurations.e2e_enabled == 'true' }}
+      if: ${{ (success() || failure()) && steps.parse.outputs.e2e_enabled == 'true' }}
       run: |
         . ci/ciLibrary.source
-        setup_e2e_bookends ${{ matrix.configurations.webserver }}
+        setup_e2e_bookends ${{ steps.parse.outputs.webserver }}
 
     ##
     # To skip E2E tests for specific docker directories,


### PR DESCRIPTION
Fixes #9221

#### Short description of what this resolves:

I broke #9217 when I merged #9220 because I trusted the fact that there were no conflicts and forgot to check that some names had changed. This fixes that.
