### PR TITLE
chore(testing): add composer script for isolated PHPUnit tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -276,6 +276,7 @@
             "phpstan analyze --memory-limit=8G --configuration=phpstan.neon.dist --generate-baseline=.phpstan/baseline/loader.php",
             "split-phpstan-baseline .phpstan/baseline/loader.php"
         ],
+        "phpunit-isolated": "phpunit -c phpunit-isolated.xml",
         "rector-check": "php -d memory_limit=4g ./vendor/bin/rector process --dry-run",
         "rector-fix": "php -d memory_limit=4g ./vendor/bin/rector process",
         "require-checker": "php -d memory_limit=4g ./vendor/bin/composer-require-checker check --config-file=.composer-require-checker.json"

--- a/composer.lock
+++ b/composer.lock
@@ -16445,5 +16445,5 @@
         "ext-zlib": "8.2",
         "php": "8.2"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
## Summary
- Adds `composer phpunit-isolated` script to run database-free unit tests

Fixes #10324

## Test plan
- [x] Run `composer phpunit-isolated` and verify tests execute

🤖 Generated with [Claude Code](https://claude.com/claude-code)