### PR TITLE
fix: remove extra quotes around attr_js() in URLSearchParams

### DIFF
--- a/interface/main/dated_reminders/dated_reminders.php
+++ b/interface/main/dated_reminders/dated_reminders.php
@@ -109,7 +109,7 @@ function openAddScreen(id){
   } else {
     top.restoreSession();
     const params = new URLSearchParams({
-        csrf_token_form: '<?php echo attr_js(CsrfUtils::collectCsrfToken()); ?>',
+        csrf_token_form: <?php echo js_escape(CsrfUtils::collectCsrfToken()); ?>,
         mID: id
     });
     dlgopen('<?php echo $GLOBALS['webroot']; ?>/interface/main/dated_reminders/dated_reminders_add.php?' + params, '_drAdd', 700, 500);

--- a/interface/patient_file/history/encounters.php
+++ b/interface/patient_file/history/encounters.php
@@ -225,7 +225,7 @@ function todocument(docid) {
   const params = new URLSearchParams({
     doc_id: docid,
     document: '',
-    patient_id: '<?php echo attr_js($pid); ?>',
+    patient_id: <?php echo js_escape($pid); ?>,
     view: ''
   });
   h = '<?php echo $GLOBALS['webroot'] ?>/controller.php?' + params;


### PR DESCRIPTION
## Summary

- Fixes double-quoting bug where `attr_js()` was used inside JavaScript string literals
- `attr_js()` uses `json_encode()` which adds its own quotes, so outer quotes are not needed

## Test plan

- [ ] Verify dated reminders add functionality works (navigate to dated reminders, click to edit one)
- [ ] Verify document viewing from encounters history works

Fixes #10020
Related to #9741

🤖 Generated with [Claude Code](https://claude.com/claude-code)