### PR TITLE
fix(phpstan): resolve return.missing findings

### DIFF
--- a/.phpstan/phpstan-remaining-baseline.neon
+++ b/.phpstan/phpstan-remaining-baseline.neon
@@ -15780,14 +15780,6 @@ parameters:
       identifier: property.notFound
       count: 4
       path: ../portal/patient/fwk/libs/verysimple/Phreeze/CacheMemCache.php
-    - message: '#^Method CacheNoCache\:\:Set\(\) should return VARIANT but return statement is missing\.$#'
-      identifier: return.missing
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/CacheNoCache.php
-    - message: '#^Method CacheRam\:\:Set\(\) should return VARIANT but return statement is missing\.$#'
-      identifier: return.missing
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/CacheRam.php
     - message: '#^Access to an undefined property DataSet\:\:\$_total\.$#'
       identifier: property.notFound
       count: 1
@@ -15820,14 +15812,6 @@ parameters:
       identifier: property.notFound
       count: 2
       path: ../portal/patient/fwk/libs/verysimple/Phreeze/PHPRenderEngine.php
-    - message: '#^Method Phreezable\:\:__serialize\(\) should return array\<mixed, mixed\> but return statement is missing\.$#'
-      identifier: return.missing
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/Phreezable.php
-    - message: '#^Method Phreezer\:\:GetPrimaryKeyMap\(\) should return KeyMap but return statement is missing\.$#'
-      identifier: return.missing
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/Phreezer.php
     - message: '#^Class GenericRouter constructor invoked with 0 parameters, 3 required\.$#'
       identifier: arguments.count
       count: 1
@@ -15848,14 +15832,6 @@ parameters:
       identifier: requireOnce.fileNotFound
       count: 1
       path: ../portal/patient/fwk/libs/verysimple/Phreeze/PortalController.php
-    - message: '#^Method Reporter\:\:__serialize\(\) should return array\<mixed, mixed\> but return statement is missing\.$#'
-      identifier: return.missing
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/Phreeze/Reporter.php
-    - message: '#^Method VerySimpleStringUtil\:\:unicode_entity_replace\(\) should return string but return statement is missing\.$#'
-      identifier: return.missing
-      count: 1
-      path: ../portal/patient/fwk/libs/verysimple/String/VerySimpleStringUtil.php
     - message: '#^Variable \$errors on left side of \?\? always exists and is not nullable\.$#'
       identifier: nullCoalesce.variable
       count: 1
@@ -16188,10 +16164,6 @@ parameters:
       identifier: class.notFound
       count: 1
       path: ../src/Common/Auth/Exception/OneTimeAuthExpiredException.php
-    - message: '#^Method OpenEMR\\Common\\Auth\\MfaUtils\:\:checkU2F\(\) should return bool but return statement is missing\.$#'
-      identifier: return.missing
-      count: 1
-      path: ../src/Common/Auth/MfaUtils.php
     - message: '#^Variable \$response might not be defined\.$#'
       identifier: variable.undefined
       count: 1
@@ -16248,14 +16220,6 @@ parameters:
       identifier: variable.undefined
       count: 1
       path: ../src/Common/ORDataObject/ORDataObject.php
-    - message: '#^Method OpenEMR\\Core\\Header\:\:readConfigFile\(\) should return array but return statement is missing\.$#'
-      identifier: return.missing
-      count: 1
-      path: ../src/Core/Header.php
-    - message: '#^Method OpenEMR\\Core\\Header\:\:setupHeader\(\) should return string but return statement is missing\.$#'
-      identifier: return.missing
-      count: 1
-      path: ../src/Core/Header.php
     - message: '#^Class OpenEMR\\Cqm\\CqmClient constructor invoked with 0 parameters, 2\-4 required\.$#'
       identifier: arguments.count
       count: 1
@@ -16268,10 +16232,6 @@ parameters:
       identifier: variable.undefined
       count: 1
       path: ../src/Easipro/Easipro.php
