### PR TITLE
chore: backport to rel-704: Refactor RxList::parseToTokens() to use preg_split and fix PHP 8.x warnings (#9525)

### DIFF
--- a/src/Rx/RxList.php
+++ b/src/Rx/RxList.php
@@ -75,7 +75,7 @@ class RxList
     public function getList($query)
     {
         $page = $this->getPage($query);
-        $tokens = $this->parseToTokens($page);
+        $tokens = $this->parseToTokens($page ?: '');
         $hash = $this->tokensToHash($tokens);
         if (!empty($hash)) {
             foreach ($hash as $data) {
@@ -102,40 +102,20 @@ class RxList
         return $list;
     }
 
-    /* break the web page into a collection of TAGS
-     * such as <input ..> or <img ... >
+    /**
+     * Parse HTML/XML content into tokens by splitting on tags
+     *
+     * Splits the input string into an array of tokens, where each token is either
+     * a tag (e.g., "<name>", "</name>") or content between tags.
+     *
+     * @param string $page The HTML/XML content to parse
+     * @return array Array of tokens (tags and content)
      */
-    public function parseToTokens($page)
+    protected function parseToTokens(string $page): array
     {
-        $pos = 0;
-        $token = 0;
-        $in_token = false;
-        while ($pos < strlen((string) $page)) {
-            switch (substr((string) $page, $pos, 1)) {
-                case "<":
-                    if ($in_token) {
-                        $token++;
-                        $in_token = false;
-                    }
-
-                    $tokens[$token] .= substr((string) $page, $pos, 1);
-                    $in_token = true;
-                    break;
-
-                case ">":
-                    $tokens[$token] .= substr((string) $page, $pos, 1);
-                    $in_token = false;
-                    $token++;
-                    break;
-
-                default:
-                    $tokens[$token] .= substr((string) $page, $pos, 1);
-                    $in_token = false;
-                    break;
-            }
-            $pos++;
-        }
-        return $tokens;
+        return array_values(array_filter(
+            preg_split('/(<[^>]*>)/', $page, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY)
+        ));
     }
 
     public function tokensToHash($tokens)
@@ -177,9 +157,9 @@ class RxList
                 $ending = "";
             }
 
-            if ($pos === ($record + 1) and ($ending != "")) {
+            if ($pos === ($record + 1) && ($ending !== "")) {
                 $my_pos = stripos((string) $tokens[$pos], "<");
-                $hash[$type] = substr((string) $tokens[$pos], 0, $my_pos);
+                $hash[$type] = $my_pos !== false ? substr((string) $tokens[$pos], 0, $my_pos) : $tokens[$pos];
                 $hash[$type] = str_replace("&amp;", "&", $hash[$type]);
                 //print "hash[$type] = ".htmlentities($hash[$type])."<BR>\n";
                 $type = "";

--- a/tests/Tests/Unit/Rx/RxListTest.php
+++ b/tests/Tests/Unit/Rx/RxListTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * RxListTest.php
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    GitHub Copilot <copilot@github.com>
+ * @copyright Copyright (c) 2025 GitHub Copilot <copilot@github.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+// Start of AI-generated code by GitHub Copilot
+namespace OpenEMR\Tests\Unit\Rx;
+
+use OpenEMR\Rx\RxList;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class RxListTest extends TestCase
+{
+    /**
+     * Helper method to access protected parseToTokens method
+     */
+    private function invokeParseToTokens(RxList $rxList, string $page): array
+    {
+        $reflection = new ReflectionClass($rxList);
+        $method = $reflection->getMethod('parseToTokens');
+        return $method->invoke($rxList, $page);
+    }
+
+    /**
+     * Test that parseToTokens properly splits content by tags
+     */
+    public function testParseToTokensSplitsByTags(): void
+    {
+        $rxList = new RxList();
+
+        // Test with XML-like content
+        $page = '<name>Aspirin</name><rxcui>1191</rxcui>';
+        $result = $this->invokeParseToTokens($rxList, $page);
+
+        // Should return an array
+        $this->assertIsArray($result);
+
+        // Should have parsed the content into tokens (tags and content separated)
+        $this->assertNotEmpty($result);
+        $this->assertCount(6, $result);
+
+        // Verify token content - tags and content are now separated
+        $this->assertEquals('<name>', $result[0]);
+        $this->assertEquals('Aspirin', $result[1]);
+        $this->assertEquals('</name>', $result[2]);
+        $this->assertEquals('<rxcui>', $result[3]);
+        $this->assertEquals('1191', $result[4]);
+        $this->assertEquals('</rxcui>', $result[5]);
+    }
+
+    /**
+     * Test parseToTokens with empty string
+     */
+    public function testParseToTokensWithEmptyString(): void
+    {
+        $rxList = new RxList();
+        $result = $this->invokeParseToTokens($rxList, '');
+
+        $this->assertIsArray($result);
+        $this->assertEmpty($result);
+    }
+
+    /**
+     * Test parseToTokens with plain text (no tags)
+     */
+    public function testParseToTokensWithPlainText(): void
+    {
+        $rxList = new RxList();
+        $result = $this->invokeParseToTokens($rxList, 'plain text');
+
+        $this->assertIsArray($result);
+        $this->assertCount(1, $result);
+        $this->assertEquals('plain text', $result[0]);
+    }
+
+    /**
+     * Test parseToTokens with multiple tags
+     */
+    public function testParseToTokensWithMultipleTags(): void
+    {
+        $rxList = new RxList();
+        $page = '<name>Drug A</name><synonym>Generic A</synonym><rxcui>12345</rxcui>';
+        $result = $this->invokeParseToTokens($rxList, $page);
+
+        $this->assertIsArray($result);
+        $this->assertNotEmpty($result);
+
+        // Should have tokens for each tag and content
+        $this->assertContains('<name>', $result);
+        $this->assertContains('</name>', $result);
+        $this->assertContains('<synonym>', $result);
+        $this->assertContains('</synonym>', $result);
+        $this->assertContains('<rxcui>', $result);
+        $this->assertContains('</rxcui>', $result);
+    }
+
+    /**
+     * Test that tokensToHash works correctly with the new tokenization
+     */
+    public function testTokensToHashIntegration(): void
+    {
+        $rxList = new RxList();
+        $page = '<name>Aspirin</name><synonym>Acetylsalicylic acid</synonym><rxcui>1191</rxcui>';
+        $tokens = $this->invokeParseToTokens($rxList, $page);
+        $hash = $rxList->tokensToHash($tokens);
+
+        $this->assertIsArray($hash);
+        $this->assertCount(1, $hash);
+        $this->assertEquals('Aspirin', $hash[0]['name']);
+        $this->assertEquals('Acetylsalicylic acid', $hash[0]['synonym']);
+    }
+}
+// End of AI-generated code by GitHub Copilot


### PR DESCRIPTION
fixes: #9600