### PR TITLE
fix(ci): correct dclint argument order and run on all PRs

### DIFF
--- a/.github/workflows/docker-compose-lint.yml
+++ b/.github/workflows/docker-compose-lint.yml
@@ -5,20 +5,10 @@ on:
     branches:
     - master
     - rel-*
-    paths:
-    - '**/*compose*.yml'
-    - '**/*compose*.yaml'
-    - '.github/workflows/docker-compose-lint.yml'
-    - '.dclintrc.yaml'
   pull_request:
     branches:
     - master
     - rel-*
-    paths:
-    - '**/*compose*.yml'
-    - '**/*compose*.yaml'
-    - '.github/workflows/docker-compose-lint.yml'
-    - '.dclintrc.yaml'
 
 permissions:
   contents: read
@@ -67,9 +57,9 @@ jobs:
     - name: Run dclint on changed files
       if: steps.files-to-check.outputs.mode == 'files'
       run: |
-        docker run --rm --volume "$PWD:$PWD" --workdir "$PWD" zavoloklom/dclint:3.1.0 --exclude .github ${{ steps.files-to-check.outputs.files }}
-    
+        docker run --rm --volume "$PWD:$PWD" --workdir "$PWD" zavoloklom/dclint:3.1.0 ${{ steps.files-to-check.outputs.files }} --exclude .github
+
     - name: Run dclint recursively
       if: steps.files-to-check.outputs.mode == 'recursive'
       run: |
-        docker run --rm --volume "$PWD:$PWD" --workdir "$PWD" zavoloklom/dclint:3.1.0 --exclude .github --recursive ci/ docker/
+        docker run --rm --volume "$PWD:$PWD" --workdir "$PWD" zavoloklom/dclint:3.1.0 ci/ docker/ --recursive --exclude .github


### PR DESCRIPTION
## Summary
- Fixed dclint argument order - files must come before `--exclude` option (fixes #9959)
- Removed `paths` filter so workflow runs on all PRs/pushes, not just when compose files change

## Root Cause
The `dclint` CLI expects `<files..> [options]` syntax. The workflow was passing `--exclude .github` **before** the file arguments, causing the `--exclude` array option to consume file paths as its values, leaving dclint with 0 positional arguments.

## Test plan
- [ ] Verify workflow runs on PRs without docker compose changes
- [ ] Verify workflow passes when docker compose files are changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)