### PR TITLE
fix(phpstan): resolve fileNotFound findings via include path config

### DIFF
--- a/.phpstan/phpstan.github.neon
+++ b/.phpstan/phpstan.github.neon
@@ -9818,22 +9818,6 @@ parameters:
       identifier: variable.undefined
       count: 1
       path: ../interface/main/calendar/find_patient_popup.php
-    - message: '#^Path in require\(\) "config\.php" is not a file or it does not exist\.$#'
-      identifier: require.fileNotFound
-      count: 1
-      path: ../interface/main/calendar/includes/pnAPI.php
-    - message: '#^Path in require\(\) "includes/pnHTML\.php" is not a file or it does not exist\.$#'
-      identifier: require.fileNotFound
-      count: 1
-      path: ../interface/main/calendar/includes/pnAPI.php
-    - message: '#^Path in require\(\) "includes/pnMod\.php" is not a file or it does not exist\.$#'
-      identifier: require.fileNotFound
-      count: 1
-      path: ../interface/main/calendar/includes/pnAPI.php
-    - message: '#^Path in require\(\) "pntables\.php" is not a file or it does not exist\.$#'
-      identifier: require.fileNotFound
-      count: 1
-      path: ../interface/main/calendar/includes/pnAPI.php
     - message: '#^Variable \$_GLOBALS might not be defined\.$#'
       identifier: variable.undefined
       count: 3
@@ -9872,14 +9856,6 @@ parameters:
       path: ../interface/main/calendar/includes/pnHTML.php
     - message: '#^Method pnHTML\:\:Text\(\) should return string but return statement is missing\.$#'
       identifier: return.missing
-      count: 1
-      path: ../interface/main/calendar/includes/pnHTML.php
-    - message: '#^Path in include\(\) "footer\.php" is not a file or it does not exist\.$#'
-      identifier: include.fileNotFound
-      count: 1
-      path: ../interface/main/calendar/includes/pnHTML.php
-    - message: '#^Path in include\(\) "header\.php" is not a file or it does not exist\.$#'
-      identifier: include.fileNotFound
       count: 1
       path: ../interface/main/calendar/includes/pnHTML.php
     - message: '#^Variable \$srcdir might not be defined\.$#'
@@ -12578,10 +12554,6 @@ parameters:
       identifier: variable.undefined
       count: 1
       path: ../interface/patient_file/pos_checkout_normal.php
-    - message: '#^Path in include_once\(\) "\.\./\.\./custom/fee_sheet_codes\.php" is not a file or it does not exist\.$#'
-      identifier: includeOnce.fileNotFound
-      count: 1
-      path: ../interface/patient_file/printed_fee_sheet.php
     - message: '#^Variable \$encounter might not be defined\.$#'
       identifier: variable.undefined
       count: 1
@@ -12910,10 +12882,6 @@ parameters:
       identifier: variable.undefined
       count: 6
       path: ../interface/patient_file/summary/demographics_full.php
-    - message: '#^Path in include\(\) "\.\./\.\./\.\./custom/demographics_print\.php" is not a file or it does not exist\.$#'
-      identifier: include.fileNotFound
-      count: 1
-      path: ../interface/patient_file/summary/demographics_print.php
     - message: '#^Variable \$pid might not be defined\.$#'
       identifier: variable.undefined
       count: 3
@@ -14134,10 +14102,6 @@ parameters:
       identifier: variable.undefined
       count: 2
       path: ../ippf_upgrade.php
-    - message: '#^Path in include\(\) "views/esign_signature_log\.php" is not a file or it does not exist\.$#'
-      identifier: include.fileNotFound
-      count: 1
-      path: ../library/ESign/DbRow/Signable.php
     - message: '#^Variable \$this might not be defined\.$#'
       identifier: variable.undefined
       count: 4
@@ -15598,10 +15562,6 @@ parameters:
       identifier: variable.undefined
       count: 1
       path: ../modules/sms_email_reminder/cron_email_notification.php
