### PR TITLE
fix: fax module php fatal error memory size exhausted

### DIFF
--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php
@@ -795,7 +795,7 @@ class EtherFaxActions extends AppDispatch
         $uid = $_SESSION['authUserID'];
         $jobId = $faxDetails->JobId;
 
-        // avoid duplicates
+        // avoid duplicates, Claude helped craft the query
         $existing = QueryUtils::querySingleRow("SELECT `id` FROM `oe_faxsms_queue` WHERE `job_id` = ? LIMIT 1", [$jobId]);
         if ($existing !== false && !empty($existing['id'])) {
             return (int)$existing['id'];  // Return existing ID instead of inserting

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php
@@ -16,6 +16,7 @@ use Document;
 use Exception;
 use MyMailer;
 use OpenEMR\Common\Crypto\CryptoGen;
+use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Modules\FaxSMS\EtherFax\EtherFaxClient;
 use OpenEMR\Modules\FaxSMS\EtherFax\FaxResult;
 use OpenEMR\Services\ImageUtilities\HandleImageService;
@@ -793,6 +794,13 @@ class EtherFaxActions extends AppDispatch
         $account = $this->credentials['account'];
         $uid = $_SESSION['authUserID'];
         $jobId = $faxDetails->JobId;
+
+        // avoid duplicates
+        $existing = QueryUtils::querySingleRow("SELECT `id` FROM `oe_faxsms_queue` WHERE `job_id` = ? LIMIT 1", [$jobId]);
+        if ($existing !== false && !empty($existing['id'])) {
+            return (int)$existing['id'];  // Return existing ID instead of inserting
+        }
+
         $to = $faxDetails->CalledNumber;
         $from = $faxDetails->CallingNumber;
         $received = date('Y-m-d H:i:s', strtotime($faxDetails->ReceivedOn . ' UTC'));


### PR DESCRIPTION
<!--Thanks for sending a pull request!
Please create an issue at https://github.com/openemr/openemr/issues/new/choose and then
-->

<!-- add that issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #10150 

<!-- PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details -->

#### Short description of what this resolves:

duplicate faxes were getting stored in the table

#### Changes proposed in this pull request:

return the id of the existing fax in the table

#### Does your code include anything generated by an AI Engine? Yes / No

#### If you answered yes: Verify that each file that has AI generated code has a description that describes what AI engine was used and that the file includes AI generated code.  Sections of code that are entirely or mostly generated by AI should be marked with a comment header and footer that includes the AI engine used and stating the code was AI.
