### PR TITLE
fix(U2F): namespace to u2flib_server\Error

### DIFF
--- a/.composer-require-checker.json
+++ b/.composer-require-checker.json
@@ -13,7 +13,6 @@
     "Laminas\\Config\\Reader\\Exception\\RuntimeException",
     "Omnipay\\Common\\CreditCard",
     "Omnipay\\Omnipay",
-    "OpenEMR\\Common\\Auth\\u2flib_server\\Error",
     "OpenEMR\\Common\\Http\\UploadedFile",
     "OpenEMR\\Common\\Utils\\Error",
     "OpenEMR\\Common\\Utils\\Exception",

--- a/interface/main/main_screen.php
+++ b/interface/main/main_screen.php
@@ -252,7 +252,7 @@ if (isset($_POST['new_login_session_management'])) {
                         "UPDATE users_secure SET last_challenge_response = NOW() WHERE id = ?",
                         [$_SESSION['authUserID']]
                     );
-                } catch (u2flib_server\Error $e) {
+                } catch (\u2flib_server\Error $e) {
                     // Authentication failed so we will build the U2F form again.
                     $form_response = '';
                     $errormsg = xl('U2F Key Authentication error') . ": " . $e->getMessage();

--- a/interface/usergroup/mfa_u2f.php
+++ b/interface/usergroup/mfa_u2f.php
@@ -147,7 +147,7 @@ function docancel() {
             }
             try {
                 $data = $u2f->doRegister(json_decode((string) $_POST['form_request']), json_decode((string) $_POST['form_registration']));
-            } catch (u2flib_server\Error $e) {
+            } catch (\u2flib_server\Error $e) {
                 die(xlt('Registration error') . ': ' . text($e->getMessage()));
             }
             echo "<script>\n";

--- a/phpstan.github.neon
+++ b/phpstan.github.neon
@@ -17032,10 +17032,6 @@ parameters:
     identifier: class.notFound
     count: 1
     path: src/Common/Auth/Exception/OneTimeAuthExpiredException.php
-  - message: '#^Caught class OpenEMR\\Common\\Auth\\u2flib_server\\Error not found\.$#'
-    identifier: class.notFound
-    count: 1
-    path: src/Common/Auth/MfaUtils.php
   - message: '#^Method OpenEMR\\Common\\Auth\\MfaUtils\:\:checkU2F\(\) should return bool but return statement is missing\.$#'
     identifier: return.missing
     count: 1

--- a/src/Common/Auth/MfaUtils.php
+++ b/src/Common/Auth/MfaUtils.php
@@ -204,7 +204,7 @@ class MfaUtils
             } else {
                 error_log("Unexpected keyHandle returned from doAuthenticate(): '" . errorLogEscape($strhandle) . "'");
             }
-        } catch (u2flib_server\Error $e) {
+        } catch (\u2flib_server\Error $e) {
             // Authentication failed so we will build the U2F form again.
             $form_response = '';
             $this->errorMsg = xl('U2F Key Authentication error') . ": " . $e->getMessage();


### PR DESCRIPTION
Fixes #9323

#### Short description of what this resolves:

The namespace for `\u2flib_server\Error` was not in `use` and wasn't otherwise fully qualified.


#### Changes proposed in this pull request:

Fully qualify the namespace.

#### Does your code include anything generated by an AI Engine? No