-    - message: '#^Path in include\(\) "getmxrr\.php" is not a file or it does not exist\.$#'
-      identifier: include.fileNotFound
-      count: 1
-      path: ../modules/sms_email_reminder/cron_functions.php
     - message: '#^Class sms constructor invoked with 3 parameters, 0 required\.$#'
       identifier: arguments.count
       count: 1
@@ -15858,42 +15818,10 @@ parameters:
       identifier: class.notFound
       count: 1
       path: ../portal/messaging/secure_chat.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/SavantRenderEngine\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/_app_config.php
     - message: '#^Instantiated class specify not found\.$#'
       identifier: class.notFound
       count: 1
       path: ../portal/patient/_global_config.php
-    - message: '#^Path in require_once\(\) "verysimple/DB/DatabaseConfig\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/_global_config.php
-    - message: '#^Path in require_once\(\) "verysimple/HTTP/RequestUtil\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/_global_config.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/GenericRouter\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/_global_config.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/ObserveToSmarty\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/_global_config.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/PortalController\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/_global_config.php
-    - message: '#^Path in require_once\(\) "verysimple/HTTP/RequestUtil\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/_machine_config.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/ConnectionSetting\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/_machine_config.php
     - message: '#^Variable \$disable_utf8_flag might not be defined\.$#'
       identifier: variable.undefined
       count: 1
@@ -15950,97 +15878,21 @@ parameters:
       identifier: function.notFound
       count: 1
       path: ../portal/patient/fwk/libs/verysimple/DB/DataDriver/MySQL.php
-    - message: '#^Path in require_once\(\) "verysimple/DB/DatabaseConfig\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/DB/DataDriver/MySQL.php
-    - message: '#^Path in require_once\(\) "verysimple/DB/DatabaseException\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/DB/DataDriver/MySQL.php
-    - message: '#^Path in require_once\(\) "verysimple/DB/ISqlFunction\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/DB/DataDriver/MySQL.php
     - message: '#^Function mysql_ping not found\.$#'
       identifier: function.notFound
       count: 1
       path: ../portal/patient/fwk/libs/verysimple/DB/DataDriver/MySQL_PDO.php
-    - message: '#^Path in require_once\(\) "verysimple/DB/DatabaseConfig\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/DB/DataDriver/MySQL_PDO.php
-    - message: '#^Path in require_once\(\) "verysimple/DB/DatabaseException\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/DB/DataDriver/MySQL_PDO.php
-    - message: '#^Path in require_once\(\) "verysimple/DB/ISqlFunction\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/DB/DataDriver/MySQL_PDO.php
-    - message: '#^Path in require_once\(\) "verysimple/DB/DatabaseConfig\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/DB/DataDriver/MySQLi.php
-    - message: '#^Path in require_once\(\) "verysimple/DB/DatabaseException\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/DB/DataDriver/MySQLi.php
-    - message: '#^Path in require_once\(\) "verysimple/DB/ISqlFunction\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/DB/DataDriver/MySQLi.php
-    - message: '#^Path in require_once\(\) "verysimple/DB/DatabaseConfig\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/DB/DataDriver/SQLite.php
-    - message: '#^Path in require_once\(\) "verysimple/DB/DatabaseException\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/DB/DataDriver/SQLite.php
-    - message: '#^Path in require_once\(\) "verysimple/DB/ISqlFunction\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/DB/DataDriver/SQLite.php
     - message: '#^Undefined variable\: \$attachment$#'
       identifier: variable.undefined
       count: 4
       path: ../portal/patient/fwk/libs/verysimple/HTTP/FileUpload.php
-    - message: '#^Path in require_once\(\) "verysimple/String/VerySimpleStringUtil\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 2
-      path: ../portal/patient/fwk/libs/verysimple/HTTP/RequestUtil.php
     - message: '#^Variable \$_POST in isset\(\) always exists and is not nullable\.$#'
       identifier: isset.variable
       count: 1
       path: ../portal/patient/fwk/libs/verysimple/HTTP/RequestUtil.php
