### PR TITLE
ci: skip slow tests for draft PRs with label

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -24,8 +24,31 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  check-skip:
+    runs-on: ubuntu-24.04
+    # Check for skip marker (see issue #10132)
+    if: github.event_name == 'pull_request'
+    outputs:
+      skip: ${{ steps.check.outputs.skip }}
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+    - name: Check for Skip-Slow-Tests trailer
+      id: check
+      run: |
+        TRAILER=$(git log -1 --format='%(trailers:key=Skip-Slow-Tests,valueonly)')
+        echo "skip=${TRAILER:-false}" >> "$GITHUB_OUTPUT"
+    - name: Fail to indicate tests were skipped
+      if: steps.check.outputs.skip == 'true'
+      run: |
+        echo "::error::Slow tests skipped due to Skip-Slow-Tests trailer"
+        exit 1
   collect:
     runs-on: ubuntu-24.04
+    needs: check-skip
+    if: '!failure()'
     steps:
     - name: Checkout Code
       uses: actions/checkout@v6

--- a/ci/README.md
+++ b/ci/README.md
@@ -196,6 +196,18 @@ When updating the shared configuration files:
 - Make sure your changes are backward compatible or update the individual environment files as needed
 - Test the changes across multiple environments to ensure they work correctly
 
+### Skipping Slow Tests During Development
+
+When iterating on a PR, you may want to skip the slow `Test All Configurations` workflow to get faster feedback from linting and static analysis. To do this, add the `Skip-Slow-Tests: true` trailer to your commit:
+
+```sh
+git commit --trailer "Skip-Slow-Tests: true" -m "fix: correct date parsing"
+```
+
+When this trailer is present, the workflow will fail immediately. This failed status prevents accidental merging without running the full test suite.
+
+Before merging, push a commit without the trailer to trigger the full tests.
+
 ### Troubleshooting CI
 
 If tests are failing in CI but passing locally, check:


### PR DESCRIPTION
Fixes #10132

## Description
Allow contributors to skip the slow `Test All Configurations` workflow by adding a `Skip-Slow-Tests: true` trailer to their commit message.

## Changes proposed in this pull request
- Add `check-skip` job that detects the trailer and fails immediately with a clear error
- Document the feature in `ci/README.md`

## AI Disclosure
Yes

🤖 Generated with [Claude Code](https://claude.com/claude-code)