### PR TITLE
refactor: Consolidate NPI validation using ValidationUtils

### DIFF
--- a/src/Billing/Claim.php
+++ b/src/Billing/Claim.php
@@ -16,6 +16,7 @@ namespace OpenEMR\Billing;
 
 use InsuranceCompany;
 use OpenEMR\Billing\InvoiceSummary;
+use OpenEMR\Common\Utils\ValidationUtils;
 use OpenEMR\Services\EncounterService;
 use OpenEMR\Services\FacilityService;
 use OpenEMR\Services\PatientService;
@@ -1619,20 +1620,7 @@ class Claim
 
     public function NPIValid($npi)
     {
-        // A NPI MUST be a 10 digit number
-        if ($npi === '') {
-            return false;
-        }
-
-        if (strlen((string) $npi) != 10) {
-            return false;
-        }
-
-        if (!preg_match("/[0-9]*/", (string) $npi)) {
-            return false;
-        }
-
-        return true;
+        return ValidationUtils::isValidNPI((string) $npi);
     }
     public function providerNPIValid($prockey = -1)
     {

--- a/src/Common/Utils/ValidationUtils.php
+++ b/src/Common/Utils/ValidationUtils.php
@@ -88,4 +88,56 @@ class ValidationUtils
 
         return filter_var($value, FILTER_VALIDATE_FLOAT, empty($options) ? 0 : ['options' => $options]);
     }
+
+    /**
+     * Validates a National Provider Identifier (NPI).
+     *
+     * NPIs are 10-digit numbers that must pass the Luhn algorithm check
+     * with the healthcare prefix 80840.
+     *
+     * @param string $npi The NPI to validate
+     * @return bool True if valid NPI, false otherwise
+     * @see https://www.cms.gov/Regulations-and-Guidance/Administrative-Simplification/NationalProvIdentStand
+     */
+    public static function isValidNPI(string $npi): bool
+    {
+        // NPI must be exactly 10 digits
+        if (!preg_match('/^\d{10}$/', $npi)) {
+            return false;
+        }
+
+        // Apply Luhn algorithm with 80840 prefix (ISO standard for US healthcare)
+        // Prepend 80840 to make a 15-digit number for the check
+        $prefixedNpi = '80840' . $npi;
+
+        return self::luhnCheck($prefixedNpi);
+    }
+
+    /**
+     * Performs Luhn algorithm check on a numeric string.
+     *
+     * @param string $number The number to check
+     * @return bool True if the number passes the Luhn check
+     */
+    private static function luhnCheck(string $number): bool
+    {
+        $sum = 0;
+        $length = strlen($number);
+        $parity = $length % 2;
+
+        for ($i = 0; $i < $length; $i++) {
+            $digit = (int) $number[$i];
+
+            if ($i % 2 === $parity) {
+                $digit *= 2;
+                if ($digit > 9) {
+                    $digit -= 9;
+                }
+            }
+
+            $sum += $digit;
+        }
+
+        return ($sum % 10) === 0;
+    }
 }

--- a/tests/Tests/Isolated/Common/Utils/ValidationUtilsIsolatedTest.php
+++ b/tests/Tests/Isolated/Common/Utils/ValidationUtilsIsolatedTest.php
@@ -227,4 +227,41 @@ class ValidationUtilsIsolatedTest extends TestCase
         $this->assertFalse(ValidationUtils::validateFloat(0.5, min: 1.0, max: 10.0));
         $this->assertFalse(ValidationUtils::validateFloat(10.5, min: 1.0, max: 10.0));
     }
+
+    public function testNpiValidationWithValidNpis(): void
+    {
+        // These NPIs pass the Luhn check with 80840 prefix
+        $validNpis = [
+            '1234567893',
+            '1245319599',
+            '1003000126',
+        ];
+
+        foreach ($validNpis as $npi) {
+            $this->assertTrue(
+                ValidationUtils::isValidNPI($npi),
+                "NPI should be valid: {$npi}"
+            );
+        }
+    }
+
+    public function testNpiValidationWithInvalidNpis(): void
+    {
+        $invalidNpis = [
+            '1234567890',  // Invalid check digit
+            '123456789',   // Too short (9 digits)
+            '12345678901', // Too long (11 digits)
+            'abcdefghij',  // Non-numeric
+            '123456789a',  // Contains letter
+            '',            // Empty string
+            '0000000000',  // All zeros (invalid check)
+        ];
+
+        foreach ($invalidNpis as $npi) {
+            $this->assertFalse(
+                ValidationUtils::isValidNPI($npi),
+                "NPI should be invalid: {$npi}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Add `ValidationUtils::isValidNPI()` method that properly validates National Provider Identifiers using the Luhn algorithm with the 80840 healthcare prefix.

Replaces the buggy regex in `Claim.php` that didn't validate the check digit or octet ranges.

Fixes #10310

## Changes

- Add `ValidationUtils::isValidNPI(string $npi): bool` with proper Luhn algorithm
- Add private `ValidationUtils::luhnCheck()` helper method
- Update `src/Billing/Claim.php` to use the new method
- Add tests in `ValidationUtilsIsolatedTest.php`

## Test plan

- [ ] Run isolated tests: `vendor/bin/phpunit -c phpunit-isolated.xml tests/Tests/Isolated/Common/Utils/ValidationUtilsIsolatedTest.php`
- [ ] Test billing claim generation with valid/invalid NPIs

### AI disclosure

- [x] Yes, I used AI to help me with this pull request

🤖 Generated with [Claude Code](https://claude.ai/code)