### PR TITLE
refactor: Consolidate integer validation using ValidationUtils

### DIFF
--- a/.phpstan/baseline/loader.php
+++ b/.phpstan/baseline/loader.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-// total 18982 errors
+// total 18980 errors
 
 return ['includes' => [
     __DIR__ . '/arguments.count.php',

--- a/.phpstan/baseline/openemr.forbiddenGlobalsAccess.php
+++ b/.phpstan/baseline/openemr.forbiddenGlobalsAccess.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-// total 3896 errors
+// total 3894 errors
 
 $ignoreErrors = [];
 $ignoreErrors[] = [
@@ -965,7 +965,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$GLOBALS is forbidden\\. Use OEGlobalsBag\\:\\:getInstance\\(\\)\\-\\>get\\(\\) instead\\.$#',
-    'count' => 8,
+    'count' => 7,
     'path' => __DIR__ . '/../../interface/main/calendar/find_appt_popup.php',
 ];
 $ignoreErrors[] = [

--- a/interface/main/calendar/find_appt_popup.php
+++ b/interface/main/calendar/find_appt_popup.php
@@ -24,6 +24,7 @@ require_once($GLOBALS['incdir'] . "/main/holidays/Holidays_Controller.php");
 
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\Common\Utils\ValidationUtils;
 use OpenEMR\Core\Header;
 
 ?>
@@ -135,13 +136,17 @@ $slotsperday = (int) (60 * 60 * 24 / $slotsecs);
 $evslots = $catslots;
 if (isset($_REQUEST['evdur'])) {
     // bug fix #445 -- Craig Bezuidenhout 09 Aug 2016
-    // if the event duration is less than or equal to zero, use the global calander interval
+    // if the event duration is less than or equal to zero, use the global calendar interval
     // if the global calendar interval is less than or equal to zero, use 10 mins
-    if (intval($_REQUEST['evdur']) <= 0) {
-        $_REQUEST['evdur'] = intval($GLOBALS['calendar_interval']) <= 0 ? 10 : intval($GLOBALS['calendar_interval']);
+    $evdur = ValidationUtils::validateInt($_REQUEST['evdur'], min: 1);
+    if ($evdur === false) {
+        $evdur = ValidationUtils::validateInt($GLOBALS['calendar_interval'], min: 1);
+        if ($evdur === false) {
+            $evdur = 10;
+        }
     }
 
-    $evslots = 60 * $_REQUEST['evdur'];
+    $evslots = 60 * $evdur;
     $evslots = (int) (($evslots + $slotsecs - 1) / $slotsecs);
 }
 

--- a/interface/main/messages/trusted-messages-ajax.php
+++ b/interface/main/messages/trusted-messages-ajax.php
@@ -13,10 +13,11 @@
 require_once("../../globals.php");
 require_once("../../../ccr/transmitCCD.php");
 
+use OpenEMR\Common\Acl\AccessDeniedException;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Common\Utils\ValidationUtils;
 use OpenEMR\Services\PatientService;
-use OpenEMR\Common\Acl\AccessDeniedException;
 
 $result = ['success' => false];
 
@@ -36,9 +37,8 @@ if (!CsrfUtils::verifyCsrfToken($csrf)) {
     $document = null;
 
     try {
-        $pid = $_REQUEST['pid'] ?? null;
-
-        if (empty($pid) || intval($pid) <= 0) {
+        $pid = ValidationUtils::validateInt($_REQUEST['pid'] ?? null, min: 1);
+        if ($pid === false) {
             throw new InvalidArgumentException("pid is required and must be a valid patient id");
         }
         $patientService = new PatientService();
@@ -57,13 +57,13 @@ if (!CsrfUtils::verifyCsrfToken($csrf)) {
             throw new InvalidArgumentException("trusted_email is required and must be a valid Direct email address");
         }
 
-        $documentId = $_REQUEST['documentId'] ?? null;
+        $documentId = ValidationUtils::validateInt($_REQUEST['documentId'] ?? null, min: 1);
         $message = $_REQUEST['message'] ?? '';
-        if ((empty($documentId) || intval($documentId) <= 0) && empty($message)) {
+        if ($documentId === false && empty($message)) {
             throw new InvalidArgumentException("document_id is required if no message is sent and must be a valid document id");
         }
 
-        if (!empty($documentId) && intval($documentId) > 0) {
+        if ($documentId !== false) {
             // now we need to lookup the document
             $document = new \Document($documentId);
 

--- a/interface/modules/zend_modules/module/Immunization/src/Immunization/Controller/ImmunizationController.php
+++ b/interface/modules/zend_modules/module/Immunization/src/Immunization/Controller/ImmunizationController.php
@@ -12,12 +12,13 @@
 
 namespace Immunization\Controller;
 
+use Application\Listener\Listener;
 use Application\Model\ApplicationTable;
+use Immunization\Form\ImmunizationForm;
 use Immunization\Model\ImmunizationTable;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\ViewModel;
-use Immunization\Form\ImmunizationForm;
-use Application\Listener\Listener;
+use OpenEMR\Common\Utils\ValidationUtils;
 
 class ImmunizationController extends AbstractActionController
 {
@@ -100,9 +101,9 @@ class ImmunizationController extends AbstractActionController
 
             foreach ($form_code as $code) {
                 // Validate that code is an integer to prevent SQL injection
-                $code = trim((string) $code);
-                if (!empty($code) && is_numeric($code) && $code > 0) {
-                    $valid_codes[] = (int)$code;
+                $validCode = ValidationUtils::validateInt(trim((string) $code), min: 1);
+                if ($validCode !== false) {
+                    $valid_codes[] = $validCode;
                 }
             }
 

--- a/library/classes/Document.class.php
+++ b/library/classes/Document.class.php
@@ -23,8 +23,9 @@ require_once(__DIR__ . "/../gprelations.inc.php");
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Crypto\CryptoGen;
 use OpenEMR\Common\ORDataObject\ORDataObject;
-use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Common\Session\SessionWrapperFactory;
+use OpenEMR\Common\Utils\ValidationUtils;
+use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Events\PatientDocuments\PatientDocumentStoreOffsite;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -997,7 +998,8 @@ class Document extends ORDataObject
             // Storing document files locally.
             $repository = $GLOBALS['oer_config']['documents']['repository'];
             $higher_level_path = preg_replace("/[^A-Za-z0-9\/]/", "_", $higher_level_path);
-            if ((!empty($higher_level_path)) && (is_numeric($patient_id) && $patient_id > 0)) {
+            $validPatientId = ValidationUtils::validateInt($patient_id, min: 1);
+            if ((!empty($higher_level_path)) && $validPatientId !== false) {
                 // Allow higher level directory structure in documents directory and a patient is mapped.
                 $filepath = $repository . $higher_level_path . "/";
             } elseif (!empty($higher_level_path)) {
@@ -1005,7 +1007,7 @@ class Document extends ORDataObject
                 // (will create up to 10000 random directories and increment the path_depth by 1).
                 $filepath = $repository . $higher_level_path . '/' . random_int(1, 10000)  . '/';
                 ++$path_depth;
-            } elseif (!(is_numeric($patient_id)) || !($patient_id > 0)) {
+            } elseif ($validPatientId === false) {
                 // This is the default action except there is no patient mapping (when patient_id is 00 or direct)
                 // (will create up to 10000 random directories and set the path_depth to 2).
                 $filepath = $repository . $patient_id . '/' . random_int(1, 10000)  . '/';

--- a/src/Common/Utils/ValidationUtils.php
+++ b/src/Common/Utils/ValidationUtils.php
@@ -46,4 +46,25 @@ class ValidationUtils
     {
         return filter_var($ip, FILTER_VALIDATE_IP, $flags) !== false;
     }
+
+    /**
+     * Validates an integer, optionally within a range.
+     *
+     * @param mixed $value The value to validate
+     * @param ?int $min Minimum allowed value (inclusive)
+     * @param ?int $max Maximum allowed value (inclusive)
+     * @return int|false The validated integer, or false if invalid
+     */
+    public static function validateInt(mixed $value, ?int $min = null, ?int $max = null): int|false
+    {
+        $options = [];
+        if ($min !== null) {
+            $options['min_range'] = $min;
+        }
+        if ($max !== null) {
+            $options['max_range'] = $max;
+        }
+
+        return filter_var($value, FILTER_VALIDATE_INT, empty($options) ? 0 : ['options' => $options]);
+    }
 }

--- a/tests/Tests/Isolated/Common/Utils/ValidationUtilsIsolatedTest.php
+++ b/tests/Tests/Isolated/Common/Utils/ValidationUtilsIsolatedTest.php
@@ -137,4 +137,49 @@ class ValidationUtilsIsolatedTest extends TestCase
         // Public IPs should pass
         $this->assertTrue(ValidationUtils::isValidIpAddress('8.8.8.8', FILTER_FLAG_NO_PRIV_RANGE));
     }
+
+    public function testValidateIntWithValidIntegers(): void
+    {
+        $this->assertSame(42, ValidationUtils::validateInt(42));
+        $this->assertSame(42, ValidationUtils::validateInt('42'));
+        $this->assertSame(0, ValidationUtils::validateInt(0));
+        $this->assertSame(0, ValidationUtils::validateInt('0'));
+        $this->assertSame(-10, ValidationUtils::validateInt(-10));
+        $this->assertSame(-10, ValidationUtils::validateInt('-10'));
+    }
+
+    public function testValidateIntWithInvalidValues(): void
+    {
+        $this->assertFalse(ValidationUtils::validateInt('not a number'));
+        $this->assertFalse(ValidationUtils::validateInt(''));
+        $this->assertFalse(ValidationUtils::validateInt('1.5'));
+        $this->assertFalse(ValidationUtils::validateInt('1e5'));
+        $this->assertFalse(ValidationUtils::validateInt(null));
+        $this->assertFalse(ValidationUtils::validateInt([]));
+    }
+
+    public function testValidateIntWithMinRange(): void
+    {
+        $this->assertSame(5, ValidationUtils::validateInt(5, min: 1));
+        $this->assertSame(1, ValidationUtils::validateInt(1, min: 1));
+        $this->assertFalse(ValidationUtils::validateInt(0, min: 1));
+        $this->assertFalse(ValidationUtils::validateInt(-5, min: 1));
+    }
+
+    public function testValidateIntWithMaxRange(): void
+    {
+        $this->assertSame(5, ValidationUtils::validateInt(5, max: 10));
+        $this->assertSame(10, ValidationUtils::validateInt(10, max: 10));
+        $this->assertFalse(ValidationUtils::validateInt(11, max: 10));
+        $this->assertFalse(ValidationUtils::validateInt(100, max: 10));
+    }
+
+    public function testValidateIntWithMinAndMaxRange(): void
+    {
+        $this->assertSame(5, ValidationUtils::validateInt(5, min: 1, max: 10));
+        $this->assertSame(1, ValidationUtils::validateInt(1, min: 1, max: 10));
+        $this->assertSame(10, ValidationUtils::validateInt(10, min: 1, max: 10));
+        $this->assertFalse(ValidationUtils::validateInt(0, min: 1, max: 10));
+        $this->assertFalse(ValidationUtils::validateInt(11, min: 1, max: 10));
+    }
 }


### PR DESCRIPTION
## Summary

Add `ValidationUtils::validateInt()` method using `filter_var()` with `FILTER_VALIDATE_INT` and optional min/max range parameters.

Replace manual `is_numeric`/`intval` checks throughout the codebase with the new centralized method.

Fixes #10307

## Changes

- Add `ValidationUtils::validateInt(mixed $value, ?int $min, ?int $max): int|false`
- Update `interface/main/messages/trusted-messages-ajax.php`
- Update `interface/modules/zend_modules/.../ImmunizationController.php`
- Update `library/classes/Document.class.php`
- Update `interface/main/calendar/find_appt_popup.php`
- Add tests in `ValidationUtilsIsolatedTest.php`

## Test plan

- [x] Run isolated tests: `vendor/bin/phpunit -c phpunit-isolated.xml tests/Tests/Isolated/Common/Utils/ValidationUtilsIsolatedTest.php`
- [ ] Test calendar appointment popup
- [ ] Test immunization controller
- [ ] Test document upload

### AI disclosure

- [x] Yes, I used AI to help me with this pull request

🤖 Generated with [Claude Code](https://claude.ai/code)