### PR TITLE
ci: add Semgrep security scanning for PHP code

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,85 @@
+name: Semgrep Security Scan
+
+on:
+  push:
+    branches:
+    - master
+    - rel-*
+  pull_request:
+    branches:
+    - master
+    - rel-*
+  schedule:
+    # Run weekly on Monday at 9am UTC
+  - cron: 0 9 * * 1
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && github.event.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  semgrep:
+    name: Semgrep PHP Security Scan
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep:latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Run Semgrep (full scan)
+      if: github.event_name != 'pull_request'
+      run: |
+        semgrep \
+          --config p/php \
+          --config p/security-audit \
+          --config ./semgrep.yaml \
+          --exclude vendor \
+          --exclude node_modules \
+          --exclude tests \
+          --exclude ccdaservice/node_modules \
+          --sarif \
+          --output=semgrep-results.sarif \
+          .
+
+    - name: Run Semgrep (PR diff only)
+      if: github.event_name == 'pull_request'
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      run: |
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        semgrep \
+          --config p/php \
+          --config p/security-audit \
+          --config ./semgrep.yaml \
+          --exclude vendor \
+          --exclude node_modules \
+          --exclude tests \
+          --exclude ccdaservice/node_modules \
+          --baseline-commit="$BASE_SHA" \
+          --sarif \
+          --output=semgrep-results.sarif \
+          .
+
+    - name: Upload SARIF results
+      uses: github/codeql-action/upload-sarif@v4
+      if: always()
+      with:
+        sarif_file: semgrep-results.sarif
+
+    - name: Upload results as artifact
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: semgrep-results
+        path: semgrep-results.sarif
+        retention-days: 30

