### PR TITLE
fix: correct typos in CCR/CCDA templates and misc files

### DIFF
--- a/acknowledge_license_cert.html
+++ b/acknowledge_license_cert.html
@@ -175,7 +175,7 @@ GNU General Public License version 3 or higher (GPL)</a>, a copy of which is inc
                 <tr>
                     <td>Juggernaut Systems Express</td>
                     <td><a href="https://www.affordablecustomehr.com/">www.affordablecustomehr.com</a>
-                        <br /> 505 Independance Pkwy, Chesapeake, VA 23320
+                        <br /> 505 Independence Pkwy, Chesapeake, VA 23320
                         <br /> Phone: +1 757 328 2736
                         <br /> Sherwin Gaddis: sherwin@affordablecustomehr.com</td>
                 </tr>

--- a/ccdaservice/README.md
+++ b/ccdaservice/README.md
@@ -15,7 +15,7 @@ Whenever there are new versions or updates, be sure to navigate into the ccdaser
 - `npm i --omit=dev`
 - `npm ci --omit=dev`
 
-To ensure the lastest libraries are installed, node version changes or the package lock file is for a different build version then it is necessary to run `node install` to update dependencies to locked versions. Next, ensure the installation is renewed by running `node ci` (clean install) will ensure package dependencies are in sync and the node_modules directory is deleted and rebuilt.
+To ensure the latest libraries are installed, node version changes or the package lock file is for a different build version then it is necessary to run `node install` to update dependencies to locked versions. Next, ensure the installation is renewed by running `node ci` (clean install) will ensure package dependencies are in sync and the node_modules directory is deleted and rebuilt.
 
 
 ## Ubuntu Setup
@@ -42,7 +42,7 @@ Navigate to: openemr/ccdaservice and run the following from an elevated PowerShe
 * This service will automatically start on demand when required by OpenEMR.
 ### Developing
 * Note that these scripts run in strict mode so javascript will hold you very much accountable with how objects and variables are handled.
-* For now, node modules are run local to service directory so all support dependecies are installed there.
+* For now, node modules are run local to service directory so all support dependencies are installed there.
 ### Tools
 * The nodejs ccda service now starts on demand.
 #### License

--- a/ccdaservice/packages/oe-cda-schematron/test/test.xml
+++ b/ccdaservice/packages/oe-cda-schematron/test/test.xml
@@ -7,12 +7,12 @@
 		<element>false</element>
 		<element>false</element>
 	</test>
-	<!-- attibute equivalence -->
+	<!-- attribute equivalence -->
 	<test root="B">
-		<element atttribute="ok">true</element>
+		<element attribute="ok">true</element>
 	</test>
 	<test root="B">
-		<element atttribute="notok">false</element>
+		<element attribute="notok">false</element>
 	</test>
 	<!-- child presence  -->
 	<test root="C">

--- a/ccdaservice/utils/demographics/populate-demographics.spec.js
+++ b/ccdaservice/utils/demographics/populate-demographics.spec.js
@@ -15,7 +15,7 @@ describe('getNpiFacility', () => {
         });
     });
 
