### PR TITLE
Portal broken page after login #10038

### DIFF
--- a/library/htmlspecialchars.inc.php
+++ b/library/htmlspecialchars.inc.php
@@ -222,7 +222,7 @@ function attr($text)
 function hsc_private_xl_or_warn($key)
 {
     if (function_exists('xl')) {
-        return xl($key);
+        return xl($key ?? '');
     } else {
         trigger_error(
             'Translation via xl() was requested, but the xl()'

--- a/library/options.inc.php
+++ b/library/options.inc.php
@@ -2366,7 +2366,7 @@ function generate_display_field($frow, $currvalue)
 
         // If match is not found in main and backup lists, return the key with exclamation mark
         if ($s == '') {
-            $s = nl2br(text(xl_list_label($currvalue))) .
+            $s = nl2br(text(xl_list_label($currvalue ?? ''))) .
                 '<span> <i class="fa fas fa-exclamation-circle ml-1"></i></span>';
         }
 


### PR DESCRIPTION
Fixes #10038

#### Short description of what this resolves:
Handle passing `null` to the `xl` function, which expects type `string`. 

#### Changes proposed in this pull request: 


#### Does your code include anything generated by an AI Engine? No