### PR TITLE
feat(ci): add SQL linting with sqruff

### DIFF
--- a/.config/sqruff/.sqruff
+++ b/.config/sqruff/.sqruff
@@ -1,0 +1,18 @@
+[sqruff]
+dialect = mysql
+
+# Disable layout rules that conflict with standard MySQL style
+# LT01: Spacing - wants `varchar (255)` instead of `varchar(255)`
+# LT02: Indent - flags indented column definitions in CREATE TABLE
+# LT05: Long lines - 80 char limit too restrictive for DDL
+# LT06: Function spacing - similar to LT01
+# LT12: End of file newline - some files may not have trailing newline
+exclude_rules = LT01, LT02, LT05, LT06, LT12
+
+# Increase line length if we re-enable LT05 later
+[layout.long_lines]
+max_line_length = 200
+
+# Enforce uppercase SQL keywords (SELECT, FROM, WHERE, etc.)
+[sqruff:rules:capitalisation.keywords]
+capitalisation_policy = upper

--- a/.config/sqruff/check-php-sql-baseline.php
+++ b/.config/sqruff/check-php-sql-baseline.php
@@ -1,0 +1,220 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Check SQL embedded in PHP files against baseline
+ *
+ * Compares current lint errors against the baseline file. Only reports errors
+ * that exceed the baseline counts, allowing gradual improvement without
+ * requiring all issues to be fixed at once.
+ *
+ * Note: This wrapper can be replaced if sqruff implements native baseline support.
+ * See: https://github.com/quarylabs/sqruff/issues/2139
+ *
+ * @package   OpenEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+use Symfony\Component\Yaml\Yaml;
+
+(new SingleCommandApplication())
+    ->setName('check-php-sql-baseline')
+    ->setDescription('Check PHP embedded SQL against baseline (only fail on new errors)')
+    ->addArgument('files', InputArgument::IS_ARRAY, 'PHP files to check (default: all .php files)')
+    ->addOption('baseline', 'b', InputOption::VALUE_REQUIRED, 'Baseline file path', '.config/sqruff/sql-baseline.yaml')
+    ->addOption('format', 'f', InputOption::VALUE_REQUIRED, 'Output format (json|github)', 'json')
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        $files = $input->getArgument('files');
+        $baselinePath = $input->getOption('baseline');
+        $format = $input->getOption('format');
+        $configPath = __DIR__ . '/.sqruff';
+        $extractorPath = __DIR__ . '/extract-sql-from-php.php';
+
+        // Load baseline
+        $baseline = [];
+        if (file_exists($baselinePath)) {
+            $baseline = Yaml::parseFile($baselinePath);
+        }
+
+        $newErrors = [];
+        $improvements = [];
+
+        // If no files specified, scan all PHP files
+        if (empty($files)) {
+            $files = array_filter(explode("\0", trim(shell_exec("git ls-files -z '*.php' '*.inc'") ?? '')));
+        }
+
+        foreach ($files as $file) {
+            if (empty($file) || !file_exists($file)) {
+                continue;
+            }
+
+            if (!str_ends_with($file, '.php') && !str_ends_with($file, '.inc')) {
+                continue;
+            }
+
+            // Extract SQL from PHP file
+            $extractOutput = shell_exec("php " . escapeshellarg($extractorPath) . " " . escapeshellarg($file) . " --json 2>/dev/null");
+            if (empty($extractOutput)) {
+                // No SQL found - check if baseline expected some (improvement)
+                if (!empty($baseline[$file])) {
+                    foreach ($baseline[$file] as $code => $count) {
+                        $improvements[] = [
+                            'file' => $file,
+                            'code' => $code,
+                            'baseline' => $count,
+                            'current' => 0,
+                            'reduced' => $count,
+                        ];
+                    }
+                }
+                continue;
+            }
+
+            $statements = json_decode($extractOutput, true);
+            if (empty($statements)) {
+                continue;
+            }
+
+            // Collect all errors for this file
+            $fileErrors = [];
+
+            foreach ($statements as $stmt) {
+                $sql = $stmt['sql'];
+                if (!preg_match('/;\s*$/', $sql)) {
+                    $sql .= ';';
+                }
+
+                $descriptors = [
+                    0 => ['pipe', 'r'],
+                    1 => ['pipe', 'w'],
+                    2 => ['pipe', 'w'],
+                ];
+
+                $process = proc_open(
+                    'sqruff lint --config ' . escapeshellarg($configPath) . ' - --dialect mysql -f json',
+                    $descriptors,
+                    $pipes
+                );
+
+                if (!is_resource($process)) {
+                    continue;
+                }
+
+                fwrite($pipes[0], $sql);
+                fclose($pipes[0]);
+
+                $lintOutput = stream_get_contents($pipes[1]);
+                fclose($pipes[1]);
+                fclose($pipes[2]);
+                proc_close($process);
+
+                $lintResults = json_decode($lintOutput, true);
+                if (empty($lintResults) || empty($lintResults['<string>'])) {
+                    continue;
+                }
+
+                foreach ($lintResults['<string>'] as $error) {
+                    $fileErrors[] = [
+                        'code' => $error['code'],
+                        'message' => $error['message'],
+                        'line' => $stmt['line'],
+                    ];
+                }
+            }
+
+            // Count current errors by rule
+            $currentCounts = [];
+            foreach ($fileErrors as $error) {
+                $code = $error['code'];
+                $currentCounts[$code] = ($currentCounts[$code] ?? 0) + 1;
+            }
+
+            $baselineCounts = $baseline[$file] ?? [];
+
+            // Check for new errors (exceeding baseline)
+            foreach ($currentCounts as $code => $count) {
+                $allowed = $baselineCounts[$code] ?? 0;
+                if ($count > $allowed) {
+                    $excess = $count - $allowed;
+                    $reported = 0;
+                    foreach ($fileErrors as $error) {
+                        if ($error['code'] === $code && $reported < $excess) {
+                            $newErrors[] = [
+                                'file' => $file,
+                                'line' => $error['line'],
+                                'code' => $code,
+                                'message' => $error['message'],
+                                'baseline' => $allowed,
+                                'current' => $count,
+                            ];
+                            $reported++;
+                        }
+                    }
+                }
+            }
+
+            // Track improvements
+            foreach ($baselineCounts as $code => $allowed) {
+                $current = $currentCounts[$code] ?? 0;
+                if ($current < $allowed) {
+                    $improvements[] = [
+                        'file' => $file,
+                        'code' => $code,
+                        'baseline' => $allowed,
+                        'current' => $current,
+                        'reduced' => $allowed - $current,
+                    ];
+                }
+            }
+        }
+
+        if ($format === 'github') {
+            foreach ($newErrors as $error) {
+                $output->writeln(sprintf(
+                    "::error file=%s,line=%d,title=sqruff::%s: %s (baseline: %d, current: %d)",
+                    $error['file'],
+                    $error['line'],
+                    $error['code'],
+                    $error['message'],
+                    $error['baseline'],
+                    $error['current']
+                ));
+            }
+            foreach ($improvements as $imp) {
+                $output->writeln(sprintf(
+                    "::notice file=%s,title=baseline improvement::%s reduced from %d to %d (-%d)",
+                    $imp['file'],
+                    $imp['code'],
+                    $imp['baseline'],
+                    $imp['current'],
+                    $imp['reduced']
+                ));
+            }
+        } else {
+            $result = [
+                'new_errors' => $newErrors,
+                'improvements' => $improvements,
+                'summary' => [
+                    'new_error_count' => count($newErrors),
+                    'files_improved' => count(array_unique(array_column($improvements, 'file'))),
+                    'total_reductions' => array_sum(array_column($improvements, 'reduced')),
+                ],
+            ];
+            $output->writeln(json_encode($result, JSON_PRETTY_PRINT));
+        }
+
+        return count($newErrors) > 0 ? Command::FAILURE : Command::SUCCESS;
+    })
+    ->run();

