### PR TITLE
perf: disable translation engine during tests

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,4 +9,10 @@ if (php_sapi_name() !== 'cli') {
 
 $_GET['site'] = 'default';
 $ignoreAuth = true;
+
+// Disable translation engine during tests to reduce database overhead.
+// Tests verify logic, not translated strings, so this is safe.
+// See: https://github.com/openemr/openemr/issues/9999
+$GLOBALS['disable_translation'] = true;
+
 require_once(__DIR__ . "/../interface/globals.php");


### PR DESCRIPTION
## Summary
- Disable the translation engine in the test bootstrap to eliminate database queries from `xl()` calls during test execution

## Background
Per #9999, the test suite loads `globals.php` which enables translation functions. With 862 `xl()` calls across 117 source files, this creates significant database overhead during test runs.

Setting `$GLOBALS['disable_translation'] = true` before loading globals causes `xl()` to return constants immediately without any database queries.

## Test plan
- [ ] Compare "Test All Configurations" workflow times against baseline data in #9999
- [ ] Verify all tests still pass

Closes: #9999

🤖 Generated with [Claude Code](https://claude.com/claude-code)