### PR TITLE
fix: Clinical Notes FHIR mismatched join #10168

### DIFF
--- a/src/Services/ClinicalNotesService.php
+++ b/src/Services/ClinicalNotesService.php
@@ -97,6 +97,7 @@ class ClinicalNotesService extends BaseService
                         ,`code`
                         ,codetext
                         ,`description`
+                        ,`pid` AS notes_pid
                         ,external_id
                         ,clinical_notes_type
                         ,note_related_to
@@ -109,21 +110,24 @@ class ClinicalNotesService extends BaseService
              ) notes
             JOIN (
                 SELECT
-                    id AS form_id,
-                    encounter
+                    id
+                    ,form_id
+                    ,encounter
                     ,pid AS form_pid
                     ,`date` AS date_created
                 FROM
                     forms
-            ) forms ON forms.form_id = notes.form_id
+                WHERE formdir = 'clinical_notes'
+            ) forms ON forms.form_id = notes.form_id AND forms.form_pid = notes.notes_pid
             LEFT JOIN (
                 select
                     encounter AS eid
                     ,uuid AS euuid
                     ,`date` AS encounter_date
+                    ,`pid` AS encounter_pid
                 FROM
                     form_encounter
-            ) encounters ON encounters.eid = forms.encounter
+            ) encounters ON encounters.eid = forms.encounter AND forms.form_pid = encounters.encounter_pid
             LEFT JOIN
             (
                 SELECT

--- a/src/Services/FHIR/DocumentReference/FhirClinicalNotesService.php
+++ b/src/Services/FHIR/DocumentReference/FhirClinicalNotesService.php
@@ -13,16 +13,13 @@ namespace OpenEMR\Services\FHIR\DocumentReference;
 
 use Monolog\Utils;
 use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRDocumentReference;
-use OpenEMR\FHIR\R4\FHIRDomainResource\FHIRObservation;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRAttachment;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRId;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRIdentifier;
-use OpenEMR\FHIR\R4\FHIRElement\FHIRMeta;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRPeriod;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRString;
 use OpenEMR\FHIR\R4\FHIRResource\FHIRDocumentReference\FHIRDocumentReferenceContent;
 use OpenEMR\FHIR\R4\FHIRResource\FHIRDocumentReference\FHIRDocumentReferenceContext;
-use OpenEMR\RestControllers\FHIR\FhirDocumentReferenceRestController;
 use OpenEMR\Services\ClinicalNotesService;
 use OpenEMR\Services\FHIR\a;
 use OpenEMR\Services\FHIR\DocumentReference\Trait\FhirDocumentReferenceTrait;
@@ -41,11 +38,9 @@ use OpenEMR\Services\Search\ISearchField;
 use OpenEMR\Services\Search\SearchFieldType;
 use OpenEMR\Services\Search\SearchModifier;
 use OpenEMR\Services\Search\ServiceField;
-use OpenEMR\Services\Search\StringSearchField;
 use OpenEMR\Services\Search\TokenSearchField;
 use OpenEMR\Services\Search\TokenSearchValue;
 use OpenEMR\Validators\ProcessingResult;
-use Twig\Token;
 
 class FhirClinicalNotesService extends FhirServiceBase
 {
@@ -189,6 +184,8 @@ class FhirClinicalNotesService extends FhirServiceBase
         } else {
             $docReference->setType(UtilsService::createNullFlavorUnknownCodeableConcept());
         }
+
+        $this->populateAuthor($docReference, $dataRecord);
 
         return $docReference;
     }


### PR DESCRIPTION
Fixed an issue where patients could get the wrong clinical notes based upon the form id joining on the FHIR query.  Made sure both the encounter form and the clinical note forms would not show up for the wrong patient by adding an additional safety check on the patient pid.

Also added in the author population for clinical notes which was missing.

Fixes #10168 