### PR TITLE
test: fix coverage by removing Covers* attribute

### DIFF
--- a/tests/Tests/Api/FacilityApiTest.php
+++ b/tests/Tests/Api/FacilityApiTest.php
@@ -5,7 +5,6 @@ namespace OpenEMR\Tests\Api;
 use OpenEMR\RestControllers\FacilityRestController;
 use OpenEMR\Tests\Fixtures\FacilityFixtureManager;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\Attributes\CoversClass;
 use Symfony\Component\HttpFoundation\Response;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -20,7 +19,6 @@ use PHPUnit\Framework\Attributes\Test;
  *
  */
 
-#[CoversClass(FacilityRestController::class)]
 class FacilityApiTest extends TestCase
 {
     const FACILITY_API_ENDPOINT = "/apis/default/api/facility";

--- a/tests/Tests/Services/CarePlanServiceTest.php
+++ b/tests/Tests/Services/CarePlanServiceTest.php
@@ -13,7 +13,6 @@ namespace OpenEMR\Tests\Services;
 
 use OpenEMR\Services\CarePlanService;
 use OpenEMR\Tests\Fixtures\CarePlanFixtureManager;
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -27,7 +26,6 @@ use PHPUnit\Framework\Attributes\Test;
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-#[CoversClass(CarePlanService::class)]
 class CarePlanServiceTest extends TestCase
 {
     /**

--- a/tests/Tests/Services/EncounterServiceTest.php
+++ b/tests/Tests/Services/EncounterServiceTest.php
@@ -15,11 +15,9 @@ use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Services\EncounterService;
 use OpenEMR\Tests\Fixtures\EncounterFixtureManager;
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 
-#[CoversClass(EncounterService::class)]
 class EncounterServiceTest extends TestCase
 {
     /**

--- a/tests/Tests/Services/FHIR/FhirAllergyIntoleranceServiceQueryTest.php
+++ b/tests/Tests/Services/FHIR/FhirAllergyIntoleranceServiceQueryTest.php
@@ -9,7 +9,6 @@ use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRAllergyIntolerance;
 use OpenEMR\Services\FHIR\FhirAllergyIntoleranceService;
 use OpenEMR\Tests\Fixtures\FixtureManager;
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
@@ -24,7 +23,6 @@ use PHPUnit\Framework\Attributes\Test;
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-#[CoversClass(FhirAllergyIntoleranceService::class)]
 class FhirAllergyIntoleranceServiceQueryTest extends TestCase
 {
     /**

--- a/tests/Tests/Services/FHIR/FhirMedicationRequestServiceUSCore8Test.php
+++ b/tests/Tests/Services/FHIR/FhirMedicationRequestServiceUSCore8Test.php
@@ -34,13 +34,11 @@ use OpenEMR\FHIR\R4\FHIRElement\FHIRPositiveInt;
 use OpenEMR\Services\FHIR\FhirCodeSystemConstants;
 use OpenEMR\Services\FHIR\FhirMedicationRequestService;
 use OpenEMR\Services\FHIR\UtilsService;
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Ramsey\Uuid\Rfc4122\UuidV4;
 
-#[CoversClass(FhirMedicationRequestService::class)]
 class FhirMedicationRequestServiceUSCore8Test extends TestCase
 {
     private FhirMedicationRequestService $fhirMedicationRequestService;

--- a/tests/Tests/Services/FHIR/FhirOrganizationServiceCrudTest.php
+++ b/tests/Tests/Services/FHIR/FhirOrganizationServiceCrudTest.php
@@ -8,7 +8,6 @@ use OpenEMR\FHIR\R4\FHIRDomainResource\FHIROrganization;
 use OpenEMR\Services\FHIR\FhirOrganizationService;
 use OpenEMR\Services\FHIR\Serialization\FhirOrganizationSerializer;
 use OpenEMR\Tests\Fixtures\FacilityFixtureManager;
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -22,7 +21,6 @@ use PHPUnit\Framework\Attributes\Test;
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-#[CoversClass(FhirOrganizationService::class)]
 class FhirOrganizationServiceCrudTest extends TestCase
 {
     /**

--- a/tests/Tests/Services/FHIR/FhirPatientServiceCrudTest.php
+++ b/tests/Tests/Services/FHIR/FhirPatientServiceCrudTest.php
@@ -8,7 +8,6 @@ use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRPatient;
 use OpenEMR\Services\FHIR\FhirPatientService;
 use OpenEMR\Services\FHIR\Serialization\FhirPatientSerializer;
 use OpenEMR\Tests\Fixtures\FixtureManager;
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -23,7 +22,6 @@ use PHPUnit\Framework\Attributes\Test;
  *
  */
 
-#[CoversClass(FhirPatientService::class)]
 class FhirPatientServiceCrudTest extends TestCase
 {
     private $fixtureManager;

--- a/tests/Tests/Services/FHIR/FhirPatientServiceMappingTest.php
+++ b/tests/Tests/Services/FHIR/FhirPatientServiceMappingTest.php
@@ -8,7 +8,6 @@ use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRPatient;
 use OpenEMR\Services\FHIR\FhirPatientService;
 use OpenEMR\Services\FHIR\Serialization\FhirPatientSerializer;
 use OpenEMR\Tests\Fixtures\FixtureManager;
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -23,7 +22,6 @@ use PHPUnit\Framework\Attributes\Test;
  *
  */
 
-#[CoversClass(FhirPatientService::class)]
 class FhirPatientServiceMappingTest extends TestCase
 {
     private $fixtureManager;

--- a/tests/Tests/Services/FHIR/FhirPatientServiceQueryTest.php
+++ b/tests/Tests/Services/FHIR/FhirPatientServiceQueryTest.php
@@ -8,7 +8,6 @@ use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Tests\Fixtures\FixtureManager;
 use OpenEMR\Services\FHIR\FhirPatientService;
 use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRPatient;
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
@@ -24,7 +23,6 @@ use PHPUnit\Framework\Attributes\Test;
  *
  */
 
-#[CoversClass(FhirPatientService::class)]
 class FhirPatientServiceQueryTest extends TestCase
 {
     private $fixtureManager;

--- a/tests/Tests/Services/FHIR/FhirPatientServiceUSCore8Test.php
+++ b/tests/Tests/Services/FHIR/FhirPatientServiceUSCore8Test.php
@@ -21,12 +21,10 @@ use OpenEMR\FHIR\R4\FHIRElement\FHIRExtension;
 use OpenEMR\Services\FHIR\FhirCodeSystemConstants;
 use OpenEMR\Services\FHIR\FhirPatientService;
 use OpenEMR\Tests\Fixtures\FixtureManager;
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-#[CoversClass(FhirPatientService::class)]
 class FhirPatientServiceUSCore8Test extends TestCase
 {
     // AI Generated code

--- a/tests/Tests/Services/FHIR/FhirPractitionerServiceCrudTest.php
+++ b/tests/Tests/Services/FHIR/FhirPractitionerServiceCrudTest.php
@@ -8,7 +8,6 @@ use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRPractitioner;
 use OpenEMR\Services\FHIR\FhirPractitionerService;
 use OpenEMR\Services\FHIR\Serialization\FhirPractitionerSerializer;
 use OpenEMR\Tests\Fixtures\PractitionerFixtureManager;
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -22,7 +21,6 @@ use PHPUnit\Framework\Attributes\Test;
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-#[CoversClass(FhirPractitionerService::class)]
 class FhirPractitionerServiceCrudTest extends TestCase
 {
     private $fixtureManager;

--- a/tests/Tests/Services/FacilityServiceTest.php
+++ b/tests/Tests/Services/FacilityServiceTest.php
@@ -5,7 +5,6 @@ namespace OpenEMR\Tests\Services;
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Services\FacilityService;
 use OpenEMR\Tests\Fixtures\FacilityFixtureManager;
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -19,7 +18,6 @@ use PHPUnit\Framework\Attributes\Test;
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-#[CoversClass(FacilityService::class)]
 class FacilityServiceTest extends TestCase
 {
     /**

--- a/tests/Tests/Services/PatientServiceTest.php
+++ b/tests/Tests/Services/PatientServiceTest.php
@@ -5,7 +5,6 @@ namespace OpenEMR\Tests\Services;
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Services\PatientService;
 use OpenEMR\Tests\Fixtures\FixtureManager;
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -20,7 +19,6 @@ use PHPUnit\Framework\Attributes\Test;
  *
  */
 
-#[CoversClass(PatientService::class)]
 class PatientServiceTest extends TestCase
 {
     /**

--- a/tests/Tests/Services/PractitionerServiceTest.php
+++ b/tests/Tests/Services/PractitionerServiceTest.php
@@ -5,7 +5,6 @@ namespace OpenEMR\Tests\Services;
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Services\PractitionerService;
 use OpenEMR\Tests\Fixtures\PractitionerFixtureManager;
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -19,7 +18,6 @@ use PHPUnit\Framework\Attributes\Test;
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-#[CoversClass(PractitionerService::class)]
 class PractitionerServiceTest extends TestCase
 {
     /**


### PR DESCRIPTION
Fixes #9257 

#### Short description of what this resolves:

The CoversClass attribute causes coverage to be ignored everywhere except for the targeted class. This causes faulty reporting, particularly by marking the tests themselves as having not been covered.


#### Changes proposed in this pull request:

Remove the CoversClass attribute.

#### Does your code include anything generated by an AI Engine? No