-    - message: '#^Method OpenEMR\\Events\\Messaging\\SendNotificationEvent\:\:setSendNotificationMethod\(\) should return OpenEMR\\Events\\Messaging\\SendNotificationEvent but return statement is missing\.$#'
-      identifier: return.missing
-      count: 1
-      path: ../src/Events/Messaging/SendNotificationEvent.php
     - message: '#^Variable \$result on left side of \?\? always exists and is not nullable\.$#'
       identifier: nullCoalesce.variable
       count: 1
@@ -16332,18 +16292,6 @@ parameters:
       identifier: variable.undefined
       count: 5
       path: ../src/Menu/MainMenuRole.php
-    - message: '#^Method OpenEMR\\Menu\\MenuRole\:\:displayMenuRoleSelector\(\) should return string but return statement is missing\.$#'
-      identifier: return.missing
-      count: 1
-      path: ../src/Menu/MenuRole.php
-    - message: '#^Method OpenEMR\\Menu\\MenuRole\:\:getMenu\(\) should return array but return statement is missing\.$#'
-      identifier: return.missing
-      count: 1
-      path: ../src/Menu/MenuRole.php
-    - message: '#^Method OpenEMR\\Menu\\MenuRole\:\:getMenuRole\(\) should return string but return statement is missing\.$#'
-      identifier: return.missing
-      count: 1
-      path: ../src/Menu/MenuRole.php
     - message: '#^Variable \$action might not be defined\.$#'
       identifier: variable.undefined
       count: 1

