### PR TITLE
chore: Backport to rel-704: fix testing for property not an array (#9730)

### DIFF
--- a/portal/patient/fwk/libs/verysimple/Phreeze/Phreezable.php
+++ b/portal/patient/fwk/libs/verysimple/Phreeze/Phreezable.php
@@ -115,7 +115,7 @@ abstract class Phreezable implements Serializable
     {
         $className = static::class;
 
-        if (! property_exists(self::$PublicPropCache, $className)) {
+        if (! isset(self::$PublicPropCache[$className])) {
             $props =  [];
             $ro = new ReflectionObject($this);
 


### PR DESCRIPTION
Fixes #9842

Cherry-picked commits:

- f3aa8b39cd - fix testing for property not an array (#9730)