### PR TITLE
Fixes #9464 encounter context capability

### DIFF
--- a/src/FHIR/SMART/Capability.php
+++ b/src/FHIR/SMART/Capability.php
@@ -45,7 +45,7 @@ class Capability
         // which in V2 is NOT the same as the /fhir/metadata endpoint used in SMART v1
         , self::PERMISSION_AUTHORIZE_POST
         // additional capabilities for SMART v2
-        // context-ehr-encounter
+        , self::CONTEXT_EHR_ENCOUNTER
         // client-confidential-asymmetric - JWT authentication
         // context-standalone-encounter
         // permission-v2


### PR DESCRIPTION
We already add the encounter to the launch context which was experimental for SMART on FHIR V1.  We now add in the capability to the .well-known statement

Fixes #9464