### PR TITLE
fix(phpstan): make eye_mag display functions return strings

### DIFF
--- a/.phpstan/phpstan.github.neon
+++ b/.phpstan/phpstan.github.neon
@@ -7166,14 +7166,6 @@ parameters:
       identifier: variable.undefined
       count: 8
       path: ../interface/forms/eye_mag/taskman.php
-    - message: '#^Result of function display_GlaucomaFlowSheet \(void\) is used\.$#'
-      identifier: function.void
-      count: 1
-      path: ../interface/forms/eye_mag/view.php
-    - message: '#^Result of function display_VisualAcuities \(void\) is used\.$#'
-      identifier: function.void
-      count: 1
-      path: ../interface/forms/eye_mag/view.php
     - message: '#^Variable \$ACT might not be defined\.$#'
       identifier: variable.undefined
       count: 2

--- a/interface/forms/eye_mag/php/eye_mag_functions.php
+++ b/interface/forms/eye_mag/php/eye_mag_functions.php
@@ -4799,10 +4799,11 @@ function cmp($a, $b)
  *
  * @param int    $pid
  * @param string $bywhat == byday or byhour
- * @return void
+ * @return string
  */
-function display_GlaucomaFlowSheet($pid, $bywhat = 'byday'): void
+function display_GlaucomaFlowSheet($pid, $bywhat = 'byday'): string
 {
+    ob_start();
     global $PMSFH;
     global $form_folder;
     global $priors;
@@ -5607,12 +5608,12 @@ function display_GlaucomaFlowSheet($pid, $bywhat = 'byday'): void
             } ?>
         </div>
     </div>
-            <?php
+    <?php
+    return ob_get_clean();
 }
 
 
 /**
- *
  * This function displays today + historical visual acuity measurements
  * I imagined this as a condensed table with top row = types of acuities
  *   Date | sc | CC | Ph | AR | MR | CR | CTL | comments
@@ -5622,11 +5623,11 @@ function display_GlaucomaFlowSheet($pid, $bywhat = 'byday'): void
  * and 3rd row on: the leftmost/first column containing Date of visit, then the actual measurements obtained
  *
  * @param int $pid
- * @return void
- *
-*/
-function display_VisualAcuities($pid = 0): void
+ * @return string
+ */
+function display_VisualAcuities($pid = 0): string
 {
+    ob_start();
     global $priors;
     global $visit_date;
     global $dated;
@@ -6082,6 +6083,7 @@ function display_VisualAcuities($pid = 0): void
             </table>
         </div>
     <?php
+    return ob_get_clean();
 }
 
 


### PR DESCRIPTION
## Summary

Modify `display_GlaucomaFlowSheet()` and `display_VisualAcuities()` to use output buffering and return strings instead of outputting directly.

## Changes

- Change return type from `void` to `string`
- Add `ob_start()` at function entry
- Add `return ob_get_clean()` at function exit
- Remove 2 resolved `function.void` baseline entries from PHPStan

## Why

Both functions were declared as `void` but their return values were being used in `view.php`:

```php
// match expression expects a value
"GFS" => display_GlaucomaFlowSheet($pid),

// echo expects a string
<?php echo display_VisualAcuities($pid); ?>
<?php echo display_GlaucomaFlowSheet($pid); ?>
```

By using output buffering, the functions can still use convenient mixed PHP/HTML syntax internally while returning strings to callers.

## Test Plan

- [x] PHPStan passes with 0 errors
- [x] CI passes
- [x] Manual testing of eye exam form (Visual Acuities and Glaucoma Flow Sheet sections)

Fixes #10048

🤖 Generated with [Claude Code](https://claude.com/claude-code)