-    describe('input wihout facility_npi value', () => {
+    describe('input without facility_npi value', () => {
         it('should return undefined for structured documents', () => {
             expect(getNpiFacility({ encounter_provider: {} }, false)).toEqual(
                 undefined

--- a/ccr/ccd/ccr_ccd.xsl
+++ b/ccr/ccd/ccr_ccd.xsl
@@ -2,9 +2,9 @@
 <!--
 Conversion of CCR to Level 3 CCD
 
-Orginal Author:   	Ken Miller
+Original Author:   	Ken Miller
 Solventus LLC
-ken.miller@solventus.coms
+ken.miller@solventus.com
 
 Contributors:
 Richard Braman, EHR Doctors, Inc rbraman@ehrdoctors.com
@@ -1686,7 +1686,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" exclude-result-prefixes="a
                                         <table>
                                             <tbody>
                                                 <tr>
-                                                    <th>Descripion</th>
+                                                    <th>Description</th>
                                                     <th>Plan Status</th>
                                                     <th>Type</th>
                                                     <th>Date</th>

--- a/ccr/ccd/templates/actor.xsl
+++ b/ccr/ccd/templates/actor.xsl
@@ -2,9 +2,9 @@
 <!--
 Conversion of CCR to Level 3 CCD
 
-Orginal Author:   	Ken Miller
+Original Author:   	Ken Miller
 Solventus LLC
-ken.miller@solventus.coms
+ken.miller@solventus.com
 
 Contributors:
 Richard Braman, EHR Doctors, Inc rbraman@ehrdoctors.com

--- a/ccr/ccd/templates/address.xsl
+++ b/ccr/ccd/templates/address.xsl
@@ -2,9 +2,9 @@
 <!--
 Conversion of CCR to Level 3 CCD
 
-Orginal Author:   	Ken Miller
+Original Author:   	Ken Miller
 Solventus LLC
-ken.miller@solventus.coms
+ken.miller@solventus.com
 
 Contributors:
 Richard Braman, EHR Doctors, Inc rbraman@ehrdoctors.com

--- a/ccr/ccd/templates/cdavocablookup.xsl
+++ b/ccr/ccd/templates/cdavocablookup.xsl
@@ -2,9 +2,9 @@
 <!--
 Conversion of CCR to Level 3 CCD
 
-Orginal Author:   	Ken Miller
+Original Author:   	Ken Miller
 Solventus LLC
-ken.miller@solventus.coms
+ken.miller@solventus.com
 
 Contributors:
 Richard Braman, EHR Doctors, Inc rbraman@ehrdoctors.com

--- a/ccr/ccd/templates/cdavocabmap.xml
+++ b/ccr/ccd/templates/cdavocabmap.xml
@@ -2,9 +2,9 @@
 <!--
 Conversion of CCR to Level 3 CCD
 
-Orginal Author:   	Ken Miller
+Original Author:   	Ken Miller
 Solventus LLC
-ken.miller@solventus.coms
+ken.miller@solventus.com
 
 Contributors:
 Richard Braman, EHR Doctors, Inc rbraman@ehrdoctors.com

--- a/ccr/ccd/templates/code.xsl
+++ b/ccr/ccd/templates/code.xsl
@@ -2,9 +2,9 @@
 <!--
 Conversion of CCR to Level 3 CCD
 
-Orginal Author:   	Ken Miller
+Original Author:   	Ken Miller
 Solventus LLC
-ken.miller@solventus.coms
+ken.miller@solventus.com
 
 Contributors:
 Richard Braman, EHR Doctors, Inc rbraman@ehrdoctors.com

--- a/ccr/ccd/templates/datetime.xsl
+++ b/ccr/ccd/templates/datetime.xsl
@@ -2,9 +2,9 @@
 <!--
 Conversion of CCR to Level 3 CCD
 
-Orginal Author:   	Ken Miller
+Original Author:   	Ken Miller
 Solventus LLC
-ken.miller@solventus.coms
+ken.miller@solventus.com
 
 Contributors:
 Richard Braman, EHR Doctors, Inc rbraman@ehrdoctors.com

--- a/ccr/ccd/templates/defaultCSS.xsl
+++ b/ccr/ccd/templates/defaultCSS.xsl
@@ -2,9 +2,9 @@
 <!--
 Conversion of CCR to Level 3 CCD
 
-Orginal Author:   	Ken Miller
+Original Author:   	Ken Miller
 Solventus LLC
-ken.miller@solventus.coms
+ken.miller@solventus.com
 
 Contributors:
 Richard Braman, EHR Doctors, Inc rbraman@ehrdoctors.com

--- a/ccr/ccd/templates/directions.xsl
+++ b/ccr/ccd/templates/directions.xsl
@@ -2,9 +2,9 @@
 <!--
 Conversion of CCR to Level 3 CCD
 
-Orginal Author:   	Ken Miller
+Original Author:   	Ken Miller
 Solventus LLC
-ken.miller@solventus.coms
+ken.miller@solventus.com
 
 Contributors:
 Richard Braman, EHR Doctors, Inc rbraman@ehrdoctors.com

--- a/ccr/ccd/templates/footer.xsl
+++ b/ccr/ccd/templates/footer.xsl
@@ -2,9 +2,9 @@
 <!--
 Conversion of CCR to Level 3 CCD
 
-Orginal Author:   	Ken Miller
+Original Author:   	Ken Miller
 Solventus LLC
-ken.miller@solventus.coms
+ken.miller@solventus.com
 
 Contributors:
 Richard Braman, EHR Doctors, Inc rbraman@ehrdoctors.com

--- a/ccr/ccd/templates/hl7oid.xml
+++ b/ccr/ccd/templates/hl7oid.xml
@@ -2,9 +2,9 @@
 <!--
 Conversion of CCR to Level 3 CCD
 
-Orginal Author:   	Ken Miller
+Original Author:   	Ken Miller
 Solventus LLC
-ken.miller@solventus.coms
+ken.miller@solventus.com
 
 Contributors:
 Richard Braman, EHR Doctors, Inc rbraman@ehrdoctors.com

--- a/ccr/ccd/templates/hl7oidlookup.xsl
+++ b/ccr/ccd/templates/hl7oidlookup.xsl
@@ -2,9 +2,9 @@
 <!--
 Conversion of CCR to Level 3 CCD
 
-Orginal Author:   	Ken Miller
+Original Author:   	Ken Miller
 Solventus LLC
-ken.miller@solventus.coms
+ken.miller@solventus.com
 
 Contributors:
 Richard Braman, EHR Doctors, Inc rbraman@ehrdoctors.com

--- a/ccr/ccd/templates/problemDescription.xsl
+++ b/ccr/ccd/templates/problemDescription.xsl
@@ -2,9 +2,9 @@
 <!--
 Conversion of CCR to Level 3 CCD
 
-Orginal Author:   	Ken Miller
+Original Author:   	Ken Miller
 Solventus LLC
-ken.miller@solventus.coms
+ken.miller@solventus.com
 
 Contributors:
 Richard Braman, EHR Doctors, Inc rbraman@ehrdoctors.com

--- a/ccr/ccr_view_retrieve.xsl
+++ b/ccr/ccr_view_retrieve.xsl
@@ -1398,7 +1398,7 @@ this XSLT back to the community.
                               <table class="list" id="planofcareorders">
                                 <tbody>
                                   <tr>
-                                    <th>Descripion</th>
+                                    <th>Description</th>
                                     <th>Plan Status</th>
                                     <th>Type</th>
                                     <th>Date</th>

--- a/ccr/stylesheet/ccr.xsl
+++ b/ccr/stylesheet/ccr.xsl
@@ -1402,7 +1402,7 @@ this XSLT back to the community.
                               <table class="list" id="planofcareorders">
                                 <tbody>
                                   <tr>
-                                    <th>Descripion</th>
+                                    <th>Description</th>
                                     <th>Plan Status</th>
                                     <th>Type</th>
                                     <th>Date</th>

--- a/ccr/stylesheet/cda.xsl
+++ b/ccr/stylesheet/cda.xsl
@@ -1702,7 +1702,7 @@
          </xsl:otherwise>
       </xsl:choose>
    </xsl:template>
-   <!-- paticipant facility and date -->
+   <!-- participant facility and date -->
    <xsl:template name="facilityAndDates">
       <table class="header_table">
          <tbody>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -68,7 +68,7 @@ if (config.install) {
 
 function log_error(isSuccess, err) {
     isSuccess = false;
-    console.error(logprefix + "An error occured! Check the log for details.");
+    console.error(logprefix + "An error occurred! Check the log for details.");
     // Log error to console
     console.error(err.toString().red);
     // Kills gulp on error since if we keep running it will

--- a/setup.php
+++ b/setup.php
@@ -1804,7 +1804,7 @@ FRM;
                         $csrf_id_esc = attr(CsrfUtils::collectCsrfToken('state1'));
                         $form = <<<FRM
                                     <br />
-                                    <p class='p-1 bg-warning'>$caution: Permisssions checking has been disabled. All required files and directories have NOT been verified, please manually verify sites/$site_id_esc .</p>
+                                    <p class='p-1 bg-warning'>$caution: Permissions checking has been disabled. All required files and directories have NOT been verified, please manually verify sites/$site_id_esc .</p>
                                     <p class='mark'>Click <b>Proceed to Step 1</b> to continue with a new installation.</p>
                                     <p class='p-1 bg-warning'>$caution: If you are upgrading from a previous version, <strong>DO NOT</strong> use this script. Please read the <strong>'Upgrading'</strong> section found in the <a href='Documentation/INSTALL' rel='noopener' target='_blank'><span style='text-decoration: underline;'>'INSTALL'</span></a> manual file.</p>
                                     <br />


### PR DESCRIPTION
## Summary
Fix spelling errors in CCR/CCD transformation templates, CCDA service files, and misc config/setup files (22 files).

Corrections include:
- `Orginal` → `Original` (author credits)
- `Descripion` → `Description` (table headers)
- `solventus.coms` → `solventus.com` (email domain typo)
- `attibute`/`atttribute` → `attribute` (test data)
- `wihout` → `without`
- `lastest` → `latest`
- `dependecies` → `dependencies`
- `occured` → `occurred`
- `Permisssions` → `Permissions`
- `Independance` → `Independence`
- `paticipant` → `participant`

Part of #7939

## Related PRs

This is PR 1 of 11 to fix typos across the codebase:

- #10333 fix: correct typos in CCR/CCDA templates and misc files ← this PR
- #10336 fix: correct typos in contrib, controllers, and misc files
- #10337 fix: correct typos in sites and templates
- #10338 fix: correct typos in FHIR resources and services
- #10339 fix: correct typos in library files
- #10340 fix: correct typos in portal files
- #10341 fix: correct typos in interface/modules
- #10342 fix: correct typos in interface files
- #10343 fix: correct typos in src/ files
- #10344 fix: correct typos in test files (merged)
- #10345 fix: correct typos in misc files

## Test plan
- [ ] Verify CCR/CCD export still functions correctly
- [ ] Verify CCDA generation is not affected

🤖 Generated with [Claude Code](https://claude.ai/code)