### PR TITLE
bug: Fixes #10250 default lists option for new patient save

### DIFF
--- a/interface/new/new_comprehensive.php
+++ b/interface/new/new_comprehensive.php
@@ -452,7 +452,7 @@ $constraints = LBF_Validation::generate_validate_constraints("DEM");
                         $data_type  = $frow['data_type'];
                         $field_id   = $frow['field_id'];
                         $list_id    = $frow['list_id'];
-                        $currvalue  = '';
+                        $currvalue  = null;
 
                         // Accumulate action conditions into a JSON expression for the browser side.
                         accumActionConditions($frow, $condition_str);


### PR DESCRIPTION
The default setting for select lists were not saving on new patients. By setting the default $currvalue to be null instead of an empty string '' it resolves this issue.  The behavior was changed in a previous PR for generate_select_list to not use empty string but a null value for the default.

From testing it appears that nothing is broken by setting the default value.

Fixes #10250