### PR TITLE
fix(config): Remove globals bag reset mechanism

### DIFF
--- a/interface/globals.php
+++ b/interface/globals.php
@@ -840,10 +840,6 @@ if ($globalsBag->getInt('user_debug', 0) > 1) {
     ini_set('display_errors', 1);
 }
 
-// CRITICAL: Reset and reinitialize the singleton to capture ALL $GLOBALS
-OEGlobalsBag::resetInstance();
-$globalsBag = OEGlobalsBag::getInstance();
-
 // Re-set the local variables that aren't in $GLOBALS
 $globalsBag->set('webserver_root', $webserver_root);
 $globalsBag->set('web_root', $web_root);

--- a/src/Core/OEGlobalsBag.php
+++ b/src/Core/OEGlobalsBag.php
@@ -33,14 +33,6 @@ class OEGlobalsBag extends ParameterBag
         return self::$instance;
     }
 
-    /**
-     * Reset the singleton instance (useful for testing)
-     */
-    public static function resetInstance(): void
-    {
-        self::$instance = null;
-    }
-
     public function __construct(array $parameters = [])
     {
         parent::__construct($parameters);


### PR DESCRIPTION
Fixes #10140

#### Short description of what this resolves:
Removes a problem API from OEGlobalsBag

#### Changes proposed in this pull request:
Since the compatibility mode option has been removed from the class and its now always on, it's effectively a very thin wrapper around `$GLOBALS`. Consequently, the act of resetting the instance has no practical effect. Because it could lead to confusing behavior in the future, I think it's most prudent to remove it outright.

#### Does your code include anything generated by an AI Engine? Yes / No
No