### PR TITLE
refactor(jscolor): use data attribute

### DIFF
--- a/interface/forms/eye_mag/css/style.css
+++ b/interface/forms/eye_mag/css/style.css
@@ -2166,10 +2166,6 @@ View.php
   text-align: center;
 }
 
-.jscolor input[type="text"] {
-  margin: 26px 2px 0 !important;
-}
-
 #LayerVision {
   border: 1px solid var(--dark);
   float: left;

--- a/interface/forms/eye_mag/php/eye_mag_functions.php
+++ b/interface/forms/eye_mag/php/eye_mag_functions.php
@@ -3193,7 +3193,7 @@ function display_draw_section($zone, $encounter, $pid, $side = 'OU', $counter = 
             <div class="tools">
                 <div id="sketch_tooled_<?php echo attr($zone); ?>_8">
                     <span id="sketch_tool_<?php echo attr($zone);?>_color"
-                          class="color_indicator jscolor"
+                          class="color_indicator"
                           data-jscolor="{ previewElement:'#sketch_tool_<?php echo attr($zone); ?>_color',
                                      previewSize:75,
                                      valueElement:'#selColor_<?php echo attr($zone); ?>',

--- a/interface/super/edit_globals.php
+++ b/interface/super/edit_globals.php
@@ -670,7 +670,7 @@ function checkBackgroundServices(): void
                                                     if ($userMode) {
                                                         $globalTitle = $globalValue;
                                                     }
-                                                    echo "  <input type='text' class='form-control jscolor {hash:true}' name='form_$i' id='form_$i' " .
+                                                    echo "  <input type='text' class='form-control' data-jscolor='' name='form_$i' id='form_$i' " .
                                                         "maxlength='15' value='" . attr($fldvalue) . "' />" .
                                                         "<input type='button' value='" . xla('Default') . "' onclick=\"document.forms[0].form_$i.jscolor.fromString(" . attr_js($flddef) . ")\">\n";
                                                 } elseif ($fldtype == GlobalSetting::DATA_TYPE_DEFAULT_VISIT_CATEGORY) {

--- a/interface/super/edit_list.php
+++ b/interface/super/edit_list.php
@@ -524,7 +524,7 @@ function writeOptionLine($option_id, $title, $seq, $default, $value, $mapping = 
     if ($list_id == 'apptstat' || $list_id == 'groupstat') {
         [$apptstat_color, $apptstat_timealert] = explode("|", (string) $notes);
         echo "  <td>";
-        echo "<input type='text' class='jscolor optin' name='opt[" . attr($opt_line_no) . "][apptstat_color]' value='" .
+        echo "<input type='text' class='optin' data-jscolor='' name='opt[" . attr($opt_line_no) . "][apptstat_color]' value='" .
             attr($apptstat_color) . "' size='6' maxlength='6' />";
         echo "</td>\n";
         echo "  <td>";


### PR DESCRIPTION
Fixes #9421

#### Short description of what this resolves:

Update jscolor to use data attribute instead of deprecated class.


#### Changes proposed in this pull request:

Update jscolor initialization to use data-jscolor attribute instead of class-based initialization per current jscolor documentation. Remove CSS rule that didn't target anything.

#### Does your code include anything generated by an AI Engine? No
