### PR TITLE
Fix deprecated PHP property_exist error in portal

### DIFF
--- a/portal/patient/fwk/libs/verysimple/Phreeze/Reporter.php
+++ b/portal/patient/fwk/libs/verysimple/Phreeze/Reporter.php
@@ -30,7 +30,7 @@ abstract class Reporter implements Serializable
     ];
 
     /** @var cache of public properties for each type for improved performance when enumerating */
-    private static $PublicPropCache =  [];
+    private static array $PublicPropCache = [];
 
     /**
      * Returns true if the current object has been loaded
@@ -176,7 +176,7 @@ abstract class Reporter implements Serializable
     {
         $className = static::class;
 
-        if (! property_exists(self::$PublicPropCache, $className)) {
+        if (! array_key_exists($className, self::$PublicPropCache)) {
             $props =  [];
             $ro = new ReflectionObject($this);
 


### PR DESCRIPTION
trying to test for property object on an array is a no no for PHP 8.0+

<!--Thanks for sending a pull request! 
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #9963

#### Short description of what this resolves:


#### Changes proposed in this pull request:

#### Does your code include anything generated by an AI Engine? Yes / No

@adunsulag I think the AI warning should be a comment in edit mode and not show on PR. Just the question. I may change if no objection. 
#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.
