### PR TITLE
fix(session): Set cookie secure flag based on install settings

### DIFF
--- a/src/Common/Session/SessionUtil.php
+++ b/src/Common/Session/SessionUtil.php
@@ -313,14 +313,14 @@ class SessionUtil
 
     public static function setAppCookie(string $appType): void
     {
-        ['secure' => $secure] = session_get_cookie_params();
         setcookie(
             self::APP_COOKIE_NAME,
             $appType,
             [
                 'expires' => time() + 3600,
                 'path' => '/',
-                'secure' => $secure,
+                // This permits the app cookie to work in non-https dev environments. It's not a sensitive value.
+                'secure' => false,
                 'httponly' => true,
                 'samesite' => Cookie::SAMESITE_STRICT
             ]


### PR DESCRIPTION
Fixes #10200

#### Short description of what this resolves:
In installs where `https` is not configured (_hopefully_ only `localhost` for development!!), the `setcookie()` call in `SessionUtil::setAppCookie()` would do nothing since it forced `secure=true` and the value would be ignored by any well-behaved user-agent. In a normal deployment that's correctly configured with `https`, it shouldn't have any effect.

#### Changes proposed in this pull request:
Replaces `secure=true` with the value from `session_get_cookie_params()`, mirroring some other cookie handling. This isn't really an ideal source of the value, but it seems reliable, consistent, and doesn't require any of the globals bootstrapping to have occurred yet since it's sourced from `php.ini`.

Even if that cookie erroneously doesn't get the `httponly` flag set on it, it still has all of the necessary flags for general protection _and_ doesn't contain anything sensitive.

> [!NOTE]
> Since it uses `path=/`, I suspect there could be some weird clashing in edge cases where a user tries to use both the main and the patient portal at the same time; the values might collide or fight with each other. I don't _think_ this is a security concern, but I'm not intimately familiar with the session handling.

#### Does your code include anything generated by an AI Engine? Yes / No
No