### PR TITLE
refactor: Consolidate validations using ValidationUtils

### DIFF
--- a/interface/modules/custom_modules/oe-module-comlink-telehealth/src/TelehealthGlobalConfig.php
+++ b/interface/modules/custom_modules/oe-module-comlink-telehealth/src/TelehealthGlobalConfig.php
@@ -16,6 +16,7 @@ use Comlink\OpenEMR\Module\GlobalConfig;
 use OpenEMR\Common\Crypto\CryptoGen;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Common\Utils\ValidationUtils;
 use OpenEMR\Common\Uuid\UniqueInstallationUuid;
 use OpenEMR\Services\Globals\GlobalSetting;
 use OpenEMR\Services\Globals\GlobalsService;
@@ -423,8 +424,8 @@ class TelehealthGlobalConfig
         $portalHost = parse_url((string) $portalAddress, PHP_URL_HOST);
         $hostnamesMatch = $qualifiedHost === $portalHost;
 
-        $isValidRegistrationUri = filter_var($this->getRegistrationAPIURI(), FILTER_VALIDATE_URL);
-        $isValidTelehealthApi = filter_var($this->getTelehealthAPIURI(), FILTER_VALIDATE_URL);
+        $isValidRegistrationUri = ValidationUtils::isValidUrl($this->getRegistrationAPIURI());
+        $isValidTelehealthApi = ValidationUtils::isValidUrl($this->getTelehealthAPIURI());
 
         $isLocaleConfigured = $this->isLocaleConfigured();
 

--- a/interface/product_registration/product_registration_controller.php
+++ b/interface/product_registration/product_registration_controller.php
@@ -11,6 +11,7 @@
  */
 
 use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Common\Utils\ValidationUtils;
 use OpenEMR\Services\ProductRegistrationService;
 use OpenEMR\Services\VersionService;
 use OpenEMR\Telemetry\BackgroundTaskManager;
