### PR TITLE
Deps - Upgrade zircote/swagger-php (v3 > v5)

### DIFF
--- a/_rest_routes.inc.php
+++ b/_rest_routes.inc.php
@@ -20,6 +20,7 @@
  */
 
 use OpenEMR\RestControllers\Config\RestConfig;
+use OpenApi\Annotations as OA;
 
 /**
  *  @OA\Info(title="OpenEMR API", version="8.0.0")

--- a/apis/routes/_rest_routes_fhir_r4_us_core_3_1_0.inc.php
+++ b/apis/routes/_rest_routes_fhir_r4_us_core_3_1_0.inc.php
@@ -18,6 +18,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+use OpenApi\Annotations as OA;
 use OpenEMR\Common\Http\HttpRestRequest;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\RestControllers\Config\RestConfig;

--- a/apis/routes/_rest_routes_portal.inc.php
+++ b/apis/routes/_rest_routes_portal.inc.php
@@ -22,6 +22,7 @@ use OpenEMR\RestControllers\PatientRestController;
 use OpenEMR\RestControllers\EncounterRestController;
 use OpenEMR\RestControllers\AppointmentRestController;
 use OpenEMR\Common\Http\HttpRestRequest;
+use OpenApi\Annotations as OA;
 
 // Note that the portal (api) route is only for patient role
 //  (there is a mechanism in place to ensure only patient role can access the portal (api) route)

--- a/apis/routes/_rest_routes_standard.inc.php
+++ b/apis/routes/_rest_routes_standard.inc.php
@@ -45,6 +45,7 @@ use OpenEMR\RestControllers\VersionRestController;
 use OpenEMR\Services\Search\SearchQueryConfig;
 // TODO: Remove this import when the OpenEMR\RestControllers\Config\RestConfig is no longer needed
 use OpenEMR\RestControllers\Config\RestConfig;
+use OpenApi\Annotations as OA;
 
 return [
     /**

--- a/composer.lock
+++ b/composer.lock
@@ -14974,5 +14974,5 @@
         "ext-zlib": "8.2",
         "php": "8.2"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/docker/development-easy/docker-compose.yml
+++ b/docker/development-easy/docker-compose.yml
@@ -31,13 +31,13 @@ services:
     - 8300:80
     - 9300:443
     volumes:
-    - ../..:/openemr:ro
+    - ../..:/openemr:rw
     - ../..:/var/www/localhost/htdocs/openemr:rw
     - assetvolume:/var/www/localhost/htdocs/openemr/public/assets:rw
     - themevolume:/var/www/localhost/htdocs/openemr/public/themes:rw
     - sitesvolume:/var/www/localhost/htdocs/openemr/sites:rw
     - nodemodules:/var/www/localhost/htdocs/openemr/node_modules:rw
-    - vendordir:/var/www/localhost/htdocs/openemr/vendor:rw
+    #- vendordir:/var/www/localhost/htdocs/openemr/vendor:rw
     - ccdanodemodules:/var/www/localhost/htdocs/openemr/ccdaservice/node_modules:rw
     - logvolume:/var/log
     - couchdbvolume:/couchdb/data
@@ -186,7 +186,7 @@ volumes:
   themevolume: {}
   sitesvolume: {}
   nodemodules: {}
-  vendordir: {}
+#  vendordir: {}
   ccdanodemodules: {}
   logvolume: {}
   couchdbvolume: {}

--- a/src/Common/Command/CreateAPIDocumentationCommand.php
+++ b/src/Common/Command/CreateAPIDocumentationCommand.php
@@ -38,7 +38,13 @@ class CreateAPIDocumentationCommand extends Command
             ->addUsage('--site=default')
             ->setDefinition(
                 new InputDefinition([
-                    new InputOption('site', null, InputOption::VALUE_REQUIRED, 'Name of site', 'default'),
+                    new InputOption(
+                        'site',
+                        null,
+                        InputOption::VALUE_REQUIRED,
+                        'Name of site',
+                        'default'
+                    ),
                 ])
             )
         ;

--- a/src/Common/Command/CreateAPIDocumentationCommand.php
+++ b/src/Common/Command/CreateAPIDocumentationCommand.php
@@ -10,6 +10,7 @@
 
 namespace OpenEMR\Common\Command;
 
+use OpenEMR\Core\OEGlobalsBag;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
@@ -20,6 +21,15 @@ use Symfony\Component\Yaml\Yaml;
 
 class CreateAPIDocumentationCommand extends Command
 {
+    private readonly string $fileroot;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->fileroot = OEGlobalsBag::getInstance()->getString('fileroot');
+    }
+
     protected function configure(): void
     {
         $this

--- a/src/Common/Command/CreateAPIDocumentationCommand.php
+++ b/src/Common/Command/CreateAPIDocumentationCommand.php
@@ -21,7 +21,7 @@ use Symfony\Component\Yaml\Yaml;
 
 class CreateAPIDocumentationCommand extends Command
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('openemr:create-api-documentation')

--- a/src/Common/Command/CreateAPIDocumentationCommand.php
+++ b/src/Common/Command/CreateAPIDocumentationCommand.php
@@ -82,11 +82,17 @@ class CreateAPIDocumentationCommand extends Command
         );
 
         if ($resultYaml === false) {
-            $output->writeln("No write access to " . $fileDestinationYaml);
+            $output->writeln(sprintf(
+                'No write access to %s',
+                $fileDestinationYaml,
+            ));
             return Command::FAILURE;
         }
 
-        $output->writeln("API file generated at " . $fileDestinationYaml);
+        $output->writeln(sprintf(
+            'API file generated at %s',
+            $fileDestinationYaml,
+        ));
         $output->writeln("Your API documentation can now be viewed by going to <webroot>/swagger/");
         $output->writeln("For example on the easy docker installation this would be https://localhost:9300/swagger/");
 

--- a/src/Common/Command/CreateAPIDocumentationCommand.php
+++ b/src/Common/Command/CreateAPIDocumentationCommand.php
@@ -93,8 +93,8 @@ class CreateAPIDocumentationCommand extends Command
             'API file generated at %s',
             $fileDestinationYaml,
         ));
-        $output->writeln("Your API documentation can now be viewed by going to <webroot>/swagger/");
-        $output->writeln("For example on the easy docker installation this would be https://localhost:9300/swagger/");
+        $output->writeln('Your API documentation can now be viewed by going to <webroot>/swagger/');
+        $output->writeln('For example on the easy docker installation this would be https://localhost:9300/swagger/');
 
         return Command::SUCCESS;
     }

--- a/src/Common/Command/CreateAPIDocumentationCommand.php
+++ b/src/Common/Command/CreateAPIDocumentationCommand.php
@@ -1,8 +1,7 @@
 <?php
 
 /**
- * CreateAPIDocumentation.php
- * @package openemr
+ * @package   openemr
  * @link      http://www.open-emr.org
  * @author    Stephen Nielson <stephen@nielson.org>
  * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>

--- a/src/Common/Command/CreateAPIDocumentationCommand.php
+++ b/src/Common/Command/CreateAPIDocumentationCommand.php
@@ -31,7 +31,8 @@ class CreateAPIDocumentationCommand extends Command
                 new InputDefinition([
                     new InputOption('site', null, InputOption::VALUE_REQUIRED, 'Name of site', 'default'),
                 ])
-            );
+            )
+        ;
     }
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/src/Common/Command/CreateAPIDocumentationCommand.php
+++ b/src/Common/Command/CreateAPIDocumentationCommand.php
@@ -39,9 +39,9 @@ class CreateAPIDocumentationCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $routesLocation = $this->fileroot . DIRECTORY_SEPARATOR . "_rest_routes.inc.php";
-        $fileDestinationFolder = $this->fileroot . DIRECTORY_SEPARATOR . "swagger" . DIRECTORY_SEPARATOR;
-        $fileDestinationYaml =  $fileDestinationFolder . "openemr-api.yaml";
+        $routesLocation = $this->fileroot . DIRECTORY_SEPARATOR . '_rest_routes.inc.php';
+        $fileDestinationFolder = $this->fileroot . DIRECTORY_SEPARATOR . 'swagger' . DIRECTORY_SEPARATOR;
+        $fileDestinationYaml =  $fileDestinationFolder . 'openemr-api.yaml';
 
         $finder = new Finder();
         $finder

--- a/src/Common/Command/CreateAPIDocumentationCommand.php
+++ b/src/Common/Command/CreateAPIDocumentationCommand.php
@@ -10,6 +10,7 @@
 
 namespace OpenEMR\Common\Command;
 
+use OpenApi\Generator as OpenApiGenerator;
 use OpenEMR\Core\OEGlobalsBag;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -48,10 +49,10 @@ class CreateAPIDocumentationCommand extends Command
             ->name('*.php')
         ;
 
-        $openapi = \OpenApi\Generator::scan([
-            $routesLocation
-            ,$finder
-        ]);
+        $openapi = OpenApiGenerator::scan(array_merge(
+            [$routesLocation],
+            iterator_to_array($finder->getIterator()),
+        ));
 
         // To have smaller diffs - we force stable order here
         $data = json_decode($openapi->toJson(), true);

--- a/src/Common/Command/CreateAPIDocumentationCommand.php
+++ b/src/Common/Command/CreateAPIDocumentationCommand.php
@@ -33,6 +33,7 @@ class CreateAPIDocumentationCommand extends Command
             )
         ;
     }
+
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $routesLocation = $GLOBALS['fileroot'] . DIRECTORY_SEPARATOR . "_rest_routes.inc.php";

--- a/src/Common/Command/CreateAPIDocumentationCommand.php
+++ b/src/Common/Command/CreateAPIDocumentationCommand.php
@@ -84,11 +84,12 @@ class CreateAPIDocumentationCommand extends Command
         if ($resultYaml === false) {
             $output->writeln("No write access to " . $fileDestinationYaml);
             return Command::FAILURE;
-        } else {
-            $output->writeln("API file generated at " . $fileDestinationYaml);
-            $output->writeln("Your API documentation can now be viewed by going to <webroot>/swagger/");
-            $output->writeln("For example on the easy docker installation this would be https://localhost:9300/swagger/");
-            return Command::SUCCESS;
         }
+
+        $output->writeln("API file generated at " . $fileDestinationYaml);
+        $output->writeln("Your API documentation can now be viewed by going to <webroot>/swagger/");
+        $output->writeln("For example on the easy docker installation this would be https://localhost:9300/swagger/");
+
+        return Command::SUCCESS;
     }
 }

--- a/src/Common/Command/CreateAPIDocumentationCommand.php
+++ b/src/Common/Command/CreateAPIDocumentationCommand.php
@@ -38,13 +38,16 @@ class CreateAPIDocumentationCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $routesLocation = $GLOBALS['fileroot'] . DIRECTORY_SEPARATOR . "_rest_routes.inc.php";
-        $fileDestinationFolder = $GLOBALS['fileroot'] . DIRECTORY_SEPARATOR . "swagger" . DIRECTORY_SEPARATOR;
+        $routesLocation = $this->fileroot . DIRECTORY_SEPARATOR . "_rest_routes.inc.php";
+        $fileDestinationFolder = $this->fileroot . DIRECTORY_SEPARATOR . "swagger" . DIRECTORY_SEPARATOR;
         $fileDestinationYaml =  $fileDestinationFolder . "openemr-api.yaml";
 
         $finder = new Finder();
-        $finder->in($GLOBALS['fileroot'] . '/apis/routes')
-            ->name('*.php');
+        $finder
+            ->in($this->fileroot . '/apis/routes')
+            ->name('*.php')
+        ;
+
         $openapi = \OpenApi\Generator::scan([
             $routesLocation
             ,$finder

--- a/src/Common/Command/CreateAPIDocumentationCommand.php
+++ b/src/Common/Command/CreateAPIDocumentationCommand.php
@@ -12,9 +12,7 @@ namespace OpenEMR\Common\Command;
 
 use OpenEMR\Core\OEGlobalsBag;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Yaml\Yaml;
@@ -35,18 +33,6 @@ class CreateAPIDocumentationCommand extends Command
         $this
             ->setName('openemr:create-api-documentation')
             ->setDescription("Generates an OpenAPI swagger file that documents the OpenEMR API")
-            ->addUsage('--site=default')
-            ->setDefinition(
-                new InputDefinition([
-                    new InputOption(
-                        'site',
-                        null,
-                        InputOption::VALUE_REQUIRED,
-                        'Name of site',
-                        'default'
-                    ),
-                ])
-            )
         ;
     }
 
@@ -55,7 +41,6 @@ class CreateAPIDocumentationCommand extends Command
         $routesLocation = $GLOBALS['fileroot'] . DIRECTORY_SEPARATOR . "_rest_routes.inc.php";
         $fileDestinationFolder = $GLOBALS['fileroot'] . DIRECTORY_SEPARATOR . "swagger" . DIRECTORY_SEPARATOR;
         $fileDestinationYaml =  $fileDestinationFolder . "openemr-api.yaml";
-        $site = $input->getOption('site') ?? 'default';
 
         $finder = new Finder();
         $finder->in($GLOBALS['fileroot'] . '/apis/routes')

--- a/src/Rest/ExampleController.php
+++ b/src/Rest/ExampleController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace OpenEMR\Rest;
+
+use OpenApi\Annotations as OA;
+
+class ExampleController
+{
+    /**
+     * @OA\Get(
+     *     path="/hello",
+     *     summary="Returns a greeting",
+     *     @OA\Response(
+     *         response=200,
+     *         description="Successful response",
+     *         @OA\JsonContent(
+     *             type="object",
+     *             @OA\Property(property="message", type="string", example="Hello, world!")
+     *         )
+     *     )
+     * )
+     */
+    public function hello()
+    {
+        return ['message' => 'Hello, world!'];
+    }
+}

--- a/swagger/openapi.php
+++ b/swagger/openapi.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+    // Directories or files to scan
+    'paths' => [
+        __DIR__ . '/_rest_routes.inc.php',
+        __DIR__ . '/apis/routes',
+    ],
+
+    // Output format: json (default) or yaml
+    'output' => [
+        'format' => 'yaml',
+    ],
+
+    // where to save output when using --config mode
+    'destination' => __DIR__ . '/swagger/openemr-api.yaml',
+
+    // optional: enable warnings
+    'analysis' => [
+        'validate' => true,
+    ],
+];


### PR DESCRIPTION
Partially fixes: https://github.com/openemr/openemr/issues/8134
Blocker: https://github.com/openemr/openemr/issues/9738

Draft reason: New version of `zircote/swagger-php` (which fixes deprecation warnings, no matter which one - v4 or v5) outputs empty file, as no longer support orphan definitions and only supports definitions attached to some classes.

Read more:
- https://zircote.github.io/swagger-php/guide/migrating-to-v4.html
- https://zircote.github.io/swagger-php/guide/migrating-to-v5.html