### PR TITLE
chore:  Backport to rel-704 Add sent fax history to etherFAX (#9851)

### DIFF
--- a/.phpstan/phpstan-database-baseline.neon
+++ b/.phpstan/phpstan-database-baseline.neon
@@ -1802,7 +1802,7 @@ parameters:
       path: ../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php
     - message: '#^Use QueryUtils\:\:sqlInsert\(\) instead of sqlInsert\(\)\.$#'
       identifier: openemr.deprecatedSqlFunction
-      count: 1
+      count: 2
       path: ../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php
     - message: '#^Use QueryUtils\:\:sqlStatementThrowException\(\) or QueryUtils\:\:fetchRecords\(\) instead of sqlStatement\(\)\.$#'
       identifier: openemr.deprecatedSqlFunction

--- a/.phpstan/phpstan-globals-baseline.neon
+++ b/.phpstan/phpstan-globals-baseline.neon
@@ -1,0 +1,3366 @@
+parameters:
+  ignoreErrors:
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../ccdaservice/ccda_gateway.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../ccr/createCCR.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../ccr/display.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 8
+      path: ../ccr/transmitCCD.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../contrib/util/billing/load_fee_schedule.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../contrib/util/de_identification_upgrade.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../contrib/util/dupecheck/index.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../contrib/util/dupecheck/mergerecords.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 43
+      path: ../controllers/C_Document.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 7
+      path: ../controllers/C_DocumentCategory.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../controllers/C_Hl7.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 9
+      path: ../controllers/C_InsuranceCompany.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 6
+      path: ../controllers/C_InsuranceNumbers.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../controllers/C_PatientFinder.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 6
+      path: ../controllers/C_Pharmacy.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 6
+      path: ../controllers/C_PracticeSettings.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 70
+      path: ../controllers/C_Prescription.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 6
+      path: ../controllers/C_X12Partner.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../custom/code_types.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../custom/download_qrda.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../custom/export_qrda_xml.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../custom/export_registry_xml.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../custom/import_xml.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../custom/qrda_category1.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../custom/qrda_download.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../gacl/admin/about.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../gacl/admin/acl_admin.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../gacl/admin/acl_debug.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../gacl/admin/acl_list.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../gacl/admin/acl_test.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../gacl/admin/acl_test2.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../gacl/admin/acl_test3.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../gacl/admin/assign_group.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../gacl/admin/edit_group.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../gacl/admin/edit_object_sections.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../gacl/admin/edit_objects.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../gacl/admin/gacl_admin.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../gacl/admin/group_admin.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../gacl/admin/object_search.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../gacl/profiler.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../interface/batchcom/batch_navigation.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 8
+      path: ../interface/batchcom/batch_phone_notification.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../interface/batchcom/batch_reminders.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/batchcom/batchcom.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/batchcom/emailnotification.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/batchcom/settingsnotification.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/batchcom/smsnotification.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 28
+      path: ../interface/billing/billing_report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/billing/billing_tracker.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/billing/clear_log.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/billing/customize_log.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/billing/edi_270.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/billing/edi_271.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/billing/edih_main.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 7
+      path: ../interface/billing/edih_view.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../interface/billing/edit_payment.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 6
+      path: ../interface/billing/era_payments.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/billing/get_claim_file.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/billing/indigent_patients_report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../interface/billing/new_payment.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/billing/print_billing_report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/billing/print_daysheet_report_num1.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/billing/print_daysheet_report_num2.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/billing/print_daysheet_report_num3.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../interface/billing/search_payments.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/billing/sl_eob_invoice.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/billing/sl_eob_process.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 17
+      path: ../interface/billing/sl_eob_search.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 12
+      path: ../interface/billing/sl_receipts_report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/billing/ub04_dispose.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/billing/ub04_form.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/clickmap/AbstractClickmapModel.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 11
+      path: ../interface/clickmap/C_AbstractClickmap.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/code_systems/dataloads_ajax.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/code_systems/list_staged.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/code_systems/standard_tables_manage.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/couchdb/couchdb_log.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/de_identification_forms/de_identification_screen1.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../interface/de_identification_forms/de_identification_screen2.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/de_identification_forms/re_identification_input_screen.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/de_identification_forms/re_identification_op_single_patient.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 12
+      path: ../interface/drugs/add_edit_drug.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/drugs/add_edit_lot.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/drugs/destroy_lot.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/drugs/dispense_drug.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/drugs/drug_inventory.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/drugs/drugs.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 7
+      path: ../interface/eRx.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/eRxXMLBuilder.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 13
+      path: ../interface/eRx_xml.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/esign/index.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/expand_contract_js.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 11
+      path: ../interface/fax/fax_dispatch.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../interface/fax/fax_view.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 10
+      path: ../interface/fax/faxq.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/CAMOS/admin.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 6
+      path: ../interface/forms/CAMOS/new.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/forms/CAMOS/notegen.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/forms/CAMOS/print.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 6
+      path: ../interface/forms/CAMOS/report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/forms/CAMOS/view.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 22
+      path: ../interface/forms/LBF/new.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/forms/LBF/printable.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/forms/LBF/report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/aftercare_plan/new.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/aftercare_plan/report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/forms/ankleinjury/new.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/ankleinjury/report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/forms/ankleinjury/view.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/forms/bronchitis/new.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/bronchitis/report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/forms/bronchitis/view.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 8
+      path: ../interface/forms/care_plan/new.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/care_plan/report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/clinic_note/report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/clinical_instructions/report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../interface/forms/clinical_notes/new.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/forms/clinical_notes/report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/dictation/report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/eye_mag/SpectacleRx.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 12
+      path: ../interface/forms/eye_mag/a_issue.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 16
+      path: ../interface/forms/eye_mag/help.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 23
+      path: ../interface/forms/eye_mag/php/eye_mag_functions.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 7
+      path: ../interface/forms/eye_mag/php/taskman_functions.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 10
+      path: ../interface/forms/eye_mag/report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/forms/eye_mag/save.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 22
+      path: ../interface/forms/eye_mag/view.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 25
+      path: ../interface/forms/fee_sheet/new.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/fee_sheet/report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../interface/forms/fee_sheet/review/initialize_review.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../interface/forms/functional_cognitive_status/new.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/functional_cognitive_status/report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/gad7/new.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/gad7/view.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/forms/group_attendance/new.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/forms/group_attendance/report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/misc_billing_options/new.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/misc_billing_options/report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 9
+      path: ../interface/forms/newGroupEncounter/common.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 11
+      path: ../interface/forms/newpatient/C_EncounterVisitForm.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/forms/newpatient/common.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/forms/newpatient/report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../interface/forms/newpatient/save.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/forms/note/new.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/note/report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/forms/note/view.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/observation/delete.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/forms/observation/new.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/forms/observation/report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/observation/save.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/forms/painmap/C_FormPainMap.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/painmap/FormPainMap.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/painmap/new.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/painmap/report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/painmap/save.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/painmap/view.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/phq9/common.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/physical_exam/report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 8
+      path: ../interface/forms/prior_auth/C_FormPriorAuth.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/prior_auth/FormPriorAuth.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/prior_auth/report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 8
+      path: ../interface/forms/procedure_order/common.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/forms/procedure_order/delete.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/forms/procedure_order/report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/forms/questionnaire_assessments/lform_webcomponents.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 11
+      path: ../interface/forms/questionnaire_assessments/questionnaire_assessments.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/questionnaire_assessments/report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/questionnaire_assessments/save.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/reviewofs/report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 8
+      path: ../interface/forms/ros/C_FormROS.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/ros/FormROS.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/ros/report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/sdoh/new.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/sdoh/save.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 9
+      path: ../interface/forms/soap/C_FormSOAP.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/soap/FormSOAP.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/soap/report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../interface/forms/track_anything/history.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../interface/forms/track_anything/new.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/track_anything/report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/transfer_summary/new.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/transfer_summary/report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/treatment_plan/new.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/forms/treatment_plan/report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 17
+      path: ../interface/forms/vitals/C_FormVitals.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../interface/forms/vitals/growthchart/chart.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 13
+      path: ../interface/forms/vitals/report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../interface/forms_admin/forms_admin.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 37
+      path: ../interface/globals.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 28
+      path: ../interface/login/login.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/logview/erx_logview.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/logview/logview.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 8
+      path: ../interface/main/about_page.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../interface/main/authorizations/authorizations.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/main/authorizations/authorizations_full.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 21
+      path: ../interface/main/backup.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 42
+      path: ../interface/main/calendar/add_edit_event.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 8
+      path: ../interface/main/calendar/find_appt_popup.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/main/calendar/find_group_popup.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/main/calendar/find_patient_popup.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 10
+      path: ../interface/main/calendar/includes/pnAPI.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 6
+      path: ../interface/main/calendar/index.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/main/calendar/modules/PostCalendar/pcSmarty.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../interface/main/calendar/modules/PostCalendar/pnadmin.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/main/calendar/modules/PostCalendar/pnuser.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 15
+      path: ../interface/main/calendar/modules/PostCalendar/pnuserapi.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../interface/main/dated_reminders/dated_reminders.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/main/dated_reminders/dated_reminders_add.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/main/dated_reminders/dated_reminders_log.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 7
+      path: ../interface/main/display_documents.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/main/finder/document_select.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 9
+      path: ../interface/main/finder/dynamic_finder.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../interface/main/finder/dynamic_finder_ajax.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/main/finder/multi_patients_finder.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 8
+      path: ../interface/main/finder/patient_select.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/main/holidays/Holidays_Controller.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/main/holidays/import_holidays.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/main/ippf_export.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/main/main_info.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 7
+      path: ../interface/main/main_screen.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 19
+      path: ../interface/main/messages/messages.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/main/messages/save.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../interface/main/messages/templates/linked_documents.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/main/messages/trusted-messages.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/main/onotes/office_comments.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/main/onotes/office_comments_full.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/main/pwd_expires_alert.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 28
+      path: ../interface/main/tabs/main.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/main/tabs/templates/patient_data_template.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-claimrev-connect/moduleConfig.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-claimrev-connect/public/EraDownload.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-claimrev-connect/public/claims.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-claimrev-connect/public/debug-info.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-claimrev-connect/public/era.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-claimrev-connect/public/index.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-claimrev-connect/public/setup.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-claimrev-connect/public/x12Tracker.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/modules/custom_modules/oe-module-claimrev-connect/src/Billing_Claimrev_Service.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-claimrev-connect/src/Bootstrap.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 9
+      path: ../interface/modules/custom_modules/oe-module-claimrev-connect/src/ClaimRevApi.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-claimrev-connect/src/ClaimRevModuleSetup.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-claimrev-connect/src/ClaimUpload.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-claimrev-connect/src/ConnectivityInfo.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/modules/custom_modules/oe-module-claimrev-connect/src/EligibilityObjectCreator.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-claimrev-connect/src/EligibilityTransfer.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-claimrev-connect/src/Eligibility_ClaimRev_Service.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/modules/custom_modules/oe-module-claimrev-connect/src/ReportDownload.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-comlink-telehealth/openemr.bootstrap.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-comlink-telehealth/public/index-portal.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-comlink-telehealth/public/index.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/modules/custom_modules/oe-module-comlink-telehealth/src/Bootstrap.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/modules/custom_modules/oe-module-comlink-telehealth/src/Controller/TeleconferenceRoomController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/modules/custom_modules/oe-module-comlink-telehealth/src/TelehealthGlobalConfig.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-comlink-telehealth/welcome.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-dorn/openemr.bootstrap.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-dorn/public/ack_lab_results.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-dorn/public/get_lab_results.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-dorn/public/lab_setup.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/modules/custom_modules/oe-module-dorn/public/orders.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-dorn/public/primary_config.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-dorn/public/primary_config_edit.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/modules/custom_modules/oe-module-dorn/public/results.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-dorn/public/route_edit.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/modules/custom_modules/oe-module-dorn/public/routes.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-dorn/src/Bootstrap.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/modules/custom_modules/oe-module-dorn/src/ConnectorApi.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 6
+      path: ../interface/modules/custom_modules/oe-module-dorn/src/ReceiveHl7Results.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-ehi-exporter/openemr.bootstrap.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../interface/modules/custom_modules/oe-module-ehi-exporter/public/index.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../interface/modules/custom_modules/oe-module-ehi-exporter/src/Bootstrap.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../interface/modules/custom_modules/oe-module-ehi-exporter/src/Services/EhiExporter.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 7
+      path: ../interface/modules/custom_modules/oe-module-faxsms/contact.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/modules/custom_modules/oe-module-faxsms/library/api_onetime.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-faxsms/library/rc_sms_notification.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../interface/modules/custom_modules/oe-module-faxsms/library/utility.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 7
+      path: ../interface/modules/custom_modules/oe-module-faxsms/messageUI.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 22
+      path: ../interface/modules/custom_modules/oe-module-faxsms/openemr.bootstrap.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 20
+      path: ../interface/modules/custom_modules/oe-module-faxsms/src/Controller/AppDispatch.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-faxsms/src/Controller/ClickatellSMSClient.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 8
+      path: ../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EmailClient.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 8
+      path: ../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 9
+      path: ../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/modules/custom_modules/oe-module-faxsms/src/Controller/TwilioSMSClient.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/modules/custom_modules/oe-module-faxsms/src/EtherFax/EtherFaxClient.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 9
+      path: ../interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-prior-authorizations/openemr.bootstrap.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-prior-authorizations/public/index.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-prior-authorizations/public/reports/list_report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-weno/moduleConfig.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../interface/modules/custom_modules/oe-module-weno/scripts/file_download.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-weno/scripts/update_pharmacy.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-weno/scripts/weno_pharmacy_search.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/modules/custom_modules/oe-module-weno/src/Bootstrap.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-weno/src/Services/DownloadWenoPharmacies.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-weno/src/Services/LogImportBuild.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 12
+      path: ../interface/modules/custom_modules/oe-module-weno/src/Services/LogProperties.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../interface/modules/custom_modules/oe-module-weno/src/Services/ModuleService.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 20
+      path: ../interface/modules/custom_modules/oe-module-weno/src/Services/TransmitProperties.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 7
+      path: ../interface/modules/custom_modules/oe-module-weno/src/Services/WenoPharmaciesJson.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-weno/src/Services/WenoValidate.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../interface/modules/custom_modules/oe-module-weno/templates/download_log_viewer.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../interface/modules/custom_modules/oe-module-weno/templates/indexrx.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-weno/templates/pharmacy_list_display.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../interface/modules/custom_modules/oe-module-weno/templates/pharmacy_list_form.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-weno/templates/setup_facilities.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/custom_modules/oe-module-weno/templates/synch.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/modules/custom_modules/oe-module-weno/templates/weno_fragment.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/modules/custom_modules/oe-module-weno/templates/weno_setup.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/modules/custom_modules/oe-module-weno/templates/weno_users.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/modules/zend_modules/config/application.config.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 18
+      path: ../interface/modules/zend_modules/config/autoload/global.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../interface/modules/zend_modules/module/Application/ajax/reporting_period_handler.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/modules/zend_modules/module/Application/src/Application/Controller/SendtoController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../interface/modules/zend_modules/module/Application/src/Application/Listener/ModuleMenuSubscriber.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../interface/modules/zend_modules/module/Application/src/Application/Model/ApplicationTable.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/zend_modules/module/Application/src/Application/Plugin/Phimail.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/CarecoordinationController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncountermanagerController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Listener/CCDAEventsSubscriber.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CarecoordinationTable.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaGlobalsConfiguration.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaServiceDocumentRequestor.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaServiceRequestModelGenerator.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 8
+      path: ../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncounterccdadispatchTable.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncountermanagerTable.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../interface/modules/zend_modules/module/Ccr/src/Ccr/Model/CcrTable.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/modules/zend_modules/module/Documents/src/Documents/Controller/DocumentsController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/zend_modules/module/Documents/src/Documents/Plugin/Documents.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../interface/modules/zend_modules/module/Immunization/src/Immunization/Controller/ImmunizationController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 34
+      path: ../interface/modules/zend_modules/module/Installer/src/Installer/Controller/InstallerController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../interface/modules/zend_modules/module/Installer/src/Installer/Model/InstModuleTable.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/modules/zend_modules/module/PatientFlowBoard/src/PatientFlowBoard/Listener/PatientFlowBoardEventsSubscriber.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/zend_modules/module/PrescriptionTemplates/src/PrescriptionTemplates/Controller/PdfTemplatesController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/modules/zend_modules/module/Syndromicsurveillance/src/Syndromicsurveillance/Controller/SyndromicsurveillanceController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../interface/modules/zend_modules/public/index.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 8
+      path: ../interface/new/new.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 50
+      path: ../interface/new/new_comprehensive.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../interface/new/new_comprehensive_save.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/new/new_search_popup.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/orders/list_reports.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/orders/load_compendium.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/orders/order_manifest.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../interface/orders/orders_results.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/orders/pending_followup.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/orders/pending_orders.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/orders/procedure_provider_edit.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../interface/orders/procedure_provider_list.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/orders/procedure_stats.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 10
+      path: ../interface/orders/receive_hl7_results.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 13
+      path: ../interface/orders/single_order_results.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 6
+      path: ../interface/orders/single_order_results.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 7
+      path: ../interface/orders/types.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/orders/types_edit.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 8
+      path: ../interface/patient_file/addr_appt_label.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../interface/patient_file/addr_label.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/patient_file/barcode_label.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../interface/patient_file/birthday_alert/birthday_pop.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../interface/patient_file/deleter.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../interface/patient_file/download_template.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/patient_file/encounter/cash_receipt.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/patient_file/encounter/coding.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/patient_file/encounter/copay.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/patient_file/encounter/delete_form.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/patient_file/encounter/diagnosis.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/patient_file/encounter/find_code_dynamic.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/patient_file/encounter/find_code_dynamic_ajax.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/patient_file/encounter/find_code_history.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/patient_file/encounter/find_code_popup.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 22
+      path: ../interface/patient_file/encounter/forms.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../interface/patient_file/encounter/load_form.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/patient_file/encounter/search_code.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/patient_file/encounter/select_codes.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 7
+      path: ../interface/patient_file/encounter/superbill_custom_full.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/patient_file/encounter/trend_form.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/patient_file/encounter/view_form.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 26
+      path: ../interface/patient_file/front_payment.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../interface/patient_file/front_payment_cc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/patient_file/history/edit_billnote.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 22
+      path: ../interface/patient_file/history/encounters.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 8
+      path: ../interface/patient_file/history/history_full.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/patient_file/history/history_sdoh_health_concerns.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/patient_file/history/history_sdoh_list.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/patient_file/history/history_sdoh_save.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/patient_file/history/history_sdoh_widget.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/patient_file/label.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 15
+      path: ../interface/patient_file/letter.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/patient_file/manage_dup_patients.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../interface/patient_file/merge_patients.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/patient_file/pos_checkout.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 68
+      path: ../interface/patient_file/pos_checkout_ippf.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 14
+      path: ../interface/patient_file/pos_checkout_normal.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/patient_file/printed_fee_sheet.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/patient_file/problem_encounter.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/patient_file/reminder/active_reminder_popup.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/patient_file/reminder/patient_reminders.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 22
+      path: ../interface/patient_file/report/custom_report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 14
+      path: ../interface/patient_file/report/patient_report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/patient_file/rules/patient_data.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../interface/patient_file/summary/add_edit_amendments.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 11
+      path: ../interface/patient_file/summary/add_edit_issue.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/patient_file/summary/advancedirectives.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 10
+      path: ../interface/patient_file/summary/browse.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/patient_file/summary/create_portallogin.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/patient_file/summary/dashboard_header_simple_return.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 71
+      path: ../interface/patient_file/summary/demographics.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 23
+      path: ../interface/patient_file/summary/demographics_full.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/patient_file/summary/demographics_print.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/patient_file/summary/demographics_save.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/patient_file/summary/disclosure_full.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 8
+      path: ../interface/patient_file/summary/immunizations.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 18
+      path: ../interface/patient_file/summary/insurance_edit.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 7
+      path: ../interface/patient_file/summary/labdata.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/patient_file/summary/lbf_fragment.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/patient_file/summary/list_amendments.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/patient_file/summary/pnotes_fragment.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../interface/patient_file/summary/pnotes_full.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/patient_file/summary/pnotes_full_add.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/patient_file/summary/print_amendments.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/patient_file/summary/record_disclosure.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/patient_file/summary/shot_record.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 13
+      path: ../interface/patient_file/summary/stats.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 7
+      path: ../interface/patient_file/summary/stats_full.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/patient_file/summary/vitals_fragment.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 13
+      path: ../interface/patient_file/transaction/add_transaction.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/patient_file/transaction/print_referral.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/patient_file/transaction/record_request.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 46
+      path: ../interface/patient_tracker/patient_tracker.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/patient_tracker/patient_tracker_status.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/practice/address_verify.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/practice/ins_search.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/procedure_tools/libs/labs_ajax.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/reports/amc_full_report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/reports/amc_tracking.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/reports/appointments_report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 6
+      path: ../interface/reports/appt_encounter_report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/reports/audit_log_tamper_report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/reports/background_services.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/reports/cdr_log.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/reports/clinical_reports.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/reports/collections_report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/reports/cqm.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/reports/custom_report_range.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/reports/daily_summary_report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/reports/destroyed_drugs_report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/reports/direct_message_log.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/reports/encounters_report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/reports/front_receipts_report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/reports/immunization_report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/reports/insurance_allocation_report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/reports/inventory_activity.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 6
+      path: ../interface/reports/inventory_list.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/reports/inventory_transactions.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 9
+      path: ../interface/reports/ip_tracker.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/reports/ippf_cyp_report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/reports/ippf_daily.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/reports/ippf_statistics.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/reports/message_list.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/reports/non_reported.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 13
+      path: ../interface/reports/pat_ledger.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/reports/patient_flow_board_report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/reports/patient_list.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 6
+      path: ../interface/reports/patient_list_creation.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../interface/reports/payment_processing_report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/reports/prescriptions_report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../interface/reports/receipts_by_method_report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/reports/referrals_report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 11
+      path: ../interface/reports/report_results.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/reports/rwt_2025_report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 36
+      path: ../interface/reports/sales_by_item.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/reports/svc_code_financial_report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/reports/unique_seen_patients_report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 10
+      path: ../interface/smart/register-app.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 8
+      path: ../interface/soap_functions/soap_accountStatusDetails.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 8
+      path: ../interface/soap_functions/soap_allergy.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 8
+      path: ../interface/soap_functions/soap_patientfullmedication.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 16
+      path: ../interface/super/edit_globals.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 7
+      path: ../interface/super/edit_layout.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/super/edit_layout_props.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 15
+      path: ../interface/super/edit_list.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/super/layout_service_codes.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/super/load_codes.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/super/manage_document_templates.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../interface/super/manage_site_files.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/super/rules/index.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/therapy_groups/therapy_groups_controllers/participants_controller.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/therapy_groups/therapy_groups_controllers/therapy_groups_controller.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/therapy_groups/therapy_groups_models/therapy_groups_events_model.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/therapy_groups/therapy_groups_views/addGroup.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../interface/therapy_groups/therapy_groups_views/appointmentComponent.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 6
+      path: ../interface/therapy_groups/therapy_groups_views/groupDetailsGeneralData.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 10
+      path: ../interface/therapy_groups/therapy_groups_views/groupDetailsParticipants.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/therapy_groups/therapy_groups_views/header.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../interface/therapy_groups/therapy_groups_views/listGroups.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/therapy_groups/therapy_groups_views/pastMeetingsComponent.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/usergroup/addrbook_edit.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../interface/usergroup/addrbook_list.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/usergroup/adminacl.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/usergroup/facilities.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../interface/usergroup/facilities_add.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../interface/usergroup/facility_admin.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/usergroup/facility_user.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 9
+      path: ../interface/usergroup/facility_user_admin.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/usergroup/mfa_u2f.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../interface/usergroup/npi_lookup.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 14
+      path: ../interface/usergroup/ssl_certificates_admin.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 23
+      path: ../interface/usergroup/user_admin.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../interface/usergroup/user_info.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 18
+      path: ../interface/usergroup/usergroup_admin.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 20
+      path: ../interface/usergroup/usergroup_admin_add.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../library/ADODB_mysqli_log.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../library/ESign/Abstract/Configuration.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../library/ESign/Abstract/Controller.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 9
+      path: ../library/ESign/Api.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../library/ESign/ButtonIF.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../library/ESign/DbRow/Signable.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../library/ESign/ESign.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../library/ESign/Encounter/Button.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/ESign/Encounter/Configuration.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 13
+      path: ../library/ESign/Encounter/Controller.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../library/ESign/Encounter/Factory.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../library/ESign/Encounter/Log.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../library/ESign/Encounter/Signable.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../library/ESign/Form/Button.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/ESign/Form/Configuration.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 12
+      path: ../library/ESign/Form/Controller.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 6
+      path: ../library/ESign/Form/Factory.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../library/ESign/Form/LBF/Signable.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../library/ESign/Form/Log.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../library/ESign/Form/Signable.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../library/ESign/LogIF.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../library/ESign/Router.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/ESign/SignableIF.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../library/ESign/Signature.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/ESign/SignatureIF.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/ESign/Utils/Verification.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../library/ESign/Viewer.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 16
+      path: ../library/FeeSheet.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 6
+      path: ../library/FeeSheetHtml.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 40
+      path: ../library/MedEx/API.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/ajax/addlistitem.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/ajax/document_helpers.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/ajax/easipro_util.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/ajax/execute_background_services.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../library/ajax/execute_cdr_report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../library/ajax/execute_pat_reminder.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/ajax/immunization_export.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/ajax/messages/validate_messages_document_ajax.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../library/ajax/sql_server_status.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../library/ajax/upload.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../library/api.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/appointment_status.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../library/appointments.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../library/auth.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/billing_sftp_service.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../library/calendar.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/checkout_receipt_array.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 6
+      path: ../library/classes/Controller.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 17
+      path: ../library/classes/CouchDB.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 14
+      path: ../library/classes/Document.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 9
+      path: ../library/classes/Installer.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../library/classes/OFX.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../library/classes/PQRIXml.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/classes/Pharmacy.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/classes/Prescription.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/classes/Tree.class.php
+    - message: '#^GenID is deprecated\. Use QueryUtils\:\:generateId\(\) or QueryUtils\:\:ediGenerateId\(\) instead\.$#'
+      identifier: openemr.deprecatedSqlFunction
+      count: 1
+      path: ../library/classes/Tree.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 11
+      path: ../library/classes/postmaster.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 8
+      path: ../library/classes/rulesets/Amc/library/AbstractAmcReport.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../library/classes/rulesets/Amc/library/AmcResult.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../library/classes/rulesets/Amc/reports/AMC_315g_2c/Numerator.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 17
+      path: ../library/classes/rulesets/Cqm/library/AbstractCqmReport.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../library/classes/rulesets/Cqm/library/CqmResult.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../library/classes/thumbnail/ThumbnailGenerator.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 37
+      path: ../library/clinical_rules.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../library/custom_template/add_context.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../library/custom_template/ajax_code.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../library/custom_template/custom_template.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/custom_template/delete_category.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../library/dated_reminder_functions.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../library/dicom_frame.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 19
+      path: ../library/direct_message_check.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../library/display_help_icon_inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/documents.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../library/edihistory/edih_csv_inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 8
+      path: ../library/encounter_events.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 6
+      path: ../library/formatting.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../library/formatting_DateToYYYYMMDD_js.js.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/formdata.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/forms.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../library/globals.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/lists.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/maviq_phone_api.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 34
+      path: ../library/options.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../library/options.js.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../library/options_listadd.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 20
+      path: ../library/patient.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../library/payment_jav.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/pnotes.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/registry.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../library/reminders.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../library/report.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 6
+      path: ../library/restoreSession.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../library/sanitize.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/smarty/plugins/function.assetVersionNumber.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/smarty/plugins/function.datetimepickerSupport.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/smarty/plugins/function.dispatchPatientDocumentEvent.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../library/smarty_legacy/smarty/Smarty_Legacy.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../library/smarty_legacy/smarty/internals/core.assign_smarty_interface.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/smarty_legacy/smarty/plugins/function.html_image.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/specialty_forms.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../library/spreadsheet.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 81
+      path: ../library/sql.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../library/sqlconf.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 34
+      path: ../library/standard_tables_capture.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/templates/address_display.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../library/templates/address_form.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/templates/relation_display.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../library/templates/relation_form.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../library/templates/telecom_display.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../library/templates/telecom_form.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 8
+      path: ../library/translation.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../library/validation/validate_core.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../library/validation/validation_script.js.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 8
+      path: ../modules/sms_email_reminder/batch_phone_notification.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../modules/sms_email_reminder/batch_reminders.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 7
+      path: ../modules/sms_email_reminder/cron_functions.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../modules/sms_email_reminder/sms_clickatell.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../modules/sms_email_reminder/sms_tmb4.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 10
+      path: ../portal/account/account.lib.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 13
+      path: ../portal/account/account.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../portal/account/index_reset.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../portal/account/register.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 12
+      path: ../portal/account/verify.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../portal/add_edit_event_user.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../portal/find_appt_popup_user.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../portal/get_patient_documents.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../portal/get_patient_info.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../portal/get_profile.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 31
+      path: ../portal/home.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../portal/import_template.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../portal/import_template_ui.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 51
+      path: ../portal/index.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../portal/lib/appsql.class.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../portal/lib/doc_lib.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 7
+      path: ../portal/lib/patient_groups.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../portal/lib/paylib.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../portal/lib/persist.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../portal/lib/track_portal_events.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../portal/messaging/handle_note.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 9
+      path: ../portal/messaging/messages.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../portal/messaging/secure_chat.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 9
+      path: ../portal/patient/_machine_config.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 10
+      path: ../portal/patient/fwk/libs/verysimple/DB/DataDriver/MySQLi.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../portal/patient/fwk/libs/verysimple/HTTP/HttpRequest.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../portal/patient/fwk/libs/verysimple/Phreeze/BladeRenderEngine.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../portal/patient/fwk/libs/verysimple/Phreeze/GenericRouter.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 11
+      path: ../portal/patient/index.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 9
+      path: ../portal/patient/libs/Controller/OnsiteDocumentController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 8
+      path: ../portal/patient/libs/Controller/OnsitePortalActivityController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 6
+      path: ../portal/patient/libs/Controller/PatientController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../portal/patient/libs/Controller/ProviderController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../portal/patient/templates/OnsiteActivityViewListView.tpl.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 30
+      path: ../portal/patient/templates/OnsiteDocumentListView.tpl.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../portal/patient/templates/OnsitePortalActivityListView.tpl.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../portal/patient/templates/PatientListView.tpl.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 21
+      path: ../portal/patient/templates/ProviderHome.tpl.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 9
+      path: ../portal/patient/templates/_FormsHeader.tpl.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 10
+      path: ../portal/patient/templates/_Header.tpl.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 16
+      path: ../portal/patient/templates/_modalFormHeader.tpl.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 18
+      path: ../portal/portal_payment.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../portal/questionnaire_render.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../portal/report/document_downloads_action.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 12
+      path: ../portal/report/pat_ledger.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 17
+      path: ../portal/report/portal_custom_report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 8
+      path: ../portal/report/portal_patient_report.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../portal/sign/assets/signer_modal.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../portal/sign/lib/save-signature.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../portal/sign/lib/show-signature.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../portal/verify_session.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 32
+      path: ../sites/default/config.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 83
+      path: ../sites/default/statement.inc.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../sphere/process_response.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../sphere/process_revert_response.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../sphere/token.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../sql_patch.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 6
+      path: ../sql_upgrade.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../src/Billing/BillingProcessor/BillingClaimBatch.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../src/Billing/BillingProcessor/BillingLogger.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../src/Billing/BillingProcessor/BillingProcessor.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Billing/BillingProcessor/Tasks/AbstractGenerator.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../src/Billing/BillingProcessor/Tasks/GeneratorHCFA_PDF.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Billing/BillingProcessor/Tasks/GeneratorHCFA_PDF_IMG.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Billing/BillingProcessor/Tasks/GeneratorX12.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../src/Billing/BillingProcessor/Tasks/GeneratorX12Direct.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Billing/BillingProcessor/X12RemoteTracker.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../src/Billing/Claim.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../src/Billing/EDI270.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 6
+      path: ../src/Billing/Hcfa1500.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Billing/ParseERA.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../src/Billing/PaymentGateway.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../src/Billing/X125010837P.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/ClinicalDecisionRules/Interface/ActionRouter.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../src/ClinicalDecisionRules/Interface/Common.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/ClinicalDecisionRules/Interface/RuleLibrary/CdrAlertManager.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../src/ClinicalDecisionRules/Interface/RuleTemplateExtension.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../src/Common/Auth/AuthGlobal.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 17
+      path: ../src/Common/Auth/AuthHash.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 71
+      path: ../src/Common/Auth/AuthUtils.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Common/Auth/OAuth2KeyConfig.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Common/Auth/OneTimeAuth.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Common/Auth/OpenIDConnect/Repositories/ClientRepository.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Common/Auth/OpenIDConnect/Repositories/ScopeRepository.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../src/Common/Auth/OpenIDConnect/Repositories/UserRepository.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Common/Command/CcdaImport.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Common/Command/CcdaNewpatient.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Common/Command/CcdaNewpatientImport.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../src/Common/Command/CreateAPIDocumentationCommand.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Common/Command/CreateClientCredentialsAssertionSymfonyCommand.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../src/Common/Command/Register.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Common/Command/SymfonyCommandRunner.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Common/Command/ZfcModule.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../src/Common/Crypto/CryptoGen.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../src/Common/Database/QueryUtils.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../src/Common/Forms/CoreFormToPortalUtility.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../src/Common/Forms/FormActionBarSettings.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../src/Common/Forms/FormLocator.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../src/Common/Forms/FormVitals.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Common/Http/oeHttpRequest.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../src/Common/Http/oeOAuth.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 20
+      path: ../src/Common/Logging/EventAuditLogger.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../src/Common/Logging/SystemLogger.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../src/Common/ORDataObject/ORDataObject.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Common/Session/SessionTracker.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../src/Common/Session/SessionUtil.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Common/System/System.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Common/Twig/TwigContainer.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../src/Common/Twig/TwigExtension.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../src/Common/Utils/CacheUtils.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../src/Common/Utils/FormatMoney.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../src/Common/Uuid/UniqueInstallationUuid.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../src/Controllers/Interface/Forms/Observation/ObservationController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 10
+      path: ../src/Core/Header.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../src/Core/ModulesApplication.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Cqm/CqmServiceManager.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../src/Cqm/QrdaControllers/QrdaReportController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 10
+      path: ../src/Easipro/Easipro.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../src/Events/Encounter/LoadEncounterFormFilterEvent.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Events/Patient/Summary/Card/CardModel.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../src/FHIR/Config/ServerConfig.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/FHIR/SMART/ClientAdminController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../src/FHIR/SMART/SmartLaunchController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 10
+      path: ../src/Gacl/Gacl.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Gacl/GaclAdminApi.php
+    - message: '#^GenID is deprecated\. Use QueryUtils\:\:generateId\(\) or QueryUtils\:\:ediGenerateId\(\) instead\.$#'
+      identifier: openemr.deprecatedSqlFunction
+      count: 4
+      path: ../src/Gacl/GaclApi.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../src/Menu/MainMenuRole.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 16
+      path: ../src/Menu/MenuRole.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 7
+      path: ../src/Menu/PatientMenuRole.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 7
+      path: ../src/OeUI/OemrUI.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Patient/Cards/BillingViewCard.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Patient/Cards/CareExperiencePreferenceViewCard.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../src/Patient/Cards/InsuranceViewCard.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../src/Patient/Cards/PortalCard.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Patient/Cards/TreatmentPreferenceViewCard.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 9
+      path: ../src/PaymentProcessing/Sphere/SpherePayment.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 10
+      path: ../src/PaymentProcessing/Sphere/SphereRevert.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 9
+      path: ../src/Pdf/Config_Mpdf.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../src/Pdf/PdfCreator.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../src/Reminder/BirthdayReminder.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 13
+      path: ../src/RestControllers/Config/RestConfig.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/FhirAllergyIntoleranceRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/FhirAppointmentRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/FhirCarePlanRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/FhirCareTeamRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/FhirConditionRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/FhirCoverageRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/FhirDeviceRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/FhirDiagnosticReportRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/FhirDocumentReferenceRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/FhirEncounterRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/FhirGoalRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/FhirGroupRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/FhirImmunizationRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/FhirLocationRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/FhirMediaRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/FhirMedicationDispenseRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/FhirMedicationRequestRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/FhirMedicationRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/FhirObservationRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/FhirOrganizationRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/FhirPatientRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/FhirPersonRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/FhirPractitionerRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/FhirPractitionerRoleRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/FhirProcedureRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/FhirProvenanceRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/FhirQuestionnaireResponseRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/FhirQuestionnaireRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/FhirRelatedPersonRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/FhirServiceRequestRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/FhirSpecimenRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/FhirValueSetRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/RestControllers/FHIR/Operations/FhirOperationDocRefRestController.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../src/RestControllers/RestControllerHelper.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../src/Services/AppointmentService.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Services/BaseService.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 3
+      path: ../src/Services/CDADocumentService.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Services/Cda/CdaTemplateParse.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 8
+      path: ../src/Services/Cda/CdaValidateDocuments.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../src/Services/DocumentService.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../src/Services/DocumentTemplates/DocumentTemplateRender.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../src/Services/DrugSalesService.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Services/EncounterService.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Services/FHIR/FhirAppointmentService.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Services/FHIR/FhirDocRefService.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../src/Services/FacilityService.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Services/Globals/UserSettingsService.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Services/InsuranceCompanyService.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 7
+      path: ../src/Services/LogoService.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 10
+      path: ../src/Services/PatientAccessOnsiteService.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Services/PatientIssuesService.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../src/Services/PatientPortalService.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 11
+      path: ../src/Services/PatientService.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Services/PatientTrackerService.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../src/Services/ProductRegistrationService.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 8
+      path: ../src/Services/Qdm/MeasureService.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 12
+      path: ../src/Services/Qrda/ExportCat3Service.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../src/Services/Qrda/QrdaReportService.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Services/SocialHistoryService.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../src/Services/UserService.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 19
+      path: ../src/Services/Utils/DateFormatterUtils.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 7
+      path: ../src/Services/Utils/SQLUpgradeService.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../src/Services/VitalsService.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../src/Telemetry/TelemetryService.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../src/Validators/CoverageValidator.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../templates/super/rules/base/template/basic.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 4
+      path: ../templates/super/rules/base/template/criteria.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 2
+      path: ../templates/super/rules/controllers/browse/plans_config.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 5
+      path: ../templates/super/rules/controllers/edit/diagnosis.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../templates/super/rules/controllers/log/view.php
+    - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
+      identifier: openemr.forbiddenGlobalsAccess
+      count: 1
+      path: ../version.php

--- a/interface/modules/custom_modules/oe-module-faxsms/messageUI.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/messageUI.php
@@ -37,7 +37,7 @@ $tabTitle = $serviceType == "sms" ? xlt('SMS') : ($serviceType == "email" ? xlt(
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title><?php echo $tabTitle ?? ''; ?></title>
     <link rel="stylesheet" href="<?php echo $GLOBALS['assets_static_relative']; ?>/dropzone/dist/dropzone.css">
-    <!--<script src="./public/WebPhoneService.js"></script>-->
+    <script src="<?php echo $GLOBALS['assets_static_relative']; ?>/utif2/UTIF.js"></script>
     <?php
     if (!$clientApp->verifyAcl()) {
         die("<h3>" . xlt("Not Authorised!") . "</h3>");
@@ -106,12 +106,11 @@ $tabTitle = $serviceType == "sms" ? xlt('SMS') : ($serviceType == "email" ? xlt(
             let url = top.webroot_url + '/interface/modules/custom_modules/oe-module-faxsms/contact.php?type=fax&isDocuments=0&isQueue=' +
                 encodeURIComponent(from) + '&file=' + encodeURIComponent(filePath);
             // leave dialog name param empty so send dialogs can cascade.
-            dlgopen(url, '', 'modal-sm', 800, '', title, { // dialog auto restores session cookie
+            dlgopen(url, '', 'modal-sm', 500, '', title, { // dialog auto restores session cookie
                 buttons: [
                     {text: btnClose, close: true, style: 'secondary btn-sm'}
                 ],
                 resolvePromiseOn: 'close',
-                sizeHeight: 'full'
             }).then(function (contact) {
                 top.restoreSession();
             });
@@ -262,6 +261,7 @@ $tabTitle = $serviceType == "sms" ? xlt('SMS') : ($serviceType == "email" ? xlt(
                     setTimeout(retrieveMsgs, 1000);
                     return false;
                 }
+
                 if (downFlag == 'true') {
                     let base64 = data.base64;
                     if (data.mime === 'image/tiff' || data.mime === 'image/tif') {
@@ -270,6 +270,7 @@ $tabTitle = $serviceType == "sms" ? xlt('SMS') : ($serviceType == "email" ? xlt(
                     } else {
                         base64 = '';
                     }
+
                     fetch('disposeDocument?type=fax', {
                         method: 'POST',
                         headers: {
@@ -290,9 +291,9 @@ $tabTitle = $serviceType == "sms" ? xlt('SMS') : ($serviceType == "email" ? xlt(
                     }).catch(error => {
                         console.error('Error:', error);
                     });
-
                     return false;
                 }
+
                 if (data.mime === 'application/pdf') {
                     showDocument(data.base64, data.mime);
                 } else if (data.mime === 'image/tiff') {
@@ -931,7 +932,7 @@ $tabTitle = $serviceType == "sms" ? xlt('SMS') : ($serviceType == "email" ? xlt(
                                                 <th><?php echo xlt("Caller Id") ?></th>
                                                 <th><?php echo xlt("To") ?></th>
                                                 <th><?php echo xlt("Pages") ?></th>
-                                                <th><?php echo xlt("Length") ?></th>
+                                                <th><?php echo xlt("Name") ?></th>
                                                 <th><?php echo xlt("Status") ?></th>
                                                 <th><?php echo xlt("Actions") ?></th>
                                                 <th><i role="button" id="delete-selected-sent" title="<?php echo xlt("Delete selected fax documents") ?>" class="delete-selected-items text-danger fa fa-trash"></i></th>

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php
@@ -141,7 +141,7 @@ class EtherFaxActions extends AppDispatch
             return '';
         }
 
-        $name = basename((string) $_FILES['fax']['name']);
+        $name = basename((string)$_FILES['fax']['name']);
         $tmp_name = $_FILES['fax']['tmp_name'];
         $targetDir = $this->baseDir . '/send';
 
@@ -189,18 +189,20 @@ class EtherFaxActions extends AppDispatch
         $hasEmail = $this->validEmail($email);
         $smtpEnabled = !empty($GLOBALS['SMTP_PASS'] ?? null) && !empty($GLOBALS["SMTP_USER"] ?? null);
         $user = $this::getLoggedInUser();
-        $facility = substr((string) $user['facility'], 0, 20);
+        $facility = substr((string)$user['facility'], 0, 20);
         $csid = $this->formatPhone($this->credentials['phone']);
         $tag = $user['username'];
+        $fileName = '';
 
         if (empty($isContent)) {
-            if (str_starts_with((string) $file, 'file://')) {
+            if (str_starts_with((string)$file, 'file://')) {
                 // Remove the "file://" prefix
-                $file = substr((string) $file, 7);
+                $file = substr((string)$file, 7);
             }
             $realPath = realpath($file);
             if ($realPath !== false) {
                 $file = str_replace("\\", "/", $realPath);
+                $fileName = pathinfo((string)$file, PATHINFO_BASENAME);
             } else {
                 return xlt('Error: No content');
             }
@@ -208,6 +210,7 @@ class EtherFaxActions extends AppDispatch
 
         if ($isDocuments) {
             $file = (new Document($docId))->get_data();
+            $fileName = (new Document($docId))->get_name() ?? 'document';
         }
 
         if ($hasEmail && $smtpEnabled) {
@@ -215,10 +218,11 @@ class EtherFaxActions extends AppDispatch
         }
 
         try {
-            $fax = $this->client->sendFax($phone, $file, null, $facility, $csid, $tag, $isDocuments, pathinfo((string) $file, PATHINFO_BASENAME));
+            $fax = $this->client->sendFax($phone, $file, null, $facility, $csid, $tag, $isDocuments, $fileName);
             if (!$fax->FaxResult) {
                 return 'Error: ' . json_encode($fax->Message);
             }
+            $status = null;
             if ($fax->FaxResult == FaxResult::InProgress) {
                 while (true) {
                     $status = $this->client->getFaxStatus($fax->JobId);
@@ -227,6 +231,11 @@ class EtherFaxActions extends AppDispatch
                     }
                     sleep(5);
                 }
+            }
+            // Store sent fax in queue for tracking (don't block waiting for completion)
+            if (!empty($status->JobId)) {
+                $status->FaxImage = $fax->FaxImage;
+                $this->insertSentFaxQueue($status, $phone, $csid, $tag, $fileName);
             }
         } catch (Exception $e) {
             return 'Error: ' . json_encode($e->getMessage());
@@ -260,8 +269,8 @@ class EtherFaxActions extends AppDispatch
      */
     public function formatPhone($number): string
     {
-        $n = preg_replace('/[^0-9]/', '', (string) $number);
-        if (stripos((string) $n, '1') === 0) {
+        $n = preg_replace('/[^0-9]/', '', (string)$number);
+        if (stripos((string)$n, '1') === 0) {
             $n = '+' . $n;
         } elseif (!empty($n)) {
             $n = '+1' . $n;
@@ -276,7 +285,7 @@ class EtherFaxActions extends AppDispatch
      */
     public function validatePhone($n): bool
     {
-        return preg_match("/^\+[1-9]\d{10,14}$/", (string) $n);
+        return preg_match("/^\+[1-9]\d{10,14}$/", (string)$n);
     }
 
     /**
@@ -291,7 +300,7 @@ class EtherFaxActions extends AppDispatch
         $hasEmail = $this->validEmail($email);
         $smtpEnabled = !empty($GLOBALS['SMTP_PASS'] ?? null) && !empty($GLOBALS["SMTP_USER"] ?? null);
         $user = $this::getLoggedInUser();
-        $facility = substr((string) $user['facility'], 0, 20);
+        $facility = substr((string)$user['facility'], 0, 20);
         $csid = $this->formatPhone($this->credentials['phone']);
         $tag = xlt("Forwarded");
         $statusMsg = xlt("Forwarding Requests") . "<br />";
@@ -314,7 +323,7 @@ class EtherFaxActions extends AppDispatch
             mkdir($this->baseDir . '/send', 0777, true);
         }
 
-        file_put_contents($filepath, base64_decode((string) $content));
+        file_put_contents($filepath, base64_decode((string)$content));
 
         if ($hasEmail && $smtpEnabled) {
             $statusMsg .= self::emailDocument($email, $this->getRequest('comments'), $filepath, $user) . "<br />";
@@ -362,15 +371,21 @@ class EtherFaxActions extends AppDispatch
         $dateTo = date("Y-m-d H:i:s", strtotime($this->getRequest('dateto') . 'T23:59:59'));
         $faxStore = $this->fetchFaxQueue($dateFrom, $dateTo, false);
 
-        $responseMsg = [0 => '', 2 => xlt('Not Implemented')];
+        $responseMsg = [0 => '', 1 => '', 2 => xlt('Not Implemented')];
 
         foreach ($faxStore as $faxDetails) {
             $id = $faxDetails->JobId;
             $record_id = $faxDetails->RecordId;
-            $faxDate = strtotime($faxDetails->ReceivedOn . ' UTC');
+            $faxDate = strtotime(($faxDetails->ReceivedOn ?? '') . ' UTC');
             $formattedDate = date('M j, Y g:i:sa T', $faxDate);
             $docLen = round($faxDetails->DocumentParams->Length / 1000, 2) . "KB";
-            $transactionType = $this->getTransactionTypeWord($faxDetails->TransactionType);
+            $transaction = 0;
+            if (!empty($faxDetails->SentOn ?? null)) {
+                $transaction = 1;
+                $faxDate = strtotime($faxDetails->SentOn . ' UTC');
+                $formattedDate = date('M j, Y g:i:sa T', $faxDate);
+            }
+            $transactionType = $this->getTransactionTypeWord($transaction);
 
             $recognizeResult = $faxDetails->AnalyzeFormResult->AnalyzeResult->DocumentResults ?? [];
             $form = $this->generateFaxForm($id, $recognizeResult);
@@ -380,7 +395,7 @@ class EtherFaxActions extends AppDispatch
             $actionLinks = $this->generateActionLinks($id, $record_id, $pid_assumed);
             $detailLink = $this->generateDetailLink($id, $recognizeResult);
 
-            if ($faxDetails->TransactionType == '1') {
+            if ($transaction == 0) {
                 $faxRow = "<tr>
                 <td>" . text($formattedDate) . "</td>
                 <td>" . text($faxDetails->CallingNumber) . "</td>
@@ -399,13 +414,13 @@ class EtherFaxActions extends AppDispatch
                 <td>" . text($faxDetails->CallingNumber) . "</td>
                 <td>" . text($faxDetails->RemoteId) . "</td>
                 <td>" . text($faxDetails->CalledNumber) . "</td>
-                <td>" . text($faxDetails->PagesReceived) . "</td>
-                <td>" . text($docLen) . "</td>
+                <td>" . text($faxDetails->PagesDelivered) . "</td>
+                <td>" . text($faxDetails->DocumentParams->Name ?? '') . "</td>
                 <td>" . text($transactionType) . "</td>
                 <td class='text-left'>" . $actionLinks . "</td>
                 <td class='text-center'><input type='checkbox' class='delete-fax-checkbox' value='" . attr($id) . "'></td></tr>";
             }
-            $responseMsg[$faxDetails->TransactionType == '1' ? 0 : 1] .= $faxRow . $form;
+            $responseMsg[$transaction] .= $faxRow . $form;
         }
 
         if (empty($responseMsg[0])) {
@@ -419,8 +434,8 @@ class EtherFaxActions extends AppDispatch
     private function getTransactionTypeWord($transactionType)
     {
         $transactionTypes = [
-            '0' => xlt('Sent'),
-            '1' => xlt('Received'),
+            '0' => xlt('Received'),
+            '1' => xlt('Sent'),
             '2' => xlt('Forwarded'),
             '3' => xlt('Failed')
             // Add more as needed
@@ -521,6 +536,7 @@ class EtherFaxActions extends AppDispatch
         $c_header = $apiResponse->DocumentParams->Type;
 
         if ($c_header == 'image/tiff' || $c_header == 'image/tif') {
+            // imagick if installed
             $formattedImage = $this->formatFax($faxImage);
             $c_header = $formattedImage ? 'application/pdf' : 'image/tiff';
             $faxImage = $formattedImage ?: $faxImage;
@@ -535,7 +551,7 @@ class EtherFaxActions extends AppDispatch
             }
 
             $file_name = "{$faxStoreDir}/Fax_{$docId}" . ($c_header == 'application/pdf' ? '.pdf' : ($c_header == 'image/tiff' ? '.tiff' : '.txt'));
-            file_put_contents($file_name, base64_decode((string) $faxImage));
+            file_put_contents($file_name, base64_decode((string)$faxImage));
             $this->setSession('where', $file_name);
             $this->setFaxDeleted($apiResponse->JobId);
 
@@ -561,7 +577,7 @@ class EtherFaxActions extends AppDispatch
     /**
      * @return string
      */
-    
+
     public function disposeDocument(): string
     {
         if (!$this->authenticate()) {
@@ -570,13 +586,13 @@ class EtherFaxActions extends AppDispatch
         }
 
         $response = ['success' => false, 'message' => '', 'url' => ''];
-        $where = (string) ($this->getRequest('file_path') ?? $this->getSession('where') ?? '');
+        $where = (string)($this->getRequest('file_path') ?? $this->getSession('where') ?? '');
 
         if (empty($where)) {
             return json_encode(['success' => false, 'message' => xlt('No file path specified')]);
         }
         $allowedRoot = realpath($this->baseDir) ?: $this->baseDir;
-        $targetPath  = $this->normalizePath($where);
+        $targetPath = $this->normalizePath($where);
 
         if (!$this->isPathAllowed($targetPath, $allowedRoot)) {
             error_log("SECURITY: Fax disposeDocument path violation: {$targetPath}");
@@ -584,8 +600,8 @@ class EtherFaxActions extends AppDispatch
             return json_encode(['success' => false, 'message' => xlt('Access denied')]);
         }
 
-        $content = (string) $this->getRequest('content', '');
-        $action  = (string) $this->getRequest('action', '');
+        $content = (string)$this->getRequest('content', '');
+        $action = (string)$this->getRequest('action', '');
 
         if ($action === 'download') {
             // Only allow download from allowed root
@@ -660,11 +676,6 @@ class EtherFaxActions extends AppDispatch
      */
     private function normalizePath(string $path): string
     {
-        // If the path is relative, anchor it under allowed baseDir
-        if (!str_starts_with($path, DIRECTORY_SEPARATOR)) {
-            $path = rtrim((string) $this->baseDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . ltrim($path, DIRECTORY_SEPARATOR);
-        }
-        // Collapse .. and .
         $parts = [];
         foreach (explode(DIRECTORY_SEPARATOR, $path) as $segment) {
             if ($segment === '' || $segment === '.') {
@@ -690,7 +701,7 @@ class EtherFaxActions extends AppDispatch
     private function isPathAllowed(string $targetPath, string $allowedRoot): bool
     {
         $allowed = realpath($allowedRoot) ?: $allowedRoot;
-        $real    = realpath($targetPath);
+        $real = realpath($targetPath);
         if ($real === false) {
             // If file does not exist yet, check its directory
             $real = realpath(dirname($targetPath));
@@ -710,8 +721,9 @@ class EtherFaxActions extends AppDispatch
     {
         // Check for PHP tags or HTML/JS script tags in first 1MB to be safe.
         $snippet = substr($data, 0, 1024 * 1024);
-        return (bool) preg_match('/<\?(php|=)|<script\b/i', $snippet);
+        return (bool)preg_match('/<\?(php|=)|<script\b/i', $snippet);
     }
+
     private function sendFile(string $filePath): void
     {
         ob_end_clean();
@@ -793,6 +805,52 @@ class EtherFaxActions extends AppDispatch
     }
 
     /**
+     * Insert a sent fax into the queue for status tracking.
+     * TransactionType 0 = Received, 1 = Sent
+     *
+     * @param object $faxStatus  The FaxStatus object returned from sendFax
+     * @param string $dialNumber The destination fax number
+     * @param string $callerId   The sender's caller ID
+     * @param string $tag        Optional tag for the fax
+     * @param string $fileName   Original filename
+     * @return int The inserted record ID
+     */
+    public function insertSentFaxQueue($faxStatus, string $dialNumber, string $callerId, string $tag = '', string $fileName = ''): int
+    {
+        $account = $this->credentials['account'];
+        $uid = $_SESSION['authUserID'];
+        $jobId = $faxStatus->JobId;
+
+        // Build a details object similar to received faxes but for sent
+        $details = new \stdClass();
+        $details->JobId = $jobId;
+        $details->TransactionType = 1; // 1 = Sent
+        $details->CalledNumber = $dialNumber;
+        $details->CallingNumber = $callerId;
+        $details->Tag = $tag;
+        $details->FaxResult = $faxStatus->FaxResult ?? FaxResult::InProgress;
+        $details->FaxResultText = FaxResult::getFaxResult($details->FaxResult);
+        $details->SentOn = date('c'); // ISO 8601 format
+        $details->CompletedOn = $faxStatus->CompletedOn ?? '';
+        $details->PagesDelivered = $faxStatus->PagesDelivered ?? 0;
+        $details->RemoteId = $faxStatus->RemoteId ?? '';
+        $details->FaxImage = $faxStatus->FaxImage ?? '';
+        // DocumentParams for consistency
+        $details->DocumentParams = new \stdClass();
+        $details->DocumentParams->Name = $fileName;
+        $details->DocumentParams->Type = 'application/pdf';
+        $details->DocumentParams->Length = strlen($details->FaxImage);
+
+        $details_encoded = json_encode($details);
+        $sentDate = date('Y-m-d H:i:s');
+
+        $sql = "INSERT INTO `oe_faxsms_queue` (`id`, `uid`, `account`, `job_id`, `date`, `receive_date`, `calling_number`, `called_number`, `mime`, `details_json`) 
+        VALUES (NULL, ?, ?, ?, current_timestamp(), ?, ?, ?, 'application/pdf', ?)";
+
+        return sqlInsert($sql, [$uid, $account, $jobId, $sentDate, $callerId, $dialNumber, $details_encoded]);
+    }
+
+    /**
      * @param      $start
      * @param      $end
      * @param bool $pollForNew
@@ -808,7 +866,7 @@ class EtherFaxActions extends AppDispatch
         $result = sqlStatement("SELECT `id`, `details_json`, `receive_date` FROM `oe_faxsms_queue` WHERE `deleted` = '0' AND (`receive_date` > ? AND `receive_date` < ?)", [$start, $end]);
 
         while ($row = sqlFetchArray($result)) {
-            $detail = json_decode((string) $row['details_json']);
+            $detail = json_decode((string)$row['details_json']);
             if (json_last_error()) {
                 continue;
             }
@@ -826,9 +884,13 @@ class EtherFaxActions extends AppDispatch
      */
     public function fetchFaxFromQueue($jobId, $id = null): mixed
     {
-        $row = $jobId ? sqlQuery("SELECT `id`, `details_json` FROM `oe_faxsms_queue` WHERE `job_id` = ? LIMIT 1", [$jobId]) : sqlQuery("SELECT `id`, `details_json` FROM `oe_faxsms_queue` WHERE `id` = ? LIMIT 1", [$id]);
-        $detail = json_decode((string) $row['details_json']);
-        $detail->RecordId = $row['id'];
+        $row = $jobId ? sqlQuery("SELECT `id`, `details_json` FROM `oe_faxsms_queue` WHERE `job_id` = ? AND `deleted` = '0' ORDER BY `date` DESC LIMIT 1", [$jobId]) : sqlQuery("SELECT `id`, `details_json` FROM `oe_faxsms_queue` WHERE `id` = ? AND `deleted` = '0' ORDER BY `date` DESC LIMIT 1", [$id]);
+        if (empty($row)) {
+            error_log("Fax not found or corrupt: " . text($jobId));
+            return [];
+        }
+        $detail = json_decode((string)$row['details_json']);
+        $detail->RecordId = $row['id'] ?? 0;
 
         return $detail;
     }
@@ -876,7 +938,7 @@ class EtherFaxActions extends AppDispatch
         $mime = $fax->DocumentParams->Type;
         $ext = $mime == 'application/pdf' ? '.pdf' : ($mime == 'image/tiff' || $mime == 'image/tif' ? '.tiff' : '.txt');
         $fileName ??= xlt("fax") . '_' . text($docId) . $ext;
-        $content = base64_decode((string) $fax->FaxImage);
+        $content = base64_decode((string)$fax->FaxImage);
         $document = new Document();
 
         $result = $document->createDocument($pid, $catid, $fileName, $mime, $content);
@@ -901,10 +963,10 @@ class EtherFaxActions extends AppDispatch
         foreach ($source as $src) {
             foreach ($val as $k => $v) {
                 foreach ($v as $s) {
-                    if (stripos((string) $src->Name, $s) !== false) {
+                    if (stripos((string)$src->Name, $s) !== false) {
                         if ($k == "sex") {
-                            $src->Text = ucfirst((string) $src->Text);
-                            $src->Text = stripos((string) $src->Name, 'Male') !== false ? 'Male' : (stripos((string) $src->Name, 'Female') !== false ? 'Female' : ($src->Text == 'M' ? 'Male' : ($src->Text == 'F' ? 'Female' : $src->Text)));
+                            $src->Text = ucfirst((string)$src->Text);
+                            $src->Text = stripos((string)$src->Name, 'Male') !== false ? 'Male' : (stripos((string)$src->Name, 'Female') !== false ? 'Female' : ($src->Text == 'M' ? 'Male' : ($src->Text == 'F' ? 'Female' : $src->Text)));
                         }
                         $rtn[$k] = $src->Text;
                     }

--- a/interface/modules/custom_modules/oe-module-faxsms/src/EtherFax/EtherFaxClient.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/EtherFax/EtherFaxClient.php
@@ -158,14 +158,16 @@ class EtherFaxClient
     }
 
     /**
-     * @param $number
-     * @param $file
-     * @param $pages
-     * @param $localId
-     * @param $callerId
-     * @param $tag
-     * @param $tz
+     * @param      $number
+     * @param      $file
+     * @param      $pages
+     * @param null $localId
+     * @param null $callerId
+     * @param null $tag
+     * @param null $isDocument
+     * @param null $fileName
      * @return FaxStatus
+     * @throws \Exception
      */
     public function sendFax($number, $file, $pages, $localId = null, $callerId = null, $tag = null, $isDocument = null, $fileName = null): FaxStatus
     {
@@ -182,6 +184,8 @@ class EtherFaxClient
             // is content of document
             $data = $file;
         }
+        $faxImage = base64_encode((string) $data);
+
         //use server timezone
         if (empty($tz)) {
             $now = new DateTime();
@@ -194,7 +198,7 @@ class EtherFaxClient
         // create post array/items
         $post = [
             'DialNumber' => $number,
-            'FaxImage' => base64_encode((string) $data),
+            'FaxImage' => $faxImage,
             'TotalPages' => $pages,
             'TimeZoneOffset' => $tz
         ];
@@ -209,7 +213,7 @@ class EtherFaxClient
             $post['Tag'] = $tag;
         }
         $DocumentParams = new \stdClass();
-        $DocumentParams->Name = $fileName ?? 'Unknown';
+        $DocumentParams->Name = $fileName;
         $post['DocumentParams'] = $DocumentParams;
 
         $post['HeaderString'] = "  {date:d-MMM-yyyy}  {time}   FROM: {csid}  TO: {number}   P. {page}";
@@ -223,6 +227,7 @@ class EtherFaxClient
             // This will have an error 'Message' in response.
             $status->set(json_decode($response));
         }
+        $status->set(['FaxImage'=>$faxImage]);
 
         return $status;
     }
@@ -234,6 +239,7 @@ class EtherFaxClient
      * @param            $url
      * @param array|null $post
      * @return bool|string
+     * @throws \Exception
      */
     private function clientHttpPost($url, ?array $post = null): bool|string
     {

--- a/interface/modules/custom_modules/oe-module-faxsms/src/EtherFax/FaxStatus.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/EtherFax/FaxStatus.php
@@ -27,6 +27,7 @@ class FaxStatus
     public $CompletedOn;
     public int $Result;
     public $Message;
+    public $FaxImage;
 
     /**
      * Default constructor.


### PR DESCRIPTION
* Add sent fax history to etherFAX add logic to store successful sent fax in local fax queue table.

* fix normalizePath relative path detect breaking content path

* Fix normalizing paths as was breaking on Linux fix tiff processor/converter. Missing dependency UTIF.js!!!

* phpstan

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #9888 

#### Short description of what this resolves:


#### Changes proposed in this pull request:

#### Does your code include anything generated by an AI Engine? Yes / No

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.
