### PR TITLE
fix(flow board): duplicate class breaks appt colors

### DIFF
--- a/interface/super/edit_list.php
+++ b/interface/super/edit_list.php
@@ -524,8 +524,8 @@ function writeOptionLine($option_id, $title, $seq, $default, $value, $mapping = 
     if ($list_id == 'apptstat' || $list_id == 'groupstat') {
         [$apptstat_color, $apptstat_timealert] = explode("|", (string) $notes);
         echo "  <td>";
-        echo "<input type='text' class='jscolor' name='opt[" . attr($opt_line_no) . "][apptstat_color]' value='" .
-            attr($apptstat_color) . "' size='6' maxlength='6' class='optin' />";
+        echo "<input type='text' class='jscolor optin' name='opt[" . attr($opt_line_no) . "][apptstat_color]' value='" .
+            attr($apptstat_color) . "' size='6' maxlength='6' />";
         echo "</td>\n";
         echo "  <td>";
         echo "<input type='text' name='opt[" . attr($opt_line_no) . "][apptstat_timealert]' value='" .


### PR DESCRIPTION
Fixes #9401

#### Short description of what this resolves:
When editing appointment statuses in Admin -> Forms -> Appointment statuses,
changing any color would cause all colors on the Flow Board to be removed,
displaying all appointment statuses with white backgrounds instead of their
configured colors.

#### Changes proposed in this pull request:
- Fixed duplicate class attribute on color input field in `edit_list.php:527-528`
- Combined `jscolor` and `optin` classes into single class attribute
- This allows the jscolor library to properly initialize the color picker
- Colors are now correctly saved to and retrieved from the database

The issue was caused by a duplicate class attribute where `class="jscolor"`
was followed by `class="optin"` on the same input element. HTML only uses
the last class attribute when duplicates exist, which prevented the jscolor
JavaScript library from initializing properly.

Does your code include anything generated by an AI Engine? Yes

AI-assisted development: This fix was identified and implemented with
assistance from Claude Code (Claude Sonnet 4.5). The root cause analysis
and code modification were AI-assisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
