### PR TITLE
fix(phpstan): resolve phpunit.mockMethod findings in EventAuditLoggerTest

### DIFF
--- a/.phpstan/phpstan.github.neon
+++ b/.phpstan/phpstan.github.neon
@@ -17354,23 +17354,3 @@ parameters:
       identifier: arguments.count
       count: 1
       path: ../tests/Tests/Unit/ClinicalDecisionRules/ControllerRouterTest.php
-    - message: '#^Trying to mock an undefined method Execute\(\) on class stdClass\.$#'
-      identifier: phpunit.mockMethod
-      count: 1
-      path: ../tests/Tests/Unit/Common/Logging/EventAuditLoggerTest.php
-    - message: '#^Trying to mock an undefined method ExecuteNoLog\(\) on class stdClass\.$#'
-      identifier: phpunit.mockMethod
-      count: 1
-      path: ../tests/Tests/Unit/Common/Logging/EventAuditLoggerTest.php
-    - message: '#^Trying to mock an undefined method FetchRow\(\) on class stdClass\.$#'
-      identifier: phpunit.mockMethod
-      count: 3
-      path: ../tests/Tests/Unit/Common/Logging/EventAuditLoggerTest.php
-    - message: '#^Trying to mock an undefined method Insert_ID\(\) on class stdClass\.$#'
-      identifier: phpunit.mockMethod
-      count: 1
-      path: ../tests/Tests/Unit/Common/Logging/EventAuditLoggerTest.php
-    - message: '#^Trying to mock an undefined method qstr\(\) on class stdClass\.$#'
-      identifier: phpunit.mockMethod
-      count: 1
-      path: ../tests/Tests/Unit/Common/Logging/EventAuditLoggerTest.php


### PR DESCRIPTION
## Summary
- Add dedicated interfaces for mocking ADODB connection and result set instead of mocking `stdClass` with `addMethods()`
- This allows PHPStan to properly validate the mock method signatures
- Remove 5 `phpunit.mockMethod` entries from baseline

## Changes
- Add `MockAdodbConnection` interface with `qstr`, `Insert_ID`, `Execute`, `ExecuteNoLog` methods
- Add `MockAdodbResultSet` interface with `FetchRow` method
- Update `createMockAdodb()` to use `MockAdodbConnection` interface
- Update result set mocks to use `MockAdodbResultSet` interface

## Test plan
- [x] PHPStan analysis passes with no errors
- [x] Unit tests pass

Fixes #10052

🤖 Generated with [Claude Code](https://claude.com/claude-code)