### PR TITLE
chore: backport to rel-704: Fix undefined array key warnings in CAMOS form POST handling (#9523)

### DIFF
--- a/interface/forms/CAMOS/new.php
+++ b/interface/forms/CAMOS/new.php
@@ -42,9 +42,6 @@ $textarea_cols = 80;
 $debug = '';
 $error = '';
 
-$preselect_category = '';
-$preselect_subcategory = '';
-$preselect_item = '';
 $preselect_category_override = '';
 $preselect_subcategory_override = '';
 $preselect_item_override = '';
@@ -57,17 +54,9 @@ $category = str_replace($quote_search, $quote_replace, $_POST['change_category']
 $subcategory = str_replace($quote_search, $quote_replace, $_POST['change_subcategory'] ?? '');
 $item = str_replace($quote_search, $quote_replace, $_POST['change_item'] ?? '');
 $content = str_replace($quote_search_content, $quote_replace_content, $_POST['textarea_content'] ?? '');
-if ($_POST['hidden_category']) {
-    $preselect_category = $_POST['hidden_category'];
-}
-
-if ($_POST['hidden_subcategory']) {
-    $preselect_subcategory = $_POST['hidden_subcategory'];
-}
-
-if ($_POST['hidden_item']) {
-    $preselect_item = $_POST['hidden_item'];
-}
+$preselect_category = $_POST['hidden_category'] ?? '';
+$preselect_subcategory = $_POST['hidden_subcategory'] ?? '';
+$preselect_item = $_POST['hidden_item'] ?? '';
 
 //handle changes to database
 if (str_starts_with($_POST['hidden_mode'] ?? '', 'add')) {


### PR DESCRIPTION
fixes: #9598