--- a/.config/sqruff/check-sql-baseline.php
+++ b/.config/sqruff/check-sql-baseline.php
@@ -1,0 +1,153 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Check SQL lint errors against baseline
+ *
+ * Compares current lint errors against the baseline file. Only reports errors
+ * that exceed the baseline counts, allowing gradual improvement without
+ * requiring all issues to be fixed at once.
+ *
+ * Note: This wrapper can be replaced if sqruff implements native baseline support.
+ * See: https://github.com/quarylabs/sqruff/issues/2139
+ *
+ * @package   OpenEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+use Symfony\Component\Yaml\Yaml;
+
+(new SingleCommandApplication())
+    ->setName('check-sql-baseline')
+    ->setDescription('Check SQL files against baseline (only fail on new errors)')
+    ->addArgument('files', InputArgument::IS_ARRAY, 'SQL files to check (default: all .sql files)')
+    ->addOption('baseline', 'b', InputOption::VALUE_REQUIRED, 'Baseline file path', '.config/sqruff/sql-baseline.yaml')
+    ->addOption('format', 'f', InputOption::VALUE_REQUIRED, 'Output format (json|github)', 'json')
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        $files = $input->getArgument('files');
+        $baselinePath = $input->getOption('baseline');
+        $format = $input->getOption('format');
+        $configPath = __DIR__ . '/.sqruff';
+
+        // Load baseline
+        $baseline = [];
+        if (file_exists($baselinePath)) {
+            $baseline = Yaml::parseFile($baselinePath);
+        }
+
+        $newErrors = [];
+        $improvements = [];
+
+        // If no files specified, scan all
+        if (empty($files)) {
+            $files = array_filter(explode("\0", trim(shell_exec("git ls-files -z '*.sql'") ?? '')));
+        }
+
+        foreach ($files as $file) {
+            if (empty($file) || !file_exists($file)) {
+                continue;
+            }
+
+            if (!str_ends_with($file, '.sql')) {
+                continue;
+            }
+
+            $lintOutput = shell_exec("sqruff lint --config " . escapeshellarg($configPath) . " " . escapeshellarg($file) . " -f json 2>/dev/null");
+            $results = json_decode($lintOutput ?: '{}', true);
+            $errors = $results[$file] ?? [];
+
+            // Count current errors by rule
+            $currentCounts = [];
+            foreach ($errors as $error) {
+                $code = $error['code'];
+                $currentCounts[$code] = ($currentCounts[$code] ?? 0) + 1;
+            }
+
+            $baselineCounts = $baseline[$file] ?? [];
+
+            // Check for new errors (exceeding baseline)
+            foreach ($currentCounts as $code => $count) {
+                $allowed = $baselineCounts[$code] ?? 0;
+                if ($count > $allowed) {
+                    $excess = $count - $allowed;
+                    $reported = 0;
+                    foreach ($errors as $error) {
+                        if ($error['code'] === $code && $reported < $excess) {
+                            $newErrors[] = [
+                                'file' => $file,
+                                'line' => $error['range']['start']['line'] ?? 1,
+                                'code' => $code,
+                                'message' => $error['message'],
+                                'baseline' => $allowed,
+                                'current' => $count,
+                            ];
+                            $reported++;
+                        }
+                    }
+                }
+            }
+
+            // Track improvements
+            foreach ($baselineCounts as $code => $allowed) {
+                $current = $currentCounts[$code] ?? 0;
+                if ($current < $allowed) {
+                    $improvements[] = [
+                        'file' => $file,
+                        'code' => $code,
+                        'baseline' => $allowed,
+                        'current' => $current,
+                        'reduced' => $allowed - $current,
+                    ];
+                }
+            }
+        }
+
+        if ($format === 'github') {
+            foreach ($newErrors as $error) {
+                $output->writeln(sprintf(
+                    "::error file=%s,line=%d,title=sqruff::%s: %s (baseline: %d, current: %d)",
+                    $error['file'],
+                    $error['line'],
+                    $error['code'],
+                    $error['message'],
+                    $error['baseline'],
+                    $error['current']
+                ));
+            }
+            foreach ($improvements as $imp) {
+                $output->writeln(sprintf(
+                    "::notice file=%s,title=baseline improvement::%s reduced from %d to %d (-%d)",
+                    $imp['file'],
+                    $imp['code'],
+                    $imp['baseline'],
+                    $imp['current'],
+                    $imp['reduced']
+                ));
+            }
+        } else {
+            $result = [
+                'new_errors' => $newErrors,
+                'improvements' => $improvements,
+                'summary' => [
+                    'new_error_count' => count($newErrors),
+                    'files_improved' => count(array_unique(array_column($improvements, 'file'))),
+                    'total_reductions' => array_sum(array_column($improvements, 'reduced')),
+                ],
+            ];
+            $output->writeln(json_encode($result, JSON_PRETTY_PRINT));
+        }
+
+        return count($newErrors) > 0 ? Command::FAILURE : Command::SUCCESS;
+    })
+    ->run();

