### PR TITLE
fix(phpstan): resolve staticMethod.notFound via @method annotations

### DIFF
--- a/.phpstan/phpstan-remaining-baseline.neon
+++ b/.phpstan/phpstan-remaining-baseline.neon
@@ -220,10 +220,6 @@ parameters:
       identifier: nullCoalesce.variable
       count: 1
       path: ../controllers/C_DocumentCategory.class.php
-    - message: '#^Call to an undefined static method OpenEMR\\Common\\Http\\oeHttp\:\:get\(\)\.$#'
-      identifier: staticMethod.notFound
-      count: 1
-      path: ../controllers/C_Prescription.class.php
     - message: '#^Variable \$p might not be defined\.$#'
       identifier: variable.undefined
       count: 1
@@ -16372,10 +16368,6 @@ parameters:
       identifier: arguments.count
       count: 1
       path: ../src/Cqm/test.php
-    - message: '#^Call to an undefined static method OpenEMR\\Common\\Http\\oeHttp\:\:usingHeaders\(\)\.$#'
-      identifier: staticMethod.notFound
-      count: 5
-      path: ../src/Easipro/Easipro.php
     - message: '#^Undefined variable\: \$row$#'
       identifier: variable.undefined
       count: 1
@@ -16444,10 +16436,6 @@ parameters:
       identifier: empty.variable
       count: 1
       path: ../src/Gacl/GaclApi.php
-    - message: '#^Call to an undefined static method OpenEMR\\Common\\Http\\oeHttp\:\:get\(\)\.$#'
-      identifier: staticMethod.notFound
-      count: 1
-      path: ../src/MedicalDevice/MedicalDevice.php
     - message: '#^Variable \$catEntry might not be defined\.$#'
       identifier: variable.undefined
       count: 5
@@ -16488,10 +16476,6 @@ parameters:
       identifier: variable.undefined
       count: 1
       path: ../src/PaymentProcessing/Sphere/SpherePayment.php
-    - message: '#^Call to an undefined static method OpenEMR\\Common\\Http\\oeHttp\:\:getCurlOptions\(\)\.$#'
-      identifier: staticMethod.notFound
-      count: 1
-      path: ../src/Pharmacy/Services/ImportPharmacies.php
     - message: '#^Variable \$zip might not be defined\.$#'
       identifier: variable.undefined
       count: 1
@@ -16512,10 +16496,6 @@ parameters:
       identifier: variable.undefined
       count: 1
       path: ../src/RestControllers/FHIR/Operations/FhirOperationExportRestController.php
-    - message: '#^Call to an undefined static method OpenEMR\\Common\\Http\\oeHttp\:\:get\(\)\.$#'
-      identifier: staticMethod.notFound
-      count: 1
-      path: ../src/Rx/RxList.php
     - message: '#^Variable \$all might not be defined\.$#'
       identifier: variable.undefined
       count: 1

--- a/library/classes/ClinicalTypes/codes.php
+++ b/library/classes/ClinicalTypes/codes.php
@@ -7,6 +7,16 @@
 // as published by the Free Software Foundation; either version 2
 // of the License, or (at your option) any later version.
 //
+
+require_once __DIR__ . '/Allergy.php';
+require_once __DIR__ . '/Communication.php';
+require_once __DIR__ . '/Diagnosis.php';
+require_once __DIR__ . '/Encounter.php';
+require_once __DIR__ . '/LabResult.php';
+require_once __DIR__ . '/Medication.php';
+require_once __DIR__ . '/PhysicalExam.php';
+require_once __DIR__ . '/Procedure.php';
+
 class Codes
 {
     const ICD9 = 'ICD9';

--- a/src/Common/Http/oeHttp.php
+++ b/src/Common/Http/oeHttp.php
@@ -23,6 +23,23 @@ use GuzzleHttp\Client;
  * extends oeOAuth
  *
  * @package OpenEMR\Common\Http
+ *
+ * Static methods forwarded via __callStatic to oeHttpRequest:
+ * @method static oeHttpRequest usingHeaders(array $headers)
+ * @method static oeHttpRequest setOptions(array $options)
+ * @method static oeHttpRequest setDebug(string $port = '')
+ * @method static oeHttpRequest asJson()
+ * @method static oeHttpRequest asFormParams()
+ * @method static oeHttpRequest contentType(string $contentType)
+ * @method static oeHttpRequest accept(string $header)
+ * @method static oeHttpRequest setParams(array $params)
+ * @method static oeHttpRequest usingBaseUri(string $baseUri)
+ * @method static oeHttpResponse get(string $url, array $queryParams = [])
+ * @method static oeHttpResponse getCurlOptions(string $url, array $queryParams = [], array $curlOptions = [])
+ * @method static oeHttpResponse post(string $url, array $params = [])
+ * @method static oeHttpResponse patch(string $url, array $params = [])
+ * @method static oeHttpResponse put(string $url, array $params = [])
+ * @method static oeHttpResponse delete(string $url, array $params = [])
  */
 class oeHttp extends oeOAuth
 {


### PR DESCRIPTION
## Summary
- Add `@method` annotations to `oeHttp` class for PHPStan to understand dynamic static method forwarding
- Add `require_once` statements to `codes.php` for ClinicalTypes dependencies
- Remove 5 `staticMethod.notFound` baseline entries

## Changes

### oeHttp class
The class uses `__callStatic` to forward static calls to `oeHttpRequest`. Added `@method` annotations:
```php
@method static oeHttpResponse get(string $url, array $queryParams = [])
@method static oeHttpResponse getCurlOptions(string $url, array $queryParams = [], array $curlOptions = [])
@method static oeHttpRequest usingHeaders(array $headers)
// ... etc
```

### codes.php
Added require_once for class dependencies:
```php
require_once __DIR__ . '/Allergy.php';
require_once __DIR__ . '/Procedure.php';
// ... etc
```

## Test plan
- [x] PHPStan analysis passes with no errors
- [x] 5 staticMethod.notFound baseline entries removed

Fixes #10058

🤖 Generated with [Claude Code](https://claude.com/claude-code)