### PR TITLE
fix: update erx_newcrop_path to ux2 URL

### DIFF
--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -3470,14 +3470,13 @@ $GLOBALS_METADATA = [
             xl('Enable NewCrop eRx Service'),
             'bool',
             '0',
-            xl('Enable NewCrop eRx Service.') . ' ' .
-            xl('Contact mi-squared at http://www.mi-squared.com/products-services/openemr/ or ZH Healthcare at https://blueehr.com/contact-us/ for subscribing to the NewCrop eRx service.')
+            xl('Enable NewCrop eRx Service.')
         ],
 
         'erx_newcrop_path' => [
             xl('NewCrop eRx Site Address'),
             'text',
-            'https://secure.newcropaccounts.com/InterfaceV7/RxEntry.aspx',
+            'https://secure.newcropaccounts.com/ux2/InterfaceV7/RxEntry.aspx',
             xl('URL for NewCrop eRx Site Address.')
         ],
 


### PR DESCRIPTION
This is the current correct URL per Cameron at NewCrop/Ensora

Fixes  https://github.com/openemr/openemr/issues/9745

#### Short description of what this resolves:
  - Update the default value for `erx_newcrop_path` in `library/globals.inc.php`
  - Cleanup text.

#### Does your code include anything generated by an AI Engine? No