-    - message: '#^Path in require_once\(\) "verysimple/HTTP/RequestUtil\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/HTTP/UrlWriter.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/ActionRouter\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/HTTP/UrlWriter.php
-    - message: '#^Path in require_once\(\) "verysimple/HTTP/RequestUtil\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/ActionRouter.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/IRouter\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/ActionRouter.php
-    - message: '#^Path in require_once\(\) "verysimple/Util/UrlWriterMode\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/ActionRouter.php
     - message: '#^Access to an undefined property CacheMemCache\:\:\$LastServerError\.$#'
       identifier: property.notFound
       count: 4
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/CacheMemCache.php
-    - message: '#^Path in require_once\(\) "verysimple/Util/ExceptionThrower\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
       path: ../portal/patient/fwk/libs/verysimple/Phreeze/CacheMemCache.php
     - message: '#^Method CacheNoCache\:\:Set\(\) should return VARIANT but return statement is missing\.$#'
       identifier: return.missing
@@ -16050,48 +15902,12 @@ parameters:
       identifier: return.missing
       count: 1
       path: ../portal/patient/fwk/libs/verysimple/Phreeze/CacheRam.php
-    - message: '#^Path in require_once\(\) "verysimple/IO/Includer\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/Criteria.php
-    - message: '#^Path in include_once\(\) "verysimple/DB/DataDriver/MySQL\.php" is not a file or it does not exist\.$#'
-      identifier: includeOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/DataAdapter.php
-    - message: '#^Path in include_once\(\) "verysimple/DB/DataDriver/MySQLi\.php" is not a file or it does not exist\.$#'
-      identifier: includeOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/DataAdapter.php
-    - message: '#^Path in include_once\(\) "verysimple/DB/DataDriver/SQLite\.php" is not a file or it does not exist\.$#'
-      identifier: includeOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/DataAdapter.php
-    - message: '#^Path in require_once\(\) "verysimple/DB/DataDriver/IDataDriver\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/DataAdapter.php
-    - message: '#^Path in require_once\(\) "verysimple/IO/Includer\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/DataAdapter.php
     - message: '#^Access to an undefined property DataSet\:\:\$_total\.$#'
       identifier: property.notFound
       count: 1
       path: ../portal/patient/fwk/libs/verysimple/Phreeze/DataSet.php
-    - message: '#^Path in require_once\(\) "verysimple/Util/ExceptionFormatter\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/DataSet.php
     - message: '#^Class GenericRouter constructor invoked with 0 parameters, 3 required\.$#'
       identifier: arguments.count
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/Dispatcher.php
-    - message: '#^Path in require_once\(\) "verysimple/HTTP/RequestUtil\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/Dispatcher.php
-    - message: '#^Path in require_once\(\) "verysimple/Util/ExceptionThrower\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
       count: 1
       path: ../portal/patient/fwk/libs/verysimple/Phreeze/Dispatcher.php
     - message: '#^Call to static method createWriter\(\) on an unknown class PHPExcel_IOFactory\.$#'
@@ -16102,14 +15918,6 @@ parameters:
       identifier: class.notFound
       count: 1
       path: ../portal/patient/fwk/libs/verysimple/Phreeze/ExportUtility.php
-    - message: '#^Path in require_once\(\) "PEAR/PHPExcel\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/ExportUtility.php
-    - message: '#^Path in require_once\(\) "verysimple/HTTP/RequestUtil\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/GenericRouter.php
     - message: '#^Access to an undefined property MockRouter\:\:\$delim\.$#'
       identifier: property.notFound
       count: 1
@@ -16118,10 +15926,6 @@ parameters:
       identifier: property.notFound
       count: 1
       path: ../portal/patient/fwk/libs/verysimple/Phreeze/MockRouter.php
-    - message: '#^Path in require_once\(\) "verysimple/HTTP/RequestUtil\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/ObserveToFile.php
     - message: '#^Access to an undefined property PHPRenderEngine\:\:\$templatePath\.$#'
       identifier: property.notFound
       count: 2
