### PR TITLE
fix(portal): fix issue persistent modal backdrop in the default signature modal after closing

### DIFF
--- a/portal/sign/assets/signer_api.js
+++ b/portal/sign/assets/signer_api.js
@@ -231,11 +231,11 @@ function archiveSignature(signImage = '', edata = '') {
             'Connection': 'close'
         }
     }).then(response => response.json()).then(function (response) {
-        const backdrop = document.querySelector('.modal-backdrop');
+        const backdrops = document.querySelectorAll('.modal-backdrop');
         $("#openSignModal").modal('hide');
-        if (backdrop) {
+        backdrops.forEach(function (backdrop) {
             backdrop.remove();
-        }
+        });
     }).catch(error => signerAlertMsg(error));
 
     return true;


### PR DESCRIPTION
Fixes #10127

#### Short description of what this resolves:
In Portal -> Settings -> Default Digital Signature, once you click on the "Sign and Save" button, it closes the modal, but the underlying backdrop stays active and prevents using the application until the page is reloaded manually.

#### Changes proposed in this pull request:
After some investigation, I found that on click to open a modal, we got multiple modal backdrops (even 4 some times). I was unable to find the real cause of this issue within a reasonable timeframe, so I decided to patch it by closing all of them in a loop. It works well for 1+ of them.

#### Does your code include anything generated by an AI Engine? No
