### PR TITLE
fix(phpstan): add missing static properties to FaxSMS AuthenticateTrait

### DIFF
--- a/.phpstan/phpstan.github.neon
+++ b/.phpstan/phpstan.github.neon
@@ -11450,14 +11450,6 @@ parameters:
       identifier: empty.variable
       count: 1
       path: ../interface/modules/custom_modules/oe-module-faxsms/src/Controller/TwilioSMSClient.php
-    - message: '#^Access to an undefined static property OpenEMR\\Modules\\FaxSMS\\Controller\\VoiceClient\:\:\$authAttemptCount\.$#'
-      identifier: staticProperty.notFound
-      count: 2
-      path: ../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php
-    - message: '#^Access to an undefined static property OpenEMR\\Modules\\FaxSMS\\Controller\\VoiceClient\:\:\$lastAuthAttempt\.$#'
-      identifier: staticProperty.notFound
-      count: 1
-      path: ../interface/modules/custom_modules/oe-module-faxsms/src/Controller/VoiceClient.php
     - message: '#^Variable \$tz in empty\(\) is never defined\.$#'
       identifier: empty.variable
       count: 1

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/AuthenticateTrait.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/AuthenticateTrait.php
@@ -18,6 +18,9 @@ use RingCentral\SDK\SDK;
 
 trait AuthenticateTrait
 {
+    private static int $authAttemptCount = 0;
+    private static int $lastAuthAttempt = 0;
+
     public function authenticate($acl = []): bool|int|string
     {
         if (empty($this->credentials['appKey'])) {


### PR DESCRIPTION
## Summary

Add missing static property declarations to `AuthenticateTrait` in the FaxSMS module.

## Changes

The `authenticateRingCentral()` method uses two static properties that were never declared:
```php
self::$authAttemptCount++;
self::$lastAuthAttempt = time();
```

Added the missing declarations:
```php
private static int $authAttemptCount = 0;
private static int $lastAuthAttempt = 0;
```

## Test Plan

- [x] PHPStan passes with 0 errors
- [x] CI passes

Fixes #10050

🤖 Generated with [Claude Code](https://claude.com/claude-code)