### PR TITLE
docs: improve contributor documentation and add AI assistant guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,159 @@
+# OpenEMR Development Guide
+
+## Project Structure
+
+```
+/src/              - Modern PSR-4 code (OpenEMR\ namespace)
+/library/          - Legacy procedural PHP code
+/interface/        - Web UI controllers and templates
+/templates/        - Smarty/Twig templates
+/tests/            - Test suite (unit, e2e, api, services)
+/sql/              - Database schema and migrations
+/public/           - Static assets
+/docker/           - Docker configurations
+/modules/          - Custom and third-party modules
+```
+
+## Technology Stack
+
+- **PHP:** 8.2+ required
+- **Backend:** Laminas MVC, Symfony components
+- **Templates:** Twig 3.x (modern), Smarty 4.5 (legacy)
+- **Frontend:** Angular 1.8, jQuery 3.7, Bootstrap 4.6
+- **Build:** Gulp 4, SASS
+- **Database:** MySQL via ADODB wrapper
+- **Testing:** PHPUnit 11, Jest 29
+
+## Local Development
+
+See `CONTRIBUTING.md` for full setup instructions. Quick start:
+
+```bash
+cd docker/development-easy
+docker compose up --detach --wait
+```
+
+- **App URL:** http://localhost:8300/ or https://localhost:9300/
+- **Login:** `admin` / `pass`
+- **phpMyAdmin:** http://localhost:8310/
+
+## Testing
+
+Tests run inside Docker via devtools. Run from `docker/development-easy/`:
+
+```bash
+# Run all tests
+docker compose exec openemr /root/devtools clean-sweep-tests
+
+# Individual test suites
+docker compose exec openemr /root/devtools unit-test
+docker compose exec openemr /root/devtools api-test
+docker compose exec openemr /root/devtools e2e-test
+docker compose exec openemr /root/devtools services-test
+
+# View PHP error log
+docker compose exec openemr /root/devtools php-log
+```
+
+**Tip:** Install [openemr-cmd](https://github.com/openemr/openemr-devops/tree/master/utilities/openemr-cmd)
+for shorter commands (e.g., `openemr-cmd ut` for unit tests) from any directory.
+
+## Code Quality
+
+These run on the host (requires local PHP/Node):
+
+```bash
+# Run all PHP quality checks (phpcs, phpstan, rector)
+composer code-quality
+
+# Individual checks (composer scripts handle memory limits)
+composer phpstan          # Static analysis
+composer phpcs            # PHP code style check
+composer phpcbf           # PHP code style auto-fix
+composer rector-check     # Code modernization (dry-run)
+
+# JavaScript/CSS
+npm run lint:js           # ESLint check
+npm run lint:js-fix       # ESLint auto-fix
+npm run stylelint         # CSS/SCSS lint
+```
+
+## Build Commands
+
+```bash
+npm run build        # Production build
+npm run dev          # Development with file watching
+npm run gulp-build   # Build only (no watch)
+```
+
+## Coding Standards
+
+- **Indentation:** 4 spaces
+- **Line endings:** LF (Unix)
+- **No strict_types:** Project doesn't use `declare(strict_types=1)`
+- **Namespaces:** PSR-4 with `OpenEMR\` prefix for `/src/`
+- New code goes in `/src/`, legacy helpers in `/library/`
+
+## Commit Messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <description>
+```
+
+**Types:** feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
+
+**Examples:**
+- `feat(api): add PATCH support for patient resource`
+- `fix(calendar): correct date parsing for recurring events`
+- `chore(deps): bump monolog/monolog to 3.10.0`
+
+## Service Layer Pattern
+
+New services should extend `BaseService`:
+
+```php
+namespace OpenEMR\Services;
+
+class ExampleService extends BaseService
+{
+    public const TABLE_NAME = "table_name";
+
+    public function __construct()
+    {
+        parent::__construct(self::TABLE_NAME);
+    }
+}
+```
+
+## File Headers
+
+When modifying PHP files, ensure proper docblock:
+
+```php
+/**
+ * Brief description
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Your Name <your@email.com>
+ * @copyright Copyright (c) YEAR Your Name or Organization
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+```
+
+Preserve existing authors/copyrights when editing files.
+
+## Common Gotchas
+
+- Multiple template engines: check extension (.twig, .html, .php)
+- Event system uses Symfony EventDispatcher
+- Pre-commit hooks available via `.pre-commit-config.yaml`
+
+## Key Documentation
+
+- `CONTRIBUTING.md` - Contributing guidelines
+- `API_README.md` - REST API docs
+- `FHIR_README.md` - FHIR implementation
+- `tests/Tests/README.md` - Testing guide

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,11 +49,39 @@ BREAKING CHANGE: The patient endpoint now returns a different JSON structure.
 
 ### Local Validation
 
-If you use [pre-commit](https://pre-commit.com/), install the commit-msg hook to validate locally:
+If you use [pre-commit](https://pre-commit.com/), install hooks to validate locally:
 
 ```sh
-pre-commit install --hook-type commit-msg
+pre-commit install --hook-type commit-msg  # Validates commit message format
+pre-commit install                          # Enables all code quality hooks
 ```
+
+The full pre-commit suite (`.pre-commit-config.yaml`) includes:
+- Trailing whitespace, line endings, JSON/YAML formatting
+- PHP syntax checking, phpcs, phpcbf, phpstan, rector
+- Composer validation and normalization
+
+## Code Quality on Host
+
+If you have PHP and Node.js installed locally, you can run code quality checks without Docker:
+
+```sh
+# Run all PHP checks (phpcs, phpstan, rector)
+composer code-quality
+
+# Individual checks (these handle memory limits automatically)
+composer phpstan          # Static analysis
+composer phpcs            # Code style check
+composer phpcbf           # Code style auto-fix
+composer rector-check     # Code modernization (dry-run)
+
+# JavaScript/CSS
+npm run lint:js           # ESLint
+npm run lint:js-fix       # ESLint auto-fix
+npm run stylelint         # CSS/SCSS linting
+```
+
+These provide higher memory limits than Docker devtools and are what CI runs.
 
 ## Code Contributions (local development)
 
@@ -85,7 +113,7 @@ You will need a "local" version of OpenEMR to make changes to the source code. T
     - (optional) It's best to also add an `upstream` origin to keep your local fork up to date. [Check out this guide](https://oneemptymind.wordpress.com/2018/07/11/keeping-a-fork-up-to-date/) for more info.
 2. `cd openemr/docker/development-easy`
     - If you haven't already, [install Docker](https://docs.docker.com/install/) and [install compose](https://docs.docker.com/compose/install/) for your system
-    - (optional) If you want to troubleshoot with the below steps easier, please also [install openemr-cmd](https://github.com/openemr/openemr-devops/tree/master/utilities/openemr-cmd) for your system
+    - (recommended) [Install openemr-cmd](https://github.com/openemr/openemr-devops/tree/master/utilities/openemr-cmd) for shorthand commands that work from any directory. Examples: `openemr-cmd ut` (unit-test), `openemr-cmd at` (api-test), `openemr-cmd et` (e2e-test), `openemr-cmd php-log`. Use `openemr-cmd-h` to search available commands.
     - (optional) If you want to monitor and easily manage the docker environment, please also [install openemr-monitor](https://github.com/openemr/openemr-devops/tree/master/utilities/openemr-monitor) and [install portainer](https://github.com/openemr/openemr-devops/tree/master/utilities/portainer) for your system
     - (optional) If you want to migrate the running docker environment, please try [openemr-env-migrator](https://github.com/openemr/openemr-devops/tree/master/utilities/openemr-env-migrator)
     - (optional) If you want to set up with orchestration tool, please try [OpenEMR Kubernetes Orchestrations](https://github.com/openemr/openemr-devops/tree/master/kubernetes/minikube)
@@ -126,6 +154,26 @@ You will need a "local" version of OpenEMR to make changes to the source code. T
     ```
 
 9. [Submit a PR](https://github.com/openemr/openemr/compare) from your fork into `openemr/openemr#master`!
+
+### After You Submit
+
+**For first-time contributors:** A maintainer must approve your PR before CI checks will run. This is a GitHub security measure for external contributors.
+
+**Automated checks** include:
+- Conventional commit validation (PR title format)
+- PHP syntax, phpcs, phpstan, rector
+- Unit, API, E2E, and integration tests across multiple PHP/database versions
+- JavaScript tests, Docker linting, and more
+
+See `ci/README.md` for details on the CI system.
+
+**Tip:** During development, you can add `Skip-Slow-Tests: true` as a commit trailer to skip the full test matrix and get faster feedback from linting:
+```sh
+git commit --trailer "Skip-Slow-Tests: true" -m "fix: work in progress"
+```
+You must remove any `Skip-Slow-Tests` or `skip-ci` trailers before your PR can be merged.
+
+**Review process:** A maintainer will review your PR. Please respond to feedback and push updates to the same branch—the PR will update automatically.
 
 We look forward to your contribution...
 


### PR DESCRIPTION
Fixes #10153
Closes #8529

#### Short description of what this resolves:

Improves documentation for contributors by filling gaps in CONTRIBUTING.md and adding CLAUDE.md for AI-assisted development.

#### Changes proposed in this pull request:

**CLAUDE.md** (new):
- Project structure overview
- Technology stack
- Local development quick start (Docker, URLs, credentials)
- Testing via Docker devtools
- Code quality commands (composer scripts)
- Coding standards, commit format, service layer pattern

**CONTRIBUTING.md** improvements:
- Expand pre-commit section to cover full hook suite (not just commit-msg)
- Add "Code Quality on Host" section for composer scripts
- Clarify openemr-cmd as recommended, with shorthand examples (ut, at, et)
- Add "After You Submit" section: CI checks, Skip-Slow-Tests trailer, review process
- Note that first-time contributors need maintainer approval before CI runs

#### Does your code include anything generated by an AI Engine? Yes

Claude Code (Claude Opus 4.5) was used to draft and refine both files.

🤖 Generated with [Claude Code](https://claude.ai/code)