### PR TITLE
fix(RandomGenUtils): correct error/exception namespaces

### DIFF
--- a/.composer-require-checker.json
+++ b/.composer-require-checker.json
@@ -13,8 +13,6 @@
     "Omnipay\\Common\\CreditCard",
     "Omnipay\\Omnipay",
     "OpenEMR\\Common\\Http\\UploadedFile",
-    "OpenEMR\\Common\\Utils\\Error",
-    "OpenEMR\\Common\\Utils\\Exception",
     "OpenEMR\\Gacl\\Hashed_Cache_Lite",
     "OpenEMR\\Pdf\\MpdfGenericPdfCreator",
     "PHPUnit\\Framework\\Attributes\\Test",

--- a/phpstan.github.neon
+++ b/phpstan.github.neon
@@ -17104,14 +17104,6 @@ parameters:
     identifier: variable.undefined
     count: 1
     path: src/Common/ORDataObject/ORDataObject.php
-  - message: '#^Caught class OpenEMR\\Common\\Utils\\Error not found\.$#'
-    identifier: class.notFound
-    count: 2
-    path: src/Common/Utils/RandomGenUtils.php
-  - message: '#^Caught class OpenEMR\\Common\\Utils\\Exception not found\.$#'
-    identifier: class.notFound
-    count: 2
-    path: src/Common/Utils/RandomGenUtils.php
   - message: '#^Method OpenEMR\\Core\\Header\:\:readConfigFile\(\) should return array but return statement is missing\.$#'
     identifier: return.missing
     count: 1

--- a/src/Common/Utils/RandomGenUtils.php
+++ b/src/Common/Utils/RandomGenUtils.php
@@ -24,11 +24,11 @@ class RandomGenUtils
     {
         try {
             return random_bytes($length);
-        } catch (Error $e) {
-            error_log('OpenEMR Error : Encryption is not working because of random_bytes() Error: ' . errorLogEscape($e->getMessage()));
+        } catch (\Error $e) {
+            error_log('OpenEMR Error: Encryption is not working because of random_bytes() Error: ' . errorLogEscape($e->getMessage()));
             return '';
-        } catch (Exception $e) {
-            error_log('OpenEMR Error : Encryption is not working because of random_bytes() Exception: ' . errorLogEscape($e->getMessage()));
+        } catch (\Exception $e) {
+            error_log('OpenEMR Error: Encryption is not working because of random_bytes() Exception: ' . errorLogEscape($e->getMessage()));
             return '';
         }
     }
@@ -49,11 +49,11 @@ class RandomGenUtils
                 $str .= $alphabet[random_int(0, $alphamax)];
             }
             return $str;
-        } catch (Error $e) {
-            error_log('OpenEMR Error : Encryption is not working because of random_int() Error: ' . errorLogEscape($e->getMessage()));
+        } catch (\Error $e) {
+            error_log('OpenEMR Error: Encryption is not working because of random_int() Error: ' . errorLogEscape($e->getMessage()));
             return '';
-        } catch (Exception $e) {
-            error_log('OpenEMR Error : Encryption is not working because of random_int() Exception: ' . errorLogEscape($e->getMessage()));
+        } catch (\Exception $e) {
+            error_log('OpenEMR Error: Encryption is not working because of random_int() Exception: ' . errorLogEscape($e->getMessage()));
             return '';
         }
     }
@@ -69,8 +69,8 @@ class RandomGenUtils
         $new_token = self::produceRandomString($length, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
 
         if (empty($new_token)) {
-            error_log('OpenEMR Error : OpenEMR is not working because unable to create a random unique token.');
-            die("OpenEMR Error : OpenEMR is not working because unable to create a random unique token.");
+            error_log('OpenEMR Error: OpenEMR is not working because unable to create a random unique token.');
+            die("OpenEMR Error: OpenEMR is not working because unable to create a random unique token.");
         }
 
         return $new_token;
@@ -93,7 +93,7 @@ class RandomGenUtils
             $the_password = self::produceRandomString(12, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789@#$%");
             if (empty($the_password)) {
                 // Something is seriously wrong with the random generator
-                $error_message = "OpenEMR Error : OpenEMR is not working because unable to create a random unique token.";
+                $error_message = "OpenEMR Error: OpenEMR is not working because unable to create a random unique token.";
                 error_log($error_message);
                 die($error_message);
             }
@@ -107,7 +107,7 @@ class RandomGenUtils
             }
         }
         // Something is seriously wrong since 1000 tries have not created a valid password
-        $error_message = "OpenEMR Error : OpenEMR is not working because unable to create a valid password in $max_tries attempts.";
+        $error_message = "OpenEMR Error: OpenEMR is not working because unable to create a valid password in $max_tries attempts.";
         error_log($error_message);
         die($error_message);
     }


### PR DESCRIPTION
Fixes #9325

#### Short description of what this resolves:

`\OpenEMR\Common\Utils\RandomGenUtils` didn't namespace `Error` and `Exception`, causing symbol checkers to think the namespaces were in the same namespace as the current class.


#### Changes proposed in this pull request:

Fully qualify the erroneous names.

#### Does your code include anything generated by an AI Engine? No
