### PR TITLE
feat: add PhpUnitsOfMeasure library for healthcare unit conversions

### DIFF
--- a/.phpstan/phpstan-globals-baseline.neon
+++ b/.phpstan/phpstan-globals-baseline.neon
@@ -742,11 +742,11 @@ parameters:
       path: ../interface/forms/vitals/C_FormVitals.class.php
     - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
       identifier: openemr.forbiddenGlobalsAccess
-      count: 4
+      count: 2
       path: ../interface/forms/vitals/growthchart/chart.php
     - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
       identifier: openemr.forbiddenGlobalsAccess
-      count: 13
+      count: 3
       path: ../interface/forms/vitals/report.php
     - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
       identifier: openemr.forbiddenGlobalsAccess

--- a/.phpstan/phpstan-globals-baseline.neon
+++ b/.phpstan/phpstan-globals-baseline.neon
@@ -1298,7 +1298,7 @@ parameters:
       path: ../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaServiceRequestModelGenerator.php
     - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
       identifier: openemr.forbiddenGlobalsAccess
-      count: 8
+      count: 6
       path: ../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncounterccdadispatchTable.php
     - message: '#^Direct access to \$GLOBALS is forbidden\. Use OEGlobalsBag\:\:getInstance\(\)\-\>get\(\) instead\.$#'
       identifier: openemr.forbiddenGlobalsAccess

--- a/composer.json
+++ b/composer.json
@@ -91,6 +91,7 @@
         "pear/archive_tar": "1.6.0",
         "php-http/discovery": "1.20.0",
         "php-http/message": "^1.16",
+        "php-units-of-measure/php-units-of-measure": "^2.1",
         "php81_bc/strftime": "0.7.6",
         "phpmailer/phpmailer": "6.12.0",
         "phpoffice/phpspreadsheet": "5.3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "277b135801ce737e528ac223e9921e53",
