### PR TITLE
Adjust styling to provide clearer row separation

### DIFF
--- a/interface/super/edit_globals.php
+++ b/interface/super/edit_globals.php
@@ -351,6 +351,10 @@ function checkBackgroundServices(): void
           width: 100%;
         }
       }
+
+      .striped .row.form-group:nth-child(even) {
+        background: var(--light);
+      }
     </style>
     <?php
     $heading_title = ($userMode) ? xl("Edit User Settings") : xl("Edit Configuration");
@@ -431,7 +435,7 @@ function checkBackgroundServices(): void
                                     if (!$userMode || in_array($grpname, $USER_SPECIFIC_TABS)) {
                                         echo " <div class='tab w-100 h-auto" . ($i ? "" : " current") . "' style='font-size: 0.9rem'>\n";
 
-                                        echo "<div class=''>";
+                                        echo '<div class="striped">';
                                         $addendum = $grpname == 'Appearance' ? ' (*' . xl("need to logout/login after changing these settings") . ')' : '';
                                         echo "<div class='col-sm-12 oe-global-tab-heading'><div class='oe-pull-toward' style='font-size: 1.4rem'>" . xlt($grpname) . " &nbsp;</div><div style='margin-top: 5px'>" . text($addendum) . "</div></div>";
                                         echo "<div class='clearfix'></div>";


### PR DESCRIPTION
Fixes #9675 

#### Short description of what this resolves:

Adds a background to every other row in the settings UIs (Admin>Config and (User Icon)>Settings) to make it clearer which label goes with which control.

#### Changes proposed in this pull request:

Small style adjustment with a CSS class to opt-in to the design change. That class has been applied to the config pages. Nothing else _should_ be affected.

To minimize the changes here, I've reused the existing `--light` CSS variable, which seems to produce the intended behavior across all packaged themes.

Note that there are `table table-striped` classes that seem to be supported by the existing stylesheets, but they're scoped to actual `<table>` elements, and the config forms are `<div>`-based.

#### Does your code include anything generated by an AI Engine? Yes / No
No
