### PR TITLE
chore(deps-dev): bump the development group with 3 updates (#9708)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5390,16 +5390,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.6.2",
+            "version": "v5.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "3a454ca033b9e06b63282ce19562e892747449bb"
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/3a454ca033b9e06b63282ce19562e892747449bb",
-                "reference": "3a454ca033b9e06b63282ce19562e892747449bb",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
                 "shasum": ""
             },
             "require": {
@@ -5442,9 +5442,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.2"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
             },
-            "time": "2025-10-21T19:32:17+00:00"
+            "time": "2025-12-06T11:56:16+00:00"
         },
         {
             "name": "nyholm/psr7",
@@ -12722,11 +12722,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.31",
+            "version": "2.1.33",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ead89849d879fe203ce9292c6ef5e7e76f867b96",
-                "reference": "ead89849d879fe203ce9292c6ef5e7e76f867b96",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9e800e6bee7d5bd02784d4c6069b48032d16224f",
+                "reference": "9e800e6bee7d5bd02784d4c6069b48032d16224f",
                 "shasum": ""
             },
             "require": {
@@ -12771,25 +12771,25 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-10-10T14:14:11+00:00"
+            "time": "2025-12-05T10:24:31+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
-            "version": "2.0.7",
+            "version": "2.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-phpunit.git",
-                "reference": "9a9b161baee88a5f5c58d816943cff354ff233dc"
+                "reference": "8d61a5854e7497d95bc85188e13537e99bd7aae7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/9a9b161baee88a5f5c58d816943cff354ff233dc",
-                "reference": "9a9b161baee88a5f5c58d816943cff354ff233dc",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/8d61a5854e7497d95bc85188e13537e99bd7aae7",
+                "reference": "8d61a5854e7497d95bc85188e13537e99bd7aae7",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0",
-                "phpstan/phpstan": "^2.1.18"
+                "phpstan/phpstan": "^2.1.32"
             },
             "conflict": {
                 "phpunit/phpunit": "<7.0"
@@ -12822,9 +12822,9 @@
             "description": "PHPUnit extensions and rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-phpunit/issues",
-                "source": "https://github.com/phpstan/phpstan-phpunit/tree/2.0.7"
+                "source": "https://github.com/phpstan/phpstan-phpunit/tree/2.0.10"
             },
-            "time": "2025-07-13T11:31:46+00:00"
+            "time": "2025-12-06T11:15:39+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -13163,16 +13163,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.5.43",
+            "version": "11.5.46",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c6b89b6cf4324a8b4cb86e1f5dfdd6c9e0371924"
+                "reference": "75dfe79a2aa30085b7132bb84377c24062193f33"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c6b89b6cf4324a8b4cb86e1f5dfdd6c9e0371924",
-                "reference": "c6b89b6cf4324a8b4cb86e1f5dfdd6c9e0371924",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/75dfe79a2aa30085b7132bb84377c24062193f33",
+                "reference": "75dfe79a2aa30085b7132bb84377c24062193f33",
                 "shasum": ""
             },
             "require": {
@@ -13244,7 +13244,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.43"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.46"
             },
             "funding": [
                 {
@@ -13268,7 +13268,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-10-30T08:39:39+00:00"
+            "time": "2025-12-06T08:01:15+00:00"
         },
         {
             "name": "rector/rector",
@@ -14681,16 +14681,16 @@
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.3",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
-                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
                 "shasum": ""
             },
             "require": {
@@ -14719,7 +14719,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
             },
             "funding": [
                 {
@@ -14727,7 +14727,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-03T12:36:25+00:00"
+            "time": "2025-11-17T20:03:58+00:00"
         }
     ],
     "aliases": [],

--- a/contrib/util/billing/load_fee_schedule.php
+++ b/contrib/util/billing/load_fee_schedule.php
@@ -21,6 +21,10 @@ if (php_sapi_name() !== 'cli') {
     die;
 }
 
+if (!isset($argv[4])) {
+    throw new RuntimeException("This script requires at least 4 arguments");
+}
+
 $_GET['site'] = $argv[1];
 $ignoreAuth = true;
 require_once __DIR__ . "/../../../interface/globals.php";

--- a/contrib/util/ccda_import/import_ccda.php
+++ b/contrib/util/ccda_import/import_ccda.php
@@ -96,7 +96,7 @@ function outputMessage($message): void
 }
 
 // collect parameters (need to do before globals)
-$args = parseArgs($argv);
+$args = parseArgs($argv ?? []);
 
 // Required arguments
 $requiredArgs = ['sourcePath', 'site', 'openemrPath'];

--- a/contrib/util/chart_review_pids.php
+++ b/contrib/util/chart_review_pids.php
@@ -21,6 +21,10 @@ if (php_sapi_name() !== 'cli') {
     die;
 }
 
+if (!isset($argv[3])) {
+    throw new RuntimeException("This script requires at least three arguments.");
+}
+
 $_GET['site'] = $argv[1];
 $ignoreAuth = true;
 require_once __DIR__ . "/../../interface/globals.php";

--- a/contrib/util/installScripts/InstallerAuto.php
+++ b/contrib/util/installScripts/InstallerAuto.php
@@ -104,7 +104,9 @@ $installSettings['no_root_db_access']        = 'BLANK';
 $installSettings['development_translations'] = 'BLANK';
 
 // Collect parameters(if exist) for installation configuration settings
