### PR TITLE
fix(security): add OpenEMR sanitizers to Semgrep echoed-request rule

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -38,6 +38,10 @@ jobs:
 
     - name: Run Semgrep (full scan)
       if: github.event_name != 'pull_request'
+      # Exclude the default echoed-request rule from p/php and use our custom
+      # version in semgrep.yaml instead. Our custom rule adds OpenEMR's
+      # sanitization functions (attr, text, xlt, etc.) to prevent false positives
+      # while still detecting real XSS vulnerabilities.
       run: |
         semgrep \
           --config p/php \
@@ -47,6 +51,7 @@ jobs:
           --exclude node_modules \
           --exclude tests \
           --exclude ccdaservice/node_modules \
+          --exclude-rule php.lang.security.injection.echoed-request.echoed-request \
           --sarif \
           --output=semgrep-results.sarif \
           .
@@ -55,6 +60,10 @@ jobs:
       if: github.event_name == 'pull_request'
       env:
         BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      # Exclude the default echoed-request rule from p/php and use our custom
+      # version in semgrep.yaml instead. Our custom rule adds OpenEMR's
+      # sanitization functions (attr, text, xlt, etc.) to prevent false positives
+      # while still detecting real XSS vulnerabilities.
       run: |
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
         semgrep \
@@ -65,6 +74,7 @@ jobs:
           --exclude node_modules \
           --exclude tests \
           --exclude ccdaservice/node_modules \
+          --exclude-rule php.lang.security.injection.echoed-request.echoed-request \
           --baseline-commit="$BASE_SHA" \
           --sarif \
           --output=semgrep-results.sarif \

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -1,27 +1,107 @@
 rules:
+  # Override echoed-request rule from p/php to add OpenEMR sanitizers
+  # This prevents false positives for OpenEMR's escaping functions like attr(), text(), xlt(), etc.
+  # See: library/htmlspecialchars.inc.php for function implementations
+- id: echoed-request
+  mode: taint
+  message: >-
+    `Echo`ing user input risks cross-site scripting vulnerability.
+    Use `attr()` for attribute values or `text()` for text content.
+    See library/htmlspecialchars.inc.php for available sanitizers.
+  languages: [php]
+  severity: ERROR
+  pattern-sources:
+  - pattern: $_REQUEST
+  - pattern: $_GET
+  - pattern: $_POST
+  pattern-sinks:
+  - pattern: echo $...VARS;
+  pattern-sanitizers:
+      # Standard PHP sanitizers
+  - pattern: htmlentities(...)
+  - pattern: htmlspecialchars(...)
+  - pattern: strip_tags(...)
+  - pattern: isset(...)
+  - pattern: empty(...)
+      # WordPress sanitizers
+  - pattern: esc_html(...)
+  - pattern: esc_attr(...)
+  - pattern: wp_kses(...)
+      # Laravel/Symfony/Twig sanitizers
+  - pattern: e(...)
+  - pattern: twig_escape_filter(...)
+      # CodeIgniter sanitizers
+  - pattern: xss_clean(...)
+  - pattern: html_escape(...)
+      # Drupal sanitizers
+  - pattern: Html::escape(...)
+  - pattern: Xss::filter(...)
+      # Laminas sanitizers
+  - pattern: escapeHtml(...)
+  - pattern: escapeHtmlAttr(...)
+      # OpenEMR sanitizers (library/htmlspecialchars.inc.php)
+  - pattern: text(...)
+  - pattern: attr(...)
+  - pattern: attr_url(...)
+  - pattern: attr_js(...)
+  - pattern: js_escape(...)
+  - pattern: js_url(...)
+  - pattern: xlt(...)
+  - pattern: xla(...)
+  - pattern: xlj(...)
+  - pattern: xlx(...)
+  - pattern: xmlEscape(...)
+  - pattern: csvEscape(...)
+  - pattern: errorLogEscape(...)
+      # OpenEMR display function (library/options.inc.php) - uses htmlspecialchars internally
+  - pattern: generate_display_field(...)
+  fix: echo attr($...VARS);
+  metadata:
+    technology:
+    - php
+    cwe:
+    - "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp:
+    - A07:2017 - Cross-Site Scripting (XSS)
+    - A03:2021 - Injection
+    category: security
+    references:
+    - https://www.php.net/manual/en/function.htmlentities.php
+    - https://www.php.net/manual/en/reserved.variables.request.php
+    - https://www.php.net/manual/en/reserved.variables.post.php
+    - https://www.php.net/manual/en/reserved.variables.get.php
+    - https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: MEDIUM
+    confidence: MEDIUM
+
   # OpenEMR-specific SQL functions with string concatenation
   # These functions are unique to OpenEMR and not covered by p/php or p/security-audit
-  - id: openemr-sql-injection-sqlstatement
-    patterns:
-      - pattern: sqlStatement($QUERY, ...)
-      - pattern-not: sqlStatement("...", ...)
-      - metavariable-pattern:
-          metavariable: $QUERY
-          pattern-either:
-            - pattern: $X . $Y
-            - pattern: '"$X$Y"'
-    message: Potential SQL injection in sqlStatement() - use parameterized queries
-    languages: [php]
-    severity: ERROR
-  - id: openemr-sql-injection-sqlquery
-    patterns:
-      - pattern: sqlQuery($QUERY, ...)
-      - pattern-not: sqlQuery("...", ...)
-      - metavariable-pattern:
-          metavariable: $QUERY
-          pattern-either:
-            - pattern: $X . $Y
-            - pattern: '"$X$Y"'
-    message: Potential SQL injection in sqlQuery() - use parameterized queries
-    languages: [php]
-    severity: ERROR
+- id: openemr-sql-injection-sqlstatement
+  patterns:
+  - pattern: sqlStatement($QUERY, ...)
+  - pattern-not: sqlStatement("...", ...)
+  - metavariable-pattern:
+      metavariable: $QUERY
+      pattern-either:
+      - pattern: $X . $Y
+      - pattern: '"$X$Y"'
+  message: Potential SQL injection in sqlStatement() - use parameterized queries
+  languages: [php]
+  severity: ERROR
+- id: openemr-sql-injection-sqlquery
+  patterns:
+  - pattern: sqlQuery($QUERY, ...)
+  - pattern-not: sqlQuery("...", ...)
+  - metavariable-pattern:
+      metavariable: $QUERY
+      pattern-either:
+      - pattern: $X . $Y
+      - pattern: '"$X$Y"'
+  message: Potential SQL injection in sqlQuery() - use parameterized queries
+  languages: [php]
+  severity: ERROR


### PR DESCRIPTION
## Summary

- Add custom `echoed-request` Semgrep rule with OpenEMR's sanitization functions
- Exclude default rule from `p/php` to use our customized version
- Prevents false positives for properly sanitized output

Fixes #10315

## Test plan

- [x] Verify `semgrep.yaml` validates successfully
- [x] Confirm lines 1460 and 1541 in `interface/patient_file/front_payment.php` are no longer flagged
- [x] Verify rule still catches actual XSS (e.g., `echo $_GET["name"];`)
- [x] Verify sanitized output is allowed (e.g., `echo attr($_GET["name"]);`)

## AI Disclosure

Yes

🤖 Generated with [Claude Code](https://claude.com/claude-code)