### PR TITLE
fix(faxsms): allow SMTP without username/password

### DIFF
--- a/.phpstan/baseline/openemr.forbiddenGlobalsAccess.php
+++ b/.phpstan/baseline/openemr.forbiddenGlobalsAccess.php
@@ -1333,7 +1333,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$GLOBALS is forbidden\\. Use OEGlobalsBag\\:\\:getInstance\\(\\)\\-\\>get\\(\\) instead\\.$#',
-    'count' => 7,
+    'count' => 6,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/contact.php',
 ];
 $ignoreErrors[] = [
@@ -1373,17 +1373,17 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$GLOBALS is forbidden\\. Use OEGlobalsBag\\:\\:getInstance\\(\\)\\-\\>get\\(\\) instead\\.$#',
-    'count' => 8,
+    'count' => 10,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EmailClient.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$GLOBALS is forbidden\\. Use OEGlobalsBag\\:\\:getInstance\\(\\)\\-\\>get\\(\\) instead\\.$#',
-    'count' => 8,
+    'count' => 6,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$GLOBALS is forbidden\\. Use OEGlobalsBag\\:\\:getInstance\\(\\)\\-\\>get\\(\\) instead\\.$#',
-    'count' => 9,
+    'count' => 7,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php',
 ];
 $ignoreErrors[] = [

--- a/interface/modules/custom_modules/oe-module-faxsms/contact.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/contact.php
@@ -35,7 +35,7 @@ $isForward = ($clientApp->getRequest('mode', false) == 'forward') ? 1 : 0;
 $isFax = ($serviceType == 'fax') ? 1 : 0;
 $isUniversal = (int)$clientApp->getRequest('isUniversal', false);
 
-$isSMTP = !empty($GLOBALS['SMTP_PASS'] ?? null) && !empty($GLOBALS["SMTP_USER"] ?? null);
+$isSMTP = !empty($GLOBALS['SMTP_HOST'] ?? null);
 $isOnetime = (int)$clientApp->getRequest('isOnetime', false);
 
 if ($isUniversal) {

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/EmailClient.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/EmailClient.php
@@ -5,8 +5,11 @@
  *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Jerry Padgett <sjpadgett@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2023 Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -39,7 +42,7 @@ class EmailClient extends AppDispatch
         $this->crypto = new CryptoGen();
         $this->baseDir = $GLOBALS['temporary_files_dir'];
         $this->uriDir = $GLOBALS['OE_SITE_WEBROOT'];
-        $this->smtpEnabled = !empty($GLOBALS['SMTP_PASS'] ?? null) && !empty($GLOBALS["SMTP_USER"] ?? null);
+        $this->smtpEnabled = !empty($GLOBALS['SMTP_HOST'] ?? null);
         parent::__construct();
     }
 
@@ -139,7 +142,12 @@ class EmailClient extends AppDispatch
             throw new InvalidEmailAddressException("Missing valid email address");
         }
         if (!$this->smtpEnabled) {
-            throw new SmtpNotConfiguredException("SMTP not configured");
+            throw new SmtpNotConfiguredException(sprintf(
+                "SMTP not configured (SMTP_HOST=%s, SMTP_PORT=%s, SMTP_USER=%s)",
+                $GLOBALS['SMTP_HOST'] ?? 'NOT_SET',
+                $GLOBALS['SMTP_PORT'] ?? 'NOT_SET',
+                !empty($GLOBALS['SMTP_USER']) ? 'SET' : 'NOT_SET'
+            ));
         }
         $from_name = text($GLOBALS["Patient Reminder Sender Name"] ?? 'UNK');
         $desc = text($body);

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/EtherFaxActions.php
@@ -187,7 +187,7 @@ class EtherFaxActions extends AppDispatch
         $isDocuments = (int)$this->getRequest('isDocuments');
         $email = $this->getRequest('email');
         $hasEmail = $this->validEmail($email);
-        $smtpEnabled = !empty($GLOBALS['SMTP_PASS'] ?? null) && !empty($GLOBALS["SMTP_USER"] ?? null);
+        $smtpEnabled = !empty($GLOBALS['SMTP_HOST'] ?? null);
         $user = $this::getLoggedInUser();
         $facility = substr((string)$user['facility'], 0, 20);
         $csid = $this->formatPhone($this->credentials['phone']);
@@ -298,7 +298,7 @@ class EtherFaxActions extends AppDispatch
         $email = $this->getRequest('email');
         $faxNumber = $this->formatPhone($this->getRequest('phone'));
         $hasEmail = $this->validEmail($email);
-        $smtpEnabled = !empty($GLOBALS['SMTP_PASS'] ?? null) && !empty($GLOBALS["SMTP_USER"] ?? null);
+        $smtpEnabled = !empty($GLOBALS['SMTP_HOST'] ?? null);
         $user = $this::getLoggedInUser();
         $facility = substr((string)$user['facility'], 0, 20);
         $csid = $this->formatPhone($this->credentials['phone']);

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/RCFaxClient.php
@@ -176,7 +176,7 @@ class RCFaxClient extends AppDispatch
         $email = $this->getRequest('email');
         $faxNumber = $this->formatPhone($this->getRequest('phone'));
         $hasEmail = $this->validEmail($email);
-        $smtpEnabled = !empty($GLOBALS['SMTP_PASS'] ?? null) && !empty($GLOBALS["SMTP_USER"] ?? null);
+        $smtpEnabled = !empty($GLOBALS['SMTP_HOST'] ?? null);
         $user = $this::getLoggedInUser();
         $facility = substr((string) $user['facility'], 0, 20);
         $csid = $this->formatPhone($this->credentials['phone']);
@@ -257,7 +257,7 @@ class RCFaxClient extends AppDispatch
         $comments = trim((string) $this->getRequest('comments', $comments));
         $email = $this->getRequest('email');
         $hasEmail = $this->validEmail($email);
-        $smtpEnabled = !empty($GLOBALS['SMTP_PASS'] ?? null) && !empty($GLOBALS["SMTP_USER"] ?? null);
+        $smtpEnabled = !empty($GLOBALS['SMTP_HOST'] ?? null);
         $user = $this::getLoggedInUser();
         $name = $this->getRequest('name', $name) . ' ' . $this->getRequest('surname', '');
         $fileName ??= pathinfo((string) $file, PATHINFO_BASENAME);

--- a/interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/src/Controller/SignalWireClient.php
@@ -144,7 +144,7 @@ class SignalWireClient extends AppDispatch
         $email = $this->getRequest('email');
         $hasEmail = $this->validEmail($email);
         $globals = OEGlobalsBag::getInstance();
-        $smtpEnabled = !empty($globals->get('SMTP_PASS') ?? null) && !empty($globals->get('SMTP_USER') ?? null);
+        $smtpEnabled = !empty($globals->get('SMTP_HOST') ?? null);
         $user = $this::getLoggedInUser();
 
         // DEBUG: Log parameters received in sendFax


### PR DESCRIPTION
## Summary
- Check `SMTP_HOST` instead of `SMTP_USER`/`SMTP_PASS` to enable SMTP functionality
- Allows legitimate use cases: dev tools (mailpit, MailHog), IP-based mail relays, corporate SMTP with firewall access
- Enhanced `SmtpNotConfiguredException` with debugging context

## Test plan
- [ ] Configure SMTP with only host/port (no credentials)
- [ ] Verify email reminder functionality works
- [ ] Verify existing SMTP with credentials still works

Fixes #9066

🤖 Generated with [Claude Code](https://claude.ai/code)