--- a/run-semgrep.sh
+++ b/run-semgrep.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+#
+# Run Semgrep on OpenEMR PHP code using Docker
+#
+# Usage:
+#   ./run-semgrep.sh [options]
+#
+# Options:
+#   --output-format <format>   Output format: text, json, sarif (default: text)
+#   --output-file <file>       Write results to file instead of stdout
+#   --config <config>          Semgrep config/ruleset (default: uses registry + local rules)
+#   --severity <level>         Filter by severity: INFO, WARNING, ERROR (can repeat)
+#   --exclude <pattern>        Additional patterns to exclude
+#   --help                     Show this help message
+#
+
+set -e
+
+# Default values
+OUTPUT_FORMAT="text"
+OUTPUT_FILE=""
+CONFIG=""  # Empty means use default (registry + local)
+SEVERITY=""
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Arrays for building arguments
+declare -a EXTRA_EXCLUDES=()
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --output-format)
+            OUTPUT_FORMAT="$2"
+            shift 2
+            ;;
+        --output-file)
+            OUTPUT_FILE="$2"
+            shift 2
+            ;;
+        --config)
+            CONFIG="$2"
+            shift 2
+            ;;
+        --severity)
+            SEVERITY="$2"
+            shift 2
+            ;;
+        --exclude)
+            EXTRA_EXCLUDES+=("--exclude=$2")
+            shift 2
+            ;;
+        --help)
+            head -20 "$0" | tail -15 || true
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# Standard excludes for OpenEMR (matches CI workflow)
+declare -a EXCLUDES=(
+    "--exclude=vendor"
+    "--exclude=node_modules"
+    "--exclude=tests"
+    "--exclude=ccdaservice/node_modules"
+)
+
+# Build output arguments
+declare -a OUTPUT_ARGS=()
+if [[ -n "${OUTPUT_FILE}" ]]; then
+    OUTPUT_ARGS+=("--output=${OUTPUT_FILE}")
+fi
+
+# Build format argument (text is default, only specify for json/sarif)
+declare -a FORMAT_ARG=()
+if [[ "${OUTPUT_FORMAT}" = "json" ]]; then
+    FORMAT_ARG+=("--json")
+elif [[ "${OUTPUT_FORMAT}" = "sarif" ]]; then
+    FORMAT_ARG+=("--sarif")
+fi
+
+# Build severity argument (can specify multiple: INFO, WARNING, ERROR)
+declare -a SEVERITY_ARG=()
+if [[ -n "${SEVERITY}" ]]; then
+    for sev in ${SEVERITY}; do
+        SEVERITY_ARG+=("--severity=${sev}")
+    done
+fi
+
+# Build config args
+declare -a CONFIG_ARGS=()
+if [[ -n "${CONFIG}" ]]; then
+    # User-specified config
+    for cfg in ${CONFIG}; do
+        if [[ -f "${cfg}" ]]; then
+            cfg="/src/$(basename "${cfg}")"
+        fi
+        CONFIG_ARGS+=("--config=${cfg}")
+    done
+    echo "Config: ${CONFIG}"
+else
+    # Default: registry rulesets + local OpenEMR-specific rules
+    CONFIG_ARGS+=(
+        "--config=p/php"
+        "--config=p/security-audit"
+        "--config=/src/semgrep.yaml"
+    )
+    echo "Config: p/php p/security-audit semgrep.yaml"
+fi
+
+echo "Running Semgrep on OpenEMR PHP code..."
+if [[ -n "${SEVERITY}" ]]; then
+    echo "Severity filter: ${SEVERITY}"
+fi
+echo "Output format: ${OUTPUT_FORMAT}"
+echo ""
+
+# Run Semgrep in Docker using official semgrep/semgrep image
+# Semgrep Docker image expects /src as mount point
+docker run --rm \
+    -v "${SCRIPT_DIR}:/src" \
+    -w /src \
+    semgrep/semgrep:latest \
+    semgrep \
+    "${CONFIG_ARGS[@]}" \
+    "${SEVERITY_ARG[@]}" \
+    "${FORMAT_ARG[@]}" \
+    --no-git-ignore \
+    "${EXCLUDES[@]}" \
+    "${EXTRA_EXCLUDES[@]}" \
+    "${OUTPUT_ARGS[@]}" \
+    .
+
+echo ""
+echo "Semgrep scan complete."

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -1,0 +1,27 @@
+rules:
+  # OpenEMR-specific SQL functions with string concatenation
+  # These functions are unique to OpenEMR and not covered by p/php or p/security-audit
+  - id: openemr-sql-injection-sqlstatement
+    patterns:
+      - pattern: sqlStatement($QUERY, ...)
+      - pattern-not: sqlStatement("...", ...)
+      - metavariable-pattern:
+          metavariable: $QUERY
+          pattern-either:
+            - pattern: $X . $Y
+            - pattern: '"$X$Y"'
+    message: Potential SQL injection in sqlStatement() - use parameterized queries
+    languages: [php]
+    severity: ERROR
+  - id: openemr-sql-injection-sqlquery
+    patterns:
+      - pattern: sqlQuery($QUERY, ...)
+      - pattern-not: sqlQuery("...", ...)
+      - metavariable-pattern:
+          metavariable: $QUERY
+          pattern-either:
+            - pattern: $X . $Y
+            - pattern: '"$X$Y"'
+    message: Potential SQL injection in sqlQuery() - use parameterized queries
+    languages: [php]
+    severity: ERROR


### PR DESCRIPTION
Fixes #10261

## Description
Add automated security scanning using Semgrep to detect potential vulnerabilities in PHP code.

## Changes proposed in this pull request
- Add `.github/workflows/semgrep.yml` - CI workflow that runs Semgrep on push/PR/schedule
- Add `semgrep.yaml` - Custom rules for OpenEMR-specific SQL functions (sqlStatement, sqlQuery)
- Add `run-semgrep.sh` - Helper script for local development testing

### Features
- Uses Semgrep's `p/php` and `p/security-audit` registry rulesets for broad coverage
- Custom rules detect SQL injection in OpenEMR-specific functions
- PR scans only check changed files (baseline comparison)
- Weekly scheduled scans for comprehensive coverage
- SARIF output uploads to GitHub Security tab
- Excludes vendor/, node_modules/, tests/ to reduce noise

## AI Disclosure
Yes - Claude Code assisted with implementation

🤖 Generated with [Claude Code](https://claude.ai/code)