### PR TITLE
ci(codecov): fix reporting without duplicates

### DIFF
--- a/.github/workflows/inferno-test.yml
+++ b/.github/workflows/inferno-test.yml
@@ -324,7 +324,10 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: junit-inferno.xml
         flags: inferno,certification,php${{ matrix.php-version }}
-        disable_search: true
+
+    - name: Hide Inferno test results from subsequent uploads
+      if: ${{ !cancelled() && hashFiles('junit-inferno.xml') != '' }}
+      run: mv junit-inferno.xml junit-inferno.saved-test-data
 
     - name: Upload PHPUnit coverage to Codecov
       if: ${{ !cancelled() && needs.check_secret.outputs.has_codecov_token == 'true' && hashFiles('coverage.inferno-phpunit.clover.xml') != '' }}
@@ -333,7 +336,10 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.inferno-phpunit.clover.xml
         flags: inferno,phpunit,php${{ matrix.php-version }}
-        disable_search: true
+
+    - name: Hide PHPUnit coverage from subsequent uploads
+      if: ${{ !cancelled() && hashFiles('coverage.inferno-phpunit.clover.xml') != '' }}
+      run: mv coverage.inferno-phpunit.clover.xml inferno-phpunit.saved-cov-data
 
     - name: Upload HTTP coverage to Codecov
       if: ${{ !cancelled() && needs.check_secret.outputs.has_codecov_token == 'true' && hashFiles('coverage.inferno-http.clover.xml') != '' }}
@@ -342,7 +348,10 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.inferno-http.clover.xml
         flags: inferno,http,php${{ matrix.php-version }}
-        disable_search: true
+
+    - name: Hide HTTP coverage from subsequent uploads
+      if: ${{ !cancelled() && hashFiles('coverage.inferno-http.clover.xml') != '' }}
+      run: mv coverage.inferno-http.clover.xml inferno-http.saved-cov-data
 
     - name: Upload combined coverage to Codecov
       if: ${{ !cancelled() && needs.check_secret.outputs.has_codecov_token == 'true' && hashFiles('coverage.clover.xml') != '' }}
@@ -351,7 +360,17 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.clover.xml
         flags: inferno,combined,php${{ matrix.php-version }}
-        disable_search: true
+
+    # Unhide files before uploading to GitHub
+    - name: Unhide test results and coverage for GitHub upload
+      if: ${{ !cancelled() }}
+      run: |
+        shopt -s nullglob
+        # Unhide junit files
+        [ -f junit-inferno.saved-test-data ] && mv junit-inferno.saved-test-data junit-inferno.xml || true
+        # Unhide coverage files
+        [ -f inferno-phpunit.saved-cov-data ] && mv inferno-phpunit.saved-cov-data coverage.inferno-phpunit.clover.xml || true
+        [ -f inferno-http.saved-cov-data ] && mv inferno-http.saved-cov-data coverage.inferno-http.clover.xml || true
 
     - name: Upload JUnit test results to GitHub
       if: ${{ !cancelled() && hashFiles('junit-inferno.xml') != '' }}

--- a/.github/workflows/isolated-tests.yml
+++ b/.github/workflows/isolated-tests.yml
@@ -86,7 +86,14 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: junit.xml
         flags: isolated,php${{ matrix.php-version }}
-        disable_search: true
+
+    - name: Hide test results from subsequent uploads
+      if: ${{ !cancelled() && hashFiles('junit.xml') != '' }}
+      run: mv junit.xml junit.saved-test-data
+
+    - name: Unhide test results for GitHub upload
+      if: ${{ !cancelled() && hashFiles('junit.saved-test-data') != '' }}
+      run: mv junit.saved-test-data junit.xml
 
     - name: Upload JUnit test results to GitHub
       if: ${{ success() || failure() }}
@@ -118,4 +125,3 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: clover.xml
         flags: isolated,php${{ matrix.php-version }}
