### PR TITLE
feat(session): add SSO authentication support for external identity providers

### DIFF
--- a/interface/main/main_screen.php
+++ b/interface/main/main_screen.php
@@ -373,6 +373,11 @@ if (isset($_POST['new_login_session_management'])) {
     } else {
         $_POST["clearPass"] = '';
     }
+} elseif (isset($_SESSION["auth_method"]) && $_SESSION["auth_method"] !== "local") {
+    // SSO login - session already authenticated via external provider (e.g., SAML, OIDC, OAuth2)
+    // These flows arrive via GET redirect with an already-authenticated session, so no CSRF token is present.
+    // Modules can set auth_method to their provider name (e.g., 'entra', 'saml', 'oidc').
+    session_regenerate_id(false);
 } else {
     // This is not a new login, so check csrf and then create a new session id and do NOT remove the old session
     if (!CsrfUtils::verifyCsrfToken($_POST["csrf_token_form"])) {


### PR DESCRIPTION
## Summary

This PR adds support for SSO authentication flows (SAML, OIDC, OAuth2) that redirect users back to OpenEMR with an already-authenticated session.

## Problem

Currently, `main_screen.php` has a CSRF check that assumes all authentication happens via form POST:

```php
} else {
    // This is not a new login, so check csrf and then create a new session id
    if (!CsrfUtils::verifyCsrfToken($_POST["csrf_token_form"])) {
        CsrfUtils::csrfNotVerified();
    }
    session_regenerate_id(false);
}
```

SSO flows arrive via GET redirect (OAuth2 callback, SAML assertion consumer) with an already-authenticated session, causing the CSRF check to fail since no POST data is present.

## Solution

Add an `elseif` branch that detects SSO sessions by checking for a non-local `auth_method` in the session:

```php
} elseif (isset($_SESSION["auth_method"]) && $_SESSION["auth_method"] !== "local") {
    // SSO login - session already authenticated via external provider
    session_regenerate_id(false);
} else {
    // existing CSRF check...
}
```

## How Module Developers Use This

SSO authentication modules should set `$_SESSION["auth_method"]` to their provider name (e.g., `'entra'`, `'saml'`, `'oidc'`) when establishing the authenticated session in their callback handler. This signals to `main_screen.php` that CSRF verification should be skipped.

Example in a module's OAuth callback:
```php
// After validating tokens and establishing session
$_SESSION["auth_method"] = "entra";  // or "saml", "oidc", etc.
header('Location: /interface/main/main_screen.php');
```

## Security Considerations

- SSO sessions are already authenticated via the external provider's secure flow
- The session ID is still regenerated to prevent session fixation
- CSRF protection remains in place for all non-SSO authentication paths
- Only sessions explicitly marked with a non-local auth_method bypass the CSRF check

## Testing

This change was tested with a Microsoft Entra ID (Azure AD) OIDC integration module. The authentication flow:
1. User clicks "Sign in with Entra ID" on login page
2. Module redirects to Entra ID authorization endpoint
3. User authenticates with Entra ID
4. Entra ID redirects back to module callback URL
5. Module validates tokens, creates OpenEMR session with `auth_method = 'entra'`
6. Module redirects to `main_screen.php`
7. `main_screen.php` now correctly handles this SSO session

## Checklist

- [x] Follows conventional commit format
- [x] Minimal, focused change
- [x] Backwards compatible (no change to existing behavior for local auth)
- [x] Security considerations documented