### PR TITLE
refactor: Consolidate float validation using ValidationUtils

### DIFF
--- a/src/Common/Utils/ValidationUtils.php
+++ b/src/Common/Utils/ValidationUtils.php
@@ -67,4 +67,25 @@ class ValidationUtils
 
         return filter_var($value, FILTER_VALIDATE_INT, empty($options) ? 0 : ['options' => $options]);
     }
+
+    /**
+     * Validates a float, optionally within a range.
+     *
+     * @param mixed $value The value to validate
+     * @param ?float $min Minimum allowed value (inclusive)
+     * @param ?float $max Maximum allowed value (inclusive)
+     * @return float|false The validated float, or false if invalid
+     */
+    public static function validateFloat(mixed $value, ?float $min = null, ?float $max = null): float|false
+    {
+        $options = [];
+        if ($min !== null) {
+            $options['min_range'] = $min;
+        }
+        if ($max !== null) {
+            $options['max_range'] = $max;
+        }
+
+        return filter_var($value, FILTER_VALIDATE_FLOAT, empty($options) ? 0 : ['options' => $options]);
+    }
 }

--- a/src/Services/FHIR/FhirCoverageService.php
+++ b/src/Services/FHIR/FhirCoverageService.php
@@ -24,6 +24,7 @@ use OpenEMR\Services\FHIR\Traits\BulkExportSupportAllOperationsTrait;
 use OpenEMR\Services\FHIR\Traits\FhirBulkExportDomainResourceTrait;
 use OpenEMR\Services\FHIR\Traits\FhirServiceBaseEmptyTrait;
 use OpenEMR\Services\FHIR\Traits\VersionedProfileTrait;
+use OpenEMR\Common\Utils\ValidationUtils;
 use OpenEMR\Services\InsuranceService;
 use OpenEMR\Services\Search\FhirSearchParameterDefinition;
 use OpenEMR\Services\Search\ISearchField;
@@ -277,7 +278,8 @@ class FhirCoverageService extends FhirServiceBase implements IPatientCompartment
         }
 
         // CostToBeneficiary - copay information
-        if (!empty($dataRecord['copay']) && is_numeric($dataRecord['copay']) && $dataRecord['copay'] > 0) {
+        $copay = ValidationUtils::validateFloat($dataRecord['copay'] ?? null, min: 0.01);
+        if ($copay !== false) {
             $costToBeneficiary = new FHIRCoverageCostToBeneficiary();
 
             $costType = new FHIRCodeableConcept();
@@ -289,7 +291,7 @@ class FhirCoverageService extends FhirServiceBase implements IPatientCompartment
             $costToBeneficiary->setType($costType);
 
             $valueMoney = new FHIRMoney();
-            $valueMoney->setValue($dataRecord['copay']);
+            $valueMoney->setValue($copay);
             $valueMoney->setCurrency('USD');
 
             $costToBeneficiary->setValueMoney($valueMoney);

--- a/tests/Tests/Isolated/Common/Utils/ValidationUtilsIsolatedTest.php
+++ b/tests/Tests/Isolated/Common/Utils/ValidationUtilsIsolatedTest.php
@@ -182,4 +182,49 @@ class ValidationUtilsIsolatedTest extends TestCase
         $this->assertFalse(ValidationUtils::validateInt(0, min: 1, max: 10));
         $this->assertFalse(ValidationUtils::validateInt(11, min: 1, max: 10));
     }
+
+    public function testValidateFloatWithValidFloats(): void
+    {
+        $this->assertSame(42.5, ValidationUtils::validateFloat(42.5));
+        $this->assertSame(42.5, ValidationUtils::validateFloat('42.5'));
+        $this->assertSame(0.0, ValidationUtils::validateFloat(0));
+        $this->assertSame(0.0, ValidationUtils::validateFloat('0'));
+        $this->assertSame(-10.5, ValidationUtils::validateFloat(-10.5));
+        $this->assertSame(-10.5, ValidationUtils::validateFloat('-10.5'));
+        $this->assertSame(42.0, ValidationUtils::validateFloat(42));
+        $this->assertSame(1000.0, ValidationUtils::validateFloat('1e3'));
+    }
+
+    public function testValidateFloatWithInvalidValues(): void
+    {
+        $this->assertFalse(ValidationUtils::validateFloat('not a number'));
+        $this->assertFalse(ValidationUtils::validateFloat(''));
+        $this->assertFalse(ValidationUtils::validateFloat(null));
+        $this->assertFalse(ValidationUtils::validateFloat([]));
+    }
+
+    public function testValidateFloatWithMinRange(): void
+    {
+        $this->assertSame(5.5, ValidationUtils::validateFloat(5.5, min: 1.0));
+        $this->assertSame(1.0, ValidationUtils::validateFloat(1.0, min: 1.0));
+        $this->assertFalse(ValidationUtils::validateFloat(0.5, min: 1.0));
+        $this->assertFalse(ValidationUtils::validateFloat(-5.0, min: 1.0));
+    }
+
+    public function testValidateFloatWithMaxRange(): void
+    {
+        $this->assertSame(5.5, ValidationUtils::validateFloat(5.5, max: 10.0));
+        $this->assertSame(10.0, ValidationUtils::validateFloat(10.0, max: 10.0));
+        $this->assertFalse(ValidationUtils::validateFloat(10.5, max: 10.0));
+        $this->assertFalse(ValidationUtils::validateFloat(100.0, max: 10.0));
+    }
+
+    public function testValidateFloatWithMinAndMaxRange(): void
+    {
+        $this->assertSame(5.5, ValidationUtils::validateFloat(5.5, min: 1.0, max: 10.0));
+        $this->assertSame(1.0, ValidationUtils::validateFloat(1.0, min: 1.0, max: 10.0));
+        $this->assertSame(10.0, ValidationUtils::validateFloat(10.0, min: 1.0, max: 10.0));
+        $this->assertFalse(ValidationUtils::validateFloat(0.5, min: 1.0, max: 10.0));
+        $this->assertFalse(ValidationUtils::validateFloat(10.5, min: 1.0, max: 10.0));
+    }
 }


### PR DESCRIPTION
## Summary

Add `ValidationUtils::validateFloat()` method using `filter_var()` with `FILTER_VALIDATE_FLOAT` and optional min/max range parameters.

Fixes #10308

## Changes

- Add `ValidationUtils::validateFloat(mixed $value, ?float $min, ?float $max): float|false`
- Update `src/Services/FHIR/FhirCoverageService.php` copay validation
- Add tests in `ValidationUtilsIsolatedTest.php`

## Test plan

- [ ] Run isolated tests: `vendor/bin/phpunit -c phpunit-isolated.xml tests/Tests/Isolated/Common/Utils/ValidationUtilsIsolatedTest.php`
- [ ] Test FHIR Coverage resource with copay values

### AI disclosure

- [x] Yes, I used AI to help me with this pull request

🤖 Generated with [Claude Code](https://claude.ai/code)