### PR TITLE
fix(session): increase app cookie expire time and better wrapper selection logic

### DIFF
--- a/src/Common/Session/SessionUtil.php
+++ b/src/Common/Session/SessionUtil.php
@@ -317,7 +317,7 @@ class SessionUtil
             self::APP_COOKIE_NAME,
             $appType,
             [
-                'expires' => time() + 3600,
+                'expires' => time() + 31536000, // 1 year
                 'path' => '/',
                 'secure' => true,
                 'httponly' => true,

--- a/src/Common/Session/SessionWrapperFactory.php
+++ b/src/Common/Session/SessionWrapperFactory.php
@@ -36,10 +36,10 @@ class SessionWrapperFactory
     private function findSessionWrapper(array $initData = []): SessionWrapperInterface
     {
         $app = SessionUtil::getAppCookie();
-        if ($app !== SessionUtil::PORTAL_SESSION_ID) {
-            $session = new PHPSessionWrapper();
-        } else if (SessionUtil::isPredisSession()) {
+        if (SessionUtil::isPredisSession()) {
             SessionUtil::portalPredisSessionStart();
+            $session = new PHPSessionWrapper();
+        } else if ($app !== SessionUtil::PORTAL_SESSION_ID) {
             $session = new PHPSessionWrapper();
         } else {
             $session = new SymfonySessionWrapper(SessionUtil::portalSessionStart());


### PR DESCRIPTION
Fixes #10215

#### Short description of what this resolves:
While switching to Symfony Session in the Portal application, two potential bugs are introduced:
1. The `expires` time for the App type cookie is set to 1h. We agree to make it without expiration, since it is set/updated on the login page of both core and portal applications.
2. Logic for choosing the proper session wrapper is wrong, and it first needs to check for the Redis session before it chooses between the core or portal one.

#### Changes proposed in this pull request:
1. Set `expires` to be 1 year
2. First check for the Redis session, then for core, and last one should be portal.

#### Does your code include anything generated by an AI Engine? No
