### PR TITLE
feat: add xlx() translation function for XML contexts

### DIFF
--- a/contrib/util/language_translations/collectConstants.pl
+++ b/contrib/util/language_translations/collectConstants.pl
@@ -154,12 +154,12 @@ foreach my $var (@filenames) {
  my $smartyXL = 0; #flag
 
 
- if ($fileString =~ /xl[astj]?\s*\(/i) {
+ if ($fileString =~ /xl[ajtx]?\s*\(/i) {
   # line contains a traditional xl(function)
   $traditionalXL = 1;
  }
 
- if ($fileString =~ /\{\s*xl[atj]?\s*t\s*=\s*/i) {
+ if ($fileString =~ /\{\s*xl[ajtx]?\s*t\s*=\s*/i) {
   # line contains a smarty xl function
   $smartyXL = 1;
  }
@@ -172,10 +172,10 @@ foreach my $var (@filenames) {
  # break apart each xl function statement if exist
  my @xlInstances;
  if ($smartyXL) {
-  @xlInstances = split(/\{\s*xl[atj]?\s*t\s*=\s*/i, $fileString);
+  @xlInstances = split(/\{\s*xl[ajtx]?\s*t\s*=\s*/i, $fileString);
  }
  elsif ($traditionalXL) {
-  @xlInstances = split(/xl[astj]?\s*\(+/i, $fileString);
+  @xlInstances = split(/xl[ajtx]?\s*\(+/i, $fileString);
  }
  else {
   # no xl functions to parse on this page

--- a/library/htmlspecialchars.inc.php
+++ b/library/htmlspecialchars.inc.php
@@ -265,3 +265,14 @@ function xlj($key)
     return js_escape(hsc_private_xl_or_warn($key));
 }
 
+/**
+ * Translate via xl() and then escape via xmlEscape() for use in XML contexts.
+ *
+ * @param string $key The string to translate and escape.
+ * @return string The translated string, escaped for XML contexts.
+ */
+function xlx($key)
+{
+    return xmlEscape(hsc_private_xl_or_warn($key));
+}
+


### PR DESCRIPTION
## Summary
- Adds new `xlx()` function that translates a string and escapes it for XML contexts using `xmlEscape()`
- Updates the translation extraction tool (`collectConstants.pl`) to recognize `xlx()` calls
- Cleans up vestigial `s` from regex patterns (no `xls()` function exists)

Closes #10015

🤖 Generated with [Claude Code](https://claude.com/claude-code)