### PR TITLE
refactor: Consolidate UUID validation using ValidationUtils

### DIFF
--- a/src/Common/Utils/ValidationUtils.php
+++ b/src/Common/Utils/ValidationUtils.php
@@ -17,6 +17,8 @@
 
 namespace OpenEMR\Common\Utils;
 
+use OpenEMR\Common\Uuid\UuidRegistry;
+
 class ValidationUtils
 {
     public static function isValidEmail($email)
@@ -201,5 +203,16 @@ class ValidationUtils
         }
 
         return true;
+    }
+
+    /**
+     * Validates a UUID string.
+     *
+     * @param string $uuid The UUID to validate
+     * @return bool True if valid UUID, false otherwise
+     */
+    public static function isValidUuid(string $uuid): bool
+    {
+        return UuidRegistry::isValidStringUUID($uuid);
     }
 }

--- a/src/Common/Uuid/UuidRegistry.php
+++ b/src/Common/Uuid/UuidRegistry.php
@@ -292,7 +292,7 @@ class UuidRegistry
      */
     public static function isValidStringUUID($uuidString)
     {
-        return (Uuid::isValid($uuidString));
+        return Uuid::isValid($uuidString);
     }
 
     /**

--- a/src/RestControllers/FHIR/FhirDocumentRestController.php
+++ b/src/RestControllers/FHIR/FhirDocumentRestController.php
@@ -20,6 +20,7 @@ use OpenEMR\Common\Http\Psr17Factory;
 use OpenEMR\Common\Http\StatusCode;
 use OpenEMR\Common\Logging\SystemLogger;
 use Psr\Log\LoggerInterface;
+use OpenEMR\Common\Utils\ValidationUtils;
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Services\CDADocumentService;
 use OpenEMR\Services\FHIR\Document\BaseDocumentDownloader;
@@ -27,7 +28,6 @@ use OpenEMR\Services\FHIR\Document\IDocumentDownloader;
 use OpenEMR\Services\PatientService;
 use OpenEMR\Services\Search\ReferenceSearchField;
 use Psr\Http\Message\ResponseInterface;
-use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class FhirDocumentRestController
@@ -137,7 +137,7 @@ class FhirDocumentRestController
 
     private function findDocumentForDocumentId(string $documentId)
     {
-        if (Uuid::isValid($documentId)) {
+        if (ValidationUtils::isValidUuid($documentId)) {
             $document = \Document::getDocumentForUuid($documentId);
         } else {
             // use our integer values

--- a/tests/Tests/Isolated/Common/Utils/ValidationUtilsIsolatedTest.php
+++ b/tests/Tests/Isolated/Common/Utils/ValidationUtilsIsolatedTest.php
@@ -362,4 +362,40 @@ class ValidationUtilsIsolatedTest extends TestCase
         $this->assertTrue(ValidationUtils::isValidUrl('http://example.com', requireHttps: false));
         $this->assertTrue(ValidationUtils::isValidUrl('https://example.com', requireHttps: false));
     }
+
+    public function testUuidValidationWithValidUuids(): void
+    {
+        $validUuids = [
+            '550e8400-e29b-41d4-a716-446655440000', // Version 4
+            '6ba7b810-9dad-11d1-80b4-00c04fd430c8', // Version 1
+            '6ba7b811-9dad-11d1-80b4-00c04fd430c8',
+            '00000000-0000-0000-0000-000000000000', // Nil UUID
+        ];
+
+        foreach ($validUuids as $uuid) {
+            $this->assertTrue(
+                ValidationUtils::isValidUuid($uuid),
+                "UUID should be valid: {$uuid}"
+            );
+        }
+    }
+
+    public function testUuidValidationWithInvalidUuids(): void
+    {
+        $invalidUuids = [
+            'not-a-uuid',
+            '550e8400-e29b-41d4-a716-44665544000', // Too short
+            '550e8400-e29b-41d4-a716-4466554400000', // Too long
+            '550e8400-e29b-41d4-a716', // Incomplete
+            '',
+            'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', // Invalid characters
+        ];
+
+        foreach ($invalidUuids as $uuid) {
+            $this->assertFalse(
+                ValidationUtils::isValidUuid($uuid),
+                "UUID should be invalid: {$uuid}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Add `ValidationUtils::isValidUuid()` method that delegates to `Ramsey\Uuid::isValid()` for robust UUID validation.

Provides a simple boolean validation without exception handling.

Fixes #10313

## Changes

- Add `ValidationUtils::isValidUuid(string $uuid): bool`
- Add tests in `ValidationUtilsIsolatedTest.php`

## Test plan

- [ ] Run isolated tests: `vendor/bin/phpunit -c phpunit-isolated.xml tests/Tests/Isolated/Common/Utils/ValidationUtilsIsolatedTest.php`

### AI disclosure

- [x] Yes, I used AI to help me with this pull request

🤖 Generated with [Claude Code](https://claude.ai/code)