### PR TITLE
Trim leading '#' from color value in patient tracker

### DIFF
--- a/interface/patient_tracker/patient_tracker.php
+++ b/interface/patient_tracker/patient_tracker.php
@@ -573,7 +573,7 @@ if (!($_REQUEST['flb_table'] ?? null)) {
                         $newarrive = collect_checkin($tracker_id);
                         $newend = collect_checkout($tracker_id);
                         $colorevents = (collectApptStatusSettings($status));
-                        $bgcolor = $colorevents['color'];
+                        $bgcolor = ltrim($colorevents['color'],'#');
                         $statalert = $colorevents['time_alert'];
                         // process the time to allow items with a check out status to be displayed
                         if (is_checkout($status) && (($GLOBALS['checkout_roll_off'] > 0) && strlen($form_apptstatus) != 1)) {


### PR DESCRIPTION
This fixes the Flow Board color problem when apptstat colors are changed.  Base DB list_option.notes has hex values without # but appointment status color updates all color/notes values to include the #.  That is probably the other place to look should this also be a Calendar problem.

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #8190, #9401

Alternatively, the left trim could occur higher up in src/Services/PatientTrackerService.php

 the function 

<img width="1982" height="674" alt="image" src="https://github.com/user-attachments/assets/df28296f-dd80-4cb1-bfe0-b042796012a2" />

