### PR TITLE
WIP Fix host name for Inferno

### DIFF
--- a/ci/inferno/compose.yml
+++ b/ci/inferno/compose.yml
@@ -47,6 +47,7 @@ services:
       INFERNO_TEST: "${INFERNO_TEST:-false}"
       XDEBUG_ON: "${XDEBUG_ON:-0}"
       XDEBUG_MODE: "${XDEBUG_MODE:-off}"
+      XDEBUG_CLIENT_HOST: host.docker.internal
     depends_on:
       couchdb:
         condition: service_started
@@ -62,6 +63,7 @@ services:
       service: inferno
     environment:
       INFERNO_DISABLE_TLS_TEST: "true"
+      INFERNO_HOST: http://localhost:8000
   worker:
     extends:
       file: onc-certification-g10-test-kit/docker-compose.yml


### PR DESCRIPTION
The EHR and standalone SMART on FHIR launch need to have the correct host name.  This allows the hostnames to be set correctly.  We still have issues dealing with ssl certificates which will have to be addressed in a different issue.

Still working on this and will come back to it later.
Fixes #9366 