+    "content-hash": "8d5c31e24581214125a0749706a9e56b",
     "packages": [
         {
             "name": "academe/authorizenet-objects",
@@ -6536,6 +6536,59 @@
                 "source": "https://github.com/php-http/promise/tree/1.3.1"
             },
             "time": "2024-03-15T13:55:21+00:00"
+        },
+        {
+            "name": "php-units-of-measure/php-units-of-measure",
+            "version": "v2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PhpUnitsOfMeasure/php-units-of-measure.git",
+                "reference": "cf1b83b1ef7615dd53f70864c9e7f496b1ec0fd1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PhpUnitsOfMeasure/php-units-of-measure/zipball/cf1b83b1ef7615dd53f70864c9e7f496b1ec0fd1",
+                "reference": "cf1b83b1ef7615dd53f70864c9e7f496b1ec0fd1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4"
+            },
+            "replace": {
+                "triplepoint/php-units-of-measure": "*"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5",
+                "squizlabs/php_codesniffer": "^3.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpUnitsOfMeasure\\": "source/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Hanson",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A PHP library for converting between standard units of measure.",
+            "homepage": "https://github.com/PhpUnitsOfMeasure/php-units-of-measure",
+            "keywords": [
+                "conversion",
+                "data",
+                "measurements"
+            ],
+            "support": {
+                "issues": "https://github.com/PhpUnitsOfMeasure/php-units-of-measure/issues",
+                "source": "https://github.com/PhpUnitsOfMeasure/php-units-of-measure"
+            },
+            "time": "2025-04-30T23:02:43+00:00"
         },
         {
             "name": "php81_bc/strftime",
@@ -14844,5 +14897,5 @@
         "ext-zlib": "8.2",
         "php": "8.2"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/interface/eRxStore.php
+++ b/interface/eRxStore.php
@@ -13,6 +13,8 @@
 
 require_once(__DIR__ . "/../library/api.inc.php");
 
+use OpenEMR\Common\Utils\MeasurementUtils;
+
 class eRxStore
 {
     /**
@@ -112,8 +114,9 @@ class eRxStore
 
         $data = formFetch("form_vitals", $result['id']);
 
-        $weight = number_format($data['weight'] * 0.45359237, 2);
-        $height = number_format(round($data['height'] * 2.54, 1), 2);
+        $measurementUtils = new MeasurementUtils();
+        $weight = number_format((float)$measurementUtils->lbToKg($data['weight']), 2);
+        $height = number_format(round((float)$measurementUtils->inchesToCm($data['height']), 1), 2);
 
         return [
             'height' => $height,

--- a/interface/eRxStore.php
+++ b/interface/eRxStore.php
@@ -115,8 +115,8 @@ class eRxStore
         $data = formFetch("form_vitals", $result['id']);
 
         $measurementUtils = new MeasurementUtils();
-        $weight = number_format((float)$measurementUtils->lbToKg($data['weight']), 2);
-        $height = number_format(round((float)$measurementUtils->inchesToCm($data['height']), 1), 2);
+        $weight = number_format($measurementUtils->convertLbToKg($data['weight']), 2);
+        $height = number_format(round($measurementUtils->convertInchesToCm($data['height']), 1), 2);
 
         return [
             'height' => $height,

--- a/interface/forms/vitals/growthchart/chart.php
+++ b/interface/forms/vitals/growthchart/chart.php
@@ -79,9 +79,16 @@ $datapoints = $vitalsService->getVitalsHistoryForPatient($pid, true);
 $first_datapoint = $datapoints[0];
 if (!empty($first_datapoint)) {
     $date = str_replace('-', '', substr((string) $first_datapoint['date'], 0, 10));
-    $height = $measurementUtils->isMetric() ? convertHeightToUs($first_datapoint['height']) : $first_datapoint['height'];
-    $weight = $measurementUtils->isMetric() ? convertWeightToUs($first_datapoint['weight']) : $first_datapoint['weight'];
-    $head_circ = $measurementUtils->isMetric() ? convertHeightToUs($first_datapoint['head_circ']) : $first_datapoint['head_circ'];
+    // When system is metric, vitals data comes in metric units - convert to US for chart plotting
+    $height = $measurementUtils->isMetric()
+        ? $measurementUtils->convertCmToInches($first_datapoint['height'])
+        : $first_datapoint['height'];
+    $weight = $measurementUtils->isMetric()
+        ? $measurementUtils->convertKgToLb($first_datapoint['weight'])
+        : $first_datapoint['weight'];
+    $head_circ = $measurementUtils->isMetric()
+        ? $measurementUtils->convertCmToInches($first_datapoint['head_circ'])
+        : $first_datapoint['head_circ'];
 
     if ($date != "") {
         $charttype_date = $date;
@@ -100,20 +107,6 @@ if (isset($_GET['chart_type'])) {
 
 //sort the datapoints
 rsort($datapoints);
-
-// Helper functions to convert vitals service data to US values for graphing
-function convertHeightToUs($height)
-{
-    global $measurementUtils;
-    return (float)$measurementUtils->cmToInches($height);
-}
-
-function convertWeightToUs($weight)
-{
-    global $measurementUtils;
-    return (float)$measurementUtils->kgToLb($weight);
-}
-
 
 $name_x = 650;
 $name_y = 50;
@@ -417,9 +410,15 @@ if (($_GET['html'] ?? null) == 1) {
         if (!empty($data)) {
             $date = str_replace('-', '', substr((string) $data['date'], 0, 10));
             // convert to US if metric locale
-            $height = ($measurementUtils->isMetric() ? convertHeightToUs($data['height']) : $data['height']);
-            $weight = ($measurementUtils->isMetric() ? convertWeightToUs($data['weight']) : $data['weight']);
-            $head_circ = ($measurementUtils->isMetric() ? convertHeightToUs($data['head_circ']) : $data['head_circ']);
+            $height = $measurementUtils->isMetric()
+                ? $measurementUtils->convertCmToInches($data['height'])
+                : $data['height'];
+            $weight = $measurementUtils->isMetric()
+                ? $measurementUtils->convertKgToLb($data['weight'])
+                : $data['weight'];
+            $head_circ = $measurementUtils->isMetric()
+                ? $measurementUtils->convertCmToInches($data['head_circ'])
+                : $data['head_circ'];
 
             if ($date == "") {
                 continue;
@@ -574,9 +573,15 @@ foreach ($datapoints as $data) {
     if (!empty($data)) {
         $date = str_replace('-', '', substr((string) $data['date'], 0, 10));
         // values can be US or metric thus convert to US for graphing
-        $height = ($measurementUtils->isMetric() ? convertHeightToUs($data['height']) : $data['height']);
-        $weight = ($measurementUtils->isMetric() ? convertWeightToUs($data['weight']) : $data['weight']);
-        $head_circ = ($measurementUtils->isMetric() ? convertHeightToUs($data['head_circ']) : $data['head_circ']);
+        $height = $measurementUtils->isMetric()
+            ? $measurementUtils->convertCmToInches($data['height'])
+            : $data['height'];
+        $weight = $measurementUtils->isMetric()
+            ? $measurementUtils->convertKgToLb($data['weight'])
+            : $data['weight'];
+        $head_circ = $measurementUtils->isMetric()
+            ? $measurementUtils->convertCmToInches($data['head_circ'])
+            : $data['head_circ'];
 
         if ($date == "") {
             continue;

--- a/interface/forms/vitals/growthchart/chart.php
+++ b/interface/forms/vitals/growthchart/chart.php
@@ -80,15 +80,15 @@ $first_datapoint = $datapoints[0];
 if (!empty($first_datapoint)) {
     $date = str_replace('-', '', substr((string) $first_datapoint['date'], 0, 10));
     // When system is metric, vitals data comes in metric units - convert to US for chart plotting
-    $height = $measurementUtils->isMetric()
-        ? $measurementUtils->convertCmToInches($first_datapoint['height'])
-        : $first_datapoint['height'];
-    $weight = $measurementUtils->isMetric()
-        ? $measurementUtils->convertKgToLb($first_datapoint['weight'])
-        : $first_datapoint['weight'];
-    $head_circ = $measurementUtils->isMetric()
-        ? $measurementUtils->convertCmToInches($first_datapoint['head_circ'])
-        : $first_datapoint['head_circ'];
+    if ($measurementUtils->isMetric()) {
+        $height = $measurementUtils->convertCmToInches($first_datapoint['height']);
+        $weight = $measurementUtils->convertKgToLb($first_datapoint['weight']);
+        $head_circ = $measurementUtils->convertCmToInches($first_datapoint['head_circ']);
+    } else {
+        $height = $first_datapoint['height'];
+        $weight = $first_datapoint['weight'];
+        $head_circ = $first_datapoint['head_circ'];
+    }
 
     if ($date != "") {
         $charttype_date = $date;
@@ -410,15 +410,15 @@ if (($_GET['html'] ?? null) == 1) {
         if (!empty($data)) {
             $date = str_replace('-', '', substr((string) $data['date'], 0, 10));
             // convert to US if metric locale
-            $height = $measurementUtils->isMetric()
-                ? $measurementUtils->convertCmToInches($data['height'])
-                : $data['height'];
-            $weight = $measurementUtils->isMetric()
-                ? $measurementUtils->convertKgToLb($data['weight'])
-                : $data['weight'];
-            $head_circ = $measurementUtils->isMetric()
-                ? $measurementUtils->convertCmToInches($data['head_circ'])
-                : $data['head_circ'];
+            if ($measurementUtils->isMetric()) {
+                $height = $measurementUtils->convertCmToInches($data['height']);
+                $weight = $measurementUtils->convertKgToLb($data['weight']);
+                $head_circ = $measurementUtils->convertCmToInches($data['head_circ']);
+            } else {
+                $height = $data['height'];
+                $weight = $data['weight'];
+                $head_circ = $data['head_circ'];
+            }
 
             if ($date == "") {
                 continue;

--- a/interface/forms/vitals/growthchart/chart.php
+++ b/interface/forms/vitals/growthchart/chart.php
@@ -42,6 +42,7 @@ require_once("../../../../interface/globals.php");
 require_once($GLOBALS['fileroot'] . "/library/patient.inc.php");
 
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Utils\MeasurementUtils;
 use OpenEMR\Services\VitalsService;
 
 
@@ -60,8 +61,7 @@ if ($pid == "") {
 }
 
 $vitalsService = new VitalsService();
-
-$isMetric = ((($GLOBALS['units_of_measurement'] == 2) || ($GLOBALS['units_of_measurement'] == 4)) ? true : false);
+$measurementUtils = new MeasurementUtils();
 
 $patient_data = "";
 if (isset($pid) && is_numeric($pid)) {
@@ -79,9 +79,9 @@ $datapoints = $vitalsService->getVitalsHistoryForPatient($pid, true);
 $first_datapoint = $datapoints[0];
 if (!empty($first_datapoint)) {
     $date = str_replace('-', '', substr((string) $first_datapoint['date'], 0, 10));
-    $height = (($isMetric) ? convertHeightToUs($first_datapoint['height']) : $first_datapoint['height']);
-    $weight = (($isMetric) ? convertWeightToUS($first_datapoint['weight']) : $first_datapoint['weight']);
-    $head_circ = (($isMetric) ? convertHeightToUs($first_datapoint['head_circ']) : $first_datapoint['head_circ']);
+    $height = $measurementUtils->isMetric() ? convertHeightToUs($first_datapoint['height']) : $first_datapoint['height'];
+    $weight = $measurementUtils->isMetric() ? convertWeightToUs($first_datapoint['weight']) : $first_datapoint['weight'];
+    $head_circ = $measurementUtils->isMetric() ? convertHeightToUs($first_datapoint['head_circ']) : $first_datapoint['head_circ'];
 
     if ($date != "") {
         $charttype_date = $date;
@@ -101,38 +101,18 @@ if (isset($_GET['chart_type'])) {
 //sort the datapoints
 rsort($datapoints);
 
-
-// convert to applicable weight units from Config Locale
-function unitsWt($wt)
-{
-    global $isMetric;
-    return $isMetric
-        ? sprintf('%s %s', number_format(($wt * 0.45359237), 2, '.', ''), xl('kg'))
-        : sprintf('%s %s', number_format($wt, 2), xl('lb'));
-}
-
-// convert to applicable length units from Config Locale
-function unitsDist($dist)
-{
-    global $isMetric;
-    return $isMetric
-        ? sprintf('%s %s', number_format(($dist * 2.54), 2, '.', ''), xl('cm'))
-        : sprintf('%s %s', number_format($dist, 2), xl('in'));
-}
-
-// convert vitals service data to US values for graphing
+// Helper functions to convert vitals service data to US values for graphing
 function convertHeightToUs($height)
 {
-    return $height * 0.393701;
+    global $measurementUtils;
+    return (float)$measurementUtils->cmToInches($height);
 }
 
 function convertWeightToUs($weight)
 {
-    return $weight * 2.20462262185;
+    global $measurementUtils;
+    return (float)$measurementUtils->kgToLb($weight);
 }
-/******************************/
-/******************************/
-/******************************/
 
 
 $name_x = 650;
@@ -437,9 +417,9 @@ if (($_GET['html'] ?? null) == 1) {
         if (!empty($data)) {
             $date = str_replace('-', '', substr((string) $data['date'], 0, 10));
             // convert to US if metric locale
-            $height = (($isMetric) ? convertHeightToUs($data['height']) : $data['height']);
-            $weight = (($isMetric) ? convertWeightToUs($data['weight']) : $data['weight']);
-            $head_circ = (($isMetric) ? convertHeightToUs($data['head_circ']) : $data['head_circ']);
+            $height = ($measurementUtils->isMetric() ? convertHeightToUs($data['height']) : $data['height']);
+            $weight = ($measurementUtils->isMetric() ? convertWeightToUs($data['weight']) : $data['weight']);
+            $head_circ = ($measurementUtils->isMetric() ? convertHeightToUs($data['head_circ']) : $data['head_circ']);
 
             if ($date == "") {
                 continue;
@@ -516,11 +496,11 @@ if (($_GET['html'] ?? null) == 1) {
                 $point = convertpoint([$datatable_x + $datatable_age_offset,$datatable_y]);
                 echo("<div id='" . attr($point[2]) . "' class='label_custom' style='position: absolute; top: " . attr($point[1]) . "pt; left: " . attr($point[0]) . "pt;'>" . text($ageinYMD) . "</div>\n");
                 $point = convertpoint([$datatable_x + $datatable_weight_offset,$datatable_y]);
-                echo("<div id='" . attr($point[2]) . "' class='label_custom' style='position: absolute; top: " . attr($point[1]) . "pt; left: " . attr($point[0]) . "pt;'>" . text(unitsWt($weight)) . "</div>\n");
+                echo("<div id='" . attr($point[2]) . "' class='label_custom' style='position: absolute; top: " . attr($point[1]) . "pt; left: " . attr($point[0]) . "pt;'>" . text($measurementUtils->formatWeight($weight, true)) . "</div>\n");
                 $point = convertpoint([$datatable_x + $datatable_height_offset,$datatable_y]);
-                echo("<div id='" . attr($point[2]) . "' class='label_custom' style='position: absolute; top: " . attr($point[1]) . "pt; left: " . attr($point[0]) . "pt;'>" . text(unitsDist($height)) . "</div>\n");
+                echo("<div id='" . attr($point[2]) . "' class='label_custom' style='position: absolute; top: " . attr($point[1]) . "pt; left: " . attr($point[0]) . "pt;'>" . text($measurementUtils->formatLength($height, true)) . "</div>\n");
                 $point = convertpoint([$datatable_x + $datatable_hc_offset,$datatable_y]);
-                echo("<div id='" . attr($point[2]) . "' class='label_custom' style='position: absolute; top: " . attr($point[1]) . "pt; left: " . attr($point[0]) . "pt;'>" . text(unitsDist($head_circ)) . "</div>\n");
+                echo("<div id='" . attr($point[2]) . "' class='label_custom' style='position: absolute; top: " . attr($point[1]) . "pt; left: " . attr($point[0]) . "pt;'>" . text($measurementUtils->formatLength($head_circ, true)) . "</div>\n");
                 $datatable_y += $datatable_y_increment; // increment the datatable "row pointer"
             }
 
@@ -531,9 +511,9 @@ if (($_GET['html'] ?? null) == 1) {
                 $point = convertpoint([$datatable_x + $datatable_age_offset,$datatable_y]);
                 echo("<div id='" . attr($point[2]) . "' class='label_custom' style='position: absolute; top: " . attr($point[1]) . "pt; left: " . attr($point[0]) . "pt;'>" . text($ageinYMD) . "</div>\n");
                 $point = convertpoint([$datatable_x + $datatable_weight_offset,$datatable_y]);
-                echo("<div id='" . attr($point[2]) . "' class='label_custom' style='position: absolute; top: " . attr($point[1]) . "pt; left: " . attr($point[0]) . "pt;'>" . text(unitsWt($weight)) . "</div>\n");
+                echo("<div id='" . attr($point[2]) . "' class='label_custom' style='position: absolute; top: " . attr($point[1]) . "pt; left: " . attr($point[0]) . "pt;'>" . text($measurementUtils->formatWeight($weight, true)) . "</div>\n");
                 $point = convertpoint([$datatable_x + $datatable_height_offset,$datatable_y]);
-                echo("<div id='" . attr($point[2]) . "' class='label_custom' style='position: absolute; top: " . attr($point[1]) . "pt; left: " . attr($point[0]) . "pt;'>" . text(unitsDist($height)) . "</div>\n");
+                echo("<div id='" . attr($point[2]) . "' class='label_custom' style='position: absolute; top: " . attr($point[1]) . "pt; left: " . attr($point[0]) . "pt;'>" . text($measurementUtils->formatLength($height, true)) . "</div>\n");
                 $point = convertpoint([$datatable_x + $datatable_bmi_offset,$datatable_y]);
                 echo("<div id='" . attr($point[2]) . "' class='label_custom' style='position: absolute; top: " . attr($point[1]) . "pt; left: " . attr($point[0]) . "pt;'>" . text(substr((string) $bmi, 0, 5)) . "</div>\n");
                 $datatable_y += $datatable_y_increment; // increment the datatable "row pointer"
@@ -546,11 +526,11 @@ if (($_GET['html'] ?? null) == 1) {
                 $point = convertpoint([$datatable2_x + $datatable2_age_offset,$datatable2_y]);
                 echo("<div id='" . attr($point[2]) . "' class='label_custom' style='position: absolute; top: " . attr($point[1]) . "pt; left: " . attr($point[0]) . "pt;'>" . text($ageinYMD) . "</div>\n");
                 $point = convertpoint([$datatable2_x + $datatable2_weight_offset,$datatable2_y]);
-                echo("<div id='" . attr($point[2]) . "' class='label_custom' style='position: absolute; top: " . attr($point[1]) . "pt; left: " . attr($point[0]) . "pt;'>" . text(unitsWt($weight)) . "</div>\n");
+                echo("<div id='" . attr($point[2]) . "' class='label_custom' style='position: absolute; top: " . attr($point[1]) . "pt; left: " . attr($point[0]) . "pt;'>" . text($measurementUtils->formatWeight($weight, true)) . "</div>\n");
                 $point = convertpoint([$datatable2_x + $datatable2_height_offset,$datatable2_y]);
-                echo("<div id='" . attr($point[2]) . "' class='label_custom' style='position: absolute; top: " . attr($point[1]) . "pt; left: " . attr($point[0]) . "pt;'>" . text(unitsDist($height)) . "</div>\n");
+                echo("<div id='" . attr($point[2]) . "' class='label_custom' style='position: absolute; top: " . attr($point[1]) . "pt; left: " . attr($point[0]) . "pt;'>" . text($measurementUtils->formatLength($height, true)) . "</div>\n");
                 $point = convertpoint([$datatable2_x + $datatable2_hc_offset,$datatable2_y]);
-                echo("<div id='" . attr($point[2]) . "' class='label_custom' style='position: absolute; top: " . attr($point[1]) . "pt; left: " . attr($point[0]) . "pt;'>" . text(unitsDist($head_circ)) . "</div>\n");
+                echo("<div id='" . attr($point[2]) . "' class='label_custom' style='position: absolute; top: " . attr($point[1]) . "pt; left: " . attr($point[0]) . "pt;'>" . text($measurementUtils->formatLength($head_circ, true)) . "</div>\n");
                 $datatable2_y += $datatable2_y_increment; // increment the datatable2 "row pointer"
             }
 
@@ -561,9 +541,9 @@ if (($_GET['html'] ?? null) == 1) {
                 $point = convertpoint([$datatable2_x + $datatable2_age_offset,$datatable2_y]);
                 echo("<div id='" . attr($point[2]) . "' class='label_custom' style='position: absolute; top: " . attr($point[1]) . "pt; left: " . attr($point[0]) . "pt;'>" . text($ageinYMD) . "</div>\n");
                 $point = convertpoint([$datatable2_x + $datatable2_weight_offset,$datatable2_y]);
-                echo("<div id='" . attr($point[2]) . "' class='label_custom' style='position: absolute; top: " . attr($point[1]) . "pt; left: " . attr($point[0]) . "pt;'>" . text(unitsWt($weight)) . "</div>\n");
+                echo("<div id='" . attr($point[2]) . "' class='label_custom' style='position: absolute; top: " . attr($point[1]) . "pt; left: " . attr($point[0]) . "pt;'>" . text($measurementUtils->formatWeight($weight, true)) . "</div>\n");
                 $point = convertpoint([$datatable2_x + $datatable2_height_offset,$datatable2_y]);
-                echo("<div id='" . attr($point[2]) . "' class='label_custom' style='position: absolute; top: " . attr($point[1]) . "pt; left: " . attr($point[0]) . "pt;'>" . text(unitsDist($height)) . "</div>\n");
+                echo("<div id='" . attr($point[2]) . "' class='label_custom' style='position: absolute; top: " . attr($point[1]) . "pt; left: " . attr($point[0]) . "pt;'>" . text($measurementUtils->formatLength($height, true)) . "</div>\n");
                 $point = convertpoint([$datatable2_x + $datatable2_bmi_offset,$datatable2_y]);
                 echo("<div id='" . attr($point[2]) . "' class='label_custom' style='position: absolute; top: " . attr($point[1]) . "pt; left: " . attr($point[0]) . "pt;'>" . text(substr((string) $bmi, 0, 5)) . "</div>\n");
                 $datatable2_y += $datatable2_y_increment; // increment the datatable2 "row pointer"
@@ -594,9 +574,9 @@ foreach ($datapoints as $data) {
     if (!empty($data)) {
         $date = str_replace('-', '', substr((string) $data['date'], 0, 10));
         // values can be US or metric thus convert to US for graphing
-        $height = (($isMetric) ? convertHeightToUs($data['height']) : $data['height']);
-        $weight = (($isMetric) ? convertWeightToUs($data['weight']) : $data['weight']);
-        $head_circ = (($isMetric) ? convertHeightToUs($data['head_circ']) : $data['head_circ']);
+        $height = ($measurementUtils->isMetric() ? convertHeightToUs($data['height']) : $data['height']);
+        $weight = ($measurementUtils->isMetric() ? convertWeightToUs($data['weight']) : $data['weight']);
+        $head_circ = ($measurementUtils->isMetric() ? convertHeightToUs($data['head_circ']) : $data['head_circ']);
 
         if ($date == "") {
             continue;
@@ -666,9 +646,9 @@ foreach ($datapoints as $data) {
         if ($count < 8 && $charttype == "birth") {
             imagestring($im, 2, $datatable_x, $datatable_y, $datestr, $color);
             imagestring($im, 2, ($datatable_x + $datatable_age_offset), $datatable_y, (string) $ageinYMD, $color);
-            imagestring($im, 2, ($datatable_x + $datatable_weight_offset), $datatable_y, (string) unitsWt($weight), $color);
-            imagestring($im, 2, ($datatable_x + $datatable_height_offset), $datatable_y, (string) unitsDist($height), $color);
-            imagestring($im, 2, ($datatable_x + $datatable_hc_offset), $datatable_y, (string) unitsDist($head_circ), $color);
+            imagestring($im, 2, ($datatable_x + $datatable_weight_offset), $datatable_y, $measurementUtils->formatWeight($weight, true), $color);
+            imagestring($im, 2, ($datatable_x + $datatable_height_offset), $datatable_y, $measurementUtils->formatLength($height, true), $color);
+            imagestring($im, 2, ($datatable_x + $datatable_hc_offset), $datatable_y, $measurementUtils->formatLength($head_circ, true), $color);
             $datatable_y += $datatable_y_increment; // increment the datatable "row pointer"
         }
 
@@ -676,8 +656,8 @@ foreach ($datapoints as $data) {
         if ($count < 7  && $charttype == "2-20") {
             imagestring($im, 2, $datatable_x, $datatable_y, $datestr, $color);
             imagestring($im, 2, ($datatable_x + $datatable_age_offset), $datatable_y, (string) $ageinYMD, $color);
-            imagestring($im, 2, ($datatable_x + $datatable_weight_offset), $datatable_y, (string) unitsWt($weight), $color);
-            imagestring($im, 2, ($datatable_x + $datatable_height_offset), $datatable_y, (string) unitsDist($height), $color);
+            imagestring($im, 2, ($datatable_x + $datatable_weight_offset), $datatable_y, $measurementUtils->formatWeight($weight, true), $color);
+            imagestring($im, 2, ($datatable_x + $datatable_height_offset), $datatable_y, $measurementUtils->formatLength($height, true), $color);
             imagestring($im, 2, ($datatable_x + $datatable_bmi_offset), $datatable_y, substr((string) $bmi, 0, 5), $color);
             $datatable_y += $datatable_y_increment; // increment the datatable "row pointer"
         }
@@ -686,9 +666,9 @@ foreach ($datapoints as $data) {
         if ($count < 5 && $charttype == "birth") {
             imagestring($im, 2, $datatable2_x, $datatable2_y, $datestr, $color);
             imagestring($im, 2, ($datatable2_x + $datatable2_age_offset), $datatable2_y, (string) $ageinYMD, $color);
-            imagestring($im, 2, ($datatable2_x + $datatable2_weight_offset), $datatable2_y, (string) unitsWt($weight), $color);
-            imagestring($im, 2, ($datatable2_x + $datatable2_height_offset), $datatable2_y, (string) unitsDist($height), $color);
-            imagestring($im, 2, ($datatable2_x + $datatable2_hc_offset), $datatable2_y, (string) unitsDist($head_circ), $color);
+            imagestring($im, 2, ($datatable2_x + $datatable2_weight_offset), $datatable2_y, $measurementUtils->formatWeight($weight, true), $color);
+            imagestring($im, 2, ($datatable2_x + $datatable2_height_offset), $datatable2_y, $measurementUtils->formatLength($height, true), $color);
+            imagestring($im, 2, ($datatable2_x + $datatable2_hc_offset), $datatable2_y, $measurementUtils->formatLength($head_circ, true), $color);
             $datatable2_y += $datatable2_y_increment; // increment the datatable2 "row pointer"
         }
 
@@ -696,8 +676,8 @@ foreach ($datapoints as $data) {
         if ($count < 14 && $charttype == "2-20") {
             imagestring($im, 2, $datatable2_x, $datatable2_y, $datestr, $color);
             imagestring($im, 2, ($datatable2_x + $datatable2_age_offset), $datatable2_y, (string) $ageinYMD, $color);
-            imagestring($im, 2, ($datatable2_x + $datatable2_weight_offset), $datatable2_y, (string) unitsWt($weight), $color);
-            imagestring($im, 2, ($datatable2_x + $datatable2_height_offset), $datatable2_y, (string) unitsDist($height), $color);
+            imagestring($im, 2, ($datatable2_x + $datatable2_weight_offset), $datatable2_y, $measurementUtils->formatWeight($weight, true), $color);
+            imagestring($im, 2, ($datatable2_x + $datatable2_height_offset), $datatable2_y, $measurementUtils->formatLength($height, true), $color);
             imagestring($im, 2, ($datatable2_x + $datatable2_bmi_offset), $datatable2_y, substr((string) $bmi, 0, 5), $color);
             $datatable2_y += $datatable2_y_increment; // increment the datatable2 "row pointer"
         }

--- a/interface/forms/vitals/report.php
+++ b/interface/forms/vitals/report.php
@@ -16,20 +16,11 @@ require_once(__DIR__ . "/../../globals.php");
 require_once($GLOBALS["srcdir"] . "/api.inc.php");
 require_once($GLOBALS['fileroot'] . "/library/patient.inc.php");
 
-function US_weight($pounds, $mode = 1)
-{
-
-    if ($mode == 1) {
-        return $pounds . " " . xl('lb') ;
-    } else {
-        $pounds_int = floor($pounds);
-        $ounces = round(($pounds - $pounds_int) * 16);
-        return $pounds_int . " " . xl('lb') . " " . $ounces . " " . xl('oz');
-    }
-}
+use OpenEMR\Common\Utils\MeasurementUtils;
 
 function vitals_report($pid, $encounter, $cols, $id, $print = true)
 {
+    $measurementUtils = new MeasurementUtils();
     $count = 0;
     $data = formFetch("form_vitals", $id);
     $patient_data = getPatientData($GLOBALS['pid']);
@@ -84,47 +75,13 @@ function vitals_report($pid, $encounter, $cols, $id, $print = true)
                 }
             } elseif ($key == "Weight") {
                 $value = floatval($value);
-                $convValue = number_format($value * 0.45359237, 2);
-                $vitals .= "<td><div class='font-weight-bold d-inline-block'>" . xlt($key) . ": </div></td><td><div class='text' style='display:inline-block'>";
-                // show appropriate units
-                $mode = $GLOBALS['us_weight_format'];
-                if ($GLOBALS['units_of_measurement'] == 2) {
-                    $vitals .=  text($convValue) . " " . xlt('kg') . " (" . text(US_weight($value, $mode)) . ")";
-                } elseif ($GLOBALS['units_of_measurement'] == 3) {
-                    $vitals .=  text(US_weight($value, $mode));
-                } elseif ($GLOBALS['units_of_measurement'] == 4) {
-                    $vitals .= text($convValue) . " " . xlt('kg');
-                } else { // = 1 or not set
-                    $vitals .= text(US_weight($value, $mode)) . " (" . text($convValue) . " " . xlt('kg')  . ")";
-                }
-
-                $vitals .= "</div></td>";
+                $vitals .= "<td><div class='font-weight-bold d-inline-block'>" . xlt($key) . ": </div></td><td><div class='text' style='display:inline-block'>" . text($measurementUtils->formatWeight($value)) . "</div></td>";
             } elseif (in_array($key, ["Height", "Waist Circ", "Head Circ"])) {
                 $value = floatval($value);
-                $convValue = number_format(round($value * 2.54, 1), 2);
-                // show appropriate units
-                if ($GLOBALS['units_of_measurement'] == 2) {
-                    $vitals .= "<td><div class='font-weight-bold d-inline-block'>" . xlt($key) . ": </div></td><td><div class='text' style='display:inline-block'>" . text($convValue) . " " . xlt('cm') . " (" . text($value) . " " . xlt('in')  . ")</div></td>";
-                } elseif ($GLOBALS['units_of_measurement'] == 3) {
-                    $vitals .= "<td><div class='font-weight-bold d-inline-block'>" . xlt($key) . ": </div></td><td><div class='text' style='display:inline-block'>" . text($value) . " " . xlt('in') . "</div></td>";
-                } elseif ($GLOBALS['units_of_measurement'] == 4) {
-                    $vitals .= "<td><div class='font-weight-bold d-inline-block'>" . xlt($key) . ": </div></td><td><div class='text' style='display:inline-block'>" . text($convValue) . " " . xlt('cm') . "</div></td>";
-                } else { // = 1 or not set
-                    $vitals .= "<td><div class='font-weight-bold d-inline-block'>" . xlt($key) . ": </div></td><td><div class='text' style='display:inline-block'>" . text($value) . " " . xlt('in') . " (" . text($convValue) . " " . xlt('cm')  . ")</div></td>";
-                }
+                $vitals .= "<td><div class='font-weight-bold d-inline-block'>" . xlt($key) . ": </div></td><td><div class='text' style='display:inline-block'>" . text($measurementUtils->formatLength($value)) . "</div></td>";
             } elseif ($key == "Temperature") {
                 $value = floatval($value);
-                $convValue = number_format((($value - 32) * 0.5556), 2);
-                // show appropriate units
-                if ($GLOBALS['units_of_measurement'] == 2) {
-                    $vitals .= "<td><div class='font-weight-bold d-inline-block'>" . xlt($key) . ": </div></td><td><div class='text' style='display:inline-block'>" . text($convValue) . " " . xlt('C') . " (" . text($value) . " " . xlt('F')  . ")</div></td>";
-                } elseif ($GLOBALS['units_of_measurement'] == 3) {
-                    $vitals .= "<td><div class='font-weight-bold d-inline-block'>" . xlt($key) . ": </div></td><td><div class='text' style='display:inline-block'>" . text($value) . " " . xlt('F') . "</div></td>";
-                } elseif ($GLOBALS['units_of_measurement'] == 4) {
-                    $vitals .= "<td><div class='font-weight-bold d-inline-block'>" . xlt($key) . ": </div></td><td><div class='text' style='display:inline-block'>" . text($convValue) . " " . xlt('C') . "</div></td>";
-                } else { // = 1 or not set
-                    $vitals .= "<td><div class='font-weight-bold d-inline-block'>" . xlt($key) . ": </div></td><td><div class='text' style='display:inline-block'>" . text($value) . " " . xlt('F') . " (" . text($convValue) . " " . xlt('C')  . ")</div></td>";
-                }
+                $vitals .= "<td><div class='font-weight-bold d-inline-block'>" . xlt($key) . ": </div></td><td><div class='text' style='display:inline-block'>" . text($measurementUtils->formatTemperature($value)) . "</div></td>";
             } elseif (in_array($key, ["Pulse", "Respiration", "Oxygen Saturation", "BMI", "Oxygen Flow Rate"])) {
                 $value = floatval($value);
                 $c_value = number_format($value, 0);

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncounterccdadispatchTable.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncounterccdadispatchTable.php
@@ -3062,10 +3062,10 @@ class EncounterccdadispatchTable extends AbstractTableGateway
                 , 'time' => $row['modifydate']
             ];
             $provenanceXml = $this->getAuthorXmlForRecord($provenanceRecord, $pid, $first_encounter);
-            $convWeightValue = number_format((float)$measurementUtils->lbToKg($row['weight']), 2);
-            $convHeightValue = number_format(round((float)$measurementUtils->inchesToCm($row['height']), 1), 2);
-            $convTempValue = number_format((float)$measurementUtils->fhToCelsius($row['temperature']), 1);
-            if ($GLOBALS['units_of_measurement'] == 2 || $GLOBALS['units_of_measurement'] == 4) {
+            $convWeightValue = number_format($measurementUtils->convertLbToKg($row['weight']), 2);
+            $convHeightValue = number_format(round($measurementUtils->convertInchesToCm($row['height']), 1), 2);
+            $convTempValue = number_format($measurementUtils->convertFhToCelsius($row['temperature']), 1);
+            if ($measurementUtils->isMetric()) {
                 $weight_value = $convWeightValue;
                 $weight_unit = 'kg';
                 $height_value = $convHeightValue;

--- a/library/ajax/graphs.php
+++ b/library/ajax/graphs.php
@@ -16,10 +16,14 @@ require_once(__DIR__ . "/../../interface/globals.php");
 
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Utils\MeasurementUtils;
 
 if (!CsrfUtils::verifyCsrfToken($_POST["csrf_token_form"])) {
     CsrfUtils::csrfNotVerified();
 }
+
+// Create measurement utils instance for unit conversions
+$measurementUtils = new MeasurementUtils();
 
 // Collect passed variable(s)
 //  $table is the sql table (or form name if LBF)
@@ -41,15 +45,20 @@ if (!AclMain::aclCheckCore('patients', 'med')) {
 // Conversion functions/constants
 function convertFtoC($a)
 {
-    return ($a - 32) * 0.5556;
+    global $measurementUtils;
+    return (float)$measurementUtils->fhToCelsius($a);
 }
 function getLbstoKgMultiplier()
 {
-    return 0.45359237;
+    global $measurementUtils;
+    // Get conversion factor by converting 1 lb to kg
+    return (float)$measurementUtils->lbToKg(1);
 }
 function getIntoCmMultiplier()
 {
-    return 2.54;
+    global $measurementUtils;
+    // Get conversion factor by converting 1 inch to cm
+    return (float)$measurementUtils->inchesToCm(1);
 }
 function getIdealYSteps($a)
 {

--- a/library/ajax/graphs.php
+++ b/library/ajax/graphs.php
@@ -46,19 +46,19 @@ if (!AclMain::aclCheckCore('patients', 'med')) {
 function convertFtoC($a)
 {
     global $measurementUtils;
-    return (float)$measurementUtils->fhToCelsius($a);
+    return $measurementUtils->convertFhToCelsius($a);
 }
 function getLbstoKgMultiplier()
 {
     global $measurementUtils;
     // Get conversion factor by converting 1 lb to kg
-    return (float)$measurementUtils->lbToKg(1);
+    return $measurementUtils->convertLbToKg(1);
 }
 function getIntoCmMultiplier()
 {
     global $measurementUtils;
     // Get conversion factor by converting 1 inch to cm
-    return (float)$measurementUtils->inchesToCm(1);
+    return $measurementUtils->convertInchesToCm(1);
 }
 function getIdealYSteps($a)
 {

--- a/library/ajax/graphs.php
+++ b/library/ajax/graphs.php
@@ -42,24 +42,6 @@ if (!AclMain::aclCheckCore('patients', 'med')) {
     exit;
 }
 
-// Conversion functions/constants
-function convertFtoC($a)
-{
-    global $measurementUtils;
-    return $measurementUtils->convertFhToCelsius($a);
-}
-function getLbstoKgMultiplier()
-{
-    global $measurementUtils;
-    // Get conversion factor by converting 1 lb to kg
-    return $measurementUtils->convertLbToKg(1);
-}
-function getIntoCmMultiplier()
-{
-    global $measurementUtils;
-    // Get conversion factor by converting 1 inch to cm
-    return $measurementUtils->convertInchesToCm(1);
-}
 function getIdealYSteps($a)
 {
     if ($a > 1000) {
@@ -126,7 +108,7 @@ if ($is_lbf) {
             break;
         case "weight_metric":
              $titleGraph = $title . " (" . xl("kg") . ")";
-             $multiplier = getLbstoKgMultiplier();
+             $multiplier = $measurementUtils->convertLbToKg(1);
              $name = "weight";
             break;
         case "height":
@@ -134,7 +116,7 @@ if ($is_lbf) {
             break;
         case "height_metric":
              $titleGraph = $title . " (" . xl("cm") . ")";
-             $multiplier = getIntoCmMultiplier();
+             $multiplier = $measurementUtils->convertInchesToCm(1);
              $name = "height";
             break;
         case "bps":
@@ -169,7 +151,7 @@ if ($is_lbf) {
             break;
         case "head_circ_metric":
              $titleGraph = $title . " (" . xl("cm") . ")";
-             $multiplier = getIntoCmMultiplier();
+             $multiplier = $measurementUtils->convertInchesToCm(1);
              $name = "head_circ";
             break;
         case "waist_circ":
@@ -177,7 +159,7 @@ if ($is_lbf) {
             break;
         case "waist_circ_metric":
              $titleGraph = $title . " (" . xl("cm") . ")";
-             $multiplier = getIntoCmMultiplier();
+             $multiplier = $measurementUtils->convertInchesToCm(1);
              $name = "waist_circ";
             break;
         case "BMI":
@@ -239,7 +221,7 @@ while ($row = sqlFetchArray($values)) {
             $y = $row["$name"] * $multiplier;
         } elseif ($isConvertFtoC ?? null) {
             // apply temp F to C conversion
-            $y = convertFtoC($row["$name"]);
+            $y = $measurementUtils->convertFhToCelsius($row["$name"]);
         } else {
            // no conversion, so use raw value
             $y = $row["$name"];
@@ -259,7 +241,7 @@ if ($isBP) {
                 $y = $row["$name_alt"] * $multiplier;
             } elseif ($isConvertFtoC ?? null) {
                 // apply temp F to C conversion
-                $y = convertFtoC($row["$name_alt"]);
+                $y = $measurementUtils->convertFhToCelsius($row["$name_alt"]);
             } else {
                // no conversion, so use raw value
                 $y = $row["$name_alt"];

--- a/src/Common/Forms/FormVitals.php
+++ b/src/Common/Forms/FormVitals.php
@@ -243,13 +243,25 @@ class FormVitals extends ORDataObject
             $this->weight = $w;
         }
     }
+    /**
+     * Format weight in US units (lb or lb/oz depending on global setting).
+     *
+     * @param float|int|string $pounds Weight in pounds
+     * @return string Formatted weight string
+     * @deprecated Use MeasurementUtils::formatWeight() instead for full formatting
+     */
     public function display_weight($pounds)
     {
-        if ($pounds != 0) {
-            if ($GLOBALS['us_weight_format'] == 2) {
-                $pounds_int = floor($pounds);
-                return $pounds_int . " " . xl('lb') . " " . round(($pounds - $pounds_int) * 16) . " " . xl('oz');
-            }
+        if ($pounds == 0) {
+            return $pounds;
+        }
+        $utils = $this->getMeasurementUtils();
+        if ($GLOBALS['us_weight_format'] == MeasurementUtils::WEIGHT_LBS_OZ) {
+            $ozPerLb = (int) $utils->convertLbToOz(1);
+            $totalOz = (int) round($utils->convertLbToOz((float) $pounds));
+            $wholeLbs = intdiv($totalOz, $ozPerLb);
+            $oz = $totalOz % $ozPerLb;
+            return $wholeLbs . " " . xl('lb') . " " . $oz . " " . xl('oz');
         }
         return $pounds;
     }

--- a/src/Common/Forms/FormVitals.php
+++ b/src/Common/Forms/FormVitals.php
@@ -24,6 +24,7 @@ use OpenEMR\Services\FHIR\Observation\FhirObservationVitalsService;
 use OpenEMR\Common\ORDataObject\ORDataObject;
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Common\Utils\MeasurementUtils;
+use OpenEMR\Common\Utils\MeasurementUtilsInterface;
 
 class FormVitals extends ORDataObject
 {
@@ -82,6 +83,11 @@ class FormVitals extends ORDataObject
      */
     private $encounter;
 
+    /**
+     * @var MeasurementUtilsInterface|null Lazy-loaded instance for unit conversions
+     */
+    private ?MeasurementUtilsInterface $_measurementUtils = null;
+
     // public $temp_methods;
     /**
      * Constructor sets all Form attributes to their default value
@@ -108,6 +114,18 @@ class FormVitals extends ORDataObject
     {
         parent::populate();
         //$this->temp_methods = parent::_load_enum("temp_locations",false);
+    }
+
+    /**
+     * Get the measurement utils instance for unit conversions.
+     * Lazily instantiated on first use.
+     */
+    private function getMeasurementUtils(): MeasurementUtilsInterface
+    {
+        if ($this->_measurementUtils === null) {
+            $this->_measurementUtils = new MeasurementUtils();
+        }
+        return $this->_measurementUtils;
     }
 
     public function toString($html = false)
@@ -217,7 +235,7 @@ class FormVitals extends ORDataObject
 
     public function get_weight_metric()
     {
-        return MeasurementUtils::lbToKg($this->get_weight());
+        return $this->getMeasurementUtils()->lbToKg($this->get_weight());
     }
     public function set_weight($w)
     {
@@ -242,7 +260,7 @@ class FormVitals extends ORDataObject
     }
     public function get_height_metric()
     {
-        return MeasurementUtils::inchesToCm($this->get_height());
+        return $this->getMeasurementUtils()->inchesToCm($this->get_height());
     }
     public function set_height($h)
     {
@@ -256,7 +274,7 @@ class FormVitals extends ORDataObject
     }
     public function get_temperature_metric()
     {
-        return MeasurementUtils::fhToCelsius($this->get_temperature());
+        return $this->getMeasurementUtils()->fhToCelsius($this->get_temperature());
     }
     public function set_temperature($t)
     {
@@ -333,7 +351,7 @@ class FormVitals extends ORDataObject
     }
     public function get_waist_circ_metric()
     {
-        return MeasurementUtils::inchesToCm($this->get_waist_circ());
+        return $this->getMeasurementUtils()->inchesToCm($this->get_waist_circ());
     }
     public function set_waist_circ($w)
     {
@@ -347,7 +365,7 @@ class FormVitals extends ORDataObject
     }
     public function get_head_circ_metric()
     {
-        return MeasurementUtils::inchesToCm($this->get_head_circ());
+        return $this->getMeasurementUtils()->inchesToCm($this->get_head_circ());
     }
     public function set_head_circ($h)
     {

--- a/src/Common/Utils/MeasurementUtils.php
+++ b/src/Common/Utils/MeasurementUtils.php
@@ -2,42 +2,223 @@
 
 /**
  * MeasurementUtils.php
+ *
  * @package openemr
  * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Stephen Nielson <stephen@nielson.org>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2021 Stephen Nielson <stephen@nielson.org>
+ * @copyright Copyright (c) 2025 OpenCoreEMR Inc
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
 namespace OpenEMR\Common\Utils;
 
-class MeasurementUtils
+use OpenEMR\Core\OEGlobalsBag;
+use PhpUnitsOfMeasure\PhysicalQuantity\Length;
+use PhpUnitsOfMeasure\PhysicalQuantity\Mass;
+use PhpUnitsOfMeasure\PhysicalQuantity\Temperature;
+
+/**
+ * Utility class for unit conversions and formatting in healthcare measurements.
+ *
+ * Uses the php-units-of-measure library for accurate conversions.
+ * Implements MeasurementUtilsInterface for dependency injection support.
+ */
+class MeasurementUtils implements MeasurementUtilsInterface
 {
-    const MEASUREMENT_PRECISION = 6;
+    public const MEASUREMENT_PRECISION = 6;
 
-    public static function kgToLb($val)
-    {
-        return number_format($val * 2.20462262185, self::MEASUREMENT_PRECISION);
-    }
-    public static function lbToKg($val)
-    {
-        return number_format($val *  0.45359237, self::MEASUREMENT_PRECISION);
-    }
-    public static function cmToInches($val)
-    {
-        return number_format(round($val / 2.54, self::MEASUREMENT_PRECISION), self::MEASUREMENT_PRECISION);
-    }
-    public static function inchesToCm($val)
-    {
-        return number_format(round($val * 2.54, self::MEASUREMENT_PRECISION), self::MEASUREMENT_PRECISION);
-    }
-    public static function fhToCelsius($val)
-    {
-        return number_format(round(($val - 32) * (5 / 9), self::MEASUREMENT_PRECISION), self::MEASUREMENT_PRECISION);
+    // Unit display modes (from $GLOBALS['units_of_measurement'])
+    public const UNITS_USA_PRIMARY = 1;
+    public const UNITS_METRIC_PRIMARY = 2;
+    public const UNITS_USA_ONLY = 3;
+    public const UNITS_METRIC_ONLY = 4;
+
+    // US weight format (from $GLOBALS['us_weight_format'])
+    public const WEIGHT_DECIMAL = 1;
+    public const WEIGHT_LBS_OZ = 2;
+
+    private readonly int $unitsMode;
+    private readonly int $usWeightFormat;
+
+    /**
+     * @param int $precision Number of decimal places for formatted output
+     * @param int|null $unitsMode Units display mode (defaults to $GLOBALS['units_of_measurement'])
+     * @param int|null $usWeightFormat US weight format (defaults to $GLOBALS['us_weight_format'])
+     */
+    public function __construct(
+        private readonly int $precision = self::MEASUREMENT_PRECISION,
+        ?int $unitsMode = null,
+        ?int $usWeightFormat = null
+    ) {
+        $globals = OEGlobalsBag::getInstance();
+        $this->unitsMode = $unitsMode ?? ($globals->get('units_of_measurement') ?? self::UNITS_USA_PRIMARY);
+        $this->usWeightFormat = $usWeightFormat ?? ($globals->get('us_weight_format') ?? self::WEIGHT_DECIMAL);
     }
 
-    public static function celsiusToFh($val)
+    /**
+     * @inheritDoc
+     */
+    public function kgToLb(float $val): string
     {
-        return number_format(round(((9 / 5) * $val) + 32, self::MEASUREMENT_PRECISION), self::MEASUREMENT_PRECISION);
+        $mass = new Mass($val, 'kg');
+        return number_format($mass->toUnit('lb'), $this->precision);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function lbToKg(float $val): string
+    {
+        $mass = new Mass($val, 'lb');
+        return number_format($mass->toUnit('kg'), $this->precision);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function cmToInches(float $val): string
+    {
+        $length = new Length($val, 'cm');
+        return number_format($length->toUnit('in'), $this->precision);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function inchesToCm(float $val): string
+    {
+        $length = new Length($val, 'in');
+        return number_format($length->toUnit('cm'), $this->precision);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function fhToCelsius(float $val): string
+    {
+        $temp = new Temperature($val, 'F');
+        return number_format($temp->toUnit('C'), $this->precision);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function celsiusToFh(float $val): string
+    {
+        $temp = new Temperature($val, 'C');
+        return number_format($temp->toUnit('F'), $this->precision);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isMetric(): bool
+    {
+        return in_array($this->unitsMode, [self::UNITS_METRIC_PRIMARY, self::UNITS_METRIC_ONLY]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function formatWeight(float $lbs, bool $primaryOnly = false): string
+    {
+        $kg = number_format((float)$this->lbToKg($lbs), 2);
+        $lbFormatted = $this->formatUsWeight($lbs);
+
+        if ($primaryOnly) {
+            return $this->isMetric()
+                ? "{$kg} " . $this->xl('kg')
+                : $lbFormatted;
+        }
+
+        return match ($this->unitsMode) {
+            self::UNITS_METRIC_PRIMARY => "{$kg} " . $this->xl('kg') . " ({$lbFormatted})",
+            self::UNITS_USA_ONLY => $lbFormatted,
+            self::UNITS_METRIC_ONLY => "{$kg} " . $this->xl('kg'),
+            default => "{$lbFormatted} ({$kg} " . $this->xl('kg') . ")",  // USA_PRIMARY
+        };
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function formatLength(float $inches, bool $primaryOnly = false): string
+    {
+        $cm = number_format((float)$this->inchesToCm($inches), 2);
+        $inFormatted = number_format($inches, 2) . ' ' . $this->xl('in');
+
+        if ($primaryOnly) {
+            return $this->isMetric()
+                ? "{$cm} " . $this->xl('cm')
+                : $inFormatted;
+        }
+
+        return match ($this->unitsMode) {
+            self::UNITS_METRIC_PRIMARY => "{$cm} " . $this->xl('cm') . " ({$inFormatted})",
+            self::UNITS_USA_ONLY => $inFormatted,
+            self::UNITS_METRIC_ONLY => "{$cm} " . $this->xl('cm'),
+            default => "{$inFormatted} ({$cm} " . $this->xl('cm') . ")",
+        };
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function formatTemperature(float $fahrenheit, bool $primaryOnly = false): string
+    {
+        $celsius = number_format((float)$this->fhToCelsius($fahrenheit), 2);
+        $fFormatted = number_format($fahrenheit, 2) . ' ' . $this->xl('F');
+
+        if ($primaryOnly) {
+            return $this->isMetric()
+                ? "{$celsius} " . $this->xl('C')
+                : $fFormatted;
+        }
+
+        return match ($this->unitsMode) {
+            self::UNITS_METRIC_PRIMARY => "{$celsius} " . $this->xl('C') . " ({$fFormatted})",
+            self::UNITS_USA_ONLY => $fFormatted,
+            self::UNITS_METRIC_ONLY => "{$celsius} " . $this->xl('C'),
+            default => "{$fFormatted} ({$celsius} " . $this->xl('C') . ")",
+        };
+    }
+
+    /**
+     * Format weight in US units (pounds or pounds/ounces).
+     *
+     * @param float $lbs Value in pounds
+     * @return string Formatted US weight
+     */
+    private function formatUsWeight(float $lbs): string
+    {
+        if ($this->usWeightFormat === self::WEIGHT_LBS_OZ) {
+            $totalOz = (int) round($lbs * 16);
+            $wholeLbs = intdiv($totalOz, 16);
+            $oz = $totalOz % 16;
+            return "{$wholeLbs} " . $this->xl('lb') . " {$oz} " . $this->xl('oz');
+        }
+        return number_format($lbs, 2) . ' ' . $this->xl('lb');
+    }
+
+    /**
+     * Translate a string using xl() if the full translation system is available.
+     *
+     * This allows the class to work in isolated test environments
+     * where the translation system is not fully loaded.
+     *
+     * @param string $text Text to translate
+     * @return string Translated text (or original if unavailable)
+     */
+    private function xl(string $text): string
+    {
+        // Only call xl() if the full translation infrastructure is available
+        // (sqlStatementNoLog is required by the real xl() function)
+        if (function_exists('xl') && function_exists('sqlStatementNoLog')) {
+            return xl($text);
+        }
+        return $text;
     }
 }

--- a/src/Common/Utils/MeasurementUtils.php
+++ b/src/Common/Utils/MeasurementUtils.php
@@ -184,6 +184,69 @@ class MeasurementUtils implements MeasurementUtilsInterface
     /**
      * @inheritDoc
      */
+    public function convertKgToLb(float $val): float
+    {
+        $mass = new Mass($val, 'kg');
+        return $mass->toUnit('lb');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function convertLbToKg(float $val): float
+    {
+        $mass = new Mass($val, 'lb');
+        return $mass->toUnit('kg');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function convertCmToInches(float $val): float
+    {
+        $length = new Length($val, 'cm');
+        return $length->toUnit('in');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function convertInchesToCm(float $val): float
+    {
+        $length = new Length($val, 'in');
+        return $length->toUnit('cm');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function convertFhToCelsius(float $val): float
+    {
+        $temp = new Temperature($val, 'F');
+        return $temp->toUnit('C');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function convertCelsiusToFh(float $val): float
+    {
+        $temp = new Temperature($val, 'C');
+        return $temp->toUnit('F');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function convertLbToOz(float $val): float
+    {
+        $mass = new Mass($val, 'lb');
+        return $mass->toUnit('oz');
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function isMetric(): bool
     {
         return in_array($this->unitsMode, [self::UNITS_METRIC_PRIMARY, self::UNITS_METRIC_ONLY]);
@@ -264,9 +327,11 @@ class MeasurementUtils implements MeasurementUtilsInterface
     private function formatUsWeight(float $lbs): string
     {
         if ($this->usWeightFormat === self::WEIGHT_LBS_OZ) {
-            $totalOz = (int) round($lbs * 16);
-            $wholeLbs = intdiv($totalOz, 16);
-            $oz = $totalOz % 16;
+            // Use library to convert lbs to oz (16 oz per lb)
+            $ozPerLb = (int) $this->convertLbToOz(1);
+            $totalOz = (int) round($this->convertLbToOz($lbs));
+            $wholeLbs = intdiv($totalOz, $ozPerLb);
+            $oz = $totalOz % $ozPerLb;
             return "{$wholeLbs} " . $this->xl('lb') . " {$oz} " . $this->xl('oz');
         }
         return number_format($lbs, 2) . ' ' . $this->xl('lb');

--- a/src/Common/Utils/MeasurementUtilsInterface.php
+++ b/src/Common/Utils/MeasurementUtilsInterface.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * MeasurementUtilsInterface.php
+ *
+ * @package openemr
+ * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2025 OpenCoreEMR Inc
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Common\Utils;
+
+/**
+ * Interface for unit measurement conversions.
+ *
+ * Implementations provide conversions between common units of measurement
+ * used in healthcare (weight, length, temperature).
+ */
+interface MeasurementUtilsInterface
+{
+    /**
+     * Convert kilograms to pounds.
+     *
+     * @param float $val Value in kilograms
+     * @return string Formatted value in pounds
+     */
+    public function kgToLb(float $val): string;
+
+    /**
+     * Convert pounds to kilograms.
+     *
+     * @param float $val Value in pounds
+     * @return string Formatted value in kilograms
+     */
+    public function lbToKg(float $val): string;
+
+    /**
+     * Convert centimeters to inches.
+     *
+     * @param float $val Value in centimeters
+     * @return string Formatted value in inches
+     */
+    public function cmToInches(float $val): string;
+
+    /**
+     * Convert inches to centimeters.
+     *
+     * @param float $val Value in inches
+     * @return string Formatted value in centimeters
+     */
+    public function inchesToCm(float $val): string;
+
+    /**
+     * Convert Fahrenheit to Celsius.
+     *
+     * @param float $val Value in Fahrenheit
+     * @return string Formatted value in Celsius
+     */
+    public function fhToCelsius(float $val): string;
+
+    /**
+     * Convert Celsius to Fahrenheit.
+     *
+     * @param float $val Value in Celsius
+     * @return string Formatted value in Fahrenheit
+     */
+    public function celsiusToFh(float $val): string;
+
+    /**
+     * Check if metric mode is enabled based on units_of_measurement setting.
+     *
+     * @return bool True if metric is the primary or only unit system
+     */
+    public function isMetric(): bool;
+
+    /**
+     * Format weight with appropriate unit label(s) based on units_of_measurement setting.
+     *
+     * @param float $lbs Value in pounds
+     * @param bool $primaryOnly If true, only show primary unit (no secondary in parentheses)
+     * @return string Formatted weight with unit label(s)
+     */
+    public function formatWeight(float $lbs, bool $primaryOnly = false): string;
+
+    /**
+     * Format length with appropriate unit label(s) based on units_of_measurement setting.
+     *
+     * @param float $inches Value in inches
+     * @param bool $primaryOnly If true, only show primary unit (no secondary in parentheses)
+     * @return string Formatted length with unit label(s)
+     */
+    public function formatLength(float $inches, bool $primaryOnly = false): string;
+
+    /**
+     * Format temperature with appropriate unit label(s) based on units_of_measurement setting.
+     *
+     * @param float $fahrenheit Value in Fahrenheit
+     * @param bool $primaryOnly If true, only show primary unit (no secondary in parentheses)
+     * @return string Formatted temperature with unit label(s)
+     */
+    public function formatTemperature(float $fahrenheit, bool $primaryOnly = false): string;
+}

--- a/src/Common/Utils/MeasurementUtilsInterface.php
+++ b/src/Common/Utils/MeasurementUtilsInterface.php
@@ -70,6 +70,62 @@ interface MeasurementUtilsInterface
     public function celsiusToFh(float $val): string;
 
     /**
+     * Convert kilograms to pounds, returning raw float for calculations.
+     *
+     * @param float $val Value in kilograms
+     * @return float Value in pounds
+     */
+    public function convertKgToLb(float $val): float;
+
+    /**
+     * Convert pounds to kilograms, returning raw float for calculations.
+     *
+     * @param float $val Value in pounds
+     * @return float Value in kilograms
+     */
+    public function convertLbToKg(float $val): float;
+
+    /**
+     * Convert centimeters to inches, returning raw float for calculations.
+     *
+     * @param float $val Value in centimeters
+     * @return float Value in inches
+     */
+    public function convertCmToInches(float $val): float;
+
+    /**
+     * Convert inches to centimeters, returning raw float for calculations.
+     *
+     * @param float $val Value in inches
+     * @return float Value in centimeters
+     */
+    public function convertInchesToCm(float $val): float;
+
+    /**
+     * Convert Fahrenheit to Celsius, returning raw float for calculations.
+     *
+     * @param float $val Value in Fahrenheit
+     * @return float Value in Celsius
+     */
+    public function convertFhToCelsius(float $val): float;
+
+    /**
+     * Convert Celsius to Fahrenheit, returning raw float for calculations.
+     *
+     * @param float $val Value in Celsius
+     * @return float Value in Fahrenheit
+     */
+    public function convertCelsiusToFh(float $val): float;
+
+    /**
+     * Convert pounds to ounces, returning raw float for calculations.
+     *
+     * @param float $val Value in pounds
+     * @return float Value in ounces
+     */
+    public function convertLbToOz(float $val): float;
+
+    /**
      * Check if metric mode is enabled based on units_of_measurement setting.
      *
      * @return bool True if metric is the primary or only unit system

--- a/src/Services/VitalsService.php
+++ b/src/Services/VitalsService.php
@@ -235,9 +235,9 @@ class VitalsService extends BaseService
         // add in all the measurement fields
         $utils = $this->measurementUtils;
 
-        $lbToKg = fn($val) => $val != 0 ? $utils->lbToKg($val) : $val;
-        $inchesToCm = fn($val) => $val != 0 ? $utils->inchesToCm($val) : $val;
-        $fhToCelsius = fn($val) => $val != 0 ? $utils->fhToCelsius($val) : $val;
+        $lbToKg = fn($val) => $utils->lbToKg($val);
+        $inchesToCm = fn($val) => $utils->inchesToCm($val);
+        $fhToCelsius = fn($val) => $utils->fhToCelsius($val);
         $identity = fn($val) => $val;
 
         $convertArrayValue = function ($index, $converter, $unit, &$array): void {

--- a/tests/Tests/Isolated/Common/Utils/MeasurementUtilsTest.php
+++ b/tests/Tests/Isolated/Common/Utils/MeasurementUtilsTest.php
@@ -23,6 +23,18 @@ use PHPUnit\Framework\TestCase;
 
 class MeasurementUtilsTest extends TestCase
 {
+    /**
+     * Exact conversion factor: 1 lb = 0.45359237 kg (international avoirdupois pound)
+     * @see https://www.nist.gov/pml/special-publication-811 NIST Guide for Use of the SI
+     */
+    private const LB_TO_KG_FACTOR = 0.45359237;
+
+    /**
+     * Exact conversion factor: 1 inch = 2.54 cm (international inch)
+     * @see https://www.nist.gov/pml/special-publication-811 NIST Guide for Use of the SI
+     */
+    private const INCH_TO_CM_FACTOR = 2.54;
+
     private MeasurementUtils $utils;
 
     protected function setUp(): void
@@ -47,13 +59,14 @@ class MeasurementUtilsTest extends TestCase
      */
     public function testLbToKg(): void
     {
-        // 1 lb = 0.45359237 kg (exact)
+        // 1 lb converts to exactly LB_TO_KG_FACTOR kg
         $result = $this->utils->lbToKg(1);
-        $this->assertEquals('0.453592', $result);
+        $this->assertEqualsWithDelta(self::LB_TO_KG_FACTOR, (float)$result, 0.000001);
 
-        // 150 lbs
+        // 150 lbs = 150 * LB_TO_KG_FACTOR kg
+        $expectedKg = 150 * self::LB_TO_KG_FACTOR;
         $result = $this->utils->lbToKg(150);
-        $this->assertEqualsWithDelta(68.039, (float)$result, 0.001);
+        $this->assertEqualsWithDelta($expectedKg, (float)$result, 0.001);
     }
 
     /**
@@ -61,13 +74,15 @@ class MeasurementUtilsTest extends TestCase
      */
     public function testKgToLb(): void
     {
-        // 1 kg = 2.20462262185 lbs
+        // 1 kg = 1/LB_TO_KG_FACTOR lbs
+        $expectedLbPerKg = 1 / self::LB_TO_KG_FACTOR;
         $result = $this->utils->kgToLb(1);
-        $this->assertEqualsWithDelta(2.20462, (float)$result, 0.00001);
+        $this->assertEqualsWithDelta($expectedLbPerKg, (float)$result, 0.00001);
 
-        // 68 kg
+        // 68 kg = 68 / LB_TO_KG_FACTOR lbs
+        $expectedLbs = 68 / self::LB_TO_KG_FACTOR;
         $result = $this->utils->kgToLb(68);
-        $this->assertEqualsWithDelta(149.914, (float)$result, 0.001);
+        $this->assertEqualsWithDelta($expectedLbs, (float)$result, 0.001);
     }
 
     /**
@@ -75,13 +90,14 @@ class MeasurementUtilsTest extends TestCase
      */
     public function testInchesToCm(): void
     {
-        // 1 inch = 2.54 cm (exact)
+        // 1 inch = exactly INCH_TO_CM_FACTOR cm
         $result = $this->utils->inchesToCm(1);
-        $this->assertEquals('2.540000', $result);
+        $this->assertEqualsWithDelta(self::INCH_TO_CM_FACTOR, (float)$result, 0.000001);
 
-        // 68 inches (5'8")
+        // 68 inches (5'8") = 68 * INCH_TO_CM_FACTOR cm
+        $expectedCm = 68 * self::INCH_TO_CM_FACTOR;
         $result = $this->utils->inchesToCm(68);
-        $this->assertEqualsWithDelta(172.72, (float)$result, 0.01);
+        $this->assertEqualsWithDelta($expectedCm, (float)$result, 0.01);
     }
 
     /**
@@ -89,12 +105,13 @@ class MeasurementUtilsTest extends TestCase
      */
     public function testCmToInches(): void
     {
-        // 2.54 cm = 1 inch
-        $result = $this->utils->cmToInches(2.54);
+        // INCH_TO_CM_FACTOR cm = 1 inch
+        $result = $this->utils->cmToInches(self::INCH_TO_CM_FACTOR);
         $this->assertEqualsWithDelta(1.0, (float)$result, 0.0001);
 
-        // 172.72 cm
-        $result = $this->utils->cmToInches(172.72);
+        // 68 * INCH_TO_CM_FACTOR cm = 68 inches
+        $cmValue = 68 * self::INCH_TO_CM_FACTOR;
+        $result = $this->utils->cmToInches($cmValue);
         $this->assertEqualsWithDelta(68.0, (float)$result, 0.01);
     }
 

--- a/tests/Tests/Isolated/Common/Utils/MeasurementUtilsTest.php
+++ b/tests/Tests/Isolated/Common/Utils/MeasurementUtilsTest.php
@@ -1,0 +1,399 @@
+<?php
+
+/**
+ * Isolated MeasurementUtils Test
+ *
+ * Tests MeasurementUtils functionality using PhpUnitsOfMeasure library.
+ *
+ * @package   OpenEMR
+ * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2025 OpenCoreEMR Inc
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Common\Utils;
+
+use OpenEMR\Common\Utils\MeasurementUtils;
+use OpenEMR\Common\Utils\MeasurementUtilsInterface;
+use PHPUnit\Framework\TestCase;
+
+class MeasurementUtilsTest extends TestCase
+{
+    private MeasurementUtils $utils;
+
+    protected function setUp(): void
+    {
+        // Default to USA primary mode for tests
+        $this->utils = new MeasurementUtils(
+            MeasurementUtils::MEASUREMENT_PRECISION,
+            MeasurementUtils::UNITS_USA_PRIMARY
+        );
+    }
+
+    /**
+     * Test that MeasurementUtils implements the interface
+     */
+    public function testImplementsInterface(): void
+    {
+        $this->assertInstanceOf(MeasurementUtilsInterface::class, $this->utils);
+    }
+
+    /**
+     * Test pounds to kilograms conversion
+     */
+    public function testLbToKg(): void
+    {
+        // 1 lb = 0.45359237 kg (exact)
+        $result = $this->utils->lbToKg(1);
+        $this->assertEquals('0.453592', $result);
+
+        // 150 lbs
+        $result = $this->utils->lbToKg(150);
+        $this->assertEqualsWithDelta(68.039, (float)$result, 0.001);
+    }
+
+    /**
+     * Test kilograms to pounds conversion
+     */
+    public function testKgToLb(): void
+    {
+        // 1 kg = 2.20462262185 lbs
+        $result = $this->utils->kgToLb(1);
+        $this->assertEqualsWithDelta(2.20462, (float)$result, 0.00001);
+
+        // 68 kg
+        $result = $this->utils->kgToLb(68);
+        $this->assertEqualsWithDelta(149.914, (float)$result, 0.001);
+    }
+
+    /**
+     * Test inches to centimeters conversion
+     */
+    public function testInchesToCm(): void
+    {
+        // 1 inch = 2.54 cm (exact)
+        $result = $this->utils->inchesToCm(1);
+        $this->assertEquals('2.540000', $result);
+
+        // 68 inches (5'8")
+        $result = $this->utils->inchesToCm(68);
+        $this->assertEqualsWithDelta(172.72, (float)$result, 0.01);
+    }
+
+    /**
+     * Test centimeters to inches conversion
+     */
+    public function testCmToInches(): void
+    {
+        // 2.54 cm = 1 inch
+        $result = $this->utils->cmToInches(2.54);
+        $this->assertEqualsWithDelta(1.0, (float)$result, 0.0001);
+
+        // 172.72 cm
+        $result = $this->utils->cmToInches(172.72);
+        $this->assertEqualsWithDelta(68.0, (float)$result, 0.01);
+    }
+
+    /**
+     * Test Fahrenheit to Celsius conversion
+     */
+    public function testFhToCelsius(): void
+    {
+        // 32°F = 0°C (freezing point)
+        $result = $this->utils->fhToCelsius(32);
+        $this->assertEqualsWithDelta(0.0, (float)$result, 0.001);
+
+        // 212°F = 100°C (boiling point)
+        $result = $this->utils->fhToCelsius(212);
+        $this->assertEqualsWithDelta(100.0, (float)$result, 0.001);
+
+        // 98.6°F = 37°C (body temperature)
+        $result = $this->utils->fhToCelsius(98.6);
+        $this->assertEqualsWithDelta(37.0, (float)$result, 0.001);
+    }
+
+    /**
+     * Test Celsius to Fahrenheit conversion
+     */
+    public function testCelsiusToFh(): void
+    {
+        // 0°C = 32°F
+        $result = $this->utils->celsiusToFh(0);
+        $this->assertEqualsWithDelta(32.0, (float)$result, 0.001);
+
+        // 100°C = 212°F
+        $result = $this->utils->celsiusToFh(100);
+        $this->assertEqualsWithDelta(212.0, (float)$result, 0.001);
+
+        // 37°C = 98.6°F
+        $result = $this->utils->celsiusToFh(37);
+        $this->assertEqualsWithDelta(98.6, (float)$result, 0.01);
+    }
+
+    /**
+     * Test round-trip conversion accuracy for weight
+     */
+    public function testWeightRoundTrip(): void
+    {
+        $originalLb = 150.5;
+        $kg = (float)$this->utils->lbToKg($originalLb);
+        $backToLb = (float)$this->utils->kgToLb($kg);
+
+        $this->assertEqualsWithDelta($originalLb, $backToLb, 0.001);
+    }
+
+    /**
+     * Test round-trip conversion accuracy for length
+     */
+    public function testLengthRoundTrip(): void
+    {
+        $originalIn = 72.5;
+        $cm = (float)$this->utils->inchesToCm($originalIn);
+        $backToIn = (float)$this->utils->cmToInches($cm);
+
+        $this->assertEqualsWithDelta($originalIn, $backToIn, 0.001);
+    }
+
+    /**
+     * Test round-trip conversion accuracy for temperature
+     */
+    public function testTemperatureRoundTrip(): void
+    {
+        $originalF = 98.6;
+        $c = (float)$this->utils->fhToCelsius($originalF);
+        $backToF = (float)$this->utils->celsiusToFh($c);
+
+        $this->assertEqualsWithDelta($originalF, $backToF, 0.01);
+    }
+
+    /**
+     * Test zero value conversions
+     */
+    public function testZeroValues(): void
+    {
+        $this->assertEquals('0.000000', $this->utils->lbToKg(0));
+        $this->assertEquals('0.000000', $this->utils->kgToLb(0));
+        $this->assertEquals('0.000000', $this->utils->inchesToCm(0));
+        $this->assertEquals('0.000000', $this->utils->cmToInches(0));
+    }
+
+    /**
+     * Test custom precision
+     */
+    public function testCustomPrecision(): void
+    {
+        $utils = new MeasurementUtils(2, MeasurementUtils::UNITS_USA_PRIMARY);
+
+        // With precision of 2, should return fewer decimal places
+        $result = $utils->lbToKg(1);
+        $this->assertEquals('0.45', $result);
+    }
+
+    /**
+     * Test isMetric() returns true for metric modes
+     */
+    public function testIsMetricTrueForMetricModes(): void
+    {
+        $metricPrimary = new MeasurementUtils(6, MeasurementUtils::UNITS_METRIC_PRIMARY);
+        $metricOnly = new MeasurementUtils(6, MeasurementUtils::UNITS_METRIC_ONLY);
+
+        $this->assertTrue($metricPrimary->isMetric());
+        $this->assertTrue($metricOnly->isMetric());
+    }
+
+    /**
+     * Test isMetric() returns false for USA modes
+     */
+    public function testIsMetricFalseForUsaModes(): void
+    {
+        $usaPrimary = new MeasurementUtils(6, MeasurementUtils::UNITS_USA_PRIMARY);
+        $usaOnly = new MeasurementUtils(6, MeasurementUtils::UNITS_USA_ONLY);
+
+        $this->assertFalse($usaPrimary->isMetric());
+        $this->assertFalse($usaOnly->isMetric());
+    }
+
+    /**
+     * Test formatWeight in USA Primary mode (shows both units, US first)
+     */
+    public function testFormatWeightUsaPrimary(): void
+    {
+        $utils = new MeasurementUtils(6, MeasurementUtils::UNITS_USA_PRIMARY);
+        $result = $utils->formatWeight(150.0);
+
+        // Should show US first, then metric in parentheses
+        $this->assertStringContainsString('150.00', $result);
+        $this->assertStringContainsString('lb', $result);
+        $this->assertStringContainsString('68.04', $result);
+        $this->assertStringContainsString('kg', $result);
+        $this->assertStringContainsString('(', $result);
+    }
+
+    /**
+     * Test formatWeight in Metric Primary mode (shows both units, metric first)
+     */
+    public function testFormatWeightMetricPrimary(): void
+    {
+        $utils = new MeasurementUtils(6, MeasurementUtils::UNITS_METRIC_PRIMARY);
+        $result = $utils->formatWeight(150.0);
+
+        // Should show metric first, then US in parentheses
+        $this->assertStringContainsString('68.04', $result);
+        $this->assertStringContainsString('kg', $result);
+        $this->assertStringContainsString('150.00', $result);
+        $this->assertStringContainsString('lb', $result);
+        // Metric should come before the parenthesis
+        $this->assertMatchesRegularExpression('/kg.*\(/', $result);
+    }
+
+    /**
+     * Test formatWeight in USA Only mode (shows only US units)
+     */
+    public function testFormatWeightUsaOnly(): void
+    {
+        $utils = new MeasurementUtils(6, MeasurementUtils::UNITS_USA_ONLY);
+        $result = $utils->formatWeight(150.0);
+
+        // Should show only US units
+        $this->assertStringContainsString('150.00', $result);
+        $this->assertStringContainsString('lb', $result);
+        $this->assertStringNotContainsString('kg', $result);
+    }
+
+    /**
+     * Test formatWeight in Metric Only mode (shows only metric units)
+     */
+    public function testFormatWeightMetricOnly(): void
+    {
+        $utils = new MeasurementUtils(6, MeasurementUtils::UNITS_METRIC_ONLY);
+        $result = $utils->formatWeight(150.0);
+
+        // Should show only metric units
+        $this->assertStringContainsString('68.04', $result);
+        $this->assertStringContainsString('kg', $result);
+        $this->assertStringNotContainsString('lb', $result);
+    }
+
+    /**
+     * Test formatWeight with primaryOnly=true
+     */
+    public function testFormatWeightPrimaryOnly(): void
+    {
+        $usaPrimary = new MeasurementUtils(6, MeasurementUtils::UNITS_USA_PRIMARY);
+        $metricPrimary = new MeasurementUtils(6, MeasurementUtils::UNITS_METRIC_PRIMARY);
+
+        $usaResult = $usaPrimary->formatWeight(150.0, true);
+        $metricResult = $metricPrimary->formatWeight(150.0, true);
+
+        // USA primary should show only lb
+        $this->assertStringContainsString('lb', $usaResult);
+        $this->assertStringNotContainsString('kg', $usaResult);
+
+        // Metric primary should show only kg
+        $this->assertStringContainsString('kg', $metricResult);
+        $this->assertStringNotContainsString('lb', $metricResult);
+    }
+
+    /**
+     * Test formatLength in USA Primary mode
+     */
+    public function testFormatLengthUsaPrimary(): void
+    {
+        $utils = new MeasurementUtils(6, MeasurementUtils::UNITS_USA_PRIMARY);
+        $result = $utils->formatLength(68.0);
+
+        // Should show US first, then metric in parentheses
+        $this->assertStringContainsString('68.00', $result);
+        $this->assertStringContainsString('in', $result);
+        $this->assertStringContainsString('172.72', $result);
+        $this->assertStringContainsString('cm', $result);
+    }
+
+    /**
+     * Test formatLength in Metric Only mode
+     */
+    public function testFormatLengthMetricOnly(): void
+    {
+        $utils = new MeasurementUtils(6, MeasurementUtils::UNITS_METRIC_ONLY);
+        $result = $utils->formatLength(68.0);
+
+        // Should show only metric
+        $this->assertStringContainsString('172.72', $result);
+        $this->assertStringContainsString('cm', $result);
+        $this->assertStringNotContainsString('in', $result);
+    }
+
+    /**
+     * Test formatTemperature in USA Primary mode
+     */
+    public function testFormatTemperatureUsaPrimary(): void
+    {
+        $utils = new MeasurementUtils(6, MeasurementUtils::UNITS_USA_PRIMARY);
+        $result = $utils->formatTemperature(98.6);
+
+        // Should show F first, then C in parentheses
+        $this->assertStringContainsString('98.60', $result);
+        $this->assertStringContainsString('F', $result);
+        $this->assertStringContainsString('37.00', $result);
+        $this->assertStringContainsString('C', $result);
+    }
+
+    /**
+     * Test formatTemperature in Metric Only mode
+     */
+    public function testFormatTemperatureMetricOnly(): void
+    {
+        $utils = new MeasurementUtils(6, MeasurementUtils::UNITS_METRIC_ONLY);
+        $result = $utils->formatTemperature(98.6);
+
+        // Should show only metric
+        $this->assertStringContainsString('37.00', $result);
+        $this->assertStringContainsString('C', $result);
+        $this->assertStringNotContainsString('F', $result);
+    }
+
+    /**
+     * Test weight formatting with lb/oz mode
+     */
+    public function testFormatWeightLbsOzMode(): void
+    {
+        $utils = new MeasurementUtils(
+            6,
+            MeasurementUtils::UNITS_USA_ONLY,
+            MeasurementUtils::WEIGHT_LBS_OZ
+        );
+        $result = $utils->formatWeight(150.5);
+
+        // 150.5 lbs = 150 lbs 8 oz
+        $this->assertStringContainsString('150', $result);
+        $this->assertStringContainsString('lb', $result);
+        $this->assertStringContainsString('8', $result);
+        $this->assertStringContainsString('oz', $result);
+    }
+
+    /**
+     * Test weight lb/oz conversion accuracy
+     */
+    public function testFormatWeightLbsOzAccuracy(): void
+    {
+        $utils = new MeasurementUtils(
+            6,
+            MeasurementUtils::UNITS_USA_ONLY,
+            MeasurementUtils::WEIGHT_LBS_OZ
+        );
+
+        // 150.25 lbs = 150 lbs 4 oz
+        $result = $utils->formatWeight(150.25);
+        $this->assertStringContainsString('150', $result);
+        $this->assertStringContainsString('4', $result);
+
+        // 150.75 lbs = 150 lbs 12 oz
+        $result = $utils->formatWeight(150.75);
+        $this->assertStringContainsString('150', $result);
+        $this->assertStringContainsString('12', $result);
+    }
+}

--- a/tests/Tests/Isolated/Common/Utils/MeasurementUtilsTest.php
+++ b/tests/Tests/Isolated/Common/Utils/MeasurementUtilsTest.php
@@ -396,4 +396,91 @@ class MeasurementUtilsTest extends TestCase
         $this->assertStringContainsString('150', $result);
         $this->assertStringContainsString('12', $result);
     }
+
+    /**
+     * Test that UCUM aliases are registered for mass units.
+     *
+     * UCUM (Unified Code for Units of Measure) is the standard unit system
+     * used in FHIR and HL7 healthcare interoperability standards.
+     *
+     * @see https://ucum.org/ucum UCUM Specification
+     * @see https://hl7.org/fhir/R4/valueset-ucum-units.html FHIR UCUM ValueSet
+     */
+    public function testUcumMassAliasesRegistered(): void
+    {
+        // Instantiate to trigger UCUM alias registration
+        new MeasurementUtils();
+
+        // [lb_av] = avoirdupois pound (UCUM code)
+        $this->assertTrue(
+            \PhpUnitsOfMeasure\PhysicalQuantity\Mass::isUnitDefined('[lb_av]'),
+            'UCUM alias [lb_av] should be registered for pounds'
+        );
+
+        // [oz_av] = avoirdupois ounce (UCUM code)
+        $this->assertTrue(
+            \PhpUnitsOfMeasure\PhysicalQuantity\Mass::isUnitDefined('[oz_av]'),
+            'UCUM alias [oz_av] should be registered for ounces'
+        );
+    }
+
+    /**
+     * Test that UCUM aliases are registered for length units.
+     *
+     * @see https://ucum.org/ucum#para-28 UCUM Length Units
+     */
+    public function testUcumLengthAliasesRegistered(): void
+    {
+        new MeasurementUtils();
+
+        // [in_i] = international inch (UCUM code)
+        $this->assertTrue(
+            \PhpUnitsOfMeasure\PhysicalQuantity\Length::isUnitDefined('[in_i]'),
+            'UCUM alias [in_i] should be registered for inches'
+        );
+    }
+
+    /**
+     * Test that UCUM aliases are registered for temperature units.
+     *
+     * @see https://ucum.org/ucum#para-32 UCUM Temperature Units
+     */
+    public function testUcumTemperatureAliasesRegistered(): void
+    {
+        new MeasurementUtils();
+
+        // Cel = degree Celsius (UCUM code)
+        $this->assertTrue(
+            \PhpUnitsOfMeasure\PhysicalQuantity\Temperature::isUnitDefined('Cel'),
+            'UCUM alias Cel should be registered for Celsius'
+        );
+
+        // [degF] = degree Fahrenheit (UCUM code)
+        $this->assertTrue(
+            \PhpUnitsOfMeasure\PhysicalQuantity\Temperature::isUnitDefined('[degF]'),
+            'UCUM alias [degF] should be registered for Fahrenheit'
+        );
+    }
+
+    /**
+     * Test conversions using UCUM codes work correctly.
+     *
+     * This verifies that FHIR-compliant code can use standard UCUM unit codes.
+     */
+    public function testConversionsWithUcumCodes(): void
+    {
+        new MeasurementUtils();
+
+        // Test mass conversion with UCUM codes
+        $mass = new \PhpUnitsOfMeasure\PhysicalQuantity\Mass(1, '[lb_av]');
+        $this->assertEqualsWithDelta(0.45359237, $mass->toUnit('kg'), 0.0001);
+
+        // Test length conversion with UCUM codes
+        $length = new \PhpUnitsOfMeasure\PhysicalQuantity\Length(1, '[in_i]');
+        $this->assertEqualsWithDelta(2.54, $length->toUnit('cm'), 0.0001);
+
+        // Test temperature conversion with UCUM codes
+        $temp = new \PhpUnitsOfMeasure\PhysicalQuantity\Temperature(32, '[degF]');
+        $this->assertEqualsWithDelta(0, $temp->toUnit('Cel'), 0.0001);
+    }
 }

--- a/tests/bootstrap-isolated.php
+++ b/tests/bootstrap-isolated.php
@@ -34,3 +34,16 @@ $GLOBALS['disable_database_connection'] = true;
 $GLOBALS['HTML_CHARSET'] = 'UTF-8';
 ini_set('default_charset', 'utf-8');
 mb_internal_encoding('UTF-8');
+
+/**
+ * Stub xl() translation function for isolated tests.
+ *
+ * In production, xl() translates strings using the database.
+ * In isolated tests, we just return the original string.
+ */
+if (!function_exists('xl')) {
+    function xl(string $constant): string
+    {
+        return $constant;
+    }
+}


### PR DESCRIPTION
Fixes #9961

#### Short description of what this resolves:

Consolidates scattered unit conversion logic throughout the codebase into a centralized `MeasurementUtils` class using the `php-units-of-measure` library for accurate, standards-compliant conversions.

#### Changes proposed in this pull request:

- Add `php-units-of-measure/php-units-of-measure` library dependency
- Create `MeasurementUtilsInterface` for dependency injection support
- Extend `MeasurementUtils` with:
  - Constructor that reads `$GLOBALS['units_of_measurement']` and `$GLOBALS['us_weight_format']`
  - `formatWeight()`, `formatLength()`, `formatTemperature()` methods supporting all 4 unit display modes
  - `isMetric()` helper method
  - Support for lb/oz weight format option
- Update call sites to use centralized formatting:
  - `interface/forms/vitals/growthchart/chart.php` - removed `unitsWt()`, `unitsDist()` functions
  - `interface/forms/vitals/report.php` - removed `US_weight()` function, simplified ~50 lines
  - `interface/eRxStore.php` - use MeasurementUtils for conversions
  - `EncounterccdadispatchTable.php` - use MeasurementUtils for CCDA exports
  - `library/ajax/graphs.php` - use MeasurementUtils for conversions
  - `src/Common/Forms/FormVitals.php` - use MeasurementUtils for weight display
- Add comprehensive isolated tests (25 tests, 69 assertions)
- Add `xl()` stub to `bootstrap-isolated.php` for test compatibility

#### Does your code include anything generated by an AI Engine? Yes

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.

This PR was developed with assistance from Claude Code (Claude Opus 4.5). The commit message includes the `Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>` attribution. The implementation follows existing OpenEMR patterns and coding standards.