### PR TITLE
fix: js error when samesite param missing

### DIFF
--- a/library/restoreSession.php
+++ b/library/restoreSession.php
@@ -34,7 +34,7 @@ var oemr_scp_lifetime = <?php echo js_escape($scparams['lifetime']); ?>;
 var oemr_scp_path = <?php echo js_escape($scparams['path']); ?>;
 var oemr_scp_domain = <?php echo js_escape($scparams['domain']); ?>;
 var oemr_scp_secure = <?php echo js_escape($scparams['secure']); ?>;
-var oemr_scp_samesite = <?php echo empty($scparams['samesite']) ? '' : js_escape($scparams['samesite']); ?>;
+var oemr_scp_samesite = <?php echo empty($scparams['samesite']) ? 'false' : js_escape($scparams['samesite']); ?>;
 var oemr_cookie = '';
 var oemr_change_count = 0; // debugging
 


### PR DESCRIPTION
Fixes #10096

#### Short description of what this resolves:

Fixes a JavaScript syntax error that occurs when the session cookie `samesite` parameter is empty or not set. The generated JavaScript was outputting an empty value without quotes, resulting in invalid syntax.

#### Changes proposed in this pull request:

- Changed the fallback value from empty string `''` to string `'false'` when `$scparams['samesite']` is empty in `library/restoreSession.php`

#### Does your code include anything generated by an AI Engine? Yes / No

No

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code. Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.

N/A