### PR TITLE
chore: backport to rel-704: Fix undefined array key 'site_id' in authCloseSession() (#9522)

### DIFF
--- a/library/auth.inc.php
+++ b/library/auth.inc.php
@@ -128,7 +128,7 @@ function authCloseSession(): void
   // Before destroying the session, save its site_id so that the next
   // login will default to that same site.
     global $incoming_site_id;
-    $incoming_site_id = $_SESSION['site_id'];
+    $incoming_site_id = $_SESSION['site_id'] ?? '';
     SessionUtil::coreSessionDestroy();
 }
 


### PR DESCRIPTION
fixes: #9593