### PR TITLE
chore(deps): bump the selenium-updates group across 3 directories with 1 update (#9824)

### DIFF
--- a/ci/compose-shared-selenium/docker-compose.yml
+++ b/ci/compose-shared-selenium/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   selenium:
-    image: selenium/standalone-chromium:4.38.0
+    image: selenium/standalone-chromium:4.39.0
     # Services with profiles don't start by default.
     profiles:
     - selenium

--- a/docker/development-easy/docker-compose.yml
+++ b/docker/development-easy/docker-compose.yml
@@ -110,7 +110,7 @@ services:
       retries: 3
   selenium:
     restart: always
-    image: selenium/standalone-chromium:4.38.0
+    image: selenium/standalone-chromium:4.39.0
     ports:
     - 4444:4444    # Selenium WebDriver interface
     - 7900:7900    # VNC port for viewing browser during tests (to work, will require SELENIUM_FORCE_HEADLESS to be "false" in openemr service)

--- a/docker/development-insane/docker-compose.yml
+++ b/docker/development-insane/docker-compose.yml
@@ -713,7 +713,7 @@ services:
     - 9443:9443
   selenium:
     restart: always
-    image: selenium/standalone-chromium:4.38.0
+    image: selenium/standalone-chromium:4.39.0
     ports:
     - 4444:4444    # Selenium WebDriver interface
     - 7900:7900    # VNC port for viewing browser during tests (to work, will require SELENIUM_FORCE_HEADLESS to be "false" in openemr service)


### PR DESCRIPTION
Bumps the selenium-updates group with 1 update in the /ci/compose-shared-selenium directory: selenium/standalone-chromium.
Bumps the selenium-updates group with 1 update in the /docker/development-easy directory: selenium/standalone-chromium.
Bumps the selenium-updates group with 1 update in the /docker/development-insane directory: selenium/standalone-chromium.


Updates `selenium/standalone-chromium` from 4.38.0 to 4.39.0

Updates `selenium/standalone-chromium` from 4.38.0 to 4.39.0

Updates `selenium/standalone-chromium` from 4.38.0 to 4.39.0

---
updated-dependencies:
- dependency-name: selenium/standalone-chromium
  dependency-version: 4.39.0
  dependency-type: direct:production
  update-type: version-update:semver-minor
  dependency-group: selenium-updates
- dependency-name: selenium/standalone-chromium
  dependency-version: 4.39.0
  dependency-type: direct:production
  update-type: version-update:semver-minor
  dependency-group: selenium-updates
- dependency-name: selenium/standalone-chromium
  dependency-version: 4.39.0
  dependency-type: direct:production
  update-type: version-update:semver-minor
  dependency-group: selenium-updates
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

---

Backport of #9824
Fixes #9913
