### PR TITLE
fix(e2e): Fix flaky testUserAdd by properly waiting for page reload

### DIFF
--- a/tests/Tests/E2e/User/UserAddTrait.php
+++ b/tests/Tests/E2e/User/UserAddTrait.php
@@ -92,16 +92,30 @@ trait UserAddTrait
         $this->crawler = $this->client->refreshCrawler();
         $this->crawler->filterXPath(XpathsConstantsUserAddTrait::CREATE_USER_BUTTON_USERADD_TRAIT)->click();
 
-        sleep(2); // wait for the form submission to be complete
+        // Switch to default content to properly detect modal state changes
+        $this->client->switchTo()->defaultContent();
+
+        // Wait for the modal iframe to disappear (dialog closes on successful user creation)
+        // The dialog calls dlgclose('reload', false) on success, which closes the modal
+        // and triggers a reload of the admin iframe
+        $this->client->wait(30)->until(
+            WebDriverExpectedCondition::invisibilityOfElementLocated(
+                WebDriverBy::xpath(XpathsConstantsUserAddTrait::NEW_USER_IFRAME_USERADD_TRAIT)
+            )
+        );
 
         // assert the new user is in the database
         $this->assertUserInDatabase($username);
 
-        // assert the new user can be seen in the gui
-        $this->client->switchTo()->defaultContent();
+        // Wait for the admin iframe to be ready (it reloads after dialog closes)
         $this->client->waitFor(XpathsConstants::ADMIN_IFRAME);
         $this->switchToIFrame(XpathsConstants::ADMIN_IFRAME);
-        // below line will throw a timeout exception and fail if the new user is not listed
+
+        // Wait for the Add User button to be visible again (indicates the iframe has fully reloaded)
+        $this->client->waitFor(XpathsConstantsUserAddTrait::ADD_USER_BUTTON_USERADD_TRAIT);
+
+        // Now wait for the new user to appear in the table
+        // This will throw a timeout exception and fail if the new user is not listed
         $this->client->waitFor("//table//a[text()='$username']");
     }
 


### PR DESCRIPTION
Fixes #10286

## Summary

- Replace unreliable `sleep(2)` with proper WebDriver wait conditions
- Wait for modal iframe to become invisible (confirms dialog closed)
- Wait for admin iframe to reload and "Add User" button to reappear
- Then look for the new user in the table

## Changes proposed in this pull request

The `testUserAdd` test was failing intermittently with:
```
TimeoutException: Element "//table//a[text()='foobar']" not found within 30 seconds.
```

This occurred because after creating a user, `dlgclose('reload', false)` closes the modal and triggers an automatic page reload of the admin iframe. The 2-second sleep was not sufficient to reliably wait for this reload to complete.

The fix uses proper WebDriver wait conditions that:
1. Complete as soon as conditions are met (typically 1-2 seconds)
2. Have a 30-second maximum timeout as fallback
3. Properly handle the asynchronous page reload

## Testing

The CI test suite will validate this fix. The test should now reliably pass across all environments (PHP versions, databases, web servers).

## AI Disclosure

Yes