### PR TITLE
fix(pre-commit): exclude vendored third-party bundles from hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,50 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
-exclude: (^|/)(composer\.lock|package-lock\.json)$|\.min\.(js|css)$|\.js\.map$|\.css\.map$
+#
+# Exclusions:
+#   - Lock files (generated): composer.lock, package-lock.json
+#   - Minified files: *.min.js, *.min.css, *-min.js, *-min.css
+#   - Source maps: *.js.map, *.css.map
+#   - Vendored/generated third-party code (alphabetized):
+#     - Documentation/EHI_Export/ (SchemaSpy + bower components)
+#     - gacl/ (phpGACL library)
+#     - interface/forms/eye_mag/js/shortcut.js-2-01-B/ (keyboard shortcut library)
+#     - interface/forms/questionnaire_assessments/lforms/ (LHC-Forms library)
+#     - interface/modules/custom_modules/oe-module-comlink-telehealth/public/assets/js/dist/ (webpack build)
+#     - interface/modules/zend_modules/public/js/lib/ (jQuery + plugins)
+#     - interface/modules/zend_modules/public/xsd/ (HL7 CDA schemas)
+#     - interface/modules/zend_modules/public/xsl/ (XSL transformations)
+#     - interface/super/rules/www/js/cdr-multiselect/ (jQuery multiselect plugins)
+#     - library/classes/fpdf/ (FPDF library)
+#     - library/fonts/ (Adobe font metrics files)
+#     - library/js/{Category,Document}TreeMenu.js, SearchHighlight.js (vendored plugins)
+#     - library/smarty_legacy/ (Smarty template engine)
+#     - public/assets/modified/ (modified third-party libs)
+#     - swagger/ (Swagger UI distribution)
+exclude: |
+  (?x)^(
+    # Lock files (generated)
+    (.*/)?(composer\.lock|package-lock\.json)$|
+    # Minified files and source maps
+    .*[.\-]min\.(js|css)$|
+    .*\.(js|css)\.map$|
+    # Vendored/generated third-party code (alphabetized)
+    Documentation/EHI_Export/|
+    gacl/|
+    interface/forms/eye_mag/js/shortcut\.js-2-01-B/|
+    interface/forms/questionnaire_assessments/lforms/|
+    interface/modules/custom_modules/oe-module-comlink-telehealth/public/assets/js/dist/|
+    interface/modules/zend_modules/public/js/lib/|
+    interface/modules/zend_modules/public/xsd/|
+    interface/modules/zend_modules/public/xsl/|
+    interface/super/rules/www/js/cdr-multiselect/|
+    library/classes/fpdf/|
+    library/fonts/|
+    library/js/(CategoryTreeMenu|DocumentTreeMenu|SearchHighlight)\.js$|
+    library/smarty_legacy/|
+    public/assets/modified/|
+    swagger/
+  )
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.5.0


### PR DESCRIPTION
## Summary

- Exclude vendored third-party bundles from pre-commit hooks (whitespace, yaml, json formatters)
- Add pattern for `*-min.js` files (alternate minification naming convention)
- Add documentation comments explaining the exclusion categories
- Use extended regex mode with inline comments for maintainability

## Excluded Directories/Files (alphabetized)

| Path | Description |
|------|-------------|
| `Documentation/EHI_Export/` | SchemaSpy + bower components (1634 files) |
| `gacl/` | phpGACL library (Mike Benoit) |
| `interface/forms/eye_mag/js/shortcut.js-2-01-B/` | Keyboard shortcut library |
| `interface/forms/questionnaire_assessments/lforms/` | LHC-Forms library webpack bundle |
| `interface/modules/custom_modules/oe-module-comlink-telehealth/public/assets/js/dist/` | Webpack build output |
| `interface/modules/zend_modules/public/js/lib/` | jQuery + plugins |
| `interface/modules/zend_modules/public/xsd/` | HL7 CDA schemas |
| `interface/modules/zend_modules/public/xsl/` | XSL transformations |
| `interface/super/rules/www/js/cdr-multiselect/` | jQuery multiselect plugins |
| `library/classes/fpdf/` | FPDF library |
| `library/fonts/` | Adobe font metrics files (AFM) |
| `library/js/{Category,Document}TreeMenu.js, SearchHighlight.js` | Vendored JS plugins |
| `library/smarty_legacy/` | Smarty template engine |
| `public/assets/modified/` | Modified third-party libs (dygraphs) |
| `swagger/` | Swagger UI distribution |

## Also Excluded (patterns)

- `*.min.js`, `*.min.css` - minified files
- `*-min.js`, `*-min.css` - alternate minification naming
- `*.js.map`, `*.css.map` - source maps
- `composer.lock`, `package-lock.json` - lock files

## Benefits

1. Prevents unnecessary diffs from upstream packages
2. Avoids potentially breaking vendored code with whitespace changes
3. Reduces CI time on files that shouldn't be modified

Note: Manual OpenEMR code in sibling directories is still checked.

## Test plan

- [x] Verified YAML syntax is valid
- [x] Tested regex pattern matches expected files and excludes manual code
- [x] Ran `pre-commit run -a` locally to verify remaining files are OpenEMR code

Fixes #10105

🤖 Generated with [Claude Code](https://claude.com/claude-code)