### PR TITLE
ci: cancel old jobs for same pr

### DIFF
--- a/.github/workflows/composer.yml
+++ b/.github/workflows/composer.yml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   composer:
     runs-on: ubuntu-24.04

--- a/.github/workflows/inferno-test.yml
+++ b/.github/workflows/inferno-test.yml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check_secret:
     runs-on: ubuntu-24.04

--- a/.github/workflows/isolated-tests.yml
+++ b/.github/workflows/isolated-tests.yml
@@ -17,6 +17,10 @@ on:
     - master
     - rel-*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   isolated-tests:
     runs-on: ubuntu-24.04

--- a/.github/workflows/js-test.yml
+++ b/.github/workflows/js-test.yml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   js_unit_test:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   phpstan:
     runs-on: ubuntu-24.04

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -10,6 +10,10 @@ on:
     - master
     - rel-*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   rector:
     name: Rector PHP Analysis

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -43,6 +43,11 @@ on:
     - docker/library/dockers/dev-php-fpm/data/docker-php-ext-enable
     - docker/library/dockers/dev-php-fpm/data/docker-php-ext-install
     - docker/library/dockers/dev-php-fpm/data/docker-php-source
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   shellcheck:
     name: ShellCheck

--- a/.github/workflows/styling.yml
+++ b/.github/workflows/styling.yml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   php_styling:

--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -19,6 +19,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   collect:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Fixes #9393

#### Short description of what this resolves:

prevent the same PR from triggering concurrent jobs by canceling the old jobs automatically when there's a push to the same PR.
