### PR TITLE
fix: mis-ordered null coalescing

### DIFF
--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php
@@ -638,7 +638,7 @@ class CarecoordinationTable extends AbstractTableGateway
                     $pid_exist = sqlQuery("SELECT pid FROM `patient_data` WHERE `referrerID` = ? ORDER BY `pid` DESC Limit 1", [$uuid])['pid'] ?? '';
                     if (!empty($pid_exist) && is_numeric($pid_exist ?? null)) {
                         // We did so let check the type. If encounters then a CDA
-                        $enc_exist = sqlQuery("SELECT COUNT(`encounter`) as `cnt` FROM `form_encounter` WHERE `pid` = ? AND `encounter` > 0", [(int)$pid_exist])['cnt'] ?? 0;
+                        $enc_exist = (sqlQuery("SELECT COUNT(`encounter`) as `cnt` FROM `form_encounter` WHERE `pid` = ? AND `encounter` > 0", [(int)$pid_exist])['cnt']) ?? 0;
                         // If not CDA and not unstructured means unstructured already created a new PID
                         // otherwise merge one or the other to each other.
                         if ((!$this->is_unstructured_import && empty($enc_exist)) || $this->is_unstructured_import) {

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncounterccdadispatchTable.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncounterccdadispatchTable.php
@@ -4096,7 +4096,7 @@ class EncounterccdadispatchTable extends AbstractTableGateway
         }
         // --- Append SDOH Goals, Concerns, and Interventions from HistorySdohService ---
         try {
-            $sdoh = HistorySdohService::getCurrentAssessment((int)$pid) ?? null;
+            $sdoh = (HistorySdohService::getCurrentAssessment((int)$pid)) ?? null;
             if ($sdoh) {
                 // Author/provenance (use last updater or current user)
                 $authorId = $sdoh['user'] ?? $sdoh['provider'] ?? ($GLOBALS['authUserID'] ?? null);

--- a/interface/reports/amc_full_report.php
+++ b/interface/reports/amc_full_report.php
@@ -19,7 +19,7 @@ use OpenEMR\Common\Logging\SystemLogger;
 
 function formatPatientReportData($report_id, &$data, $type_report, $amc_report_types = [])
 {
-    $dataSheet = json_decode((string) $data, true) ?? [];
+    $dataSheet = (json_decode((string) $data, true)) ?? [];
     $formatted = [];
     $main_pass_filter = 0;
     foreach ($dataSheet as $row) {
@@ -98,7 +98,7 @@ function collectItemizedPatientData($report_id, $itemized_test_id)
                 if (empty($ruleObjectHash[$ruleId])) {
                     $ruleObjectHash[$ruleId] = getRuleObjectForId($ruleId) ?? new AMC_Unimplemented();
                 }
-                $data = json_decode((string) $row['item_details'], true) ?? null;
+                $data = (json_decode((string) $row['item_details'], true)) ?? null;
                 if (!empty($data)) {
                     $data = $ruleObjectHash[$ruleId]->hydrateItemizedDataFromRecord($data)->getActionData();
 

--- a/library/ajax/upload.php
+++ b/library/ajax/upload.php
@@ -44,7 +44,7 @@ if (!CsrfUtils::verifyCsrfToken($_REQUEST["csrf_token_form"])) {
 
 // check if this is for dicom image maintenance.
 $action = $_POST['action'] ?? null;
-$doc_id = (int)$_POST['doc_id'] ?? null;
+$doc_id = (int)($_POST['doc_id'] ?? null);
 $json_data = $_POST['json_data'] ?? null;
 
 if ($action == 'save') {

--- a/library/report_database.inc.php
+++ b/library/report_database.inc.php
@@ -468,7 +468,7 @@ function collectItemizedPatientsCdrReport($report_id, $itemized_test_id, $pass =
  */
 function formatReportData($report_id, &$data, $is_amc, $is_cqm, $type_report, $amc_report_types = [])
 {
-    $dataSheet = json_decode((string) $data, true) ?? [];
+    $dataSheet = (json_decode((string) $data, true)) ?? [];
     $formatted = [];
     $main_pass_filter = 0;
     foreach ($dataSheet as $row) {

--- a/library/specialty_forms.php
+++ b/library/specialty_forms.php
@@ -21,7 +21,7 @@ if (!CsrfUtils::verifyCsrfToken($_GET["csrf_token_form"])) {
     CsrfUtils::csrfNotVerified();
 }
 
-$disablePreviousNameAdds = (int)$_SESSION['disablePreviousNameAdds'] ?? 0;
+$disablePreviousNameAdds = (int)($_SESSION['disablePreviousNameAdds'] ?? 0);
 
 $form = trim((string) $_GET['form_handler']);
 echo "<script>var form=" . js_escape($form) . "</script>";

--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -1463,7 +1463,7 @@ class AuthorizationController
                     throw new HttpException(Response::HTTP_UNAUTHORIZED, $message);
                 }
             }
-            $session_nonce = json_decode((string) $trustedUser['session_cache'], true)['nonce'] ?? '';
+            $session_nonce = (json_decode((string) $trustedUser['session_cache'], true)['nonce']) ?? '';
             // this should be enough to confirm valid id
             if ($session_nonce !== $id_nonce) {
                 throw new OAuthServerException('Id token not issued from this server', 0, 'invalid _request', Response::HTTP_BAD_REQUEST);

--- a/src/Services/Cda/CdaTemplateImportDispose.php
+++ b/src/Services/Cda/CdaTemplateImportDispose.php
@@ -2290,7 +2290,7 @@ class CdaTemplateImportDispose
             ORDER BY fe.encounter DESC, fe.date DESC Limit 1";
         $rtn = sqlQuery($sql, [$item_date, $item_pid]);
 
-        return (int)$rtn['encounter'] ?? 0;
+        return (int)($rtn['encounter'] ?? 0);
     }
 
     /**

--- a/src/Services/Cda/CdaTemplateParse.php
+++ b/src/Services/Cda/CdaTemplateParse.php
@@ -621,7 +621,7 @@ class CdaTemplateParse
 
             $this->templateData['field_name_value_array']['lists3'][$i]['route'] = $entry['substanceAdministration']['routeCode']['code'] ?? null;
             $this->templateData['field_name_value_array']['lists3'][$i]['route_display'] = $entry['substanceAdministration']['routeCode']['displayName'] ?? null;
-            $this->templateData['field_name_value_array']['lists3'][$i]['dose'] = number_format((float)$entry['substanceAdministration']['doseQuantity']['value'], 2, '.', '') ?? null;
+            $this->templateData['field_name_value_array']['lists3'][$i]['dose'] = number_format((float)$entry['substanceAdministration']['doseQuantity']['value'], 2, '.', '');
 
             $this->templateData['field_name_value_array']['lists3'][$i]['dose_unit'] = $entry['substanceAdministration']['doseQuantity']['unit'] ?? null;
             $this->templateData['field_name_value_array']['lists3'][$i]['rate'] = $entry['substanceAdministration']['rateQuantity']['value'] ?? null;

--- a/src/Services/FHIR/FhirPatientService.php
+++ b/src/Services/FHIR/FhirPatientService.php
@@ -754,7 +754,7 @@ class FhirPatientService extends FhirServiceBase implements IFhirExportableResou
         }
 
         $data = [];
-        $data['uuid'] = (string)$fhirResource->getId() ?? null;
+        $data['uuid'] = (string)$fhirResource->getId();
 
         if (!empty($fhirResource->getName())) {
             $name = new FHIRHumanName();
@@ -764,7 +764,7 @@ class FhirPatientService extends FhirServiceBase implements IFhirExportableResou
                     break;
                 }
             }
-            $data['lname'] = (string)$name->getFamily() ?? null;
+            $data['lname'] = (string)$name->getFamily();
 
             $given = $name->getGiven() ?? [];
             // we cast due to the way FHIRString works
@@ -799,18 +799,18 @@ class FhirPatientService extends FhirServiceBase implements IFhirExportableResou
 
             $lineValues = array_map(fn($val): string => (string)$val, $activeAddress->getLine() ?? []);
             $data['street'] = implode("\n", $lineValues) ?? null;
-            $data['postal_code'] = (string)$activeAddress->getPostalCode() ?? null;
-            $data['city'] = (string)$activeAddress->getCity() ?? null;
-            $data['state'] = (string)$activeAddress->getState() ?? null;
+            $data['postal_code'] = (string)$activeAddress->getPostalCode();
+            $data['city'] = (string)$activeAddress->getCity();
+            $data['state'] = (string)$activeAddress->getState();
         }
 
         $telecom = $fhirResource->getTelecom();
         if (!empty($telecom)) {
             foreach ($telecom as $contactPoint) {
-                $systemValue = (string)$contactPoint->getSystem() ?? "contact_other";
+                $systemValue = (string)$contactPoint->getSystem();
                 $contactValue = (string)$contactPoint->getValue();
                 if ($systemValue === 'email') {
-                    $use = (string)$contactPoint->getUse() ?? "home";
+                    $use = (string)$contactPoint->getUse();
                     $useMapping = ['mobile' => 'email_direct'];
                     if (isset($useMapping[$use])) {
                         $data[$useMapping[$use]] = $contactValue;
@@ -818,7 +818,7 @@ class FhirPatientService extends FhirServiceBase implements IFhirExportableResou
                         $data[$systemValue] = $contactValue;
                     }
                 } elseif ($systemValue == "phone") {
-                    $use = (string)$contactPoint->getUse() ?? "work";
+                    $use = (string)$contactPoint->getUse();
                     $useMapping = ['mobile' => 'phone_cell', 'home' => 'phone_home', 'work' => 'phone_biz'];
                     if (isset($useMapping[$use])) {
                         $data[$useMapping[$use]] = $contactValue;

--- a/src/Services/FHIR/FhirPractitionerService.php
+++ b/src/Services/FHIR/FhirPractitionerService.php
@@ -200,7 +200,7 @@ class FhirPractitionerService extends FhirServiceBase implements IFhirExportable
         }
 
         $data = [];
-        $data['uuid'] = (string)$fhirResource->getId() ?? null;
+        $data['uuid'] = (string)$fhirResource->getId();
 
         if (!empty($fhirResource->getName())) {
             $name = new FHIRHumanName();
@@ -210,7 +210,7 @@ class FhirPractitionerService extends FhirServiceBase implements IFhirExportable
                     break;
                 }
             }
-            $data['lname'] = (string)$name->getFamily() ?? null;
+            $data['lname'] = (string)$name->getFamily();
 
             $given = $name->getGiven() ?? [];
             // we cast due to the way FHIRString works
@@ -243,20 +243,20 @@ class FhirPractitionerService extends FhirServiceBase implements IFhirExportable
 
             $lineValues = array_map(fn($val): string => (string)$val, $activeAddress->getLine() ?? []);
             $data['street'] = implode("\n", $lineValues) ?? null;
-            $data['zip'] = (string)$activeAddress->getPostalCode() ?? null;
-            $data['city'] = (string)$activeAddress->getCity() ?? null;
-            $data['state'] = (string)$activeAddress->getState() ?? null;
+            $data['zip'] = (string)$activeAddress->getPostalCode();
+            $data['city'] = (string)$activeAddress->getCity();
+            $data['state'] = (string)$activeAddress->getState();
         }
 
         $telecom = $fhirResource->getTelecom();
         if (!empty($telecom)) {
             foreach ($telecom as $contactPoint) {
-                $systemValue = (string)$contactPoint->getSystem() ?? "contact_other";
+                $systemValue = (string)$contactPoint->getSystem();
                 $contactValue = (string)$contactPoint->getValue();
                 if ($systemValue === 'email') {
                     $data[$systemValue] = $contactValue;
                 } else if ($systemValue == "phone") {
-                    $use = (string)$contactPoint->getUse() ?? "work";
+                    $use = (string)$contactPoint->getUse();
                     $useMapping = ['mobile' => 'phonecell', 'home' => 'phone', 'work' => 'phonew1'];
                     if (isset($useMapping[$use])) {
                         $data[$useMapping[$use]] = $contactValue;
@@ -267,7 +267,7 @@ class FhirPractitionerService extends FhirServiceBase implements IFhirExportable
 
         foreach ($fhirResource->getIdentifier() as $identifier) {
             if ((string)$identifier->getSystem() == FhirCodeSystemConstants::PROVIDER_NPI) {
-                $data['npi'] = (string)$identifier->getValue() ?? null;
+                $data['npi'] = (string)$identifier->getValue();
             }
         }
 

--- a/src/Services/FHIR/Organization/FhirOrganizationFacilityService.php
+++ b/src/Services/FHIR/Organization/FhirOrganizationFacilityService.php
@@ -252,9 +252,9 @@ class FhirOrganizationFacilityService extends FhirServiceBase
 
         $data = [];
 
-        $data['uuid'] = (string)$fhirResource->getId() ?? null;
+        $data['uuid'] = (string)$fhirResource->getId();
         // convert the strings to a
-        $data['name'] = (string)$fhirResource->getName() ?? null;
+        $data['name'] = (string)$fhirResource->getName();
 
         $addresses = $fhirResource->getAddress();
         if (!empty($addresses)) {
@@ -273,28 +273,28 @@ class FhirOrganizationFacilityService extends FhirServiceBase
 
             $lineValues = array_map(fn($val): string => (string)$val, $activeAddress->getLine() ?? []);
             $data['street'] = implode("\n", $lineValues) ?? null;
-            $data['postal_code'] = (string)$activeAddress->getPostalCode() ?? null;
-            $data['city'] = (string)$activeAddress->getCity() ?? null;
-            $data['state'] = (string)$activeAddress->getState() ?? null;
+            $data['postal_code'] = (string)$activeAddress->getPostalCode();
+            $data['city'] = (string)$activeAddress->getCity();
+            $data['state'] = (string)$activeAddress->getState();
         }
 
         $telecom = $fhirResource->getTelecom();
         if (!empty($telecom)) {
             foreach ($telecom as $contactPoint) {
-                $systemValue = (string)$contactPoint->getSystem() ?? "contact_other";
+                $systemValue = (string)$contactPoint->getSystem();
                 $validSystems = ['phone' => 'phone', 'email' => 'email', 'fax' => 'fax'];
                 if (isset($validSystems[$systemValue])) {
-                    $data[$systemValue] = (string)$contactPoint->getValue() ?? null;
+                    $data[$systemValue] = (string)$contactPoint->getValue();
                 }
             }
         }
 
         foreach ($fhirResource->getIdentifier() as $identifier) {
             if ((string)$identifier->getSystem() == FhirCodeSystemConstants::PROVIDER_NPI) {
-                $data['facility_npi'] = (string)$identifier->getValue() ?? null;
+                $data['facility_npi'] = (string)$identifier->getValue();
             }
             if ((string)$identifier->getSystem() == FhirCodeSystemConstants::OID_CLINICAL_LABORATORY_IMPROVEMENT_ACT_NUMBER) {
-                $data['domain_identifier'] = (string)$identifier->getValue() ?? null;
+                $data['domain_identifier'] = (string)$identifier->getValue();
             }
         }
         return $data;

--- a/src/Services/Qdm/Services/AbstractMedicationService.php
+++ b/src/Services/Qdm/Services/AbstractMedicationService.php
@@ -79,7 +79,7 @@ abstract class AbstractMedicationService extends AbstractQdmService implements Q
 
         if ($record['dosage']) {
             $qdmModel->dosage = new Quantity([
-                'value' => (int)$record['dosage'] ?? null,
+                'value' => (int)$record['dosage'],
                 'unit' => $record['drug_unit'] ?? null,
             ]);
         }

--- a/src/Services/Utils/SQLUpgradeService.php
+++ b/src/Services/Utils/SQLUpgradeService.php
@@ -1402,7 +1402,7 @@ class SQLUpgradeService implements ISQLUpgradeService
         try {
             while ($row = sqlFetchArray($result)) {
                 if (in_array($row['field_id'], $subject)) {
-                    $options = json_decode((string) $row['edit_options'], true) ?? [];
+                    $options = (json_decode((string) $row['edit_options'], true)) ?? [];
                     if (!in_array($add_option, $options) && stripos((string) $mode, 'add') !== false) {
                         $options[] = $add_option;
                     } elseif (in_array($add_option, $options) && stripos((string) $mode, 'remove') !== false) {


### PR DESCRIPTION
Fixes #9450

#### Short description of what this resolves:

Fixes incorrect or meaningless uses of the `??` operator.


#### Changes proposed in this pull request:

- [x] Fix cases where type casts taking precedence meant the undefined value could raise a warning before the null coalesce could take effect.
- [x] Remove uses of `?? null` where the value to the left could never be undefined.


#### Does your code include anything generated by an AI Engine? Yes

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.

These are all carefully guided cleanups of individual lines, not new code. Marking each one as AI-edited would not make sense.