-        disable_search: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -411,7 +411,10 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: junit-unit.xml
         flags: unit,php${{ steps.parse.outputs.php }},${{ steps.parse.outputs.webserver }},${{ steps.parse.outputs.database }}${{ steps.parse.outputs.db }}
-        disable_search: true
+
+    - name: Hide unit test results from subsequent uploads
+      if: ${{ !cancelled() && hashFiles('junit-unit.xml') != '' }}
+      run: mv junit-unit.xml junit-unit.saved-test-data
 
     - name: Upload unit test coverage to Codecov
       if: ${{ env.ENABLE_COVERAGE == 'true' && !cancelled() && hashFiles('coverage.unit.clover.xml') != '' }}
@@ -420,7 +423,19 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.unit.clover.xml
         flags: unit,php${{ steps.parse.outputs.php }},${{ steps.parse.outputs.webserver }},${{ steps.parse.outputs.database }}${{ steps.parse.outputs.db }}
-        disable_search: true
+
+    ##
+    # Hide coverage files after uploading to prevent codecov from re-uploading them
+    # in subsequent test steps. We'll unhide them before the combine step.
+    # This solves the issue where disable_search: true was preventing codecov
+    # from properly processing source code.
+    # We rename to .saved-cov-data to fully obscure from codecov's file detection.
+    - name: Hide unit coverage files from subsequent uploads
+      if: ${{ env.ENABLE_COVERAGE == 'true' && !cancelled() && hashFiles('coverage.unit.clover.xml') != '' }}
+      run: |
+        mv coverage.unit.clover.xml unit.saved-cov-data
+        sudo chmod -R 777 coverage
+        mv coverage/coverage.unit.cov coverage/unit.saved-cov-data
 
     - name: Api testing
       if: ${{ success() || failure() }}
@@ -439,7 +454,10 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: junit-api.xml
         flags: api,php${{ steps.parse.outputs.php }},${{ steps.parse.outputs.webserver }},${{ steps.parse.outputs.database }}${{ steps.parse.outputs.db }}
-        disable_search: true
+
+    - name: Hide api test results from subsequent uploads
+      if: ${{ !cancelled() && hashFiles('junit-api.xml') != '' }}
+      run: mv junit-api.xml junit-api.saved-test-data
 
     - name: Copy API coverage files from container
       if: ${{ !cancelled() && env.ENABLE_COVERAGE == 'true' }}
@@ -476,7 +494,12 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.api.clover.xml
         flags: api,php${{ steps.parse.outputs.php }},${{ steps.parse.outputs.webserver }},${{ steps.parse.outputs.database }}${{ steps.parse.outputs.db }}
-        disable_search: true
+
+    - name: Hide api coverage files from subsequent uploads
+      if: ${{ env.ENABLE_COVERAGE == 'true' && !cancelled() && hashFiles('coverage.api.clover.xml') != '' }}
+      run: |
+        mv coverage.api.clover.xml api.saved-cov-data
+        mv coverage/coverage.api.cov coverage/api.saved-cov-data
 
     - name: Fixtures testing
       if: ${{ success() || failure() }}
@@ -491,7 +514,10 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: junit-fixtures.xml
         flags: fixtures,php${{ steps.parse.outputs.php }},${{ steps.parse.outputs.webserver }},${{ steps.parse.outputs.database }}${{ steps.parse.outputs.db }}
-        disable_search: true
+
+    - name: Hide fixtures test results from subsequent uploads
+      if: ${{ !cancelled() && hashFiles('junit-fixtures.xml') != '' }}
+      run: mv junit-fixtures.xml junit-fixtures.saved-test-data
 
     - name: Upload fixtures test coverage to Codecov
       if: ${{ env.ENABLE_COVERAGE == 'true' && !cancelled() && hashFiles('coverage.fixtures.clover.xml') != '' }}
@@ -500,7 +526,12 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.fixtures.clover.xml
         flags: fixtures,php${{ steps.parse.outputs.php }},${{ steps.parse.outputs.webserver }},${{ steps.parse.outputs.database }}${{ steps.parse.outputs.db }}