-for ($i = 1; $i < count($argv); $i++) {
+$argc ??= 0;
+$argv ??= [];
+for ($i = 1; $i < $argc; $i++) {
     $indexandvalue = explode("=", $argv[$i]);
     $index = $indexandvalue[0];
     $value = $indexandvalue[1];

--- a/gacl/admin/acl_admin.php
+++ b/gacl/admin/acl_admin.php
@@ -20,6 +20,11 @@ if (!AclMain::aclCheckCore('admin', 'acl')) {
 
 require_once('gacl_admin.inc.php');
 
+// Variables defined in gacl_admin.inc.php
+/** @var \OpenEMR\Gacl\GaclAdminApi $gacl_api Defined in gacl_admin.inc.php line 53 */
+/** @var \ADOConnection $db Database connection reference from $gacl_api->db, defined in gacl_admin.inc.php line 57 */
+/** @var \Smarty $smarty Smarty template engine, defined in gacl_admin.inc.php line 59 */
+
 if (!isset($_POST['action']) ) {
     $_POST['action'] = FALSE;
 }
@@ -147,7 +152,7 @@ switch ($_POST['action']) {
         }
 
         //Grab sections for select boxes
-        foreach (['acl','aco','aro','axo'] as $type) {
+        foreach (['acl', 'aco', 'aro', 'axo'] as $type) {
             $type_array = 'options_'. $type .'_sections';
             ${$type_array} = [];
 
@@ -167,6 +172,12 @@ switch ($_POST['action']) {
             ${$type .'_section_id'} = reset(${$type_array});
         }
 
+        // Variables created dynamically above (lines 155-173)
+        /** @var array<string, string> $options_acl_sections */
+        /** @var array<string, string> $options_aco_sections */
+        /** @var array<string, string> $options_aro_sections */
+        /** @var array<string, string> $options_axo_sections */
+
         //Init the main js array
         $js_array = 'var options = new Array();' . "\n";
 
@@ -182,7 +193,7 @@ switch ($_POST['action']) {
 				FROM '. $gacl_api->_db_table_prefix . $type .'
 				WHERE hidden=0
 				ORDER BY section_value,order_value,name';
-            $rs = $db->SelectLimit($query,$gacl_api->_max_select_box_items);
+            $rs = $db->SelectLimit($query, $gacl_api->_max_select_box_items);
 
             if (is_object($rs)) {
                 while ($row = $rs->FetchRow()) {

--- a/interface/main/backuplog.php
+++ b/interface/main/backuplog.php
@@ -20,6 +20,10 @@ if (php_sapi_name() !== 'cli') {
     exit;
 }
 
+if (!isset($argv[1])) {
+    throw new RuntimeException("At least one argument is required");
+}
+
 require_once("$argv[1]/library/sqlconf.php");
 $backuptime = date("Ymd_His");
 $BACKUP_EVENTLOG_DIR = $argv[2] . "/emr_eventlog_backup";

--- a/interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php
@@ -33,7 +33,9 @@ $error = '';
 $runtime = [];
 
 // Check for other arguments and perform your script logic
-if (($argc ?? null) > 1) {
+$argc ??= 0;
+$argv ??= [];
+if ($argc > 1) {
     foreach ($argv as $k => $v) {
         if ($k == 0) {
             continue;

--- a/library/allow_cronjobs.php
+++ b/library/allow_cronjobs.php
@@ -21,7 +21,7 @@ if (php_sapi_name() !== 'cli') {
  *
  * Code below translates $argv to $_REQUEST
  */
-foreach ($argv as $argk => $argval) {
+foreach (($argv ?? []) as $argk => $argval) {
     if ($argk == 0) {
         continue;
     }

--- a/library/edihistory/test_edih_sftp_files.php
+++ b/library/edihistory/test_edih_sftp_files.php
@@ -227,7 +227,7 @@ function edih_disp_sftp_upload()
 
 
 if (php_sapi_name() == 'cli') {
-    parse_str(implode('&', array_slice($argv, 1)), $_GET);
+    parse_str(implode('&', array_slice($argv ?? [], 1)), $_GET);
     $_SERVER['REQUEST_URI'] = $_SERVER['PHP_SELF'];
     $_SERVER['SERVER_NAME'] = 'localhost';
     $backpic = "";

--- a/modules/sms_email_reminder/cron_sms_notification.php
+++ b/modules/sms_email_reminder/cron_sms_notification.php
@@ -24,9 +24,9 @@ $ignoreAuth = 1;
 include_once("../../interface/globals.php");
 include_once("cron_functions.php");
 
-// check command line for quite option
+// check command line for option
 $bTestRun = 0;
-if ($argc > 1 && $argv[1] == 'test') {
+if (($argc ?? 0) > 1 && ($argv[1] ?? '') == 'test') {
     $bTestRun = 1;
 }
 


### PR DESCRIPTION
* chore(deps-dev): bump the development group with 3 updates

---
updated-dependencies:
- dependency-name: phpstan/phpstan
  dependency-version: 2.1.33
  dependency-type: direct:development
  update-type: version-update:semver-patch
  dependency-group: development
- dependency-name: phpstan/phpstan-phpunit
  dependency-version: 2.0.10
  dependency-type: direct:development
  update-type: version-update:semver-patch
  dependency-group: development
- dependency-name: phpunit/phpunit
  dependency-version: 11.5.46
  dependency-type: direct:development
  update-type: version-update:semver-patch
  dependency-group: development
...

Signed-off-by: dependabot[bot] <support@github.com>

* fix(php): phpstan requires $arg* vars to be set

* fix(gacl): tell phpstan where the vars come from

---------

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: Michael A. Smith <michael@opencoreemr.com>

---

Backport of #9708
Fixes #9795
