### PR TITLE
fix: remove duplicate property in rcfaxclient

### DIFF
--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php
@@ -38,8 +38,6 @@ class RCFaxClient extends AppDispatch
     protected $rcsdk;
     protected CryptoGen $crypto;
 
-    private static $lastAuthAttempt = 0;
-    private static $authAttemptCount = 0;
     private const AUTH_RATE_LIMIT = 5; // Max attempts per minute
 
     public function __construct()


### PR DESCRIPTION
Fixes #10248

#### Short description of what this resolves:

Fixes:

```
[16-Jan-2026 15:07:42 America/New_York] PHP Fatal error:  OpenEMR\Modules\FaxSMS\Controller\RCFaxClient and OpenEMR\Modules\FaxSMS\Controller\AuthenticateTrait define the same property ($authAttemptCount) in the composition of OpenEMR\Modules\FaxSMS\Controller\RCFaxClient. However, the definition differs and is considered incompatible. Class was composed in C:\xampp\htdocs\openemr\interface\modules\custom_modules\oe-module-faxsms\src\Controller\RCFaxClient.php on line 23
```

#### Changes proposed in this pull request:

Remove the offending property from the class -- it is handled by the trait.

#### Does your code include anything generated by an AI Engine? No