-        disable_search: true
+
+    - name: Hide fixtures coverage files from subsequent uploads
+      if: ${{ env.ENABLE_COVERAGE == 'true' && !cancelled() && hashFiles('coverage.fixtures.clover.xml') != '' }}
+      run: |
+        mv coverage.fixtures.clover.xml fixtures.saved-cov-data
+        mv coverage/coverage.fixtures.cov coverage/fixtures.saved-cov-data
 
     - name: Services testing
       if: ${{ success() || failure() }}
@@ -515,7 +546,10 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: junit-services.xml
         flags: services,php${{ steps.parse.outputs.php }},${{ steps.parse.outputs.webserver }},${{ steps.parse.outputs.database }}${{ steps.parse.outputs.db }}
-        disable_search: true
+
+    - name: Hide services test results from subsequent uploads
+      if: ${{ !cancelled() && hashFiles('junit-services.xml') != '' }}
+      run: mv junit-services.xml junit-services.saved-test-data
 
     - name: Upload services test coverage to Codecov
       if: ${{ env.ENABLE_COVERAGE == 'true' && !cancelled() && hashFiles('coverage.services.clover.xml') != '' }}
@@ -524,7 +558,12 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.services.clover.xml
         flags: services,php${{ steps.parse.outputs.php }},${{ steps.parse.outputs.webserver }},${{ steps.parse.outputs.database }}${{ steps.parse.outputs.db }}
-        disable_search: true
+
+    - name: Hide services coverage files from subsequent uploads
+      if: ${{ env.ENABLE_COVERAGE == 'true' && !cancelled() && hashFiles('coverage.services.clover.xml') != '' }}
+      run: |
+        mv coverage.services.clover.xml services.saved-cov-data
+        mv coverage/coverage.services.cov coverage/services.saved-cov-data
 
     - name: Validators testing
       if: ${{ success() || failure() }}
@@ -539,7 +578,10 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: junit-validators.xml
         flags: validators,php${{ steps.parse.outputs.php }},${{ steps.parse.outputs.webserver }},${{ steps.parse.outputs.database }}${{ steps.parse.outputs.db }}
-        disable_search: true
+
+    - name: Hide validators test results from subsequent uploads
+      if: ${{ !cancelled() && hashFiles('junit-validators.xml') != '' }}
+      run: mv junit-validators.xml junit-validators.saved-test-data
 
     - name: Upload validators test coverage to Codecov
       if: ${{ env.ENABLE_COVERAGE == 'true' && !cancelled() && hashFiles('coverage.validators.clover.xml') != '' }}
@@ -548,7 +590,12 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.validators.clover.xml
         flags: validators,php${{ steps.parse.outputs.php }},${{ steps.parse.outputs.webserver }},${{ steps.parse.outputs.database }}${{ steps.parse.outputs.db }}
-        disable_search: true
+
+    - name: Hide validators coverage files from subsequent uploads
+      if: ${{ env.ENABLE_COVERAGE == 'true' && !cancelled() && hashFiles('coverage.validators.clover.xml') != '' }}
+      run: |
+        mv coverage.validators.clover.xml validators.saved-cov-data
+        mv coverage/coverage.validators.cov coverage/validators.saved-cov-data
 
     - name: Controllers testing
       if: ${{ success() || failure() }}
@@ -563,7 +610,10 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: junit-controllers.xml
         flags: controllers,php${{ steps.parse.outputs.php }},${{ steps.parse.outputs.webserver }},${{ steps.parse.outputs.database }}${{ steps.parse.outputs.db }}
-        disable_search: true
+
+    - name: Hide controllers test results from subsequent uploads
+      if: ${{ !cancelled() && hashFiles('junit-controllers.xml') != '' }}
+      run: mv junit-controllers.xml junit-controllers.saved-test-data
 
     - name: Upload controllers test coverage to Codecov
       if: ${{ env.ENABLE_COVERAGE == 'true' && !cancelled() && hashFiles('coverage.controllers.clover.xml') != '' }}
