### PR TITLE
Use constants instead of their values in module management UI

### DIFF
--- a/interface/modules/zend_modules/module/Installer/view/installer/installer/index.phtml
+++ b/interface/modules/zend_modules/module/Installer/view/installer/installer/index.phtml
@@ -162,7 +162,7 @@ $help_items = [
                         if ($moduleResult->modName == 'Acl') {
                             continue;
                         }
-                        if ($moduleResult->type == 1) {
+                        if ($moduleResult->type == ModulesApplication::MODULE_TYPE_LAMINAS) {
                             continue;
                         }
                         $count++;
@@ -201,7 +201,7 @@ $help_items = [
                                 ?>
                             </td>
                             <td>
-                                <?php echo $this->escapeHtml(($moduleResult->type == 1) ? "Laminas" : "Custom"); ?>
+                                <?php echo $this->escapeHtml(($moduleResult->type == ModulesApplication::MODULE_TYPE_LAMINAS) ? "Laminas" : "Custom"); ?>
                             </td>
                             <td>
                                 <?php
@@ -235,10 +235,10 @@ $help_items = [
                                     <a href="javascript:void(0)" class="link_submit active" onclick="manage('<?php echo $this->escapeHtml($moduleResult->modId) ?>','reset_module');" title="<?php echo $listener->z_xla('Click Here to Reset this Module to the initial unregistered and uninstalled state.'); ?>"><i class="fa fa-registered text-warning fa-1x" aria-hidden="true"></i></a>
                                 <?php } elseif ($moduleResult->modActive == 1) { ?>
                                     <a href="javascript:void(0)" class="link_submit active" onclick="configure('<?php echo $this->escapeHtml($moduleResult->modId) ?>','<?php echo $this->basePath() ?>');" title="<?php echo $listener->z_xla('Click Here to Configure This module'); ?>"><i class="fa fa-cog fa-1x <?php echo $moduleResult->modUiActive == 1 ? ' fa-spin text-danger' : 'text-dark'; ?>"></i></a>
-                                    <?php if ($moduleResult->modUiActive == 1 && $moduleResult->type == 0) { ?>
+                                    <?php if ($moduleResult->modUiActive == 1 && $moduleResult->type == ModulesApplication::MODULE_TYPE_CUSTOM) { ?>
                                         <a href="javascript:void(0)" class="link_submit active" onclick="manage('<?php echo $this->escapeHtml($moduleResult->modId) ?>','unregister');" title="<?php echo $listener->z_xla('Click Here to UnRegister this Module. All database information is left intact except this module registration entry is removed from database.'); ?>"><i class="fa fa-trash text-warning fa-1x" aria-hidden="true"></i></a>
                                     <?php } ?>
-                                <?php } elseif ($moduleResult->modActive == 0 && $moduleResult->type == 0) { ?>
+                                <?php } elseif ($moduleResult->modActive == 0 && $moduleResult->type == ModulesApplication::MODULE_TYPE_CUSTOM) { ?>
                                     <?php if ($moduleResult->modUiActive == 1) {
                                         // only allow if module requests by setting the mod_ui_active column
                                         // because module will have to deal with namespace setting for called config script.
@@ -288,7 +288,7 @@ $help_items = [
                         if ($moduleResult->modName == 'Acl') {
                             continue;
                         }
-                        if ($moduleResult->type == 0) {
+                        if ($moduleResult->type == ModulesApplication::MODULE_TYPE_CUSTOM) {
                             continue;
                         }
                         $count++;
@@ -327,7 +327,7 @@ $help_items = [
                                 ?>
                             </td>
                             <td>
-                                <?php echo $this->escapeHtml(($moduleResult->type == 1) ? "Laminas" : "Custom"); ?>
+                                <?php echo $this->escapeHtml(($moduleResult->type == ModulesApplication::MODULE_TYPE_LAMINAS) ? "Laminas" : "Custom"); ?>
                             </td>
                             <td>
                                 <?php


### PR DESCRIPTION
Fixes #9587

#### Short description of what this resolves:
Changes some conditionals in the modules management UI to reference constants instead of their backing values

#### Changes proposed in this pull request:
No logic changes, this only improves readability.

I'd be open to additional refactoring in here (I came across it while starting development of a new module) but this seems like it should be relatively non-controversial.

#### Does your code include anything generated by an AI Engine? Yes / No
No

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.
