### PR TITLE
refactor: Consolidate IP address validation using filter_var

### DIFF
--- a/library/classes/smtp/smtp.php
+++ b/library/classes/smtp/smtp.php
@@ -219,8 +219,9 @@ class smtp_class
             || !extension_loaded("openssl"))
                 return("establishing SSL connections requires the OpenSSL extension enabled");
         }
-        if(preg_match('/^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$/',(string) $domain))
-            $ip=$domain;
+        if (\OpenEMR\Common\Utils\ValidationUtils::isValidIpAddress((string) $domain, FILTER_FLAG_IPV4)) {
+            $ip = $domain;
+        }
         else
         {
             if($this->debug)

--- a/src/Common/Utils/ValidationUtils.php
+++ b/src/Common/Utils/ValidationUtils.php
@@ -5,10 +5,13 @@
  *
  * @package   OpenEMR
  * @link      http://www.open-emr.org
+ * @link      https://opencoreemr.com
  * @author    Cassian LUP <cassi.lup@gmail.com>
  * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2011 Cassian LUP <cassi.lup@gmail.com>
  * @copyright Copyright (c) 2022 Discover and Change, Inc <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -29,5 +32,18 @@ class ValidationUtils
         }
 
         return false;
+    }
+
+    /**
+     * Validates an IP address using filter_var.
+     *
+     * @param string $ip The IP address to validate
+     * @param int $flags Optional flags: FILTER_FLAG_IPV4, FILTER_FLAG_IPV6,
+     *                   FILTER_FLAG_NO_PRIV_RANGE, FILTER_FLAG_NO_RES_RANGE
+     * @return bool True if valid IP address, false otherwise
+     */
+    public static function isValidIpAddress(string $ip, int $flags = 0): bool
+    {
+        return filter_var($ip, FILTER_VALIDATE_IP, $flags) !== false;
     }
 }

--- a/src/Telemetry/GeoTelemetry.php
+++ b/src/Telemetry/GeoTelemetry.php
@@ -13,12 +13,17 @@
  *
  * @package        OpenEMR
  * @link           https://www.open-emr.org
+ * @link           https://opencoreemr.com
  * @author         Jerry Padgett <sjpadgett@gmail.com>
+ * @author         Michael A. Smith <michael@opencoreemr.com>
  * @copyright      Copyright (c) 2025 <sjpadgett@gmail.com>
+ * @copyright      Copyright (c) 2026 OpenCoreEMR Inc.
  * @license        https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
 namespace OpenEMR\Telemetry;
+
+use OpenEMR\Common\Utils\ValidationUtils;
 
 class GeoTelemetry implements GeoTelemetryInterface
 {
@@ -68,7 +73,7 @@ class GeoTelemetry implements GeoTelemetryInterface
     public function getServerGeoData(): array
     {
         $ip = trim($this->fetchText(self::GET_IP_URL));
-        if (filter_var($ip, FILTER_VALIDATE_IP)) {
+        if (ValidationUtils::isValidIpAddress($ip)) {
             return $this->getGeoData($ip);
         }
         return ['error' => 'Unable to determine server IP'];

--- a/tests/Tests/Isolated/Common/Utils/ValidationUtilsIsolatedTest.php
+++ b/tests/Tests/Isolated/Common/Utils/ValidationUtilsIsolatedTest.php
@@ -53,4 +53,88 @@ class ValidationUtilsIsolatedTest extends TestCase
             );
         }
     }
+
+    public function testIpAddressValidationWithValidIpv4(): void
+    {
+        $validIps = [
+            '192.168.1.1',
+            '10.0.0.1',
+            '172.16.0.1',
+            '8.8.8.8',
+            '0.0.0.0',
+            '255.255.255.255'
+        ];
+
+        foreach ($validIps as $ip) {
+            $this->assertTrue(
+                ValidationUtils::isValidIpAddress($ip),
+                "IP should be valid: {$ip}"
+            );
+        }
+    }
+
+    public function testIpAddressValidationWithValidIpv6(): void
+    {
+        $validIps = [
+            '::1',
+            '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+            '2001:db8::1',
+            'fe80::1'
+        ];
+
+        foreach ($validIps as $ip) {
+            $this->assertTrue(
+                ValidationUtils::isValidIpAddress($ip),
+                "IPv6 should be valid: {$ip}"
+            );
+        }
+    }
+
+    public function testIpAddressValidationWithInvalidIps(): void
+    {
+        $invalidIps = [
+            'not-an-ip',
+            '256.256.256.256',
+            '192.168.1',
+            '192.168.1.1.1',
+            '999.999.999.999',
+            ''
+        ];
+
+        foreach ($invalidIps as $ip) {
+            $this->assertFalse(
+                ValidationUtils::isValidIpAddress($ip),
+                "IP should be invalid: {$ip}"
+            );
+        }
+    }
+
+    public function testIpAddressValidationWithIpv4Flag(): void
+    {
+        // Valid IPv4
+        $this->assertTrue(ValidationUtils::isValidIpAddress('192.168.1.1', FILTER_FLAG_IPV4));
+
+        // IPv6 should fail with IPv4 flag
+        $this->assertFalse(ValidationUtils::isValidIpAddress('::1', FILTER_FLAG_IPV4));
+    }
+
+    public function testIpAddressValidationWithIpv6Flag(): void
+    {
+        // Valid IPv6
+        $this->assertTrue(ValidationUtils::isValidIpAddress('::1', FILTER_FLAG_IPV6));
+
+        // IPv4 should fail with IPv6 flag
+        $this->assertFalse(ValidationUtils::isValidIpAddress('192.168.1.1', FILTER_FLAG_IPV6));
+    }
+
+    public function testIpAddressValidationWithPrivateRangeFlag(): void
+    {
+        // Private IPs should fail with NO_PRIV_RANGE flag
+        $this->assertFalse(ValidationUtils::isValidIpAddress('192.168.1.1', FILTER_FLAG_NO_PRIV_RANGE));
+        $this->assertFalse(ValidationUtils::isValidIpAddress('10.0.0.1', FILTER_FLAG_NO_PRIV_RANGE));
+        $this->assertFalse(ValidationUtils::isValidIpAddress('172.16.0.1', FILTER_FLAG_NO_PRIV_RANGE));
+
+        // Public IPs should pass
+        $this->assertTrue(ValidationUtils::isValidIpAddress('8.8.8.8', FILTER_FLAG_NO_PRIV_RANGE));
+    }
 }


### PR DESCRIPTION
## Summary
- Add `ValidationUtils::isValidIpAddress()` method using `filter_var()` with `FILTER_VALIDATE_IP`
- Replace incomplete regex in `smtp.php` that didn't validate octet ranges
- Update `GeoTelemetry.php` to use the centralized method

Fixes #10305

## Test plan
- [ ] Verify existing isolated tests pass for ValidationUtils and GeoTelemetry
- [ ] Test SMTP functionality with IP addresses and hostnames

### AI disclosure
- [x] Yes, I used AI to help me with this pull request

🤖 Generated with [Claude Code](https://claude.ai/code)