### PR TITLE
perf: add composite index on lang_definitions for translation lookups

### DIFF
--- a/sql/7_0_4-to-7_0_5_upgrade.sql
+++ b/sql/7_0_4-to-7_0_5_upgrade.sql
@@ -112,3 +112,7 @@
 --  #IfMBOEncounterNeeded
 --    desc: Add encounter to the form_misc_billing_options table
 --    arguments: none
+
+#IfNotIndex lang_definitions lang_cons
+CREATE INDEX `lang_cons` ON `lang_definitions` (`lang_id`, `cons_id`);
+#EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -3537,7 +3537,8 @@ CREATE TABLE `lang_definitions` (
   `lang_id` int(11) NOT NULL default '0',
   `definition` mediumtext,
   UNIQUE KEY `def_id` (`def_id`),
-  KEY `cons_id` (`cons_id`)
+  KEY `cons_id` (`cons_id`),
+  KEY `lang_cons` (`lang_id`, `cons_id`)
 ) ENGINE=InnoDB;
 
 -- --------------------------------------------------------

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@ $v_realpatch = '0';
 // is a database change in the course of development.  It is used
 // internally to determine when a database upgrade is needed.
 //
-$v_database = 529;
+$v_database = 530;
 
 // Access control version identifier, this is to be incremented whenever there
 // is a access control change in the course of development.  It is used


### PR DESCRIPTION
Fixes #9971

#### Short description of what this resolves:

The `xl()` translation function performs a JOIN query between `lang_definitions` and `lang_constants` tables, filtering by `lang_id`. Without an index on `lang_id`, MySQL must scan the entire `lang_definitions` table for each translation lookup.

#### Changes proposed in this pull request:

- Add composite index `(lang_id, cons_id)` on `lang_definitions` table in `database.sql` for fresh installations
- Add migration in `7_0_4-to-7_0_5_upgrade.sql` to create the index for existing installations

This index allows MySQL to efficiently filter by language and join on `cons_id` in a single index scan, significantly improving translation query performance.

#### Does your code include anything generated by an AI Engine? Yes / No

Yes

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.

The changes were generated with Claude Code (Claude Opus 4.5). The commit message includes the standard Claude Code attribution footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)