### PR TITLE
fix(dclint): npx hides arguments from command

### DIFF
--- a/.github/workflows/docker-compose-lint.yml
+++ b/.github/workflows/docker-compose-lint.yml
@@ -31,8 +31,6 @@ jobs:
   dclint:
     name: Docker Compose Linting
     runs-on: ubuntu-latest
-    container:
-      image: zavoloklom/dclint:3.1.0
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
@@ -69,9 +67,9 @@ jobs:
     - name: Run dclint on changed files
       if: steps.files-to-check.outputs.mode == 'files'
       run: |
-        dclint --exclude .github ${{ steps.files-to-check.outputs.files }}
+        docker run --rm --volume "$PWD:$PWD" --workdir "$PWD" zavoloklom/dclint:3.1.0 --exclude .github ${{ steps.files-to-check.outputs.files }}
     
     - name: Run dclint recursively
       if: steps.files-to-check.outputs.mode == 'recursive'
       run: |
-        dclint --exclude .github --recursive ci/ docker/
+        docker run --rm --volume "$PWD:$PWD" --workdir "$PWD" zavoloklom/dclint:3.1.0 --exclude .github --recursive ci/ docker/


### PR DESCRIPTION
Switch to docker to avoid npx entanglements.

From #9776

