### PR TITLE
fix(phpstan): indent size for neon files at .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
 
-[*.{json,jsn,sh,yaml,yml}]
+[*.{json,jsn,sh,yaml,yml,neon,neon.dist}]
 indent_size = 2
 
 [composer.{json,lock}]


### PR DESCRIPTION
Related: https://github.com/openemr/openemr/issues/10078
Related: https://github.com/openemr/openemr/issues/10077

Draft reason - we should decide which formatting suit best for us first. I have feeling we should migrate to php (for performance reasons) and this PR will be not needed.