### PR TITLE
ci(codecov): wait until 14 reports have been submitted

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,6 @@
 codecov:
   notify:
-    after_n_builds: 5
+    after_n_builds: 14
 
 coverage:
   status:


### PR DESCRIPTION
#### Short description of what this resolves:

Codecov reports to PRs too early, before all reports are in. This can lead to confusion where the coverage number appears temporarily lower than it actually is.
