### PR TITLE
refactor(eye-mag): replace per-zone and per-panel if/else chains with enums

### DIFF
--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -3967,11 +3967,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/eye_mag/a_issue.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$r of function sqlFetchArray expects ADORecordSet\\|false, mixed given\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/a_issue.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$string of function htmlspecialchars expects string, mixed given\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/a_issue.php',
@@ -3993,7 +3988,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$text of function attr expects string, mixed given\\.$#',
-    'count' => 52,
+    'count' => 48,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/a_issue.php',
 ];
 $ignoreErrors[] = [
@@ -4094,6 +4089,11 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$r of function sqlFetchArray expects ADORecordSet\\|false, mixed given\\.$#',
     'count' => 1,
+    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Parameter \\#1 \\$record of static method OpenEMR\\\\Forms\\\\EyeMag\\\\CopyForward\\:\\:pick\\(\\) expects array\\<string, mixed\\>, array given\\.$#',
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
@@ -4203,7 +4203,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#2 \\$form_id of function build_IMPPLAN_items expects string, mixed given\\.$#',
-    'count' => 4,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
@@ -4442,11 +4442,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/eye_mag/save.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$zone of function copy_forward expects string, mixed given\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/save.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$zone of function display_PRIOR_section expects string, mixed given\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/save.php',
@@ -4489,11 +4484,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#4 \\$error of function addNewDocument expects string, int given\\.$#',
     'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/save.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#4 \\$pid of function copy_forward expects string, mixed given\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/save.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -3938,7 +3938,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$text of function attr expects string, mixed given\\.$#',
-    'count' => 50,
+    'count' => 49,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/SpectacleRx.php',
 ];
 $ignoreErrors[] = [
@@ -4089,11 +4089,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$r of function sqlFetchArray expects ADORecordSet\\|false, mixed given\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$record of static method OpenEMR\\\\Forms\\\\EyeMag\\\\CopyForward\\:\\:pick\\(\\) expects array\\<string, mixed\\>, array given\\.$#',
-    'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -333,7 +333,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 7,
+    'count' => 6,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/SpectacleRx.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -2597,16 +2597,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Function copy_forward\\(\\) has parameter \\$copy_from with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Function copy_forward\\(\\) has parameter \\$copy_to with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Function display_PRIOR_section\\(\\) has parameter \\$id_to_show with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',

--- a/.phpstan/baseline/offsetAccess.invalidOffset.php
+++ b/.phpstan/baseline/offsetAccess.invalidOffset.php
@@ -83,7 +83,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Possibly invalid array key type mixed\\.$#',
-    'count' => 4,
+    'count' => 3,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/SpectacleRx.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -5137,236 +5137,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT10CCDIST\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT10CCNEAR\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT10SCDIST\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT10SCNEAR\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT11CCDIST\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT11CCNEAR\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT11SCDIST\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT11SCNEAR\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT1CCDIST\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT1CCNEAR\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT1SCDIST\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT1SCNEAR\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT2CCDIST\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT2CCNEAR\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT2SCDIST\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT2SCNEAR\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT3CCDIST\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT3CCNEAR\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT3SCDIST\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT3SCNEAR\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT4CCDIST\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT4CCNEAR\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT4SCDIST\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT4SCNEAR\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT5CCDIST\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT5CCNEAR\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT5SCDIST\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT5SCNEAR\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT6CCDIST\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT6CCNEAR\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT6SCDIST\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT6SCNEAR\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT7CCDIST\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT7CCNEAR\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT7SCDIST\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT7SCNEAR\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT8CCDIST\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT8CCNEAR\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT8SCDIST\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT8SCNEAR\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT9CCDIST\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT9CCNEAR\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT9SCDIST\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ACT9SCNEAR\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ANTSEG_COMMENTS\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'ARODVA\' on mixed\\.$#',
     'count' => 4,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
@@ -5378,16 +5148,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'Allergy\' on mixed\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'CACCDIST\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'CACCNEAR\' on array\\|false\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
@@ -5422,51 +5182,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'DACCDIST\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'DACCNEAR\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'DIMODPUPILREACTIVITY\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'DIMODPUPILSIZE1\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'DIMODPUPILSIZE2\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'DIMOSPUPILREACTIVITY\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'DIMOSPUPILSIZE1\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'DIMOSPUPILSIZE2\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'DIVERGENCEAMPS\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'DOB\' on mixed\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
@@ -5474,11 +5189,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'Drawings\' on mixed\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'EXT_COMMENTS\' on array\\|false\\.$#',
-    'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
@@ -5492,122 +5202,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'HERTELBASE\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'IMP\' on array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'IMPPLAN\' on array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'IOPTIME\' on mixed\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'LADNEXA\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'LBROW\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'LCAROTID\' on array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'LCNV\' on array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'LCNVII\' on array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'LLF\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'LLL\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'LMCT\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'LMRD\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'LTEMPART\' on array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'LUL\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'LVFISSURE\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'MOTILITY_LI\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'MOTILITY_LL\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'MOTILITY_LR\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'MOTILITY_LS\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'MOTILITY_RI\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'MOTILITY_RL\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'MOTILITY_RR\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'MOTILITY_RS\' on array\\|false\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
@@ -5627,58 +5222,8 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'NEURO_COMMENTS\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'NPC\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'OCT\' on mixed\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODAC\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODAPD\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODCMT\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODCOINS\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODCOLOR\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODCONJ\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODCORNEA\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODCUP\' on array\\|false\\.$#',
-    'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
@@ -5687,28 +5232,8 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODDISC\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODDRAWING\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODGONIO\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'ODGONIO\' on mixed\\.$#',
     'count' => 4,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODHERTEL\' on array\\|false\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
@@ -5727,108 +5252,8 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODIRIS\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODKTHICKNESS\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODLENS\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODMACULA\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODNPA\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODPERIPH\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODPIC\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODPUPILREACTIVITY\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODPUPILSIZE1\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODPUPILSIZE2\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODREDDESAT\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODSCHIRMER1\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODSCHIRMER2\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODTBUT\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'ODVA\' on array\\|false\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODVESSELS\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODVF1\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODVF2\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODVF3\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODVF4\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODVITREOUS\' on array\\|false\\.$#',
-    'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
@@ -5837,73 +5262,13 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSAC\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSAPD\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSCMT\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSCOINS\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSCOLOR\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSCONJ\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSCORNEA\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSCUP\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'OSCUP\' on mixed\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSDISC\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSDRAWING\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSGONIO\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'OSGONIO\' on mixed\\.$#',
     'count' => 4,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSHERTEL\' on array\\|false\\.$#',
-    'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
@@ -5922,108 +5287,8 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSIRIS\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSKTHICKNESS\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSLENS\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSMACULA\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSNPA\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSPERIPH\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSPIC\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSPUPILREACTIVITY\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSPUPILSIZE1\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSPUPILSIZE2\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSREDDESAT\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSSCHIRMER1\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSSCHIRMER2\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSTBUT\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'OSVA\' on array\\|false\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSVESSELS\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSVF1\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSVF2\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSVF3\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSVF4\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSVITREOUS\' on array\\|false\\.$#',
-    'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
@@ -6057,68 +5322,13 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'PUPIL_COMMENTS\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'Patient Photograph\' on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'RADNEXA\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'RBROW\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'RCAROTID\' on array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'RCNV\' on array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'RCNVII\' on array\\|false\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'RD\' on mixed\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'RETINA_COMMENTS\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'RLF\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'RLL\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'RMCT\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'RMRD\' on array\\|false\\.$#',
-    'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
@@ -6192,21 +5402,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'RTEMPART\' on array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'RUL\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'RVFISSURE\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'SCODVA\' on mixed\\.$#',
     'count' => 4,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
@@ -6222,22 +5417,12 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'STEREOPSIS\' on array\\|false\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'Surgery\' on mixed\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'TODO\' on mixed\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'VERTFUSAMPS\' on array\\|false\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -4962,67 +4962,12 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/forms/dictation/view.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'COMMENTS\' on array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/SpectacleRx.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODADD\' on array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/SpectacleRx.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODAXIS\' on array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/SpectacleRx.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODCYL\' on array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/SpectacleRx.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODMIDADD\' on array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/SpectacleRx.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot access offset \'ODMPDD\' on array\\|false\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/SpectacleRx.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'ODPDMeasured\' on array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/SpectacleRx.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'ODSPH\' on array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/SpectacleRx.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSADD\' on array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/SpectacleRx.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSAXIS\' on array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/SpectacleRx.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSCYL\' on array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/SpectacleRx.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSMIDADD\' on array\\|false\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/SpectacleRx.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot access offset \'OSSPH\' on array\\|false\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/SpectacleRx.php',
 ];

