### PR TITLE
fix(sql): aggregate uuid in care_teams migration GROUP BY

### DIFF
--- a/sql/7_0_3-to-7_0_4_upgrade.sql
+++ b/sql/7_0_3-to-7_0_4_upgrade.sql
@@ -233,7 +233,7 @@ CREATE TABLE `care_teams` (
 #IfTable care_teams_v1
 INSERT INTO `care_teams` (`uuid`, `pid`, `status`, `team_name`, `date_created`, `date_updated`)
 SELECT
-    `uuid`,
+    MIN(`uuid`) AS `uuid`,
     `pid`,
     `status`,
     `team_name`,


### PR DESCRIPTION
## Summary
- Fixes invalid SQL in 7_0_3-to-7_0_4_upgrade.sql where `uuid` was selected without aggregation in a GROUP BY query
- Wraps `uuid` in `MIN()` to make the query valid and deterministic

## Test plan
- [ ] Verify the migration runs without SQL errors on a database with existing care_teams data
- [ ] Confirm the migrated care_teams retain valid UUIDs

Fixes #9984

🤖 Generated with [Claude Code](https://claude.com/claude-code)