--- a/portal/patient/fwk/libs/verysimple/Phreeze/CacheNoCache.php
+++ b/portal/patient/fwk/libs/verysimple/Phreeze/CacheNoCache.php
@@ -25,6 +25,7 @@ class CacheNoCache implements ICache
     }
     public function Set($key, $val, $flags = null, $timeout = 0)
     {
+        return $val;
     }
     public function Delete($key)
     {

--- a/portal/patient/fwk/libs/verysimple/Phreeze/CacheRam.php
+++ b/portal/patient/fwk/libs/verysimple/Phreeze/CacheRam.php
@@ -30,6 +30,7 @@ class CacheRam implements ICache
     public function Set($key, $val, $flags = null, $timeout = 0)
     {
         $this->ram [$key] = $val;
+        return $val;
     }
     public function Delete($key)
     {

--- a/portal/patient/fwk/libs/verysimple/Phreeze/ICache.php
+++ b/portal/patient/fwk/libs/verysimple/Phreeze/ICache.php
@@ -28,9 +28,9 @@ interface ICache
      * @param string $key
      * @param variant $val
      * @param int $flags
-     * @param int $timout
+     * @param int $timeout
      *          in seconds
-     * @return variant
+     * @return mixed
      */
     public function Set($key, $val, $flags = null, $timeout = 0);
 

--- a/portal/patient/fwk/libs/verysimple/Phreeze/Phreezable.php
+++ b/portal/patient/fwk/libs/verysimple/Phreeze/Phreezable.php
@@ -2,6 +2,8 @@
 
 /** @package    verysimple::Phreeze */
 
+require_once("SerializableTrait.php");
+
 /**
  * Phreezable Class
  *
@@ -13,8 +15,9 @@
  * @license http://www.gnu.org/licenses/lgpl.html LGPL
  * @version 1.3
  */
-abstract class Phreezable implements Serializable
+abstract class Phreezable
 {
+    use SerializableTrait;
     private $_cache =  [];
     protected $_phreezer;
     protected $_val_errors =  [];
@@ -136,31 +139,6 @@ abstract class Phreezable implements Serializable
     }
 
     /**
-     * When serializing, make sure that we ommit certain properties that
-     * should never be cached or serialized.
-     */
-    function serialize()
-    {
-        $propvals =  [];
-        $ro = new ReflectionObject($this);
-
-        foreach ($ro->getProperties() as $rp) {
-            $propname = $rp->getName();
-
-            if (! in_array($propname, self::$NoCacheProperties)) {
-                if (method_exists($rp, "setAccessible")) {
-                    $propvals [$propname] = $rp->getValue($this);
-                } elseif (! $rp->isPrivate()) {
-                    // if < php 5.3 we can't serialize private vars
-                    $propvals [$propname] = $rp->getValue($this);
-                }
-            }
-        }
-
-        return serialize($propvals);
-    }
-
-    /**
      *
      * @deprecated use ToObject
      */
@@ -206,30 +184,6 @@ abstract class Phreezable implements Serializable
         }
 
         return $obj;
-    }
-
-    /**
-     * Reload the object when it awakes from serialization
-     *
-     * @param
-     *          $data
-     */
-    function unserialize($data)
-    {
-        $propvals = unserialize($data);
-        $ro = new ReflectionObject($this);
-
-        foreach ($ro->getProperties() as $rp) {
-            $propname = $rp->name;
-            if (array_key_exists($propname, $propvals)) {
-                if (method_exists($rp, "setAccessible")) {
-                    $rp->setValue($this, $propvals [$propname]);
-                } elseif (! $rp->isPrivate()) {
-                    // if < php 5.3 we can't serialize private vars
-                    $rp->setValue($this, $propvals [$propname]);
-                }
-            }
-        }
     }
 
     /**
@@ -785,10 +739,4 @@ abstract class Phreezable implements Serializable
     {
         throw new Exception("Unknown property: $key");
     }
-
-    function __serialize()
-    {}
-
-    function __unserialize($data)
-    {}
 }

--- a/portal/patient/fwk/libs/verysimple/Phreeze/Phreezer.php
+++ b/portal/patient/fwk/libs/verysimple/Phreeze/Phreezer.php
@@ -285,7 +285,7 @@ class Phreezer extends Observable
 
     // if the object hasn't changed at level 1, then supress the cache update
         $obj = $this->_level1Cache->Get($objectclass . "_" . $id);
-        if ($obj && $obj->serialize() == $val->serialize()) {
+        if ($obj && serialize($obj) == serialize($val)) {
             $this->Observe("TYPE='$objectclass' ID='$id' level 1 cache has not changed.  SetCache was supressed", OBSERVE_DEBUG);
             return false;
         }
@@ -857,7 +857,7 @@ class Phreezer extends Observable
 * @access public
 * @param string $objectclass
 *          the type of object
-* @return KeyMap object
+* @return KeyMap|null
 */
     public function GetPrimaryKeyMap($objectclass)
     {
@@ -867,6 +867,7 @@ class Phreezer extends Observable
                 return $fm;
             }
         }
+        return null;
     }
 
 /**

--- a/portal/patient/fwk/libs/verysimple/Phreeze/Reporter.php
+++ b/portal/patient/fwk/libs/verysimple/Phreeze/Reporter.php
@@ -2,6 +2,8 @@
 
 /** @package    verysimple::Phreeze */
 
+require_once("SerializableTrait.php");
+
 /**
  * Reporter allows creating dynamic objects that do not necessarily reflect
  * the structure of the datastore table.
@@ -14,8 +16,9 @@
  * @license http://www.gnu.org/licenses/lgpl.html LGPL
  * @version 1.0
  */
