### PR TITLE
Deps - Upgraded particle/validator (2.3.5 > 2.3.6)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
         "nyholm/psr7-server": "1.1.0",
         "omnipay/stripe": "3.2.0",
         "openemr/mustache": "2.15.2",
-        "particle/validator": "2.3.5",
+        "particle/validator": "^2.3.6",
         "pear/archive_tar": "1.6.0",
         "php-http/discovery": "1.20.0",
         "php-http/message": "^1.16",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "917d58845bd25588958edb42fd08c438",
+    "content-hash": "a44aa32db6a2864b55de24c08691fd87",
     "packages": [
         {
             "name": "academe/authorizenet-objects",
@@ -5870,16 +5870,16 @@
         },
         {
             "name": "particle/validator",
-            "version": "v2.3.5",
+            "version": "v2.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/particle-php/Validator.git",
-                "reference": "aab07e734bc40e8777fb4a1f9d9037dc11fb60b6"
+                "reference": "8a1677866a4e7ab448b969539a94601a7b00b279"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/particle-php/Validator/zipball/aab07e734bc40e8777fb4a1f9d9037dc11fb60b6",
-                "reference": "aab07e734bc40e8777fb4a1f9d9037dc11fb60b6",
+                "url": "https://api.github.com/repos/particle-php/Validator/zipball/8a1677866a4e7ab448b969539a94601a7b00b279",
+                "reference": "8a1677866a4e7ab448b969539a94601a7b00b279",
                 "shasum": ""
             },
             "require": {
@@ -5930,9 +5930,9 @@
             ],
             "support": {
                 "issues": "https://github.com/particle-php/Validator/issues",
-                "source": "https://github.com/particle-php/Validator/tree/v2.3.5"
+                "source": "https://github.com/particle-php/Validator/tree/v2.3.6"
             },
-            "time": "2022-12-12T19:35:42+00:00"
+            "time": "2025-12-09T13:33:27+00:00"
         },
         {
             "name": "pear/archive_tar",


### PR DESCRIPTION
Fixes: https://github.com/openemr/openemr/issues/9415
Partially fixes: https://github.com/openemr/openemr/issues/8134

Before:
```bash
/var/www/localhost/htdocs/openemr # vendor/bin/phpunit -c phpunit-isolated.xml --filter=BaseValidatorTest
PHPUnit 11.5.41 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.11
Configuration: /var/www/localhost/htdocs/openemr/phpunit-isolated.xml

D..................                                               19 / 19 (100%)

Time: 00:00.121, Memory: 18.00 MB

1 test triggered 1 PHP deprecation:

1) /var/www/localhost/htdocs/openemr/vendor/particle/validator/src/Validator.php:115
Particle\Validator\Validator::copyContext(): Implicitly marking parameter $callback as nullable is deprecated, the explicit nullable type must be used instead

Triggered by:

* OpenEMR\Tests\Isolated\Validators\BaseValidatorTest::testValidatorConstants
  /var/www/localhost/htdocs/openemr/tests/Tests/Isolated/Validators/BaseValidatorTest.php:31
```

After:

```bash
/var/www/localhost/htdocs/openemr # vendor/bin/phpunit -c phpunit-isolated.xml --filter=BaseValidatorTest
PHPUnit 11.5.43 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.11
Configuration: /var/www/localhost/htdocs/openemr/phpunit-isolated.xml

...................                                               19 / 19 (100%)

Time: 00:00.089, Memory: 18.00 MB

OK (19 tests, 33 assertions)
```