@@ -16132,10 +15936,6 @@ parameters:
       path: ../portal/patient/fwk/libs/verysimple/Phreeze/Phreezable.php
     - message: '#^Method Phreezer\:\:GetPrimaryKeyMap\(\) should return KeyMap but return statement is missing\.$#'
       identifier: return.missing
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/Phreezer.php
-    - message: '#^Path in require_once\(\) "verysimple/IO/Includer\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
       count: 1
       path: ../portal/patient/fwk/libs/verysimple/Phreeze/Phreezer.php
     - message: '#^Class GenericRouter constructor invoked with 0 parameters, 3 required\.$#'
@@ -16150,50 +15950,10 @@ parameters:
       identifier: class.notFound
       count: 1
       path: ../portal/patient/fwk/libs/verysimple/Phreeze/PortalController.php
-    - message: '#^Path in require_once\(\) "verysimple/Authentication/Auth401\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/PortalController.php
-    - message: '#^Path in require_once\(\) "verysimple/Authentication/Authenticator\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 2
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/PortalController.php
-    - message: '#^Path in require_once\(\) "verysimple/Authentication/IAuthenticatable\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/PortalController.php
-    - message: '#^Path in require_once\(\) "verysimple/HTTP/BrowserDevice\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/PortalController.php
-    - message: '#^Path in require_once\(\) "verysimple/HTTP/Context\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/PortalController.php
-    - message: '#^Path in require_once\(\) "verysimple/HTTP/RequestUtil\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/PortalController.php
-    - message: '#^Path in require_once\(\) "verysimple/RSS/IRSSFeedItem\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/PortalController.php
-    - message: '#^Path in require_once\(\) "verysimple/RSS/Writer\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/PortalController.php
-    - message: '#^Path in require_once\(\) "verysimple/String/VerySimpleStringUtil\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/PortalController.php
     - message: '#^Method Reporter\:\:__serialize\(\) should return array\<mixed, mixed\> but return statement is missing\.$#'
       identifier: return.missing
       count: 1
       path: ../portal/patient/fwk/libs/verysimple/Phreeze/Reporter.php
-    - message: '#^Path in require_once\(\) "savant/Savant3\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/SavantRenderEngine.php
     - message: '#^Constructor of class SimpleRouter has an unused parameter \$appRootUrl\.$#'
       identifier: constructor.unusedParameter
       count: 1
@@ -16202,166 +15962,18 @@ parameters:
       identifier: return.missing
       count: 1
       path: ../portal/patient/fwk/libs/verysimple/Phreeze/SimpleRouter.php
-    - message: '#^Path in require_once\(\) "verysimple/HTTP/RequestUtil\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/SimpleRouter.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/IRouter\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/SimpleRouter.php
     - message: '#^Method VerySimpleStringUtil\:\:unicode_entity_replace\(\) should return string but return statement is missing\.$#'
       identifier: return.missing
       count: 1
       path: ../portal/patient/fwk/libs/verysimple/String/VerySimpleStringUtil.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/CacheMemCache\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Util/MemCacheProxy.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/Dispatcher\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/index.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/PortalController\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Controller/AppBasePortalController.php
-    - message: '#^Path in require_once\(\) "Model/OnsiteActivityView\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Controller/OnsiteActivityViewController.php
-    - message: '#^Path in require_once\(\) "Model/OnsiteDocument\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Controller/OnsiteDocumentController.php
     - message: '#^Variable \$errors on left side of \?\? always exists and is not nullable\.$#'
       identifier: nullCoalesce.variable
       count: 1
       path: ../portal/patient/libs/Controller/OnsiteDocumentController.php
-    - message: '#^Path in require_once\(\) "Model/OnsitePortalActivity\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Controller/OnsitePortalActivityController.php
-    - message: '#^Path in require_once\(\) "Model/Patient\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Controller/PatientController.php
     - message: '#^Variable \$output might not be defined\.$#'
       identifier: variable.undefined
       count: 1
       path: ../portal/patient/libs/Controller/PatientController.php