@@ -40,7 +41,7 @@ if ($method === 'POST') {
         $email = trim($_POST['email'] ?? '');
 
         // validate email address
-        if (!empty($email) && filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
+        if (!empty($email) && !ValidationUtils::isValidEmail($email)) {
             http_response_code(400);
             echo json_encode(["message" => xlt("Invalid email")]);
             exit;

--- a/src/Common/Auth/OpenIDConnect/Entities/UserEntity.php
+++ b/src/Common/Auth/OpenIDConnect/Entities/UserEntity.php
@@ -20,6 +20,7 @@ use OpenEMR\Common\Auth\OpenIDConnect\FhirUserClaim;
 use OpenEMR\Common\Auth\UuidUserAccount;
 use OpenEMR\Common\Http\HttpRestRequest;
 use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Common\Utils\ValidationUtils;
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Services\PractitionerService;
 use OpenIDConnectServer\Entities\ClaimSetInterface;
@@ -44,7 +45,7 @@ class UserEntity implements ClaimSetInterface, UserEntityInterface
 
     public function setFhirBaseUrl(string $fhirBaseUrl): void
     {
-        if (filter_var($fhirBaseUrl, FILTER_VALIDATE_URL)) {
+        if (ValidationUtils::isValidUrl($fhirBaseUrl)) {
             $this->fhirBaseUrl = $fhirBaseUrl;
         } else {
             throw OAuthServerException::invalidRequest('fhirBaseUrl', 'Invalid FHIR base URL provided.');

--- a/src/Common/Auth/OpenIDConnect/FhirUserClaim.php
+++ b/src/Common/Auth/OpenIDConnect/FhirUserClaim.php
@@ -14,6 +14,7 @@ use League\OAuth2\Server\Exception\OAuthServerException;
 use OpenEMR\Common\Auth\UuidUserAccount;
 use OpenEMR\Common\Logging\SystemLogger;
 use OpenEMR\Common\Logging\SystemLoggerAwareTrait;
+use OpenEMR\Common\Utils\ValidationUtils;
 use OpenEMR\Services\PractitionerService;
 
 class FhirUserClaim {
@@ -50,7 +51,7 @@ class FhirUserClaim {
 
     public function setFhirBaseUrl(string $fhirBaseUrl): void
     {
-        if (filter_var($fhirBaseUrl, FILTER_VALIDATE_URL)) {
+        if (ValidationUtils::isValidUrl($fhirBaseUrl)) {
             $this->fhirBaseUrl = $fhirBaseUrl;
         } else {
             throw OAuthServerException::invalidRequest('fhirBaseUrl', 'Invalid FHIR base URL provided.');

--- a/src/Common/Utils/NetworkUtils.php
+++ b/src/Common/Utils/NetworkUtils.php
@@ -29,7 +29,7 @@ class NetworkUtils
     public function isLoopbackAddress(string $url_or_host): bool
     {
         // Extract hostname from URL if needed
-        if (filter_var($url_or_host, FILTER_VALIDATE_URL)) {
+        if (ValidationUtils::isValidUrl($url_or_host)) {
             $parsed = parse_url($url_or_host);
             $host = $parsed['host'] ?? '';
         } else {

--- a/src/Common/Utils/ValidationUtils.php
+++ b/src/Common/Utils/ValidationUtils.php
@@ -182,4 +182,24 @@ class ValidationUtils
     {
         return (bool) preg_match('/^[A-Z]\d[A-Z]\s?\d[A-Z]\d$/i', $postalCode);
     }
+
+    /**
+     * Validates a URL using filter_var.
+     *
+     * @param string $url The URL to validate
+     * @param bool $requireHttps If true, only accept HTTPS URLs
+     * @return bool True if valid URL, false otherwise
+     */
+    public static function isValidUrl(string $url, bool $requireHttps = false): bool
+    {
+        if (!filter_var($url, FILTER_VALIDATE_URL)) {
+            return false;
+        }
+
+        if ($requireHttps) {
+            return strtolower(parse_url($url, PHP_URL_SCHEME) ?? '') === 'https';
+        }
+
+        return true;
+    }
 }

--- a/src/Patient/Cards/CareTeamViewCard.php
+++ b/src/Patient/Cards/CareTeamViewCard.php
@@ -15,6 +15,7 @@ namespace OpenEMR\Patient\Cards;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Common\Utils\ValidationUtils;
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Events\Patient\Summary\Card\CardModel;
 use OpenEMR\Events\Patient\Summary\Card\RenderEvent;
@@ -126,7 +127,7 @@ class CareTeamViewCard extends CardModel
                 CsrfUtils::csrfNotVerified();
             }
 
-            $teamId = filter_var($_POST['team_id'], FILTER_VALIDATE_INT);
+            $teamId = ValidationUtils::validateInt($_POST['team_id']);
             $teamId = $teamId === false ? null : $teamId;
             $teamName = trim($_POST['team_name'] ?? '');
             $team = $_POST['team'] ?? [];

--- a/src/Services/ContactTelecomService.php
+++ b/src/Services/ContactTelecomService.php
@@ -14,8 +14,9 @@ namespace OpenEMR\Services;
 use OpenEMR\Common\ORDataObject\Contact;
 use OpenEMR\Common\ORDataObject\ContactTelecom;
 use OpenEMR\Common\Database\QueryUtils;
-use OpenEMR\Services\BaseService;
 use OpenEMR\Common\Logging\SystemLogger;
+use OpenEMR\Common\Utils\ValidationUtils;
+use OpenEMR\Services\BaseService;
 use OpenEMR\Services\Utils\DateFormatterUtils;
 use OpenEMR\Validators\ProcessingResult;
 
@@ -412,13 +413,13 @@ class ContactTelecomService extends BaseService
                 break;
 
             case 'email':
-                if (!filter_var($value, FILTER_VALIDATE_EMAIL)) {
+                if (!ValidationUtils::isValidEmail($value)) {
                     $errors['value'] = "Invalid email address format";
                 }
                 break;
 
             case 'url':
-                if (!filter_var($value, FILTER_VALIDATE_URL)) {
+                if (!ValidationUtils::isValidUrl($value)) {
                     $errors['value'] = "Invalid URL format";
                 }
                 break;

--- a/src/Services/FHIR/Observation/FhirObservationLaboratoryService.php
+++ b/src/Services/FHIR/Observation/FhirObservationLaboratoryService.php
@@ -33,6 +33,7 @@ use OpenEMR\Services\FHIR\openEMRSearchParameters;
 use OpenEMR\Services\FHIR\Traits\FhirServiceBaseEmptyTrait;
 use OpenEMR\Services\FHIR\Traits\VersionedProfileTrait;
 use OpenEMR\Services\FHIR\UtilsService;
+use OpenEMR\Common\Utils\ValidationUtils;
 use OpenEMR\Services\ProcedureService;
 use OpenEMR\Services\Search\FhirSearchParameterDefinition;
 use OpenEMR\Services\Search\ISearchField;
@@ -194,7 +195,7 @@ class FhirObservationLaboratoryService extends FhirServiceBase implements IPatie
                         if (!empty($report['specimens'])) {
                             $result['specimens'] = $report['specimens'];
                         }
-                        $ranges = array_filter(array_map(static fn($item): float|false => filter_var($item, FILTER_VALIDATE_FLOAT), explode('-', $record['range'] ?? '')));
+                        $ranges = array_filter(array_map(ValidationUtils::validateFloat(...), explode('-', $record['range'] ?? '')));
                         $result['range_low'] = $ranges[0] ?? null;
                         $result['range_high'] = $ranges[0] ?? null;
                         $result['result_abnormal'] = $result['abnormal'] ?? null;
@@ -268,7 +269,7 @@ class FhirObservationLaboratoryService extends FhirServiceBase implements IPatie
         $status = $this->getValidStatus($dataRecord['status'] ?? 'unknown');
         $observation->setStatus($status);
 
-        $ranges = array_filter(array_map(static fn($item): float|false => filter_var($item, FILTER_VALIDATE_FLOAT), explode('-', $dataRecord['range'] ?? '')));
+        $ranges = array_filter(array_map(ValidationUtils::validateFloat(...), explode('-', $dataRecord['range'] ?? '')));
         $low = $ranges[0] ?? null;
         $high = $ranges[1] ?? null;
         if (isset($low) && isset($high)) {

--- a/tests/Tests/Isolated/Common/Utils/ValidationUtilsIsolatedTest.php
+++ b/tests/Tests/Isolated/Common/Utils/ValidationUtilsIsolatedTest.php
@@ -311,4 +311,55 @@ class ValidationUtilsIsolatedTest extends TestCase
         $this->assertTrue(ValidationUtils::isValidPostalCode('anything', 'DE'));
         $this->assertFalse(ValidationUtils::isValidPostalCode('', 'UK'));
     }
+
+    public function testUrlValidationWithValidUrls(): void
+    {
+        $validUrls = [
+            'http://example.com',
+            'https://example.com',
+            'http://www.example.com/path',
+            'https://example.com/path?query=value',
+            'ftp://ftp.example.com',
+        ];
+
+        foreach ($validUrls as $url) {
+            $this->assertTrue(
+                ValidationUtils::isValidUrl($url),
+                "URL should be valid: {$url}"
+            );
+        }
+    }
+
+    public function testUrlValidationWithInvalidUrls(): void
+    {
+        $invalidUrls = [
+            'not-a-url',
+            'example.com',       // Missing scheme
+            '://missing-scheme',
+            '',
+            'http://',           // Missing host
+        ];
+
+        foreach ($invalidUrls as $url) {
+            $this->assertFalse(
+                ValidationUtils::isValidUrl($url),
+                "URL should be invalid: {$url}"
+            );
+        }
+    }
+
+    public function testUrlValidationWithHttpsRequirement(): void
+    {
+        // HTTPS URLs should pass when requireHttps is true
+        $this->assertTrue(ValidationUtils::isValidUrl('https://example.com', requireHttps: true));
+        $this->assertTrue(ValidationUtils::isValidUrl('HTTPS://EXAMPLE.COM', requireHttps: true));
+
+        // HTTP URLs should fail when requireHttps is true
+        $this->assertFalse(ValidationUtils::isValidUrl('http://example.com', requireHttps: true));
+        $this->assertFalse(ValidationUtils::isValidUrl('ftp://example.com', requireHttps: true));
+
+        // All valid URLs should pass when requireHttps is false
+        $this->assertTrue(ValidationUtils::isValidUrl('http://example.com', requireHttps: false));
+        $this->assertTrue(ValidationUtils::isValidUrl('https://example.com', requireHttps: false));
+    }
 }


### PR DESCRIPTION
## Summary

Consolidate scattered `filter_var()` validation calls to use centralized `ValidationUtils` methods across the codebase.

Fixes #10312

## Changes

- Add `ValidationUtils::isValidUrl(string $url, bool $requireHttps = false): bool`
- Replace all `filter_var(..., FILTER_VALIDATE_URL)` calls with `ValidationUtils::isValidUrl()`
- Replace all `filter_var(..., FILTER_VALIDATE_EMAIL)` calls with `ValidationUtils::isValidEmail()`
- Replace all `filter_var(..., FILTER_VALIDATE_INT)` calls with `ValidationUtils::validateInt()`
- Replace all `filter_var(..., FILTER_VALIDATE_FLOAT)` calls with `ValidationUtils::validateFloat()`

### Files updated

- `src/Common/Utils/ValidationUtils.php` - add `isValidUrl()` method
- `src/Common/Auth/OpenIDConnect/Entities/UserEntity.php` - use `isValidUrl()`
- `src/Common/Auth/OpenIDConnect/FhirUserClaim.php` - use `isValidUrl()`
- `src/Common/Utils/NetworkUtils.php` - use `isValidUrl()`
- `src/Services/ContactTelecomService.php` - use `isValidUrl()` and `isValidEmail()`
- `src/Patient/Cards/CareTeamViewCard.php` - use `validateInt()`
- `src/Services/FHIR/Observation/FhirObservationLaboratoryService.php` - use `validateFloat()`
- `interface/product_registration/product_registration_controller.php` - use `isValidEmail()`
- `interface/modules/custom_modules/oe-module-comlink-telehealth/src/TelehealthGlobalConfig.php` - use `isValidUrl()`

## Test plan

- [x] Run isolated tests: `vendor/bin/phpunit -c phpunit-isolated.xml tests/Tests/Isolated/Common/Utils/ValidationUtilsIsolatedTest.php`
- [x] Run unit tests to verify no regressions

### AI disclosure

- [x] Yes, I used AI to help me with this pull request

🤖 Generated with [Claude Code](https://claude.ai/code)