### PR TITLE
fix(Cda\XmlExtended): RuntimeException namespace

### DIFF
--- a/.composer-require-checker.json
+++ b/.composer-require-checker.json
@@ -10,7 +10,6 @@
     "IS_WINDOWS",
     "Installer\\Controller\\InstallerController",
     "Installer\\Model\\InstModuleTable",
-    "Laminas\\Config\\Reader\\Exception\\RuntimeException",
     "Omnipay\\Common\\CreditCard",
     "Omnipay\\Omnipay",
     "OpenEMR\\Common\\Auth\\u2flib_server\\Error",

--- a/phpstan.github.neon
+++ b/phpstan.github.neon
@@ -17448,10 +17448,6 @@ parameters:
     identifier: nullCoalesce.variable
     count: 4
     path: src/Services/Cda/CdaTemplateParse.php
-  - message: '#^Instantiated class Laminas\\Config\\Reader\\Exception\\RuntimeException not found\.$#'
-    identifier: class.notFound
-    count: 3
-    path: src/Services/Cda/XmlExtended.php
   - message: '#^Variable \$form_id in empty\(\) always exists and is not falsy\.$#'
     identifier: empty.variable
     count: 1

--- a/src/Services/Cda/XmlExtended.php
+++ b/src/Services/Cda/XmlExtended.php
@@ -12,10 +12,10 @@
 
 namespace OpenEMR\Services\Cda;
 
+use Laminas\Config\Exception\RuntimeException;
 use Laminas\Config\Reader\ReaderInterface;
 use Laminas\Config\Reader\Xml;
 use XMLReader;
-use Laminas\Config\Reader\Exception\RuntimeException;
 
 class XmlExtended extends Xml implements ReaderInterface
 {


### PR DESCRIPTION
Fixes #9322

#### Short description of what this resolves:

The namespace for `Laminas\Config\Exception\RuntimeException` was wrong.


#### Changes proposed in this pull request:

Use the right namespace.

#### Does your code include anything generated by an AI Engine? No
