### PR TITLE
Fixes #9374 webroot issue with asymetric auth

### DIFF
--- a/src/FHIR/Config/ServerConfig.php
+++ b/src/FHIR/Config/ServerConfig.php
@@ -162,7 +162,7 @@ class ServerConfig
 
     public function getOauthAuthorizationUrl(): string
     {
-        return $this->oauthAddress . "/oauth2/" . $this->getSiteId();
+        return $this->oauthAddress . $this->webRoot . "/oauth2/" . $this->getSiteId();
     }
     public function getTokenUrl(): string
     {


### PR DESCRIPTION
Fixes #9374 issue with webroot.

@sjpadgett this should fix your issue.  Let me know if you keep having problems with client_credentials grant.