### PR TITLE
fix: use maridab for mariadb 11.4 aka mariadb-old dev insane

### DIFF
--- a/docker/development-insane/docker-compose.yml
+++ b/docker/development-insane/docker-compose.yml
@@ -454,7 +454,7 @@ services:
   mariadb-old:
     restart: always
     image: mariadb:11.4
-    command: ['mariadb','--character-set-server=utf8mb4']
+    command: ['mariadbd','--character-set-server=utf8mb4']
     environment:
       MYSQL_ROOT_PASSWORD: root
     healthcheck:


### PR DESCRIPTION
<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #9955 

#### Short description of what this resolves:


#### Changes proposed in this pull request:

#### Does your code include anything generated by an AI Engine? Yes / No

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.