@@ -572,7 +622,12 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.controllers.clover.xml
         flags: controllers,php${{ steps.parse.outputs.php }},${{ steps.parse.outputs.webserver }},${{ steps.parse.outputs.database }}${{ steps.parse.outputs.db }}
-        disable_search: true
+
+    - name: Hide controllers coverage files from subsequent uploads
+      if: ${{ env.ENABLE_COVERAGE == 'true' && !cancelled() && hashFiles('coverage.controllers.clover.xml') != '' }}
+      run: |
+        mv coverage.controllers.clover.xml controllers.saved-cov-data
+        mv coverage/coverage.controllers.cov coverage/controllers.saved-cov-data
 
     - name: Common testing
       if: ${{ success() || failure() }}
@@ -587,7 +642,10 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: junit-common.xml
         flags: common,php${{ steps.parse.outputs.php }},${{ steps.parse.outputs.webserver }},${{ steps.parse.outputs.database }}${{ steps.parse.outputs.db }}
-        disable_search: true
+
+    - name: Hide common test results from subsequent uploads
+      if: ${{ !cancelled() && hashFiles('junit-common.xml') != '' }}
+      run: mv junit-common.xml junit-common.saved-test-data
 
     - name: Upload common test coverage to Codecov
       if: ${{ env.ENABLE_COVERAGE == 'true' && !cancelled() && hashFiles('coverage.common.clover.xml') != '' }}
@@ -596,7 +654,12 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.common.clover.xml
         flags: common,php${{ steps.parse.outputs.php }},${{ steps.parse.outputs.webserver }},${{ steps.parse.outputs.database }}${{ steps.parse.outputs.db }}
-        disable_search: true
+
+    - name: Hide common coverage files from subsequent uploads
+      if: ${{ env.ENABLE_COVERAGE == 'true' && !cancelled() && hashFiles('coverage.common.clover.xml') != '' }}
+      run: |
+        mv coverage.common.clover.xml common.saved-cov-data
+        mv coverage/coverage.common.cov coverage/common.saved-cov-data
 
     - name: Email testing
       if: ${{ success() || failure() }}
@@ -611,7 +674,10 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: junit-email.xml
         flags: email,php${{ steps.parse.outputs.php }},${{ steps.parse.outputs.webserver }},${{ steps.parse.outputs.database }}${{ steps.parse.outputs.db }}
-        disable_search: true
+
+    - name: Hide email test results from subsequent uploads
+      if: ${{ !cancelled() && hashFiles('junit-email.xml') != '' }}
+      run: mv junit-email.xml junit-email.saved-test-data
 
     - name: Upload email test coverage to Codecov
       if: ${{ env.ENABLE_COVERAGE == 'true' && !cancelled() && hashFiles('coverage.email.clover.xml') != '' }}
@@ -620,7 +686,12 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.email.clover.xml
         flags: email,php${{ steps.parse.outputs.php }},${{ steps.parse.outputs.webserver }},${{ steps.parse.outputs.database }}${{ steps.parse.outputs.db }}
-        disable_search: true
+
+    - name: Hide email coverage files from subsequent uploads
+      if: ${{ env.ENABLE_COVERAGE == 'true' && !cancelled() && hashFiles('coverage.email.clover.xml') != '' }}
+      run: |
+        mv coverage.email.clover.xml email.saved-cov-data
+        mv coverage/coverage.email.cov coverage/email.saved-cov-data
 
     ##
     # To skip E2E tests for specific docker directories,
@@ -688,7 +759,10 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: junit-e2e.xml
         flags: e2e,php${{ steps.parse.outputs.php }},${{ steps.parse.outputs.webserver }},${{ steps.parse.outputs.database }}${{ steps.parse.outputs.db }}
-        disable_search: true
+
+    - name: Hide e2e test results from subsequent uploads
+      if: ${{ !cancelled() && hashFiles('junit-e2e.xml') != '' }}
+      run: mv junit-e2e.xml junit-e2e.saved-test-data
 
     - name: Upload e2e test coverage to Codecov
       if: ${{ env.ENABLE_COVERAGE == 'true' && !cancelled() && hashFiles('coverage.e2e.clover.xml') != '' }}
