### PR TITLE
fix: deselect initial empty option in generate_select_list

### DIFF
--- a/library/options.inc.php
+++ b/library/options.inc.php
@@ -23,7 +23,7 @@
  * @copyright Copyright (c) 2026 Stephen Waite <stephen.waite@open-emr.org>
  * @copyright 2026 OpenCoreEMR Inc
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
- * 
+ *
  * Note: there are translation wrappers for the lists and layout labels
  * at library/translation.inc.php. The functions are titled xl_list_label()
  * and xl_layout_label() and are controlled by the $GLOBALS['translate_lists']


### PR DESCRIPTION
<!--Thanks for sending a pull request!
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #10112 

#### Short description of what this resolves:


#### Changes proposed in this pull request:

#### Does your code include anything generated by an AI Engine?  No

