### PR TITLE
Update node versions php-fpm dockers Fixes #10022

### DIFF
--- a/docker/library/dockers/dev-php-fpm-8-1-redis/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-1-redis/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
                        mariadb-client
 
 # Install correct version nodejs
-RUN curl -sL https://deb.nodesource.com/setup_20.x \
+RUN curl -sL https://deb.nodesource.com/setup_22.x \
   | bash - \
  && apt-get update \
  && apt-get install -y nodejs

--- a/docker/library/dockers/dev-php-fpm-8-1/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-1/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
                        mariadb-client
 
 # Install correct version nodejs
-RUN curl -sL https://deb.nodesource.com/setup_20.x \
+RUN curl -sL https://deb.nodesource.com/setup_22.x \
   | bash - \
  && apt-get update \
  && apt-get install -y nodejs

--- a/docker/library/dockers/dev-php-fpm-8-2-redis/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-2-redis/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
                        mariadb-client
 
 # Install correct version nodejs
-RUN curl -sL https://deb.nodesource.com/setup_20.x \
+RUN curl -sL https://deb.nodesource.com/setup_22.x \
   | bash - \
  && apt-get update \
  && apt-get install -y nodejs

--- a/docker/library/dockers/dev-php-fpm-8-2/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-2/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
                        mariadb-client
 
 # Install correct version nodejs
-RUN curl -sL https://deb.nodesource.com/setup_20.x \
+RUN curl -sL https://deb.nodesource.com/setup_22.x \
   | bash - \
  && apt-get update \
  && apt-get install -y nodejs

--- a/docker/library/dockers/dev-php-fpm-8-3-redis/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-3-redis/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
                        mariadb-client
 
 # Install correct version nodejs
-RUN curl -sL https://deb.nodesource.com/setup_20.x \
+RUN curl -sL https://deb.nodesource.com/setup_22.x \
   | bash - \
  && apt-get update \
  && apt-get install -y nodejs

--- a/docker/library/dockers/dev-php-fpm-8-3/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-3/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
                        mariadb-client
 
 # Install correct version nodejs
-RUN curl -sL https://deb.nodesource.com/setup_20.x \
+RUN curl -sL https://deb.nodesource.com/setup_22.x \
   | bash - \
  && apt-get update \
  && apt-get install -y nodejs

--- a/docker/library/dockers/dev-php-fpm-8-4-redis/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-4-redis/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
                        mariadb-client
 
 # Install correct version nodejs
-RUN curl -sL https://deb.nodesource.com/setup_20.x \
+RUN curl -sL https://deb.nodesource.com/setup_22.x \
   | bash - \
  && apt-get update \
  && apt-get install -y nodejs

--- a/docker/library/dockers/dev-php-fpm-8-4/Dockerfile
+++ b/docker/library/dockers/dev-php-fpm-8-4/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
                        mariadb-client
 
 # Install correct version nodejs
-RUN curl -sL https://deb.nodesource.com/setup_20.x \
+RUN curl -sL https://deb.nodesource.com/setup_22.x \
   | bash - \
  && apt-get update \
  && apt-get install -y nodejs


### PR DESCRIPTION
The php-fpm dockers were failing on the node ccda tests. This bumps the node version up to be the same as whats in the 8.5/8.6 php-fpm docker images.

Fixes #10022 