-abstract class Reporter implements Serializable
+abstract class Reporter
 {
+    use SerializableTrait;
     private $_isLoaded;
     private $_isPartiallyLoaded;
     private $_cacheLevel = 0;
@@ -111,56 +114,6 @@ abstract class Reporter implements Serializable
     {
         if ($row) {
             $this->Load($row);
-        }
-    }
-
-    /**
-     * When serializing, make sure that we ommit certain properties that
-     * should never be cached or serialized.
-     */
-    function serialize()
-    {
-        $propvals =  [];
-        $ro = new ReflectionObject($this);
-
-        foreach ($ro->getProperties() as $rp) {
-            $propname = $rp->getName();
-
-            if (! in_array($propname, self::$NoCacheProperties)) {
-                if (method_exists($rp, "setAccessible")) {
-                    $propvals [$propname] = $rp->getValue($this);
-                } elseif (! $rp->isPrivate()) {
-                    // if < php 5.3 we can't serialize private vars
-                    $propvals [$propname] = $rp->getValue($this);
-                }
-            }
-        }
-
-        return serialize($propvals);
-    }
-
-    /**
-     * Reload the object when it awakes from serialization
-     *
-     * @param
-     *          $data
-     */
-    function unserialize($data)
-    {
-        $propvals = unserialize($data);
-
-        $ro = new ReflectionObject($this);
-
-        foreach ($ro->getProperties() as $rp) {
-            $propname = $rp->name;
-            if (array_key_exists($propname, $propvals)) {
-                if (method_exists($rp, "setAccessible")) {
-                    $rp->setValue($this, $propvals [$propname]);
-                } elseif (! $rp->isPrivate()) {
-                    // if < php 5.3 we can't serialize private vars
-                    $rp->setValue($this, $propvals [$propname]);
-                }
-            }
         }
     }
 
@@ -337,10 +290,4 @@ abstract class Reporter implements Serializable
     protected function OnLoad()
     {
     }
-
-    function __serialize()
-    {}
-
-    function __unserialize($data)
-    {}
 }

--- a/portal/patient/fwk/libs/verysimple/Phreeze/SerializableTrait.php
+++ b/portal/patient/fwk/libs/verysimple/Phreeze/SerializableTrait.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * SerializableTrait provides custom serialization that excludes internal
+ * framework properties from serialization.
+ *
+ * Classes using this trait must define a static $NoCacheProperties array
+ * listing property names to exclude from serialization.
+ *
+ * @package verysimple::Phreeze
+ * @link https://www.open-emr.org
+ * @link https://opencoreemr.com
+ * @author Michael A. Smith <michael@opencoreemr.com>
+ * @copyright 2026 OpenCoreEMR Inc
+ * @license http://www.gnu.org/licenses/lgpl.html LGPL
+ */
+trait SerializableTrait
+{
+    /**
+     * @return array
+     */
+    public function __serialize(): array
+    {
+        $propvals = [];
+        $ro = new ReflectionObject($this);
+
+        foreach ($ro->getProperties() as $rp) {
+            $propname = $rp->getName();
+            if (!in_array($propname, self::$NoCacheProperties)) {
+                $propvals[$propname] = $rp->getValue($this);
+            }
+        }
+
+        return $propvals;
+    }
+
+    /**
+     * @param array $data
+     */
+    public function __unserialize(array $data): void
+    {
+        $ro = new ReflectionObject($this);
+
+        foreach ($ro->getProperties() as $rp) {
+            $propname = $rp->name;
+            if (array_key_exists($propname, $data)) {
+                $rp->setValue($this, $data[$propname]);
+            }
+        }
+    }
+}

--- a/portal/patient/fwk/libs/verysimple/String/VerySimpleStringUtil.php
+++ b/portal/patient/fwk/libs/verysimple/String/VerySimpleStringUtil.php
@@ -456,6 +456,7 @@ class VerySimpleStringUtil
             $h = "&#" . $h . ";";
             return $h;
         }
+        return $c;
     }
 
     /**

--- a/src/Common/Auth/MfaUtils.php
+++ b/src/Common/Auth/MfaUtils.php
@@ -203,6 +203,7 @@ class MfaUtils
                 return true;
             } else {
                 error_log("Unexpected keyHandle returned from doAuthenticate(): '" . errorLogEscape($strhandle) . "'");
+                return false;
             }
         } catch (\u2flib_server\Error $e) {
             // Authentication failed so we will build the U2F form again.

--- a/src/Core/Header.php
+++ b/src/Core/Header.php
@@ -126,9 +126,8 @@ class Header
 
         if ($echoOutput) {
             echo $output;
-        } else {
-            return $output;
         }
+        return $output;
     }
 
     public static function getFavIcon()
@@ -421,6 +420,7 @@ class Header
         } catch (ParseException $e) {
             error_log(errorLogEscape($e->getMessage()));
             // @TODO need to handle this better. RD 2017-05-24
+            return [];
         }
     }
 

--- a/src/Events/Messaging/SendNotificationEvent.php
+++ b/src/Events/Messaging/SendNotificationEvent.php
@@ -53,9 +53,9 @@ class SendNotificationEvent extends Event
 
     /**
      * @param string $sendNotificationMethod
-     * @return SendNotificationEvent
+     * @return void
      */
