### PR TITLE
chore: backport to rel-704: Fix PHP 8.0+ warnings for undefined Smarty variables in prescription lookup (#9517)

### DIFF
--- a/templates/prescription/general_lookup.html
+++ b/templates/prescription/general_lookup.html
@@ -27,7 +27,7 @@
 <div style="width:100%;height:100%;border:0;" class="drug_lookup" id="newlistitem">
 	<form class="form-inline" NAME="lookup" ACTION="{$FORM_ACTION}" METHOD="POST" onsubmit="return top.restoreSession()" style="margin:0px">
 
-	{if $drug_options}
+	{if isset($drug_options) && $drug_options}
         <div>
         {html_options name="drug" class="form-control" values=$drug_values options=$drug_options}<br/>
         </div>
@@ -37,7 +37,7 @@
             <a href="{$CONTROLLER_THIS}" onclick="top.restoreSession()">{xlt t='New Search'}</a>
         </div>
 	{else}
-		{$NO_RESULTS|text}
+		{if isset($NO_RESULTS)}{$NO_RESULTS|text}{else}{xlt t='No results'}{/if}
 
 		<input TYPE="HIDDEN" NAME="varname" VALUE=""/>
 		<input TYPE="HIDDEN" NAME="formname" VALUE=""/>


### PR DESCRIPTION
fixes: #9592