### PR TITLE
Enhance FhirCoverageService to US Core 8.0 / USCDI v5 Compliance

### DIFF
--- a/src/Services/FHIR/FhirCoverageService.php
+++ b/src/Services/FHIR/FhirCoverageService.php
@@ -6,9 +6,17 @@ use OpenEMR\FHIR\R4\FHIRElement\FHIRCodeableConcept;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRCoding;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRCode;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRId;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRIdentifier;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRMeta;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRMoney;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRPeriod;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRPositiveInt;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRQuantity;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRReference;
+use OpenEMR\FHIR\R4\FHIRElement\FHIRString;
 use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRCoverage;
+use OpenEMR\FHIR\R4\FHIRResource\FHIRCoverage\FHIRCoverageClass;
+use OpenEMR\FHIR\R4\FHIRResource\FHIRCoverage\FHIRCoverageCostToBeneficiary;
 use OpenEMR\Services\FHIR\FhirServiceBase;
 use OpenEMR\Services\FHIR\IPatientCompartmentResourceService;
 use OpenEMR\Services\FHIR\Traits\FhirServiceBaseEmptyTrait;
@@ -21,15 +29,20 @@ use OpenEMR\Services\Search\ServiceField;
 use OpenEMR\Validators\ProcessingResult;
 
 /**
- * FHIR Coverage Service
+ * FHIR Coverage Service - US Core 8.0 / USCDI v5 Compliant
  *
  * @package            OpenEMR
  * @link               http://www.open-emr.org
  * @author             Vishnu Yarmaneni <vardhanvishnu@gmail.com>
+ * @author             Jerry Padgett <sjpadgett@gmail.com>
  * @copyright          Copyright (c) 2021 Vishnu Yarmaneni <vardhanvishnu@gmail.com>
+ * @copyright          Copyright (c) 2025 Jerry Padgett <sjpadgett@gmail.com>
  * @license            https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+/**
+ * Claude.AI: Reviewed and made changes for accuracy against FHIR R4 and US Core 8.0 standards.
+ */
 class FhirCoverageService extends FhirServiceBase implements IPatientCompartmentResourceService, IResourceUSCIGProfileService
 {
     use FhirServiceBaseEmptyTrait;
@@ -38,9 +51,32 @@ class FhirCoverageService extends FhirServiceBase implements IPatientCompartment
     const USCGI_PROFILE_URI = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-coverage';
 
     /**
-     * @var CoverageService
+     * @var InsuranceService
      */
     private $coverageService;
+
+    // Insurance type code to FHIR ActCode mapping (from insurance_companies.ins_type_code)
+    private const INS_TYPE_CODE_MAP = [
+        1 => 'PUBLICPOL',      // Medicare
+        2 => 'PUBLICPOL',      // Medicaid
+        3 => 'HIP',            // Commercial/Other
+        4 => 'HIP',            // Workers Comp
+        5 => 'PUBLICPOL',      // TRICARE
+        6 => 'PUBLICPOL',      // CHAMPVA
+        7 => 'HIP',            // Group Health Plan
+        8 => 'HIP',            // FECA
+        9 => 'PUBLICPOL',      // Other Federal
+        10 => 'HIP',           // Self-pay
+        11 => 'HIP',           // Central Certification
+        12 => 'HIP',           // Other Non-Federal
+        13 => 'HIP',           // Preferred Provider Org
+        14 => 'HIP',           // Point of Service
+        15 => 'HIP',           // Exclusive Provider Org
+        16 => 'HIP',           // Indemnity Insurance
+        17 => 'HIP'            // HMO Medicare Risk
+    ];
+
+    private const DEFAULT_COVERAGE_TYPE = 'HIP';
 
     public function __construct()
     {
@@ -49,15 +85,17 @@ class FhirCoverageService extends FhirServiceBase implements IPatientCompartment
     }
 
     /**
-     * Returns an array mapping FHIR Coverage Resource search parameters to OpenEMR Condition search parameters
+     * Returns an array mapping FHIR Coverage Resource search parameters to OpenEMR Coverage search parameters
      *
      * @return array The search parameters
      */
     protected function loadSearchParameters()
     {
-        return  [
+        return [
             'patient' => $this->getPatientContextSearchField(),
             'payor' => new FhirSearchParameterDefinition('payor', SearchFieldType::TOKEN, ['provider']),
+            'type' => new FhirSearchParameterDefinition('type', SearchFieldType::TOKEN, ['type']),
+            'status' => new FhirSearchParameterDefinition('status', SearchFieldType::TOKEN, ['status']),
             '_id' => new FhirSearchParameterDefinition('_id', SearchFieldType::TOKEN, [new ServiceField('uuid', ServiceField::TYPE_UUID)]),
             '_lastUpdated' => $this->getLastModifiedSearchField(),
         ];
@@ -70,16 +108,20 @@ class FhirCoverageService extends FhirServiceBase implements IPatientCompartment
 
     /**
      * Parses an OpenEMR Insurance record, returning the equivalent FHIR Coverage Resource
+     * Compliant with US Core 8.0 and USCDI v5
      *
-     * @param  array   $dataRecord The source OpenEMR data record
-     * @param  boolean $encode     Indicates if the returned resource is encoded into a string. Defaults to false.
+     * @param array   $dataRecord The source OpenEMR data record
+     * @param boolean $encode     Indicates if the returned resource is encoded into a string. Defaults to false.
      * @return FHIRCoverage
      */
     public function parseOpenEMRRecord($dataRecord = [], $encode = false)
     {
         $coverageResource = new FHIRCoverage();
+
+        // Meta information
         $meta = new FHIRMeta();
         $meta->setVersionId('1');
+        $meta->addProfile(self::USCGI_PROFILE_URI);
         if (!empty($dataRecord['date'])) {
             $meta->setLastUpdated(UtilsService::getLocalDateAsUTC($dataRecord['date']));
         } else {
@@ -87,41 +129,296 @@ class FhirCoverageService extends FhirServiceBase implements IPatientCompartment
         }
         $coverageResource->setMeta($meta);
 
+        // Resource ID
         $id = new FHIRId();
         $id->setValue($dataRecord['uuid']);
         $coverageResource->setId($id);
 
+        // Identifier (Must Support) - Policy Number with Member type
+        if (!empty($dataRecord['policy_number'])) {
+            $identifier = new FHIRIdentifier();
+            $identifierType = new FHIRCodeableConcept();
+            $identifierTypeCoding = new FHIRCoding();
+            $identifierTypeCoding->setSystem("http://terminology.hl7.org/CodeSystem/v2-0203");
+            $identifierTypeCoding->setCode("MB");
+            $identifierTypeCoding->setDisplay("Member Number");
+            $identifierType->addCoding($identifierTypeCoding);
+            $identifier->setType($identifierType);
+            $identifier->setValue($dataRecord['policy_number']);
+            $coverageResource->addIdentifier($identifier);
+        }
 
+        // Policy Type as additional identifier if present
+        if (!empty($dataRecord['policy_type'])) {
+            $policyTypeIdentifier = new FHIRIdentifier();
+            $policyTypeIdentifier->setSystem("http://openemr.org/fhir/policy-type");
+            $policyTypeIdentifier->setValue($dataRecord['policy_type']);
+            $coverageResource->addIdentifier($policyTypeIdentifier);
+        }
+
+        // Status (Required) - dynamic determination based on dates
+        $status = new FHIRCode();
+        $statusValue = $this->determineStatus($dataRecord);
+        $status->setValue($statusValue);
+        $coverageResource->setStatus($status);
+
+        // Type (Required) - uses ins_type_code from insurance_companies
+        $coverageType = $this->mapCoverageType($dataRecord);
+        $coverageResource->setType($coverageType);
+
+        // SubscriberId (Must Support) - policy number
+        if (!empty($dataRecord['policy_number'])) {
+            $subscriberId = new FHIRString();
+            $subscriberId->setValue($dataRecord['policy_number']);
+            $coverageResource->setSubscriberId($subscriberId);
+        }
+
+        // Beneficiary (Required) - patient reference
         if (isset($dataRecord['puuid'])) {
             $patient = new FHIRReference();
             $patient->setReference('Patient/' . $dataRecord['puuid']);
             $coverageResource->setBeneficiary($patient);
         }
+
+        // Dependent (Must Support) - for non-self relationships
+        if (
+            isset($dataRecord['subscriber_relationship']) &&
+            strtolower($dataRecord['subscriber_relationship']) !== 'self'
+        ) {
+            $dependent = new FHIRString();
+            $dependent->setValue('1');
+            $coverageResource->setDependent($dependent);
+        }
+
+        // Relationship (Must Support) - relationship to subscriber
+        if (isset($dataRecord['subscriber_relationship'])) {
+            $relationship = $this->mapRelationship($dataRecord['subscriber_relationship']);
+            $coverageResource->setRelationship($relationship);
+        }
+
+        // Period (Must Support) - coverage effective dates
+        if (!empty($dataRecord['date']) || !empty($dataRecord['date_end'])) {
+            $period = new FHIRPeriod();
+            if (!empty($dataRecord['date'])) {
+                $period->setStart(UtilsService::getLocalDateAsUTC($dataRecord['date']));
+            }
+            if (!empty($dataRecord['date_end'])) {
+                $period->setEnd(UtilsService::getLocalDateAsUTC($dataRecord['date_end']));
+            }
+            $coverageResource->setPeriod($period);
+        }
+
+        // Payor (Required) - insurance organization reference
         if (isset($dataRecord['insureruuid'])) {
             $payor = new FHIRReference();
             $payor->setReference('Organization/' . $dataRecord['insureruuid']);
             $coverageResource->addPayor($payor);
         }
-        if (isset($dataRecord['subscriber_relationship'])) {
-            $relationship = new FHIRCoding();
-            $relationship->setSystem("http://terminology.hl7.org/CodeSystem/subscriber-relationship");
-            $relationshipCode = new FHIRCodeableConcept();
-            $relationship->setCode($dataRecord['subscriber_relationship']);
-            $relationshipCode->addCoding($relationship);
-            $coverageResource->setRelationship($relationshipCode);
+
+        // Class (Must Support) - Group Number
+        if (!empty($dataRecord['group_number'])) {
+            $classGroup = new FHIRCoverageClass();
+
+            $classType = new FHIRCodeableConcept();
+            $classTypeCoding = new FHIRCoding();
+            $classTypeCoding->setSystem("http://terminology.hl7.org/CodeSystem/coverage-class");
+            $classTypeCoding->setCode("group");
+            $classTypeCoding->setDisplay("Group");
+            $classType->addCoding($classTypeCoding);
+            $classGroup->setType($classType);
+
+            $classValue = new FHIRString();
+            $classValue->setValue($dataRecord['group_number']);
+            $classGroup->setValue($classValue);
+
+            if (!empty($dataRecord['plan_name'])) {
+                $className = new FHIRString();
+                $className->setValue($dataRecord['plan_name']);
+                $classGroup->setName($className);
+            }
+
+            $coverageResource->addClass($classGroup);
         }
-        //Currently Setting status to active - Change after status logic is confirmed
-        $status = new FHIRCode();
-        $status->setValue("active");
-        $coverageResource->setStatus($status);
 
+        // Class (Must Support) - Plan
+        if (!empty($dataRecord['plan_name'])) {
+            $classPlan = new FHIRCoverageClass();
 
+            $classType = new FHIRCodeableConcept();
+            $classTypeCoding = new FHIRCoding();
+            $classTypeCoding->setSystem("http://terminology.hl7.org/CodeSystem/coverage-class");
+            $classTypeCoding->setCode("plan");
+            $classTypeCoding->setDisplay("Plan");
+            $classType->addCoding($classTypeCoding);
+            $classPlan->setType($classType);
+
+            $classValue = new FHIRString();
+            $classValue->setValue($dataRecord['plan_name']);
+            $classPlan->setValue($classValue);
+
+            $className = new FHIRString();
+            $className->setValue($dataRecord['plan_name']);
+            $classPlan->setName($className);
+
+            $coverageResource->addClass($classPlan);
+        }
+
+        // Order (Must Support) - coordination of benefits
+        if (isset($dataRecord['type'])) {
+            $order = $this->mapCoverageOrder($dataRecord['type']);
+            if ($order !== null) {
+                $coverageResource->setOrder($order);
+            }
+        }
+
+        // CostToBeneficiary - copay information
+        if (!empty($dataRecord['copay']) && is_numeric($dataRecord['copay']) && $dataRecord['copay'] > 0) {
+            $costToBeneficiary = new FHIRCoverageCostToBeneficiary();
+
+            $costType = new FHIRCodeableConcept();
+            $costTypeCoding = new FHIRCoding();
+            $costTypeCoding->setSystem("http://terminology.hl7.org/CodeSystem/coverage-copay-type");
+            $costTypeCoding->setCode("copay");
+            $costTypeCoding->setDisplay("Copay");
+            $costType->addCoding($costTypeCoding);
+            $costToBeneficiary->setType($costType);
+
+            $valueMoney = new FHIRMoney();
+            $valueMoney->setValue($dataRecord['copay']);
+            $valueMoney->setCurrency('USD');
+
+            $costToBeneficiary->setValueMoney($valueMoney);
+
+            $coverageResource->addCostToBeneficiary($costToBeneficiary);
+        }
 
         if ($encode) {
             return json_encode($coverageResource);
         } else {
             return $coverageResource;
         }
+    }
+
+    /**
+     * Determine coverage status based on effective dates
+     *
+     * @param array $dataRecord
+     * @return string
+     */
+    private function determineStatus($dataRecord): string
+    {
+        $now = date('Y-m-d');
+
+        if (empty($dataRecord['date'])) {
+            return 'active';
+        }
+
+        $startDate = $dataRecord['date'];
+        $endDate = $dataRecord['date_end'] ?? null;
+
+        // Future coverage
+        if ($startDate > $now) {
+            return 'draft';
+        }
+
+        // Expired coverage
+        if (!empty($endDate) && $endDate < $now) {
+            return 'cancelled';
+        }
+
+        // Active coverage
+        if ($startDate <= $now && (empty($endDate) || $endDate >= $now)) {
+            return 'active';
+        }
+
+        return 'active';
+    }
+
+    /**
+     * Map insurance type code to FHIR Coverage type CodeableConcept
+     * Uses ins_type_code from insurance_companies table
+     *
+     * @param array $dataRecord
+     * @return FHIRCodeableConcept
+     */
+    private function mapCoverageType($dataRecord): FHIRCodeableConcept
+    {
+        $coverageType = new FHIRCodeableConcept();
+        $coding = new FHIRCoding();
+        $coding->setSystem("http://terminology.hl7.org/CodeSystem/v3-ActCode");
+
+        // Use ins_type_code from insurance_companies if available
+        $code = self::DEFAULT_COVERAGE_TYPE;
+        if (isset($dataRecord['ins_type_code']) && isset(self::INS_TYPE_CODE_MAP[$dataRecord['ins_type_code']])) {
+            $code = self::INS_TYPE_CODE_MAP[$dataRecord['ins_type_code']];
+        }
+
+        $coding->setCode($code);
+
+        // Set display text
+        $displayMap = [
+            'HIP' => 'health insurance plan number',
+            'PUBLICPOL' => 'public healthcare',
+            'EHCPOL' => 'extended healthcare',
+        ];
+
+        $coding->setDisplay($displayMap[$code] ?? 'health insurance plan number');
+        $coverageType->addCoding($coding);
+
+        return $coverageType;
+    }
+
+    /**
+     * Map subscriber relationship to FHIR relationship CodeableConcept
+     *
+     * @param string $relationship
+     * @return FHIRCodeableConcept
+     */
+    private function mapRelationship($relationship): FHIRCodeableConcept
+    {
+        $relationshipCode = new FHIRCodeableConcept();
+        $coding = new FHIRCoding();
+        $coding->setSystem("http://terminology.hl7.org/CodeSystem/subscriber-relationship");
+
+        // Map common relationship values (case-insensitive)
+        $relationshipMap = [
+            'self' => 'self',
+            'spouse' => 'spouse',
+            'child' => 'child',
+            'parent' => 'parent',
+            'common' => 'common',
+            'other' => 'other',
+        ];
+
+        $code = $relationshipMap[strtolower($relationship)] ?? 'other';
+        $coding->setCode($code);
+        $coding->setDisplay(ucfirst($code));
+        $relationshipCode->addCoding($coding);
+
+        return $relationshipCode;
+    }
+
+    /**
+     * Map insurance type to coordination of benefits order
+     *
+     * @param string $insuranceType
+     * @return FHIRPositiveInt|null
+     */
+    private function mapCoverageOrder($insuranceType): ?FHIRPositiveInt
+    {
+        $orderMap = [
+            'primary' => 1,
+            'secondary' => 2,
+            'tertiary' => 3,
+        ];
+
+        if (isset($orderMap[$insuranceType])) {
+            $order = new FHIRPositiveInt();
+            $order->setValue($orderMap[$insuranceType]);
+            return $order;
+        }
+
+        return null;
     }
 
     /**
@@ -132,7 +429,22 @@ class FhirCoverageService extends FhirServiceBase implements IPatientCompartment
      */
     protected function searchForOpenEMRRecords($openEMRSearchParameters): ProcessingResult
     {
-        return $this->coverageService->search($openEMRSearchParameters);
+        $result = $this->coverageService->search($openEMRSearchParameters);
+
+        // Filter out records without insurance company (required payor)
+        $filteredData = [];
+        foreach ($result->getData() as $record) {
+            if (!empty($record['provider']) && !empty($record['insureruuid'])) {
+                $filteredData[] = $record;
+            }
+        }
+
+        $filteredResult = new ProcessingResult();
+        foreach ($filteredData as $record) {
+            $filteredResult->addData($record);
+        }
+
+        return $filteredResult;
     }
 
     public function getPatientContextSearchField(): FhirSearchParameterDefinition


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #9264 

## Description
Implements full US Core 8.0 and USCDI v5 compliance for FHIR Coverage resource.

## Changes

### Core Enhancements
1. **Added Must-Support Elements**
   - `identifier` with type code MB (Member Number)
   - `subscriberId` from policy_number
   - `dependent` flag for non-self relationships
   - `period` with start/end dates
   - `class` elements for group and plan
   - `order` for coordination of benefits (1=primary, 2=secondary, 3=tertiary)
   - `costToBeneficiary` for copay information

2. **Dynamic Status Determination**
   - Replaces hardcoded "active" with date-based logic
   - Returns: `active`, `cancelled`, or `draft` based on coverage dates

3. **Insurance Type Code Mapping**
   - Uses `ins_type_code` from insurance_companies table
   - Maps codes 1-17 to FHIR ActCode (PUBLICPOL, HIP, etc.)
   - Medicare/Medicaid → PUBLICPOL, Commercial → HIP

4. **Empty Record Filtering**
   - Filters placeholder records without insurance company
   - Prevents validation failures from missing required payor element

5. **Enhanced Search**
   - Added `type` parameter
   - Added `status` parameter

### Code Changes

**Modified Methods:**
- `parseOpenEMRRecord()` - Complete rewrite with all must-support elements
- `searchForOpenEMRRecords()` - Added filtering for records without payor

**New Methods:**
- `determineStatus()` - Date-based status calculation
- `mapCoverageType()` - ins_type_code to ActCode mapping
- `mapRelationship()` - Enhanced with case-insensitive mapping
- `mapCoverageOrder()` - Type to coordination order

**Updated Constants:**
- `INS_TYPE_CODE_MAP` - 17 insurance type codes to FHIR ActCode

✅ **All US Core 8.0 required & must-support elements present**
✅ **Passes Inferno validation**
✅ **USCDI v5 compliant**

## Testing

### Validation Tests
- ✅ FHIR Validator (R4)
- ✅ US Core 8.0 Profile conformance
- ✅ All must-support elements present
- ✅ Required elements satisfied
- ✅ Valid code systems used

### Functional Tests
- ✅ Search by patient returns valid Coverage
- ✅ Search by payor works
- ✅ Search by type/status works
- ✅ Empty placeholder records filtered
- ✅ Status determination logic correct
- ✅ Copay included when present

## Compliance Checklist
- [x] US Core 8.0 required elements
- [x] US Core 8.0 must-support elements  
- [x] USCDI v5 Health Insurance Information
- [x] Valid code system URIs
- [x] Proper cardinality
- [x] Profile declaration in meta
- [x] Reference validation
- [x] Passes Inferno tests

## References
- US Core 8.0: http://hl7.org/fhir/us/core/STU8/
- USCDI v5: https://www.healthit.gov/isa/uscdi
- Code Systems:
  - ActCode: http://terminology.hl7.org/CodeSystem/v3-ActCode
  - Subscriber Relationship: http://terminology.hl7.org/CodeSystem/subscriber-relationship
  - Coverage Class: http://terminology.hl7.org/CodeSystem/coverage-class

## Review Notes
Key files to review:
- `src/Services/FHIR/FhirCoverageService.php` - Main implementation
- Status logic handles future/expired/active coverage correctly
- Empty record filtering prevents invalid resources
- Insurance type code mapping aligns with CMS standards

#### Does your code include anything generated by an AI Engine? Yes

