### PR TITLE
fix(ci): Update path for phpstan baseline artifacts

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -71,12 +71,14 @@ jobs:
       if: steps.phpstan-analyze.outcome == 'failure'
       run: composer run phpstan-baseline
       continue-on-error: true
+    # Upload the resulting baseline as an artifact. This is intended mostly for
+    # debugging and isn't actively used by GH workflows.
     - name: Upload PHPStan Baseline
       if: steps.phpstan-analyze.outcome == 'failure'
       uses: actions/upload-artifact@v6
       with:
         name: phpstan-baseline-php${{ matrix.php-version }}
-        path: .phpstan/phpstan-*-baseline.neon
+        path: .phpstan/baseline/*.php
       continue-on-error: true
     - name: Check PHPStan Results
       if: steps.phpstan-analyze.outcome == 'failure'


### PR DESCRIPTION
Fixes #10238

#### Short description of what this resolves:
Artifacts for phpstan baseline files reflect the change from neon to php files

#### Changes proposed in this pull request:
^^

#### Does your code include anything generated by an AI Engine? Yes / No
No