-    - message: '#^Path in require_once\(\) "Model/Patient\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Controller/PortalPatientController.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/Criteria\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Model/DAO/OnsiteActivityViewCriteriaDAO.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/Phreezable\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Model/DAO/OnsiteActivityViewDAO.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/IDaoMap\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Model/DAO/OnsiteActivityViewMap-query.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/IDaoMap2\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Model/DAO/OnsiteActivityViewMap-query.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/IDaoMap\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Model/DAO/OnsiteActivityViewMap.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/IDaoMap2\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Model/DAO/OnsiteActivityViewMap.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/Criteria\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Model/DAO/OnsiteDocumentCriteriaDAO.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/Phreezable\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Model/DAO/OnsiteDocumentDAO.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/IDaoMap\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Model/DAO/OnsiteDocumentMap.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/IDaoMap2\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Model/DAO/OnsiteDocumentMap.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/Criteria\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Model/DAO/OnsitePortalActivityCriteriaDAO.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/Phreezable\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Model/DAO/OnsitePortalActivityDAO.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/IDaoMap\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Model/DAO/OnsitePortalActivityMap.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/IDaoMap2\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Model/DAO/OnsitePortalActivityMap.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/Criteria\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Model/DAO/PatientCriteriaDAO.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/Phreezable\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Model/DAO/PatientDAO.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/IDaoMap\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Model/DAO/PatientMap.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/IDaoMap2\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Model/DAO/PatientMap.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/Criteria\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Model/DAO/UserCriteriaDAO.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/Phreezable\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Model/DAO/UserDAO.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/IDaoMap\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Model/DAO/UserMap.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/IDaoMap2\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Model/DAO/UserMap.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/Reporter\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Reporter/OnsiteActivityViewReporter-query.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/Reporter\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Reporter/OnsiteActivityViewReporter.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/Reporter\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Reporter/OnsiteDocumentReporter.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/Reporter\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Reporter/OnsitePortalActivityReporter.php
-    - message: '#^Path in require_once\(\) "verysimple/Phreeze/Reporter\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/libs/Reporter/PatientReporter.php
     - message: '#^Variable \$this might not be defined\.$#'
       identifier: variable.undefined
       count: 2
@@ -16382,10 +15994,6 @@ parameters:
       identifier: variable.undefined
       count: 4
       path: ../portal/patient/templates/OnsitePortalActivityListView.tpl.php
-    - message: '#^Path in require_once\(\) "\.\./\.\./library/options\.inc\.php" is not a file or it does not exist\.$#'
-      identifier: requireOnce.fileNotFound
-      count: 1
-      path: ../portal/patient/templates/PatientListView.tpl.php
     - message: '#^Variable \$this might not be defined\.$#'
       identifier: variable.undefined
       count: 14
@@ -17346,3 +16954,57 @@ parameters:
       identifier: arguments.count
       count: 1
       path: ../tests/Tests/Unit/ClinicalDecisionRules/ControllerRouterTest.php
