### PR TITLE
fix(portal): fix leftover issue with _documents.html.twig in portal_patient_report.html.twig

### DIFF
--- a/templates/portal/portal_patient_report.html.twig
+++ b/templates/portal/portal_patient_report.html.twig
@@ -31,8 +31,6 @@
         <!-- Procedure Orders -->
         {% include "portal/partial/reports/patient_report/_procedure_orders.html.twig" with {procedureOrders: procedureOrders} %}
 
-        {% include "portal/partial/reports/patient_report/_documents.html.twig" with {documents: documents} %}
-
     </form>
     <input type="button" class="genreport" value="{{ 'Generate Report'|xla }}" />&nbsp;
     <input type="button" class="genpdfrep" value="{{ 'Download PDF'|xla }}" />&nbsp;


### PR DESCRIPTION
Fixes #10266

#### Short description of what this resolves:

The error "Unable to find template 'portal/partial/reports/patient_report/_documents.html.twig'" was caused by an incomplete refactoring in commit `f002ca65800d8cbfb523bcfdd1e00c8727c421ca`. While the template file `_documents.html.twig` and its associated logic in the controllers were removed to eliminate "all document references in custom reports," the `{% include %}` statement in `templates/portal/portal_patient_report.html.twig` was accidentally left behind.

#### Changes proposed in this pull request:

I have removed the orphaned `{% include %}` statement from `templates/portal/portal_patient_report.html.twig`, which resolves the template loading error.

- Modified `templates/portal/portal_patient_report.html.twig`: Removed the line attempting to include the non-existent `portal/partial/reports/patient_report/_documents.html.twig`.

#### Does your code include anything generated by an AI Engine? Yes (for investigation only. PHPStorm Junie was used)

