### PR TITLE
fix(medex): recall event iteration

### DIFF
--- a/library/MedEx/API.php
+++ b/library/MedEx/API.php
@@ -2324,8 +2324,22 @@ class Display extends Base
         $show['progression'] .= $show['EMAIL']['text'] . $show['SMS']['text'] . $show['AVM']['text'];
 
         $camps = '0';
-        if (is_countable($events)) {
-            foreach ($events as $event) {
+        // BEGIN AI-GENERATED CODE (GitHub Copilot)
+        // Normalize $events: callers may pass either a single event array or a list of event arrays.
+        // If a single event array is iterated as-is, foreach() yields scalar values and breaks lookups
+        // like $event['M_group'].
+        $eventList = [];
+        if (is_array($events)) {
+            if (isset($events['M_group']) || isset($events['M_type']) || isset($events['C_UID'])) {
+                $eventList = [$events];
+            } else {
+                $eventList = $events;
+            }
+        }
+        // END AI-GENERATED CODE (GitHub Copilot)
+
+        if (!empty($eventList) && is_array($eventList)) {
+            foreach ($eventList as $event) {
                 if ($event['M_group'] != "RECALL") {
                     continue;
                 }


### PR DESCRIPTION
Fixes #10257 and the recall board.  

Problem:

Display::show_progress_recall($recall, $events) is called from multiple paths with different $events shapes.
In some cases $events is a single associative event array (not a list). Iterating that with foreach yields scalar values, so checks like $event['M_group'] break and recall progression/campaign handling fails.
Solution:

Normalize $events into a consistent $eventList:
If $events looks like a single event (keys like M_group, M_type, C_UID), wrap it as [$events].
If it’s already a list of events, use it as-is.
If it’s empty/non-array, safely no-op.
Impact:

Recall Board and background/cron paths handle “no events”, “single event”, and “multiple events” consistently without PHP warnings or broken progression logic.
Files:

[API.php](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Notes:

AI-generated portion is clearly marked in the code (normalization block).