### PR TITLE
chore(composer): remove mobiledetect/mobiledetectlib

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -38,7 +38,6 @@
         <delete dir="${dir.vendor}/illuminate/support/Testing" verbose="true"/>
         <delete dir="${dir.vendor}/knplabs/knp-snappy/doc" verbose="true"/>
         <delete dir="${dir.vendor}/markbaker/complex/examples" verbose="true"/>
-        <delete dir="${dir.vendor}/mobiledetect/mobiledetectlib/docs" verbose="true"/>
         <delete dir="${dir.vendor}/myclabs/deep-copy/doc" verbose="true"/>
         <delete dir="${dir.vendor}/phenx/php-font-lib/tests" verbose="true"/>
         <delete dir="${dir.vendor}/phenx/php-svg-lib/tests" verbose="true"/>

--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,6 @@
         "league/csv": "^9.28.0",
         "league/oauth2-server": "^8.4",
         "league/omnipay": "^3.2.1",
-        "mobiledetect/mobiledetectlib": "^4.8.09",
         "monolog/monolog": "^3.9.0",
         "mpdf/mpdf": "^8.2.7",
         "nyholm/psr7": "^1.8.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f0d99aa151defb337799d8b9696b9d10",
+    "content-hash": "24d1007e54a57ad1448b7d386b9da536",
     "packages": [
         {
             "name": "academe/authorizenet-objects",
@@ -16264,5 +16264,5 @@
         "ext-zlib": "8.2",
         "php": "8.2"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
fixes #10188 
Remove mobiledetect/mobiledetectlib, an unused dependency.

Co-authored-by: stephenwaite <5618372+stephenwaite@users.noreply.github.com>
