### PR TITLE
PHPStan - Added rule directory to scanDirectories

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -38,5 +38,6 @@ parameters:
   - version.php
   scanDirectories:
   - ./vendor
+  - ./.phpstan
   scanFiles:
   - library/sql.inc.php


### PR DESCRIPTION
Fixes https://github.com/openemr/openemr/issues/9604

#### Short description of what this resolves:

Fixes cause of warning:

```
Result cache might not behave correctly.
You're using custom extension in your project config
but this extension is not part of analysed paths:

- OpenEMR\PHPStan\Rules\ForbiddenGlobalsAccessRule

When you edit them and re-run PHPStan, the result cache will get stale.
Add this directory to your analysed paths to get rid of this problem:

- .phpstan
```

# How I ensured this fixes issue

- Added dummy change at `ForbiddenGlobalsAccessRule`
```php
        if (false) {
            return [];
        }
```
- Executed `vendor/bin/phpstan --memory-limit=8G analyze` 3 times and ensured each time I had that warning
- Added change from this PR
- Executed `vendor/bin/phpstan --memory-limit=8G analyze` few times more and ensured each time I had that NO warning
- Removed fix and changed `ForbiddenGlobalsAccessRule` file again
- Executed `vendor/bin/phpstan --memory-limit=8G analyze` one more time and ensured I see warning again