--- a/.config/sqruff/extract-sql-from-php.php
+++ b/.config/sqruff/extract-sql-from-php.php
@@ -1,0 +1,223 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Extract SQL strings from PHP files for linting using AST parsing
+ *
+ * Usage: php extract-sql-from-php.php <file.php> [--json]
+ *        php extract-sql-from-php.php <file.php> | sqruff lint - --dialect mysql -f json
+ *
+ * @package   OpenEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+use PhpParser\ParserFactory;
+use PhpParser\PhpVersion;
+
+if ($argc < 2) {
+    fwrite(STDERR, "Usage: {$argv[0]} <file.php> [--json]\n");
+    exit(1);
+}
+
+$file = $argv[1];
+$jsonOutput = in_array('--json', $argv);
+
+if (!file_exists($file)) {
+    fwrite(STDERR, "File not found: $file\n");
+    exit(1);
+}
+
+// SQL-executing functions to look for
+$sqlFunctions = [
+    'sqlStatement',
+    'sqlStatementNoLog',
+    'sqlStatementThrowException',
+    'sqlQuery',
+    'sqlQueryNoLog',
+    'sqlInsert',
+    'sqlFetchArray',
+];
+
+// Static methods on QueryUtils
+$sqlStaticMethods = [
+    'QueryUtils' => ['fetchRecords', 'fetchRecordsNoLog', 'sqlStatementThrowException', 'fetchTableColumn'],
+];
+
+// ADODB method calls: $db->Execute($sql), $db->GetOne($sql), etc.
+$adodbMethods = [
+    'Execute',
+    'GetOne',
+    'GetAll',
+    'GetRow',
+];
+
+class SqlExtractorVisitor extends NodeVisitorAbstract
+{
+    public array $results = [];
+    private string $file;
+    private array $sqlFunctions;
+    private array $sqlStaticMethods;
+    private array $adodbMethods;
+
+    public function __construct(string $file, array $sqlFunctions, array $sqlStaticMethods, array $adodbMethods)
+    {
+        $this->file = $file;
+        $this->sqlFunctions = $sqlFunctions;
+        $this->sqlStaticMethods = $sqlStaticMethods;
+        $this->adodbMethods = $adodbMethods;
+    }
+
+    public function enterNode(Node $node)
+    {
+        // Check for function calls: sqlStatement($sql, ...)
+        if ($node instanceof Node\Expr\FuncCall) {
+            if ($node->name instanceof Node\Name) {
+                $funcName = $node->name->toString();
+                if (in_array($funcName, $this->sqlFunctions) && !empty($node->args)) {
+                    $this->extractSqlFromArg($node->args[0], $node->getStartLine());
+                }
+            }
+        }
+
+        // Check for static method calls: QueryUtils::fetchRecords($sql, ...)
+        if ($node instanceof Node\Expr\StaticCall) {
+            if ($node->class instanceof Node\Name && $node->name instanceof Node\Identifier) {
+                $className = $node->class->toString();
+                $methodName = $node->name->toString();
+
+                // Check short name (QueryUtils) or full name
+                $shortClass = basename(str_replace('\\', '/', $className));
+                if (isset($this->sqlStaticMethods[$shortClass])) {
+                    if (in_array($methodName, $this->sqlStaticMethods[$shortClass]) && !empty($node->args)) {
+                        $this->extractSqlFromArg($node->args[0], $node->getStartLine());
+                    }
+                }
+            }
+        }
+
+        // Check for ADODB method calls: $db->Execute($sql), $db->GetOne($sql), etc.
+        if ($node instanceof Node\Expr\MethodCall) {
+            if ($node->name instanceof Node\Identifier) {
+                $methodName = $node->name->toString();
+                if (in_array($methodName, $this->adodbMethods) && !empty($node->args)) {
+                    $this->extractSqlFromArg($node->args[0], $node->getStartLine());
+                }
+            }
+        }
+
+        // Check for variable assignments: $sql = "SELECT ..."
+        if ($node instanceof Node\Expr\Assign) {
+            if ($node->var instanceof Node\Expr\Variable && $node->var->name === 'sql') {
+                $this->extractSqlFromExpr($node->expr, $node->getStartLine());
+            }
+        }
+
+        return null;
+    }
+
+    private function extractSqlFromArg(Node\Arg $arg, int $line): void
+    {
+        $this->extractSqlFromExpr($arg->value, $line);
+    }
+
+    private function extractSqlFromExpr(Node\Expr $expr, int $line): void
+    {
+        $sql = $this->resolveStringExpr($expr);
+        if ($sql !== null && $this->looksLikeSql($sql)) {
+            $this->results[] = [
+                'file' => $this->file,
+                'line' => $line,
+                'sql' => $sql,
+            ];
+        }
+    }
+
+    private function resolveStringExpr(Node\Expr $expr): ?string
+    {
+        // Simple string literal
+        if ($expr instanceof Node\Scalar\String_) {
+            return $expr->value;
+        }
+
+        // String concatenation
+        if ($expr instanceof Node\Expr\BinaryOp\Concat) {
+            $left = $this->resolveStringExpr($expr->left);
+            $right = $this->resolveStringExpr($expr->right);
+            if ($left !== null && $right !== null) {
+                return $left . $right;
+            }
+            // If one side has a variable, use placeholder
+            if ($left !== null) {
+                return $left . '?';
+            }
+            if ($right !== null) {
+                return '?' . $right;
+            }
+        }
+
+        // Interpolated string - try to extract the literal parts
+        if ($expr instanceof Node\Scalar\InterpolatedString) {
+            $result = '';
+            foreach ($expr->parts as $part) {
+                if ($part instanceof Node\InterpolatedStringPart) {
+                    $result .= $part->value;
+                } else {
+                    $result .= '?'; // placeholder for variables
+                }
+            }
+            return $result;
+        }
+
+        // Variable - can't resolve
+        return null;
+    }
+
+    private function looksLikeSql(string $str): bool
+    {
+        $keywords = ['SELECT', 'INSERT', 'UPDATE', 'DELETE', 'CREATE', 'ALTER', 'DROP', 'SHOW', 'DESCRIBE', 'REPLACE'];
+        $upper = strtoupper(trim($str));
+        foreach ($keywords as $keyword) {
+            if (strpos($upper, $keyword) === 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+$code = file_get_contents($file);
+$parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 2));
+
+try {
+    $ast = $parser->parse($code);
+} catch (PhpParser\Error $e) {
+    fwrite(STDERR, "Parse error in $file: " . $e->getMessage() . "\n");
+    exit(1);
+}
+
+$traverser = new NodeTraverser();
+$visitor = new SqlExtractorVisitor($file, $sqlFunctions, $sqlStaticMethods, $adodbMethods);
+$traverser->addVisitor($visitor);
+$traverser->traverse($ast);
+
+if ($jsonOutput) {
+    echo json_encode($visitor->results, JSON_PRETTY_PRINT) . "\n";
+} else {
+    foreach ($visitor->results as $i => $result) {
+        $sql = $result['sql'];
+        if (!preg_match('/;\s*$/', $sql)) {
+            $sql .= ';';
+        }
+        // Output with comment showing source location
+        // sqruff will report line numbers relative to this output
+        echo "-- sqruff-source: {$result['file']}:{$result['line']}\n";
+        echo $sql . "\n\n";
+    }
+}

--- a/.config/sqruff/generate-sql-baseline.php
+++ b/.config/sqruff/generate-sql-baseline.php
@@ -1,0 +1,163 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Generate SQL lint baseline file
+ *
+ * Scans SQL files and PHP files with embedded SQL, counts errors per file per rule,
+ * and outputs a YAML baseline file that can be used to track progress.
+ *
+ * Note: This wrapper can be replaced if sqruff implements native baseline support.
+ * See: https://github.com/quarylabs/sqruff/issues/2139
+ *
+ * @package   OpenEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+use Symfony\Component\Yaml\Yaml;
+
+(new SingleCommandApplication())
+    ->setName('generate-sql-baseline')
+    ->setDescription('Generate SQL lint baseline file from current codebase state')
+    ->addOption('output', 'o', InputOption::VALUE_REQUIRED, 'Output file path', '.config/sqruff/sql-baseline.yaml')
+    ->addOption('sql-only', null, InputOption::VALUE_NONE, 'Only scan .sql files (skip PHP)')
+    ->addOption('php-only', null, InputOption::VALUE_NONE, 'Only scan PHP files (skip .sql)')
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        $outputPath = $input->getOption('output');
+        $sqlOnly = $input->getOption('sql-only');
+        $phpOnly = $input->getOption('php-only');
+        $configPath = __DIR__ . '/.sqruff';
+        $extractorPath = __DIR__ . '/extract-sql-from-php.php';
+
+        $baseline = [];
+
+        // Lint .sql files
+        if (!$phpOnly) {
+            $output->writeln('<info>Scanning .sql files...</info>');
+            $sqlFiles = explode("\0", trim(shell_exec("git ls-files -z '*.sql'") ?? ''));
+            $sqlFiles = array_filter($sqlFiles);
+
+            if (!empty($sqlFiles)) {
+                $cmd = 'sqruff lint --config ' . escapeshellarg($configPath) . ' -f json ' . implode(' ', array_map('escapeshellarg', $sqlFiles)) . ' 2>/dev/null';
+                $lintOutput = shell_exec($cmd);
+
+                if (!empty($lintOutput)) {
+                    $results = json_decode($lintOutput, true);
+                    if (is_array($results)) {
+                        foreach ($results as $file => $errors) {
+                            if (empty($errors)) {
+                                continue;
+                            }
+                            $counts = [];
+                            foreach ($errors as $error) {
+                                $code = $error['code'];
+                                $counts[$code] = ($counts[$code] ?? 0) + 1;
+                            }
+                            if (!empty($counts)) {
+                                ksort($counts);
+                                $baseline[$file] = $counts;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Lint SQL in PHP files
+        if (!$sqlOnly) {
+            $output->writeln('<info>Scanning PHP files for embedded SQL...</info>');
+            $phpFiles = explode("\0", trim(shell_exec("git ls-files -z '*.php' '*.inc'") ?? ''));
+            $phpFiles = array_filter($phpFiles);
+
+            foreach ($phpFiles as $file) {
+                if (empty($file)) {
+                    continue;
+                }
+
+                $extractOutput = shell_exec("php " . escapeshellarg($extractorPath) . " " . escapeshellarg($file) . " --json 2>/dev/null");
+                if (empty($extractOutput)) {
+                    continue;
+                }
+
+                $statements = json_decode($extractOutput, true);
+                if (empty($statements)) {
+                    continue;
+                }
+
+                $counts = [];
+                foreach ($statements as $stmt) {
+                    $sql = $stmt['sql'];
+                    if (!preg_match('/;\s*$/', $sql)) {
+                        $sql .= ';';
+                    }
+
+                    $descriptors = [
+                        0 => ['pipe', 'r'],
+                        1 => ['pipe', 'w'],
+                        2 => ['pipe', 'w'],
+                    ];
+
+                    $process = proc_open(
+                        'sqruff lint --config ' . escapeshellarg($configPath) . ' - --dialect mysql -f json',
+                        $descriptors,
+                        $pipes
+                    );
+
+                    if (!is_resource($process)) {
+                        continue;
+                    }
+
+                    fwrite($pipes[0], $sql);
+                    fclose($pipes[0]);
+
+                    $lintOutput = stream_get_contents($pipes[1]);
+                    fclose($pipes[1]);
+                    fclose($pipes[2]);
+                    proc_close($process);
+
+                    $lintResults = json_decode($lintOutput, true);
+                    if (empty($lintResults) || empty($lintResults['<string>'])) {
+                        continue;
+                    }
+
+                    foreach ($lintResults['<string>'] as $error) {
+                        $code = $error['code'];
+                        $counts[$code] = ($counts[$code] ?? 0) + 1;
+                    }
+                }
+
+                if (!empty($counts)) {
+                    ksort($counts);
+                    $baseline[$file] = $counts;
+                }
+            }
+        }
+
+        ksort($baseline);
+
+        $yaml = Yaml::dump($baseline, 2, 2);
+        file_put_contents($outputPath, $yaml);
+
+        $totalFiles = count($baseline);
+        $totalErrors = 0;
+        foreach ($baseline as $counts) {
+            $totalErrors += array_sum($counts);
+        }
+
+        $output->writeln("<info>Baseline generated: $outputPath</info>");
+        $output->writeln("<info>Files with issues: $totalFiles</info>");
+        $output->writeln("<info>Total errors: $totalErrors</info>");
+
+        return Command::SUCCESS;
+    })
+    ->run();

--- a/.config/sqruff/lint-php-sql-filter.sh
+++ b/.config/sqruff/lint-php-sql-filter.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Filter PHP files that contain SQL and lint them
+# Usage: lint-php-sql-filter.sh [file1.php file2.php ...]
+#
+# If no files provided, scans all PHP files in the repo.
+# Otherwise, filters provided files to only those containing SQL calls.
+
+set -e
+
+SQL_PATTERN='(sqlStatement|sqlQuery|sqlInsert|QueryUtils::|->Execute|->GetOne|->GetAll|->GetRow)'
+
+if (( $# == 0 )); then
+    # No files provided - scan all PHP files with SQL
+    # shellcheck disable=SC2312
+    git grep -l -zE "${SQL_PATTERN}" -- '*.php' '*.inc' | xargs -0 php .config/sqruff/lint-php-sql.php || true
+else
+    # Filter provided files to only those with SQL
+    files_with_sql=()
+    for file in "$@"; do
+        if grep -qE "${SQL_PATTERN}" "${file}" 2>/dev/null; then
+            files_with_sql+=("${file}")
+        fi
+    done
+
+    if (( ${#files_with_sql[@]} > 0 )); then
+        php .config/sqruff/lint-php-sql.php "${files_with_sql[@]}"
+    fi
+fi

--- a/.config/sqruff/lint-php-sql.php
+++ b/.config/sqruff/lint-php-sql.php
@@ -1,0 +1,118 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Lint SQL embedded in PHP files using sqruff
+ *
+ * @package   OpenEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+
+(new SingleCommandApplication())
+    ->setName('lint-php-sql')
+    ->setDescription('Lint SQL embedded in PHP files using sqruff')
+    ->addArgument('files', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'PHP files to lint')
+    ->addOption('format', 'f', InputOption::VALUE_REQUIRED, 'Output format (json|github)', 'json')
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        $files = $input->getArgument('files');
+        $format = $input->getOption('format');
+        $extractorPath = __DIR__ . '/extract-sql-from-php.php';
+        $configPath = __DIR__ . '/.sqruff';
+
+        $allResults = [];
+
+        foreach ($files as $file) {
+            if (!file_exists($file)) {
+                $output->writeln("<error>File not found: $file</error>", OutputInterface::VERBOSITY_VERBOSE);
+                continue;
+            }
+
+            // Extract SQL from PHP file
+            $extractOutput = shell_exec("php " . escapeshellarg($extractorPath) . " " . escapeshellarg($file) . " --json 2>/dev/null");
+            if (empty($extractOutput)) {
+                continue;
+            }
+
+            $statements = json_decode($extractOutput, true);
+            if (empty($statements)) {
+                continue;
+            }
+
+            foreach ($statements as $stmt) {
+                $sql = $stmt['sql'];
+                if (!preg_match('/;\s*$/', $sql)) {
+                    $sql .= ';';
+                }
+
+                // Lint this SQL statement
+                $descriptors = [
+                    0 => ['pipe', 'r'],
+                    1 => ['pipe', 'w'],
+                    2 => ['pipe', 'w'],
+                ];
+
+                $process = proc_open(
+                    'sqruff lint --config ' . escapeshellarg($configPath) . ' - --dialect mysql -f json',
+                    $descriptors,
+                    $pipes
+                );
+
+                if (!is_resource($process)) {
+                    continue;
+                }
+
+                fwrite($pipes[0], $sql);
+                fclose($pipes[0]);
+
+                $lintOutput = stream_get_contents($pipes[1]);
+                fclose($pipes[1]);
+                fclose($pipes[2]);
+                proc_close($process);
+
+                $lintResults = json_decode($lintOutput, true);
+                if (empty($lintResults) || empty($lintResults['<string>'])) {
+                    continue;
+                }
+
+                foreach ($lintResults['<string>'] as $error) {
+                    $allResults[] = [
+                        'file' => $stmt['file'],
+                        'line' => $stmt['line'],
+                        'sql_line' => $error['range']['start']['line'],
+                        'code' => $error['code'],
+                        'message' => $error['message'],
+                        'sql' => $sql,
+                    ];
+                }
+            }
+        }
+
+        if ($format === 'github') {
+            foreach ($allResults as $error) {
+                $output->writeln(sprintf(
+                    "::error file=%s,line=%d,title=sqruff::%s: %s",
+                    $error['file'],
+                    $error['line'],
+                    $error['code'],
+                    $error['message']
+                ));
+            }
+        } else {
+            $output->writeln(json_encode($allResults, JSON_PRETTY_PRINT));
+        }
+
+        return count($allResults) > 0 ? Command::FAILURE : Command::SUCCESS;
+    })
+    ->run();

--- a/.github/workflows/sql-lint.yml
+++ b/.github/workflows/sql-lint.yml
@@ -1,0 +1,127 @@
+name: SQL Lint
+
+on:
+  push:
+    branches:
+    - master
+    - rel-*
+  pull_request:
+    branches:
+    - master
+    - rel-*
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && github.event.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  sql-lint:
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Get changed SQL files
+      id: changed-sql
+      run: |
+        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          BASE="${{ github.event.pull_request.base.sha }}"
+        else
+          BASE="${{ github.event.before }}"
+        fi
+        FILES=$(git diff --name-only --diff-filter=ACMR "$BASE" HEAD -- '*.sql' | tr '\n' ' ')
+        echo "files=$FILES" >> $GITHUB_OUTPUT
+        if [[ -n "$FILES" ]]; then
+          echo "has_files=true" >> $GITHUB_OUTPUT
+        else
+          echo "has_files=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Install sqruff
+      if: steps.changed-sql.outputs.has_files == 'true'
+      run: |
+        curl -fsSL https://github.com/quarylabs/sqruff/releases/latest/download/sqruff-linux-x86_64-musl.tar.gz | tar xz
+        sudo mv sqruff /usr/local/bin/
+        sqruff --version
+
+    - name: Lint changed SQL files
+      if: steps.changed-sql.outputs.has_files == 'true'
+      run: sqruff lint --config .config/sqruff/.sqruff ${{ steps.changed-sql.outputs.files }} -f github-annotation-native
+
+  php-sql-lint:
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Get changed PHP files with SQL
+      id: changed-php
+      env:
+        SQL_PATTERN: (sqlStatement|sqlQuery|sqlInsert|QueryUtils::|->Execute|->GetOne|->GetAll|->GetRow)
+      run: |
+        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          BASE="${{ github.event.pull_request.base.sha }}"
+        else
+          BASE="${{ github.event.before }}"
+        fi
+        # Get changed PHP files that contain SQL-calling functions
+        FILES=""
+        for file in $(git diff --name-only --diff-filter=ACMR "$BASE" HEAD -- '*.php' '*.inc'); do
+          if [[ -f "$file" ]] && grep -qE "$SQL_PATTERN" "$file"; then
+            FILES="$FILES $file"
+          fi
+        done
+        echo "files=$FILES" >> $GITHUB_OUTPUT
+        if [[ -n "$FILES" ]]; then
+          echo "has_files=true" >> $GITHUB_OUTPUT
+        else
+          echo "has_files=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Setup PHP
+      if: steps.changed-php.outputs.has_files == 'true'
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.2'
+        coverage: none
+
+    - name: Get composer cache directory
+      if: steps.changed-php.outputs.has_files == 'true'
+      id: composer-cache
+      run: |
+        {
+          printf 'dir='
+          composer config cache-files-dir
+        } >> $GITHUB_OUTPUT
+
+    - name: Composer Cache
+      if: steps.changed-php.outputs.has_files == 'true'
+      uses: actions/cache@v5
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: ${{ runner.os }}-composer-8.2-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-composer-8.2-
+          ${{ runner.os }}-composer-
+
+    - name: Composer Install
+      if: steps.changed-php.outputs.has_files == 'true'
+      run: composer install --prefer-dist --no-progress
+
+    - name: Install sqruff
+      if: steps.changed-php.outputs.has_files == 'true'
+      run: |
+        curl -fsSL https://github.com/quarylabs/sqruff/releases/latest/download/sqruff-linux-x86_64-musl.tar.gz | tar xz
+        sudo mv sqruff /usr/local/bin/
+        sqruff --version
+
+    - name: Lint SQL in changed PHP files
+      if: steps.changed-php.outputs.has_files == 'true'
+      run: php .config/sqruff/lint-php-sql.php --format=github ${{ steps.changed-php.outputs.files }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -142,3 +142,17 @@ repos:
     language: system
     stages:
     - commit-msg
+
+  - id: sql-lint
+    name: SQL Lint (sqruff)
+    entry: sqruff lint --config .config/sqruff/.sqruff
+    language: system
+    types:
+    - sql
+
+  - id: sql-lint-php
+    name: SQL Lint (PHP embedded)
+    entry: .config/sqruff/lint-php-sql-filter.sh
+    language: system
+    types:
+    - php

--- a/composer.json
+++ b/composer.json
@@ -286,6 +286,8 @@
         ],
         "rector-check": "php -d memory_limit=4g ./vendor/bin/rector process --dry-run",
         "rector-fix": "php -d memory_limit=4g ./vendor/bin/rector process",
-        "require-checker": "php -d memory_limit=4g ./vendor/bin/composer-require-checker check --config-file=.composer-require-checker.json"
+        "require-checker": "php -d memory_limit=4g ./vendor/bin/composer-require-checker check --config-file=.composer-require-checker.json",
+        "sql-lint": "sqruff lint --config .config/sqruff/.sqruff sql/ interface/ -f json",
+        "sql-lint-php": "git grep -l -zE '(sqlStatement|sqlQuery|sqlInsert|QueryUtils::|->Execute|->GetOne|->GetAll|->GetRow)' -- '*.php' '*.inc' | xargs -0 php .config/sqruff/lint-php-sql.php"
     }
 }


### PR DESCRIPTION
Fixes #10131

#### Short description of what this resolves:

Adds automated SQL linting to catch quality issues in both `.sql` files and SQL embedded in PHP code.

#### Changes proposed in this pull request:

**Configuration (`.config/sqruff/`):**
- MySQL dialect with uppercase keyword enforcement (CP01 rule)
- Layout rules disabled (LT01, LT02, LT05, LT06, LT12) for gradual adoption
- 200 character line length limit

**CLI Tools (Symfony Console):**
- `lint-php-sql.php` - Lint SQL embedded in PHP files with source location mapping
- `extract-sql-from-php.php` - AST-based SQL extractor using nikic/php-parser
- `generate-sql-baseline.php` - Generate YAML baseline of current violations
- `check-sql-baseline.php` - Check SQL files against baseline
- `check-php-sql-baseline.php` - Check PHP embedded SQL against baseline
- `lint-php-sql-filter.sh` - Pre-filters PHP files to only those containing SQL calls

**GitHub Action (`.github/workflows/sql-lint.yml`):**
- Lints only changed files in PRs (not entire codebase)
- Filters PHP files to only those with SQL-calling functions
- GitHub annotation output for inline PR feedback

**Pre-commit hooks:**
- `sql-lint` - Lint `.sql` files with sqruff
- `sql-lint-php` - Lint SQL in changed PHP files

**Composer scripts:**
- `sql-lint` - Lint all SQL files
- `sql-lint-php` - Lint SQL in PHP files

#### Does your code include anything generated by an AI Engine? Yes

All new files in `.config/sqruff/` were generated with Claude Code (Claude Opus 4.5). Each file includes the standard OpenEMR header identifying the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)