### PR TITLE
feat: Fixes #10251 Related Person save existing patient when locale date format is not YYYY-MM-DD.

### DIFF
--- a/src/Services/ContactRelationService.php
+++ b/src/Services/ContactRelationService.php
@@ -728,7 +728,8 @@ class ContactRelationService extends BaseService
             'middle_name' => $patient['mname'] ?? '',
             'title' => $patient['title'] ?? '',
             'suffix' => $patient['suffix'] ?? '',
-            'birth_date' => $patient['DOB'] ?? '',
+            // birth date is expected to be in the format the frontend entered it so we have to convert it to an OpenEMR date
+            'birth_date' => DateFormatterUtils::oeFormatShortDate($patient['DOB'] ?? ''),
             'gender' => $patient['sex'] ?? '',
             'ssn' => $patient['ss'] ?? '',
             'email_direct' => $patient['email_direct'] ?? '',


### PR DESCRIPTION
Using an existing patient was failing to save due to the DOB validation on the person controller.  The person controller was assuming the DOB it receives was formatted in a localized format.  Whereas the ContactRelationService was grabbing the DOB directly from the patient_data.DOB field which is formatted in the YYYY-MM-DD format.  So if a localized format is used, the existing patient fails to add / save.

Fixes #10251