### PR TITLE
ci(isolated-tests): fix upload htmlcov to github

### DIFF
--- a/.github/workflows/isolated-tests.yml
+++ b/.github/workflows/isolated-tests.yml
@@ -100,21 +100,21 @@ jobs:
       run: mv junit.saved-test-data junit.xml
 
     - name: Upload JUnit test results to GitHub
-      if: ${{ success() || failure() }}
+      if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v5
       with:
         name: junit-isolated-tests-php-${{ matrix.php-version }}
         path: junit.xml
 
     - name: Check if coverage files exist
-      if: ${{ (success() || failure()) }}
+      if: ${{ !cancelled() }}
       id: check-files
       run: |
         echo "clover_exists=$(test -f clover.xml && echo true || echo false)" >> $GITHUB_OUTPUT
         echo "htmlcov_exists=$(test -d ./htmlcov && echo true || echo false)" >> $GITHUB_OUTPUT
 
     - name: Upload clover coverage report to GitHub
-      if: ${{ steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+      if: ${{ steps.check-files.outputs.clover_exists == 'true' && !cancelled() }}
       uses: actions/upload-artifact@v5
       with:
         name: coverage-clover-isolated-tests-php-${{ matrix.php-version }}
@@ -122,7 +122,7 @@ jobs:
           clover.xml
 
     - name: Upload html coverage report to GitHub
-      if: ${{ steps.check-files.outputs.htmlcov_exists == 'true' && (success() || failure()) }}
+      if: ${{ steps.check-files.outputs.htmlcov_exists == 'true' && !cancelled() }}
       uses: actions/upload-artifact@v5
       with:
         name: coverage-html-isolated-tests-php-${{ matrix.php-version }}
@@ -130,7 +130,7 @@ jobs:
           htmlcov
 
     - name: Upload coverage reports to Codecov
-      if: ${{ steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+      if: ${{ steps.check-files.outputs.clover_exists == 'true' && !cancelled() }}
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -729,25 +729,25 @@ jobs:
     # The logs for the e2e run are directly in the container logs for nginx/php-fpm
     # but in /var/log/apache2/error.log for apache.
     - name: E2e container logs
-      if: ${{ (success() || failure()) && steps.parse.outputs.e2e_enabled == 'true' }}
+      if: ${{ !cancelled() && steps.parse.outputs.e2e_enabled == 'true' }}
       run: |
         . ci/ciLibrary.source
         dc logs openemr
 
     - name: E2e error logs
-      if: ${{ (success() || failure()) && steps.parse.outputs.e2e_enabled == 'true' && steps.parse.outputs.webserver == 'apache' }}
+      if: ${{ !cancelled() && steps.parse.outputs.e2e_enabled == 'true' && steps.parse.outputs.webserver == 'apache' }}
       run: |
         . ci/ciLibrary.source
         dump_error_log ${{ steps.parse.outputs.webserver }}
 
     - name: E2e selenium logs
-      if: ${{ (success() || failure()) && steps.parse.outputs.e2e_enabled == 'true' }}
+      if: ${{ !cancelled() && steps.parse.outputs.e2e_enabled == 'true' }}
       run: |
         . ci/ciLibrary.source
         dc logs selenium
 
     - name: E2e video logs
-      if: ${{ (success() || failure()) && steps.parse.outputs.e2e_enabled == 'true' }}
+      if: ${{ !cancelled() && steps.parse.outputs.e2e_enabled == 'true' }}
       run: |
         . ci/ciLibrary.source
         dc logs video
@@ -779,7 +779,7 @@ jobs:
         mv coverage/coverage.e2e.cov coverage/e2e.saved-cov-data
 
     - name: Upload E2E test videos to GitHub
-      if: ${{ (success() || failure()) && steps.parse.outputs.e2e_enabled == 'true' && hashFiles('selenium-videos/video.mp4') != '' }}
+      if: ${{ !cancelled() && steps.parse.outputs.e2e_enabled == 'true' && hashFiles('selenium-videos/video.mp4') != '' }}
       uses: actions/upload-artifact@v5
       with:
         name: e2e-test-videos-${{ steps.parse.outputs.docker_dir }}
@@ -806,7 +806,7 @@ jobs:
 
     # Unhide coverage files before combining them
     - name: Unhide coverage files for merging
-      if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+      if: ${{ env.ENABLE_COVERAGE == 'true' && !cancelled() }}
       run: |
         shopt -s nullglob
         # Unhide .clover.xml files
@@ -828,13 +828,13 @@ jobs:
         done
 
     - name: Combine coverage
-      if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+      if: ${{ env.ENABLE_COVERAGE == 'true' && !cancelled() }}
       run: |
         . ci/ciLibrary.source
         merge_coverage
 
     - name: Check if combined coverage files exist
-      if: ${{ env.ENABLE_COVERAGE == 'true' && (success() || failure()) }}
+      if: ${{ env.ENABLE_COVERAGE == 'true' && !cancelled() }}
       id: check-files
       run: |
         {
@@ -846,14 +846,14 @@ jobs:
 
     - name: Upload clover coverage to GitHub
       uses: actions/upload-artifact@v5
-      if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && (success() || failure()) }}
+      if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.clover_exists == 'true' && !cancelled() }}
       with:
         name: coverage.clover.xml
         path: coverage.clover.xml
 
     - name: Upload html coverage to GitHub
       uses: actions/upload-artifact@v5
-      if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.htmlcov_exists == 'true' && (success() || failure()) }}
+      if: ${{ env.ENABLE_COVERAGE == 'true' && steps.check-files.outputs.htmlcov_exists == 'true' && !cancelled() }}
       with:
         name: htmlcov
         path: ./htmlcov/


### PR DESCRIPTION
Fixes #9417

#### Short description of what this resolves:

Fix typo in check to upload htmlcov report to github

#### Other changes in this PR

Simplified workflows by replacing `success() || failure()` conditions with `!cancelled()`. (There's a slight difference, but not one that should matter to us.)