### PR TITLE
fix(ci): use valid GitHub Actions expression for conditional job

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -48,7 +48,7 @@ jobs:
   collect:
     runs-on: ubuntu-24.04
     needs: check-skip
-    if: success() || skipped()
+    if: ${{ always() && (needs.check-skip.result == 'success' || needs.check-skip.result == 'skipped') }}
     steps:
     - name: Checkout Code
       uses: actions/checkout@v6


### PR DESCRIPTION
Fixes #10173

## Description
PR #10174 attempted to fix the test-all workflow not running on master pushes, but used `skipped()` which is not a valid GitHub Actions function. This caused the workflow to fail with a "workflow file issue" error.

## Changes proposed in this pull request
- Replace invalid `if: success() || skipped()` with explicit job result checking
- Use `always()` to ensure the condition is evaluated even when dependencies are skipped

The valid status check functions in GitHub Actions are: `success()`, `failure()`, `always()`, and `cancelled()`. To check if a specific job was skipped, you must use `needs.<job_id>.result == 'skipped'`.

## AI Disclosure
Yes

🤖 Generated with [Claude Code](https://claude.com/claude-code)