-    public function setSendNotificationMethod(string $sendNotificationMethod)
+    public function setSendNotificationMethod(string $sendNotificationMethod): void
     {
         $this->sendNotificationMethod = $sendNotificationMethod;
     }

--- a/src/Menu/MenuRole.php
+++ b/src/Menu/MenuRole.php
@@ -21,7 +21,7 @@ require_once(__DIR__ . "/../../library/registry.inc.php");
 
 use OpenEMR\Common\Acl\AclMain;
 
-class MenuRole
+abstract class MenuRole implements MenuRoleInterface
 {
     /**
      * @var array
@@ -38,34 +38,6 @@ class MenuRole
         //   constructor. Adding to this array will link special menu items
         //   to functions in the class.
         $this->menu_update_map = [];
-    }
-
-    /**
-     * Collect the Menu for logged in user.
-     *
-     * @return array representation of the Menu
-     */
-    public function getMenu()
-    {
-    }
-
-    /**
-     * Build the html select element to list the MenuRole options.
-     *
-     * @var string $selected Current MenuRole for current users.
-     * @return string Html select element to list the MenuRole options.
-     */
-    public function displayMenuRoleSelector($selected = "")
-    {
-    }
-
-    /**
-     * Collect the MenuRole for logged in user.
-     *
-     * @return string Identifier for the MenuRole
-     */
-    private function getMenuRole()
-    {
     }
 
     protected function menuUpdateEntries(&$menu_list)

--- a/src/Menu/MenuRoleInterface.php
+++ b/src/Menu/MenuRoleInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * MenuRoleInterface defines the contract for menu role implementations.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @link      https://opencoreemr.com
+ * @author    Kevin Yeh <kevin.y@integralemr.com>
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Rod Roark <rod@sunsetsystems.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2016 Kevin Yeh <kevin.y@integralemr.com>
+ * @copyright Copyright (c) 2016-2018 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2017 Rod Roark <rod@sunsetsystems.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Menu;
+
+interface MenuRoleInterface
+{
+    /**
+     * Collect the Menu for logged in user.
+     *
+     * @return array representation of the Menu
+     */
+    public function getMenu();
+
+    /**
+     * Build the html select element to list the MenuRole options.
+     *
+     * @param string $selected Current MenuRole for current users.
+     * @return string Html select element to list the MenuRole options.
+     */
+    public function displayMenuRoleSelector($selected = "");
+}


### PR DESCRIPTION
Fixes #10067

## Summary

Resolves PHPStan `return.missing` findings by addressing root causes rather than blindly adding return statements:

- **Remove dead code**: Delete unused `SimpleRouter.php` (zero instantiations in codebase)
- **Abstract base class**: Make `MenuRole` abstract with new `MenuRoleInterface` instead of adding stub returns
- **Fix docblocks**: Correct `ICache::Set()` and `Phreezer::GetPrimaryKeyMap()` return type annotations
- **Modernize serialization**: Replace deprecated `Serializable` interface with `__serialize()`/`__unserialize()` magic methods via new `SerializableTrait`
  - The `Serializable` interface is deprecated in PHP 8.1 due to reference handling and nesting issues
  - Magic methods integrate properly with PHP's internal serialization engine
- **Fix method call**: Update `Phreezer::SetCache()` to use `serialize()` function instead of removed method

## Test plan

- [x] PHPStan analysis passes with no errors
- [x] Patient portal functionality works correctly
- [x] Menu system functions as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)