--- a/.phpstan/baseline/openemr.deprecatedSqlFunction.php
+++ b/.phpstan/baseline/openemr.deprecatedSqlFunction.php
@@ -763,7 +763,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:fetchRecords\\(\\) or QueryUtils\\:\\:fetchArrayFromResultSet\\(\\) instead of sqlFetchArray\\(\\)\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/a_issue.php',
 ];
 $ignoreErrors[] = [
@@ -773,7 +773,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:sqlStatementThrowException\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlStatement\\(\\)\\.$#',
-    'count' => 3,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/a_issue.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.deprecatedSqlFunction.php
+++ b/.phpstan/baseline/openemr.deprecatedSqlFunction.php
@@ -773,7 +773,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:sqlStatementThrowException\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlStatement\\(\\)\\.$#',
-    'count' => 15,
+    'count' => 3,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/a_issue.php',
 ];
 $ignoreErrors[] = [
@@ -803,7 +803,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:fetchRecords\\(\\) or QueryUtils\\:\\:fetchArrayFromResultSet\\(\\) instead of sqlFetchArray\\(\\)\\.$#',
-    'count' => 22,
+    'count' => 21,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
@@ -813,7 +813,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:sqlStatementThrowException\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlStatement\\(\\)\\.$#',
-    'count' => 25,
+    'count' => 24,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.deprecatedSqlFunction.php
+++ b/.phpstan/baseline/openemr.deprecatedSqlFunction.php
@@ -748,7 +748,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:fetchRecords\\(\\) or QueryUtils\\:\\:fetchArrayFromResultSet\\(\\) instead of sqlFetchArray\\(\\)\\.$#',
-    'count' => 4,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/SpectacleRx.php',
 ];
 $ignoreErrors[] = [
@@ -758,7 +758,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:sqlStatementThrowException\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlStatement\\(\\)\\.$#',
-    'count' => 6,
+    'count' => 3,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/SpectacleRx.php',
 ];
 $ignoreErrors[] = [
@@ -803,17 +803,17 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:fetchRecords\\(\\) or QueryUtils\\:\\:fetchArrayFromResultSet\\(\\) instead of sqlFetchArray\\(\\)\\.$#',
-    'count' => 21,
+    'count' => 20,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:querySingleRow\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlQuery\\(\\)\\.$#',
-    'count' => 11,
+    'count' => 10,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Use QueryUtils\\:\\:sqlStatementThrowException\\(\\) or QueryUtils\\:\\:fetchRecords\\(\\) instead of sqlStatement\\(\\)\\.$#',
-    'count' => 24,
+    'count' => 23,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.forbiddenGlobalKeyword.php
+++ b/.phpstan/baseline/openemr.forbiddenGlobalKeyword.php
@@ -318,7 +318,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use of the "global" keyword is forbidden \\(\\$form_id\\)\\. Use dependency injection instead\\.$#',
-    'count' => 5,
+    'count' => 4,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -808,7 +808,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_REQUEST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 27,
+    'count' => 26,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/SpectacleRx.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -858,7 +858,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_REQUEST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 165,
+    'count' => 163,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/save.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -858,7 +858,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_REQUEST is forbidden\\. Use Symfony\'s Request object or filter_input\\(\\) instead\\.$#',
-    'count' => 163,
+    'count' => 162,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/save.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/parameter.notFound.php
+++ b/.phpstan/baseline/parameter.notFound.php
@@ -12,11 +12,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../custom/code_types.inc.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^PHPDoc tag @param references unknown parameter\\: \\$form_id$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',
-];
-$ignoreErrors[] = [
     'message' => '#^PHPDoc tag @param references unknown parameter\\: \\$visit_date$#',
     'count' => 3,
     'path' => __DIR__ . '/../../interface/forms/eye_mag/php/eye_mag_functions.php',

--- a/interface/forms/eye_mag/SpectacleRx.php
+++ b/interface/forms/eye_mag/SpectacleRx.php
@@ -238,7 +238,7 @@ if ($refType !== null) {
         // A wearing prescription re-prescribes the patient's current glasses, so
         // it is read back out of form_eye_mag_wearing rather than the refraction.
         // We have rx_number 1-5 to process...
-        $wearing = QueryUtils::querySingleRow(
+        $wearingRow = QueryUtils::querySingleRow(
             <<<'SQL'
             SELECT *
               FROM form_eye_mag_wearing
@@ -250,20 +250,20 @@ if ($refType !== null) {
             [$encounter, $_REQUEST['form_id'], $_REQUEST['pid'], $_REQUEST['rx_number']],
         );
 
-        // No such wearing prescription: every field stays at its blank default.
-        if (is_array($wearing)) {
-            $ODSPH = $wearing['ODSPH'];
-            $ODAXIS = $wearing['ODAXIS'];
-            $ODCYL = $wearing['ODCYL'];
-            $OSSPH = $wearing['OSSPH'];
-            $OSCYL = $wearing['OSCYL'];
-            $OSAXIS = $wearing['OSAXIS'];
-            $COMMENTS = $wearing[$refType->commentsColumn()];
-            $ODMIDADD = $wearing['ODMIDADD'];
-            $ODADD2 = $wearing['ODADD'];
-            $OSMIDADD = $wearing['OSMIDADD'];
-            $OSADD2 = $wearing['OSADD'];
-        }
+        // A field the wearing prescription does not carry reads null, so the
+        // dispense insert below leaves it out rather than recording it blank.
+        $wearing = is_array($wearingRow) ? $wearingRow : [];
+        $ODSPH = $wearing['ODSPH'] ?? null;
+        $ODAXIS = $wearing['ODAXIS'] ?? null;
+        $ODCYL = $wearing['ODCYL'] ?? null;
+        $OSSPH = $wearing['OSSPH'] ?? null;
+        $OSCYL = $wearing['OSCYL'] ?? null;
+        $OSAXIS = $wearing['OSAXIS'] ?? null;
+        $COMMENTS = $wearing[$refType->commentsColumn()] ?? null;
+        $ODMIDADD = $wearing['ODMIDADD'] ?? null;
+        $ODADD2 = $wearing['ODADD'] ?? null;
+        $OSMIDADD = $wearing['OSMIDADD'] ?? null;
+        $OSADD2 = $wearing['OSADD'] ?? null;
 
         //do LT and Lens materials
     } else {

--- a/interface/forms/eye_mag/SpectacleRx.php
+++ b/interface/forms/eye_mag/SpectacleRx.php
@@ -16,6 +16,7 @@
 
 require_once(__DIR__ . "/../../globals.php");
 
+use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
@@ -221,10 +222,10 @@ if ($refType !== null) {
     $rxType = is_string($requestedRxType) ? RxType::tryFrom($requestedRxType) ?? RxType::DEFAULT : RxType::DEFAULT;
     $RXTYPE = $rxType->name;
 
-    $Single = ($rxType === RxType::Single) ? "checked='checked'" : '';
-    $Bifocal = ($rxType === RxType::Bifocal) ? "checked='checked'" : '';
-    $Trifocal = ($rxType === RxType::Trifocal) ? "checked='checked'" : '';
-    $Progressive = ($rxType === RxType::Progressive) ? "checked='checked'" : '';
+    $Single = RxType::Single->checkedAttribute($rxType);
+    $Bifocal = RxType::Bifocal->checkedAttribute($rxType);
+    $Trifocal = RxType::Trifocal->checkedAttribute($rxType);
+    $Progressive = RxType::Progressive->checkedAttribute($rxType);
 
     $id = $_REQUEST['id'] ?? null;
     $table_name = "form_eye_mag";
@@ -232,105 +233,94 @@ if ($refType !== null) {
 
 
 
-    if ($refType === RefType::W) {
-        //we have rx_number 1-5 to process...
-        $query = "select * from form_eye_mag_wearing where ENCOUNTER=? and FORM_ID=? and PID=? and RX_NUMBER=?";
-        $wear = sqlStatement($query, [$encounter, $_REQUEST['form_id'], $_REQUEST['pid'], $_REQUEST['rx_number']]);
-        $wearing = sqlFetchArray($wear);
-        $ODSPH = $wearing['ODSPH'];
-        $ODAXIS = $wearing['ODAXIS'];
-        $ODCYL = $wearing['ODCYL'];
-        $OSSPH = $wearing['OSSPH'];
-        $OSCYL = $wearing['OSCYL'];
-        $OSAXIS = $wearing['OSAXIS'];
-        $COMMENTS = $wearing['COMMENTS'];
-        $ODMIDADD = $wearing['ODMIDADD'];
-        $ODADD2 = $wearing['ODADD'];
-        $OSMIDADD = $wearing['OSMIDADD'];
-        $OSADD2 = $wearing['OSADD'];
+    $prefix = $refType->columnPrefix();
+    if ($prefix === null) {
+        // A wearing prescription re-prescribes the patient's current glasses, so
+        // it is read back out of form_eye_mag_wearing rather than the refraction.
+        // We have rx_number 1-5 to process...
+        $wearing = QueryUtils::querySingleRow(
+            <<<'SQL'
+            SELECT *
+              FROM form_eye_mag_wearing
+             WHERE ENCOUNTER = ?
+               AND FORM_ID = ?
+               AND PID = ?
+               AND RX_NUMBER = ?
+            SQL,
+            [$encounter, $_REQUEST['form_id'], $_REQUEST['pid'], $_REQUEST['rx_number']],
+        );
+
+        // No such wearing prescription: every field stays at its blank default.
+        if (is_array($wearing)) {
+            $ODSPH = $wearing['ODSPH'];
+            $ODAXIS = $wearing['ODAXIS'];
+            $ODCYL = $wearing['ODCYL'];
+            $OSSPH = $wearing['OSSPH'];
+            $OSCYL = $wearing['OSCYL'];
+            $OSAXIS = $wearing['OSAXIS'];
+            $COMMENTS = $wearing[$refType->commentsColumn()];
+            $ODMIDADD = $wearing['ODMIDADD'];
+            $ODADD2 = $wearing['ODADD'];
+            $OSMIDADD = $wearing['OSMIDADD'];
+            $OSADD2 = $wearing['OSADD'];
+        }
 
         //do LT and Lens materials
-    } elseif ($refType === RefType::AR) {
-        $ODSPH      = $data['ARODSPH'];
-        $ODAXIS     = $data['ARODAXIS'];
-        $ODCYL      = $data['ARODCYL'];
-        $ODPRISM    = $data['ARODPRISM'];
-        $OSSPH      = $data['AROSSPH'];
-        $OSCYL      = $data['AROSCYL'];
-        $OSAXIS     = $data['AROSAXIS'];
-        $OSPRISM    = $data['AROSPRISM'];
-        $COMMENTS   = $data['CRCOMMENTS'];
-        $ODADD2     = $data['ARODADD'];
-        $OSADD2     = $data['AROSADD'];
-    } elseif ($refType === RefType::MR) {
-        $ODSPH      = $data['MRODSPH'];
-        $ODAXIS     = $data['MRODAXIS'];
-        $ODCYL      = $data['MRODCYL'];
-        $ODPRISM    = $data['MRODPRISM'];
-        $OSSPH      = $data['MROSSPH'];
-        $OSCYL      = $data['MROSCYL'];
-        $OSAXIS     = $data['MROSAXIS'];
-        $OSPRISM    = $data['MROSPRISM'];
-        $COMMENTS   = $data['CRCOMMENTS'];
-        $ODADD2     = $data['MRODADD'];
-        $OSADD2     = $data['MROSADD'];
-    } elseif ($refType === RefType::CR) {
-        $ODSPH      = $data['CRODSPH'];
-        $ODAXIS     = $data['CRODAXIS'];
-        $ODCYL      = $data['CRODCYL'];
-        $ODPRISM    = $data['CRODPRISM'];
-        $OSSPH      = $data['CROSSPH'];
-        $OSCYL      = $data['CROSCYL'];
-        $OSAXIS     = $data['CROSAXIS'];
-        $OSPRISM    = $data['CROSPRISM'];
-        $COMMENTS   = $data['CRCOMMENTS'];
-    } elseif ($refType === RefType::CTL) {
-        $ODSPH      = $data['CTLODSPH'];
-        $ODAXIS     = $data['CTLODAXIS'];
-        $ODCYL      = $data['CTLODCYL'];
-        $ODPRISM    = $data['CTLODPRISM'];
+    } else {
+        // Every refraction stores the same eight measurements on the joined
+        // record under its own column prefix, so the method picks the columns
+        // instead of a branch per method.
+        $ODSPH      = $data[$prefix . 'ODSPH'];
+        $ODAXIS     = $data[$prefix . 'ODAXIS'];
+        $ODCYL      = $data[$prefix . 'ODCYL'];
+        $ODPRISM    = $data[$prefix . 'ODPRISM'];
+        $OSSPH      = $data[$prefix . 'OSSPH'];
+        $OSCYL      = $data[$prefix . 'OSCYL'];
+        $OSAXIS     = $data[$prefix . 'OSAXIS'];
+        $OSPRISM    = $data[$prefix . 'OSPRISM'];
+        $COMMENTS   = $data[$refType->commentsColumn()];
 
-        $OSSPH      = $data['CTLOSSPH'];
-        $OSCYL      = $data['CTLOSCYL'];
-        $OSAXIS     = $data['CTLOSAXIS'];
-        $OSPRISM    = $data['CTLOSPRISM'];
+        if ($refType->hasAddPower()) {
+            $ODADD2 = $data[$prefix . 'ODADD'];
+            $OSADD2 = $data[$prefix . 'OSADD'];
+        }
 
-        $ODBC       = $data['CTLODBC'];
-        $ODDIAM     = $data['CTLODDIAM'];
-        $ODADD      = $data['CTLODADD'];
-        $ODVA       = $data['CTLODVA'];
+        // A contact lens is fitted, not just refracted, so it carries the lens
+        // geometry and the brand/supplier list selections as well.
+        if ($refType->isContactLens()) {
+            $ODBC       = $data[$prefix . 'ODBC'];
+            $ODDIAM     = $data[$prefix . 'ODDIAM'];
+            $ODADD      = $data[$prefix . 'ODADD'];
+            $ODVA       = $data[$prefix . 'ODVA'];
 
-        $OSBC       = $data['CTLOSBC'];
-        $OSDIAM     = $data['CTLOSDIAM'];
-        $OSADD      = $data['CTLOSADD'];
-        $OSVA       = $data['CTLOSVA'];
+            $OSBC       = $data[$prefix . 'OSBC'];
+            $OSDIAM     = $data[$prefix . 'OSDIAM'];
+            $OSADD      = $data[$prefix . 'OSADD'];
+            $OSVA       = $data[$prefix . 'OSVA'];
 
-        $COMMENTS   = $data['COMMENTS'];//in form_eye_mag_dispense there is no leading 'CTL_'
-
-        $CTLMANUFACTUREROD  = getListItemTitle('CTLManufacturer', $data['CTLMANUFACTUREROD']);
-        $CTLMANUFACTUREROS  = getListItemTitle('CTLManufacturer', $data['CTLMANUFACTUREROS']);
-        $CTLSUPPLIEROD      = getListItemTitle('CTLManufacturer', $data['CTLSUPPLIEROD']);
-        $CTLSUPPLIEROS      = getListItemTitle('CTLManufacturer', $data['CTLSUPPLIEROS']);
-        $CTLBRANDOD         = getListItemTitle('CTLManufacturer', $data['CTLBRANDOD']);
-        $CTLBRANDOS         = getListItemTitle('CTLManufacturer', $data['CTLBRANDOS']);
+            $CTLMANUFACTUREROD  = getListItemTitle('CTLManufacturer', $data[$prefix . 'MANUFACTUREROD']);
+            $CTLMANUFACTUREROS  = getListItemTitle('CTLManufacturer', $data[$prefix . 'MANUFACTUREROS']);
+            $CTLSUPPLIEROD      = getListItemTitle('CTLManufacturer', $data[$prefix . 'SUPPLIEROD']);
+            $CTLSUPPLIEROS      = getListItemTitle('CTLManufacturer', $data[$prefix . 'SUPPLIEROS']);
+            $CTLBRANDOD         = getListItemTitle('CTLManufacturer', $data[$prefix . 'BRANDOD']);
+            $CTLBRANDOS         = getListItemTitle('CTLManufacturer', $data[$prefix . 'BRANDOS']);
+        }
     }
 
     //Since we selected the Print Icon, we must be dispensing this - add to dispensed table now
     $table_name      = "form_eye_mag_dispense";
-    $query           = "show columns from " . $table_name;
-    $dispense_fields = sqlStatement($query);
+    $dispense_fields = QueryUtils::listTableFields($table_name);
     $fields          = [];
 
-    if (sqlNumRows($dispense_fields) > 0) {
-        while ($row = sqlFetchArray($dispense_fields)) {
-            //exclude critical columns/fields, define below as needed
-            if (
-                in_array($row['Field'], ['id', 'pid', 'user', 'groupname', 'authorized', 'activity', 'RXTYPE', 'REFDATE', 'date'])
-            ) {
+    if (count($dispense_fields) > 0) {
+        //exclude critical columns/fields, define below as needed
+        $reserved = ['id', 'pid', 'user', 'groupname', 'authorized', 'activity', 'RXTYPE', 'REFDATE', 'date'];
+        foreach ($dispense_fields as $dispense_field) {
+            if (in_array($dispense_field, $reserved, true)) {
                 continue;
             }
-            if (isset(${$row['Field']})) {
-                $fields[$row['Field']] = ${$row['Field']};
+            if (isset(${$dispense_field})) {
+                $fields[$dispense_field] = ${$dispense_field};
             }
         }
 
@@ -341,8 +331,10 @@ if ($refType !== null) {
 }
 
 if ($_REQUEST['dispensed'] ?? '') {
-    $query = "SELECT * from form_eye_mag_dispense where pid =? ORDER BY date DESC";
-    $dispensed = sqlStatement($query, [$_REQUEST['pid']]);
+    $dispensed = QueryUtils::fetchRecords(
+        'SELECT * FROM form_eye_mag_dispense WHERE pid = ? ORDER BY date DESC',
+        [$_REQUEST['pid']],
+    );
     ?><html>
     <title><?php echo xlt('Rx Dispensed History'); ?></title>
     <head>
@@ -464,34 +456,22 @@ if ($_REQUEST['dispensed'] ?? '') {
                     <td colspan="2"><h4 class="underline"><?php echo xlt('Rx History'); ?></h4></td>
                 </tr>
                 <?php
-                if (sqlNumRows($dispensed) == 0) {
+                if (count($dispensed) === 0) {
                     echo "<tr><td colspan='2' class='text-center p-3' style='font-size:1.2em;'>" . xlt('There are no Glasses or Contact Lens Presciptions on file for this patient') . "</td></tr>";
                 }
                 ?>
             </table>
             <?php
             $i = 0;
-            while ($row = sqlFetchArray($dispensed)) {
+            foreach ($dispensed as $row) {
                 $i++;
-                $Single = '';
-                $Bifocal = '';
-                $Trifocal = '';
-                $Progressive = '';
-                if ($row['RXTYPE'] == "Single") {
-                    $Single = "checked='checked'";
-                }
-
-                if ($row['RXTYPE'] == "Bifocal") {
-                    $Bifocal = "checked='checked'";
-                }
-
-                if ($row['RXTYPE'] == "Trifocal") {
-                    $Trifocal = "checked='checked'";
-                }
-
-                if ($row['RXTYPE'] == "Progressive") {
-                    $Progressive = "checked='checked'";
-                }
+                // The dispense table records the lens type by name, so it reads
+                // back through fromLabel() rather than the numeric-code tryFrom().
+                $rowRxType = is_string($row['RXTYPE']) ? RxType::fromLabel($row['RXTYPE']) : null;
+                $Single = RxType::Single->checkedAttribute($rowRxType);
+                $Bifocal = RxType::Bifocal->checkedAttribute($rowRxType);
+                $Trifocal = RxType::Trifocal->checkedAttribute($rowRxType);
+                $Progressive = RxType::Progressive->checkedAttribute($rowRxType);
 
                 $rowRefType = is_string($row['REFTYPE']) ? RefType::tryFrom($row['REFTYPE']) : null;
 

--- a/interface/forms/eye_mag/SpectacleRx.php
+++ b/interface/forms/eye_mag/SpectacleRx.php
@@ -208,8 +208,11 @@ if (!is_string($requestedRefType)) {
 }
 $refType = RefType::tryFrom($requestedRefType);
 
-if ($requestedRefType) {
-    $REFTYPE = $requestedRefType;
+// A REFTYPE the form doesn't recognize used to reach the dispense insert below
+// with every field still at its blank default, writing an empty prescription
+// record. Only a known refraction method gets that far.
+if ($refType !== null) {
+    $REFTYPE = $refType->value;
 
     // Map the rx_type numeric code passed from view.php to a display string and
     // set the corresponding checkbox state. Default to Single (0) if the value

--- a/interface/forms/eye_mag/SpectacleRx.php
+++ b/interface/forms/eye_mag/SpectacleRx.php
@@ -8,7 +8,9 @@
  * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @author    Ray Magauran <magauran@MedFetch.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2016 Raymond Magauran <magauran@MedFetch.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -17,6 +19,8 @@ require_once(__DIR__ . "/../../globals.php");
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\Forms\EyeMag\RefType;
+use OpenEMR\Forms\EyeMag\RxType;
 use OpenEMR\Services\FacilityService;
 
 $srcdir = OEGlobalsBag::getInstance()->getSrcDir();
@@ -195,20 +199,23 @@ $CTLSUPPLIEROD = '';
 $CTLSUPPLIEROS = '';
 $insert_this_id = null;
 
-if ($_REQUEST['REFTYPE'] ?? '') {
-    $REFTYPE = $_REQUEST['REFTYPE'];
+// Parsed once here; $REFTYPE stays a string because the form posts it back verbatim.
+$requestedRefType = $_REQUEST['REFTYPE'] ?? '';
+$refType = is_string($requestedRefType) ? RefType::tryFrom($requestedRefType) : null;
+
+if ($requestedRefType) {
+    $REFTYPE = $requestedRefType;
 
     // Map the rx_type numeric code passed from view.php to a display string and
     // set the corresponding checkbox state. Default to Single (0) if the value
     // is missing or not one of the four expected codes.
-    $valid_rx_types = ['0' => 'Single', '1' => 'Bifocal', '2' => 'Trifocal', '3' => 'Progressive'];
-    $rx_type_raw    = (string) ($_REQUEST['rx_type'] ?? '');
-    $RXTYPE         = $valid_rx_types[$rx_type_raw] ?? 'Single';
+    $rxType = RxType::tryFrom((string) ($_REQUEST['rx_type'] ?? '')) ?? RxType::DEFAULT;
+    $RXTYPE = $rxType->name;
 
-    $Single     = ($RXTYPE === 'Single')      ? "checked='checked'" : '';
-    $Bifocal    = ($RXTYPE === 'Bifocal')     ? "checked='checked'" : '';
-    $Trifocal   = ($RXTYPE === 'Trifocal')    ? "checked='checked'" : '';
-    $Progressive = ($RXTYPE === 'Progressive') ? "checked='checked'" : '';
+    $Single = ($rxType === RxType::Single) ? "checked='checked'" : '';
+    $Bifocal = ($rxType === RxType::Bifocal) ? "checked='checked'" : '';
+    $Trifocal = ($rxType === RxType::Trifocal) ? "checked='checked'" : '';
+    $Progressive = ($rxType === RxType::Progressive) ? "checked='checked'" : '';
 
     $id = $_REQUEST['id'] ?? null;
     $table_name = "form_eye_mag";
@@ -216,7 +223,7 @@ if ($_REQUEST['REFTYPE'] ?? '') {
 
 
 
-    if ($REFTYPE == "W") {
+    if ($refType === RefType::W) {
         //we have rx_number 1-5 to process...
         $query = "select * from form_eye_mag_wearing where ENCOUNTER=? and FORM_ID=? and PID=? and RX_NUMBER=?";
         $wear = sqlStatement($query, [$encounter, $_REQUEST['form_id'], $_REQUEST['pid'], $_REQUEST['rx_number']]);
@@ -234,7 +241,7 @@ if ($_REQUEST['REFTYPE'] ?? '') {
         $OSADD2 = $wearing['OSADD'];
 
         //do LT and Lens materials
-    } elseif ($REFTYPE == "AR") {
+    } elseif ($refType === RefType::AR) {
         $ODSPH      = $data['ARODSPH'];
         $ODAXIS     = $data['ARODAXIS'];
         $ODCYL      = $data['ARODCYL'];
@@ -246,7 +253,7 @@ if ($_REQUEST['REFTYPE'] ?? '') {
         $COMMENTS   = $data['CRCOMMENTS'];
         $ODADD2     = $data['ARODADD'];
         $OSADD2     = $data['AROSADD'];
-    } elseif ($REFTYPE == "MR") {
+    } elseif ($refType === RefType::MR) {
         $ODSPH      = $data['MRODSPH'];
         $ODAXIS     = $data['MRODAXIS'];
         $ODCYL      = $data['MRODCYL'];
@@ -258,7 +265,7 @@ if ($_REQUEST['REFTYPE'] ?? '') {
         $COMMENTS   = $data['CRCOMMENTS'];
         $ODADD2     = $data['MRODADD'];
         $OSADD2     = $data['MROSADD'];
-    } elseif ($REFTYPE == "CR") {
+    } elseif ($refType === RefType::CR) {
         $ODSPH      = $data['CRODSPH'];
         $ODAXIS     = $data['CRODAXIS'];
         $ODCYL      = $data['CRODCYL'];
@@ -268,7 +275,7 @@ if ($_REQUEST['REFTYPE'] ?? '') {
         $OSAXIS     = $data['CROSAXIS'];
         $OSPRISM    = $data['CROSPRISM'];
         $COMMENTS   = $data['CRCOMMENTS'];
-    } elseif ($REFTYPE == "CTL") {
+    } elseif ($refType === RefType::CTL) {
         $ODSPH      = $data['CTLODSPH'];
         $ODAXIS     = $data['CTLODAXIS'];
         $ODCYL      = $data['CTLODCYL'];
@@ -477,8 +484,10 @@ if ($_REQUEST['dispensed'] ?? '') {
                     $Progressive = "checked='checked'";
                 }
 
+                $rowRefType = is_string($row['REFTYPE']) ? RefType::tryFrom($row['REFTYPE']) : null;
+
                 $row['date'] = oeFormatShortDate(date('Y-m-d', strtotime((string) $row['date'])));
-                if ($row['REFTYPE'] == "CTL") {
+                if ($rowRefType?->isContactLens()) {
                     $expir = date("Y-m-d", strtotime($CTL_expir, strtotime((string) $row['REFDATE'])));
                 } else {
                     $expir = date("Y-m-d", strtotime($RX_expir, strtotime((string) $row['REFDATE'])));
@@ -515,25 +524,13 @@ if ($_REQUEST['dispensed'] ?? '') {
                                 <tr>
                                     <td class="text-right align-middle font-weight-bold"><?php echo xlt('Refraction Method'); ?>:</td>
                                     <td>&nbsp;&nbsp;<?php
-                                    if ($row['REFTYPE'] == "W") {
-                                        echo xlt('Duplicate Rx -- unchanged from current Rx{{The refraction did not change, New Rx=old Rx}}');
-                                    } elseif ($row['REFTYPE'] == "CR") {
-                                        echo xlt('Cycloplegic (Wet) Refraction');
-                                    } elseif ($row['REFTYPE'] == "MR") {
-                                        echo xlt('Manifest (Dry) Refraction');
-                                    } elseif ($row['REFTYPE'] == "AR") {
-                                        echo xlt('Auto-Refraction');
-                                    } elseif ($row['REFTYPE'] == "CTL") {
-                                        echo xlt('Contact Lens');
-                                    } else {
-                                        echo text($row['REFTYPE']);
-                                    } ?>
+                                    echo $rowRefType?->displayName() ?? text($row['REFTYPE']); ?>
                                         <input type="hidden" name="REFTYPE" value="<?php echo attr($row['REFTYPE']); ?>"/>
                                     </td>
                                 </tr>
                                 <tr>
                                     <td colspan="2" class="text-center"> <?php
-                                    if ($row['REFTYPE'] != "CTL") { ?>
+                                    if (!$rowRefType?->isContactLens()) { ?>
                                                 <table id="SpectacleRx" name="SpectacleRx" class="refraction" style="top:0px;">
                                                     <tr class="font-weight-bold">
                                                         <td></td>
@@ -951,7 +948,7 @@ if ($_REQUEST['dispensed'] ?? '') {
 <?php echo report_header($pid, "web");  ?>
 <br/><br/>
 <?php
-if ($REFTYPE == "CTL") {
+if ($refType?->isContactLens()) {
     $expir = date("Y-m-d", strtotime($CTL_expir, strtotime((string) $data['date'])));
 } else {
     $expir = date("Y-m-d", strtotime($RX_expir, strtotime((string) $data['date'])));
@@ -977,7 +974,7 @@ if ($REFTYPE == "CTL") {
             <tr>
                 <td>
                     <?php
-                    if ($REFTYPE != "CTL") { ?>
+                    if (!$refType?->isContactLens()) { ?>
                             <table id="SpectacleRx" name="SpectacleRx" class="refraction bordershadow"
                                    style="min-width:610px;top:0px;">
                                 <tr class="font-weight-bold text-center">

--- a/interface/forms/eye_mag/SpectacleRx.php
+++ b/interface/forms/eye_mag/SpectacleRx.php
@@ -200,8 +200,13 @@ $CTLSUPPLIEROS = '';
 $insert_this_id = null;
 
 // Parsed once here; $REFTYPE stays a string because the form posts it back verbatim.
+// Anything that is not a string (REFTYPE[]=W) is treated as absent rather than
+// flowing on to be echoed into the form markup.
 $requestedRefType = $_REQUEST['REFTYPE'] ?? '';
-$refType = is_string($requestedRefType) ? RefType::tryFrom($requestedRefType) : null;
+if (!is_string($requestedRefType)) {
+    $requestedRefType = '';
+}
+$refType = RefType::tryFrom($requestedRefType);
 
 if ($requestedRefType) {
     $REFTYPE = $requestedRefType;
@@ -209,7 +214,8 @@ if ($requestedRefType) {
     // Map the rx_type numeric code passed from view.php to a display string and
     // set the corresponding checkbox state. Default to Single (0) if the value
     // is missing or not one of the four expected codes.
-    $rxType = RxType::tryFrom((string) ($_REQUEST['rx_type'] ?? '')) ?? RxType::DEFAULT;
+    $requestedRxType = $_REQUEST['rx_type'] ?? '';
+    $rxType = is_string($requestedRxType) ? RxType::tryFrom($requestedRxType) ?? RxType::DEFAULT : RxType::DEFAULT;
     $RXTYPE = $rxType->name;
 
     $Single = ($rxType === RxType::Single) ? "checked='checked'" : '';

--- a/interface/forms/eye_mag/a_issue.php
+++ b/interface/forms/eye_mag/a_issue.php
@@ -24,6 +24,7 @@ TODO: Code cleanup */
 
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
+use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
@@ -148,14 +149,14 @@ $ROSCOMMENTS   = $rres['ROSCOMMENTS']   ?? '';
             }
 
             $recent = $panel->recentTitlesQuery($quickPickProviderId);
-            $qry = sqlStatement($recent->sql, $recent->params);
-            if (sqlNumRows($qry) < IssueQuickPick::MIN_RECENT_TITLES) {
+            $picks = QueryUtils::fetchRecords($recent->sql, $recent->params);
+            if (count($picks) < IssueQuickPick::MIN_RECENT_TITLES) {
                 // The provider is just starting out; offer the stock list instead.
                 $stock = $panel->stockTitlesQuery();
-                $qry = sqlStatement($stock->sql, $stock->params);
+                $picks = QueryUtils::fetchRecords($stock->sql, $stock->params);
             }
 
-            while ($res = sqlFetchArray($qry)) { //Should we take the top 10 and display alphabetically?
+            foreach ($picks as $res) { //Should we take the top 10 and display alphabetically?
                 echo " aopts['" . attr($key) . "'][aopts['" . attr($key) . "'].length] = new Option(" . js_escape(xl_list_label(trim((string) $res['title']))) . ", " . js_escape(trim((string) $res['option_id'])) . ", false, false);\n";
                 if ($res['codes']) {
                     echo " aopts['" . attr($key) . "'][aopts['" . attr($key) . "'].length-1].setAttribute('data-code','" . attr(trim((string) $res['codes'])) . "');\n";

--- a/interface/forms/eye_mag/a_issue.php
+++ b/interface/forms/eye_mag/a_issue.php
@@ -28,6 +28,7 @@ use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\Forms\EyeMag\IssueQuickPick;
 
 $form_folder = "eye_mag";
 require_once('../../globals.php');
@@ -134,101 +135,32 @@ $ROSCOMMENTS   = $rres['ROSCOMMENTS']   ?? '';
 // If the provider has more 2 items already defined in the last month, they are collated
 // and ranked by frequency, sort alphabetically and <=10 are listed.
 // If not, we use the defaults from list_options/
-        $i = '0';
         $providerID = $session->get('providerID');
+        $quickPickProviderId = is_numeric($providerID) ? (int) $providerID : 0;
         foreach ($PMSFH[0] as $key => $value) {
             echo " aopts['" . attr($key) . "'] = [];\n";
-            $local = '1';
             echo " aitypes['" . attr($key) . "'] = '0';\n";
-            if ($key == "PMH") { // "0" = medical_problem_issue_list leave out Dental "4"
-                $qry = sqlStatement("SELECT title, title as option_id, diagnosis as codes, count(title) AS freq  FROM `lists` WHERE `type` LIKE ? and subtype = '' and pid in (select pid from form_encounter where provider_id =? and date BETWEEN NOW() - INTERVAL 30 DAY AND NOW()) GROUP BY title order by freq desc limit 20", [
-                    "medical_problem",
-                    $providerID
-                ]);
 
-                if (sqlNumRows($qry) < '4') { //if they are just starting out, use the list_options for all
-                    $qry = sqlStatement("SELECT * FROM list_options WHERE list_id = ? and subtype not like 'eye'", [
-                        "medical_problem_issue_list"
-                    ]);
-                }
-            } elseif ($key == "Medication") {
-                $qry = sqlStatement("SELECT title, title as option_id, diagnosis as codes, count(title) AS freq  FROM `lists` WHERE `type` LIKE ? and subtype = '' and pid in (select pid from form_encounter where provider_id =? and date BETWEEN NOW() - INTERVAL 30 DAY AND NOW()) GROUP BY title order by freq desc limit 10", [
-                    "medication",
-                    $providerID
-                ]);
-                if (sqlNumRows($qry) < '4') { //if they are just starting out, use the list_options for all
-                    $qry = sqlStatement("SELECT * FROM list_options WHERE list_id = ? and subtype not like 'eye'", [
-                        "medication_issue_list"
-                    ]);
-                }
-            } elseif ($key == "Surgery") {
-                $qry = sqlStatement("SELECT title, title as option_id, diagnosis as codes, count(title) AS freq  FROM `lists` WHERE `type` LIKE ? and
-    subtype = '' and pid in (select pid from form_encounter where provider_id =?
-    and date BETWEEN NOW() - INTERVAL 30 DAY AND NOW()) GROUP BY title order by freq desc limit 10", [
-                    "surgery",
-                    $providerID
-                ]);
-
-                if (sqlNumRows($qry) < '4') { //if they are just starting out, use the list_options for all
-                    $qry = sqlStatement("SELECT * FROM list_options WHERE list_id = ? and subtype not like 'eye'", [
-                        "surgery_issue_list"
-                    ]);
-                }
-            } elseif ($key == "Allergy") {
-                $qry = sqlStatement("SELECT title, title as option_id, diagnosis as codes, count(title) AS freq  FROM `lists` WHERE `type` LIKE ? and subtype = '' and pid in (select pid from form_encounter where provider_id =? and date BETWEEN NOW() - INTERVAL 30 DAY AND NOW()) GROUP BY title order by freq desc limit 10", [
-                    "allergy",
-                    $providerID
-                ]);
-                if (sqlNumRows($qry) < '4') { //if they are just starting out, use the list_options for all
-                    $qry = sqlStatement("SELECT * FROM list_options WHERE list_id = ? and subtype not like 'eye'", [
-                        "allergy_issue_list"
-                    ]);
-                }
-            } elseif ($key == "POH") { // POH medical group
-                $query = "SELECT title, title as option_id, diagnosis as codes, count(title) AS freq  FROM `lists` WHERE `type` LIKE 'medical_problem' and subtype = 'eye' and pid in (select pid from form_encounter where provider_id =? and date BETWEEN NOW() - INTERVAL 30 DAY AND NOW()) GROUP BY title order by freq desc limit 10";
-                $qry = sqlStatement($query, [
-                    $providerID
-                ]);
-                if (sqlNumRows($qry) < '4') { //if they are just starting out, use the list_options for all
-                    $qry = sqlStatement("SELECT * FROM list_options WHERE list_id = 'medical_problem_issue_list' and subtype = 'eye'");
-                }
-            } elseif ($key == "POS") { // POS surgery group
-                $query = "SELECT title, title as option_id, diagnosis as codes, count(title) AS freq  FROM `lists` WHERE `type` LIKE 'surgery' and subtype = 'eye' and pid in (select pid from form_encounter where provider_id =? and date BETWEEN NOW() - INTERVAL 30 DAY AND NOW()) GROUP BY title order by freq desc limit 10";
-                $qry = sqlStatement($query, [
-                    $providerID
-                ]);
-
-                if (sqlNumRows($qry) < '4') { //if they are just starting out, use the list_options for all
-                    $qry = sqlStatement("SELECT * FROM list_options WHERE list_id = 'surgery_issue_list' and subtype = 'eye'");
-                }
-            } elseif ($key == "Eye Meds") { // POS surgery group
-                $query = "SELECT title, title as option_id, diagnosis as codes, count(title) AS freq FROM `lists` WHERE `type` LIKE 'medication' and subtype = 'eye' and pid in ( select pid from form_encounter where provider_id =? and date BETWEEN NOW() - INTERVAL 30 DAY AND NOW()) GROUP BY title order by freq desc limit 10";
-                $qry = sqlStatement($query, [
-                    $providerID
-                ]);
-                if (sqlNumRows($qry) < '4') { //if they are just starting out, use the list_options for all
-                    $qry = sqlStatement("SELECT * FROM list_options WHERE list_id = 'medication_issue_list' and subtype = 'eye'");
-                }
-            } elseif ($key == "FH") {
-                $local = "";
-                $qry = "";
-            } elseif ($key == "SOCH") {
-                $local = "";
-                $qry = "";
-            } elseif ($key == "ROS") {
-                $local = "";
-                $qry = "";
+            // FH, SocHx and ROS have no quick-pick list of their own; they are built below.
+            $panel = is_string($key) ? IssueQuickPick::tryFrom($key) : null;
+            if ($panel === null) {
+                continue;
             }
 
-            if ($local == "1") { // leave FH/SocHx/ROS for later - done below separately
-                while ($res = sqlFetchArray($qry ?? '')) { //Should we take the top 10 and display alphabetically?
-                    echo " aopts['" . attr($key) . "'][aopts['" . attr($key) . "'].length] = new Option(" . js_escape(xl_list_label(trim((string) $res['title']))) . ", " . js_escape(trim((string) $res['option_id'])) . ", false, false);\n";
-                    if ($res['codes']) {
-                        echo " aopts['" . attr($key) . "'][aopts['" . attr($key) . "'].length-1].setAttribute('data-code','" . attr(trim((string) $res['codes'])) . "');\n";
-                    }
+            $recent = $panel->recentTitlesQuery($quickPickProviderId);
+            $qry = sqlStatement($recent->sql, $recent->params);
+            if (sqlNumRows($qry) < IssueQuickPick::MIN_RECENT_TITLES) {
+                // The provider is just starting out; offer the stock list instead.
+                $stock = $panel->stockTitlesQuery();
+                $qry = sqlStatement($stock->sql, $stock->params);
+            }
+
+            while ($res = sqlFetchArray($qry)) { //Should we take the top 10 and display alphabetically?
+                echo " aopts['" . attr($key) . "'][aopts['" . attr($key) . "'].length] = new Option(" . js_escape(xl_list_label(trim((string) $res['title']))) . ", " . js_escape(trim((string) $res['option_id'])) . ", false, false);\n";
+                if ($res['codes']) {
+                    echo " aopts['" . attr($key) . "'][aopts['" . attr($key) . "'].length-1].setAttribute('data-code','" . attr(trim((string) $res['codes'])) . "');\n";
                 }
             }
-            ++$i;
         }
 
         ?>

--- a/interface/forms/eye_mag/php/EyeMagEnums.php
+++ b/interface/forms/eye_mag/php/EyeMagEnums.php
@@ -76,13 +76,7 @@ enum RefType: string
      */
     public function columnPrefix(): string
     {
-        return match ($this) {
-            self::W => '',
-            self::AR => 'AR',
-            self::MR => 'MR',
-            self::CR => 'CR',
-            self::CTL => 'CTL',
-        };
+        return $this === self::W ? '' : $this->name;
     }
 
     /**

--- a/interface/forms/eye_mag/php/EyeMagEnums.php
+++ b/interface/forms/eye_mag/php/EyeMagEnums.php
@@ -152,6 +152,28 @@ enum RefType: string
             default => [],
         };
     }
+
+    /**
+     * Get translated human-readable display name for this refraction type.
+     */
+    public function displayName(): string
+    {
+        return match ($this) {
+            self::W => xlt('Duplicate Rx -- unchanged from current Rx'),
+            self::AR => xlt('Auto-Refraction'),
+            self::MR => xlt('Manifest (Dry) Refraction'),
+            self::CR => xlt('Cycloplegic (Wet) Refraction'),
+            self::CTL => xlt('Contact Lens'),
+        };
+    }
+
+    /**
+     * Check if this is a contact lens prescription.
+     */
+    public function isContactLens(): bool
+    {
+        return $this === self::CTL;
+    }
 }
 
 /**

--- a/interface/forms/eye_mag/php/EyeMagEnums.php
+++ b/interface/forms/eye_mag/php/EyeMagEnums.php
@@ -1,0 +1,186 @@
+<?php
+
+/**
+ * Enums for the eye_mag form module.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Forms\EyeMag;
+
+/**
+ * Subtype filter options for PMSFH and issue queries.
+ */
+enum SubtypeFilter: string
+{
+    case Eye = 'eye';
+    case Empty = 'empty';
+    case None = 'none';
+
+    /**
+     * Get the SQL condition fragment and parameter for this filter.
+     *
+     * @return array{sql: string, params: array}
+     */
+    public function toSqlCondition(): array
+    {
+        return match ($this) {
+            self::Eye => ['sql' => 'AND subtype = ?', 'params' => ['eye']],
+            self::Empty => ['sql' => 'AND (subtype = ? OR subtype IS NULL)', 'params' => ['']],
+            self::None => ['sql' => '', 'params' => []],
+        };
+    }
+
+    /**
+     * Get the list_options SQL condition for fallback queries.
+     * Used in a_issue.php for quick-pick lists.
+     *
+     * @return array{sql: string, params: array}
+     */
+    public function toListOptionsSqlCondition(): array
+    {
+        return match ($this) {
+            self::Eye => ['sql' => 'AND subtype = ?', 'params' => ['eye']],
+            self::Empty, self::None => ['sql' => 'AND subtype NOT LIKE ?', 'params' => ['eye']],
+        };
+    }
+}
+
+/**
+ * RX type for spectacle prescriptions.
+ * Use ->name to get the display string (e.g., RxType::Single->name === 'Single').
+ */
+enum RxType: string
+{
+    case Single = '0';
+    case Bifocal = '1';
+    case Trifocal = '2';
+    case Progressive = '3';
+}
+
+/**
+ * Refraction type for spectacle/contact lens prescriptions.
+ */
+enum RefType: string
+{
+    case W = 'W';       // Wearing (current glasses)
+    case AR = 'AR';     // Auto-refraction
+    case MR = 'MR';     // Manifest refraction
+    case CR = 'CR';     // Cycloplegic refraction
+    case CTL = 'CTL';   // Contact lens
+
+    /**
+     * Get the database column prefix for this refraction type.
+     */
+    public function columnPrefix(): string
+    {
+        return match ($this) {
+            self::W => '',
+            self::AR => 'AR',
+            self::MR => 'MR',
+            self::CR => 'CR',
+            self::CTL => 'CTL',
+        };
+    }
+
+    /**
+     * Get the comments field name for this refraction type.
+     */
+    public function commentsField(): string
+    {
+        return match ($this) {
+            self::W => 'COMMENTS',
+            self::AR, self::MR, self::CR => 'CRCOMMENTS',
+            self::CTL => 'COMMENTS',
+        };
+    }
+
+    /**
+     * Get the default checked RX type for this refraction type.
+     */
+    public function defaultRxType(): ?RxType
+    {
+        return match ($this) {
+            self::AR, self::MR, self::CTL => RxType::Bifocal,
+            self::W, self::CR => null,
+        };
+    }
+
+    /**
+     * Check if this refraction type has manufacturer fields (CTL only).
+     */
+    public function hasManufacturerFields(): bool
+    {
+        return $this === self::CTL;
+    }
+
+    /**
+     * Get extra fields mapping for this refraction type.
+     * Returns target field => source column mappings.
+     *
+     * @return array<string, string>
+     */
+    public function extraFields(): array
+    {
+        return match ($this) {
+            self::W => [],
+            self::AR => ['ODADD2' => 'ARODADD', 'OSADD2' => 'AROSADD'],
+            self::MR => ['ODADD2' => 'MRODADD', 'OSADD2' => 'MROSADD'],
+            self::CR => [],
+            self::CTL => [
+                'ODBC' => 'CTLODBC', 'ODDIAM' => 'CTLODDIAM', 'ODADD' => 'CTLODADD', 'ODVA' => 'CTLODVA',
+                'OSBC' => 'CTLOSBC', 'OSDIAM' => 'CTLOSDIAM', 'OSADD' => 'CTLOSADD', 'OSVA' => 'CTLOSVA',
+            ],
+        };
+    }
+
+    /**
+     * Get manufacturer field names for CTL type.
+     *
+     * @return string[]
+     */
+    public function manufacturerFields(): array
+    {
+        return match ($this) {
+            self::CTL => [
+                'CTLMANUFACTUREROD', 'CTLMANUFACTUREROS',
+                'CTLSUPPLIEROD', 'CTLSUPPLIEROS',
+                'CTLBRANDOD', 'CTLBRANDOS',
+            ],
+            default => [],
+        };
+    }
+}
+
+/**
+ * Field-based zones for the eye exam form.
+ */
+enum Zone: string
+{
+    case EXT = 'EXT';
+    case ANTSEG = 'ANTSEG';
+    case RETINA = 'RETINA';
+    case NEURO = 'NEURO';
+
+    /**
+     * Get all zones as an array.
+     *
+     * @return Zone[]
+     */
+    public static function all(): array
+    {
+        return [self::EXT, self::ANTSEG, self::RETINA, self::NEURO];
+    }
+}
+
+/**
+ * Copy-forward operation modes (meta-operations, not field zones).
+ */
+enum CopyMode: string
+{
+    case IMPPLAN = 'IMPPLAN';
+    case ALL = 'ALL';
+    case READONLY = 'READONLY';
+}

--- a/interface/forms/eye_mag/php/eye_mag_functions.php
+++ b/interface/forms/eye_mag/php/eye_mag_functions.php
@@ -1693,11 +1693,8 @@ function build_PMSFH($pid)
             continue;
         }
 
-        $subtype = $panel->subtypeFilter()->condition();
-        $pres = sqlStatement(
-            'SELECT * FROM lists WHERE pid = ? AND type = ? ' . $subtype->sql . ' ' . $panel->orderBy(),
-            [$pid, $panel->issueType(), ...$subtype->params],
-        );
+        $issues = $panel->issuesQuery($pid);
+        $pres = sqlStatement($issues->sql, $issues->params);
         $row_counter = '0';
         while ($row = sqlFetchArray($pres)) {
             $rowid = $row['id'];

--- a/interface/forms/eye_mag/php/eye_mag_functions.php
+++ b/interface/forms/eye_mag/php/eye_mag_functions.php
@@ -8,7 +8,9 @@
  * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @author    Ray Magauran <rmagauran@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2016- Raymond Magauran <rmagauran@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -16,6 +18,10 @@ use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\Forms\EyeMag\CopyForward;
+use OpenEMR\Forms\EyeMag\CopyMode;
+use OpenEMR\Forms\EyeMag\PmsfhPanel;
+use OpenEMR\Forms\EyeMag\Zone;
 use OpenEMR\Services\FacilityService;
 
 $facilityService = new FacilityService();
@@ -1670,58 +1676,28 @@ function build_PMSFH($pid)
     $PMSFH_labels = ["POH", "POS", "Eye Meds", "PMH", "Surgery", "Medication", "Allergy", "SOCH", "FH", "ROS"];
     foreach ($PMSFH_labels as $panel_type) {
         $PMSFH[$panel_type] = [];
-        $subtype = " and (subtype is NULL or subtype ='' )";
-        $order = "ORDER BY title";
-        if (in_array($panel_type, ["FH", "SOCH", "ROS"])) {
-            /*
-             *  We are going to build SocHx, FH and ROS separately below since they don't feed off of
-             *  the pre-existing ISSUE_TYPE array - so for now do nothing
-             */
+        /*
+         *  SocHx, FH and ROS have no PmsfhPanel case: they don't feed off of the
+         *  pre-existing ISSUE_TYPE array and are built separately below.
+         *
+         *  The remaining panels are one stock ISSUE_TYPE narrowed by a subtype.
+         *  This is an "eye" form: providers would like ophthalmic medical problems
+         *  listed separately, so the ISSUE_TYPE 'medical_problem' is split using
+         *  subtype "eye" -- but it could be "GYN", "ONC", "GU" etc for whoever wants
+         *  to extend this with their own specific "sub"-lists. The same concept
+         *  covers Past Ocular Surgery, Oncology Medications, and so on; add a case
+         *  to PmsfhPanel rather than another branch here.
+         */
+        $panel = PmsfhPanel::tryFrom($panel_type);
+        if ($panel === null) {
             continue;
-        } elseif ($panel_type == 'POH') {
-            $focusISSUE = "medical_problem"; //openEMR ISSUE_TYPE
-            $subtype = " and subtype ='eye'";
-            /* This is an "eye" form: providers would like ophthalmic medical problems listed separately.
-             * Thus we split the ISSUE_TYPE 'medical_problem' using subtype "eye"
-             * but it could be "GYN", "ONC", "GU" etc - for whoever wants to
-             * extend this for their own specific "sub"-lists.
-             * Similarly, consider Past Ocular Surgery, or Past GYN Surgery, etc for specialty-specific
-             * surgery lists.  They would be subtypes of the ISSUE_TYPE 'surgery'...
-             * eg.
-             *   if ($panel_type =='POS') { //Past Ocular Surgery
-             *   $focusISSUE = "surgery";
-             *   $subtype=" and subtype ='eye'";
-             *   }
-             * The concept is extensible to sub lists for Allergies & Medications too.
-             * eg.
-             *   if ($panel_type =='OncMeds') {
-             *      $focusISSUE = "medication";
-             *      $subtype=" and subtype ='onc'";
-             *   }
-             */
-        } elseif ($panel_type == 'POS') {
-            $focusISSUE = "surgery"; //openEMR ISSUE_TYPE
-            $subtype = " and subtype ='eye'";
-        } elseif ($panel_type == 'PMH') {
-            $focusISSUE = "medical_problem"; //openEMR ISSUE_TYPE
-            $subtype = " and (subtype = '' OR subtype IS NULL)"; //fee_sheet makes subtype=
-        } elseif ($panel_type == 'Surgery') {
-            $focusISSUE = "surgery"; //openEMR ISSUE_TYPE
-            $subtype = "  and (subtype = '' OR subtype IS NULL)";
-            $order = "ORDER BY begdate DESC";
-        } elseif ($panel_type == 'Allergy') {
-            $focusISSUE = "allergy"; //openEMR ISSUE_TYPE
-            $subtype = "";
-        } elseif ($panel_type == 'Medication') {
-            $focusISSUE = "medication"; //openEMR ISSUE_TYPE
-            $subtype = "";
-        } elseif ($panel_type == 'Eye Meds') {
-            $focusISSUE = "medication"; //openEMR ISSUE_TYPE
-            $subtype = "and subtype = 'eye'";// and subtype ='eye' ";
         }
 
-        $pres = sqlStatement("SELECT * FROM lists WHERE pid = ? AND type = ? " .
-            $subtype . " " . $order, [$pid,$focusISSUE]);
+        $subtype = $panel->subtypeFilter()->condition();
+        $pres = sqlStatement(
+            'SELECT * FROM lists WHERE pid = ? AND type = ? ' . $subtype->sql . ' ' . $panel->orderBy(),
+            [$pid, $panel->issueType(), ...$subtype->params],
+        );
         $row_counter = '0';
         while ($row = sqlFetchArray($pres)) {
             $rowid = $row['id'];
@@ -3355,433 +3331,36 @@ function display_draw_section($zone, $encounter, $pid, $side = 'OU', $counter = 
 }
 
 /**
- *  This function returns a JSON object to replace a requested section with copy_forward values (3 input values)
+ *  Echoes the JSON payload the browser applies to today's chart when copying a
+ *  section (or the whole record) forward from a prior encounter.
  *  It will not replace the drawings with older encounter drawings... Not yet anyway.
  *
- * @param string $zone options ALL,EXT,ANTSEG,RETINA,NEURO, EXT_DRAW, ANTSEG_DRAW, RETINA_DRAW, NEURO_DRAW
- * @param string $form_id is the form_eye_*.id where the data to carry forward is located
+ * @param Zone|CopyMode $mode what to copy: a single exam zone, or a whole-form operation
+ * @param string $copy_from is the form_eye_*.id where the data to carry forward is located
  * @param string $pid value = patient id
- * @return void : outputs the ZONE specific HTML for a prior record + widget for the desired zone
+ * @return void : echoes the values of the requested zone as JSON
  */
-function copy_forward($zone, $copy_from, $copy_to, $pid): void
+function copy_forward(Zone|CopyMode $mode, string $copy_from, string $pid): void
 {
-    global $form_id;
-
-    $query = "select  *,form_encounter.date as encounter_date
-
-               from forms,form_encounter,form_eye_base,
-                form_eye_hpi,form_eye_ros,form_eye_vitals,
-                form_eye_acuity,form_eye_refraction,form_eye_biometrics,
-                form_eye_external,form_eye_antseg,form_eye_postseg,
-                form_eye_neuro,form_eye_locking
-                    where
-                    forms.deleted != '1'  and
-                    forms.formdir='eye_mag' and
-                    forms.encounter=form_encounter.encounter and
-                    forms.form_id=form_eye_base.id and
-                    forms.form_id=form_eye_hpi.id and
-                    forms.form_id=form_eye_ros.id and
-                    forms.form_id=form_eye_vitals.id and
-                    forms.form_id=form_eye_acuity.id and
-                    forms.form_id=form_eye_refraction.id and
-                    forms.form_id=form_eye_biometrics.id and
-                    forms.form_id=form_eye_external.id and
-                    forms.form_id=form_eye_antseg.id and
-                    forms.form_id=form_eye_postseg.id and
-                    forms.form_id=form_eye_neuro.id and
-                    forms.form_id=form_eye_locking.id and
-                    forms.pid =? and
-                    forms.form_id =? ";
-
-    $objQuery = sqlQuery($query, [$pid,$copy_from]);
-    if ($zone == "EXT") {
-        $result['RUL'] = $objQuery['RUL'];
-        $result['LUL'] = $objQuery['LUL'];
-        $result['RLL'] = $objQuery['RLL'];
-        $result['LLL'] = $objQuery['LLL'];
-        $result['RBROW'] = $objQuery['RBROW'];
-        $result['LBROW'] = $objQuery['LBROW'];
-        $result['RMCT'] = $objQuery['RMCT'];
-        $result['LMCT'] = $objQuery['LMCT'];
-        $result['RADNEXA'] = $objQuery['RADNEXA'];
-        $result['LADNEXA'] = $objQuery['LADNEXA'];
-        $result['RMRD'] = $objQuery['RMRD'];
-        $result['LMRD'] = $objQuery['LMRD'];
-        $result['RLF'] = $objQuery['RLF'];
-        $result['LLF'] = $objQuery['LLF'];
-        $result['RVFISSURE'] = $objQuery['RVFISSURE'];
-        $result['LVFISSURE'] = $objQuery['LVFISSURE'];
-        $result['RCAROTID'] = $objQuery['RCAROTID'];
-        $result['LCAROTID'] = $objQuery['LCAROTID'];
-        $result['RTEMPART'] = $objQuery['RTEMPART'];
-        $result['LTEMPART'] = $objQuery['LTEMPART'];
-        $result['RCNV'] = $objQuery['RCNV'];
-        $result['LCNV'] = $objQuery['LCNV'];
-        $result['RCNVII'] = $objQuery['RCNVII'];
-        $result['LCNVII'] = $objQuery['LCNVII'];
-        $result['ODSCHIRMER1'] = $objQuery['ODSCHIRMER1'];
-        $result['OSSCHIRMER1'] = $objQuery['OSSCHIRMER1'];
-        $result['ODSCHIRMER2'] = $objQuery['ODSCHIRMER2'];
-        $result['OSSCHIRMER2'] = $objQuery['OSSCHIRMER2'];
-        $result['ODTBUT'] = $objQuery['ODTBUT'];
-        $result['OSTBUT'] = $objQuery['OSTBUT'];
-        $result['OSHERTEL'] = $objQuery['OSHERTEL'];
-        $result['HERTELBASE'] = $objQuery['HERTELBASE'];
-        $result['ODPIC'] = $objQuery['ODPIC'];
-        $result['OSPIC'] = $objQuery['OSPIC'];
-        $result['EXT_COMMENTS'] = $objQuery['EXT_COMMENTS'];
-        $result["json"] = json_encode($result);
-        echo json_encode($result);
-    } elseif ($zone == "ANTSEG") {
-        $result['OSCONJ'] = $objQuery['OSCONJ'];
-        $result['ODCONJ'] = $objQuery['ODCONJ'];
-        $result['ODCORNEA'] = $objQuery['ODCORNEA'];
-        $result['OSCORNEA'] = $objQuery['OSCORNEA'];
-        $result['ODAC'] = $objQuery['ODAC'];
-        $result['OSAC'] = $objQuery['OSAC'];
-        $result['ODLENS'] = $objQuery['ODLENS'];
-        $result['OSLENS'] = $objQuery['OSLENS'];
-        $result['ODIRIS'] = $objQuery['ODIRIS'];
-        $result['OSIRIS'] = $objQuery['OSIRIS'];
-        $result['ODKTHICKNESS'] = $objQuery['ODKTHICKNESS'];
-        $result['OSKTHICKNESS'] = $objQuery['OSKTHICKNESS'];
-        $result['ODGONIO'] = $objQuery['ODGONIO'];
-        $result['OSGONIO'] = $objQuery['OSGONIO'];
-        $result['ODSCHIRMER1'] = $objQuery['ODSCHIRMER1'];
-        $result['OSSCHIRMER1'] = $objQuery['OSSCHIRMER1'];
-        $result['ODSCHIRMER2'] = $objQuery['ODSCHIRMER2'];
-        $result['OSSCHIRMER2'] = $objQuery['OSSCHIRMER2'];
-        $result['ODTBUT'] = $objQuery['ODTBUT'];
-        $result['OSTBUT'] = $objQuery['OSTBUT'];
-        $result['ANTSEG_COMMENTS'] = $objQuery['ANTSEG_COMMENTS'];
-        $result["json"] = json_encode($result);
-        echo json_encode($result);
-    } elseif ($zone == "RETINA") {
-        $result['ODDISC'] = $objQuery['ODDISC'];
-        $result['OSDISC'] = $objQuery['OSDISC'];
-        $result['ODCUP'] = $objQuery['ODCUP'];
-        $result['OSCUP'] = $objQuery['OSCUP'];
-        $result['ODMACULA'] = $objQuery['ODMACULA'];
-        $result['OSMACULA'] = $objQuery['OSMACULA'];
-        $result['ODVESSELS'] = $objQuery['ODVESSELS'];
-        $result['OSVESSELS'] = $objQuery['OSVESSELS'];
-        $result['ODVITREOUS'] = $objQuery['ODVITREOUS'];
-        $result['OSVITREOUS'] = $objQuery['OSVITREOUS'];
-        $result['ODPERIPH'] = $objQuery['ODPERIPH'];
-        $result['OSPERIPH'] = $objQuery['OSPERIPH'];
-        $result['ODDRAWING'] = $objQuery['ODDRAWING'];
-        $result['OSDRAWING'] = $objQuery['OSDRAWING'];
-        $result['ODCMT'] = $objQuery['ODCMT'];
-        $result['OSCMT'] = $objQuery['OSCMT'];
-        $result['RETINA_COMMENTS'] = $objQuery['RETINA_COMMENTS'];
-        $result["json"] = json_encode($result);
-        echo json_encode($result);
-    } elseif ($zone == "NEURO") {
-        $result['ACT'] = $objQuery['ACT'];
-        $result['ACT5CCDIST'] = $objQuery['ACT5CCDIST'];
-        $result['ACT1CCDIST'] = $objQuery['ACT1CCDIST'];
-        $result['ACT2CCDIST'] = $objQuery['ACT2CCDIST'];
-        $result['ACT3CCDIST'] = $objQuery['ACT3CCDIST'];
-        $result['ACT4CCDIST'] = $objQuery['ACT4CCDIST'];
-        $result['ACT6CCDIST'] = $objQuery['ACT6CCDIST'];
-        $result['ACT7CCDIST'] = $objQuery['ACT7CCDIST'];
-        $result['ACT8CCDIST'] = $objQuery['ACT8CCDIST'];
-        $result['ACT9CCDIST'] = $objQuery['ACT9CCDIST'];
-        $result['ACT10CCDIST'] = $objQuery['ACT10CCDIST'];
-        $result['ACT11CCDIST'] = $objQuery['ACT11CCDIST'];
-        $result['ACT1SCDIST'] = $objQuery['ACT1SCDIST'];
-        $result['ACT2SCDIST'] = $objQuery['ACT2SCDIST'];
-        $result['ACT3SCDIST'] = $objQuery['ACT3SCDIST'];
-        $result['ACT4SCDIST'] = $objQuery['ACT4SCDIST'];
-        $result['ACT5SCDIST'] = $objQuery['ACT5SCDIST'];
-        $result['ACT6SCDIST'] = $objQuery['ACT6SCDIST'];
-        $result['ACT7SCDIST'] = $objQuery['ACT7SCDIST'];
-        $result['ACT8SCDIST'] = $objQuery['ACT8SCDIST'];
-        $result['ACT9SCDIST'] = $objQuery['ACT9SCDIST'];
-        $result['ACT10SCDIST'] = $objQuery['ACT10SCDIST'];
-        $result['ACT11SCDIST'] = $objQuery['ACT11SCDIST'];
-        $result['ACT1SCNEAR'] = $objQuery['ACT1SCNEAR'];
-        $result['ACT2SCNEAR'] = $objQuery['ACT2SCNEAR'];
-        $result['ACT3SCNEAR'] = $objQuery['ACT3SCNEAR'];
-        $result['ACT4SCNEAR'] = $objQuery['ACT4SCNEAR'];
-        $result['ACT5CCNEAR'] = $objQuery['ACT5CCNEAR'];
-        $result['ACT6CCNEAR'] = $objQuery['ACT6CCNEAR'];
-        $result['ACT7CCNEAR'] = $objQuery['ACT7CCNEAR'];
-        $result['ACT8CCNEAR'] = $objQuery['ACT8CCNEAR'];
-        $result['ACT9CCNEAR'] = $objQuery['ACT9CCNEAR'];
-        $result['ACT10CCNEAR'] = $objQuery['ACT10CCNEAR'];
-        $result['ACT11CCNEAR'] = $objQuery['ACT11CCNEAR'];
-        $result['ACT5SCNEAR'] = $objQuery['ACT5SCNEAR'];
-        $result['ACT6SCNEAR'] = $objQuery['ACT6SCNEAR'];
-        $result['ACT7SCNEAR'] = $objQuery['ACT7SCNEAR'];
-        $result['ACT8SCNEAR'] = $objQuery['ACT8SCNEAR'];
-        $result['ACT9SCNEAR'] = $objQuery['ACT9SCNEAR'];
-        $result['ACT10SCNEAR'] = $objQuery['ACT10SCNEAR'];
-        $result['ACT11SCNEAR'] = $objQuery['ACT11SCNEAR'];
-        $result['ACT1CCNEAR'] = $objQuery['ACT1CCNEAR'];
-        $result['ACT2CCNEAR'] = $objQuery['ACT2CCNEAR'];
-        $result['ACT3CCNEAR'] = $objQuery['ACT3CCNEAR'];
-        $result['ACT4CCNEAR'] = $objQuery['ACT4CCNEAR'];
-        $result['ODVF1'] = $objQuery['ODVF1'];
-        $result['ODVF2'] = $objQuery['ODVF2'];
-        $result['ODVF3'] = $objQuery['ODVF3'];
-        $result['ODVF4'] = $objQuery['ODVF4'];
-        $result['OSVF1'] = $objQuery['OSVF1'];
-        $result['OSVF2'] = $objQuery['OSVF2'];
-        $result['OSVF3'] = $objQuery['OSVF3'];
-        $result['OSVF4'] = $objQuery['OSVF4'];
-        $result['MOTILITY_RS'] = $objQuery['MOTILITY_RS'];
-        $result['MOTILITY_RI'] = $objQuery['MOTILITY_RI'];
-        $result['MOTILITY_RR'] = $objQuery['MOTILITY_RR'];
-        $result['MOTILITY_RL'] = $objQuery['MOTILITY_RL'];
-        $result['MOTILITY_LS'] = $objQuery['MOTILITY_LS'];
-        $result['MOTILITY_LI'] = $objQuery['MOTILITY_LI'];
-        $result['MOTILITY_LR'] = $objQuery['MOTILITY_LR'];
-        $result['MOTILITY_LL'] = $objQuery['MOTILITY_LL'];
-        $result['NEURO_COMMENTS'] = $objQuery['NEURO_COMMENTS'];
-        $result['STEREOPSIS'] = $objQuery['STEREOPSIS'];
-        $result['ODNPA'] = $objQuery['ODNPA'];
-        $result['OSNPA'] = $objQuery['OSNPA'];
-        $result['VERTFUSAMPS'] = $objQuery['VERTFUSAMPS'];
-        $result['DIVERGENCEAMPS'] = $objQuery['DIVERGENCEAMPS'];
-        $result['NPC'] = $objQuery['NPC'];
-        $result['DACCDIST'] = $objQuery['DACCDIST'];
-        $result['DACCNEAR'] = $objQuery['DACCNEAR'];
-        $result['CACCDIST'] = $objQuery['CACCDIST'];
-        $result['CACCNEAR'] = $objQuery['CACCNEAR'];
-        $result['ODCOLOR'] = $objQuery['ODCOLOR'];
-        $result['OSCOLOR'] = $objQuery['OSCOLOR'];
-        $result['ODCOINS'] = $objQuery['ODCOINS'];
-        $result['OSCOINS'] = $objQuery['OSCOINS'];
-        $result['ODREDDESAT'] = $objQuery['ODREDDESAT'];
-        $result['OSREDDESAT'] = $objQuery['OSREDDESAT'];
-        $result['ODPUPILSIZE1'] = $objQuery['ODPUPILSIZE1'];
-        $result['ODPUPILSIZE2'] = $objQuery['ODPUPILSIZE2'];
-        $result['ODPUPILREACTIVITY'] = $objQuery['ODPUPILREACTIVITY'];
-        $result['ODAPD'] = $objQuery['ODAPD'];
-        $result['OSPUPILSIZE1'] = $objQuery['OSPUPILSIZE1'];
-        $result['OSPUPILSIZE2'] = $objQuery['OSPUPILSIZE2'];
-        $result['OSPUPILREACTIVITY'] = $objQuery['OSPUPILREACTIVITY'];
-        $result['OSAPD'] = $objQuery['OSAPD'];
-        $result['DIMODPUPILSIZE1'] = $objQuery['DIMODPUPILSIZE1'];
-        $result['DIMODPUPILSIZE2'] = $objQuery['DIMODPUPILSIZE2'];
-        $result['DIMODPUPILREACTIVITY'] = $objQuery['DIMODPUPILREACTIVITY'];
-        $result['DIMOSPUPILSIZE1'] = $objQuery['DIMOSPUPILSIZE1'];
-        $result['DIMOSPUPILSIZE2'] = $objQuery['DIMOSPUPILSIZE2'];
-        $result['DIMOSPUPILREACTIVITY'] = $objQuery['DIMOSPUPILREACTIVITY'];
-        $result['PUPIL_COMMENTS'] = $objQuery['PUPIL_COMMENTS'];
-        $result["json"] = json_encode($result);
-        echo json_encode($result);
-    } elseif ($zone == "IMPPLAN") {
-        $result['IMPPLAN'] = build_IMPPLAN_items($pid, $copy_from);
-        echo json_encode($result);
-    } elseif ($zone == "ALL") {
-        $result['RUL'] = $objQuery['RUL'];
-        $result['LUL'] = $objQuery['LUL'];
-        $result['RLL'] = $objQuery['RLL'];
-        $result['LLL'] = $objQuery['LLL'];
-        $result['RBROW'] = $objQuery['RBROW'];
-        $result['LBROW'] = $objQuery['LBROW'];
-        $result['RMCT'] = $objQuery['RMCT'];
-        $result['LMCT'] = $objQuery['LMCT'];
-        $result['RADNEXA'] = $objQuery['RADNEXA'];
-        $result['LADNEXA'] = $objQuery['LADNEXA'];
-        $result['RMRD'] = $objQuery['RMRD'];
-        $result['LMRD'] = $objQuery['LMRD'];
-        $result['RLF'] = $objQuery['RLF'];
-        $result['LLF'] = $objQuery['LLF'];
-        $result['RVFISSURE'] = $objQuery['RVFISSURE'];
-        $result['LVFISSURE'] = $objQuery['LVFISSURE'];
-        $result['ODHERTEL'] = $objQuery['ODHERTEL'];
-        $result['OSHERTEL'] = $objQuery['OSHERTEL'];
-        $result['HERTELBASE'] = $objQuery['HERTELBASE'];
-        $result['ODPIC'] = $objQuery['ODPIC'];
-        $result['OSPIC'] = $objQuery['OSPIC'];
-        $result['EXT_COMMENTS'] = $objQuery['EXT_COMMENTS'];
-
-        $result['OSCONJ'] = $objQuery['OSCONJ'];
-        $result['ODCONJ'] = $objQuery['ODCONJ'];
-        $result['ODCORNEA'] = $objQuery['ODCORNEA'];
-        $result['OSCORNEA'] = $objQuery['OSCORNEA'];
-        $result['ODAC'] = $objQuery['ODAC'];
-        $result['OSAC'] = $objQuery['OSAC'];
-        $result['ODLENS'] = $objQuery['ODLENS'];
-        $result['OSLENS'] = $objQuery['OSLENS'];
-        $result['ODIRIS'] = $objQuery['ODIRIS'];
-        $result['OSIRIS'] = $objQuery['OSIRIS'];
-        $result['ODKTHICKNESS'] = $objQuery['ODKTHICKNESS'];
-        $result['OSKTHICKNESS'] = $objQuery['OSKTHICKNESS'];
-        $result['ODGONIO'] = $objQuery['ODGONIO'];
-        $result['OSGONIO'] = $objQuery['OSGONIO'];
-        $result['ANTSEG_COMMENTS'] = $objQuery['ANTSEG_COMMENTS'];
-
-        $result['ODDISC'] = $objQuery['ODDISC'];
-        $result['OSDISC'] = $objQuery['OSDISC'];
-        $result['ODCUP'] = $objQuery['ODCUP'];
-        $result['OSCUP'] = $objQuery['OSCUP'];
-        $result['ODMACULA'] = $objQuery['ODMACULA'];
-        $result['OSMACULA'] = $objQuery['OSMACULA'];
-        $result['ODVESSELS'] = $objQuery['ODVESSELS'];
-        $result['OSVESSELS'] = $objQuery['OSVESSELS'];
-        $result['ODVITREOUS'] = $objQuery['ODVITREOUS'];
-        $result['OSVITREOUS'] = $objQuery['OSVITREOUS'];
-        $result['ODPERIPH'] = $objQuery['ODPERIPH'];
-        $result['OSPERIPH'] = $objQuery['OSPERIPH'];
-        $result['ODDRAWING'] = $objQuery['ODDRAWING'];
-        $result['OSDRAWING'] = $objQuery['OSDRAWING'];
-        $result['ODCMT'] = $objQuery['ODCMT'];
-        $result['OSCMT'] = $objQuery['OSCMT'];
-        $result['RETINA_COMMENTS'] = $objQuery['RETINA_COMMENTS'];
-
-        $result['ACT'] = $objQuery['ACT'];
-        $result['ACT5CCDIST'] = $objQuery['ACT5CCDIST'];
-        $result['ACT1CCDIST'] = $objQuery['ACT1CCDIST'];
-        $result['ACT2CCDIST'] = $objQuery['ACT2CCDIST'];
-        $result['ACT3CCDIST'] = $objQuery['ACT3CCDIST'];
-        $result['ACT4CCDIST'] = $objQuery['ACT4CCDIST'];
-        $result['ACT6CCDIST'] = $objQuery['ACT6CCDIST'];
-        $result['ACT7CCDIST'] = $objQuery['ACT7CCDIST'];
-        $result['ACT8CCDIST'] = $objQuery['ACT8CCDIST'];
-        $result['ACT9CCDIST'] = $objQuery['ACT9CCDIST'];
-        $result['ACT10CCDIST'] = $objQuery['ACT10CCDIST'];
-        $result['ACT11CCDIST'] = $objQuery['ACT11CCDIST'];
-        $result['ACT1SCDIST'] = $objQuery['ACT1SCDIST'];
-        $result['ACT2SCDIST'] = $objQuery['ACT2SCDIST'];
-        $result['ACT3SCDIST'] = $objQuery['ACT3SCDIST'];
-        $result['ACT4SCDIST'] = $objQuery['ACT4SCDIST'];
-        $result['ACT5SCDIST'] = $objQuery['ACT5SCDIST'];
-        $result['ACT6SCDIST'] = $objQuery['ACT6SCDIST'];
-        $result['ACT7SCDIST'] = $objQuery['ACT7SCDIST'];
-        $result['ACT8SCDIST'] = $objQuery['ACT8SCDIST'];
-        $result['ACT9SCDIST'] = $objQuery['ACT9SCDIST'];
-        $result['ACT10SCDIST'] = $objQuery['ACT10SCDIST'];
-        $result['ACT11SCDIST'] = $objQuery['ACT11SCDIST'];
-        $result['ACT1SCNEAR'] = $objQuery['ACT1SCNEAR'];
-        $result['ACT2SCNEAR'] = $objQuery['ACT2SCNEAR'];
-        $result['ACT3SCNEAR'] = $objQuery['ACT3SCNEAR'];
-        $result['ACT4SCNEAR'] = $objQuery['ACT4SCNEAR'];
-        $result['ACT5CCNEAR'] = $objQuery['ACT5CCNEAR'];
-        $result['ACT6CCNEAR'] = $objQuery['ACT6CCNEAR'];
-        $result['ACT7CCNEAR'] = $objQuery['ACT7CCNEAR'];
-        $result['ACT8CCNEAR'] = $objQuery['ACT8CCNEAR'];
-        $result['ACT9CCNEAR'] = $objQuery['ACT9CCNEAR'];
-        $result['ACT10CCNEAR'] = $objQuery['ACT10CCNEAR'];
-        $result['ACT11CCNEAR'] = $objQuery['ACT11CCNEAR'];
-        $result['ACT5SCNEAR'] = $objQuery['ACT5SCNEAR'];
-        $result['ACT6SCNEAR'] = $objQuery['ACT6SCNEAR'];
-        $result['ACT7SCNEAR'] = $objQuery['ACT7SCNEAR'];
-        $result['ACT8SCNEAR'] = $objQuery['ACT8SCNEAR'];
-        $result['ACT9SCNEAR'] = $objQuery['ACT9SCNEAR'];
-        $result['ACT10SCNEAR'] = $objQuery['ACT10SCNEAR'];
-        $result['ACT11SCNEAR'] = $objQuery['ACT11SCNEAR'];
-        $result['ACT1CCNEAR'] = $objQuery['ACT1CCNEAR'];
-        $result['ACT2CCNEAR'] = $objQuery['ACT2CCNEAR'];
-        $result['ACT3CCNEAR'] = $objQuery['ACT3CCNEAR'];
-        $result['ACT4CCNEAR'] = $objQuery['ACT4CCNEAR'];
-        $result['ODVF1'] = $objQuery['ODVF1'];
-        $result['ODVF2'] = $objQuery['ODVF2'];
-        $result['ODVF3'] = $objQuery['ODVF3'];
-        $result['ODVF4'] = $objQuery['ODVF4'];
-        $result['OSVF1'] = $objQuery['OSVF1'];
-        $result['OSVF2'] = $objQuery['OSVF2'];
-        $result['OSVF3'] = $objQuery['OSVF3'];
-        $result['OSVF4'] = $objQuery['OSVF4'];
-        $result['MOTILITY_RS'] = $objQuery['MOTILITY_RS'];
-        $result['MOTILITY_RI'] = $objQuery['MOTILITY_RI'];
-        $result['MOTILITY_RR'] = $objQuery['MOTILITY_RR'];
-        $result['MOTILITY_RL'] = $objQuery['MOTILITY_RL'];
-        $result['MOTILITY_LS'] = $objQuery['MOTILITY_LS'];
-        $result['MOTILITY_LI'] = $objQuery['MOTILITY_LI'];
-        $result['MOTILITY_LR'] = $objQuery['MOTILITY_LR'];
-        $result['MOTILITY_LL'] = $objQuery['MOTILITY_LL'];
-        $result['NEURO_COMMENTS'] = $objQuery['NEURO_COMMENTS'];
-        $result['STEREOPSIS'] = $objQuery['STEREOPSIS'];
-        $result['ODNPA'] = $objQuery['ODNPA'];
-        $result['OSNPA'] = $objQuery['OSNPA'];
-        $result['VERTFUSAMPS'] = $objQuery['VERTFUSAMPS'];
-        $result['DIVERGENCEAMPS'] = $objQuery['DIVERGENCEAMPS'];
-        $result['NPC'] = $objQuery['NPC'];
-        $result['DACCDIST'] = $objQuery['DACCDIST'];
-        $result['DACCNEAR'] = $objQuery['DACCNEAR'];
-        $result['CACCDIST'] = $objQuery['CACCDIST'];
-        $result['CACCNEAR'] = $objQuery['CACCNEAR'];
-        $result['ODCOLOR'] = $objQuery['ODCOLOR'];
-        $result['OSCOLOR'] = $objQuery['OSCOLOR'];
-        $result['ODCOINS'] = $objQuery['ODCOINS'];
-        $result['OSCOINS'] = $objQuery['OSCOINS'];
-        $result['ODREDDESAT'] = $objQuery['ODREDDESAT'];
-        $result['OSREDDESAT'] = $objQuery['OSREDDESAT'];
-        $result['ODPUPILSIZE1'] = $objQuery['ODPUPILSIZE1'];
-        $result['ODPUPILSIZE2'] = $objQuery['ODPUPILSIZE2'];
-        $result['ODPUPILREACTIVITY'] = $objQuery['ODPUPILREACTIVITY'];
-        $result['ODAPD'] = $objQuery['ODAPD'];
-        $result['OSPUPILSIZE1'] = $objQuery['OSPUPILSIZE1'];
-        $result['OSPUPILSIZE2'] = $objQuery['OSPUPILSIZE2'];
-        $result['OSPUPILREACTIVITY'] = $objQuery['OSPUPILREACTIVITY'];
-        $result['OSAPD'] = $objQuery['OSAPD'];
-        $result['DIMODPUPILSIZE1'] = $objQuery['DIMODPUPILSIZE1'];
-        $result['DIMODPUPILSIZE2'] = $objQuery['DIMODPUPILSIZE2'];
-        $result['DIMODPUPILREACTIVITY'] = $objQuery['DIMODPUPILREACTIVITY'];
-        $result['DIMOSPUPILSIZE1'] = $objQuery['DIMOSPUPILSIZE1'];
-        $result['DIMOSPUPILSIZE2'] = $objQuery['DIMOSPUPILSIZE2'];
-        $result['DIMOSPUPILREACTIVITY'] = $objQuery['DIMOSPUPILREACTIVITY'];
-        $result['PUPIL_COMMENTS'] = $objQuery['PUPIL_COMMENTS'];
-        $result['IMP'] = $objQuery['IMP'];
-        $result["json"] = json_encode($result);
-        echo json_encode($result);
-    } elseif ($zone == "READONLY") {
-        $result = $objQuery;
-        $count_rx = '0';
-        $query1 = "select * from form_eye_mag_wearing where PID=? and ENCOUNTER=? and FORM_ID >'0' ORDER BY RX_NUMBER";
-        $session = SessionWrapperFactory::getInstance()->getActiveSession();
-        $wear = sqlStatement($query1, [$pid,$session->get('encounter')]);
-        while ($wearing = sqlFetchArray($wear)) {
-            ${"display_W_$count_rx"}        = '';
-                  ${"ODSPH_$count_rx"}            = $wearing['ODSPH'];
-                  ${"ODCYL_$count_rx"}            = $wearing['ODCYL'];
-                  ${"ODAXIS_$count_rx"}           = $wearing['ODAXIS'];
-                  ${"OSSPH_$count_rx"}            = $wearing['OSSPH'];
-                  ${"OSCYL_$count_rx"}            = $wearing['OSCYL'];
-                  ${"OSAXIS_$count_rx"}           = $wearing['OSAXIS'];
-                  ${"ODMIDADD_$count_rx"}         = $wearing['ODMIDADD'];
-                  ${"OSMIDADD_$count_rx"}         = $wearing['OSMIDADD'];
-                  ${"ODADD_$count_rx"}            = $wearing['ODADD'];
-                  ${"OSADD_$count_rx"}            = $wearing['OSADD'];
-                  ${"ODVA_$count_rx"}             = $wearing['ODVA'];
-                  ${"OSVA_$count_rx"}             = $wearing['OSVA'];
-                  ${"ODNEARVA_$count_rx"}         = $wearing['ODNEARVA'];
-                  ${"OSNEARVA_$count_rx"}         = $wearing['OSNEARVA'];
-                  ${"ODPRISM_$count_rx"}          = $wearing['ODPRISM'] ?? '';
-                  ${"OSPRISM_$count_rx"}          = $wearing['OSPRISM'] ?? '';
-                  ${"W_$count_rx"}                = '1';
-                  ${"RX_TYPE_$count_rx"}          = $wearing['RX_TYPE'];
-                  ${"ODHPD_$count_rx"}            = $wearing['ODHPD'];
-                  ${"ODHBASE_$count_rx"}          = $wearing['ODHBASE'];
-                  ${"ODVPD_$count_rx"}            = $wearing['ODVPD'];
-                  ${"ODVBASE_$count_rx"}          = $wearing['ODVBASE'];
-                  ${"ODSLABOFF_$count_rx"}        = $wearing['ODSLABOFF'];
-                  ${"ODVERTEXDIST_$count_rx"}     = $wearing['ODVERTEXDIST'];
-                  ${"OSHPD_$count_rx"}            = $wearing['OSHPD'];
-                  ${"OSHBASE_$count_rx"}          = $wearing['OSHBASE'];
-                  ${"OSVPD_$count_rx"}            = $wearing['OSVPD'];
-                  ${"OSVBASE_$count_rx"}          = $wearing['OSVBASE'];
-                  ${"OSSLABOFF_$count_rx"}        = $wearing['OSSLABOFF'];
-                  ${"OSVERTEXDIST_$count_rx"}     = $wearing['OSVERTEXDIST'];
-                  ${"ODMPDD_$count_rx"}           = $wearing['ODMPDD'];
-                  ${"ODMPDN_$count_rx"}           = $wearing['ODMPDN'];
-                  ${"OSMPDD_$count_rx"}           = $wearing['OSMPDD'];
-                  ${"OSMPDN_$count_rx"}           = $wearing['OSMPDN'];
-                  ${"BPDD_$count_rx"}             = $wearing['BPDD'];
-                  ${"BPDN_$count_rx"}             = $wearing['BPDN'];
-                  ${"LENS_MATERIAL_$count_rx"}    = $wearing['LENS_MATERIAL'];
-                  ${"LENS_TREATMENTS_$count_rx"}  = $wearing['LENS_TREATMENTS'];
-                  ${"COMMENTS_$count_rx"}         = $wearing['COMMENTS'];
-        }
-        $result['IMPPLAN'] = build_IMPPLAN_items($pid, $copy_from);
-        $result['query'] = $query;
-        $result["json"] = json_encode($result);
-        echo json_encode($result);
+    $record = sqlQuery(CopyForward::RECORD_QUERY, [$pid, $copy_from]);
+    if (!is_array($record)) {
+        // No such form for this patient: nothing to carry forward.
+        echo json_encode([]);
+        return;
     }
+
+    if ($mode instanceof Zone) {
+        echo json_encode(CopyForward::pick($record, $mode->fields()));
+        return;
+    }
+
+    $result = match ($mode) {
+        CopyMode::IMPPLAN => ['IMPPLAN' => build_IMPPLAN_items($pid, $copy_from)],
+        CopyMode::ALL => CopyForward::pick($record, CopyForward::allFields()),
+        CopyMode::READONLY => $record + ['IMPPLAN' => build_IMPPLAN_items($pid, $copy_from)],
+    };
+
+    echo json_encode($result);
 }
 
 /**

--- a/interface/forms/eye_mag/php/eye_mag_functions.php
+++ b/interface/forms/eye_mag/php/eye_mag_functions.php
@@ -1672,26 +1672,18 @@ function build_PMSFH($pid)
 
     $PMSFH = [];
     $PMSFH['CHRONIC'] = [];
-    //Define the PMSFH array elements as you need them:
-    $PMSFH_labels = ["POH", "POS", "Eye Meds", "PMH", "Surgery", "Medication", "Allergy", "SOCH", "FH", "ROS"];
-    foreach ($PMSFH_labels as $panel_type) {
+    /*
+     *  Each of these panels is one stock ISSUE_TYPE narrowed by a subtype. This
+     *  is an "eye" form: providers would like ophthalmic medical problems listed
+     *  separately, so the ISSUE_TYPE 'medical_problem' is split using subtype
+     *  "eye" -- but it could be "GYN", "ONC", "GU" etc for whoever wants to
+     *  extend this with their own specific "sub"-lists. The same concept covers
+     *  Past Ocular Surgery, Oncology Medications, and so on; add a case to
+     *  PmsfhPanel rather than another branch here.
+     */
+    foreach (PmsfhPanel::cases() as $panel) {
+        $panel_type = $panel->value;
         $PMSFH[$panel_type] = [];
-        /*
-         *  SocHx, FH and ROS have no PmsfhPanel case: they don't feed off of the
-         *  pre-existing ISSUE_TYPE array and are built separately below.
-         *
-         *  The remaining panels are one stock ISSUE_TYPE narrowed by a subtype.
-         *  This is an "eye" form: providers would like ophthalmic medical problems
-         *  listed separately, so the ISSUE_TYPE 'medical_problem' is split using
-         *  subtype "eye" -- but it could be "GYN", "ONC", "GU" etc for whoever wants
-         *  to extend this with their own specific "sub"-lists. The same concept
-         *  covers Past Ocular Surgery, Oncology Medications, and so on; add a case
-         *  to PmsfhPanel rather than another branch here.
-         */
-        $panel = PmsfhPanel::tryFrom($panel_type);
-        if ($panel === null) {
-            continue;
-        }
 
         $issues = $panel->issuesQuery($pid);
         $row_counter = '0';
@@ -1773,6 +1765,16 @@ function build_PMSFH($pid)
             $row_counter++;
         }
     }
+
+    /*
+     *  SocHx, FH and ROS are PMSFH panels too, but they are assembled from the
+     *  history and layout tables rather than from the ISSUE_TYPE array, so they
+     *  have no PmsfhPanel case. Declaring their keys here keeps them in the
+     *  order the form renders them, after the issue-list panels above.
+     */
+    $PMSFH['SOCH'] = [];
+    $PMSFH['FH'] = [];
+    $PMSFH['ROS'] = [];
 
     //Build the SocHx portion of $PMSFH for this patient.
     //$given ="coffee,tobacco,alcohol,sleep_patterns,exercise_patterns,seatbelt_use,counseling,hazardous_activities,recreational_drugs";

--- a/interface/forms/eye_mag/php/eye_mag_functions.php
+++ b/interface/forms/eye_mag/php/eye_mag_functions.php
@@ -1694,9 +1694,8 @@ function build_PMSFH($pid)
         }
 
         $issues = $panel->issuesQuery($pid);
-        $pres = sqlStatement($issues->sql, $issues->params);
         $row_counter = '0';
-        while ($row = sqlFetchArray($pres)) {
+        foreach (QueryUtils::fetchRecords($issues->sql, $issues->params) as $row) {
             $rowid = $row['id'];
             $disptitle = text(trim((string) $row['title'])) ? text($row['title']) : "[" . xlt("Missing Title") . "]";
             //  look up the diag codes
@@ -3339,7 +3338,7 @@ function display_draw_section($zone, $encounter, $pid, $side = 'OU', $counter = 
  */
 function copy_forward(Zone|CopyMode $mode, string $copy_from, string $pid): void
 {
-    $record = sqlQuery(CopyForward::RECORD_QUERY, [$pid, $copy_from]);
+    $record = QueryUtils::querySingleRow(CopyForward::RECORD_QUERY, [$pid, $copy_from]);
     if (!is_array($record)) {
         // No such form for this patient: nothing to carry forward.
         echo json_encode([]);

--- a/interface/forms/eye_mag/save.php
+++ b/interface/forms/eye_mag/save.php
@@ -1229,7 +1229,7 @@ if ($_REQUEST['canvas'] ?? '') {
 }
 
 if ($_REQUEST['copy']) {
-    copy_forward($_REQUEST['zone'], $_REQUEST['copy_from'], ($_SESSION['ID'] ?? ''), $pid);
+    echo getCopyForwardJson($_REQUEST['zone'], $_REQUEST['copy_from'], $pid);
     return;
 }
 

--- a/interface/forms/eye_mag/save.php
+++ b/interface/forms/eye_mag/save.php
@@ -44,6 +44,8 @@ require_once("$srcdir/report.inc.php");
 use Mpdf\Mpdf;
 use OpenEMR\Billing\BillingUtilities;
 use OpenEMR\Common\Logging\EventAuditLogger;
+use OpenEMR\Forms\EyeMag\CopyMode;
+use OpenEMR\Forms\EyeMag\Zone;
 use OpenEMR\Pdf\Config_Mpdf;
 use OpenEMR\Services\PatientIssuesService;
 
@@ -1229,7 +1231,12 @@ if ($_REQUEST['canvas'] ?? '') {
 }
 
 if ($_REQUEST['copy']) {
-    echo getCopyForwardJson($_REQUEST['zone'], $_REQUEST['copy_from'], $pid);
+    $mode = Zone::tryFrom($_REQUEST['zone']) ?? CopyMode::tryFrom($_REQUEST['zone']);
+    if ($mode === null) {
+        echo json_encode([]);
+        return;
+    }
+    echo getCopyForwardJson($mode, $_REQUEST['copy_from'], $pid);
     return;
 }
 

--- a/interface/forms/eye_mag/save.php
+++ b/interface/forms/eye_mag/save.php
@@ -1313,7 +1313,9 @@ if ($_REQUEST['copy']) {
         ? Zone::tryFrom($requestedZone) ?? CopyMode::tryFrom($requestedZone)
         : null;
 
-    if ($copyMode !== null && is_string($copyFrom) && is_scalar($pid)) {
+    // A patient id reaches here as either the session's int or a request string;
+    // anything else is not a patient and must not be stringified into the query.
+    if ($copyMode !== null && is_string($copyFrom) && (is_string($pid) || is_int($pid))) {
         copy_forward($copyMode, $copyFrom, (string) $pid);
     } else {
         // The browser asked for this with dataType: 'json'; an empty body is a parse error.

--- a/interface/forms/eye_mag/save.php
+++ b/interface/forms/eye_mag/save.php
@@ -38,6 +38,8 @@ use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Logging\EventAuditLogger;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\Forms\EyeMag\CopyMode;
+use OpenEMR\Forms\EyeMag\Zone;
 use OpenEMR\Pdf\Config_Mpdf;
 use OpenEMR\Services\PatientIssuesService;
 
@@ -1305,7 +1307,14 @@ if ($_REQUEST['canvas'] ?? '') {
 }
 
 if ($_REQUEST['copy']) {
-    copy_forward($_REQUEST['zone'], $_REQUEST['copy_from'], ($session->get('ID') ?? ''), $pid);
+    $requestedZone = $_REQUEST['zone'] ?? '';
+    $copyFrom = $_REQUEST['copy_from'] ?? '';
+    if (is_string($requestedZone) && is_string($copyFrom) && is_scalar($pid)) {
+        $copyMode = Zone::tryFrom($requestedZone) ?? CopyMode::tryFrom($requestedZone);
+        if ($copyMode !== null) {
+            copy_forward($copyMode, $copyFrom, (string) $pid);
+        }
+    }
     return;
 }
 

--- a/interface/forms/eye_mag/save.php
+++ b/interface/forms/eye_mag/save.php
@@ -42,6 +42,7 @@ use OpenEMR\Forms\EyeMag\CopyMode;
 use OpenEMR\Forms\EyeMag\Zone;
 use OpenEMR\Pdf\Config_Mpdf;
 use OpenEMR\Services\PatientIssuesService;
+use Symfony\Component\HttpFoundation\Request;
 
 $srcdir = OEGlobalsBag::getInstance()->getSrcDir();
 require_once($srcdir . "/api.inc.php");
@@ -56,6 +57,11 @@ require_once($srcdir . "/report.inc.php");
 
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
 $pid = $session->get('pid');
+
+// Captured here, at the top, because the form-save paths below rewrite $_POST
+// and $_REQUEST in place as they normalize fields. Reading the request through
+// this object gets the values the browser actually sent.
+$request = Request::createFromGlobals();
 
 $returnurl = 'encounter_top.php';
 
@@ -1307,15 +1313,15 @@ if ($_REQUEST['canvas'] ?? '') {
 }
 
 if ($_REQUEST['copy']) {
-    $requestedZone = $_REQUEST['zone'] ?? '';
-    $copyFrom = $_REQUEST['copy_from'] ?? '';
-    $copyMode = is_string($requestedZone)
-        ? Zone::tryFrom($requestedZone) ?? CopyMode::tryFrom($requestedZone)
-        : null;
+    // Both copy-forward callers post these; the typed getters hand back strings,
+    // so the enums are the only thing that still has to recognize the value.
+    $requestedZone = $request->request->getString('zone');
+    $copyFrom = $request->request->getString('copy_from');
+    $copyMode = Zone::tryFrom($requestedZone) ?? CopyMode::tryFrom($requestedZone);
 
     // A patient id reaches here as either the session's int or a request string;
     // anything else is not a patient and must not be stringified into the query.
-    if ($copyMode !== null && is_string($copyFrom) && (is_string($pid) || is_int($pid))) {
+    if ($copyMode !== null && (is_string($pid) || is_int($pid))) {
         copy_forward($copyMode, $copyFrom, (string) $pid);
     } else {
         // The browser asked for this with dataType: 'json'; an empty body is a parse error.

--- a/interface/forms/eye_mag/save.php
+++ b/interface/forms/eye_mag/save.php
@@ -1309,11 +1309,15 @@ if ($_REQUEST['canvas'] ?? '') {
 if ($_REQUEST['copy']) {
     $requestedZone = $_REQUEST['zone'] ?? '';
     $copyFrom = $_REQUEST['copy_from'] ?? '';
-    if (is_string($requestedZone) && is_string($copyFrom) && is_scalar($pid)) {
-        $copyMode = Zone::tryFrom($requestedZone) ?? CopyMode::tryFrom($requestedZone);
-        if ($copyMode !== null) {
-            copy_forward($copyMode, $copyFrom, (string) $pid);
-        }
+    $copyMode = is_string($requestedZone)
+        ? Zone::tryFrom($requestedZone) ?? CopyMode::tryFrom($requestedZone)
+        : null;
+
+    if ($copyMode !== null && is_string($copyFrom) && is_scalar($pid)) {
+        copy_forward($copyMode, $copyFrom, (string) $pid);
+    } else {
+        // The browser asked for this with dataType: 'json'; an empty body is a parse error.
+        echo json_encode([]);
     }
     return;
 }

--- a/interface/forms/eye_mag/save.php
+++ b/interface/forms/eye_mag/save.php
@@ -1312,9 +1312,9 @@ if ($_REQUEST['canvas'] ?? '') {
     exit;
 }
 
-if ($_REQUEST['copy']) {
-    // Both copy-forward callers post these; the typed getters hand back strings,
-    // so the enums are the only thing that still has to recognize the value.
+// Both copy-forward callers post these; the typed getters hand back strings, so
+// the enums are the only thing that still has to recognize the value.
+if ($request->request->getString('copy') !== '') {
     $requestedZone = $request->request->getString('zone');
     $copyFrom = $request->request->getString('copy_from');
     $copyMode = Zone::tryFrom($requestedZone) ?? CopyMode::tryFrom($requestedZone);

--- a/src/Forms/EyeMag/CopyForward.php
+++ b/src/Forms/EyeMag/CopyForward.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * Field selection for eye exam copy-forward requests.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Forms\EyeMag;
+
+/**
+ * Decides which columns of a prior eye exam record a copy-forward request
+ * carries into today's chart.
+ */
+final class CopyForward
+{
+    /**
+     * Selects one prior exam as a single flat row spanning every `form_eye_*` table.
+     */
+    public const RECORD_QUERY = <<<'SQL'
+        SELECT *, form_encounter.date AS encounter_date
+        FROM forms, form_encounter, form_eye_base,
+             form_eye_hpi, form_eye_ros, form_eye_vitals,
+             form_eye_acuity, form_eye_refraction, form_eye_biometrics,
+             form_eye_external, form_eye_antseg, form_eye_postseg,
+             form_eye_neuro, form_eye_locking
+        WHERE forms.deleted != '1'
+          AND forms.formdir = 'eye_mag'
+          AND forms.encounter = form_encounter.encounter
+          AND forms.form_id = form_eye_base.id
+          AND forms.form_id = form_eye_hpi.id
+          AND forms.form_id = form_eye_ros.id
+          AND forms.form_id = form_eye_vitals.id
+          AND forms.form_id = form_eye_acuity.id
+          AND forms.form_id = form_eye_refraction.id
+          AND forms.form_id = form_eye_biometrics.id
+          AND forms.form_id = form_eye_external.id
+          AND forms.form_id = form_eye_antseg.id
+          AND forms.form_id = form_eye_postseg.id
+          AND forms.form_id = form_eye_neuro.id
+          AND forms.form_id = form_eye_locking.id
+          AND forms.pid = ?
+          AND forms.form_id = ?
+        SQL;
+
+    /**
+     * Fields carried forward by a whole-form copy. Zone fields overlap (the tear
+     * film measurements belong to both the external and anterior segment exams),
+     * so the union is deduplicated.
+     *
+     * @return list<string>
+     */
+    public static function allFields(): array
+    {
+        $fields = array_merge(...array_map(static fn(Zone $zone): array => $zone->fields(), Zone::cases()));
+        $fields[] = 'IMP';
+
+        return array_values(array_unique($fields));
+    }
+
+    /**
+     * Reads the named fields out of an exam record, defaulting anything the
+     * record does not carry to null.
+     *
+     * @param array<string, mixed> $record
+     * @param list<string> $fields
+     * @return array<string, mixed>
+     */
+    public static function pick(array $record, array $fields): array
+    {
+        return array_combine(
+            $fields,
+            array_map(static fn(string $field): mixed => $record[$field] ?? null, $fields),
+        );
+    }
+}

--- a/src/Forms/EyeMag/CopyForward.php
+++ b/src/Forms/EyeMag/CopyForward.php
@@ -68,8 +68,8 @@ final class CopyForward
      * Reads the named fields out of an exam record, defaulting anything the
      * record does not carry to null.
      *
-     * The record comes straight from sqlQuery(), which promises nothing about
-     * its keys, so this takes the row as loosely as the database hands it over.
+     * The record is a raw database row, which promises nothing about its keys,
+     * so this takes it as loosely as the database hands it over.
      *
      * @param array<array-key, mixed> $record
      * @param list<string> $fields

--- a/src/Forms/EyeMag/CopyForward.php
+++ b/src/Forms/EyeMag/CopyForward.php
@@ -68,7 +68,10 @@ final class CopyForward
      * Reads the named fields out of an exam record, defaulting anything the
      * record does not carry to null.
      *
-     * @param array<string, mixed> $record
+     * The record comes straight from sqlQuery(), which promises nothing about
+     * its keys, so this takes the row as loosely as the database hands it over.
+     *
+     * @param array<array-key, mixed> $record
      * @param list<string> $fields
      * @return array<string, mixed>
      */

--- a/src/Forms/EyeMag/CopyMode.php
+++ b/src/Forms/EyeMag/CopyMode.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Whole-form copy-forward operations of the eye exam form.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Forms\EyeMag;
+
+/**
+ * Copy-forward requests that are not scoped to a single {@see Zone}. The browser
+ * sends these through the same `zone` request parameter the zones use.
+ */
+enum CopyMode: string
+{
+    /** Impression and plan items only. */
+    case IMPPLAN = 'IMPPLAN';
+
+    /** Every zone, plus the impression. */
+    case ALL = 'ALL';
+
+    /** The entire prior record, for the read-only live view of another user's charting. */
+    case READONLY = 'READONLY';
+}

--- a/src/Forms/EyeMag/IssueQuickPick.php
+++ b/src/Forms/EyeMag/IssueQuickPick.php
@@ -1,0 +1,140 @@
+<?php
+
+/**
+ * Quick-pick option lists offered next to each eye exam issue panel.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Forms\EyeMag;
+
+/**
+ * The issue panels that offer a quick-pick list.
+ *
+ * A panel's quick picks are the titles this provider has used most in the last
+ * 30 days; until a provider has built up a history, the stock `list_options`
+ * entries stand in. Panels with no case here (family history, social history,
+ * review of systems) build their picks elsewhere.
+ */
+enum IssueQuickPick: string
+{
+    case PMH = 'PMH';
+    case Medication = 'Medication';
+    case Surgery = 'Surgery';
+    case Allergy = 'Allergy';
+    case POH = 'POH';
+    case POS = 'POS';
+    case EyeMeds = 'Eye Meds';
+
+    /**
+     * Below this many recent titles the provider is treated as just starting
+     * out, and the stock list is used instead.
+     */
+    public const MIN_RECENT_TITLES = 4;
+
+    /**
+     * The stock OpenEMR ISSUE_TYPE this panel draws from.
+     */
+    public function issueType(): string
+    {
+        return match ($this) {
+            self::PMH, self::POH => 'medical_problem',
+            self::Surgery, self::POS => 'surgery',
+            self::Medication, self::EyeMeds => 'medication',
+            self::Allergy => 'allergy',
+        };
+    }
+
+    /**
+     * How this panel narrows its ISSUE_TYPE.
+     */
+    public function subtypeFilter(): SubtypeFilter
+    {
+        return match ($this) {
+            self::POH, self::POS, self::EyeMeds => SubtypeFilter::Eye,
+            self::PMH, self::Medication, self::Surgery, self::Allergy => SubtypeFilter::Blank,
+        };
+    }
+
+    /**
+     * How many recent titles to offer.
+     */
+    public function recentLimit(): int
+    {
+        return match ($this) {
+            self::PMH => 20,
+            self::Medication, self::Surgery, self::Allergy, self::POH, self::POS, self::EyeMeds => 10,
+        };
+    }
+
+    /**
+     * The `list_options` list backing this panel's stock picks.
+     */
+    public function listOptionsId(): string
+    {
+        return match ($this) {
+            self::PMH, self::POH => 'medical_problem_issue_list',
+            self::Surgery, self::POS => 'surgery_issue_list',
+            self::Medication, self::EyeMeds => 'medication_issue_list',
+            self::Allergy => 'allergy_issue_list',
+        };
+    }
+
+    /**
+     * The titles this provider has used most over the last 30 days.
+     */
+    public function recentTitlesQuery(int $providerId): SqlFragment
+    {
+        $subtype = $this->subtypeFilter()->condition();
+
+        // The only interpolation is $subtype->sql, which SubtypeFilter builds from
+        // a closed set of literals. Every value is bound, including the limit.
+        $sql = <<<SQL
+            SELECT title,
+                   title AS option_id,
+                   diagnosis AS codes,
+                   COUNT(title) AS freq
+              FROM lists
+             WHERE type LIKE ?
+               {$subtype->sql}
+               AND pid IN (
+                   SELECT pid
+                     FROM form_encounter
+                    WHERE provider_id = ?
+                      AND date BETWEEN NOW() - INTERVAL 30 DAY AND NOW()
+                   )
+             GROUP BY title
+             ORDER BY freq DESC
+             LIMIT ?
+            SQL;
+
+        return new SqlFragment(
+            $sql,
+            [$this->issueType(), ...$subtype->params, $providerId, $this->recentLimit()],
+        );
+    }
+
+    /**
+     * The stock picks to fall back on, split the same ophthalmic/general way the
+     * panels are.
+     */
+    public function stockTitlesQuery(): SqlFragment
+    {
+        return match ($this->subtypeFilter()) {
+            SubtypeFilter::Eye => new SqlFragment(
+                'SELECT * FROM list_options WHERE list_id = ? AND subtype = ?',
+                [$this->listOptionsId(), 'eye'],
+            ),
+            SubtypeFilter::Blank, SubtypeFilter::BlankOrNull, SubtypeFilter::Any => new SqlFragment(
+                'SELECT * FROM list_options WHERE list_id = ? AND subtype NOT LIKE ?',
+                [$this->listOptionsId(), 'eye'],
+            ),
+        };
+    }
+}

--- a/src/Forms/EyeMag/PmsfhPanel.php
+++ b/src/Forms/EyeMag/PmsfhPanel.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Issue-list panels of the eye exam PMSFH (past medical, surgical, family history).
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Forms\EyeMag;
+
+/**
+ * The PMSFH panels that are built from the `lists` table.
+ *
+ * Family history, social history and review of systems are also PMSFH panels,
+ * but they are assembled from other sources and so have no case here —
+ * {@see self::tryFrom()} returning null is how callers recognize them.
+ *
+ * Each panel is one stock ISSUE_TYPE narrowed by a subtype, which is how the
+ * form separates ophthalmic problems, surgeries and medications from general
+ * ones without adding ISSUE_TYPES to the base install.
+ */
+enum PmsfhPanel: string
+{
+    case POH = 'POH';
+    case POS = 'POS';
+    case EyeMeds = 'Eye Meds';
+    case PMH = 'PMH';
+    case Surgery = 'Surgery';
+    case Medication = 'Medication';
+    case Allergy = 'Allergy';
+
+    /**
+     * The stock OpenEMR ISSUE_TYPE this panel draws from.
+     */
+    public function issueType(): string
+    {
+        return match ($this) {
+            self::POH, self::PMH => 'medical_problem',
+            self::POS, self::Surgery => 'surgery',
+            self::EyeMeds, self::Medication => 'medication',
+            self::Allergy => 'allergy',
+        };
+    }
+
+    /**
+     * How this panel narrows its ISSUE_TYPE.
+     */
+    public function subtypeFilter(): SubtypeFilter
+    {
+        return match ($this) {
+            self::POH, self::POS, self::EyeMeds => SubtypeFilter::Eye,
+            // fee_sheet stores '' where other paths leave NULL, so both count as "not ophthalmic".
+            self::PMH, self::Surgery => SubtypeFilter::BlankOrNull,
+            self::Medication, self::Allergy => SubtypeFilter::Any,
+        };
+    }
+
+    /**
+     * Sort order for the panel. Surgeries read most-recent-first; everything
+     * else reads alphabetically.
+     */
+    public function orderBy(): string
+    {
+        return match ($this) {
+            self::Surgery => 'ORDER BY begdate DESC',
+            self::POH, self::POS, self::EyeMeds, self::PMH, self::Medication, self::Allergy => 'ORDER BY title',
+        };
+    }
+}

--- a/src/Forms/EyeMag/PmsfhPanel.php
+++ b/src/Forms/EyeMag/PmsfhPanel.php
@@ -72,4 +72,26 @@ enum PmsfhPanel: string
             self::POH, self::POS, self::EyeMeds, self::PMH, self::Medication, self::Allergy => 'ORDER BY title',
         };
     }
+
+    /**
+     * The issues to list in this panel for one patient.
+     */
+    public function issuesQuery(string $pid): SqlFragment
+    {
+        $subtype = $this->subtypeFilter()->condition();
+
+        // The only interpolation is the subtype predicate and the sort order,
+        // both of which this class and SubtypeFilter build from closed sets of
+        // literals. Every value is bound.
+        $sql = <<<SQL
+            SELECT *
+              FROM lists
+             WHERE pid = ?
+               AND type = ?
+               {$subtype->sql}
+             {$this->orderBy()}
+            SQL;
+
+        return new SqlFragment($sql, [$pid, $this->issueType(), ...$subtype->params]);
+    }
 }

--- a/src/Forms/EyeMag/RefType.php
+++ b/src/Forms/EyeMag/RefType.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Refraction methods behind an eye exam spectacle or contact lens prescription.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Forms\EyeMag;
+
+/**
+ * How the refraction behind a prescription was measured. Stored in
+ * `form_eye_mag_dispense.REFTYPE`.
+ */
+enum RefType: string
+{
+    /** Wearing: the patient's current glasses, re-prescribed unchanged. */
+    case W = 'W';
+
+    /** Auto-refraction. */
+    case AR = 'AR';
+
+    /** Manifest (dry) refraction. */
+    case MR = 'MR';
+
+    /** Cycloplegic (wet) refraction. */
+    case CR = 'CR';
+
+    /** Contact lens. */
+    case CTL = 'CTL';
+
+    /**
+     * Translated label for the refraction method, as printed on the prescription.
+     */
+    public function displayName(): string
+    {
+        return match ($this) {
+            self::W => xlt('Duplicate Rx -- unchanged from current Rx{{The refraction did not change, New Rx=old Rx}}'),
+            self::AR => xlt('Auto-Refraction'),
+            self::MR => xlt('Manifest (Dry) Refraction'),
+            self::CR => xlt('Cycloplegic (Wet) Refraction'),
+            self::CTL => xlt('Contact Lens'),
+        };
+    }
+
+    /**
+     * Contact lens prescriptions print a different table and expire sooner than
+     * spectacle prescriptions.
+     */
+    public function isContactLens(): bool
+    {
+        return $this === self::CTL;
+    }
+}

--- a/src/Forms/EyeMag/RefType.php
+++ b/src/Forms/EyeMag/RefType.php
@@ -57,4 +57,52 @@ enum RefType: string
     {
         return $this === self::CTL;
     }
+
+    /**
+     * The prefix the measurements behind this prescription carry on the joined
+     * `form_eye_*` record: `MRODSPH` is the manifest refraction's right-eye
+     * sphere, `CTLOSCYL` the contact lens trial's left-eye cylinder, and so on.
+     *
+     * A wearing prescription is not a refraction at all -- it is the patient's
+     * current glasses read back out of `form_eye_mag_wearing`, whose columns are
+     * unprefixed -- so it has no prefix here.
+     */
+    public function columnPrefix(): ?string
+    {
+        return match ($this) {
+            self::W => null,
+            self::AR, self::MR, self::CR, self::CTL => $this->value,
+        };
+    }
+
+    /**
+     * The column this prescription's comments are read from.
+     *
+     * The three spectacle refractions share the one `CRCOMMENTS` column of the
+     * refraction record. A wearing or contact lens prescription carries its own
+     * unprefixed `COMMENTS` instead.
+     */
+    public function commentsColumn(): string
+    {
+        return match ($this) {
+            self::AR, self::MR, self::CR => 'CRCOMMENTS',
+            self::W, self::CTL => 'COMMENTS',
+        };
+    }
+
+    /**
+     * Whether this prescription records a near-add power alongside the distance
+     * correction, in an `ODADD`/`OSADD` column pair.
+     *
+     * A cycloplegic refraction paralyzes accommodation, so there is no add to
+     * measure; a contact lens trial keeps its add in the `CTLODADD` pair the
+     * lens table reads, not in the spectacle add fields.
+     */
+    public function hasAddPower(): bool
+    {
+        return match ($this) {
+            self::W, self::AR, self::MR => true,
+            self::CR, self::CTL => false,
+        };
+    }
 }

--- a/src/Forms/EyeMag/RxType.php
+++ b/src/Forms/EyeMag/RxType.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Lens types available on an eye exam spectacle prescription.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Forms\EyeMag;
+
+/**
+ * The lens type a spectacle prescription is written for. The backing values are
+ * the numeric codes stored in `form_eye_mag_wearing.RX_TYPE` and passed through
+ * the print form as `rx_type`; the case names are the labels the form renders.
+ */
+enum RxType: string
+{
+    case Single = '0';
+    case Bifocal = '1';
+    case Trifocal = '2';
+    case Progressive = '3';
+
+    /**
+     * The lens type the print form falls back to when the request carries no
+     * recognized code.
+     */
+    public const DEFAULT = self::Single;
+}

--- a/src/Forms/EyeMag/RxType.php
+++ b/src/Forms/EyeMag/RxType.php
@@ -31,4 +31,31 @@ enum RxType: string
      * recognized code.
      */
     public const DEFAULT = self::Single;
+
+    /**
+     * Resolves the label stored in `form_eye_mag_dispense.RXTYPE`.
+     *
+     * The dispense table records the lens type by name rather than by the code
+     * `form_eye_mag_wearing.RX_TYPE` holds, so a dispensed prescription is read
+     * back through here instead of {@see self::tryFrom()}.
+     */
+    public static function fromLabel(string $label): ?self
+    {
+        foreach (self::cases() as $case) {
+            if ($case->name === $label) {
+                return $case;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * The `checked` attribute for this lens type's radio button, given the lens
+     * type the prescription was written for.
+     */
+    public function checkedAttribute(?self $selected): string
+    {
+        return $this === $selected ? "checked='checked'" : '';
+    }
 }

--- a/src/Forms/EyeMag/SqlFragment.php
+++ b/src/Forms/EyeMag/SqlFragment.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * A parameterized SQL fragment: a snippet of SQL plus the binds it needs.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Forms\EyeMag;
+
+/**
+ * Keeps a conditional SQL snippet and its bind values together so callers
+ * cannot append one without the other.
+ */
+final readonly class SqlFragment
+{
+    /**
+     * @param list<string|int> $params
+     */
+    public function __construct(
+        public string $sql,
+        public array $params = [],
+    ) {
+    }
+}

--- a/src/Forms/EyeMag/SubtypeFilter.php
+++ b/src/Forms/EyeMag/SubtypeFilter.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Subtype filters applied to `lists` rows by the eye exam form.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Forms\EyeMag;
+
+/**
+ * The eye exam form splits the stock ISSUE_TYPES (`medical_problem`, `surgery`,
+ * `medication`) into ophthalmic and general lists using `lists.subtype`. Each
+ * case is one of the subtype predicates the form needs.
+ */
+enum SubtypeFilter
+{
+    /** Ophthalmic rows only. */
+    case Eye;
+
+    /** Rows whose subtype was explicitly stored as an empty string. */
+    case Blank;
+
+    /** Rows with no subtype, however it was stored (fee_sheet writes ''; other paths leave NULL). */
+    case BlankOrNull;
+
+    /** No subtype predicate at all. */
+    case Any;
+
+    /**
+     * The predicate to append to a query over the `lists` table.
+     */
+    public function condition(): SqlFragment
+    {
+        return match ($this) {
+            self::Eye => new SqlFragment('AND subtype = ?', ['eye']),
+            self::Blank => new SqlFragment('AND subtype = ?', ['']),
+            self::BlankOrNull => new SqlFragment('AND (subtype = ? OR subtype IS NULL)', ['']),
+            self::Any => new SqlFragment(''),
+        };
+    }
+}

--- a/src/Forms/EyeMag/Zone.php
+++ b/src/Forms/EyeMag/Zone.php
@@ -18,6 +18,9 @@ namespace OpenEMR\Forms\EyeMag;
  * The four field-bearing zones of the exam. Each case knows which columns of the
  * joined `form_eye_*` record belong to it, which is what makes copy-forward a
  * table lookup instead of a branch per zone.
+ *
+ * Drawings are not listed here. They live in the documents table, not in a
+ * `form_eye_*` column, and copy-forward does not carry them.
  */
 enum Zone: string
 {
@@ -41,7 +44,7 @@ enum Zone: string
                 'RTEMPART', 'LTEMPART', 'RCNV', 'LCNV', 'RCNVII', 'LCNVII',
                 'ODSCHIRMER1', 'OSSCHIRMER1', 'ODSCHIRMER2', 'OSSCHIRMER2',
                 'ODTBUT', 'OSTBUT', 'ODHERTEL', 'OSHERTEL', 'HERTELBASE',
-                'ODPIC', 'OSPIC', 'EXT_COMMENTS',
+                'EXT_COMMENTS',
             ],
             self::ANTSEG => [
                 'OSCONJ', 'ODCONJ', 'ODCORNEA', 'OSCORNEA', 'ODAC', 'OSAC',
@@ -53,7 +56,7 @@ enum Zone: string
             self::RETINA => [
                 'ODDISC', 'OSDISC', 'ODCUP', 'OSCUP', 'ODMACULA', 'OSMACULA',
                 'ODVESSELS', 'OSVESSELS', 'ODVITREOUS', 'OSVITREOUS',
-                'ODPERIPH', 'OSPERIPH', 'ODDRAWING', 'OSDRAWING',
+                'ODPERIPH', 'OSPERIPH',
                 'ODCMT', 'OSCMT', 'RETINA_COMMENTS',
             ],
             self::NEURO => [

--- a/src/Forms/EyeMag/Zone.php
+++ b/src/Forms/EyeMag/Zone.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Exam zones of the eye exam form, and the fields each one owns.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Forms\EyeMag;
+
+/**
+ * The four field-bearing zones of the exam. Each case knows which columns of the
+ * joined `form_eye_*` record belong to it, which is what makes copy-forward a
+ * table lookup instead of a branch per zone.
+ */
+enum Zone: string
+{
+    case EXT = 'EXT';
+    case ANTSEG = 'ANTSEG';
+    case RETINA = 'RETINA';
+    case NEURO = 'NEURO';
+
+    /**
+     * Columns of the joined eye exam record that belong to this zone.
+     *
+     * @return list<string>
+     */
+    public function fields(): array
+    {
+        return match ($this) {
+            self::EXT => [
+                'RUL', 'LUL', 'RLL', 'LLL', 'RBROW', 'LBROW', 'RMCT', 'LMCT',
+                'RADNEXA', 'LADNEXA', 'RMRD', 'LMRD', 'RLF', 'LLF',
+                'RVFISSURE', 'LVFISSURE', 'RCAROTID', 'LCAROTID',
+                'RTEMPART', 'LTEMPART', 'RCNV', 'LCNV', 'RCNVII', 'LCNVII',
+                'ODSCHIRMER1', 'OSSCHIRMER1', 'ODSCHIRMER2', 'OSSCHIRMER2',
+                'ODTBUT', 'OSTBUT', 'ODHERTEL', 'OSHERTEL', 'HERTELBASE',
+                'ODPIC', 'OSPIC', 'EXT_COMMENTS',
+            ],
+            self::ANTSEG => [
+                'OSCONJ', 'ODCONJ', 'ODCORNEA', 'OSCORNEA', 'ODAC', 'OSAC',
+                'ODLENS', 'OSLENS', 'ODIRIS', 'OSIRIS',
+                'ODKTHICKNESS', 'OSKTHICKNESS', 'ODGONIO', 'OSGONIO',
+                'ODSCHIRMER1', 'OSSCHIRMER1', 'ODSCHIRMER2', 'OSSCHIRMER2',
+                'ODTBUT', 'OSTBUT', 'ANTSEG_COMMENTS',
+            ],
+            self::RETINA => [
+                'ODDISC', 'OSDISC', 'ODCUP', 'OSCUP', 'ODMACULA', 'OSMACULA',
+                'ODVESSELS', 'OSVESSELS', 'ODVITREOUS', 'OSVITREOUS',
+                'ODPERIPH', 'OSPERIPH', 'ODDRAWING', 'OSDRAWING',
+                'ODCMT', 'OSCMT', 'RETINA_COMMENTS',
+            ],
+            self::NEURO => [
+                'ACT',
+                'ACT1CCDIST', 'ACT2CCDIST', 'ACT3CCDIST', 'ACT4CCDIST', 'ACT5CCDIST', 'ACT6CCDIST',
+                'ACT7CCDIST', 'ACT8CCDIST', 'ACT9CCDIST', 'ACT10CCDIST', 'ACT11CCDIST',
+                'ACT1SCDIST', 'ACT2SCDIST', 'ACT3SCDIST', 'ACT4SCDIST', 'ACT5SCDIST', 'ACT6SCDIST',
+                'ACT7SCDIST', 'ACT8SCDIST', 'ACT9SCDIST', 'ACT10SCDIST', 'ACT11SCDIST',
+                'ACT1CCNEAR', 'ACT2CCNEAR', 'ACT3CCNEAR', 'ACT4CCNEAR', 'ACT5CCNEAR', 'ACT6CCNEAR',
+                'ACT7CCNEAR', 'ACT8CCNEAR', 'ACT9CCNEAR', 'ACT10CCNEAR', 'ACT11CCNEAR',
+                'ACT1SCNEAR', 'ACT2SCNEAR', 'ACT3SCNEAR', 'ACT4SCNEAR', 'ACT5SCNEAR', 'ACT6SCNEAR',
+                'ACT7SCNEAR', 'ACT8SCNEAR', 'ACT9SCNEAR', 'ACT10SCNEAR', 'ACT11SCNEAR',
+                'ODVF1', 'ODVF2', 'ODVF3', 'ODVF4', 'OSVF1', 'OSVF2', 'OSVF3', 'OSVF4',
+                'MOTILITY_RS', 'MOTILITY_RI', 'MOTILITY_RR', 'MOTILITY_RL',
+                'MOTILITY_LS', 'MOTILITY_LI', 'MOTILITY_LR', 'MOTILITY_LL',
+                'NEURO_COMMENTS', 'STEREOPSIS', 'ODNPA', 'OSNPA',
+                'VERTFUSAMPS', 'DIVERGENCEAMPS', 'NPC',
+                'DACCDIST', 'DACCNEAR', 'CACCDIST', 'CACCNEAR',
+                'ODCOLOR', 'OSCOLOR', 'ODCOINS', 'OSCOINS', 'ODREDDESAT', 'OSREDDESAT',
+                'ODPUPILSIZE1', 'ODPUPILSIZE2', 'ODPUPILREACTIVITY', 'ODAPD',
+                'OSPUPILSIZE1', 'OSPUPILSIZE2', 'OSPUPILREACTIVITY', 'OSAPD',
+                'DIMODPUPILSIZE1', 'DIMODPUPILSIZE2', 'DIMODPUPILREACTIVITY',
+                'DIMOSPUPILSIZE1', 'DIMOSPUPILSIZE2', 'DIMOSPUPILREACTIVITY',
+                'PUPIL_COMMENTS',
+            ],
+        };
+    }
+}

--- a/tests/Tests/Isolated/Forms/EyeMag/CopyForwardTest.php
+++ b/tests/Tests/Isolated/Forms/EyeMag/CopyForwardTest.php
@@ -83,6 +83,19 @@ class CopyForwardTest extends TestCase
         $this->assertSame(array_values(array_unique($all)), $all);
     }
 
+    /**
+     * Drawings and photos live in the documents table, not in a `form_eye_*`
+     * column, so naming them here would only ever copy nulls forward.
+     */
+    public function testNoZoneCarriesDrawingsOrPhotos(): void
+    {
+        foreach (Zone::cases() as $zone) {
+            foreach (['ODPIC', 'OSPIC', 'ODDRAWING', 'OSDRAWING'] as $absent) {
+                $this->assertNotContains($absent, $zone->fields(), "{$zone->value} carries {$absent}");
+            }
+        }
+    }
+
     public function testRecordQueryBindsThePatientAndFormRatherThanInterpolatingThem(): void
     {
         $this->assertStringContainsString('forms.pid = ?', CopyForward::RECORD_QUERY);

--- a/tests/Tests/Isolated/Forms/EyeMag/CopyForwardTest.php
+++ b/tests/Tests/Isolated/Forms/EyeMag/CopyForwardTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Isolated tests for eye exam copy-forward field selection.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Forms\EyeMag;
+
+use OpenEMR\Forms\EyeMag\CopyForward;
+use OpenEMR\Forms\EyeMag\Zone;
+use PHPUnit\Framework\TestCase;
+
+class CopyForwardTest extends TestCase
+{
+    public function testPickReturnsOnlyTheRequestedFields(): void
+    {
+        $picked = CopyForward::pick(
+            ['ODCUP' => '0.3', 'OSCUP' => '0.4', 'PUPIL_COMMENTS' => 'unrelated'],
+            ['ODCUP', 'OSCUP'],
+        );
+
+        $this->assertSame(['ODCUP' => '0.3', 'OSCUP' => '0.4'], $picked);
+    }
+
+    public function testPickDefaultsFieldsMissingFromTheRecordToNull(): void
+    {
+        $picked = CopyForward::pick(['ODCUP' => '0.3'], ['ODCUP', 'OSCUP']);
+
+        $this->assertSame(['ODCUP' => '0.3', 'OSCUP' => null], $picked);
+    }
+
+    public function testPickPreservesFalsyValuesRatherThanDroppingThem(): void
+    {
+        $picked = CopyForward::pick(['ODCUP' => '0', 'OSCUP' => ''], ['ODCUP', 'OSCUP']);
+
+        $this->assertSame(['ODCUP' => '0', 'OSCUP' => ''], $picked);
+    }
+
+    public function testEveryZoneDeclaresFieldsAndNoneRepeatsOne(): void
+    {
+        foreach (Zone::cases() as $zone) {
+            $fields = $zone->fields();
+
+            $this->assertNotEmpty($fields, "{$zone->value} declares no fields");
+            $this->assertSame(
+                array_values(array_unique($fields)),
+                $fields,
+                "{$zone->value} repeats a field",
+            );
+        }
+    }
+
+    public function testAllFieldsCoversEveryZone(): void
+    {
+        $all = CopyForward::allFields();
+
+        foreach (Zone::cases() as $zone) {
+            $this->assertSame(
+                [],
+                array_diff($zone->fields(), $all),
+                "whole-form copy omits fields of {$zone->value}",
+            );
+        }
+    }
+
+    public function testAllFieldsCarriesTheImpressionAndDeduplicatesSharedZoneFields(): void
+    {
+        $all = CopyForward::allFields();
+
+        $this->assertContains('IMP', $all);
+        // The tear film measurements belong to both the external and anterior
+        // segment exams, so the union has to collapse them.
+        $this->assertContains('ODTBUT', Zone::EXT->fields());
+        $this->assertContains('ODTBUT', Zone::ANTSEG->fields());
+        $this->assertSame(array_values(array_unique($all)), $all);
+    }
+
+    public function testRecordQueryBindsThePatientAndFormRatherThanInterpolatingThem(): void
+    {
+        $this->assertStringContainsString('forms.pid = ?', CopyForward::RECORD_QUERY);
+        $this->assertStringContainsString('forms.form_id = ?', CopyForward::RECORD_QUERY);
+        $this->assertStringNotContainsString('$', CopyForward::RECORD_QUERY);
+    }
+}

--- a/tests/Tests/Isolated/Forms/EyeMag/IssuePanelTest.php
+++ b/tests/Tests/Isolated/Forms/EyeMag/IssuePanelTest.php
@@ -103,6 +103,21 @@ class IssuePanelTest extends TestCase
         }
     }
 
+    public function testIssuesQueryBindsEveryPlaceholder(): void
+    {
+        foreach (PmsfhPanel::cases() as $panel) {
+            $query = $panel->issuesQuery('7');
+
+            $this->assertCount(
+                substr_count($query->sql, '?'),
+                $query->params,
+                "{$panel->value} has a placeholder without a bind",
+            );
+            $this->assertSame(['7', $panel->issueType()], array_slice($query->params, 0, 2));
+            $this->assertStringContainsString($panel->orderBy(), $query->sql);
+        }
+    }
+
     public function testRecentTitlesQueryBindsEveryPlaceholder(): void
     {
         foreach (IssueQuickPick::cases() as $panel) {

--- a/tests/Tests/Isolated/Forms/EyeMag/IssuePanelTest.php
+++ b/tests/Tests/Isolated/Forms/EyeMag/IssuePanelTest.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * Isolated tests for the eye exam issue panels and their subtype filters.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Forms\EyeMag;
+
+use OpenEMR\Forms\EyeMag\IssueQuickPick;
+use OpenEMR\Forms\EyeMag\PmsfhPanel;
+use OpenEMR\Forms\EyeMag\SubtypeFilter;
+use PHPUnit\Framework\TestCase;
+
+class IssuePanelTest extends TestCase
+{
+    /**
+     * Panels built from other sources have no case, so callers can recognize
+     * them by a null lookup.
+     */
+    public function testDerivedPanelsHaveNoCase(): void
+    {
+        foreach (['FH', 'SOCH', 'ROS'] as $derived) {
+            $this->assertNull(PmsfhPanel::tryFrom($derived));
+            $this->assertNull(IssueQuickPick::tryFrom($derived));
+        }
+    }
+
+    public function testEveryFilterBindsItsSubtypeRatherThanInterpolatingIt(): void
+    {
+        foreach (SubtypeFilter::cases() as $filter) {
+            $condition = $filter->condition();
+
+            $this->assertSame(
+                substr_count($condition->sql, '?'),
+                count($condition->params),
+                "{$filter->name} has a placeholder without a bind",
+            );
+        }
+    }
+
+    public function testAnyFilterAddsNoPredicate(): void
+    {
+        $condition = SubtypeFilter::Any->condition();
+
+        $this->assertSame('', $condition->sql);
+        $this->assertSame([], $condition->params);
+    }
+
+    public function testBlankOrNullFilterMatchesRowsStoredEitherWay(): void
+    {
+        $condition = SubtypeFilter::BlankOrNull->condition();
+
+        $this->assertSame('AND (subtype = ? OR subtype IS NULL)', $condition->sql);
+        $this->assertSame([''], $condition->params);
+    }
+
+    public function testOphthalmicPanelsFilterOnTheEyeSubtype(): void
+    {
+        foreach ([PmsfhPanel::POH, PmsfhPanel::POS, PmsfhPanel::EyeMeds] as $panel) {
+            $this->assertSame(SubtypeFilter::Eye, $panel->subtypeFilter());
+        }
+
+        foreach ([IssueQuickPick::POH, IssueQuickPick::POS, IssueQuickPick::EyeMeds] as $panel) {
+            $this->assertSame(SubtypeFilter::Eye, $panel->subtypeFilter());
+        }
+    }
+
+    public function testOphthalmicAndGeneralPanelsShareAnIssueTypeButNotASubtype(): void
+    {
+        $this->assertSame(PmsfhPanel::POH->issueType(), PmsfhPanel::PMH->issueType());
+        $this->assertNotSame(PmsfhPanel::POH->subtypeFilter(), PmsfhPanel::PMH->subtypeFilter());
+
+        $this->assertSame(PmsfhPanel::POS->issueType(), PmsfhPanel::Surgery->issueType());
+        $this->assertSame(PmsfhPanel::EyeMeds->issueType(), PmsfhPanel::Medication->issueType());
+    }
+
+    public function testOnlySurgeryReadsMostRecentFirst(): void
+    {
+        $this->assertSame('ORDER BY begdate DESC', PmsfhPanel::Surgery->orderBy());
+
+        foreach (PmsfhPanel::cases() as $panel) {
+            if ($panel !== PmsfhPanel::Surgery) {
+                $this->assertSame('ORDER BY title', $panel->orderBy());
+            }
+        }
+    }
+
+    public function testRecentTitlesQueryBindsEveryPlaceholder(): void
+    {
+        foreach (IssueQuickPick::cases() as $panel) {
+            $query = $panel->recentTitlesQuery(42);
+
+            $this->assertSame(
+                substr_count($query->sql, '?'),
+                count($query->params),
+                "{$panel->value} has a placeholder without a bind",
+            );
+            $this->assertSame($panel->issueType(), $query->params[0]);
+            $this->assertContains(42, $query->params);
+            $this->assertContains($panel->recentLimit(), $query->params);
+        }
+    }
+
+    public function testRecentTitlesQueryBindsTheLimitAsAnInt(): void
+    {
+        // ADODB's emulated binds quote string values, so a string limit would
+        // render as LIMIT '20' and fail.
+        $query = IssueQuickPick::PMH->recentTitlesQuery(1);
+
+        $this->assertStringContainsString('LIMIT ?', $query->sql);
+        $this->assertSame(20, $query->params[array_key_last($query->params)]);
+    }
+
+    public function testStockTitlesQuerySplitsOphthalmicFromGeneralLists(): void
+    {
+        $this->assertStringContainsString('AND subtype = ?', IssueQuickPick::POH->stockTitlesQuery()->sql);
+        $this->assertStringContainsString('AND subtype NOT LIKE ?', IssueQuickPick::PMH->stockTitlesQuery()->sql);
+
+        foreach (IssueQuickPick::cases() as $panel) {
+            $query = $panel->stockTitlesQuery();
+
+            $this->assertSame([$panel->listOptionsId(), 'eye'], $query->params);
+        }
+    }
+
+    public function testQuickPickPanelsAgreeWithPmsfhPanelsOnIssueType(): void
+    {
+        foreach (IssueQuickPick::cases() as $panel) {
+            $pmsfh = PmsfhPanel::from($panel->value);
+
+            $this->assertSame($pmsfh->issueType(), $panel->issueType());
+        }
+    }
+}

--- a/tests/Tests/Isolated/Forms/EyeMag/IssuePanelTest.php
+++ b/tests/Tests/Isolated/Forms/EyeMag/IssuePanelTest.php
@@ -17,6 +17,7 @@ namespace OpenEMR\Tests\Isolated\Forms\EyeMag;
 use OpenEMR\Forms\EyeMag\IssueQuickPick;
 use OpenEMR\Forms\EyeMag\PmsfhPanel;
 use OpenEMR\Forms\EyeMag\SubtypeFilter;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class IssuePanelTest extends TestCase
@@ -25,12 +26,21 @@ class IssuePanelTest extends TestCase
      * Panels built from other sources have no case, so callers can recognize
      * them by a null lookup.
      */
-    public function testDerivedPanelsHaveNoCase(): void
+    #[DataProvider('derivedPanelProvider')]
+    public function testDerivedPanelsHaveNoCase(string $derived): void
     {
-        foreach (['FH', 'SOCH', 'ROS'] as $derived) {
-            $this->assertNull(PmsfhPanel::tryFrom($derived));
-            $this->assertNull(IssueQuickPick::tryFrom($derived));
-        }
+        $this->assertNull(PmsfhPanel::tryFrom($derived));
+        $this->assertNull(IssueQuickPick::tryFrom($derived));
+    }
+
+    /**
+     * @return list<array{string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function derivedPanelProvider(): array
+    {
+        return [['FH'], ['SOCH'], ['ROS'], ['CHRONIC']];
     }
 
     public function testEveryFilterBindsItsSubtypeRatherThanInterpolatingIt(): void
@@ -38,9 +48,9 @@ class IssuePanelTest extends TestCase
         foreach (SubtypeFilter::cases() as $filter) {
             $condition = $filter->condition();
 
-            $this->assertSame(
+            $this->assertCount(
                 substr_count($condition->sql, '?'),
-                count($condition->params),
+                $condition->params,
                 "{$filter->name} has a placeholder without a bind",
             );
         }
@@ -98,9 +108,9 @@ class IssuePanelTest extends TestCase
         foreach (IssueQuickPick::cases() as $panel) {
             $query = $panel->recentTitlesQuery(42);
 
-            $this->assertSame(
+            $this->assertCount(
                 substr_count($query->sql, '?'),
-                count($query->params),
+                $query->params,
                 "{$panel->value} has a placeholder without a bind",
             );
             $this->assertSame($panel->issueType(), $query->params[0]);
@@ -116,7 +126,8 @@ class IssuePanelTest extends TestCase
         $query = IssueQuickPick::PMH->recentTitlesQuery(1);
 
         $this->assertStringContainsString('LIMIT ?', $query->sql);
-        $this->assertSame(20, $query->params[array_key_last($query->params)]);
+        $this->assertNotEmpty($query->params);
+        $this->assertSame(20, $query->params[count($query->params) - 1]);
     }
 
     public function testStockTitlesQuerySplitsOphthalmicFromGeneralLists(): void

--- a/tests/Tests/Isolated/Forms/EyeMag/PrescriptionTypeTest.php
+++ b/tests/Tests/Isolated/Forms/EyeMag/PrescriptionTypeTest.php
@@ -99,4 +99,114 @@ class PrescriptionTypeTest extends TestCase
     {
         $this->assertNull(RxType::tryFrom($code));
     }
+
+    /**
+     * The dispense table stores the label, so a round trip through it has to
+     * land back on the same case the numeric code came from.
+     */
+    #[DataProvider('lensTypeCodeProvider')]
+    public function testStoredLabelsResolveBackToTheirLensType(string $code, string $label): void
+    {
+        $this->assertSame(RxType::from($code), RxType::fromLabel($label));
+    }
+
+    /**
+     * @return list<array{string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function unrecognizedLensLabelProvider(): array
+    {
+        return [[''], ['0'], ['single'], ['Varifocal']];
+    }
+
+    #[DataProvider('unrecognizedLensLabelProvider')]
+    public function testUnrecognizedLensLabelsDoNotResolve(string $label): void
+    {
+        $this->assertNull(RxType::fromLabel($label));
+    }
+
+    public function testOnlyTheSelectedLensTypeIsChecked(): void
+    {
+        foreach (RxType::cases() as $selected) {
+            $checked = array_filter(
+                RxType::cases(),
+                static fn(RxType $case): bool => $case->checkedAttribute($selected) !== '',
+            );
+
+            $this->assertSame([$selected], array_values($checked));
+        }
+    }
+
+    public function testNothingIsCheckedWhenNoLensTypeIsSelected(): void
+    {
+        foreach (RxType::cases() as $case) {
+            $this->assertSame('', $case->checkedAttribute(null));
+        }
+    }
+
+    /**
+     * The prefix is what lets the print form read one refraction's measurements
+     * without a branch per method, so it has to be distinct and non-empty for
+     * every method that has one.
+     */
+    public function testEveryRefractionHasADistinctColumnPrefix(): void
+    {
+        $prefixes = [];
+        foreach (RefType::cases() as $refType) {
+            $prefix = $refType->columnPrefix();
+            if ($prefix === null) {
+                continue;
+            }
+
+            $this->assertNotSame('', $prefix);
+            $prefixes[] = $prefix;
+        }
+
+        $this->assertCount(count($prefixes), array_unique($prefixes));
+    }
+
+    /**
+     * A wearing prescription is copied out of `form_eye_mag_wearing`, whose
+     * columns are unprefixed, so it is the one method with no prefix.
+     */
+    public function testOnlyWearingPrescriptionsLackAColumnPrefix(): void
+    {
+        $this->assertNull(RefType::W->columnPrefix());
+
+        foreach (RefType::cases() as $refType) {
+            if ($refType !== RefType::W) {
+                $this->assertNotNull($refType->columnPrefix(), "{$refType->value} reads prefixed columns");
+            }
+        }
+    }
+
+    /**
+     * The three spectacle refractions share the single CRCOMMENTS column of the
+     * refraction record; the other two carry their own unprefixed COMMENTS.
+     */
+    public function testSpectacleRefractionsShareTheRefractionCommentsColumn(): void
+    {
+        foreach ([RefType::AR, RefType::MR, RefType::CR] as $refType) {
+            $this->assertSame('CRCOMMENTS', $refType->commentsColumn());
+        }
+
+        $this->assertSame('COMMENTS', RefType::W->commentsColumn());
+        $this->assertSame('COMMENTS', RefType::CTL->commentsColumn());
+    }
+
+    /**
+     * A cycloplegic refraction paralyzes accommodation and a contact lens keeps
+     * its add in the lens columns, so neither carries a spectacle add power.
+     */
+    public function testOnlyRefractionsWithAnAddPowerReportOne(): void
+    {
+        foreach ([RefType::W, RefType::AR, RefType::MR] as $refType) {
+            $this->assertTrue($refType->hasAddPower(), "{$refType->value} records an add power");
+        }
+
+        foreach ([RefType::CR, RefType::CTL] as $refType) {
+            $this->assertFalse($refType->hasAddPower(), "{$refType->value} records no add power");
+        }
+    }
 }

--- a/tests/Tests/Isolated/Forms/EyeMag/PrescriptionTypeTest.php
+++ b/tests/Tests/Isolated/Forms/EyeMag/PrescriptionTypeTest.php
@@ -16,6 +16,7 @@ namespace OpenEMR\Tests\Isolated\Forms\EyeMag;
 
 use OpenEMR\Forms\EyeMag\RefType;
 use OpenEMR\Forms\EyeMag\RxType;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class PrescriptionTypeTest extends TestCase
@@ -36,34 +37,66 @@ class PrescriptionTypeTest extends TestCase
         $labels = array_map(static fn(RefType $refType): string => $refType->displayName(), RefType::cases());
 
         $this->assertSame([], array_filter($labels, static fn(string $label): bool => $label === ''));
-        $this->assertSame(count($labels), count(array_unique($labels)));
+        $this->assertCount(count($labels), array_unique($labels));
     }
 
-    public function testUnknownRefractionMethodsDoNotResolve(): void
+    /**
+     * @return list<array{string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function unknownRefractionMethodProvider(): array
     {
-        $this->assertNull(RefType::tryFrom(''));
-        $this->assertNull(RefType::tryFrom('ctl'));
-        $this->assertNull(RefType::tryFrom('BOGUS'));
+        return [[''], ['ctl'], ['BOGUS'], ['Wearing']];
+    }
+
+    #[DataProvider('unknownRefractionMethodProvider')]
+    public function testUnknownRefractionMethodsDoNotResolve(string $value): void
+    {
+        $this->assertNull(RefType::tryFrom($value));
     }
 
     /**
      * The codes come from `form_eye_mag_wearing.RX_TYPE` and the names are what
      * the print form renders and stores in `form_eye_mag_dispense.RXTYPE`.
+     *
+     * @return list<array{string, string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
      */
-    public function testLensTypeCodesMapToTheStoredLabels(): void
+    public static function lensTypeCodeProvider(): array
     {
-        $this->assertSame('Single', RxType::from('0')->name);
-        $this->assertSame('Bifocal', RxType::from('1')->name);
-        $this->assertSame('Trifocal', RxType::from('2')->name);
-        $this->assertSame('Progressive', RxType::from('3')->name);
+        return [
+            ['0', 'Single'],
+            ['1', 'Bifocal'],
+            ['2', 'Trifocal'],
+            ['3', 'Progressive'],
+        ];
     }
 
-    public function testUnrecognizedLensCodesFallBackToSingleVision(): void
+    #[DataProvider('lensTypeCodeProvider')]
+    public function testLensTypeCodesMapToTheStoredLabels(string $code, string $label): void
     {
-        foreach (['', '4', 'Single', 'x'] as $unrecognized) {
-            $this->assertNull(RxType::tryFrom($unrecognized));
-        }
+        $this->assertSame($label, RxType::from($code)->name);
+    }
 
-        $this->assertSame(RxType::Single, RxType::DEFAULT);
+    /**
+     * @return list<array{string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function unrecognizedLensCodeProvider(): array
+    {
+        return [[''], ['4'], ['Single'], ['x']];
+    }
+
+    /**
+     * Anything the print form does not recognize has to miss, so that it falls
+     * back to {@see RxType::DEFAULT} rather than rendering a stray label.
+     */
+    #[DataProvider('unrecognizedLensCodeProvider')]
+    public function testUnrecognizedLensCodesDoNotResolve(string $code): void
+    {
+        $this->assertNull(RxType::tryFrom($code));
     }
 }

--- a/tests/Tests/Isolated/Forms/EyeMag/PrescriptionTypeTest.php
+++ b/tests/Tests/Isolated/Forms/EyeMag/PrescriptionTypeTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * Isolated tests for eye exam prescription refraction and lens types.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Forms\EyeMag;
+
+use OpenEMR\Forms\EyeMag\RefType;
+use OpenEMR\Forms\EyeMag\RxType;
+use PHPUnit\Framework\TestCase;
+
+class PrescriptionTypeTest extends TestCase
+{
+    public function testOnlyContactLensPrescriptionsAreContactLenses(): void
+    {
+        $this->assertTrue(RefType::CTL->isContactLens());
+
+        foreach (RefType::cases() as $refType) {
+            if ($refType !== RefType::CTL) {
+                $this->assertFalse($refType->isContactLens(), "{$refType->value} is not a contact lens");
+            }
+        }
+    }
+
+    public function testEveryRefractionMethodHasADistinctNonEmptyLabel(): void
+    {
+        $labels = array_map(static fn(RefType $refType): string => $refType->displayName(), RefType::cases());
+
+        $this->assertSame([], array_filter($labels, static fn(string $label): bool => $label === ''));
+        $this->assertSame(count($labels), count(array_unique($labels)));
+    }
+
+    public function testUnknownRefractionMethodsDoNotResolve(): void
+    {
+        $this->assertNull(RefType::tryFrom(''));
+        $this->assertNull(RefType::tryFrom('ctl'));
+        $this->assertNull(RefType::tryFrom('BOGUS'));
+    }
+
+    /**
+     * The codes come from `form_eye_mag_wearing.RX_TYPE` and the names are what
+     * the print form renders and stores in `form_eye_mag_dispense.RXTYPE`.
+     */
+    public function testLensTypeCodesMapToTheStoredLabels(): void
+    {
+        $this->assertSame('Single', RxType::from('0')->name);
+        $this->assertSame('Bifocal', RxType::from('1')->name);
+        $this->assertSame('Trifocal', RxType::from('2')->name);
+        $this->assertSame('Progressive', RxType::from('3')->name);
+    }
+
+    public function testUnrecognizedLensCodesFallBackToSingleVision(): void
+    {
+        foreach (['', '4', 'Single', 'x'] as $unrecognized) {
+            $this->assertNull(RxType::tryFrom($unrecognized));
+        }
+
+        $this->assertSame(RxType::Single, RxType::DEFAULT);
+    }
+}


### PR DESCRIPTION
## Summary

The eye exam form decided what to do by comparing strings against long if/elseif chains — one branch per exam zone, one per issue panel, one per refraction method. Each branch carried its own copy of the field list or the SQL, so the same column name appeared in up to three places and drifted between them. This moves that configuration onto enums, so each fact is stated once and PHPStan checks the matches are exhaustive.

New enums live in `src/Forms/EyeMag/`, so they autoload under the existing `OpenEMR\` PSR-4 mapping.

Closes #13563.

### Copy-forward (`eye_mag_functions.php`, `save.php`)

`copy_forward()` carried 400 lines of `$result['X'] = $objQuery['X']` across a branch per zone, plus a hand-maintained duplicate list for the whole-form copy. The field lists now live on a `Zone` enum, and the whole-form copy takes the union of the zones.

The request's `zone` parameter is parsed into `Zone|CopyMode` at the entry point in `save.php`, so `copy_forward()` takes an enum and an unrecognized zone can no longer fall through every branch to echo nothing. The unused `$copy_to` parameter and `global $form_id` are gone.

### PMSFH and issue quick picks (`eye_mag_functions.php`, `a_issue.php`)

`build_PMSFH()` and the `a_issue.php` quick-pick builder each branched per panel to pick an issue type, a subtype predicate and a sort order, writing the SQL out once per branch. That configuration moves onto `PmsfhPanel` and `IssueQuickPick`, with each subtype predicate paired with its binds in an `SqlFragment` so a caller cannot append one without the other. Subtype predicates and the quick-pick row limit are now bound rather than inlined as SQL literals.

Family history, social history and review of systems have no enum case — they are assembled from other sources — so they are recognized by a null lookup instead of by name in three places.

### Prescription types (`SpectacleRx.php`)

`RefType` and `RxType` replace comparisons against string literals in six places and a seven-branch chain that rebuilt each refraction method's label. "Is this a contact lens prescription", which drives both the expiry interval and which table is printed, is now a method rather than a repeated `== "CTL"`.

The five-arm chain that reads each method's measurements out of the exam record is gone too. Every refraction stored the same eight measurements under its own column prefix — `MRODSPH`, `CTLOSCYL` — so `RefType` carries the prefix along with the two other per-method facts those branches encoded: which column the comments come from, and whether the method records an add power. What is left is the wearing case, which reads a different table, plus one prefix-driven block.

The four-way chain that set the lens-type radio buttons in the dispensed history reproduced the selection the print path already computes. `RxType` now resolves the label the dispense table stores — it records the name where `form_eye_mag_wearing` records the numeric code — and answers which button is checked, so both call sites go through it.

### Legacy SQL wrappers

The paths this PR touches no longer call `sqlStatement()`, `sqlFetchArray()`, `sqlNumRows()` or `sqlQuery()`. The wearing lookup and the copy-forward record become `QueryUtils::querySingleRow()`, the dispense column list becomes `QueryUtils::listTableFields()`, and the dispensed history and the PMSFH issue list become `QueryUtils::fetchRecords()`. Multi-line queries move to nowdocs.

## Behavior changes

Most of these are cases where the duplicated lists had drifted apart. The new field lists were checked against the old if/elseif chain with a PHP-Parser script before the old code was removed, so nothing real is dropped — the one removal below is of column names that never existed.

- Copying the external exam forward now carries `ODHERTEL`. Its `OS` counterpart and the base measurement were already carried.
- The whole-form copy now carries the carotid, temporal artery, cranial nerve, Schirmer and tear break-up fields. The individual zones already carried them.
- The quick-pick loop no longer reuses the previous panel's result set for a key it does not recognize. `$qry` was never reset between iterations, so an unrecognized key re-emitted the previous panel's options.
- Copy-forward no longer echoes the record query or a duplicate copy of the payload back to the browser. Nothing reads either.
- Copy-forward no longer carries `ODPIC`, `OSPIC`, `ODDRAWING` or `OSDRAWING`. They are not columns of any `form_eye_*` table and appear nowhere else in the codebase, so the old chain read them off the record and got undefined-index notices for its trouble.
- A `REFTYPE` the form does not recognize no longer reaches the dispense insert with every field at its blank default, writing an empty prescription record.
- A database error in one of the converted queries now raises `SqlQueryException` instead of taking the legacy die-with-message path.

## Static analysis

Reading the copy-forward record through a helper that takes an array drops 326 `offsetAccess.nonOffsetAccessible` baseline entries — one per field the old chain read off an `array|false` return — and the legacy-SQL conversions drop 26 more, for 369 across the whole baseline. Every baseline file's count goes down; no new entries.

## Test plan

57 isolated tests cover the enums, the field-list invariants and the query construction. They run without a database:

```
composer phpunit-isolated -- --filter EyeMag
```

Manual verification against the form:

- [ ] Copy forward each zone (EXT, ANTSEG, RETINA, NEURO) and confirm the fields populate
- [ ] Copy forward IMPPLAN, ALL and READONLY
- [ ] Confirm each PMSFH panel lists the right issues, and that Surgery reads most-recent-first
- [ ] Confirm the quick-pick lists populate for a provider with recent history and for one without
- [ ] Print a prescription for each of W, AR, MR, CR and CTL, and confirm the refraction method label, the measurements, and the expiry date
- [ ] Print a contact lens prescription and confirm the lens geometry and the brand/manufacturer/supplier labels
- [ ] Open the Rx History and confirm each row shows the right lens type selected