@@ -697,7 +771,12 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.e2e.clover.xml
         flags: e2e,php${{ steps.parse.outputs.php }},${{ steps.parse.outputs.webserver }},${{ steps.parse.outputs.database }}${{ steps.parse.outputs.db }}
-        disable_search: true
+
+    - name: Hide e2e coverage files from subsequent uploads
+      if: ${{ env.ENABLE_COVERAGE == 'true' && !cancelled() && hashFiles('coverage.e2e.clover.xml') != '' }}
+      run: |
+        mv coverage.e2e.clover.xml e2e.saved-cov-data
+        mv coverage/coverage.e2e.cov coverage/e2e.saved-cov-data
 
     - name: Upload E2E test videos to GitHub
       if: ${{ (success() || failure()) && steps.parse.outputs.e2e_enabled == 'true' && hashFiles('selenium-videos/video.mp4') != '' }}
@@ -706,12 +785,47 @@ jobs:
         name: e2e-test-videos-${{ steps.parse.outputs.docker_dir }}
         path: selenium-videos/
 
+    # Unhide junit files before uploading to GitHub
+    - name: Unhide JUnit test results for GitHub upload
+      if: ${{ !cancelled() }}
+      run: |
+        shopt -s nullglob
+        for hidden in junit-*.saved-test-data; do
+          # Convert junit-unit.saved-test-data back to junit-unit.xml
+          file="${hidden%.saved-test-data}.xml"
+          echo "Unhiding: $hidden -> $file"
+          mv "$hidden" "$file"
+        done
+
     - name: Upload JUnit test results to GitHub
       if: ${{ !cancelled() && hashFiles('junit-*.xml') != '' }}
       uses: actions/upload-artifact@v5
       with:
         name: junit-test-results-${{ steps.parse.outputs.docker_dir }}
         path: junit-*.xml
+
+    # Unhide coverage files before combining them
+    - name: Unhide coverage files for merging
+      if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+      run: |
+        shopt -s nullglob
+        # Unhide .clover.xml files
+        for hidden in *.saved-cov-data; do
+          # Convert unit.saved-cov-data back to coverage.unit.clover.xml
+          base="${hidden%.saved-cov-data}"
+          file="coverage.${base}.clover.xml"
+          echo "Unhiding: $hidden -> $file"
+          mv "$hidden" "$file"
+        done
+        # Unhide .cov files in coverage/ directory
+        for hidden in coverage/*.saved-cov-data; do
+          # Convert coverage/unit.saved-cov-data back to coverage/coverage.unit.cov
+          base="${hidden%.saved-cov-data}"
+          base="${base#coverage/}"
+          file="coverage/coverage.${base}.cov"
+          echo "Unhiding: $hidden -> $file"
+          mv "$hidden" "$file"
+        done
 
     - name: Combine coverage
       if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
@@ -723,8 +837,12 @@ jobs:
       if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
       id: check-files
       run: |
-        echo "clover_exists=$(test -f coverage.clover.xml && echo true || echo false)" >> $GITHUB_OUTPUT
-        echo "htmlcov_exists=$(test -d ./htmlcov && echo true || echo false)" >> $GITHUB_OUTPUT
+        {
+          printf clover_exists=
+          [[ -f coverage.clover.xml ]] && echo true || echo false
+          printf htmlcov_exists=
+          [[ -d ./htmlcov ]] && echo true || echo false
+        } >> $GITHUB_OUTPUT
 
     - name: Upload clover coverage to GitHub
       uses: actions/upload-artifact@v5


### PR DESCRIPTION
Fixes #9293

#### Short description of what this resolves:

`disable_search: true` prevents the codecov uploader from duplicating uploads, but it also causes errors. So we needed to find another way to avoid duplication.


#### Changes proposed in this pull request:

Rename each coverage file to `*.hidden` so codecov won't see it. Then rename them all back to combine them.

#### Does your code include anything generated by an AI Engine? No