+
+    # Optional custom files - checked with file_exists() before include
+    -
+      message: '#^Path in include_once\(\) "\.\./\.\./custom/fee_sheet_codes\.php" is not a file or it does not exist\.$#'
+      identifier: includeOnce.fileNotFound
+      path: ../interface/patient_file/printed_fee_sheet.php
+    -
+      message: '#^Path in include\(\) "\.\./\.\./\.\./custom/demographics_print\.php" is not a file or it does not exist\.$#'
+      identifier: include.fileNotFound
+      path: ../interface/patient_file/summary/demographics_print.php
+
+    # Legacy PostNuke calendar files - header/footer don't exist
+    -
+      message: '#^Path in include\(\) "header\.php" is not a file or it does not exist\.$#'
+      identifier: include.fileNotFound
+      path: ../interface/main/calendar/includes/pnHTML.php
+    -
+      message: '#^Path in include\(\) "footer\.php" is not a file or it does not exist\.$#'
+      identifier: include.fileNotFound
+      path: ../interface/main/calendar/includes/pnHTML.php
+
+    # Windows compatibility file for getmxrr - conditionally included
+    -
+      message: '#^Path in include\(\) "getmxrr\.php" is not a file or it does not exist\.$#'
+      identifier: include.fileNotFound
+      path: ../modules/sms_email_reminder/cron_functions.php
+
+    # Dead code - renderForm() is never called, path is wrong
+    -
+      message: '#^Path in include\(\) "views/esign_signature_log\.php" is not a file or it does not exist\.$#'
+      identifier: include.fileNotFound
+      path: ../library/ESign/DbRow/Signable.php
+
+    # Optional PEAR/PHPExcel dependency - not installed
+    -
+      message: '#^Path in require_once\(\) "PEAR/PHPExcel\.php" is not a file or it does not exist\.$#'
+      identifier: requireOnce.fileNotFound
+      path: ../portal/patient/fwk/libs/verysimple/Phreeze/ExportUtility.php
+
+    # Optional RSS functionality - files don't exist
+    -
+      message: '#^Path in require_once\(\) "verysimple/RSS/Writer\.php" is not a file or it does not exist\.$#'
+      identifier: requireOnce.fileNotFound
+      path: ../portal/patient/fwk/libs/verysimple/Phreeze/PortalController.php
+    -
+      message: '#^Path in require_once\(\) "verysimple/RSS/IRSSFeedItem\.php" is not a file or it does not exist\.$#'
+      identifier: requireOnce.fileNotFound
+      path: ../portal/patient/fwk/libs/verysimple/Phreeze/PortalController.php
+
+    # Template path depends on runtime working directory
+    -
+      message: '#^Path in require_once\(\) "\.\./\.\./library/options\.inc\.php" is not a file or it does not exist\.$#'
+      identifier: requireOnce.fileNotFound
+      path: ../portal/patient/templates/PatientListView.tpl.php

--- a/.phpstan/phpstan_include_paths.php
+++ b/.phpstan/phpstan_include_paths.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * PHPStan bootstrap file to set up include paths for static analysis.
+ *
+ * This file configures the PHP include_path to match the runtime configuration,
+ * allowing PHPStan to properly resolve require/include statements that use
+ * relative paths.
+ *
+ * The portal patient module uses Phreeze framework which sets include paths
+ * dynamically at runtime via set_include_path() in _app_config.php.
+ */
+
+// Add Phreeze framework paths used by portal/patient
+set_include_path(
+    __DIR__ . '/../portal/patient/libs/' . PATH_SEPARATOR .
+    __DIR__ . '/../portal/patient/fwk/libs/' . PATH_SEPARATOR .
+    get_include_path()
+);
+
+// Add PostNuke calendar paths
+// pnAPI.php includes config.php and pntables.php which are one level up
+set_include_path(
+    __DIR__ . '/../interface/main/calendar/' . PATH_SEPARATOR .
+    __DIR__ . '/../interface/main/calendar/includes/' . PATH_SEPARATOR .
+    get_include_path()
+);

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,6 +4,7 @@ includes:
 parameters:
   bootstrapFiles:
   - .phpstan/phpstan_panther_alias.php
+  - .phpstan/phpstan_include_paths.php
   level: 1
   # Set tmpDir explicitly so we know what it is
   tmpDir: tmp-phpstan


### PR DESCRIPTION
## Summary
- Add PHPStan bootstrap file that configures include paths to match runtime configuration
- This allows PHPStan to resolve `require`/`include` statements using relative paths
- **Net reduction: 88 baseline entries removed (98 → 10)**

## Changes
- Create `.phpstan/phpstan_include_paths.php` bootstrap file
- Configure paths for Phreeze framework (`portal/patient/libs/`, `portal/patient/fwk/libs/`)
- Configure paths for PostNuke calendar (`interface/main/calendar/`)
- Remove 88 resolved `*.fileNotFound` entries from `.phpstan/phpstan.github.neon`
- Keep 10 documented entries for genuinely missing/optional files:
  - Optional custom files (checked with `file_exists()`)
  - Legacy PostNuke header/footer
  - Windows compatibility file
  - Optional dependencies (PEAR/PHPExcel, RSS)
  - Runtime-dependent template path
  - Dead code in ESign

## Test plan
- [x] PHPStan analysis passes with no errors
- [x] Baseline reduced from 98 to 10 fileNotFound entries

Fixes #10056

🤖 Generated with [Claude Code](https://claude.com/claude-code)