### PR TITLE
fix(tracker): trim leading '#' from color setting in PatientTrackerService

### DIFF
--- a/src/Services/PatientTrackerService.php
+++ b/src/Services/PatientTrackerService.php
@@ -292,7 +292,7 @@ class PatientTrackerService extends BaseService
         }
 
         [$color_settings['color'], $color_settings['time_alert']] = explode("|", (string) $row['notes']);
-        $color_setting['color'] = ltrim($color_settings['color'],'#');
+        $color_settings['color'] = ltrim($color_settings['color'],'#');
         return $color_settings;
     }
 


### PR DESCRIPTION
Fixes #8190, #9401

#### Short description of what this resolves:
The Flow Board color problem when appointment status colors are changed. The base DB `list_option.notes` has hex values without `#` but appointment status color updates include the `#`. This caused color mismatches.

#### Changes proposed in this pull request:
- Trim leading `#` from color value in `PatientTrackerService::collectApptStatusSettings()` at the service layer, so all callers benefit

Supersedes #9461 which fixed it at the view layer.

#### Does your code include anything generated by an AI Engine? No