### PR TITLE
fix(sql): add migration for care_team_roles primary_care option_id

### DIFF
--- a/sql/patch.sql
+++ b/sql/patch.sql
@@ -47,3 +47,7 @@
 
 --  #EndIf
 --    all blocks are terminated with and #EndIf statement.
+
+#IfRow2D list_options list_id care_team_roles option_id primary_care
+UPDATE `list_options` SET `option_id` = 'primary_care_provider' WHERE `list_id` = 'care_team_roles' AND `option_id` = 'primary_care';
+#EndIf


### PR DESCRIPTION
## Summary
- Adds missing migration to update `list_options.option_id` from `'primary_care'` to `'primary_care_provider'` for the `care_team_roles` list
- Uses `#IfRow2D` conditional to only run the update if the old value exists

## Test plan
- [ ] Verify migration runs successfully on a database with the old `primary_care` option_id
- [ ] Verify migration is skipped (no error) on databases already using `primary_care_provider`

Fixes #9983

🤖 Generated with [Claude Code](https://claude.com/claude-code)